### PR TITLE
Keep import-bound Attribute bodies loud

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -164,6 +164,11 @@ def test_silent_completion_stays_a_separate_loud_discrepancy() -> None:
     assert len(report.discrepancies) == 1
     assert "completed without" in report.discrepancies[0].detail
     assert (
+        "unaccounted body=pandas/example.py:1:BoolOp node=BoolOp "
+        "detail=pandas/example.py:1:BoolOp (BoolOp) completed without"
+        in report.render()
+    )
+    assert (
         "OUTCOME TOTAL DISCREPANCY enrolled=1 threeOutcomeTotal=0 unaccounted=1"
         in report.render()
     )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -8785,48 +8785,15 @@ class Attribute(Expression):
         """`<value>.<attr>` constructs AttributeSugar WITH the receiver's sugar.
         The attr name is a static identifier carried onto the coordinate.
 
-        When the whole chain is a closed import-bound export
-        (``import M as h; h.a.b``), the coordinate is the joined export
-        ``M.a.b`` — the same authority Call uses for import-bound callees.
-        No module receiver is projected, so no AttributeError is invented and
-        no vendor member table is consulted.
-
         An opaque receiver still constructs this native operation. Its floor
         decides whether source testimony supplies a value or exceptional exit;
         when neither is known, the producer refuses instead of inventing a
         completed ``py.getattr`` projection or guessing ``AttributeError``."""
-        export = self._import_bound_export_symbol()
-        if export is not None:
-            from sugar_lift_py_tests.sugar.import_member_sugar import ImportMemberSugar
-
-            return ImportMemberSugar(qualified_name=export, site=self.fragment)
         from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
 
         return AttributeSugar(
             receiver=self.value.sugar(), name=self.attr, site=self.fragment
         )
-
-    def _import_bound_export_symbol(self) -> Optional[str]:
-        """Closed ``module.attr…`` coordinate when the head is uniquely import-bound.
-
-        Mirrors ``Call._import_bound_callee_symbol`` for non-call Attribute
-        expressions (exception types, dtype constructors used as values).
-        """
-        link = self
-        attributes: list[str] = []
-        while isinstance(link, Attribute):
-            attributes.append(link.attr)
-            link = link.value
-        if not isinstance(link, Name):
-            return None
-        span = link.line_col_span()
-        target = self.unit.import_bound_name_target(
-            (span.start_line, span.start_col, span.end_line, span.end_col)
-        )
-        if target is None:
-            return None
-        module = target[len("python:") :] if target.startswith("python:") else target
-        return ".".join([module, *reversed(attributes)])
 
     def substitute(self, scope):
         """Project only from a construction-authenticated object place."""

--- a/implementations/python/sugar-source-tree/tests/test_imported_exception_attribute_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_imported_exception_attribute_construction.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 from pathlib import Path
 from types import MappingProxyType
 
+import pytest
+
 from sugar_lift_py_tests.context_manager_contract import (
     CallParameterV1,
     EffectBoundarySemanticsV1,
@@ -298,7 +300,7 @@ def test_no_pyarrow_spelling_arm_in_authenticator():
 
 
 def test_importorskip_binding_authenticates_arrow_invalid(tmp_path):
-    """Truthful: ``pa = pytest.importorskip("pyarrow")`` is an import binding."""
+    """Truthful: the manager operand role authenticates the import coordinate."""
     path = tmp_path / "skip.py"
     path.write_text(
         "import pytest\n"
@@ -316,13 +318,27 @@ def test_importorskip_binding_authenticates_arrow_invalid(tmp_path):
         "python:exception_type_identity",
         [str_const("import"), str_const("pyarrow.ArrowInvalid")],
     )
-    sugar = _attribute(tree, "ArrowInvalid").sugar()
-    from sugar_lift_py_tests.sugar.import_member_sugar import ImportMemberSugar
+    boundary = _boundary(tmp_path, path.read_text(encoding="utf-8"))
+    expected = boundary.manager.desugar().value.arg_values[0]
+    assert isinstance(expected, AuthenticatedExceptionTypeValue)
+    assert expected.exception_type_identity() == identity
 
-    assert isinstance(sugar, ImportMemberSugar)
-    assert sugar.qualified_name == "pyarrow.ArrowInvalid"
-    floor = sugar.desugar().value
-    assert floor.exception_type_identity() == identity
+
+def test_import_bound_attribute_body_does_not_invent_member_success(tmp_path):
+    """Lying twin: an import coordinate alone is not member-existence testimony."""
+    from sugar_source_tree.panic import SugarNotWritten
+
+    path = tmp_path / "body.py"
+    path.write_text(
+        "import pandas as pd\n"
+        "def f():\n"
+        "    return pd.util.foo\n",
+        encoding="utf-8",
+    )
+    tree = SourceFile(path_source(str(path)))
+
+    with pytest.raises(SugarNotWritten, match="attribute"):
+        _attribute(tree, "foo").sugar().desugar()
 
 
 def test_try_import_optional_binding_authenticates_module_attr(tmp_path):


### PR DESCRIPTION
## What changed

- Restrict import-bound exception coordinates to the authenticated exception-operand path.
- Restore ordinary import-bound Attribute bodies to native receiver/member evaluation, where missing member testimony remains a named refusal.
- Add a lying twin proving an import coordinate cannot fabricate member success.
- Strengthen the row-level conservation twin so a silent completion prints its concrete unaccounted row.

## Root cause

#6567 made generic Attribute construction return a completed ImportMemberValue for every import-bound chain. That role-free shortcut was valid for authenticated exception-type operands but fabricated member success in ordinary body position, allowing three Attribute rows to complete without any terminal attribution.

## Validation

- Exact local runtime: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3.
- Focused tests: 28 passed.
- Exact-runtime Attribute-family rerun over the authenticated shared demand table: 53 enrolled, 0 authenticated exceptional exits, 53 named refusals, 0 construction panics, 0 discrepancies. This is a focused local result; Battleaxe crash/timeout zeros and corpus-wide deltas are not claimed.
- Concrete rows at tests/api/test_api.py:491, tests/indexes/datetimes/test_scalar_compat.py:37, and tests/internals/test_api.py:81 each report named refusal at SymbolicValue.attribute.
- Mutation transaction: restoring the generic import-member completion makes the lying twin fail; reverting it restores green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove ImportMemberSugar construction from import-bound `Attribute` chains
> - `Attribute._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6578/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) no longer special-cases import-bound attribute chains; it now always returns `AttributeSugar` instead of `ImportMemberSugar`.
> - The `_import_bound_export_symbol` helper method is deleted along with the related docstring explaining import-bound export behavior.
> - Tests are updated to reflect that desugaring an import-bound attribute (e.g. `pd.util.foo`) raises `SugarNotWritten` rather than succeeding via an import coordinate.
> - Behavioral Change: import-bound module attribute chains that previously resolved to `ImportMemberSugar` will now produce `AttributeSugar` and raise on desugar if no member testimony exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7709259.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->