### PR TITLE
Dig method bodies under not for returned-manager exits

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
@@ -84,6 +84,31 @@ class UnaryOpSugar(Sugar):
         if self.op_kind == "Not":
             # `not x` = not bool(x): only a decided truthiness may be negated.
             def project_not(value):
+                from sugar_lift_py_tests.floor.block_value import BlockValue
+                from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+                from sugar_lift_py_tests.floor.return_value import ReturnValue
+
+                # Method calls with authenticated bodies
+                # (``not self._check_type(e)`` / ``not self.matches(e)``) dig
+                # the body before truth refusal. Opaque CallSiteValue is neither
+                # bool nor TypeError — dig is the sole door for source-visible
+                # method returns on returned-manager exit faces.
+                if isinstance(value, CallSiteValue) and value.body is not None:
+                    dug = value._dig_floor_or_none(
+                        ctx, owner="UnaryOpSugar.not method body"
+                    )
+                    if dug is not None:
+                        value = dug
+                # Method bodies dig to BlockValue; truth rides the returned floor
+                # (side-effect assigns precede the return).
+                if isinstance(value, BlockValue) and not value.fall_through:
+                    returns = [
+                        statement.value
+                        for statement in value.statements
+                        if isinstance(statement, ReturnValue)
+                    ]
+                    if len(returns) == 1:
+                        value = returns[0]
                 refuse_undecided_unary_truth(value, self.site)
                 return value.truth(self.site)
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -251,26 +251,34 @@ def _floor_object_tuple_fields(
     from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
     from sugar_lift_py_tests.floor.class_value import ClassValue
     from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+    from sugar_lift_py_tests.floor.none_value import NoneValue
     from sugar_lift_py_tests.floor.object_value import ObjectField
     from sugar_lift_py_tests.floor.tuple_value import TupleValue
 
-    class_actuals = tuple(
-        item for item in actuals if isinstance(item, ClassValue)
-    )
-    new_fields = []
+    class_actuals = tuple(item for item in actuals if isinstance(item, ClassValue))
+    fields_by_name = {field.name: field.value for field in obj.fields}
     changed = False
-    for field in obj.fields:
-        value = field.value
+    for name, value in list(fields_by_name.items()):
         floored = _floor_one_tuple_callsite(value, class_actuals)
         if floored is not None:
-            value = floored
+            fields_by_name[name] = floored
             changed = True
-        new_fields.append(ObjectField(field.name, value))
+    # AbstractRaises stores match/check in super().__init__. When that super
+    # call remains bodyless, written match=None / check=None still need field
+    # testimony so _check_match and NoMessagePattern can floor on the exit face.
+    method_names = {method.name for method in obj.methods}
+    if "matches" in method_names and "expected_exceptions" in fields_by_name:
+        for optional in ("match", "check"):
+            if optional not in fields_by_name:
+                fields_by_name[optional] = NoneValue()
+                changed = True
     if not changed:
         return obj
     return ObjectValue(
         obj.class_name,
-        tuple(new_fields),
+        tuple(
+            ObjectField(name, fields_by_name[name]) for name in sorted(fields_by_name)
+        ),
         obj.methods,
         obj.class_fields,
         obj.identity,

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
@@ -153,8 +153,10 @@ def test_external_error_raised_follows_authenticated_returned_manager() -> None:
         return
 
     # Stage-keyed residual after dual-mode return follow-through. The returned
-    # manager constructed through isinstance/tuple/len field flooring; summary
-    # derivation still stops at the matches() UnaryOp gate on CallSiteValue.
+    # manager constructed through isinstance/tuple/len field flooring, and
+    # ``not self.matches(...)`` digs method bodies instead of refusing the
+    # CallSiteValue at the UnaryOp producer. Summary derivation still has not
+    # sealed EffectBoundary.
     assert isinstance(reference, ContextManagerResolutionGapV1), reference
     assert reference.kind in {
         "exit-may-halt",
@@ -171,11 +173,13 @@ def test_external_error_raised_follows_authenticated_returned_manager() -> None:
     )
     assert "SymbolicValue + CallSiteValue" not in (reference.detail or "")
     assert "comparison_operation_exception_floor" not in (reference.detail or "")
-    # expected_exceptions floors to TupleValue; residual is matches() truth.
-    assert reference.kind == "exit-may-halt"
-    assert "unary_operation_exception_floor:CallSiteValue not" in (
+    assert "unary_operation_exception_floor:CallSiteValue not" not in (
         reference.detail or ""
     )
+    # Current residual is deeper in matches() / method-body truth after the
+    # CallSiteValue UnaryOp gate digs.
+    assert reference.kind == "exit-may-halt"
+    assert reference.detail == "truth:BlockValue"
 
 
 def test_external_error_raised_population_is_the_authenticated_47_with_sites() -> None:


### PR DESCRIPTION
## Summary

Owner 1 — returned assertion managers. Advances the 42 UnaryOp `external_error_raised` residuals past the matches/CallSiteValue `not` gate.

### Construction (not reporting-only)

1. **UnaryOp `not` digs authenticated method bodies** before truth refusal (`not self.matches(...)` / `not self._check_type(...)`).
2. **Single-return BlockValue unwrap** so method dig rides the returned floor, not the block record.
3. **Project absent `match`/`check` fields as `NoneValue`** when RaisesExc-style receivers have `matches` + `expected_exceptions` but bodyless `super().__init__` never stored them (written `match=None` path).

### Residual advance (pinned corpus)

| Site | Before | After |
|------|--------|-------|
| `pandas/tests/io/test_feather.py:40` | `exit-may-halt` / `unary_operation_exception_floor:CallSiteValue not` | `exit-may-halt` / `truth:BlockValue` |

Still **0 authenticated exceptional exits / 47 named refusals** of the authenticated demand population (manager exit not sealed EffectBoundary yet). Dual-mode identity-exit managers still seal EffectBoundary; lying `external_error_raised` spelling twin still cannot invent it.

### Validation

```bash
PYTHONPATH=implementations/python/sugar-lift-python-source/src:\
implementations/python/sugar-lift-py-tests/src:\
implementations/python/sugar-source-tree/src \
.venv-py312/bin/python -m pytest -q \
  implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py::test_external_error_raised_follows_authenticated_returned_manager \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_dual_mode_effect_boundary_installs_with_effect_boundary_sugar \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_external_error_raised_spelling_cannot_replace_native_return_shape \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_renamed_returned_assertion_manager_is_derived_from_protocol \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_raises_style_if_not_args_factory_projects_guarded_return
# 5 passed
```

Does not supersede #6546 (reporting-only coordinates); this is production mechanism.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dig into method bodies for `not` operator on returned-manager `CallSiteValue` exits
> - `UnaryOpSugar.desugar` now traverses `CallSiteValue` method bodies when evaluating `not`: if the body floors to a `BlockValue` with no fall-through and a single `ReturnValue`, truth is evaluated on that return value instead of refusing at the `CallSiteValue` boundary.
> - `_floor_object_tuple_fields` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6579/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) now inserts `match` and `check` fields defaulted to `NoneValue` for objects that define a `matches` method and have an `expected_exceptions` field, when those fields are absent.
> - The test in [test_returned_assertion_manager.py](https://github.com/TSavo/sugar/pull/6579/files#diff-ae95b2e3d9589f08dcd37a7451092b43741299d876a5c9b72987042097bfb795) is updated to expect `truth:BlockValue` in the residual instead of `unary_operation_exception_floor:CallSiteValue not`.
> - Behavioral Change: `not` on a returned-manager call site no longer stops at the call boundary; it now resolves truth deeper into the method body.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47bbc50.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->