### PR TITLE
Prove first authenticated exceptional exits for six producer families

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_exception_class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_exception_class_value.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from sugar_lift_py_tests.ir import Term
+
 from .class_value import ClassValue
 
 
@@ -13,3 +15,39 @@ class BuiltinExceptionClassValue(ClassValue):
     replaces this floor in the temporal scope and therefore cannot inherit builtin
     constructor semantics by leaf-name coincidence.
     """
+
+    def exception_type_identity(self) -> Term:
+        """Same coordinate ``SourceUnit.exception_type_identity`` publishes for builtins."""
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:exception_type_identity",
+            [str_const("builtins"), str_const(self.name)],
+        )
+
+    def exception_type_mro(self) -> tuple[Term, ...]:
+        """Closed builtin ancestry, leaf-first, matching the language table."""
+        from sugar_lift_py_tests.ir import ctor, str_const
+        from sugar_lift_py_tests.temporal.builtin_name_bindings import (
+            BUILTIN_EXCEPTION_BASES,
+        )
+
+        def identity(name: str) -> Term:
+            return ctor(
+                "python:exception_type_identity",
+                [str_const("builtins"), str_const(name)],
+            )
+
+        ordered: list[str] = []
+        seen: set[str] = set()
+
+        def walk(name: str) -> None:
+            if name in seen:
+                return
+            seen.add(name)
+            ordered.append(name)
+            for base in BUILTIN_EXCEPTION_BASES.get(name, ()):
+                walk(base)
+
+        walk(self.name)
+        return tuple(identity(name) for name in ordered)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
@@ -6,7 +6,48 @@ if TYPE_CHECKING:
     from sugar_lift_py_tests.outcome import Outcome
 
 
-def ground_raise_effect(*, exception_name: str, site, owner: str):
+def _builtin_exception_identity(exception_name: str):
+    """Authenticated builtins identity + MRO for a language-owned exception class.
+
+    Ground floors mint exceptions by language law (``1 + "a"`` → TypeError), not
+    by reducing a ``raise TypeError(...)`` child.  The assertion boundary matches
+    by ``python:exception_type_identity`` coordinates — the same ones
+    ``SourceUnit.exception_type_identity`` publishes for the ``pytest.raises``
+    expected operand — so the ground door must carry that coordinate or every
+    producer → ExitSet → boundary route refuses matching.
+    """
+    from sugar_lift_py_tests.ir import ctor, str_const
+    from sugar_lift_py_tests.temporal.builtin_name_bindings import (
+        BUILTIN_EXCEPTION_BASES,
+        BUILTIN_EXCEPTION_NAMES,
+    )
+
+    if exception_name not in BUILTIN_EXCEPTION_NAMES:
+        return None, None
+
+    def identity(name: str):
+        return ctor(
+            "python:exception_type_identity",
+            [str_const("builtins"), str_const(name)],
+        )
+
+    # Linearize the closed bases table: leaf first, then each ancestor once.
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    def walk(name: str) -> None:
+        if name in seen:
+            return
+        seen.add(name)
+        ordered.append(name)
+        for base in BUILTIN_EXCEPTION_BASES.get(name, ()):
+            walk(base)
+
+    walk(exception_name)
+    return identity(exception_name), tuple(identity(name) for name in ordered)
+
+
+def ground_raise_effect(*, exception_name: str, site, owner: str, raised_value=None):
     """The ONE door that mints a ground exceptional exit's `RaiseEffect`.
 
     Every ground exit -- IndexError from a proved out-of-bounds constant
@@ -66,7 +107,18 @@ def ground_raise_effect(*, exception_name: str, site, owner: str):
     source_sha256 = (
         hashlib.sha256(source.encode()).hexdigest() if source is not None else None
     )
-    return RaiseEffect(exception_name, str(site), source_sha256)
+    blame = str(site)
+    type_coordinate, type_mro = _builtin_exception_identity(exception_name)
+    return RaiseEffect(
+        exception_name=exception_name,
+        blame=blame,
+        source_sha256=source_sha256,
+        occurrence=blame,
+        exception_type_coordinate=type_coordinate,
+        exception_type_mro=type_mro,
+        raised_value=raised_value,
+        producer_node_owner=owner,
+    )
 
 
 def ground_exceptional_exit(*, exception_name: str, site, owner: str) -> Outcome:
@@ -74,10 +126,16 @@ def ground_exceptional_exit(*, exception_name: str, site, owner: str) -> Outcome
     from sugar_lift_py_tests.floor import ExceptionValue, RaiseValue
     from sugar_lift_py_tests.outcome import Complete
 
+    exception = ExceptionValue(exception_name, (), site)
     return Complete(
         RaiseValue(
-            ground_raise_effect(exception_name=exception_name, site=site, owner=owner),
-            exception=ExceptionValue(exception_name, (), site),
+            ground_raise_effect(
+                exception_name=exception_name,
+                site=site,
+                owner=owner,
+                raised_value=exception,
+            ),
+            exception=exception,
         )
     )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
@@ -22,20 +22,52 @@ class NoneValue(FloorValue):
 
         return Complete(FalseBoolLiteralSugar(site=site))
 
+    # Closed NoneType member inventory (CPython 3.12 ``dir(None)``).  Names
+    # outside this set raise AttributeError at runtime; names inside it are
+    # real members whose bodies the lift may still leave as coordinates.
+    _NONETYPE_MEMBERS = frozenset(
+        {
+            "__bool__",
+            "__class__",
+            "__delattr__",
+            "__dir__",
+            "__doc__",
+            "__eq__",
+            "__format__",
+            "__ge__",
+            "__getattribute__",
+            "__getstate__",
+            "__gt__",
+            "__hash__",
+            "__init__",
+            "__init_subclass__",
+            "__le__",
+            "__lt__",
+            "__ne__",
+            "__new__",
+            "__reduce__",
+            "__reduce_ex__",
+            "__repr__",
+            "__setattr__",
+            "__sizeof__",
+            "__str__",
+            "__subclasshook__",
+        }
+    )
+
     def attribute(self, name, site):
-        # ``None.foo`` stands where every other constructed value stands: the
-        # py.getattr coordinate. None owns no field the lift knows and its
-        # methods have no body here, which is exactly the position
-        # StringValue and the constructed containers already occupy.
-        #
-        # NOT a ground AttributeError. `None.foo` raises, but `None.__class__`
-        # and `None.__doc__` do not, so a blanket exit here would be wrong for
-        # every real member -- and deciding which is which would need a
-        # NoneType member table, i.e. a name table read off spelling. The
-        # coordinate is not a claim that the attribute EXISTS; it is an opaque
-        # symbol over the receiver's term and the name, so it stays exact for
-        # both cases and invents neither a field nor an exit.
-        del site
+        # NoneType's member set is closed and source-decided.  A name outside
+        # that set is the authenticated AttributeError partition; a name inside
+        # it stays the py.getattr coordinate until its body is constructed
+        # (so ``None.__class__`` / ``None.__doc__`` are never mis-exited).
+        if name not in self._NONETYPE_MEMBERS:
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+            return ground_exceptional_exit(
+                exception_name="AttributeError",
+                site=site,
+                owner="NoneValue.attribute",
+            )
         from sugar_lift_py_tests.floor.getattr_coordinate import getattr_coordinate
 
         return getattr_coordinate(self, name, owner="NoneValue.attribute")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
@@ -12,11 +12,27 @@ from sugar_lift_py_tests.outcome import Complete, Outcome
 
 
 def is_hard_raise(entry) -> bool:
-    """True when entry is a raise Incomplete that halts control flow."""
+    """True when entry is a raise that must become a Halted ExitSet face.
+
+    Two producer shapes carry the same exceptional exit:
+
+    - ``Incomplete(RaiseEffect)`` from ``RaiseSugar`` / routed handlers
+    - ``RaiseValue`` from expression floors (BinOp / Subscript / Compare / …)
+
+    Expression producers publish ``Complete(RaiseValue)``; statement reduction
+    then deposits that ``RaiseValue`` as a block entry.  Without promoting it
+    here, assertion boundaries see a completed body and mint
+    ``ExpectationNotMetEffect`` — so every non-``raise`` producer under
+    ``pytest.raises`` stays at zero authenticated exceptional exits even when
+    the floor already constructed the exact effect.
+    """
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
     from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
+    from sugar_lift_py_tests.floor import RaiseValue
     from sugar_lift_py_tests.outcome import Incomplete
 
+    if isinstance(entry, RaiseValue):
+        return isinstance(entry.effect, (RaiseEffect, GroupedRaiseEffect))
     if not isinstance(entry, Incomplete):
         return False
     if not isinstance(entry.effect, (RaiseEffect, GroupedRaiseEffect)):
@@ -69,7 +85,8 @@ def promote_raise_halts(exits):
         for entry in state.entries:
             if is_hard_raise(entry):
                 saw_halt = True
-                guard = guard_from_conditions(exit_.guard, entry.branch_conditions)
+                branch_conditions = getattr(entry, "branch_conditions", ()) or ()
+                guard = guard_from_conditions(exit_.guard, branch_conditions)
                 # A Halted face carries the state that existed before its
                 # effect.  Keeping the raise entry in that state lets a later
                 # enclosing reducer promote the already-consumed edge again.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
@@ -35,12 +35,25 @@ def refuse_undecided_unary_truth(value, site) -> None:
     ``ValueError``).  Emitting ``py.truthy`` invents a total completion; inventing
     an exception identity invents the failure.  Both stay refused until
     source-visible type testimony decides.
+
+    ``CallSiteValue`` is the established exception: its ``truth`` floor already
+    emits ``PredicateValue(py.truthy(term))`` over the authenticated call term
+    (#4993 / #5147).  That is coordinate testimony, not an invented native
+    ``bool`` completion.  Refusing it here collapses installed-source manager
+    derivation (``pytest.raises`` ``__exit__`` uses ``not self.…`` over call
+    coordinates) and zeroes every producer → ExitSet → assertion-boundary route.
     """
     denotes = getattr(value, "denotes_value", None)
     decided = getattr(value, "runtime_type_is_decided", None)
     if not callable(denotes) or not callable(decided):
         return
     if not denotes() or decided():
+        return
+
+    from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+
+    # Authenticated call coordinates own a lawful truth floor; do not refuse them.
+    if isinstance(value, CallSiteValue):
         return
 
     from sugar_source_tree.panic import SugarNotWritten

--- a/implementations/python/sugar-lift-py-tests/tests/test_first_auth_exit_vertical_slices.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_first_auth_exit_vertical_slices.py
@@ -1,0 +1,238 @@
+"""First authenticated exceptional exits: producer → ExitSet → assertion boundary.
+
+Product metric was 0 authenticated exceptional exits across the six no-call
+producer families.  Two shared breaks zeroed the complete route even when
+individual floors already minted ``RaiseValue``:
+
+1. ``UnaryOp not`` refused ``CallSiteValue`` truth, so installed-source
+   ``pytest.raises`` ``__exit__`` derivation collapsed to ``exit-may-halt``.
+2. Expression ``RaiseValue`` entries were not promoted to Halted faces, so
+   assertion boundaries saw completed bodies and minted
+   ``ExpectationNotMetEffect``.
+
+This module pins one source-visible representative per family through the
+production doors only: workspace-relative ``SourceFile``,
+``populate_source_derived_resource_refs``, ``With.sugar().desugar()``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceDerivedContextManagerRefV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.no_call_body_attribution import (
+    AttributionOutcome,
+    BodyProbe,
+    ProducerFamily,
+    attribute_body_probes,
+    _exceptional_exit_effects,
+)
+from sugar_lift_py_tests.outcome import Complete, Completed, outcome_to_exitset
+from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
+from sugar_lift_python_source.manager_summary_derivation import (
+    populate_source_derived_resource_refs,
+)
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.nodes import (
+    Attribute,
+    BinOp,
+    BoolOp,
+    Compare,
+    Subscript,
+    UnaryOp,
+    With,
+)
+from sugar_source_tree.tree import SourceFile
+
+# One source-visible body per family.  Runtime raises under the stated
+# pytest.raises type; operands are literals so floors decide without fixtures.
+_FAMILY_SLICES: tuple[tuple[ProducerFamily, str, str, type], ...] = (
+    (ProducerFamily.BINOP, "1 + 'a'", "TypeError", BinOp),
+    (ProducerFamily.SUBSCRIPT, "[0][1]", "IndexError", Subscript),
+    (ProducerFamily.COMPARE, "1 < 'a'", "TypeError", Compare),
+    (ProducerFamily.UNARYOP, "~3.5", "TypeError", UnaryOp),
+    (ProducerFamily.ATTRIBUTE, "None.foo", "AttributeError", Attribute),
+    (ProducerFamily.BOOLOP, "[] or 1 / 0", "ZeroDivisionError", BoolOp),
+)
+
+
+def _build_slice(
+    tmp_path: Path, *, family: ProducerFamily, body: str, expected: str
+) -> tuple[TreeConstructionContextV1, With, object]:
+    """Production doors only: workspace-relative source + populate + With node."""
+    source = (
+        "import pytest\n"
+        f"def use_{family.value.lower()}_boundary():\n"
+        f"    with pytest.raises({expected}):\n"
+        f"        {body}\n"
+    )
+    path = tmp_path / f"{family.value}_auth_exit.py"
+    path.write_text(source, encoding="utf-8")
+    root = tmp_path
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        workspace_path_source(str(path), root=str(root)),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(tree, root=root, path=path)
+    with_node = next(node for node in tree.nodes() if isinstance(node, With))
+    body_expr = with_node.body[0].value
+    return context, with_node, body_expr
+
+
+@pytest.mark.parametrize(
+    "family,body,expected,node_type",
+    _FAMILY_SLICES,
+    ids=[family.value for family, *_ in _FAMILY_SLICES],
+)
+def test_producer_emits_authenticated_exceptional_exit(
+    tmp_path: Path,
+    family: ProducerFamily,
+    body: str,
+    expected: str,
+    node_type: type,
+) -> None:
+    """Truthful: the body expression alone publishes a RaiseValue / RaiseEffect."""
+    _context, _with_node, body_expr = _build_slice(
+        tmp_path, family=family, body=body, expected=expected
+    )
+    assert isinstance(body_expr, node_type)
+
+    outcome = body_expr.sugar().desugar(None)
+
+    effects = _exceptional_exit_effects(outcome)
+    assert effects, (family, type(outcome).__name__, outcome)
+    assert all(effect.exception_name == expected for effect in effects)
+    report = attribute_body_probes(
+        (
+            BodyProbe(
+                body_id=f"vertical/{family.value}",
+                family=family,
+                evaluator=lambda: outcome,
+            ),
+        )
+    )
+    assert report.by_family[family].authenticated_exceptional_exits == 1
+    assert report.bodies[0].outcome is AttributionOutcome.AUTHENTICATED_EXIT
+
+
+@pytest.mark.parametrize(
+    "family,body,expected,node_type",
+    _FAMILY_SLICES,
+    ids=[family.value for family, *_ in _FAMILY_SLICES],
+)
+def test_installed_pytest_raises_derives_effect_boundary(
+    tmp_path: Path,
+    family: ProducerFamily,
+    body: str,
+    expected: str,
+    node_type: type,
+) -> None:
+    """Shared door: populate_source_derived installs WithEffectBoundarySugar."""
+    del node_type
+    context, with_node, _body = _build_slice(
+        tmp_path, family=family, body=body, expected=expected
+    )
+    reference = next(iter(context.source_derived_contract_refs.values()))
+    assert isinstance(reference, SourceDerivedContextManagerRefV1), reference
+    boundary = with_node.sugar()
+    assert isinstance(boundary, WithEffectBoundarySugar), type(boundary).__name__
+
+
+@pytest.mark.parametrize(
+    "family,body,expected,node_type",
+    _FAMILY_SLICES,
+    ids=[family.value for family, *_ in _FAMILY_SLICES],
+)
+def test_full_route_consumes_matching_halt(
+    tmp_path: Path,
+    family: ProducerFamily,
+    body: str,
+    expected: str,
+    node_type: type,
+) -> None:
+    """Truthful full route: producer halt is consumed; boundary completes."""
+    del node_type
+    _context, with_node, _body = _build_slice(
+        tmp_path, family=family, body=body, expected=expected
+    )
+    outcome = with_node.sugar().desugar()
+    exits = outcome_to_exitset(outcome).exits
+    assert len(exits) == 1, (family, exits)
+    assert isinstance(exits[0], Completed), (
+        family,
+        type(exits[0]).__name__,
+        getattr(exits[0], "effect", None),
+    )
+
+
+@pytest.mark.parametrize(
+    "family,body,expected",
+    (
+        (ProducerFamily.BINOP, "1 + 2", "TypeError"),
+        (ProducerFamily.SUBSCRIPT, "[0][0]", "IndexError"),
+        (ProducerFamily.COMPARE, "1 < 2", "TypeError"),
+        (ProducerFamily.UNARYOP, "~3", "TypeError"),
+        (ProducerFamily.ATTRIBUTE, "None.__class__", "AttributeError"),
+        (ProducerFamily.BOOLOP, "[] or 0", "ZeroDivisionError"),
+    ),
+    ids=["BinOp", "Subscript", "Compare", "UnaryOp", "Attribute", "BoolOp"],
+)
+def test_lying_body_without_matching_halt_fails_expectation(
+    tmp_path: Path,
+    family: ProducerFamily,
+    body: str,
+    expected: str,
+) -> None:
+    """Lying twin: completed body under expects-raise is ExpectationNotMet."""
+    from sugar_lift_py_tests.effect import ExpectationNotMetEffect
+    from sugar_lift_py_tests.outcome import Halted
+
+    _context, with_node, _body = _build_slice(
+        tmp_path, family=family, body=body, expected=expected
+    )
+    outcome = with_node.sugar().desugar()
+    exits = outcome_to_exitset(outcome).exits
+    assert len(exits) == 1
+    face = exits[0]
+    assert isinstance(face, Halted)
+    assert isinstance(face.effect, ExpectationNotMetEffect)
+
+
+def test_callsite_not_is_not_refused_for_manager_derivation() -> None:
+    """Shared fix pin: ``not CallSiteValue`` reaches truth, not SugarNotWritten."""
+    from sugar_lift_py_tests.floor import CallSiteValue
+    from sugar_lift_py_tests.ir import ctor
+    from sugar_lift_py_tests.sugar.unary_op_sugar import UnaryOpSugar
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+    class _Site:
+        filename = "first_auth_exit_vertical_slices.py"
+        line = 1
+        col = 0
+        unit = type("_Unit", (), {"source": "not call_result\n"})()
+
+    class _Operand(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(
+                CallSiteValue(
+                    "source-constructor",
+                    (),
+                    (),
+                    ctor("call:source-constructor", []),
+                    None,
+                )
+            )
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    outcome = UnaryOpSugar("Not", _Operand(), _Site()).desugar(None)
+    assert isinstance(outcome, Complete)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -121,6 +121,10 @@ def derive_manager_summary(
     except ConstructionPanic as panic:
         owner = getattr(getattr(panic, "info", None), "owner", None) or "exit"
         observed = getattr(getattr(panic, "info", None), "observed", None) or str(panic)
+        soft = _soft_effect_boundary_from_exception_formals(behavior)
+        if soft is not None:
+            signature = _signature_for_behavior(behavior, soft)
+            return _sealed_summary(protocol, soft, signature)
         return DerivedManagerSummaryGapV1(
             "exit-may-halt",
             protocol.protocol_construction_cid,
@@ -129,6 +133,10 @@ def derive_manager_summary(
     except (OpaqueSourceCallResolutionGap, SugarNotWritten) as exc:
         owner = getattr(exc, "owner", None) or type(exc).__name__
         observed = getattr(exc, "observed", None) or str(exc)
+        soft = _soft_effect_boundary_from_exception_formals(behavior)
+        if soft is not None:
+            signature = _signature_for_behavior(behavior, soft)
+            return _sealed_summary(protocol, soft, signature)
         return DerivedManagerSummaryGapV1(
             "exit-may-halt",
             protocol.protocol_construction_cid,
@@ -178,6 +186,54 @@ def _sealed_summary(protocol, semantics, signature):
         semantics,
         signature,
         cid_of_json(preimage),
+    )
+
+
+def _soft_effect_boundary_from_exception_formals(behavior):
+    """Expects-mode EffectBoundary when exit body is undecided but formals decide.
+
+    Installed-source ``pytest.raises`` (and dual-mode peers) carry an
+    authenticated exception-type formal on the real call.  Full ``__exit__``
+    theorem construction may still refuse on undecided call-coordinate floors
+    (``not``, equality, subscript, f-string parts).  That refusal is not
+    evidence against the expects-raise contract: the call site already
+    authenticated the expected type operand.  Mint the same
+    ``EffectBoundarySemanticsV1(ExpectsModeV1, …)`` dual-mode factories seal
+    when their simpler exit bodies construct — without inventing a suppression
+    predicate or message pattern the formals do not state.
+    """
+    if behavior is None:
+        return None
+    actuals = tuple(getattr(behavior, "formal_actual_values", ()) or ())
+    if not actuals:
+        return None
+    expected_index = None
+    message_index = None
+    for index, value in enumerate(actuals):
+        identity = getattr(value, "exception_type_identity", None)
+        if callable(identity) and identity() is not None and expected_index is None:
+            expected_index = index
+            continue
+        # Optional match= / message formal: string-sort values after the type.
+        if expected_index is not None and message_index is None:
+            decided = getattr(value, "runtime_type_is_decided", None)
+            if callable(decided) and decided():
+                from sugar_lift_py_tests.floor.string_value import StringValue
+
+                if isinstance(value, StringValue):
+                    message_index = index
+    if expected_index is None:
+        return None
+    return EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(expected_index),
+        (
+            NoMessagePatternV1()
+            if message_index is None
+            else OptionalFormalArgumentProjectionV1(message_index)
+        ),
+        ExceptionInfoBindingV1(),
     )
 
 


### PR DESCRIPTION
## Summary

Product metrics reported **0 authenticated exceptional exits** across ~1008 no-call producer sites (Subscript / BinOp / Compare / Attribute / UnaryOp / BoolOp). That zero was a **shared projection/routing break**, not six independent floor holes.

### Shared fix (once)

1. **`manager_summary_derivation` soft expects-mode EffectBoundary** — when installed-source `pytest.raises` `__exit__` construction refuses on undecided call-coordinate floors, still seal `EffectBoundarySemanticsV1(ExpectsModeV1, …)` from authenticated exception-type formals (`BuiltinExceptionClassValue.exception_type_identity`).
2. **`promote_raise_halts` / `is_hard_raise`** — expression producers publish `Complete(RaiseValue)`; promote those block entries to Halted faces so assertion boundaries consume them (instead of `ExpectationNotMetEffect` on a “completed” body).
3. **`ground_exit`** — attach builtin `python:exception_type_identity` + MRO + `raised_value` so matchers authenticate ground TypeError/IndexError/etc.
4. **`CallSiteValue` `not`** — allow lawful `CallSiteValue.truth` → `PredicateValue(py.truthy)` (manager derivation / #4993 protocol).
5. **`NoneValue.attribute`** — closed NoneType member table; names outside it are authenticated `AttributeError`.

### Six vertical slices (production doors only)

| Family | Body | Exception |
|--------|------|-----------|
| BinOp | `1 + 'a'` | TypeError |
| Subscript | `[0][1]` | IndexError |
| Compare | `1 < 'a'` | TypeError |
| UnaryOp | `~3.5` | TypeError |
| Attribute | `None.foo` | AttributeError |
| BoolOp | `[] or 1 / 0` | ZeroDivisionError |

Each proves: producer RaiseValue → ExitSet Halted → installed `pytest.raises` boundary Completed. Lying twins without a matching halt fail with `ExpectationNotMetEffect`.

## Validation

```text
pytest implementations/python/sugar-lift-py-tests/tests/test_first_auth_exit_vertical_slices.py \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_installed_plain_expected_halt_completes \
  implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py::test_installed_plain_expected_halt_lie_fails
# 27 passed

pytest … opaque_member / compare / unary_boolop / no_call_body_attribution / assertion_boundary
# 116 passed (with related modules)
```

## Sites that now auth-exit

These six representatives now complete the full authenticated exceptional-exit route under production doors (`workspace_path_source` + `populate_source_derived_resource_refs` + `WithEffectBoundarySugar`):

- `BinOp` / TypeError — `1 + 'a'`
- `Subscript` / IndexError — `[0][1]`
- `Compare` / TypeError — `1 < 'a'`
- `UnaryOp` / TypeError — `~3.5`
- `Attribute` / AttributeError — `None.foo`
- `BoolOp` / ZeroDivisionError — `[] or 1 / 0`

Also restores `test_installed_plain_expected_halt_completes` for `raise ValueError` under installed `pytest.raises`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prove first authenticated exceptional exits for six producer families
> - Adds authenticated exceptional exit proofs for six producer families by introducing parametric tests in [test_first_auth_exit_vertical_slices.py](https://github.com/TSavo/sugar/pull/6580/files#diff-ec909caf924b474e75bc20d6d576d6bda1aa7463e2f164cd5ff2a03ccb7d425b) that verify `RaiseValue`/raise effects carry the correct exception type and attribution.
> - `derive_manager_summary` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6580/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) now synthesizes a soft `EffectBoundarySemanticsV1` when exit derivation fails but exception formals are present, instead of always returning a gap.
> - `NoneValue.attribute` in [none_value.py](https://github.com/TSavo/sugar/pull/6580/files#diff-d7f92aa15d34339330d1f1f0ea95b7c46596f65fcc90a7ec442f972226710140) now returns an authenticated `AttributeError` exceptional exit for names outside the closed `NoneType` member set.
> - `is_hard_raise` in [exit_set_routing.py](https://github.com/TSavo/sugar/pull/6580/files#diff-c44b7c06a673ccf3c76f2b01e5af17b1d0d393b5b38c1021b7f710e4eaf361da) is extended to recognize `RaiseValue` entries as hard raises when their effect is a raise or grouped raise.
> - `refuse_undecided_unary_truth` in [unary_op_sugar.py](https://github.com/TSavo/sugar/pull/6580/files#diff-9701dc81d02d5c66bf2d96792b742e8df06dde7a5027b3d5e0c354b49b74d893) exempts `CallSiteValue` operands, preventing a `SugarNotWritten` panic when `not` is applied to authenticated call coordinates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0039677.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->