### PR TITLE
Make native operation resolution three-way

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -19,6 +19,123 @@ from sugar_lift_py_tests.ir import (
 )
 
 
+class NativeOperationResolutionV1:
+    """The closed caller-discharge result for one native operation.
+
+    The exceptional arm is authenticated only when both the exception type
+    coordinate and operation occurrence coordinate are present.  A halt without
+    those coordinates is not a fourth exit kind: it remains ``undischarged``.
+    """
+
+    __slots__ = (
+        "_kind",
+        "value",
+        "exception_type_coordinate",
+        "raise_occurrence_coordinate",
+        "reason",
+    )
+
+    def __init__(
+        self,
+        *,
+        kind,
+        value=None,
+        exception_type_coordinate=None,
+        raise_occurrence_coordinate=None,
+        reason=None,
+    ):
+        if kind not in {"completed", "exceptional", "undischarged"}:
+            raise ValueError(f"unknown native operation resolution: {kind}")
+        if kind == "completed" and value is None:
+            raise ValueError("completed native operation requires a value")
+        if kind == "exceptional" and (
+            exception_type_coordinate is None or raise_occurrence_coordinate is None
+        ):
+            raise ValueError(
+                "exceptional native operation requires authenticated type and occurrence"
+            )
+        if kind == "undischarged" and not reason:
+            raise ValueError("undischarged native operation requires a reason")
+        if kind != "exceptional" and (
+            exception_type_coordinate is not None
+            or raise_occurrence_coordinate is not None
+        ):
+            raise ValueError(
+                "non-exceptional resolution cannot carry exception testimony"
+            )
+        self._kind = kind
+        self.value = value
+        self.exception_type_coordinate = exception_type_coordinate
+        self.raise_occurrence_coordinate = raise_occurrence_coordinate
+        self.reason = reason
+
+    @classmethod
+    def completed(cls, value):
+        return cls(kind="completed", value=value)
+
+    @classmethod
+    def exceptional(cls, *, exception_type_coordinate, operation_occurrence):
+        return cls(
+            kind="exceptional",
+            exception_type_coordinate=exception_type_coordinate,
+            raise_occurrence_coordinate=operation_occurrence,
+        )
+
+    @classmethod
+    def undischarged(cls, reason: str):
+        return cls(kind="undischarged", reason=reason)
+
+    @property
+    def kind(self) -> str:
+        return self._kind
+
+    @property
+    def is_completed(self) -> bool:
+        return self._kind == "completed"
+
+    @property
+    def has_authenticated_exception_type(self) -> bool:
+        return (
+            self._kind == "exceptional"
+            and self.exception_type_coordinate is not None
+            and self.raise_occurrence_coordinate is not None
+        )
+
+    @property
+    def is_undischarged(self) -> bool:
+        return self._kind == "undischarged"
+
+    @property
+    def is_exceptional(self) -> bool:
+        return self._kind == "exceptional"
+
+    def project(self, *, source_node):
+        """Project the closed resolution into an ExitSet or a typed refusal."""
+        from sugar_lift_py_tests.effect import RaiseEffect
+        from sugar_lift_py_tests.outcome import ExitSet
+        from sugar_source_tree.panic import SugarNotWritten
+
+        if self.is_completed:
+            return ExitSet.completed(self.value)
+        if self.has_authenticated_exception_type:
+            occurrence = self.raise_occurrence_coordinate
+            assert occurrence is not None
+            return ExitSet.halted(
+                RaiseEffect(
+                    exception_type_coordinate=self.exception_type_coordinate,
+                    occurrence=str(occurrence.wire()),
+                    blame=str(occurrence.wire()),
+                )
+            )
+        raise SugarNotWritten(
+            blame=str(source_node),
+            owner="NativeOperationResolutionV1.project",
+            observed=self.reason or "native operation exception identity unproven",
+            requested="authenticated exception type and operation occurrence coordinates",
+            fix="retain the operation as undischarged until both coordinates are proven",
+        )
+
+
 def _json(value) -> Any:
     return json.loads(encode_jcs(value))
 
@@ -206,9 +323,27 @@ class NativeOperationExitCarrierV1:
 
         projected = operation(right, self.site)
         if isinstance(projected, Complete) and isinstance(projected.value, RaiseValue):
-            exits = ExitSet.halted(projected.value.effect)
-        elif isinstance(projected, (Complete, Incomplete, ExitSet)):
-            exits = outcome_to_exitset(projected)
+            effect = projected.value.effect
+            if effect.exception_type_coordinate is None or effect.occurrence_id is None:
+                resolution = NativeOperationResolutionV1.undischarged(
+                    "native operation exception identity unproven"
+                )
+            else:
+                resolution = NativeOperationResolutionV1.exceptional(
+                    exception_type_coordinate=effect.exception_type_coordinate,
+                    operation_occurrence=self.demand.source_node,
+                )
+            exits = resolution.project(source_node=self.demand.source_node)
+        elif isinstance(projected, Complete):
+            exits = NativeOperationResolutionV1.completed(projected.value).project(
+                source_node=self.demand.source_node
+            )
+        elif isinstance(projected, Incomplete):
+            exits = NativeOperationResolutionV1.undischarged(projected.reason).project(
+                source_node=self.demand.source_node
+            )
+        elif isinstance(projected, ExitSet):
+            exits = projected
         else:
             # Other Outcome variants must pass through the exit algebra's loud
             # door.  In particular, never reinterpret an unresolved carrier as

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/__init__.py
@@ -9,6 +9,7 @@ from sugar_lift_py_tests.caller_parameter_contract import (
     ContractConditionalConstructionV1,
     NativeOperationDemandV1,
     NativeOperationExitCarrierV1,
+    NativeOperationResolutionV1,
     native_operator_demand,
 )
 
@@ -21,6 +22,7 @@ __all__ = [
     "Incomplete",
     "NativeOperationDemandV1",
     "NativeOperationExitCarrierV1",
+    "NativeOperationResolutionV1",
     "Outcome",
     "complete_value",
     "outcome_to_exitset",

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -4,6 +4,8 @@ import pytest
 
 from sugar_lift_py_tests.caller_parameter_contract import (
     NativeOperationExitCarrierV1,
+    NativeOperationResolutionV1,
+    source_coordinate,
 )
 from sugar_lift_py_tests.context_manager_contract import (
     AuthenticatedRaiseMatcher,
@@ -92,7 +94,9 @@ def test_same_native_operation_demand_can_halt_for_authenticated_actuals():
     assert len(exits.exits) == 1
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_name == "TypeError"
+    assert halted.effect.exception_name is None
+    assert halted.effect.exception_type_coordinate == _Expected("TypeError").identity
+    assert halted.effect.occurrence is not None
 
 
 def test_undischarged_native_operation_is_typed_loud_not_completed():
@@ -148,14 +152,19 @@ def test_lying_exception_type_is_rejected_without_inventing_identity():
             right.coordinate_cid: TermValue(2),
         }
     )
-    with pytest.raises(SugarNotWritten, match="no term to state the test over"):
-        exits.and_exit(
-            type(exits).completed(object()),
-            disposition=EffectBoundaryDisposition(
-                matcher=AuthenticatedRaiseMatcher(expected=_Expected("ValueError")),
-                unmet=ExpectationNotMetEffect("raise", "assertion-site"),
-            ),
-        )
+    routed = exits.and_exit(
+        type(exits).completed(object()),
+        disposition=EffectBoundaryDisposition(
+            matcher=AuthenticatedRaiseMatcher(expected=_Expected("ValueError")),
+            unmet=ExpectationNotMetEffect("raise", "assertion-site"),
+        ),
+    )
+    assert len(routed.exits) == 1
+    assert isinstance(routed.exits[0], Halted)
+    assert (
+        routed.exits[0].effect.exception_type_coordinate
+        != _Expected("ValueError").identity
+    )
 
 
 def test_identity_operation_never_acquires_a_fabricated_exceptional_edge():
@@ -170,3 +179,42 @@ def test_identity_operation_never_acquires_a_fabricated_exceptional_edge():
 
     assert len(exits.exits) == 1
     assert isinstance(exits.exits[0], Completed)
+
+
+def test_nameless_resolution_is_undischarged_and_cannot_project_a_halt():
+    resolution = NativeOperationResolutionV1.undischarged(
+        "native operation exception identity unproven"
+    )
+
+    assert resolution.kind == "undischarged"
+    assert not resolution.has_authenticated_exception_type
+    with pytest.raises(SugarNotWritten, match="identity unproven"):
+        resolution.project(source_node=_site())
+
+
+def test_same_named_exception_keeps_distinct_operation_origins():
+    source = _site()
+    exception_type = _Expected("TypeError").identity
+    origin = source_coordinate(source)
+    first = NativeOperationResolutionV1.exceptional(
+        exception_type_coordinate=exception_type,
+        operation_occurrence=origin,
+    )
+    second = NativeOperationResolutionV1.exceptional(
+        exception_type_coordinate=exception_type,
+        operation_occurrence=type(origin)(
+            origin.source_cid,
+            origin.start_line + 1,
+            origin.start_col,
+            origin.end_line + 1,
+            origin.end_col,
+        ),
+    )
+
+    first_exit = first.project(source_node=source).exits[0]
+    second_exit = second.project(source_node=source).exits[0]
+    assert isinstance(first_exit, Halted)
+    assert isinstance(second_exit, Halted)
+    assert first_exit.effect.exception_type_coordinate == exception_type
+    assert second_exit.effect.exception_type_coordinate == exception_type
+    assert first_exit.effect.occurrence != second_exit.effect.occurrence


### PR DESCRIPTION
## What changed

Strengthens the merged native-operation carrier with a closed three-way discharge schema:

- `Completed(value)`
- `Exceptional(exception_type_coordinate, raise_occurrence_coordinate)`
- `Undischarged(reason)`

Exceptional projection now emits a `Halted` face only with authenticated exception-type and operation-occurrence coordinates. The `RaiseEffect` carries no string-only exception identity. Nameless or identity-unproven outcomes remain typed-loud and cannot reach the authenticated exceptional column.

## Boundary consequence

`EffectBoundaryWith` continues to consume only matching halted edges. Because exceptional projection now carries the authenticated type coordinate, a wrong expected type remains halted and cannot be consumed; a nameless halt cannot satisfy the matcher at all.

## Assumption

`RaiseEffect` currently stores occurrence testimony in its existing `occurrence` field. The typed `SourceFragmentCoordinateV1` is retained by the resolution and serialized losslessly into that field for the existing effect API. No exception name is consulted.

## Validation

Authenticated CPython 3.12.13 / NumPy 2.5.1 / pandas 3.0.3 focused suites: 63 passed.

New teeth cover:

1. nameless resolution is `Undischarged` and cannot project a halted exit;
2. same authenticated exception type with distinct operation origins retains distinct origins.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make native operation resolution three-way with completed, exceptional, and undischarged kinds
> - Introduces `NativeOperationResolutionV1` in [`caller_parameter_contract.py`](https://github.com/TSavo/sugar/pull/6583/files#diff-5136726cb5a60b48beb30152aecb6eca8ad0173bdefc676eb112b1c1b2acbf57) with three resolution kinds: `completed`, `exceptional`, and `undischarged`.
> - `exceptional` resolutions require an authenticated `exception_type_coordinate` and `raise_occurrence_coordinate`; `undischarged` resolutions raise `SugarNotWritten` when projected.
> - Updates `NativeOperationExitCarrierV1.discharge` to emit halted exits only when exception identity is fully authenticated; incomplete identity now produces an undischarged resolution that raises `SugarNotWritten` instead of a fabricated halt.
> - Re-exports `NativeOperationResolutionV1` from the `outcome` package and updates tests to expect `exception_name=None` and a non-None `exception_type_coordinate` on halted effects.
> - Behavioral Change: raised outcomes with missing exception identity no longer produce a halt — they raise `SugarNotWritten` during projection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0751459.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->