### PR TITLE
Strengthen comparison law teeth

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -340,10 +340,16 @@ def test_ground_decided_equality_still_completes() -> None:
     assert isinstance(outcome.value, FalseBoolLiteralSugar)
 
 
-def test_undecided_symbolic_membership_emits_completed_and_exceptional_edges() -> None:
-    node = _synthetic_compare("1 in container")
+@pytest.mark.parametrize(
+    ("op_kind", "expression"),
+    (("In", "1 in container"), ("NotIn", "1 not in container")),
+)
+def test_membership_law_routes_through_authenticated_contains(
+    op_kind: str, expression: str
+) -> None:
+    node = _synthetic_compare(expression)
     outcome = ComparisonOpSugar(
-        "In",
+        op_kind,
         _ValueSugar(TermValue(1)),
         _ValueSugar(SymbolicValue(make_var("container"))),
         node.fragment,
@@ -590,15 +596,18 @@ def test_undecided_dispatch_partition_keys_are_law_scoped(
     )
 
 
-def test_identity_comparison_never_publishes_a_raise_partition() -> None:
-    """Identity law is completion-only: ``is`` cannot invoke user code."""
+@pytest.mark.parametrize(("op_kind", "negated"), (("Is", False), ("IsNot", True)))
+def test_identity_law_never_publishes_a_raise_partition(
+    op_kind: str, negated: bool
+) -> None:
+    """Identity law is total for both ``is`` and ``is not``."""
     from sugar_lift_py_tests.floor import PredicateValue, SymbolicValue
     from sugar_lift_py_tests.ir import make_var
     from sugar_lift_py_tests.outcome import Complete, ExitSet
     from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
 
     outcome = ComparisonOpSugar(
-        "Is",
+        op_kind,
         _ValueSugar(SymbolicValue(make_var("a"))),
         _ValueSugar(SymbolicValue(make_var("b"))),
         "identity-site",
@@ -606,6 +615,7 @@ def test_identity_comparison_never_publishes_a_raise_partition() -> None:
     assert isinstance(outcome, Complete)
     assert not isinstance(outcome, ExitSet)
     assert isinstance(outcome.value, PredicateValue)
+    assert ("not" in repr(outcome.value.formula)) is negated
 
 
 def test_chained_comparison_composes_pair_ordering_laws() -> None:
@@ -615,6 +625,7 @@ def test_chained_comparison_composes_pair_ordering_laws() -> None:
     adjacent ComparisonOpSugar pairs). Residual faces are ordered dual-edge
     composition under short-circuit And — not a monomorphic chain panic.
     """
+    from sugar_lift_py_tests.ir import and_, atomic, make_var, not_, or_
     from sugar_lift_py_tests.outcome import ExitSet
     from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
 
@@ -625,5 +636,21 @@ def test_chained_comparison_composes_pair_ordering_laws() -> None:
     assert len(sugar.values) == 2
     outcome = sugar.desugar(None)
     assert isinstance(outcome, ExitSet)
-    assert any(isinstance(face, Halted) for face in outcome.exits)
-    assert any(isinstance(face, Completed) for face in outcome.exits)
+    halted = [face for face in outcome.exits if isinstance(face, Halted)]
+    completed = [face for face in outcome.exits if isinstance(face, Completed)]
+    assert len(halted) == 1  # normalization merges the same Compare effect
+
+    a, b, c = make_var("a"), make_var("b"), make_var("c")
+    first_raises = atomic("python.lt_dispatch_raises", [a, b])
+    first_true = atomic("py.lt", [a, b])
+    second_raises = atomic("python.lt_dispatch_raises", [b, c])
+    assert halted[0].guard == or_(
+        [
+            first_raises,
+            and_([not_(first_raises), and_([first_true, second_raises])]),
+        ]
+    )
+    assert any(
+        face.guard == and_([not_(first_raises), not_(first_true)])
+        for face in completed
+    )


### PR DESCRIPTION
## What changed

Main landed #6571 while this branch was in flight. This PR preserves that stronger `CompareLaw` implementation and adds only missing executable teeth:

- exercise both `is` and `is not` through the named non-raising identity law
- exercise both `in` and `not in` through the authenticated membership law
- strengthen the chained-comparison test from shape checks to exact short-circuit ExitSet guards
- pin `tests/series/indexing/test_getitem.py:595` so its Subscript root preserves the nested Compare-owned halt after #6570's carrier repair

## Chaining law

For `a < b < c`, the halted guard is exactly:

`first_raises OR (not first_raises AND first_true AND second_raises)`

The short-circuit completion is exactly:

`not first_raises AND not first_true`

This prevents a later routing change from attributing the second comparison on a face where the first halted or completed false.

## Validation

- authenticated battleaxe runtime: CPython 3.12.13, pandas 3.0.3, NumPy 2.5.1, canonical corpus manifest
- focused Compare producer, family attribution, and membership modules: 57 passed
- mutation transaction: changed the actual chained Compare constructor from `And` to `Or`; the exact guard tooth failed; reverted; identical diff hash restored; test passed
- `git diff --check`: clean

No production files or reserved ExitSet/outcome/generator/Floor/BinOp files are changed. The 127 Compare-root rows and the one Subscript-root row now have concrete teeth; the Compare-family denominator and outcome split remain unchanged.
