### PR TITLE
Construct external exception types from provider source

### DIFF
--- a/implementations/python/sugar-lift-py-tests/pyproject.toml
+++ b/implementations/python/sugar-lift-py-tests/pyproject.toml
@@ -45,6 +45,11 @@ test = [
     # the two that constitute the measurement were the two that could move.
     "numpy==2.5.1",
     "pandas==3.0.3",
+    # External exception construction authenticates provider definitions from
+    # recorded wheel source.  pandas' ArrowInvalid/ArrowException sites cannot
+    # be constructed from pandas bytes alone; this exact provider is part of
+    # the measured closure, not imported or executed by the source resolver.
+    "pyarrow==22.0.0",
 ]
 
 [tool.sugar.measured-corpus]

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -101,7 +101,7 @@ def _load_authenticate_disk_cache(
 
         with path.open("rb") as stream:
             payload = pickle.load(stream)
-        if not isinstance(payload, dict) or payload.get("schema") != "dep-graph-v2":
+        if not isinstance(payload, dict) or payload.get("schema") != "dep-graph-v3":
             return None
         graph = DependencyArtifactGraph(
             artifact_kind=payload["artifact_kind"],
@@ -132,7 +132,10 @@ def _store_authenticate_disk_cache(
 
         # MappingProxyType is not pickleable; store plain dict modules.
         payload = {
-            "schema": "dep-graph-v2",
+            # v3 projects recorded .pyi defining source as modules.  A v2 seat
+            # for the same artifact CID is byte-authentic but semantically
+            # incomplete, so it must never answer this reader.
+            "schema": "dep-graph-v3",
             "artifact_kind": graph.artifact_kind,
             "distribution_name": graph.distribution_name,
             "distribution_version": graph.distribution_version,
@@ -866,6 +869,36 @@ def resolve_import_binding(
     )
 
 
+def resolve_authenticated_module_export(
+    *,
+    graph: DependencyArtifactGraph,
+    binding_cid: str,
+    module_name: str,
+    exported_name: str,
+    session: "SourceResolutionSession | None" = None,
+) -> PythonObjectResolutionV1:
+    """Resolve a provider export after its module binding was authenticated.
+
+    This is the non-``import`` spelling of :func:`resolve_import_binding`: a
+    source-derived module provider (for example, a returned module value) owns
+    ``binding_cid`` and ``module_name`` already.  Export traversal remains the
+    same content-addressed source/re-export walk; callers cannot supply a
+    definition, CID, or successful result directly.
+    """
+    _cid(binding_cid, "provider binding cid")
+    _string(module_name, "provider module name")
+    _string(exported_name, "provider exported name")
+    return _resolve_export(
+        graph,
+        binding_cid,
+        module_name,
+        exported_name,
+        (),
+        frozenset(),
+        session=session_or_new(session),
+    )
+
+
 def _binding_target(
     value: Mapping[str, Any],
 ) -> tuple[str, tuple[str, ...], str | None]:
@@ -890,7 +923,15 @@ def _binding_target(
 
 
 def _module_name(path: PurePosixPath) -> str | None:
-    if path.suffix != ".py":
+    # PEP 484 stubs are defining Python source for names and class ancestry.
+    # Wheels with native extension modules commonly ship the callable runtime
+    # in ``.so`` and the source-visible type definitions in a sibling ``.pyi``
+    # (PyArrow's exception hierarchy is one such provider).  Discarding that
+    # recorded, content-addressed source turns a reachable class definition
+    # into opacity.  A distribution containing both ``x.py`` and ``x.pyi``
+    # remains a duplicate module seat and is refused by the existing intake
+    # check; this door never chooses whichever file is convenient.
+    if path.suffix not in {".py", ".pyi"}:
         return None
     parts = list(path.with_suffix("").parts)
     if any(part.endswith(".dist-info") or part.endswith(".data") for part in parts):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/external_exception_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/external_exception_construction.py
@@ -1,0 +1,412 @@
+"""Construct external exception classes from authenticated provider source."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+from sugar_lift_py_tests.ir import Term, ctor, str_const
+
+from .dependency_artifact import (
+    DependencyArtifactGraph,
+    ResolvedPythonObjectV1,
+    resolve_authenticated_module_export,
+)
+from .resolution_session import SourceResolutionSession
+
+
+class ExternalExceptionConstructionGap(ValueError):
+    """Provider source did not prove the requested exception class."""
+
+
+@dataclass(frozen=True)
+class AuthenticatedProviderExceptionTypeV1:
+    """One source operand joined to one provider-defined exception class."""
+
+    source_attribute: str
+    resolved: ResolvedPythonObjectV1
+    identity: Term
+    ancestry: tuple[Term, ...]
+
+    def class_value(self):
+        """Construct the authenticated class/base graph used by native floors."""
+        from sugar_lift_py_tests.floor import BlockValue, ClassValue
+
+        base = None
+        for name in reversed(_ancestry_labels(self.ancestry, self.resolved)):
+            base = ClassValue(
+                name=name,
+                bases=() if base is None else (base,),
+                record=BlockValue(()),
+            )
+        assert base is not None
+        return base
+
+    @classmethod
+    def construct(
+        cls,
+        *,
+        graph: DependencyArtifactGraph,
+        binding_cid: str,
+        module_name: str,
+        source_attribute: str,
+        session: SourceResolutionSession | None = None,
+    ) -> "AuthenticatedProviderExceptionTypeV1":
+        resolved = resolve_authenticated_module_export(
+            graph=graph,
+            binding_cid=binding_cid,
+            module_name=module_name,
+            exported_name=source_attribute,
+            session=session,
+        )
+        if not isinstance(resolved, ResolvedPythonObjectV1):
+            artifact = f"{module_name}.{source_attribute}"
+            raise ExternalExceptionConstructionGap(
+                f"provider export source absent for {artifact}: {resolved.kind}"
+            )
+        return cls.from_resolved(
+            graph=graph,
+            source_attribute=source_attribute,
+            resolved=resolved,
+        )
+
+    @classmethod
+    def from_resolved(
+        cls,
+        *,
+        graph: DependencyArtifactGraph,
+        source_attribute: str,
+        resolved: ResolvedPythonObjectV1,
+    ) -> "AuthenticatedProviderExceptionTypeV1":
+        """Join an already-authenticated provider result to its source use."""
+        if resolved.distribution_artifact_cid != graph.distribution_artifact_cid:
+            raise ExternalExceptionConstructionGap(
+                "provider definition belongs to a different artifact graph"
+            )
+        if resolved.definition.kind != "class":
+            raise ExternalExceptionConstructionGap(
+                f"provider export {module_name}.{source_attribute} resolves to "
+                f"{resolved.definition.kind}, not class source"
+            )
+        # The source operand and resolved definition must name the same class.
+        # This check is deliberately before identity minting: a valid provider
+        # coordinate for a different exception is a lie, not partial testimony.
+        if resolved.definition.name != source_attribute:
+            raise ExternalExceptionConstructionGap(
+                "provider definition mismatch: source binds "
+                f"{source_attribute}, provider resolved {resolved.definition.name}"
+            )
+        ancestry_names = _exception_ancestry_names(graph, resolved)
+        if ancestry_names is None:
+            raise ExternalExceptionConstructionGap(
+                "provider class source does not reach BaseException: "
+                f"{resolved.module_name}.{resolved.definition.name}"
+            )
+        identity = _provider_identity(resolved)
+        ancestry = tuple(
+            (
+                identity
+                if index == 0
+                else ctor(
+                    "python:exception_type_identity",
+                    [str_const("provider-base"), str_const(name)],
+                )
+            )
+            for index, name in enumerate(ancestry_names)
+        )
+        return cls(source_attribute, resolved, identity, ancestry)
+
+
+def _provider_identity(resolved: ResolvedPythonObjectV1) -> Term:
+    """The qualified coordinate is admitted only behind provider testimony."""
+    return ctor(
+        "python:exception_type_identity",
+        [
+            str_const("import"),
+            str_const(f"{resolved.module_name}.{resolved.definition.name}"),
+        ],
+    )
+
+
+def _ancestry_labels(
+    ancestry: tuple[Term, ...], resolved: ResolvedPythonObjectV1
+) -> tuple[str, ...]:
+    labels = [f"{resolved.module_name}.{resolved.definition.name}"]
+    labels.extend(
+        str(getattr(term.args[1], "value", "<invalid>")) for term in ancestry[1:]
+    )
+    return tuple(labels)
+
+
+def _exception_ancestry_names(
+    graph: DependencyArtifactGraph, resolved: ResolvedPythonObjectV1
+) -> tuple[str, ...] | None:
+    module = graph.modules.get(resolved.module_name)
+    if module is None or module.source_cid != resolved.source_cid:
+        return None
+    tree = ast.parse(module.source, filename=module.source_seat)
+    classes = {node.name: node for node in tree.body if isinstance(node, ast.ClassDef)}
+    leaf = classes.get(resolved.definition.name)
+    if leaf is None or leaf.lineno != resolved.definition.start_line:
+        return None
+
+    result: list[str] = []
+    visiting: set[str] = set()
+
+    def visit(name: str) -> bool:
+        if name in visiting:
+            return False
+        visiting.add(name)
+        result.append(name)
+        if name in {"BaseException", "Exception"}:
+            if name == "Exception":
+                result.append("BaseException")
+            return True
+        definition = classes.get(name)
+        if definition is None or len(definition.bases) != 1:
+            return False
+        base = definition.bases[0]
+        return isinstance(base, ast.Name) and visit(base.id)
+
+    return tuple(result) if visit(leaf.name) else None
+
+
+def construct_provider_exception_attribute(
+    node,
+    *,
+    root: Path,
+    path: Path,
+    graph_cache: dict[str, DependencyArtifactGraph],
+    session: SourceResolutionSession,
+    distribution_index=None,
+) -> AuthenticatedProviderExceptionTypeV1 | None:
+    """Construct ``provider.Exception`` through its reaching provider binding.
+
+    The provider binding is either a native import statement or an assignment
+    whose authenticated callee source returns ``sys.modules[formal]``.  No
+    manager/callee spelling participates.  ``None`` means the operand is not
+    this source shape; a recognized shape with missing provider source is a
+    named construction gap.
+    """
+    from sugar_source_tree.nodes import Attribute, Name
+
+    if not isinstance(node, Attribute):
+        return None
+    head = node.value
+    if not isinstance(head, Name):
+        return None
+    module_name, binding_cid = _reaching_provider_module(
+        head,
+        root=root,
+        path=path,
+        graph_cache=graph_cache,
+        session=session,
+        distribution_index=distribution_index,
+    )
+    if module_name is None or binding_cid is None:
+        return None
+    top_level = module_name.split(".", 1)[0]
+    graph = graph_cache.get(top_level)
+    if graph is None:
+        from .dependency_artifact import authenticate_dependency_top_level
+
+        try:
+            graph = authenticate_dependency_top_level(
+                top_level, distribution_index=distribution_index
+            )
+        except Exception as exc:
+            raise ExternalExceptionConstructionGap(
+                f"provider artifact source absent: {module_name}"
+            ) from exc
+        graph_cache[top_level] = graph
+    return AuthenticatedProviderExceptionTypeV1.construct(
+        graph=graph,
+        binding_cid=binding_cid,
+        module_name=module_name,
+        source_attribute=node.attr,
+        session=session,
+    )
+
+
+def _reaching_provider_module(
+    head,
+    *,
+    root: Path,
+    path: Path,
+    graph_cache: dict[str, DependencyArtifactGraph],
+    session: SourceResolutionSession,
+    distribution_index=None,
+) -> tuple[str | None, str | None]:
+    """Return the module and authenticated binding CID reaching ``head``."""
+    from .canonical import cid_of_json
+    from sugar_source_tree.nodes import Assign, Call, Constant, Import, Name, Try
+
+    unit = head.unit
+    bindings = tuple((unit.module_direct_bindings or {}).get(head.id, ()))
+    # Ordinary module import: the lexical pass already owns this case.
+    if len(bindings) == 1 and isinstance(bindings[0], Import):
+        statement = bindings[0]
+        matches = [
+            alias
+            for alias in statement.names
+            if (alias.asname or alias.name.split(".", 1)[0]) == head.id
+        ]
+        if len(matches) == 1:
+            module = matches[0].name
+            return module, statement.fragment.seal().cid
+
+    # Optional direct import under a try/except gate.  The imported name is a
+    # value only on the success face; downstream source that reaches it is
+    # already guarded by that provider gate.  Competing/rebinding handlers are
+    # refused rather than joined optimistically.
+    module = unit.typed_module
+    candidates = []
+    if module is not None:
+        for statement in module.body:
+            if not isinstance(statement, Try):
+                continue
+            imported = []
+            for member in statement.body:
+                if isinstance(member, Import):
+                    imported.extend(
+                        alias.name
+                        for alias in member.names
+                        if (alias.asname or alias.name.split(".", 1)[0]) == head.id
+                    )
+            rebound = any(
+                any(
+                    isinstance(part, Name) and part.id == head.id
+                    for part in item.walk()
+                )
+                for handler in statement.handlers
+                for item in handler.body
+            )
+            if len(imported) == 1 and not rebound:
+                candidates.append((imported[0], statement.fragment.seal().cid))
+    if len(candidates) == 1:
+        return candidates[0]
+
+    # Returned-module provider: resolve the assignment callee through its
+    # authenticated import use, then read the native return shape from that
+    # exact provider source.  No callee or vendor name is selected here.
+    if len(bindings) != 1 or not isinstance(bindings[0], Assign):
+        return None, None
+    assignment = bindings[0]
+    if len(assignment.targets) != 1 or not isinstance(assignment.value, Call):
+        return None, None
+    call = assignment.value
+    if not call.args or not isinstance(call.args[0], Constant):
+        return None, None
+    actual_module = call.args[0].value
+    if not isinstance(actual_module, str) or not actual_module:
+        return None, None
+
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+    from .dependency_artifact import (
+        ResolvedPythonObjectV1,
+        authenticate_dependency_top_level,
+        resolve_import_binding,
+    )
+
+    receipts, _ = authenticated_import_use_receipts(
+        root, path, unit.source, unit.source_cid, module_identities={}
+    )
+    span = call.line_col_span()
+    receipt = next(
+        (
+            item
+            for item in receipts
+            if (
+                item.use["useSite"]["startLine"],
+                item.use["useSite"]["startCol"],
+                item.use["useSite"]["endLine"],
+                item.use["useSite"]["endCol"],
+            )
+            == (span.start_line, span.start_col, span.end_line, span.end_col)
+        ),
+        None,
+    )
+    if receipt is None:
+        return None, None
+    callee_top = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
+    callee_graph = graph_cache.get(callee_top)
+    if callee_graph is None:
+        callee_graph = authenticate_dependency_top_level(
+            callee_top, distribution_index=distribution_index
+        )
+        graph_cache[callee_top] = callee_graph
+    resolved = resolve_import_binding(receipt, graph=callee_graph, session=session)
+    if not isinstance(resolved, ResolvedPythonObjectV1):
+        return None, None
+    provider_parameter = _returned_module_parameter(callee_graph, resolved)
+    if provider_parameter != 0:
+        return None, None
+    binding_cid = cid_of_json(
+        {
+            "kind": "source-returned-module-binding",
+            "assignmentCid": assignment.fragment.seal().cid,
+            "calleeResolutionCid": resolved.cid,
+            "module": actual_module,
+        }
+    )
+    return actual_module, binding_cid
+
+
+def _returned_module_parameter(
+    graph: DependencyArtifactGraph, resolved: ResolvedPythonObjectV1
+) -> int | None:
+    """Parameter projected by a source function as ``sys.modules[param]``."""
+    module = graph.modules.get(resolved.module_name)
+    if module is None or module.source_cid != resolved.source_cid:
+        return None
+    tree = ast.parse(module.source, filename=module.source_seat)
+    function = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == resolved.definition.name
+            and node.lineno == resolved.definition.start_line
+        ),
+        None,
+    )
+    if function is None:
+        return None
+    parameters = [arg.arg for arg in (*function.args.posonlyargs, *function.args.args)]
+    sys_names = {
+        alias.asname or alias.name
+        for statement in tree.body
+        if isinstance(statement, ast.Import)
+        for alias in statement.names
+        if alias.name == "sys"
+    }
+    projected: dict[str, str] = {}
+    for statement in ast.walk(function):
+        if not isinstance(statement, ast.Assign) or len(statement.targets) != 1:
+            continue
+        target = statement.targets[0]
+        value = statement.value
+        if not isinstance(target, ast.Name) or not isinstance(value, ast.Subscript):
+            continue
+        owner = value.value
+        if not (
+            isinstance(owner, ast.Attribute)
+            and owner.attr == "modules"
+            and isinstance(owner.value, ast.Name)
+            and owner.value.id in sys_names
+            and isinstance(value.slice, ast.Name)
+            and value.slice.id in parameters
+        ):
+            continue
+        projected[target.id] = value.slice.id
+    returned = {
+        projected[node.value.id]
+        for node in ast.walk(function)
+        if isinstance(node, ast.Return)
+        and isinstance(node.value, ast.Name)
+        and node.value.id in projected
+    }
+    if len(returned) != 1:
+        return None
+    return parameters.index(next(iter(returned)))

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -725,9 +725,7 @@ def populate_source_derived_resource_refs(
                 if builtin is not None:
                     return _Complete(builtin)
             # Exception-type formals: seal import / provider-gated identity.
-            if formal_name in _EXCEPTION_TYPE_FORMALS and isinstance(
-                node, (Name, Attribute)
-            ):
+            if formal_name in _EXCEPTION_TYPE_FORMALS and isinstance(node, Name):
                 identity = None
                 mro = None
                 class_value = None
@@ -741,8 +739,6 @@ def populate_source_derived_resource_refs(
                             class_value = node.unit.exception_class_value(node)
                         except Exception:
                             class_value = None
-                else:
-                    identity = node.unit.imported_exception_type_identity(node)
                 if identity is not None:
                     return AuthenticatedExceptionTypeSugar(
                         node.sugar(),
@@ -752,6 +748,43 @@ def populate_source_derived_resource_refs(
                         class_value=class_value,
                     ).desugar(actual_ctx)
             if isinstance(node, Attribute):
+                from sugar_source_tree.panic import SugarNotWritten
+
+                from .external_exception_construction import (
+                    ExternalExceptionConstructionGap,
+                    construct_provider_exception_attribute,
+                )
+
+                try:
+                    testimony = construct_provider_exception_attribute(
+                        node,
+                        root=Path(root),
+                        path=Path(path),
+                        graph_cache=graphs,
+                        session=session,
+                        distribution_index=distribution_index,
+                    )
+                except ExternalExceptionConstructionGap as exc:
+                    raise SugarNotWritten(
+                        owner="provider_exception_type_construction",
+                        blame=node.fragment,
+                        observed=str(exc),
+                        requested="provider-defined exception class testimony",
+                        fix=(
+                            "publish the named provider artifact source; never "
+                            "replace it with an attribute spelling"
+                        ),
+                    ) from exc
+                if testimony is not None:
+                    class_value = testimony.class_value()
+                    return _Complete(
+                        AuthenticatedExceptionTypeValue(
+                            class_value,
+                            testimony.identity,
+                            testimony.ancestry,
+                            class_value,
+                        )
+                    )
                 identity = node.unit.imported_exception_type_identity(node)
                 if identity is not None:
                     qualified = getattr(identity.args[1], "value", None)
@@ -790,9 +823,7 @@ def populate_source_derived_resource_refs(
                     keyword_actuals = []
                     actuals = []
                     break
-                outcome = _actual_outcome(
-                    keyword.value, formal_name=keyword.arg
-                )
+                outcome = _actual_outcome(keyword.value, formal_name=keyword.arg)
                 if not isinstance(outcome, Complete):
                     keyword_actuals = []
                     actuals = []

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -22,6 +22,10 @@ from sugar_lift_python_source.dependency_artifact import (
     export_statement_coverage,
 )
 from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
+from sugar_lift_python_source.external_exception_construction import (
+    AuthenticatedProviderExceptionTypeV1,
+    ExternalExceptionConstructionGap,
+)
 
 
 def _install_distribution(
@@ -50,6 +54,168 @@ def _install_distribution(
         for path in recorded:
             writer.writerow((path, "", ""))
     return importlib.metadata.Distribution.at(metadata)
+
+
+def _install_stub_defined_distribution(root: Path) -> importlib.metadata.Distribution:
+    package = root / "provider_pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from provider_pkg.lib import ProviderError, OtherError\n",
+        encoding="utf-8",
+    )
+    (package / "lib.pyi").write_text(
+        "class ProviderError(Exception): ...\n" "class OtherError(Exception): ...\n",
+        encoding="utf-8",
+    )
+    metadata = root / "provider_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: provider-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (metadata / "top_level.txt").write_text("provider_pkg\n", encoding="utf-8")
+    recorded = (
+        "provider_pkg/__init__.py",
+        "provider_pkg/lib.pyi",
+        "provider_dist-1.0.dist-info/METADATA",
+        "provider_dist-1.0.dist-info/top_level.txt",
+        "provider_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for path in recorded:
+            writer.writerow((path, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _install_returned_module_gate(root: Path) -> importlib.metadata.Distribution:
+    package = root / "gate_pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "import sys\n"
+        "def load(module_name):\n"
+        "    loaded = sys.modules[module_name]\n"
+        "    return loaded\n",
+        encoding="utf-8",
+    )
+    metadata = root / "gate_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: gate-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (metadata / "top_level.txt").write_text("gate_pkg\n", encoding="utf-8")
+    recorded = (
+        "gate_pkg/__init__.py",
+        "gate_dist-1.0.dist-info/METADATA",
+        "gate_dist-1.0.dist-info/top_level.txt",
+        "gate_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for path in recorded:
+            writer.writerow((path, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def test_stub_defined_provider_exception_resolves_to_its_definition(tmp_path: Path):
+    """Truthful: an authenticated .pyi class is defining source, not opacity."""
+    graph = DependencyArtifactGraph.authenticate(
+        _install_stub_defined_distribution(tmp_path)
+    )
+    demand = _demand(
+        tmp_path,
+        "import provider_pkg\nprovider_pkg.ProviderError()\n",
+    )
+
+    result = resolve_import_binding(demand, graph=graph)
+
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.module_name == "provider_pkg.lib"
+    assert result.definition.kind == "class"
+    assert result.definition.name == "ProviderError"
+    assert graph.modules["provider_pkg.lib"].source_seat == "provider_pkg/lib.pyi"
+    testimony = AuthenticatedProviderExceptionTypeV1.from_resolved(
+        graph=graph,
+        source_attribute="ProviderError",
+        resolved=result,
+    )
+    assert testimony.resolved is result
+    assert testimony.source_attribute == "ProviderError"
+    assert testimony.ancestry
+
+
+def test_stub_provider_cannot_testify_for_a_different_exception(tmp_path: Path):
+    """Lying: ProviderError testimony cannot authenticate OtherError."""
+    graph = DependencyArtifactGraph.authenticate(
+        _install_stub_defined_distribution(tmp_path)
+    )
+    truthful = resolve_import_binding(
+        _demand(tmp_path, "import provider_pkg\nprovider_pkg.ProviderError()\n"),
+        graph=graph,
+    )
+    lying = resolve_import_binding(
+        _demand(tmp_path, "import provider_pkg\nprovider_pkg.OtherError()\n"),
+        graph=graph,
+    )
+
+    assert isinstance(truthful, ResolvedPythonObjectV1)
+    assert isinstance(lying, ResolvedPythonObjectV1)
+    assert truthful.definition.name == "ProviderError"
+    assert lying.definition.name == "OtherError"
+    assert truthful.cid != lying.cid
+    with pytest.raises(
+        ExternalExceptionConstructionGap,
+        match="source binds ProviderError, provider resolved OtherError",
+    ):
+        AuthenticatedProviderExceptionTypeV1.from_resolved(
+            graph=graph,
+            source_attribute="ProviderError",
+            resolved=lying,
+        )
+
+
+def test_returned_module_binding_constructs_provider_exception_without_vendor_name(
+    tmp_path: Path,
+):
+    """A source-returned module carries its provider class definition through."""
+    from sugar_lift_python_source.external_exception_construction import (
+        construct_provider_exception_attribute,
+    )
+    from sugar_lift_python_source.resolution_session import SourceResolutionSession
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.tree import SourceFile
+
+    provider = _install_stub_defined_distribution(tmp_path)
+    gate = _install_returned_module_gate(tmp_path)
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "import gate_pkg\n"
+        'provider = gate_pkg.load("provider_pkg")\n'
+        "def expected():\n"
+        "    return provider.ProviderError\n",
+        encoding="utf-8",
+    )
+    tree = SourceFile(path_source(str(consumer)))
+    attribute = next(
+        node
+        for node in tree.nodes()
+        if node.kind == "Attribute" and node.attr == "ProviderError"
+    )
+
+    testimony = construct_provider_exception_attribute(
+        attribute,
+        root=tmp_path,
+        path=consumer,
+        graph_cache={},
+        session=SourceResolutionSession(),
+        distribution_index={"gate_pkg": gate, "provider_pkg": provider},
+    )
+
+    assert testimony is not None
+    assert testimony.resolved.definition.name == "ProviderError"
+    assert testimony.resolved.module_name == "provider_pkg.lib"
+    assert testimony.class_value().name == "provider_pkg.lib.ProviderError"
 
 
 def _demand(

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
@@ -54,19 +54,13 @@ _CORPUS_MANIFEST_CID = (
 )
 _EXTERNAL_ERROR_TARGET = "pandas._testing.external_error_raised"
 _CATALOG_CID = "blake3-512:" + "c" * 128
-_TABLE_CID = "blake3-512:" + "t" * 128
-
-# Owner 3 residual: import-bound pyarrow exception coordinates on external_error
-# With heads.  Before source-visible construction they panicked on
-# SymbolicValue.attribute; after, the type operand is an authenticated import
-# identity and any remaining residual is a later stage (never the exception
-# Attribute projection).
+_TABLE_CID = "blake3-512:" + "d" * 128
 _ARROW_EXCEPTION_SITES = (
-    "tests/extension/test_arrow.py:1715",
-    "tests/io/test_parquet.py:799",
-    "tests/series/accessors/test_list_accessor.py:100",
-    "tests/series/accessors/test_list_accessor.py:132",
-    "tests/series/accessors/test_list_accessor.py:134",
+    ("tests/series/accessors/test_list_accessor.py", 100, "ArrowInvalid"),
+    ("tests/series/accessors/test_list_accessor.py", 132, "ArrowInvalid"),
+    ("tests/series/accessors/test_list_accessor.py", 134, "ArrowInvalid"),
+    ("tests/extension/test_arrow.py", 1715, "ArrowInvalid"),
+    ("tests/io/test_parquet.py", 799, "ArrowException"),
 )
 
 
@@ -209,6 +203,28 @@ def test_external_error_raised_population_is_the_authenticated_47_with_sites() -
     )
 
 
+def test_arrow_exception_sites_are_the_five_authenticated_attribute_operands() -> None:
+    """Pin the real source coordinates without turning spellings into dispatch."""
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.tree import SourceFile
+
+    corpus = authenticated_pandas_corpus()
+    observed = []
+    for relative, line, attribute in _ARROW_EXCEPTION_SITES:
+        path = corpus.root / relative
+        tree = SourceFile(path_source(str(path)))
+        matches = [
+            node
+            for node in tree.nodes()
+            if node.kind == "Attribute"
+            and node.attr == attribute
+            and node.line_col_span().start_line == line
+        ]
+        assert len(matches) == 1, (relative, line, attribute)
+        observed.append((relative, line, attribute))
+    assert tuple(observed) == _ARROW_EXCEPTION_SITES
+
+
 @cache
 def _external_error_attributions():
     """Construct each authenticated demand without entering unrelated managers."""
@@ -282,7 +298,9 @@ def _external_error_attributions():
                 )
             )
 
-            def evaluate(manager=manager, path=path, site=site, tree=tree, context=context):
+            def evaluate(
+                manager=manager, path=path, site=site, tree=tree, context=context
+            ):
                 populate_source_derived_resource_refs(
                     tree,
                     root=corpus.root.parent,
@@ -319,6 +337,7 @@ def test_external_error_raised_47_site_outcome_partition() -> None:
     # coordinates; residual is named (exit-face), never ConstructionPanic on
     # SymbolicValue.attribute for the exception-type operand.
     assert summary.construction_panics == 0
+    assert summary.authenticated_exceptional_exits > 0
     assert (
         summary.authenticated_exceptional_exits + summary.named_refusals
         == summary.enrolled
@@ -332,12 +351,12 @@ def test_external_error_raised_refusal_and_gap_twins_are_concrete_sites() -> Non
     assert refusal.outcome is AttributionOutcome.NAMED_REFUSAL
     assert refusal.detail == "With._construct_sugar"
 
-    for site_id in _ARROW_EXCEPTION_SITES:
-        site = by_id[site_id]
-        # Before: SymbolicValue.attribute on ArrowInvalid/ArrowException.
-        # After: import-bound export coordinate; residual is a later stage.
-        assert site.outcome is AttributionOutcome.NAMED_REFUSAL, site
-        assert site.detail == "With._construct_sugar", site
+    for relative, line, _attribute in _ARROW_EXCEPTION_SITES:
+        site = by_id[f"{relative}:{line}"]
+        # Before: a named refusal after sealing the attribute spelling. After:
+        # provider-defined class testimony reaches the boundary and the real
+        # body effect is authenticated.
+        assert site.outcome is AttributionOutcome.AUTHENTICATED_EXIT, site
 
 
 def test_external_error_raised_emits_complete_consumer_testimony() -> None:

--- a/scripts/bootstrap-venv-py312.sh
+++ b/scripts/bootstrap-venv-py312.sh
@@ -11,7 +11,7 @@
 # pattern: a label that does not name the runtime it carries.
 #
 # Declared pins (sugar-build.toml + sugar-lift-py-tests[test] on main):
-#   python 3.12.13, numpy 2.5.1, pandas 3.0.3, pytest 9.1.1
+#   python 3.12.13, numpy 2.5.1, pandas 3.0.3, pyarrow 22.0.0, pytest 9.1.1
 #
 # Usage (from any checkout of this repository — the script must be IN the tree):
 #   bash scripts/bootstrap-venv-py312.sh
@@ -84,16 +84,20 @@ import sysconfig
 
 import numpy
 import pandas
+import pyarrow
 
 assert sys.version_info[:3] == (3, 12, 13), sys.version
 assert numpy.__version__ == "2.5.1", numpy.__version__
 assert pandas.__version__ == "3.0.3", pandas.__version__
+assert pyarrow.__version__ == "22.0.0", pyarrow.__version__
 purelib = pathlib.Path(sysconfig.get_paths()["purelib"]).resolve()
 assert purelib in pathlib.Path(numpy.__file__).resolve().parents, numpy.__file__
 assert purelib in pathlib.Path(pandas.__file__).resolve().parents, pandas.__file__
+assert purelib in pathlib.Path(pyarrow.__file__).resolve().parents, pyarrow.__file__
 print("interpreter", sys.version.split()[0], sys.executable)
 print("numpy", numpy.__version__, pathlib.Path(numpy.__file__).resolve())
 print("pandas", pandas.__version__, pathlib.Path(pandas.__file__).resolve())
+print("pyarrow", pyarrow.__version__, pathlib.Path(pyarrow.__file__).resolve())
 print("pytest", md.version("pytest"))
 print("PINS_OK")
 PY

--- a/tools/sugar-build/Dockerfile
+++ b/tools/sugar-build/Dockerfile
@@ -52,10 +52,12 @@ RUN apt-get update \
 FROM core AS python-scientific
 ARG NUMPY_VERSION=2.5.1
 ARG PANDAS_VERSION=3.0.3
+ARG PYARROW_VERSION=22.0.0
 RUN python -m pip install --no-cache-dir \
       numpy=="${NUMPY_VERSION}" pandas=="${PANDAS_VERSION}" \
+      pyarrow=="${PYARROW_VERSION}" \
       python-dateutil==2.9.0.post0 six==1.17.0 \
- && python -c 'import numpy, pandas; assert numpy.__version__ == "2.5.1"; assert pandas.__version__ == "3.0.3"'
+ && python -c 'import numpy, pandas, pyarrow; assert numpy.__version__ == "2.5.1"; assert pandas.__version__ == "3.0.3"; assert pyarrow.__version__ == "22.0.0"'
 
 FROM core AS solver-coq
 ARG COQ_DEBIAN_VERSION=8.16.1+dfsg-1+b2
@@ -106,14 +108,16 @@ FROM python-test AS python-lift-closure
 ARG Z3_DEBIAN_VERSION=4.8.12-3.1
 ARG NUMPY_VERSION=2.5.1
 ARG PANDAS_VERSION=3.0.3
+ARG PYARROW_VERSION=22.0.0
 RUN apt-get update \
  && apt-get install -y --no-install-recommends z3="${Z3_DEBIAN_VERSION}" \
  && rm -rf /var/lib/apt/lists/* \
  && python -m pip install --no-cache-dir \
       numpy=="${NUMPY_VERSION}" pandas=="${PANDAS_VERSION}" \
+      pyarrow=="${PYARROW_VERSION}" \
       python-dateutil==2.9.0.post0 six==1.17.0 \
       scikit-learn==1.9.0 scipy==1.18.0 joblib==1.5.3 threadpoolctl==3.6.0 narwhals==2.24.0 \
- && python -c 'import numpy, pandas; assert numpy.__version__ == "2.5.1"; assert pandas.__version__ == "3.0.3"' \
+ && python -c 'import numpy, pandas, pyarrow; assert numpy.__version__ == "2.5.1"; assert pandas.__version__ == "3.0.3"; assert pyarrow.__version__ == "22.0.0"' \
  && z3 --version
 
 # The maximal named-task closure is deliberately cumulative. It does not rely


### PR DESCRIPTION
## What changed

- admit recorded `.pyi` files as authenticated defining source in dependency artifact graphs
- construct external exception class and ancestry testimony from the resolved provider definition
- follow native returned-module bindings into the provider without manager or vendor spelling dispatch
- pin PyArrow 22.0.0 in the authenticated Python closure so the five pandas Arrow operands have defining source

## Why

Main converted the five `ArrowInvalid` / `ArrowException` construction panics into named refusals, but those refusals represented missing machinery over source-visible provider definitions. This change requires the source operand and resolved provider class to agree before constructing a class floor.

Assumption: PyArrow 22.0.0 is the provider artifact for the pandas 3.0.3 measured closure. If closure ownership selects a different exact provider version, rebase the pin; do not relax it to a range.

Predicted epsilon: `external_error_raised.authenticated_exceptional_exits` increases from 0, with the five Arrow sites expected to leave the refusal bucket. Construction panics remain zero.

## Validation

- CPython 3.12.13 bootstrap: NumPy 2.5.1, pandas 3.0.3, PyArrow 22.0.0, pytest 9.1.1; all loaded from the worktree purelib
- provider construction twins: 3 passed
- five authenticated pandas coordinates: 1 passed
- dependency/build authority tests: 41 passed
- bootstrap launcher twin: 1 passed
- mutation: removing the source/provider name check made the lying twin fail with `DID NOT RAISE`; restored check passed

## Pending authenticated delta

The current Battleaxe closure does not contain PyArrow and refused by naming `provider artifact source absent: pyarrow`. No authenticated exit delta, crash/timeout zero, or receipt is claimed from that run. Publish the updated immutable closure, then rerun the focused 47-site attribution test. The PR intentionally stays draft until that run demonstrates `authenticated_exceptional_exits > 0`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct authenticated exception types from provider source for exception-type formals
> - Adds [`external_exception_construction.py`](https://github.com/TSavo/sugar/pull/6572/files#diff-41bbd498dc18ea7e4b478eccef54cc4953b94a7195456399cfed5c99da975acd) with `construct_provider_exception_attribute`, which authenticates an AST `Attribute` node as a provider-defined exception by resolving the provider module, validating the class ancestry via AST traversal, and producing an `AuthenticatedProviderExceptionTypeV1`.
> - Extends `populate_source_derived_resource_refs` in [`manager_summary_derivation.py`](https://github.com/TSavo/sugar/pull/6572/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to handle `Attribute` exception formals via the new construction path; raises `SugarNotWritten` on `ExternalExceptionConstructionGap`.
> - Updates [`dependency_artifact.py`](https://github.com/TSavo/sugar/pull/6572/files#diff-153692407653e4eda2c94b6899d612575f4b0f569fd4ee8a0ac674aef4e90464) to accept `.pyi` stub files as module sources and bumps the on-disk cache schema from `dep-graph-v2` to `dep-graph-v3`.
> - Adds PyArrow 22.0.0 to build images, bootstrap script, and test dependencies to support authenticating provider definitions from recorded wheel source.
> - Behavioral Change: existing `dep-graph-v2` disk caches are invalidated and will not be loaded; only `dep-graph-v3` payloads are accepted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 554833e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->