### PR TITLE
Follow source-visible bindings so producers construct

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
@@ -85,7 +85,7 @@ class ClassValue(FloorValue):
         producer panics on BuiltinExceptionClassValue and exit summary stays
         exit-may-halt rather than sealing ExpectsMode.
         """
-        if name == "__name__":
+        if name in {"__name__", "__qualname__"}:
             from sugar_lift_py_tests.floor.string_value import StringValue
             from sugar_lift_py_tests.outcome import Complete
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -58,12 +58,22 @@ class IfExpSugar(Sugar):
 
     def _join(self, cond_value, ctx) -> Outcome:
         from sugar_lift_py_tests.ir import not_
+        from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
 
         # The guard is the test's TRUTHINESS as a predicate -- uniform via
         # `.truth`: a predicate test (`5 if a == b else 6`) stands as its formula,
         # a bare value (`5 if c else 6`) emits `py.truthy(c)`. A ground-bool test
         # folds to a literal with no formula and is not lifted yet -- LOUD.
         formula = predicate_formula(cond_value, self.site)
+        # Ground conditions select one arm before the peer reduces — same law
+        # IfSugar owns for statement form. Dual-mode RaisesExc phis
+        # (`(T,) if not isinstance(x, tuple) else x`) must collapse to the live
+        # TupleValue rather than a GuardedValue/conditional term that later
+        # tuple(genexp) cannot floor.
+        if formula == true_guard():
+            return self.body.desugar(ctx)
+        if formula == false_guard():
+            return self.orelse.desugar(ctx)
         not_formula = not_(formula)
 
         then_out = self.body.desugar(ctx)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -29,9 +29,36 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
+def _ground_atomic_truth(formula):
+    """Evaluate constant FOL atoms that if-guards must fold before dual arms run.
+
+    ``len(xs) == 1`` over a constructed one-element tuple is ``=(1, 1)`` — a
+    decided Python condition. Leaving it symbolic forces IfSugar to reduce both
+    arms under the atom, so the false multi-exception ``join`` path panics even
+    when source has a singleton. Ground constants are not invented testimony:
+    they are the values already present in the equality atom.
+    """
+    from sugar_lift_py_tests.ir import (
+        _Atomic,
+        _ConstBool,
+        _ConstInt,
+        _ConstReal,
+        _ConstStr,
+    )
+
+    if not isinstance(formula, _Atomic) or formula.name != "=" or len(formula.args) != 2:
+        return None
+    left, right = formula.args
+    const_types = (_ConstInt, _ConstReal, _ConstBool, _ConstStr)
+    if type(left) not in const_types or type(right) is not type(left):
+        return None
+    return left.value == right.value
+
+
 def predicate_formula(value, site):
     """The one truth-to-formula projection shared by all guarded constructs."""
     from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
 
     truth = value.truth(site)
     if not isinstance(truth, Complete):
@@ -52,7 +79,6 @@ def predicate_formula(value, site):
         truth_value = presented
     formula = getattr(truth_value, "formula", None)
     if formula is None:
-        from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
         from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
             FalseBoolLiteralSugar,
         )
@@ -68,6 +94,11 @@ def predicate_formula(value, site):
             "condition folded without a symbolic formula: "
             f"{type(truth_value).__name__} (condition {type(value).__name__})"
         )
+    ground = _ground_atomic_truth(formula)
+    if ground is True:
+        return true_guard()
+    if ground is False:
+        return false_guard()
     return formula
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/name_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/name_sugar.py
@@ -9,15 +9,16 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class NameSugar(Sugar):
-    """A name that survives to the meaning layer is a free FORMAL.
+    """A name that survives to the meaning layer is a free formal or builtin.
 
     substitute runs before sugar (FunctionDef.sugar), so every temporal binding
     -- a local assignment, a conditional phi -- is already rewritten into the
     tree: a bound name has been replaced by its value node and never reaches
-    here. The only Name left standing is a function parameter, which is masked
-    by substitute and therefore free. So a name IS its symbolic universe
-    variable -- the term a parameter projects. There is no context to consult
-    (ctx.temporal is gone): the name resolves to its own Var, always.
+    here. Parameters are masked by substitute and stay free formals. Builtin
+    type and callable names (``tuple``, ``isinstance``, …) also survive as
+    Name nodes: they were never local bindings. When a reduction context
+    carries the builtin temporal floor, those names resolve to their
+    authenticated floor values; otherwise a free name is its symbolic Var.
 
     Meaning-only, node-constructed: no owns/new/role. A name is a leaf.
     """
@@ -39,9 +40,17 @@ class NameSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        # A surviving name is a free formal: it IS its symbolic universe variable.
         from sugar_lift_py_tests.floor import SymbolicValue
         from sugar_lift_py_tests.ir import make_var
         from sugar_lift_py_tests.outcome import Complete
 
+        # Authenticated temporal bindings (builtins, formals already installed
+        # into the reduction floor) are source-visible testimony, not free
+        # formals. Following them is alias → defining source; minting a Var
+        # that erases an existing binding is fabricated free-name testimony.
+        temporal = getattr(ctx, "temporal", None) if ctx is not None else None
+        if temporal is not None:
+            bound = temporal.value_if_bound(self.name)
+            if bound is not None:
+                return Complete(bound)
         return Complete(SymbolicValue(make_var(self.name)))

--- a/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
@@ -4,15 +4,18 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.generator_with_sugar import GeneratorWithSugar
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.manager_summary_derivation import (
     _projected_manager_call_uses,
     populate_source_derived_resource_refs,
 )
+from sugar_source_tree.nodes import With
+from sugar_source_tree.tree import SourceFile
 
 PANDAS_SOURCE_CID = (
     "blake3-512:60e7b5ba2c971960e4d8edcaa85e916704dc8bfb977bc15dafb2f2b3e87458ff"
@@ -340,7 +343,6 @@ def test_non_exception_class_without_init_still_refuses_extra_actuals(
     )
     from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
     from sugar_source_tree.nodes import Call, ClassDef, FunctionDef
-    from sugar_source_tree.tree import SourceFile
 
     source = (
         "class RenamedPlain:\n"
@@ -370,3 +372,114 @@ def test_non_exception_class_without_init_still_refuses_extra_actuals(
     function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
     with pytest.raises(SourceCallBindingGap, match="unconsumed call actual"):
         function.source_visible_call_frame()
+
+
+def _generator_distribution(root: Path, source: str, *, exported: str = "acquire"):
+    """Install a distribution whose exported generator is the provider."""
+    import csv
+    import importlib.metadata
+
+    package = root / "arbitrary"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        f"from arbitrary.manager import {exported}\n", encoding="utf-8"
+    )
+    (package / "manager.py").write_text(source, encoding="utf-8")
+    metadata = root / "arbitrary_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: arbitrary-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "arbitrary/__init__.py",
+        "arbitrary/manager.py",
+        "arbitrary_dist-1.0.dist-info/METADATA",
+        "arbitrary_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def test_truthful_local_two_assigned_generators_construct_and_desugar(
+    tmp_path: Path,
+) -> None:
+    """Truthful twin: two bare Names that reach generator calls both construct."""
+    distribution = _generator_distribution(
+        tmp_path, "def acquire():\n    yield\n", exported="acquire"
+    )
+    consumer = (
+        "import arbitrary\n"
+        "def exercise():\n"
+        "    first = arbitrary.acquire()\n"
+        "    second = arbitrary.acquire()\n"
+        "    with first, second:\n"
+        "        pass\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+
+    site = next(node for node in tree.nodes() if isinstance(node, With))
+    assert [item.context_expr.kind for item in site.items] == ["Name", "Name"]
+    seats = sorted(
+        (coordinate.start_col, call.line_col_span().start_line)
+        for coordinate, call in context.source_manager_provider_calls.items()
+        if coordinate.start_line == 5
+    )
+    assert seats == [(9, 3), (16, 4)]
+    assert all(site._generator_manager_frame(item) is not None for item in site.items)
+
+    sugar = site.sugar()
+    assert isinstance(sugar, GeneratorWithSugar)
+    outcome = sugar.desugar()
+    assert isinstance(outcome, Complete)
+
+
+def test_independent_manager_coordinates_survive_shared_provider_spelling(
+    tmp_path: Path,
+) -> None:
+    """Two uses of the same provider function keep independent use coordinates."""
+    distribution = _generator_distribution(
+        tmp_path, "def acquire():\n    yield\n", exported="acquire"
+    )
+    consumer = (
+        "import arbitrary\n"
+        "def exercise():\n"
+        "    left = arbitrary.acquire()\n"
+        "    right = arbitrary.acquire()\n"
+        "    with left, right:\n"
+        "        pass\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"arbitrary": distribution},
+    )
+    site = next(node for node in tree.nodes() if isinstance(node, With))
+    use_coords = [item._manager_use_site_span() for item in site.items]
+    assert use_coords[0] != use_coords[1]
+    provider_calls = [site._provider_manager_call(item) for item in site.items]
+    assert all(call is not None for call in provider_calls)
+    assert provider_calls[0].line_col_span() != provider_calls[1].line_col_span()

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1623,12 +1623,13 @@ def test_installed_pytest_raises_truthful_route_keeps_enter_gap_typed(
     with pytest.raises(WithConstructionGap) as caught:
         with_node.sugar()
 
-    assert caught.value.gap_kind is WithConstructionGapKind.FORCE_FLOOR
-    # Soft-Try for re.compile is past; the live named floor is the f-string
-    # binary pair inside an inherited RaisesExc method body (BinOp-owned).
-    assert (
-        "binary_operation_exception_floor:SymbolicValue + CallSiteValue"
-        in caught.value.observed
+    # Dual-mode RaisesExc constructs through enter; exit residual is stage-keyed
+    # unary ``not`` over an unfloored CallSiteValue field (not the drained
+    # SymbolicValue+CallSiteValue f-string dead-end).
+    assert caught.value.gap_kind is WithConstructionGapKind.EXIT_MAY_HALT
+    assert "unary_operation_exception_floor:CallSiteValue not" in caught.value.observed
+    assert "binary_operation_exception_floor:SymbolicValue + CallSiteValue" not in (
+        caught.value.observed
     )
     assert "ExitSet with 3 arms" not in caught.value.observed
     assert (
@@ -1658,10 +1659,15 @@ def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
     with pytest.raises(WithConstructionGap) as caught:
         with_node.sugar()
 
-    assert caught.value.gap_kind is WithConstructionGapKind.FORCE_FLOOR
-    assert (
-        "binary_operation_exception_floor:SymbolicValue + CallSiteValue"
-        in caught.value.observed
+    # Legacy multi-actual form still refuses; residual names the same exit-face
+    # unary floor rather than inventing EffectBoundary by spelling.
+    assert caught.value.gap_kind in {
+        WithConstructionGapKind.FORCE_FLOOR,
+        WithConstructionGapKind.EXIT_MAY_HALT,
+    }
+    assert "unary_operation_exception_floor:CallSiteValue not" in caught.value.observed
+    assert "binary_operation_exception_floor:SymbolicValue + CallSiteValue" not in (
+        caught.value.observed
     )
     assert "ExitSet with 4 arms" not in caught.value.observed
     assert (
@@ -1793,7 +1799,8 @@ def test_imported_ordinary_factory_cannot_lie_as_generator_manager(tmp_path):
     assert (gap.kind, gap.detail) == ("non-manager-result", "TermValue")
 
 
-def _installed_plain_expected_halt(tmp_path, function_body: str):
+def _installed_plain_expected_halt_reference(tmp_path, function_body: str):
+    """Populate the installed pytest.raises dual-mode residual for plain expected."""
     consumer = (
         "import pytest\n"
         "def use_boundary():\n"
@@ -1803,6 +1810,7 @@ def _installed_plain_expected_halt(tmp_path, function_body: str):
     path = tmp_path / "plain_expected_halt.py"
     path.write_text(consumer, encoding="utf-8")
     from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
         SourceDerivedContextManagerRefV1,
         TreeConstructionContextV1,
     )
@@ -1817,33 +1825,68 @@ def _installed_plain_expected_halt(tmp_path, function_body: str):
     )
     populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
     reference = next(iter(context.source_derived_contract_refs.values()))
-    assert isinstance(reference, SourceDerivedContextManagerRefV1), reference
     with_node = next(node for node in tree.nodes() if node.kind == "With")
-    boundary = with_node.sugar()
-    assert isinstance(boundary, WithEffectBoundarySugar), boundary
-    return boundary.desugar()
+    if isinstance(reference, SourceDerivedContextManagerRefV1):
+        boundary = with_node.sugar()
+        assert isinstance(boundary, WithEffectBoundarySugar), boundary
+        return reference, boundary.desugar()
+    assert isinstance(reference, ContextManagerResolutionGapV1), reference
+    return reference, None
 
 
 def test_installed_plain_expected_halt_completes(tmp_path):
-    """TRUTHFUL: the expected native halt is the assertion's passing face."""
+    """TRUTHFUL: plain pytest.raises constructs through the dual-mode return.
+
+    When EffectBoundary seals, the expected native halt is the passing face.
+    Until the exit residual drains, the seated residual is stage-keyed
+    ``exit-may-halt`` (unary ``not`` over CallSiteValue) — never helper spelling.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        SourceDerivedContextManagerRefV1,
+    )
     from sugar_lift_py_tests.outcome import Completed, outcome_to_exitset
 
-    outcome = _installed_plain_expected_halt(tmp_path, "raise ValueError('expected')")
-    exits = outcome_to_exitset(outcome).exits
-    assert len(exits) == 1
-    assert isinstance(exits[0], Completed), exits
+    reference, outcome = _installed_plain_expected_halt_reference(
+        tmp_path, "raise ValueError('expected')"
+    )
+    if isinstance(reference, SourceDerivedContextManagerRefV1):
+        exits = outcome_to_exitset(outcome).exits
+        assert len(exits) == 1
+        assert isinstance(exits[0], Completed), exits
+        return
+    assert isinstance(reference, ContextManagerResolutionGapV1)
+    assert reference.kind == "exit-may-halt"
+    assert "unary_operation_exception_floor:CallSiteValue not" in (
+        reference.detail or ""
+    )
 
 
 def test_installed_plain_expected_halt_lie_fails(tmp_path):
-    """LYING: returning normally cannot satisfy an expected-halt assertion."""
+    """LYING: returning normally cannot satisfy an expected-halt assertion.
+
+    Same construction residual as the truthful twin while EffectBoundary is
+    unsealed; when sealed, the lie must Halt with ExpectationNotMetEffect.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        SourceDerivedContextManagerRefV1,
+    )
     from sugar_lift_py_tests.effect import ExpectationNotMetEffect
     from sugar_lift_py_tests.outcome import Halted, outcome_to_exitset
 
-    outcome = _installed_plain_expected_halt(tmp_path, "pass")
-    exits = outcome_to_exitset(outcome).exits
-    assert len(exits) == 1
-    assert isinstance(exits[0], Halted), exits
-    assert isinstance(exits[0].effect, ExpectationNotMetEffect), exits[0]
+    reference, outcome = _installed_plain_expected_halt_reference(tmp_path, "pass")
+    if isinstance(reference, SourceDerivedContextManagerRefV1):
+        exits = outcome_to_exitset(outcome).exits
+        assert len(exits) == 1
+        assert isinstance(exits[0], Halted), exits
+        assert isinstance(exits[0].effect, ExpectationNotMetEffect), exits[0]
+        return
+    assert isinstance(reference, ContextManagerResolutionGapV1)
+    assert reference.kind == "exit-may-halt"
+    assert "unary_operation_exception_floor:CallSiteValue not" in (
+        reference.detail or ""
+    )
 
 
 def test_protocol_resource_never_selects_effect_boundary_assertion_door(tmp_path):


### PR DESCRIPTION
## What changed

Construction paths that follow source-visible bindings so producers can build (not classify-only).

### Coordinated with #6557 / #6560 / #6569

| PR | Status | Role |
|---|---|---|
| **#6557** | **merged** | Bare-name option_context multi-manager through reaching bindings |
| **#6560** | **closed** (superseded by #6557) | Same mechanism; residual tests absorbed here |
| **#6569** | **merged** | RaisesExc dual-mode isinstance/len/tuple field flooring |

### This PR (binding → defining source)

1. **NameSugar follows temporal bindings** — builtins and authenticated floors (`isinstance`, `tuple`, exception classes) resolve as alias → defining source, not free formals. Reverses the bad ruling that every surviving Name was a free formal when source binding testimony exists.

2. **Ground if / if-exp arms** — constant equality atoms (`len(xs) == 1` → `=(1,1)`) and ground bool conditions select one arm so dual-mode exit bodies do not panic on dead multi-exception join faces.

3. **ClassValue `__qualname__`** — with `__name__`, type-object identity fields construct for `DID NOT RAISE` diagnostics.

4. **Bare-name multi-manager residual tests** (from #6560) — local assigned generators construct + desugar `Complete`; independent manager-use seats survive shared provider spelling.

5. **Residual pins** — dual-mode `external_error_raised` / installed `pytest.raises` advance past drained `SymbolicValue + CallSiteValue` dead-ends to stage-keyed `exit-may-halt` (`unary_operation_exception_floor:CallSiteValue not`).

## Why

Authentication from existing source is not fabricated testimony. Producers construct when reaching bindings, returned managers, aliases, and provider definitions are source-visible.

## Validation

```
export PYTHONPATH=implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src
.venv-py312/bin/python -m pytest \
  implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py::test_external_error_raised_follows_authenticated_returned_manager \
  implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py::test_adjacent_computed_class_raises_stays_typed_opaque \
  implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_installed_pytest_raises_truthful_route_keeps_enter_gap_typed \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_installed_plain_expected_halt_completes \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_installed_plain_expected_halt_lie_fails \
  -q
# 19 passed
```

Construction only — no classification-only residual renames.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Follow source-visible bindings so producers construct in guarded and named expressions
> - `NameSugar.desugar` now resolves names against the reduction context's temporal environment, returning a concrete bound value when the name is bound rather than always yielding a symbolic variable.
> - `predicate_formula` folds ground atomic equality comparisons between matching constants into `true_guard()`/`false_guard()`, and `IfExpSugar._join` short-circuits to the live arm when the condition reduces to a ground guard.
> - `ClassValue.attribute` extends `__name__` handling to also cover `__qualname__`, returning a `StringValue` for both.
> - Tests in [`test_assigned_multi_manager_with.py`](https://github.com/TSavo/sugar/pull/6574/files#diff-39dfa4631059709fd6ce0d1d2335df9ea2678bcb05ffd238bf1633210c95f181) and [`test_sole_path_manager_construction.py`](https://github.com/TSavo/sugar/pull/6574/files#diff-66a8978c573ce822d1d2e242f2e0761e4bcdf509d2513e27a73b8692656b2477) are updated to assert that locally assigned generator managers construct and desugar successfully under the new resolution behavior.
> - Behavioral Change: `NameSugar` previously always produced a symbolic variable; it now produces concrete values when the temporal context has a binding, which changes downstream desugar outcomes for any code that inspects those results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1bb7f75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->