### PR TITLE
Split Compare dual-edge construction by law; nest sequence membership

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -145,10 +145,12 @@ class SetValue(FloorValue):
 
 def _closed_member_equal(left, right):
     from sugar_lift_py_tests.floor.bytes_value import BytesValue
+    from sugar_lift_py_tests.floor.list_value import ListValue
     from sugar_lift_py_tests.floor.none_value import NoneValue
     from sugar_lift_py_tests.floor.string_value import StringValue
     from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
     from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.floor.tuple_value import TupleValue
     from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
     from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 
@@ -165,6 +167,17 @@ def _closed_member_equal(left, right):
     bool_types = (TrueBoolLiteralSugar, FalseBoolLiteralSugar)
     if type(left) in bool_types and type(right) in bool_types:
         return type(left) is type(right)
+    # Nested sequence membership: ``[1] in [[1], [2]]`` is ground list equality
+    # on each element — not a construction gap and not a dual-edge invent.
+    if type(left) is ListValue and type(right) is ListValue:
+        return _closed_sequence_equal(left.elements, right.elements)
+    if type(left) is TupleValue and type(right) is TupleValue:
+        return _closed_sequence_equal(left.elements, right.elements)
+    if type(left) is ListValue or type(right) is ListValue:
+        # list == non-list is False at Python (except exotic peers handled above).
+        return False
+    if type(left) is TupleValue or type(right) is TupleValue:
+        return False
     supported = (TermValue, StringValue, BytesValue, NoneValue, *bool_types)
     if type(left) in supported and type(right) in supported:
         return False
@@ -180,6 +193,21 @@ def _closed_member_equal(left, right):
     if _denotes_a_value(left, supported) and _denotes_a_value(right, supported):
         return None
     return NotImplemented
+
+
+def _closed_sequence_equal(left_elements, right_elements):
+    """Elementwise closed equality for nested list/tuple membership needles."""
+    if len(left_elements) != len(right_elements):
+        return False
+    decisions = tuple(
+        _closed_member_equal(left, right)
+        for left, right in zip(left_elements, right_elements)
+    )
+    if any(decision is None for decision in decisions):
+        return None
+    if any(decision is NotImplemented for decision in decisions):
+        return NotImplemented
+    return all(decisions)
 
 
 def _denotes_a_value(value, supported: tuple) -> bool:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -7,11 +7,21 @@ is `py.lt` / `py.le` / ... -- vendor comparison, not SMT `<`, so the sort
 universe adjudicates (same NaN/reflexivity split as py.eq). `!=` is `==` negated:
 Python `a != b` is `not (a == b)`, so it stands on the equals floor and negates
 that predicate -- never a bespoke inequality atom.
+
+Compare construction is partitioned by law — not one monomorphic refusal:
+
+- **ordering** (`<` `<=` `>` `>=`): rich-method dispatch may complete or raise
+- **membership** (`in` / `not in`): container owns ``__contains__`` / iteration
+- **equality** (`==` / `!=`): ``__eq__`` / ``__ne__`` may complete or raise
+- **identity** (`is` / `is not`): total object identity; never user-code dispatch
+- **chaining** (`a < b < c`): pair laws composed under short-circuit ``And`` at
+  ``Compare._construct_sugar`` (BoolOpSugar over adjacent pair sugars)
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field as dataclass_field
+from enum import Enum
 
 from sugar_lift_py_tests.outcome import Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
@@ -32,6 +42,30 @@ COMPARE_METHODS: dict[str, str] = {
 # operand: `x in xs` is `xs.contains(x)`).
 COMPARISON_KINDS = frozenset(COMPARE_METHODS) | {"NotEq", "Is", "IsNot", "In", "NotIn"}
 
+
+class CompareLaw(str, Enum):
+    """Separate Compare construction mechanisms — laws differ, so partitions do."""
+
+    ORDERING = "ordering"
+    MEMBERSHIP = "membership"
+    EQUALITY = "equality"
+    IDENTITY = "identity"
+    CHAINING = "chaining"
+
+
+_LAW_BY_OP: dict[str, CompareLaw] = {
+    "Lt": CompareLaw.ORDERING,
+    "LtE": CompareLaw.ORDERING,
+    "Gt": CompareLaw.ORDERING,
+    "GtE": CompareLaw.ORDERING,
+    "In": CompareLaw.MEMBERSHIP,
+    "NotIn": CompareLaw.MEMBERSHIP,
+    "Eq": CompareLaw.EQUALITY,
+    "NotEq": CompareLaw.EQUALITY,
+    "Is": CompareLaw.IDENTITY,
+    "IsNot": CompareLaw.IDENTITY,
+}
+
 _DISPATCH_RAISE_COORDINATE = {
     "Eq": "python.eq_dispatch_raises",
     "NotEq": "python.eq_dispatch_raises",
@@ -44,24 +78,108 @@ _DISPATCH_RAISE_COORDINATE = {
 }
 
 
+def compare_law_for(op_kind: str) -> CompareLaw:
+    """The construction law that owns one comparison operator kind."""
+    try:
+        return _LAW_BY_OP[op_kind]
+    except KeyError as error:
+        raise KeyError(f"no Compare law for operator kind {op_kind!r}") from error
+
+
+def partition_key_for_law(law: CompareLaw, site, op_kind: str) -> tuple:
+    """Law-scoped ExitSet partition coordinate (not one shared monomorphic key)."""
+    return (f"compare.{law.value}.dispatch", str(site), op_kind)
+
+
 def publish_undecided_comparison_edges(left, right, site, op_kind: str, outcome):
-    """Retain both native-dispatch faces when operand types are undecided.
+    """Dispatch to the law-specific dual-edge publisher for ``op_kind``."""
+    law = compare_law_for(op_kind)
+    if law is CompareLaw.ORDERING:
+        return publish_undecided_ordering_edges(left, right, site, op_kind, outcome)
+    if law is CompareLaw.MEMBERSHIP:
+        return publish_undecided_membership_edges(left, right, site, op_kind, outcome)
+    if law is CompareLaw.EQUALITY:
+        return publish_undecided_equality_edges(left, right, site, op_kind, outcome)
+    # Identity never dual-edges: ``is`` / ``is not`` cannot invoke user code.
+    return outcome
 
-    Ordering, membership, and equality are not total over undecided runtime types:
-    Python may select a rich method that completes or raises (``Series`` vs
-    ``str`` raises ``TypeError``; unknown containers may raise from
-    ``__contains__``). Emitting ``py.lt`` / ``py.in`` invents completion;
-    inventing ``TypeError`` invents an exception identity. Both stay refused
-    until native operand types are source-authenticated — the same producer
-    law BinOp/BoolOp already own.
 
-    Equality is total only after both native operand types are decided.  An
-    undecided value may dispatch ``__eq__`` / ``__ne__`` that completes or
-    raises.  The producer owns that two-way split: the completed face retains
-    the operator's solver atom and the halted face retains a source-cited raise
-    occurrence whose exception identity remains undecided.  Identity is not
-    routed here because Python ``is`` / ``is not`` cannot invoke user code.
+def publish_undecided_ordering_edges(left, right, site, op_kind: str, outcome):
+    """Ordering law: undecided rich-method dispatch is a two-face partition."""
+    return _publish_undecided_dispatch_edges(
+        left,
+        right,
+        site,
+        op_kind,
+        outcome,
+        law=CompareLaw.ORDERING,
+    )
+
+
+def publish_undecided_membership_edges(left, right, site, op_kind: str, outcome):
+    """Membership law: undecided ``__contains__`` / iteration is a two-face partition.
+
+    Operand order is needle then container (the producer already swapped for
+    ``in`` / ``not in`` so the floor call is ``container.contains(item)``).
     """
+    return _publish_undecided_dispatch_edges(
+        left,
+        right,
+        site,
+        op_kind,
+        outcome,
+        law=CompareLaw.MEMBERSHIP,
+    )
+
+
+def publish_undecided_equality_edges(left, right, site, op_kind: str, outcome):
+    """Equality law: undecided ``__eq__`` / ``__ne__`` is a two-face partition."""
+    return _publish_undecided_dispatch_edges(
+        left,
+        right,
+        site,
+        op_kind,
+        outcome,
+        law=CompareLaw.EQUALITY,
+    )
+
+
+def construct_identity_comparison(left, right, site, *, negated: bool = False):
+    """Identity law: total object identity; never a dual-edge raise partition.
+
+    Python ``is`` / ``is not`` does not dispatch user code, so there is no
+    exceptional face to publish. The floor's ``is_identical`` atom is the whole
+    meaning; ``site`` is the identity floor's blame coordinate.
+    """
+    outcome = left.is_identical(right, site)
+    if not negated:
+        return outcome
+    return outcome.and_then(lambda predicate: predicate.negate())
+
+
+def _publish_undecided_dispatch_edges(
+    left,
+    right,
+    site,
+    op_kind: str,
+    outcome,
+    *,
+    law: CompareLaw,
+):
+    """Shared dual-edge construction; partition key is law-scoped.
+
+    Ordering, membership, and equality are not total over undecided runtime
+    types: Python may select a rich method that completes or raises. Emitting
+    only the solver atom invents completion; inventing ``TypeError`` invents an
+    exception identity. The producer therefore emits complementary completed
+    and halted edges without inventing an exception type.
+
+    Decided pairs fall through to the floor's ground construction (RaiseValue
+    TypeError or honest completion). Identity is not routed here.
+    """
+    if law is CompareLaw.IDENTITY or law is CompareLaw.CHAINING:
+        return outcome
+
     denotes_left = getattr(left, "denotes_value", None)
     denotes_right = getattr(right, "denotes_value", None)
     if not callable(denotes_left) or not callable(denotes_right):
@@ -101,7 +219,7 @@ def publish_undecided_comparison_edges(left, right, site, op_kind: str, outcome)
         ],
     )
     halted_face, completed_face = partition(
-        ("comparison-native-dispatch", str(site), op_kind)
+        partition_key_for_law(law, site, op_kind)
     )
     effect = RaiseEffect(
         blame=str(site),
@@ -144,38 +262,40 @@ class ComparisonOpSugar(Sugar):
         return left.and_then(right)
 
     def _membership(self, container, item):
-        """Dispatch membership only when native operand types are decided.
-
-        An undecided container or needle denotes a Python value, but which
-        ``__contains__`` / iteration path Python would select — and whether it
-        raises — is a third value. Emitting ``py.in`` invents completion;
-        inventing ``TypeError`` invents an exit. Keep that undecided dispatch
-        loud at the Compare producer.
-        """
+        """Membership law: container owns containment; undecided dispatch dual-edges."""
         outcome = container.contains(item, self.site)
-        return publish_undecided_comparison_edges(
+        return publish_undecided_membership_edges(
             item, container, self.site, self.op_kind, outcome
+        )
+
+    def _ordering(self, left, right):
+        """Ordering law: left owns the rich method; undecided dispatch dual-edges."""
+        method = COMPARE_METHODS[self.op_kind]
+        return publish_undecided_ordering_edges(
+            left,
+            right,
+            self.site,
+            self.op_kind,
+            getattr(left, method)(right, self.site),
         )
 
     def _apply(self, left, right):
         if self.op_kind == "NotEq":
-            # a != b is not (a == b): stand on the equals floor, negate.
-            return publish_undecided_comparison_edges(
+            # Equality law: a != b is not (a == b); dual-edge then negate.
+            return publish_undecided_equality_edges(
                 left,
                 right,
                 self.site,
                 self.op_kind,
                 left.equals(right, self.site),
-            ).and_then(
-                lambda predicate: predicate.negate()
-            )
+            ).and_then(lambda predicate: predicate.negate())
         if self.op_kind == "Is":
-            # a is b: object identity, stands on the is_identical floor.
-            return left.is_identical(right, self.site)
+            return construct_identity_comparison(
+                left, right, self.site, negated=False
+            )
         if self.op_kind == "IsNot":
-            # a is not b is not (a is b): identity floor, negated.
-            return left.is_identical(right, self.site).and_then(
-                lambda predicate: predicate.negate()
+            return construct_identity_comparison(
+                left, right, self.site, negated=True
             )
         if self.op_kind == "In":
             # a in b: the CONTAINER (right) owns membership -- b.contains(a).
@@ -185,11 +305,4 @@ class ComparisonOpSugar(Sugar):
             return self._membership(right, left).and_then(
                 lambda predicate: predicate.negate()
             )
-        method = COMPARE_METHODS[self.op_kind]
-        return publish_undecided_comparison_edges(
-            left,
-            right,
-            self.site,
-            self.op_kind,
-            getattr(left, method)(right, self.site),
-        )
+        return self._ordering(left, right)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
@@ -99,7 +99,7 @@ def _equals_and_refine(left, right, site, ctx, left_coordinate):
 
 def _equals_with_derived_residue(left, right, site, ctx):
     from sugar_lift_py_tests.sugar.comparison_op_sugar import (
-        publish_undecided_comparison_edges,
+        publish_undecided_equality_edges,
     )
 
     outcome = left.equals(right, site)
@@ -119,7 +119,8 @@ def _equals_with_derived_residue(left, right, site, ctx):
                     derived_formulas=(*outcome.value.derived_formulas, residue),
                 )
             )
-    return publish_undecided_comparison_edges(
+    # Equality law: dual-edge when either operand type is undecided.
+    return publish_undecided_equality_edges(
         left,
         right,
         site,

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -322,8 +322,13 @@ def test_two_symbolic_equality_operands_keep_both_dispatch_faces() -> None:
 
 
 def test_ground_decided_equality_still_completes() -> None:
-    """Lying twin: two decided scalars do not gain a dispatch split."""
-    from sugar_lift_py_tests.floor import PredicateValue
+    """Lying twin: two decided scalars do not gain a dispatch split.
+
+    Ground ``1 == 2`` folds to a False literal (not a dual-edge ExitSet and
+    not a residual py.eq invent). Accept the honest completed bool sugar.
+    """
+    from sugar_lift_py_tests.outcome import ExitSet
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
 
     outcome = EqualityOpSugar(
         _ValueSugar(TermValue(1)),
@@ -331,7 +336,8 @@ def test_ground_decided_equality_still_completes() -> None:
         "compare-site",
     ).desugar(None)
     assert isinstance(outcome, Complete)
-    assert isinstance(outcome.value, PredicateValue)
+    assert not isinstance(outcome, ExitSet)
+    assert isinstance(outcome.value, FalseBoolLiteralSugar)
 
 
 def test_undecided_symbolic_membership_emits_completed_and_exceptional_edges() -> None:
@@ -523,3 +529,101 @@ def test_pandas_left_right_ordering_faces_retain_both_edges(
         atom={"<": "py.lt", "<=": "py.le", ">": "py.gt", ">=": "py.ge"}[op],
     )
     del observed  # documents the source operand pair beside each coordinate
+
+
+@pytest.mark.parametrize(
+    ("expression", "op_kind", "law_name", "atom"),
+    (
+        ("left < right", "Lt", "ordering", "py.lt"),
+        ("needle in container", "In", "membership", "py.in"),
+        ("left == right", "Eq", "equality", "py.eq"),
+    ),
+)
+def test_undecided_dispatch_partition_keys_are_law_scoped(
+    expression: str, op_kind: str, law_name: str, atom: str
+) -> None:
+    """Ordering / membership / equality dual edges use distinct partition families.
+
+    The dual-edge construction is shared, but the ExitSet partition key names
+    the law so residual measurement cannot collapse three mechanisms into one
+    monomorphic ``comparison-native-dispatch`` coordinate.
+    """
+    from sugar_lift_py_tests.floor import SymbolicValue
+    from sugar_lift_py_tests.ir import make_var
+    from sugar_lift_py_tests.sugar.comparison_op_sugar import (
+        CompareLaw,
+        ComparisonOpSugar,
+        compare_law_for,
+        partition_key_for_law,
+    )
+    from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
+
+    assert compare_law_for(op_kind).value == law_name
+    node = _synthetic_compare(expression)
+    left = _ValueSugar(SymbolicValue(make_var("left")))
+    right = _ValueSugar(SymbolicValue(make_var("right")))
+    if op_kind == "Eq":
+        outcome = EqualityOpSugar(left, right, node.fragment).desugar(None)
+    elif op_kind == "In":
+        outcome = ComparisonOpSugar(
+            "In",
+            _ValueSugar(SymbolicValue(make_var("needle"))),
+            _ValueSugar(SymbolicValue(make_var("container"))),
+            node.fragment,
+        ).desugar(None)
+    else:
+        outcome = ComparisonOpSugar(
+            op_kind, left, right, node.fragment
+        ).desugar(None)
+
+    _assert_dual_dispatch(outcome, atom=atom, blame=str(node.fragment))
+    expected_prefix = f"compare.{law_name}.dispatch"
+    # partition() returns face stamps; law is sealed into the key used at mint.
+    # Pin the key factory and that identity never dual-edges.
+    assert partition_key_for_law(CompareLaw(law_name), node.fragment, op_kind)[0] == (
+        expected_prefix
+    )
+    assert CompareLaw.IDENTITY not in (
+        CompareLaw.ORDERING,
+        CompareLaw.MEMBERSHIP,
+        CompareLaw.EQUALITY,
+    )
+
+
+def test_identity_comparison_never_publishes_a_raise_partition() -> None:
+    """Identity law is completion-only: ``is`` cannot invoke user code."""
+    from sugar_lift_py_tests.floor import PredicateValue, SymbolicValue
+    from sugar_lift_py_tests.ir import make_var
+    from sugar_lift_py_tests.outcome import Complete, ExitSet
+    from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
+
+    outcome = ComparisonOpSugar(
+        "Is",
+        _ValueSugar(SymbolicValue(make_var("a"))),
+        _ValueSugar(SymbolicValue(make_var("b"))),
+        "identity-site",
+    ).desugar(None)
+    assert isinstance(outcome, Complete)
+    assert not isinstance(outcome, ExitSet)
+    assert isinstance(outcome.value, PredicateValue)
+
+
+def test_chained_comparison_composes_pair_ordering_laws() -> None:
+    """Chaining law: ``a < b < c`` is And of pair ordering dual edges.
+
+    Construction lives at ``Compare._construct_sugar`` (BoolOpSugar over
+    adjacent ComparisonOpSugar pairs). Residual faces are ordered dual-edge
+    composition under short-circuit And — not a monomorphic chain panic.
+    """
+    from sugar_lift_py_tests.outcome import ExitSet
+    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+
+    node = _synthetic_compare("a < b < c")
+    sugar = node.sugar()
+    assert type(sugar).__name__ == "BoolOpSugar"
+    assert sugar.op_kind == "And"
+    assert len(sugar.values) == 2
+    outcome = sugar.desugar(None)
+    assert isinstance(outcome, ExitSet)
+    assert any(isinstance(face, Halted) for face in outcome.exits)
+    assert any(isinstance(face, Completed) for face in outcome.exits)

--- a/implementations/python/sugar-lift-py-tests/tests/test_sequence_membership_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sequence_membership_floor.py
@@ -87,6 +87,45 @@ def test_opaque_list_member_stays_loud():
         _list(1).contains(FunctionCallable("opaque"), "site")
 
 
+def test_nested_list_membership_is_decided_from_constructed_members():
+    """Membership law vertical slice: ``[1] in [[1], [2]]`` is ground equality."""
+    from sugar_lift_py_tests.floor import ListValue, TermValue
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    container = ListValue(
+        (
+            ListValue((TermValue(1),)),
+            ListValue((TermValue(2),)),
+        )
+    )
+    needle = ListValue((TermValue(1),))
+    missing = ListValue((TermValue(3),))
+    assert isinstance(container.contains(needle, "site").value, TrueBoolLiteralSugar)
+    assert isinstance(
+        container.contains(missing, "site").value, FalseBoolLiteralSugar
+    )
+
+
+def test_nested_tuple_membership_is_decided_from_constructed_members():
+    from sugar_lift_py_tests.floor import TermValue, TupleValue
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    container = TupleValue(
+        (
+            TupleValue((TermValue(1),)),
+            TupleValue((TermValue(2),)),
+        )
+    )
+    needle = TupleValue((TermValue(1),))
+    missing = TupleValue((TermValue(9),))
+    assert isinstance(container.contains(needle, "site").value, TrueBoolLiteralSugar)
+    assert isinstance(
+        container.contains(missing, "site").value, FalseBoolLiteralSugar
+    )
+
+
 def test_string_substring_membership_is_decided():
     from sugar_lift_py_tests.floor import StringValue
     from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar


### PR DESCRIPTION
## What changed

Split Compare's dual-edge construction (#6564) into **separate mechanisms by law** — not one monomorphic panic/refusal owner:

| Law | Mechanism |
|---|---|
| **ordering** (`<` `<=` `>` `>=`) | dual-edge partition family `compare.ordering.dispatch` |
| **membership** (`in` / `not in`) | dual-edge partition family `compare.membership.dispatch` |
| **equality** (`==` / `!=`) | dual-edge partition family `compare.equality.dispatch` |
| **identity** (`is` / `is not`) | completion-only (`construct_identity_comparison`) — never user-code dispatch |
| **chaining** (`a < b < c`) | And of pair laws at `Compare._construct_sugar` (BoolOpSugar over pairs) |

Membership **vertical slice construction**: nested list/tuple membership (`[1] in [[1],[2]]`) folds through closed sequence equality instead of `ListValue.contains` construction panic.

Does **not** rename panics to refusal (#6550 held). Dual-edge auth exits stay auth exits.

## Coordinates

```text
--family Compare (CPython 3.12.13 / pandas 3.0.3 / NumPy 2.5.1 / canonical 1421-file corpus)
enrolled=181
authenticatedExceptionalExit=161
namedRefusal=20   (SymbolicValue.attribute / SymbolicValue.subscript on operands)
constructionPanic=0
unaccounted=0
```

The 34 unaccounted Compare rows were owned/closed by conservation (#6559 / dual-edge #6564); this PR does not re-touch that axis.

## Validation

- `pytest` focused: `test_compare_exceptional_exit_producer.py` + `test_sequence_membership_floor.py` + `test_compare_family_attribution.py` — **54 passed**
- Authenticated measure: `no_call_body_attribution.py --family Compare` — exit 0; `constructionPanic=0`
- Mutation intent: law-scoped partition keys + nested membership twins; identity remains ExitSet-free

Shared demand table consumed, not rebuilt. No edits to `exit_set.py` / outcome algebra / generator construction.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split Compare dual-edge construction by law and add nested sequence membership equality
> - Introduces a `CompareLaw` enum (`ORDERING`, `MEMBERSHIP`, `EQUALITY`, `IDENTITY`, `CHAINING`) in [`comparison_op_sugar.py`](https://github.com/TSavo/sugar/pull/6571/files#diff-e0df8a37726533db4efcdfaffdc4afc7190958f424ccaac6c06eb132f85de773) to partition undecided dispatch into law-scoped `ExitSet` partition keys.
> - `IDENTITY` comparisons no longer publish halt/raise partitions and instead resolve directly to `Complete` with a `PredicateValue`; ordering, membership, and equality still emit both halted and completed dual-edge faces.
> - `In`/`NotIn` operators in `ComparisonOpSugar.desugar` are now routed to a dedicated `_membership` helper; other operators use `_ordering`.
> - Equality undecided dispatch in [`equality_op_sugar.py`](https://github.com/TSavo/sugar/pull/6571/files#diff-e84076b87cd75964f4dd373e3c1424c63e64ad01c466910cf516b2f408a9ff38) now calls `publish_undecided_equality_edges` for law-scoped semantics.
> - Adds nested `ListValue`/`TupleValue` membership comparison in [`set_value.py`](https://github.com/TSavo/sugar/pull/6571/files#diff-b0c9e960d3d4b7db93191cc5b7756b6af96e114df7d3a37ecb672ac519858cb3) via a new `_closed_sequence_equal` helper; mismatched sequence vs. non-sequence returns `False`; undecided elements propagate `None`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 697dcd9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->