### PR TITLE
Defer formal comparisons to caller discharge

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -157,6 +157,31 @@ def construct_identity_comparison(left, right, site, *, negated: bool = False):
     return outcome.and_then(lambda predicate: predicate.negate())
 
 
+def defer_formal_native_operation(left, right, site, *, operator: str):
+    """Preserve one formal-bound native operation for caller discharge.
+
+    A formal's runtime type is supplied outside this frame.  Constructing an
+    immediate normal or exceptional face here would therefore invent caller
+    testimony.  The shared carrier records the ordered Floor operation and
+    lets authenticated actual operands select its real ExitSet later.
+    """
+    left_coordinate = getattr(left, "formal_coordinate", None)
+    right_coordinate = getattr(right, "formal_coordinate", None)
+    if left_coordinate is None and right_coordinate is None:
+        return None
+
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+
+    return NativeOperationExitCarrierV1.mint(
+        site=site,
+        operator=operator,
+        operands=(left, right),
+        coordinates=(left_coordinate, right_coordinate),
+    )
+
+
 def _publish_undecided_dispatch_edges(
     left,
     right,
@@ -263,6 +288,11 @@ class ComparisonOpSugar(Sugar):
 
     def _membership(self, container, item):
         """Membership law: container owns containment; undecided dispatch dual-edges."""
+        deferred = defer_formal_native_operation(
+            container, item, self.site, operator="contains"
+        )
+        if deferred is not None:
+            return deferred
         outcome = container.contains(item, self.site)
         return publish_undecided_membership_edges(
             item, container, self.site, self.op_kind, outcome
@@ -271,6 +301,11 @@ class ComparisonOpSugar(Sugar):
     def _ordering(self, left, right):
         """Ordering law: left owns the rich method; undecided dispatch dual-edges."""
         method = COMPARE_METHODS[self.op_kind]
+        deferred = defer_formal_native_operation(
+            left, right, self.site, operator=method
+        )
+        if deferred is not None:
+            return deferred
         return publish_undecided_ordering_edges(
             left,
             right,
@@ -282,6 +317,11 @@ class ComparisonOpSugar(Sugar):
     def _apply(self, left, right):
         if self.op_kind == "NotEq":
             # Equality law: a != b is not (a == b); dual-edge then negate.
+            deferred = defer_formal_native_operation(
+                left, right, self.site, operator="equals"
+            )
+            if deferred is not None:
+                return deferred.and_then(lambda predicate: predicate.negate())
             return publish_undecided_equality_edges(
                 left,
                 right,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field as dataclass_field
+from dataclasses import dataclass, field as dataclass_field, replace
 
 from sugar_lift_py_tests.outcome import Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
@@ -99,8 +99,13 @@ def _equals_and_refine(left, right, site, ctx, left_coordinate):
 
 def _equals_with_derived_residue(left, right, site, ctx):
     from sugar_lift_py_tests.sugar.comparison_op_sugar import (
+        defer_formal_native_operation,
         publish_undecided_equality_edges,
     )
+
+    deferred = defer_formal_native_operation(left, right, site, operator="equals")
+    if deferred is not None:
+        return deferred
 
     outcome = left.equals(right, site)
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -12,8 +12,9 @@ import pytest
 
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
-from sugar_lift_py_tests.floor import CallSiteValue, SymbolicValue, TermValue
-from sugar_lift_py_tests.ir import ctor, make_var
+from sugar_lift_py_tests.floor import CallSiteValue, NoneValue, SymbolicValue, TermValue
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
 from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
@@ -101,6 +102,32 @@ def _synthetic_compare(expression: str) -> Compare:
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
     )
     return next(node for node in tree.nodes() if isinstance(node, Compare))
+
+
+def _formal_coordinate(
+    node: Compare, name: str, ordinal: int
+) -> FormalParameterCoordinateV1:
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+
+    span = node.fragment.line_col_span
+    owner = SourceFragmentCoordinateV1(
+        node.fragment.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    return FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=node.fragment.source_cid,
+        owner_definition_locus=owner,
+        declaration_locus=owner,
+        ordinal=ordinal,
+        parameter_kind="positional-or-keyword",
+        declared_name=name,
+        sort=PrimitiveSort("Value"),
+    )
 
 
 def _assert_dual_dispatch(outcome, *, atom: str, blame: str) -> None:
@@ -356,6 +383,185 @@ def test_membership_law_routes_through_authenticated_contains(
         node.fragment,
     ).desugar(None)
     _assert_dual_dispatch(outcome, atom="py.in", blame=str(node.fragment))
+
+
+def test_formal_ordering_survives_until_authenticated_caller_discharge() -> None:
+    """One ordered operation may honestly complete or halt at its callers."""
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+
+    node = _synthetic_compare("left < container")
+    left_coordinate = _formal_coordinate(node, "left", 0)
+    right_coordinate = _formal_coordinate(node, "container", 1)
+    carrier = ComparisonOpSugar(
+        "Lt",
+        _ValueSugar(SymbolicValue(make_var("left"), left_coordinate)),
+        _ValueSugar(SymbolicValue(make_var("container"), right_coordinate)),
+        node.fragment,
+    ).desugar(None)
+
+    assert isinstance(carrier, NativeOperationExitCarrierV1)
+    assert carrier.demand.operator == "less_than"
+    assert carrier.demand.operand_coordinate_cids == (
+        left_coordinate.coordinate_cid,
+        right_coordinate.coordinate_cid,
+    )
+
+    completed = carrier.discharge(
+        {
+            left_coordinate.coordinate_cid: TermValue(1),
+            right_coordinate.coordinate_cid: TermValue(2),
+        }
+    )
+    halted = carrier.discharge(
+        {
+            left_coordinate.coordinate_cid: NoneValue(),
+            right_coordinate.coordinate_cid: TermValue(2),
+        }
+    )
+    assert len(completed.exits) == 1
+    assert isinstance(completed.exits[0], Completed)
+    assert len(halted.exits) == 1
+    assert isinstance(halted.exits[0], Halted)
+    assert halted.exits[0].effect.exception_name == "TypeError"
+
+
+def test_formal_ordering_rejects_a_lying_exception_identity() -> None:
+    """A ValueError boundary cannot consume an authenticated TypeError halt."""
+    from sugar_lift_py_tests.context_manager_contract import (
+        AuthenticatedRaiseMatcher,
+        EffectBoundaryDisposition,
+    )
+    from sugar_lift_py_tests.effect.expectation_not_met_effect import (
+        ExpectationNotMetEffect,
+    )
+    from sugar_lift_py_tests.outcome import ExitSet
+    from sugar_lift_py_tests.outcome.exit_set import Halted
+    from sugar_lift_py_tests.ir import str_const
+
+    class _ExpectedValueError:
+        identity = ctor(
+            "python:exception_type_identity",
+            [str_const("builtins"), str_const("ValueError")],
+        )
+
+        def exception_type_identity(self):
+            return self.identity
+
+    node = _synthetic_compare("left < container")
+    left_coordinate = _formal_coordinate(node, "left", 0)
+    carrier = ComparisonOpSugar(
+        "Lt",
+        _ValueSugar(SymbolicValue(make_var("left"), left_coordinate)),
+        _ValueSugar(TermValue(2)),
+        node.fragment,
+    ).desugar(None)
+    exits = carrier.discharge({left_coordinate.coordinate_cid: NoneValue()})
+    projected = exits.and_exit(
+        ExitSet.completed(object()),
+        disposition=EffectBoundaryDisposition(
+            matcher=AuthenticatedRaiseMatcher(expected=_ExpectedValueError()),
+            unmet=ExpectationNotMetEffect("raise", "assertion-site"),
+        ),
+    )
+
+    assert len(projected.exits) == 1
+    assert isinstance(projected.exits[0], Halted)
+    assert projected.exits[0].effect.exception_name == "TypeError"
+
+
+def test_formal_membership_records_authenticated_contains_receiver_order() -> None:
+    """``item in container`` defers ``container.contains(item)`` in that order."""
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+
+    node = _synthetic_compare("left in container")
+    item_coordinate = _formal_coordinate(node, "left", 0)
+    container_coordinate = _formal_coordinate(node, "container", 1)
+    carrier = ComparisonOpSugar(
+        "In",
+        _ValueSugar(SymbolicValue(make_var("left"), item_coordinate)),
+        _ValueSugar(SymbolicValue(make_var("container"), container_coordinate)),
+        node.fragment,
+    ).desugar(None)
+
+    assert isinstance(carrier, NativeOperationExitCarrierV1)
+    assert carrier.demand.operator == "contains"
+    assert carrier.demand.operand_coordinate_cids == (
+        container_coordinate.coordinate_cid,
+        item_coordinate.coordinate_cid,
+    )
+
+
+def test_formal_equality_keeps_py_eq_solver_work_until_discharge() -> None:
+    """A formal equality is deferred; its authenticated ground result completes."""
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+    from sugar_lift_py_tests.outcome.exit_set import Completed
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+
+    node = _synthetic_compare("left == 2")
+    left_coordinate = _formal_coordinate(node, "left", 0)
+    carrier = EqualityOpSugar(
+        _ValueSugar(SymbolicValue(make_var("left"), left_coordinate)),
+        _ValueSugar(TermValue(2)),
+        node.fragment,
+    ).desugar(None)
+
+    assert isinstance(carrier, NativeOperationExitCarrierV1)
+    assert carrier.demand.operator == "equals"
+    exits = carrier.discharge({left_coordinate.coordinate_cid: TermValue(1)})
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Completed)
+    assert isinstance(exits.exits[0].value, FalseBoolLiteralSugar)
+
+
+def test_formal_ordering_keeps_swapped_operand_coordinates_distinct() -> None:
+    node = _synthetic_compare("left < container")
+    left_coordinate = _formal_coordinate(node, "left", 0)
+    right_coordinate = _formal_coordinate(node, "container", 1)
+    left = SymbolicValue(make_var("left"), left_coordinate)
+    right = SymbolicValue(make_var("container"), right_coordinate)
+
+    forward = ComparisonOpSugar(
+        "Lt", _ValueSugar(left), _ValueSugar(right), node.fragment
+    ).desugar(None)
+    swapped = ComparisonOpSugar(
+        "Lt", _ValueSugar(right), _ValueSugar(left), node.fragment
+    ).desugar(None)
+
+    assert forward.demand.operand_coordinate_cids == (
+        left_coordinate.coordinate_cid,
+        right_coordinate.coordinate_cid,
+    )
+    assert swapped.demand.operand_coordinate_cids == (
+        right_coordinate.coordinate_cid,
+        left_coordinate.coordinate_cid,
+    )
+    assert forward.demand.demand_cid != swapped.demand.demand_cid
+
+
+def test_formal_identity_remains_total_without_a_native_operation_carrier() -> None:
+    """A formal binding does not make ``is`` acquire a fabricated raise face."""
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+
+    node = _synthetic_compare("left is container")
+    left_coordinate = _formal_coordinate(node, "left", 0)
+    outcome = ComparisonOpSugar(
+        "Is",
+        _ValueSugar(SymbolicValue(make_var("left"), left_coordinate)),
+        _ValueSugar(SymbolicValue(make_var("container"))),
+        node.fragment,
+    ).desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert not isinstance(outcome, NativeOperationExitCarrierV1)
 
 
 def test_identity_never_gains_an_exceptional_dispatch_edge() -> None:


### PR DESCRIPTION
## What changed

- preserve ordering, membership, and equality operations with formal-bound operands as `NativeOperationExitCarrierV1`
- record native receiver order (`container.contains(item)`) and retain negation as a deferred continuation
- keep identity comparison total and carrier-free
- add caller-pair twins for completed and halted discharge, swapped coordinates, equality completion, membership order, a lying exception identity, and identity non-raising
- restore the missing `dataclasses.replace` import in the equality refinement path

Assumption made under the standing ruling: any operand carrying `formal_coordinate` supplies enough source-visible testimony to defer that existing Floor operation to authenticated caller discharge. Non-formal undecided comparisons retain the landed five-law dual-edge/refusal behavior.

## Evidence

- red first: ordering and membership returned immediate symbolic `ExitSet` values instead of `NativeOperationExitCarrierV1` (2 failed, identity passed)
- mutation transaction: replacing the formal-carrier helper with `return None` made ordering, membership, and equality twins fail; revert restored the exact source hash and 5 focused twins passed
- CPython 3.12.13 focused Compare producer: `48 passed`
- focused producer-to-boundary slices: `14 passed`
- focused pyright for both touched sugar modules: `0 errors, 0 warnings`
- authenticated battleaxe no-call attribution, exit 0: Compare `181 = 161 authenticated exceptional exits + 20 named refusals + 0 construction panics`; full denominators remained 1,008

## Baseline issue observed

The unchanged shared carrier test `test_lying_exception_type_is_rejected_without_inventing_identity` expects `SugarNotWritten`, but current main preserves the unmatched authenticated `TypeError` halted edge instead. This PR does not touch the reserved carrier/ExitSet plumbing; its Compare-specific lying twin asserts that the `ValueError` boundary cannot consume that `TypeError` edge.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer formal comparison operations to caller discharge via `NativeOperationExitCarrierV1`
> - Adds `defer_formal_native_operation` helper in [comparison_op_sugar.py](https://github.com/TSavo/sugar/pull/6584/files#diff-e0df8a37726533db4efcdfaffdc4afc7190958f424ccaac6c06eb132f85de773) that detects formal-bound operands and returns a `NativeOperationExitCarrierV1` instead of evaluating immediately.
> - Applies deferral to membership (`in`), ordering (`<`, `<=`, `>`, `>=`), inequality (`!=`), and equality (`==`) — all in [comparison_op_sugar.py](https://github.com/TSavo/sugar/pull/6584/files#diff-e0df8a37726533db4efcdfaffdc4afc7190958f424ccaac6c06eb132f85de773) and [equality_op_sugar.py](https://github.com/TSavo/sugar/pull/6584/files#diff-e84076b87cd75964f4dd373e3c1424c63e64ad01c466910cf516b2f408a9ff38).
> - For `!=`, negation is applied after discharge via `carrier.and_then(lambda predicate: predicate.negate())`.
> - Identity (`is`) comparisons are intentionally excluded and remain fully evaluated.
> - Behavioral Change: comparisons involving formal-bound operands no longer publish undecided edges immediately; evaluation is deferred until authenticated discharge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e0c93a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->