### PR TITLE
Defer formal binary operations to caller discharge

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -343,6 +343,18 @@ class SymbolicValue(FloorValue):
         )
         if isinstance(other, GuardedValue):
             return other.map_from_left(owner, self, site)
+        other_coordinate = getattr(other, "formal_coordinate", None)
+        if self.formal_coordinate is not None or other_coordinate is not None:
+            from sugar_lift_py_tests.caller_parameter_contract import (
+                NativeOperationExitCarrierV1,
+            )
+
+            return NativeOperationExitCarrierV1.mint(
+                site=site,
+                operator=owner,
+                operands=(self, other),
+                coordinates=(self.formal_coordinate, other_coordinate),
+            )
         refused = self._undecided_binary_law(other, site, operator)
         if refused is not None:
             return refused

--- a/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
@@ -33,14 +33,50 @@ from sugar_lift_py_tests.floor.set_value import SetValue
 from sugar_lift_py_tests.floor.string_value import StringValue
 from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
 from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import PrimitiveSort, _Atomic, _Lambda, ctor, make_var
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.tree import SourceFile
 
 SITE = "undecided-binary-site"
 
 
 def _symbolic() -> SymbolicValue:
     return SymbolicValue(make_var("s"))
+
+
+def _native_operation_site():
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+
+    source = "def operation(left, right):\n    return left + right\n"
+    tree = SourceFile(
+        (source, "native-operation-floor.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    return next(tree.functions()).fragment
+
+
+def _formal(name: str, ordinal: int) -> FormalParameterCoordinateV1:
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+
+    source_cid = "blake3-512:" + "b" * 128
+    owner = SourceFragmentCoordinateV1(source_cid, 1, 0, 2, 23)
+    return FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=source_cid,
+        owner_definition_locus=owner,
+        declaration_locus=SourceFragmentCoordinateV1(
+            source_cid, 1, 14 + ordinal * 6, 1, 18 + ordinal * 6
+        ),
+        ordinal=ordinal,
+        parameter_kind="positional-or-keyword",
+        declared_name=name,
+        sort=PrimitiveSort("Value"),
+    )
 
 
 def _callsite() -> CallSiteValue:
@@ -90,6 +126,109 @@ def test_undecided_native_bitwise_dispatch_refuses_in_the_producer() -> None:
     )
     assert "TypeError" not in str(info)
     assert "RuntimeEffect" not in str(info)
+
+
+def _formal_addition_demand():
+    left_coordinate = _formal("left", 0)
+    right_coordinate = _formal("right", 1)
+    outcome = SymbolicValue(make_var("left"), left_coordinate).add(
+        SymbolicValue(make_var("right"), right_coordinate), _native_operation_site()
+    )
+    return outcome, left_coordinate, right_coordinate
+
+
+def test_formal_binary_operation_survives_construction_as_native_demand() -> None:
+    """The Floor records one ordered occurrence; it does not choose an exit."""
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+
+    outcome, left, right = _formal_addition_demand()
+
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    assert outcome.demand.operator == "add"
+    assert outcome.demand.operand_terms == (make_var("left"), make_var("right"))
+    assert outcome.demand.operand_coordinate_cids == (
+        left.coordinate_cid,
+        right.coordinate_cid,
+    )
+
+
+def test_same_formal_binary_demand_completes_for_authenticated_actuals() -> None:
+    """Truthful caller twin: authenticated integer actuals complete normally."""
+    from sugar_lift_py_tests.outcome.exit_set import Completed
+
+    outcome, left, right = _formal_addition_demand()
+    exits = outcome.discharge(
+        {
+            left.coordinate_cid: TermValue(1),
+            right.coordinate_cid: TermValue(2),
+        }
+    )
+
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Completed)
+    assert exits.exits[0].value == TermValue(3)
+
+
+def test_same_formal_binary_demand_halts_for_authenticated_actuals() -> None:
+    """Lying caller twin: incompatible actuals produce the authenticated halt."""
+    from sugar_lift_py_tests.outcome.exit_set import Halted
+
+    outcome, left, right = _formal_addition_demand()
+    exits = outcome.discharge(
+        {
+            left.coordinate_cid: NoneValue(),
+            right.coordinate_cid: TermValue(2),
+        }
+    )
+
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Halted)
+    assert exits.exits[0].effect.exception_name == "TypeError"
+
+
+def test_one_formal_operand_is_enough_to_defer_native_dispatch() -> None:
+    """A decided sibling is retained while the caller supplies the one formal."""
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+    from sugar_lift_py_tests.outcome.exit_set import Completed
+
+    left = _formal("left", 0)
+    outcome = SymbolicValue(make_var("left"), left).multiply(
+        TermValue(3), _native_operation_site()
+    )
+
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    assert outcome.demand.operand_coordinate_cids == (left.coordinate_cid, None)
+    exits = outcome.discharge({left.coordinate_cid: TermValue(2)})
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Completed)
+    assert exits.exits[0].value == TermValue(6)
+
+
+def test_swapped_formal_binary_operands_have_distinct_occurrence_identity() -> None:
+    """Subtraction order is content identity: ``a - b`` is not ``b - a``."""
+    left = _formal("left", 0)
+    right = _formal("right", 1)
+    site = _native_operation_site()
+    forward = SymbolicValue(make_var("left"), left).subtract(
+        SymbolicValue(make_var("right"), right), site
+    )
+    reverse = SymbolicValue(make_var("right"), right).subtract(
+        SymbolicValue(make_var("left"), left), site
+    )
+
+    assert forward.demand.operand_coordinate_cids == (
+        left.coordinate_cid,
+        right.coordinate_cid,
+    )
+    assert reverse.demand.operand_coordinate_cids == (
+        right.coordinate_cid,
+        left.coordinate_cid,
+    )
+    assert forward.demand.demand_cid != reverse.demand.demand_cid
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

- replace `SymbolicValue._runtime_binary_refusal`'s panic default only when at least one ordered operand has a formal coordinate
- mint #6570's `NativeOperationExitCarrierV1` with the Floor method, ordered operands, source occurrence, and aligned formal coordinates
- retain the existing typed-loud `binary_operation_exception_floor` path when neither operand has caller-discharge evidence
- leave `BinOpSugar`, assertion-With consumption, ExitSet/outcome plumbing, and comparison construction untouched

## Assigned coordinates and outcome movement

Assigned receipt population: 341 construction-panic rows owned by `binary_operation_exception_floor` (340 BinOp plus `tests/extension/base/getitem.py:147` Subscript), concentrated in the named datetime/timedelta/period/timestamp arithmetic and logical-operation files.

Before, a formal `SymbolicValue + SymbolicValue` occurrence raised `ConstructionPanic(owner=binary_operation_exception_floor)` during construction. After this change, that occurrence survives construction as one native-operation demand. At authenticated caller discharge, the same recorded row projects either:

- compatible actuals: `Completed(real FloorValue)`
- source-decided incompatible actuals: `Halted(RaiseEffect(TypeError))`
- unresolved actual dispatch: the existing typed-loud floor path

The focused before/after transaction proves the mechanism, not a fabricated aggregate: the four initial wiring twins failed at `binary_operation_exception_floor`; after the implementation, the complete/halt/ordering twins pass. The corpus-wide 341-row delta is intentionally deferred to the aggregate BinOp/Compare wave on battleaxe; this PR does not claim 341 authenticated exits from the shared Mac.

## Discrimination teeth

- same helper demand + integer actuals completes
- same helper demand + incompatible actuals halts
- coordinate-free operands remain loud
- one formal plus one ground operand retains the ground operand and discharges
- swapped operands retain distinct coordinate order and demand CIDs
- #6570's lying exception type is rejected

## Validation

Authenticated local environment printed exact `CPython 3.12.13` and `NumPy 2.5.1`.

```text
.venv-py312/bin/python -m pytest implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py -q
79 passed in 3.04s
```

```text
.venv-py312/bin/python -m black --check implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
2 files would be left unchanged
```

Known baseline red, unchanged by this patch: `test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer` expects the older `SymbolicValue.attribute` refusal, while #6566/current carrier base constructs `np.nan` as `ImportMemberValue` and panics at `bitwise_and`. I proved the same failure with this patch stashed and did not weaken or update that detector.

Stacked on #6570 because that PR owns the reserved `NativeOperationDemand -> ExitSet` carrier.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer formal binary operations to caller discharge in `SymbolicValue`
> - When `SymbolicValue._runtime_binary_refusal` detects that either operand carries a `formal_coordinate`, it now returns a `NativeOperationExitCarrierV1` demand instead of falling through to undecided/refusal handling, deferring the actual operation to the caller.
> - The carrier encodes the operator, both operand terms, and their coordinates (which may be `None` for decided operands), so callers can discharge it later with concrete actuals.
> - New tests in [`test_undecided_binary_operand_law.py`](https://github.com/TSavo/sugar/pull/6576/files#diff-9998d1328333d54a7b5c59ca17ab35198a7558b224afbe0df116ce7b9e33fb0b) cover: construction of the demand, discharge with compatible actuals (completing to a value), discharge with incompatible actuals (halting with TypeError), single-formal operand deferral, and operand-order identity for subtraction.
> - Behavioral Change: binary operations on `SymbolicValue` with at least one formal coordinate no longer produce an undecided/refusal result — they produce a deferral demand that must be explicitly discharged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da7b60b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->