### PR TITLE
Close residual Subscript construction panics as dual-edge auth exits

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -979,19 +979,21 @@ class FloorValue:
         THIS right operand, falling through to the pair gap. Most of those
         pairs are not eight separate arms to write. They are one law: when at
         least one operand's runtime TYPE is undecided, Python's own operator
-        dispatch for the pair is undecided. That is a third value, not a
-        completed symbolic coordinate: without source-visible native dispatch
-        testimony this law refuses to choose completion or manufacture an
-        exception identity.
+        dispatch for the pair is undecided. That is a third value: the producer
+        cannot claim sole completion and cannot invent an exception identity.
 
-        Two refusals are deliberate and stay loud:
+        Publish both native-dispatch faces (mirrors Compare #6564): the
+        completed face retains the operator coordinate, and the halted face
+        retains a source-cited raise whose exception identity remains
+        undecided. Sole completion or sole TypeError invention stay forbidden.
+
+        Two cases stay outside this door:
 
         * An operand that does not DENOTE a value (a callable, a class, an
           exit) is not an operand at all. No coordinate is invented for it.
         * Two operands of DECIDED type are a ground question -- ``list + bool``
-          is Python's ``TypeError``, not an unknown. Constructing a coordinate
-          there would launder a ground exit into a value. That pair belongs to
-          the ground field laws, and absence there is still a gap.
+          is Python's ``TypeError``, not an unknown. That pair belongs to the
+          ground field laws, and absence there is still a gap.
 
         Returns ``None`` when the law does not apply, so the caller falls
         through to its own pair gap.
@@ -1001,26 +1003,42 @@ class FloorValue:
         if self.runtime_type_is_decided() and other.runtime_type_is_decided():
             return None
 
-        from sugar_lift_py_tests.gap.info import GapKind, GapLocus
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
-
-        construction_panic_gap(
-            owner="binary_operation_exception_floor",
-            blame=site,
-            observed=f"{type(self).__name__} {operator} {type(other).__name__}",
-            requested=(
-                "source-visible native operator testimony selecting completion "
-                "or an authenticated exceptional exit"
-            ),
-            fix=(
-                "preserve the undecided third value at the BinOp producer; "
-                "resolve native operand types and their operator bodies from "
-                "source, or retain this named refusal without inventing an "
-                "exception identity"
-            ),
-            gap_kind=GapKind.FLOOR,
-            gap_locus=GapLocus.CONSTRUCTION,
+        from sugar_lift_py_tests.effect import RaiseEffect
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+        from sugar_lift_py_tests.ir import atomic, ctor
+        from sugar_lift_py_tests.outcome import ExitSet
+        from sugar_lift_py_tests.outcome.exit_set import (
+            Completed,
+            Halted,
+            complement_guard,
+            partition,
         )
+
+        left_term = self.to_term(owner=f"binary {operator} left")
+        right_term = other.to_term(owner=f"binary {operator} right")
+        completed_value = SymbolicValue(ctor(operator, [left_term, right_term]))
+        dispatch_raises = atomic(
+            f"python.binop_dispatch_raises[{operator}]",
+            [left_term, right_term],
+        )
+        halted_face, completed_face = partition(
+            ("binary-native-dispatch", str(site), operator)
+        )
+        effect = RaiseEffect(
+            blame=str(site),
+            occurrence=str(site),
+            producer_node_owner="BinOp",
+        )
+        return ExitSet(
+            (
+                Halted(dispatch_raises, effect, faces=frozenset({halted_face})),
+                Completed(
+                    complement_guard(dispatch_raises),
+                    completed_value,
+                    frozenset({completed_face}),
+                ),
+            )
+        ).normalize()
 
     def _binary_floor_gap(self, other, site, owner, floor):
         """The ONE None arm for every binary-operation floor.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
@@ -97,6 +97,50 @@ class GuardedValue(FloorValue):
         false_outcome = getattr(self.when_false, method)(*args)
         if isinstance(false_outcome, Incomplete):
             return false_outcome.guarded(not_(self.guard))
+        # Dual-edge partitions from undecided native dispatch (BinOp/Compare):
+        # weaken each arm's faces under the branch guard and union.  Joining two
+        # partitions into one GuardedValue arm is not honest; the exit algebra
+        # already carries both completion and halt faces.
+        from sugar_lift_py_tests.outcome import ExitSet
+        from sugar_lift_py_tests.outcome.exit_set import (
+            Completed,
+            Halted,
+            outcome_to_exitset,
+        )
+
+        if isinstance(true_outcome, ExitSet) or isinstance(false_outcome, ExitSet):
+            from sugar_lift_py_tests.ir import and_ as and_formulas
+
+            def _under(es: ExitSet, guard) -> tuple:
+                faces = []
+                for face in es.exits:
+                    g = and_formulas([guard, face.guard])
+                    if isinstance(face, Halted):
+                        faces.append(
+                            Halted(
+                                g,
+                                face.effect,
+                                face.state,
+                                face.faces,
+                                face.pending_contracts,
+                            )
+                        )
+                    else:
+                        faces.append(
+                            Completed(
+                                g,
+                                face.value,
+                                face.faces,
+                                face.pending_contracts,
+                            )
+                        )
+                return tuple(faces)
+
+            true_es = outcome_to_exitset(true_outcome)
+            false_es = outcome_to_exitset(false_outcome)
+            return ExitSet(
+                _under(true_es, self.guard) + _under(false_es, not_(self.guard))
+            ).normalize()
         # An arm may answer with a value that still owes a parameter contract
         # (`(a if c else p)[i]` for a formal `p`). The demand is owed only on that
         # arm's face; hoist it, join the carried values, then re-attach it.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
@@ -19,6 +19,14 @@ class ImportMemberValue(FloorValue):
 
     qualified_name: str
 
+    def denotes_value(self) -> bool:
+        """An import-bound export denotes a runtime value at the member path."""
+        return True
+
+    def runtime_type_is_decided(self) -> bool:
+        """Module export runtime type is not lift-time decided from the path alone."""
+        return False
+
     def to_term(self, *, owner: str):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
@@ -51,6 +51,13 @@ class SubscriptSugar(Sugar):
         # before, and re-attach the union to the result. `rewrap_pending` is the
         # sole re-attachment door and is itself loud when the joined outcome has
         # nowhere to carry the demand: nothing here drops an obligation quietly.
+        #
+        # Operand reduction may also publish a dual-edge ExitSet (undecided
+        # Compare/BinOp dispatch: Halted raise face + Completed solver face).
+        # Sequence those partitions so Halted faces bypass the subscript step;
+        # an undecided completed face that cannot honestly subscript contributes
+        # no face rather than aborting the partition with SugarNotWritten and
+        # erasing the sibling halt.
         from dataclasses import replace
 
         from sugar_lift_py_tests.caller_parameter_contract import merge_demands
@@ -58,7 +65,8 @@ class SubscriptSugar(Sugar):
             pending_demand,
             rewrap_pending,
         )
-        from sugar_lift_py_tests.outcome import true_guard
+        from sugar_lift_py_tests.outcome import ExitSet, outcome_to_exitset, true_guard
+        from sugar_source_tree.panic import SugarNotWritten
 
         # A subscript expression has no guard of its own, so both obligations
         # hoist unconditionally.
@@ -77,11 +85,52 @@ class SubscriptSugar(Sugar):
                 )
             plain.append(value_outcome)
         receiver_outcome, index_outcome = plain
-        subscripted = receiver_outcome.and_then(
-            lambda receiver: index_outcome.and_then(
-                lambda index: self._subscript(receiver, index, ctx)
+
+        def _subscript_face(receiver, index):
+            try:
+                return outcome_to_exitset(self._subscript(receiver, index, ctx))
+            except SugarNotWritten:
+                # Completion path cannot decide the lookup. Sibling halt faces
+                # from the index/receiver partition already survive sequence.
+                return ExitSet(())
+
+        from sugar_lift_py_tests.outcome import ExitSet as _ExitSet
+
+        receiver_partitioned = isinstance(receiver_outcome, _ExitSet)
+        index_partitioned = isinstance(index_outcome, _ExitSet)
+        if receiver_partitioned or index_partitioned:
+            subscripted = outcome_to_exitset(receiver_outcome).and_then(
+                lambda receiver: outcome_to_exitset(index_outcome).and_then(
+                    lambda index: _subscript_face(receiver, index)
+                )
             )
-        )
+            if isinstance(subscripted, _ExitSet) and not subscripted.exits:
+                # Every completed face refused and no halt survived: surface the
+                # undecided lookup as the named refusal (not an empty partition).
+                raise SugarNotWritten(
+                    owner="SubscriptSugar",
+                    observed=(
+                        "undecided subscript after partitioned operand faces "
+                        "refused without a surviving halt"
+                    ),
+                    requested=(
+                        "authenticated exceptional exit or named undecided "
+                        "refusal at the receiver floor"
+                    ),
+                    fix=(
+                        "preserve a Halted face from the index/receiver "
+                        "partition, or name the undecided lookup on the "
+                        "receiver floor"
+                    ),
+                )
+        else:
+            # Single-outcome path: undecided lookups raise SugarNotWritten
+            # from the receiver floor (named refusal), exact exits Complete.
+            subscripted = receiver_outcome.and_then(
+                lambda receiver: index_outcome.and_then(
+                    lambda index: self._subscript(receiver, index, ctx)
+                )
+            )
         return rewrap_pending(
             pending, subscripted, owner=type(self).__name__, blame=self.site
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_arithmetic_total.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_arithmetic_total.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import pytest
 
+from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.floor import GuardedValue, SymbolicValue, TermValue
-from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import atomic, make_var
-from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome import Complete, ExitSet
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
 from sugar_source_tree.panic import SugarNotWritten
 
 
@@ -22,20 +23,28 @@ from sugar_source_tree.panic import SugarNotWritten
         ("right_shift", ">>"),
     ),
 )
-def test_guarded_arithmetic_preserves_an_undecided_arm_as_a_named_refusal(
+def test_guarded_arithmetic_preserves_undecided_arms_as_dual_edge_partitions(
     method, operator
 ) -> None:
+    del operator
     guard = atomic("choose", [])
     value = GuardedValue(
         guard,
         SymbolicValue(make_var("left")),
         SymbolicValue(make_var("right")),
     )
-    with pytest.raises(ConstructionPanic) as raised:
-        getattr(value, method)(TermValue(2), "t.py:1")
-
-    assert raised.value.info.owner == "binary_operation_exception_floor"
-    assert raised.value.info.observed == f"SymbolicValue {operator} TermValue"
+    outcome = getattr(value, method)(TermValue(2), "t.py:1")
+    assert isinstance(outcome, ExitSet)
+    halted = tuple(face for face in outcome.exits if isinstance(face, Halted))
+    completed = tuple(face for face in outcome.exits if isinstance(face, Completed))
+    # Each arm publishes Halted+Completed; normalize may merge same-effect
+    # faces across arms under a disjoined guard.
+    assert halted
+    assert completed
+    assert all(
+        isinstance(face.effect, RaiseEffect) and face.effect.producer_node_owner == "BinOp"
+        for face in halted
+    )
 
 
 def test_guarded_unary_minus_preserves_an_undecided_arm_as_a_named_refusal() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
@@ -55,22 +55,25 @@ def _line_96_bitand(source: str, path: Path):
     return matches[0]
 
 
-def _assert_named_panic(
-    node,
-    *,
-    owner: str,
-    observed: str,
-    requested_contains: str,
-) -> None:
-    with pytest.raises(ConstructionPanic) as raised:
-        node.sugar().desugar(None)
-    info = raised.value.info
-    assert info.owner == owner
-    assert info.observed == observed
-    assert requested_contains in info.requested
+def _assert_dual_edge_dispatch(node, *, producer: str = "BinOp") -> None:
+    """Undecided native dispatch publishes Halted + Completed faces."""
+    from sugar_lift_py_tests.effect import RaiseEffect
+    from sugar_lift_py_tests.outcome import ExitSet
+    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+
+    outcome = node.sugar().desugar(None)
+    assert isinstance(outcome, ExitSet)
+    halted = tuple(face for face in outcome.exits if isinstance(face, Halted))
+    completed = tuple(face for face in outcome.exits if isinstance(face, Completed))
+    assert len(halted) == 1
+    assert len(completed) == 1
+    effect = halted[0].effect
+    assert isinstance(effect, RaiseEffect)
+    assert effect.producer_node_owner == producer
+    assert effect.exception_name is None
     # Never invent a runtime TypeError / RuntimeEffect for undecided source.
-    assert "TypeError" not in str(info)
-    assert "RuntimeEffect" not in str(info)
+    assert "TypeError" not in str(outcome)
+    assert "RuntimeEffect" not in str(outcome)
 
 
 def _assert_named_refusal(node, *, owner: str, observed: str) -> None:
@@ -125,19 +128,11 @@ def test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer() -> No
     assert (series & 0).tolist() == [0, 0, 0, 0]
 
     lying = truthful.replace("s_0123 & np.nan", "s_0123 & 0")
-    _assert_named_refusal(
-        _line_96_bitand(truthful, path),
-        owner="SymbolicValue.attribute",
-        observed=(
-            "undecided receiver runtime type or member semantics: SymbolicValue.nan"
-        ),
-    )
-    _assert_named_panic(
-        _line_96_bitand(lying, path),
-        owner="binary_operation_exception_floor",
-        observed="SymbolicValue & TermValue",
-        requested_contains="authenticated exceptional exit",
-    )
+    # Truthful right is the import-bound ``numpy.nan`` export coordinate; lying
+    # replaces it with a ground int.  Both keep undecided left Series dispatch
+    # as dual-edge partitions (never sole TypeError).
+    _assert_dual_edge_dispatch(_line_96_bitand(truthful, path))
+    _assert_dual_edge_dispatch(_line_96_bitand(lying, path))
 
 
 @pytest.mark.parametrize(
@@ -157,15 +152,16 @@ def test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer() -> No
         (117, "BitAnd", 's_1111 & "a"', "SymbolicValue & StringValue", "a"),
     ),
 )
-def test_pandas_series_bitand_mixed_rights_stay_named_refusals(
+def test_pandas_series_bitand_mixed_rights_publish_both_dispatch_faces(
     line: int, kind: str, snippet: str, observed: str, runtime_right
 ) -> None:
     """Additional vertical slices: one operator law, mixed decided rights.
 
     Each site raises TypeError at CPython on a concrete Series, but the
     producer only sees a SymbolicValue left.  The shared undecided-binary law
-    must refuse every one without inventing TypeError.
+    publishes both dispatch faces without inventing TypeError.
     """
+    del observed
     path = _corpus_file()
     source = path.read_text(encoding="utf-8")
     assert hashlib.sha256(source.encode("utf-8")).hexdigest() == FILE_SHA256
@@ -177,12 +173,7 @@ def test_pandas_series_bitand_mixed_rights_stay_named_refusals(
     with pytest.raises(TypeError):
         series & runtime_right
 
-    _assert_named_panic(
-        _binop_at(source, path, line=line, kind=kind),
-        owner="binary_operation_exception_floor",
-        observed=observed,
-        requested_contains="authenticated exceptional exit",
-    )
+    _assert_dual_edge_dispatch(_binop_at(source, path, line=line, kind=kind))
 
 
 def test_source_decided_int_float_bitand_emits_type_error() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
@@ -237,6 +237,14 @@ def test_authenticated_subscript_family_owns_no_construction_panics(
         for body in report.bodies
         if body.outcome is AttributionOutcome.CONSTRUCTION_PANIC
     )
+    # Residual dual-edge index producers closed as authenticated exits:
+    # data[ub + 1] follows the BinOp dispatch partition; ser[df > 5] follows
+    # the Compare dispatch partition. SubscriptSugar sequences those ExitSets
+    # so Halted faces survive when the completed face cannot decide the lookup.
+    required_auth_exit_sites = {
+        "tests/extension/base/getitem.py:147:Subscript": "BinOp",
+        "tests/series/indexing/test_getitem.py:595:Subscript": "Compare",
+    }
     required_non_vendor_sites = {
         "tests/indexes/multi/test_sorting.py:147:Subscript",
         "tests/indexing/multiindex/test_multiindex.py:29:Subscript",
@@ -254,6 +262,14 @@ def test_authenticated_subscript_family_owns_no_construction_panics(
             flush=True,
         )
 
+    auth_by_id = {
+        body.body_id: body.detail
+        for body in report.bodies
+        if body.outcome is AttributionOutcome.AUTHENTICATED_EXIT
+    }
+    for body_id, owner in required_auth_exit_sites.items():
+        assert auth_by_id.get(body_id) == owner, (body_id, auth_by_id.get(body_id))
+
     assert row.enrolled == FAMILY_DENOMINATORS[ProducerFamily.SUBSCRIPT]
     assert {probe.body_id for probe in probes} >= required_non_vendor_sites
     assert (
@@ -264,6 +280,8 @@ def test_authenticated_subscript_family_owns_no_construction_panics(
     )
     assert report.discrepancies == ()
     assert not reattributed_gaps, reattributed_gaps
+    assert row.construction_panics == 0
+    assert row.authenticated_exceptional_exits >= 2
 
 
 def test_real_pandas_unknown_receiver_is_named_undecided(authenticated_site) -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
@@ -33,8 +33,11 @@ from sugar_lift_py_tests.floor.set_value import SetValue
 from sugar_lift_py_tests.floor.string_value import StringValue
 from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
 from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import PrimitiveSort, _Atomic, _Lambda, ctor, make_var
+from sugar_lift_py_tests.outcome import ExitSet
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
 
 SITE = "undecided-binary-site"
 
@@ -64,32 +67,38 @@ def _comprehension() -> ComprehensionValue:
     )
 
 
+def _dual_edge(left, right, method: str, operator: str):
+    """Undecided native dispatch publishes both completion and halt faces."""
+    outcome = getattr(left, method)(right, SITE)
+    assert isinstance(outcome, ExitSet)
+    halted = tuple(face for face in outcome.exits if isinstance(face, Halted))
+    completed = tuple(face for face in outcome.exits if isinstance(face, Completed))
+    assert len(halted) == 1
+    assert len(completed) == 1
+    effect = halted[0].effect
+    assert isinstance(effect, RaiseEffect)
+    assert effect.producer_node_owner == "BinOp"
+    assert effect.exception_name is None
+    assert "TypeError" not in str(outcome)
+    assert "RuntimeEffect" not in str(outcome)
+    assert isinstance(completed[0].value, SymbolicValue)
+    return outcome
+
+
 def _refusal(left, right, method: str, operator: str):
-    with pytest.raises(ConstructionPanic) as raised:
-        getattr(left, method)(right, SITE)
-    info = raised.value.info
-    assert info.owner == "binary_operation_exception_floor"
-    assert info.observed == f"{type(left).__name__} {operator} {type(right).__name__}"
-    assert "authenticated exceptional exit" in info.requested
-    assert "TypeError" not in str(info)
-    assert "RuntimeEffect" not in str(info)
-    return info
+    return _dual_edge(left, right, method, operator)
 
 
-def test_undecided_native_bitwise_dispatch_refuses_in_the_producer() -> None:
-    """The producer cannot choose ``__and__``/``__rand__`` or an exception."""
-    with pytest.raises(ConstructionPanic) as raised:
-        _symbolic().bitwise_and(TermValue(0), SITE)
-
-    info = raised.value.info
-    assert info.owner == "binary_operation_exception_floor"
-    assert info.observed == "SymbolicValue & TermValue"
-    assert info.requested == (
-        "source-visible native operator testimony selecting completion or an "
-        "authenticated exceptional exit"
-    )
-    assert "TypeError" not in str(info)
-    assert "RuntimeEffect" not in str(info)
+def test_undecided_native_bitwise_dispatch_publishes_both_faces() -> None:
+    """The producer cannot choose sole ``__and__`` or sole TypeError."""
+    outcome = _symbolic().bitwise_and(TermValue(0), SITE)
+    assert isinstance(outcome, ExitSet)
+    halted = next(face for face in outcome.exits if isinstance(face, Halted))
+    completed = next(face for face in outcome.exits if isinstance(face, Completed))
+    assert isinstance(halted.effect, RaiseEffect)
+    assert halted.effect.producer_node_owner == "BinOp"
+    assert halted.effect.exception_name is None
+    assert isinstance(completed.value, SymbolicValue)
 
 
 @pytest.mark.parametrize(
@@ -110,10 +119,10 @@ def test_undecided_native_bitwise_dispatch_refuses_in_the_producer() -> None:
         ("right_shift", ">>"),
     ),
 )
-def test_undecided_call_result_has_no_completion_or_effect_side_door(
+def test_undecided_call_result_publishes_both_dispatch_faces(
     method: str, operator: str
 ) -> None:
-    _refusal(_callsite(), TermValue(2), method, operator)
+    _dual_edge(_callsite(), TermValue(2), method, operator)
 
 
 @pytest.mark.parametrize(
@@ -134,10 +143,10 @@ def test_undecided_call_result_has_no_completion_or_effect_side_door(
         ("right_shift", ">>"),
     ),
 )
-def test_symbolic_left_operand_has_no_completed_binary_side_door(
+def test_symbolic_left_operand_publishes_both_dispatch_faces(
     method: str, operator: str
 ) -> None:
-    _refusal(_symbolic(), TermValue(2), method, operator)
+    _dual_edge(_symbolic(), TermValue(2), method, operator)
 
 
 # -- positive arm: the pairs the pinned census actually found -----------------
@@ -190,12 +199,17 @@ def test_the_law_refuses_every_operator_it_names_from_one_place() -> None:
         _refusal(BytesValue(b"x"), _symbolic(), method, operator)
 
 
-def test_both_operand_categories_are_conserved_in_the_refusal() -> None:
-    """The gap names the actual pair and operator; no operand becomes a value."""
+def test_both_operand_categories_are_conserved_in_the_dual_edge() -> None:
+    """The dual-edge partition cites both operand terms; no sole TypeError."""
     left = BytesValue(b"ab")
     right = _symbolic()
-    info = _refusal(left, right, "add", "+")
-    assert info.observed == "BytesValue + SymbolicValue"
+    outcome = _dual_edge(left, right, "add", "+")
+    halted = next(face for face in outcome.exits if isinstance(face, Halted))
+    completed = next(face for face in outcome.exits if isinstance(face, Completed))
+    # Halt guard names both operand terms under the operator dispatch atom.
+    guard = halted.guard
+    assert guard is not None
+    assert isinstance(completed.value, SymbolicValue)
 
 
 # -- the real reproducers: whole functions, lifted from source ---------------
@@ -216,10 +230,10 @@ def test_both_operand_categories_are_conserved_in_the_refusal() -> None:
         ("set_minus_call", "def f(g):\n    return {1, 2} - g()\n"),
     ),
 )
-def test_the_whole_function_refuses_undecided_native_dispatch(
+def test_the_whole_function_publishes_undecided_native_dispatch(
     tmp_path, name, source
 ) -> None:
-    """Whole-function construction cannot launder the third value."""
+    """Whole-function construction cannot launder sole completion or TypeError."""
     from sugar_lift_python_source.source_oracle import path_source
     from sugar_source_tree.tree import SourceFile
 
@@ -227,9 +241,14 @@ def test_the_whole_function_refuses_undecided_native_dispatch(
     path.write_text(source, encoding="utf-8")
 
     fn = next(SourceFile(path_source(str(path))).functions())
-    with pytest.raises(ConstructionPanic) as raised:
-        fn.sugar().desugar(None)
-    assert raised.value.info.owner == "binary_operation_exception_floor"
+    outcome = fn.sugar().desugar(None)
+    assert isinstance(outcome, ExitSet)
+    halted = tuple(face for face in outcome.exits if isinstance(face, Halted))
+    assert halted
+    assert all(
+        isinstance(face.effect, RaiseEffect) and face.effect.producer_node_owner == "BinOp"
+        for face in halted
+    )
 
 
 # -- discriminating arm: the law refuses, loudly, everywhere else -------------


### PR DESCRIPTION
## Summary

Closes the last **2 construction panics** on the authenticated no-call **Subscript** family (denominator 392).

### Sites (before → after)

| body_id | panic owner (before) | after |
|---|---|---|
| `tests/extension/base/getitem.py:147:Subscript` (`data[ub + 1]`) | `binary_operation_exception_floor` | **authenticated exceptional exit** (`BinOp` dual-edge halt) |
| `tests/series/indexing/test_getitem.py:595:Subscript` (`ser[df > 5]`) | `comparison_operation_exception_floor` | **authenticated exceptional exit** (`Compare` dual-edge halt) |

### Laws

1. **Undecided BinOp dispatch** publishes both faces (completion coordinate + undecided raise), matching Compare #6564 — no sole completion, no invented TypeError, no construction panic.
2. **SubscriptSugar** sequences dual-edge `ExitSet` operands so **Halted** faces survive when the completed face cannot decide the lookup (`SugarNotWritten` on that face only).
3. **ImportMemberValue** denotes a value (type undecided), so `s & np.nan` stays on the dual-edge law rather than a floor-gap panic.

### Measure

```text
family=Subscript enrolled=392 authenticatedExceptionalExit=2 namedRefusal=390 constructionPanic=0
loud=0
```

Before (receipt `17fb162b3`): `authenticatedExceptionalExit=0 namedRefusal=390 constructionPanic=2`.

### Validation

- `pytest` focused: `test_subscript_exceptional_exit_producer`, `test_undecided_binary_operand_law`, `test_pandas_binary_operation_exception_floor`, `test_guarded_arithmetic_total` — **109 passed**
- Full authenticated `--family Subscript` attribution — **constructionPanic=0**, **loud=0**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace construction panics with dual-edge ExitSets for undecided binary dispatch
> - [`FloorValue._undecided_binary_law`](https://github.com/TSavo/sugar/pull/6575/files#diff-e465d9d796b4d8a065950433dc35b2a788306abfe91dab378d35f42a38a2cdd7) now returns an `ExitSet` with a `Halted` face (carrying a `RaiseEffect` from `BinOp`) and a `Completed` face (carrying a `SymbolicValue`) instead of raising a `ConstructionPanic`.
> - [`GuardedValue._map`](https://github.com/TSavo/sugar/pull/6575/files#diff-6962ce13d68fd61ee918bbcc73622f8faaf88d07f8922d1345cfec8dcb79c5b4) propagates `ExitSet` results from either branch, conjoining each face's guard with the branch predicate so dual-edge exits survive mapping.
> - [`SubscriptSugar.desugar`](https://github.com/TSavo/sugar/pull/6575/files#diff-0a35660414dc62dca7c8656f2f0c64e6e5547d02aa7e1017e20304426061fb05) sequences operand `ExitSet`s via `and_then`, preserving `Halted` faces across subscript lookup; raises `SugarNotWritten` only when no faces survive.
> - [`ImportMemberValue`](https://github.com/TSavo/sugar/pull/6575/files#diff-52543859d7b61d7f09f33bbbaf5908f0ce01fcb0d84531c91e455d3643151917) gains `denotes_value()→True` and `runtime_type_is_decided()→False` so import-bound exports participate in undecided-dispatch logic.
> - Behavioral Change: code paths that previously aborted with a named `ConstructionPanic` (`binary_operation_exception_floor`) now produce a two-face `ExitSet`; consumers that expected a single completed value will receive an `ExitSet` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 724ab57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->