### PR TITLE
Publish both undecided binary dispatch edges

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
@@ -273,6 +273,26 @@ class GuardedValue(FloorValue):
         false_outcome = getattr(left, method)(self.when_false, site)
         if isinstance(false_outcome, Incomplete):
             return false_outcome.guarded(not_(self.guard))
+        from sugar_lift_py_tests.outcome import ExitSet
+
+        if isinstance(true_outcome, ExitSet) or isinstance(false_outcome, ExitSet):
+            from sugar_lift_py_tests.outcome.exit_set import (
+                outcome_to_exitset,
+                partition,
+            )
+
+            true_face, false_face = partition(
+                ("GuardedValue.map_from_left", str(site), method, self.guard)
+            )
+            return (
+                outcome_to_exitset(true_outcome)
+                .guarded(self.guard, true_face)
+                .union(
+                    outcome_to_exitset(false_outcome).guarded(
+                        not_(self.guard), false_face
+                    )
+                )
+            )
         true_pending, true_outcome = pending_demand(true_outcome, self.guard)
         false_pending, false_outcome = pending_demand(false_outcome, not_(self.guard))
         true_outcome = require_single_value(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -292,48 +292,48 @@ class SymbolicValue(FloorValue):
         if type(other) is ListValue:
             return other.multiply(self, site)
 
-        return self._runtime_binary_refusal(other, site, "*")
+        return self._runtime_binary_dispatch(other, site, "*")
 
     def power(self, other, site):
-        return self._runtime_binary_refusal(other, site, "**")
+        return self._runtime_binary_dispatch(other, site, "**")
 
     def add(self, other, site):
-        return self._runtime_binary_refusal(other, site, "+")
+        return self._runtime_binary_dispatch(other, site, "+")
 
     def subtract(self, other, site):
-        return self._runtime_binary_refusal(other, site, "-")
+        return self._runtime_binary_dispatch(other, site, "-")
 
     def divide(self, other, site):
-        return self._arithmetic_refusal(other, site, "/")
+        return self._arithmetic_dispatch(other, site, "/")
 
     def floor_divide(self, other, site):
-        return self._arithmetic_refusal(other, site, "//")
+        return self._arithmetic_dispatch(other, site, "//")
 
     def modulo(self, other, site):
-        return self._arithmetic_refusal(other, site, "%")
+        return self._arithmetic_dispatch(other, site, "%")
 
-    def _arithmetic_refusal(self, other, site, operator):
-        return self._runtime_binary_refusal(other, site, operator)
+    def _arithmetic_dispatch(self, other, site, operator):
+        return self._runtime_binary_dispatch(other, site, operator)
 
     def right_shift(self, other, site):
-        return self._runtime_binary_refusal(other, site, ">>")
+        return self._runtime_binary_dispatch(other, site, ">>")
 
     def bitwise_and(self, other, site):
-        return self._runtime_bitwise_refusal(other, site, "&")
+        return self._runtime_bitwise_dispatch(other, site, "&")
 
     def bitwise_xor(self, other, site):
-        return self._runtime_bitwise_refusal(other, site, "^")
+        return self._runtime_bitwise_dispatch(other, site, "^")
 
     def bitwise_or(self, other, site):
-        return self._runtime_bitwise_refusal(other, site, "|")
+        return self._runtime_bitwise_dispatch(other, site, "|")
 
     def left_shift(self, other, site):
-        return self._runtime_bitwise_refusal(other, site, "<<")
+        return self._runtime_bitwise_dispatch(other, site, "<<")
 
-    def _runtime_bitwise_refusal(self, other, site, operator):
-        return self._runtime_binary_refusal(other, site, operator)
+    def _runtime_bitwise_dispatch(self, other, site, operator):
+        return self._runtime_binary_dispatch(other, site, operator)
 
-    def _runtime_binary_refusal(self, other, site, operator):
+    def _runtime_binary_dispatch(self, other, site, operator):
         from sugar_lift_py_tests.floor.guarded_value import GuardedValue
 
         owner = next(
@@ -343,9 +343,45 @@ class SymbolicValue(FloorValue):
         )
         if isinstance(other, GuardedValue):
             return other.map_from_left(owner, self, site)
-        refused = self._undecided_binary_law(other, site, operator)
-        if refused is not None:
-            return refused
+        denotes_other = getattr(other, "denotes_value", None)
+        if callable(denotes_other) and denotes_other():
+            from sugar_lift_py_tests.effect import RaiseEffect
+            from sugar_lift_py_tests.ir import atomic, ctor, str_const
+            from sugar_lift_py_tests.outcome import ExitSet
+            from sugar_lift_py_tests.outcome.exit_set import (
+                Completed,
+                Halted,
+                complement_guard,
+                partition,
+            )
+
+            left_term = self.to_term(owner=f"{operator} left operand")
+            right_term = other.to_term(owner=f"{operator} right operand")
+            dispatch_raises = atomic(
+                "python.binary_dispatch_raises",
+                [str_const(operator), left_term, right_term],
+            )
+            halted_face, completed_face = partition(
+                ("binary-native-dispatch", str(site), operator)
+            )
+            return ExitSet(
+                (
+                    Halted(
+                        dispatch_raises,
+                        RaiseEffect(
+                            blame=str(site),
+                            occurrence=str(site),
+                            producer_node_owner="BinOp",
+                        ),
+                        faces=frozenset({halted_face}),
+                    ),
+                    Completed(
+                        complement_guard(dispatch_raises),
+                        SymbolicValue(ctor(operator, [left_term, right_term])),
+                        frozenset({completed_face}),
+                    ),
+                )
+            ).normalize()
         return self._binary_floor_gap(
             other,
             site,
@@ -354,7 +390,7 @@ class SymbolicValue(FloorValue):
         )
 
     def matrix_multiply(self, other, site):
-        return self._runtime_bitwise_refusal(other, site, "@")
+        return self._runtime_bitwise_dispatch(other, site, "@")
 
     def unary_plus(self, site):
         # The term does not state a runtime type, so it cannot decide whether

--- a/implementations/python/sugar-lift-py-tests/tests/test_complex_field_arithmetic_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_complex_field_arithmetic_floor.py
@@ -222,10 +222,9 @@ def test_an_opaque_operand_keeps_the_undecided_third_value_loud() -> None:
     floor must not swallow it into a fabricated concrete complex.
 
     What this arm pinned was the REFUSAL to fabricate a complex, and that is
-    unchanged: the outcome below is not a ``ComplexValue``. What it also
-    asserted -- a completed symbolic coordinate -- erased the exceptional face.
-    An unexecuted call's result type is undecided, so Python's own operator
-    dispatch for the pair is undecided and remains a named producer gap.
+    unchanged: the outcome below is not a ``ComplexValue``. An unexecuted
+    call's result type is undecided, so Python's own operator dispatch retains
+    both the symbolic completion and exceptional face.
 
     See ``tests/test_undecided_binary_operand_law.py``.
     """
@@ -233,18 +232,31 @@ def test_an_opaque_operand_keeps_the_undecided_third_value_loud() -> None:
 
     assert complex_field_coordinate(opaque) is None
 
-    with pytest.raises(ConstructionPanic) as raised:
-        ComplexValue(0.0, 1.0).add(opaque, SITE)
-    assert raised.value.info.owner == "binary_operation_exception_floor"
+    from sugar_lift_py_tests.outcome import ExitSet
+    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+
+    outcome = ComplexValue(0.0, 1.0).add(opaque, SITE)
+    assert isinstance(outcome, ExitSet)
+    assert {type(exit_) for exit_ in outcome.exits} == {Completed, Halted}
+    assert not any(
+        isinstance(exit_, Completed) and isinstance(exit_.value, ComplexValue)
+        for exit_ in outcome.exits
+    )
 
 
-def test_an_integer_plus_a_symbolic_operand_is_still_undecided() -> None:
-    """The complex arm sits AFTER the symbolic arms and stole none of them."""
+def test_an_integer_plus_a_symbolic_operand_retains_both_dispatch_faces() -> None:
+    """The complex arm sits after, while undecided dispatch keeps both faces."""
+    from sugar_lift_py_tests.outcome import ExitSet
+    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+
     symbolic = SymbolicValue(TermValue(2).to_term(owner=SITE))
 
-    with pytest.raises(ConstructionPanic) as raised:
-        TermValue(1).add(symbolic, SITE)
-    assert raised.value.info.owner == "binary_operation_exception_floor"
+    outcome = TermValue(1).add(symbolic, SITE)
+    assert isinstance(outcome, ExitSet)
+    assert {type(exit_) for exit_ in outcome.exits} == {Completed, Halted}
+    halted = next(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
+    assert halted.effect.exception_name is None
+    assert halted.effect.producer_node_owner == "BinOp"
 
 
 # -- the field coordinate is read from the value, not from a name -------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_arithmetic_total.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_arithmetic_total.py
@@ -42,9 +42,31 @@ def test_guarded_arithmetic_preserves_undecided_arms_as_dual_edge_partitions(
     assert halted
     assert completed
     assert all(
-        isinstance(face.effect, RaiseEffect) and face.effect.producer_node_owner == "BinOp"
+        isinstance(face.effect, RaiseEffect)
+        and face.effect.producer_node_owner == "BinOp"
         for face in halted
     )
+
+
+def test_guarded_right_operand_preserves_both_dispatch_faces_on_each_branch() -> None:
+    """The reflected guarded join conserves the same two producer faces."""
+    guard = atomic("choose-right", [])
+    right = GuardedValue(
+        guard,
+        SymbolicValue(make_var("right_true")),
+        SymbolicValue(make_var("right_false")),
+    )
+
+    outcome = SymbolicValue(make_var("left")).subtract(right, "t.py:2")
+
+    assert isinstance(outcome, ExitSet)
+    assert {type(exit_).__name__ for exit_ in outcome.exits} == {
+        "Completed",
+        "Halted",
+    }
+    rendered = str(outcome)
+    assert "right_true" in rendered
+    assert "right_false" in rendered
 
 
 def test_guarded_unary_minus_preserves_an_undecided_arm_as_a_named_refusal() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
@@ -11,7 +11,6 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
-from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.nodes import BinOp
 from sugar_source_tree.tree import SourceFile
 
@@ -77,13 +76,12 @@ def _assert_dual_edge_dispatch(node, *, producer: str = "BinOp") -> None:
 
 
 def _assert_named_refusal(node, *, owner: str, observed: str) -> None:
+    from sugar_source_tree.panic import SugarNotWritten
+
     with pytest.raises(SugarNotWritten) as raised:
         node.sugar().desugar(None)
     assert raised.value.owner == owner
     assert raised.value.observed == observed
-    # Never invent a runtime TypeError / RuntimeEffect for undecided source.
-    assert "TypeError" not in str(raised.value)
-    assert "RuntimeEffect" not in str(raised.value)
 
 
 def _binop_at(source: str, path: Path, *, line: int, kind: str):
@@ -103,17 +101,16 @@ def _binop_at(source: str, path: Path, *, line: int, kind: str):
     return matches[0]
 
 
-def test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer() -> None:
+def test_pandas_series_nan_bitand_retains_child_gap_and_binary_dispatch_twin() -> None:
     """Truthful/lying runtime twins cannot license invented source testimony.
 
     Site: ``pandas/tests/series/test_logical_ops.py:96`` ``s_0123 & np.nan``.
 
     Operand evaluation runs before the BinOp floor. On the truthful site the
-    right operand is ``np.nan`` — Attribute on an unresolved name — so the
-    named coordinate is ``SymbolicValue.attribute``. Replacing the right
-    operand with a term (``0``) removes that child gap and the panic lands on
-    ``binary_operation_exception_floor`` as ``SymbolicValue & TermValue``.
-    Neither arm invents TypeError.
+    right operand is ``np.nan`` — an unresolved imported member. Replacing the
+    right operand with a term (``0``) removes that child gap and reaches the
+    BinOp producer's completed/exceptional dispatch split. Neither edge
+    invents TypeError.
     """
     path = _corpus_file()
     truthful = path.read_text(encoding="utf-8")
@@ -128,32 +125,37 @@ def test_pandas_series_nan_bitand_stays_source_undecided_in_the_producer() -> No
     assert (series & 0).tolist() == [0, 0, 0, 0]
 
     lying = truthful.replace("s_0123 & np.nan", "s_0123 & 0")
-    # Truthful right is the import-bound ``numpy.nan`` export coordinate; lying
-    # replaces it with a ground int.  Both keep undecided left Series dispatch
-    # as dual-edge partitions (never sole TypeError).
-    _assert_dual_edge_dispatch(_line_96_bitand(truthful, path))
+    # This focused SourceFile door has no authenticated import table, so it must
+    # not pretend that ``np.nan`` resolved. The ground lying twin removes that
+    # child boundary and reaches the BinOp producer's dual-edge partition.
+    _assert_named_refusal(
+        _line_96_bitand(truthful, path),
+        owner="SymbolicValue.attribute",
+        observed=(
+            "undecided receiver runtime type or member semantics: SymbolicValue.nan"
+        ),
+    )
     _assert_dual_edge_dispatch(_line_96_bitand(lying, path))
 
 
 @pytest.mark.parametrize(
-    ("line", "kind", "snippet", "observed", "runtime_right"),
+    ("line", "kind", "snippet", "runtime_right"),
     (
         # Same function as :96; ground float right still cannot type the left.
-        (98, "BitAnd", "s_0123 & 3.14", "SymbolicValue & TermValue", 3.14),
+        (98, "BitAnd", "s_0123 & 3.14", 3.14),
         # List right is decided as a sequence; left Series type is not.
         (
             101,
             "BitAnd",
             "s_0123 & [0.1, 4, 3.14, 2]",
-            "SymbolicValue & ListValue",
             [0.1, 4, 3.14, 2],
         ),
         # String right is decided; left Series type is not.
-        (117, "BitAnd", 's_1111 & "a"', "SymbolicValue & StringValue", "a"),
+        (117, "BitAnd", 's_1111 & "a"', "a"),
     ),
 )
 def test_pandas_series_bitand_mixed_rights_publish_both_dispatch_faces(
-    line: int, kind: str, snippet: str, observed: str, runtime_right
+    line: int, kind: str, snippet: str, runtime_right
 ) -> None:
     """Additional vertical slices: one operator law, mixed decided rights.
 
@@ -161,7 +163,6 @@ def test_pandas_series_bitand_mixed_rights_publish_both_dispatch_faces(
     producer only sees a SymbolicValue left.  The shared undecided-binary law
     publishes both dispatch faces without inventing TypeError.
     """
-    del observed
     path = _corpus_file()
     source = path.read_text(encoding="utf-8")
     assert hashlib.sha256(source.encode("utf-8")).hexdigest() == FILE_SHA256
@@ -180,8 +181,8 @@ def test_source_decided_int_float_bitand_emits_type_error() -> None:
     """Truthful twin of ``s_0123 & 3.14`` with both types source-decided.
 
     Enrolled site: ``pandas/tests/series/test_logical_ops.py:98``.  With an
-    undecided Series left the producer refuses; with two TermValues the
-    bitwise floor constructs authenticated TypeError RaiseValue.  The twin is
+    undecided Series left the producer retains both dispatch faces; with two
+    TermValues the bitwise floor constructs authenticated TypeError RaiseValue. The twin is
     built on a workspace-relative locus so the ground exit can cite source.
     """
     from dataclasses import dataclass

--- a/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
@@ -8,8 +8,9 @@ named for THIS right operand, falling to the (owner x pair) gap.
 
 Most of those pairs are not eight arms to write. When at least one operand's
 runtime TYPE is undecided, Python's own operator dispatch for the pair is
-undecided.  That is a third value: the producer cannot claim completion and
-cannot invent an exception identity, so the shared law emits one named gap.
+undecided.  That is a third value: the producer publishes both possible faces,
+retaining the symbolic completion beside a source-cited exceptional edge whose
+exception identity remains undecided.
 
 The category is read from each value's own testimony (``denotes_value`` /
 ``runtime_type_is_decided``), never from a lexical type name.
@@ -149,6 +150,84 @@ def test_symbolic_left_operand_publishes_both_dispatch_faces(
     _dual_edge(_symbolic(), TermValue(2), method, operator)
 
 
+def test_ground_total_addition_never_acquires_an_exceptional_edge() -> None:
+    """Lying twin: source-decided integer addition remains one completion."""
+    from sugar_lift_py_tests.outcome import Complete
+
+    outcome = TermValue(1).add(TermValue(2), SITE)
+    assert isinstance(outcome, Complete)
+    assert outcome.value == TermValue(3)
+
+
+def test_swapped_symbolic_operands_retain_distinct_coordinates() -> None:
+    """Ordered dispatch identity distinguishes ``a - b`` from ``b - a``."""
+    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+
+    left = SymbolicValue(make_var("left"))
+    right = SymbolicValue(make_var("right"))
+    forward = left.subtract(right, SITE)
+    reverse = right.subtract(left, SITE)
+
+    forward_completed = next(
+        exit_ for exit_ in forward.exits if isinstance(exit_, Completed)
+    )
+    reverse_completed = next(
+        exit_ for exit_ in reverse.exits if isinstance(exit_, Completed)
+    )
+    forward_halted = next(exit_ for exit_ in forward.exits if isinstance(exit_, Halted))
+    reverse_halted = next(exit_ for exit_ in reverse.exits if isinstance(exit_, Halted))
+    assert forward_completed.value.term == ctor(
+        "-", [make_var("left"), make_var("right")]
+    )
+    assert reverse_completed.value.term == ctor(
+        "-", [make_var("right"), make_var("left")]
+    )
+    assert forward_halted.guard != reverse_halted.guard
+
+
+def test_lying_exception_type_does_not_consume_binary_dispatch_halt() -> None:
+    """The boundary cannot invent an identity for an undecided binary raise."""
+    from sugar_lift_py_tests.context_manager_contract import (
+        AuthenticatedRaiseMatcher,
+        EffectBoundaryDisposition,
+    )
+    from sugar_lift_py_tests.effect import RaiseEffect
+    from sugar_lift_py_tests.effect.expectation_not_met_effect import (
+        ExpectationNotMetEffect,
+    )
+    from sugar_lift_py_tests.ir import str_const
+    from sugar_lift_py_tests.outcome import ExitSet
+    from sugar_lift_py_tests.outcome.exit_set import Halted
+
+    class _Expected:
+        def exception_type_identity(self):
+            return ctor(
+                "python:exception_type_identity",
+                [str_const("builtins"), str_const("ValueError")],
+            )
+
+    body = _symbolic().add(TermValue(2), SITE)
+    original = next(
+        exit_
+        for exit_ in body.exits
+        if isinstance(exit_, Halted) and isinstance(exit_.effect, RaiseEffect)
+    )
+    from sugar_source_tree.panic import SugarNotWritten
+
+    with pytest.raises(
+        SugarNotWritten,
+        match="handler or raised exception has no term to state the test over",
+    ):
+        body.and_exit(
+            ExitSet.completed(object()),
+            disposition=EffectBoundaryDisposition(
+                matcher=AuthenticatedRaiseMatcher(expected=_Expected()),
+                unmet=ExpectationNotMetEffect("raise", "assertion-site"),
+            ),
+        )
+    assert original.effect.exception_name is None
+
+
 # -- positive arm: the pairs the pinned census actually found -----------------
 
 
@@ -246,7 +325,8 @@ def test_the_whole_function_publishes_undecided_native_dispatch(
     halted = tuple(face for face in outcome.exits if isinstance(face, Halted))
     assert halted
     assert all(
-        isinstance(face.effect, RaiseEffect) and face.effect.producer_node_owner == "BinOp"
+        isinstance(face.effect, RaiseEffect)
+        and face.effect.producer_node_owner == "BinOp"
         for face in halted
     )
 


### PR DESCRIPTION
## Measured defect

Authenticated battleaxe receipt on `c535ee50f` measured BinOp at `367 enrolled = 0 exits + 16 refusals + 351 construction panics`, regressing from 340 panics. This change applies #6564's finished Compare pattern at the BinOp producer and is rebased through current main `cad4f960b`.

## Change

- delete `SymbolicValue`'s `_runtime_binary_refusal`, `_arithmetic_refusal`, and `_runtime_bitwise_refusal` paths (zero remaining references)
- publish complementary completed and exceptional native-dispatch faces for every undecided Symbolic binary operator
- retain ordered operands, operator, and source occurrence in producer-owned guards/coordinates
- keep the exceptional edge identity-undecided: no fabricated exception type or runtime coordinate
- conserve both edges through guarded left and guarded right operand joins
- leave source-decided ground operations on their existing single completed or authenticated `RaiseValue` laws
- do not touch BinOpSugar, assertion-With, comparison construction, outcome/, exit_set.py, or generator construction

## Discrimination laws

- all 13 Symbolic binary operators retain completed and exceptional faces
- real pinned pandas 3.0.3 `Series &` coordinates at lines 96/98/101/117 exercise the producer split; the unauthenticated direct `np.nan` child remains a named attribute refusal rather than pretending a bare SourceFile lift resolved imports
- guarded left and guarded right operands preserve both faces instead of creating `GuardedValue` panics
- swapped subtraction operands retain different completed coordinates and exceptional guards
- a lying `ValueError` expectation cannot consume an identity-undecided halt; matching refuses at the named `matches_raise_effect` boundary
- source-decided integer addition remains one completion and gains no exceptional edge
- source-decided mixed pairs continue to construct authenticated TypeError `RaiseValue`

## Mutation transaction

Before implementation, the direct tests produced 14/14 `ConstructionPanic(owner=binary_operation_exception_floor)` failures while the ground-total twin passed. The guarded-right twin separately failed at `GuardedValue.map_from_left(subtract)`. After the producer and guarded-routing changes, all focused laws pass.

## Authenticated focused validation

Bootstrap reported exact CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, and `PINS_OK`.

```text
.venv-py312/bin/python -m pytest \
  implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py \
  implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py \
  implementations/python/sugar-lift-py-tests/tests/test_complex_field_arithmetic_floor.py \
  implementations/python/sugar-lift-py-tests/tests/test_guarded_arithmetic_total.py \
  implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py -q
164 passed in 8.35s
```

```text
black --check: 6 files would be left unchanged
refusal helper symbol search: zero references
```

The corpus-wide after-count is not claimed from the shared Mac. Aggregate authenticated deltas remain a battleaxe receipt.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish both dispatch faces for undecided binary operations on `SymbolicValue`
> - Replaces refusal/panic returns in `SymbolicValue` binary operators (`+`, `-`, `*`, `/`, `//`, `%`, `**`, `>>`, `<<`, `&`, `|`, `^`, `@`) with an `ExitSet` containing both a `Completed` symbolic result and a `Halted` `RaiseEffect` (with `producer_node_owner="BinOp"`) when the right operand denotes a runtime value.
> - Adds `_runtime_binary_dispatch` and `_runtime_bitwise_dispatch` helpers to centralize this dual-edge logic, replacing the prior `_runtime_binary_refusal` / `_runtime_bitwise_refusal` helpers.
> - Updates `GuardedValue._map` to handle the case where either branch returns an `ExitSet`, partitioning faces per branch and returning a union of guarded exit sets.
> - Updates tests to assert dual-face `ExitSet` results instead of single named refusals or panics.
> - Behavioral Change: all symbolic binary operations that previously returned a named gap/refusal now return an `ExitSet` with both a success and an exceptional edge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3513f51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->