### PR TITLE
Require named native operation exits in tallies

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -109,6 +109,11 @@ class NativeOperationResolutionV1:
     def is_exceptional(self) -> bool:
         return self._kind == "exceptional"
 
+    @property
+    def is_authenticated_exceptional_exit(self) -> bool:
+        """The only resolution arm admitted to an authenticated-exit tally."""
+        return self.has_authenticated_exception_type
+
     def project(self, *, source_node):
         """Project the closed resolution into an ExitSet or a typed refusal."""
         from sugar_lift_py_tests.effect import RaiseEffect
@@ -135,6 +140,12 @@ class NativeOperationResolutionV1:
             fix="retain the operation as undischarged until both coordinates are proven",
         )
 
+
+def authenticated_exceptional_resolution_count(resolutions) -> int:
+    """Count named exceptional resolutions by coordinates, never by arm kind."""
+    return sum(
+        resolution.is_authenticated_exceptional_exit for resolution in resolutions
+    )
 
 def _json(value) -> Any:
     return json.loads(encode_jcs(value))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/__init__.py
@@ -10,6 +10,7 @@ from sugar_lift_py_tests.caller_parameter_contract import (
     NativeOperationDemandV1,
     NativeOperationExitCarrierV1,
     NativeOperationResolutionV1,
+    authenticated_exceptional_resolution_count,
     native_operator_demand,
 )
 
@@ -23,6 +24,7 @@ __all__ = [
     "NativeOperationDemandV1",
     "NativeOperationExitCarrierV1",
     "NativeOperationResolutionV1",
+    "authenticated_exceptional_resolution_count",
     "Outcome",
     "complete_value",
     "outcome_to_exitset",

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -5,6 +5,7 @@ import pytest
 from sugar_lift_py_tests.caller_parameter_contract import (
     NativeOperationExitCarrierV1,
     NativeOperationResolutionV1,
+    authenticated_exceptional_resolution_count,
     source_coordinate,
 )
 from sugar_lift_py_tests.context_manager_contract import (
@@ -15,6 +16,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
+from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
     ExpectationNotMetEffect,
 )
@@ -22,7 +24,13 @@ from sugar_lift_py_tests.floor import NoneValue, SymbolicValue, TermValue
 from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var, str_const
-from sugar_lift_py_tests.outcome import Completed, Halted, outcome_to_exitset
+from sugar_lift_py_tests.outcome import (
+    Completed,
+    ExitSet,
+    Halted,
+    outcome_to_exitset,
+    true_guard,
+)
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
@@ -190,6 +198,39 @@ def test_nameless_resolution_is_undischarged_and_cannot_project_a_halt():
     assert not resolution.has_authenticated_exception_type
     with pytest.raises(SugarNotWritten, match="identity unproven"):
         resolution.project(source_node=_site())
+
+
+def test_only_coordinate_authenticated_resolutions_count_as_exceptional_exits():
+    source = _site()
+    named = NativeOperationResolutionV1.exceptional(
+        exception_type_coordinate=_Expected("TypeError").identity,
+        operation_occurrence=source_coordinate(source),
+    )
+    nameless = NativeOperationResolutionV1.undischarged("identity unproven")
+    completed = NativeOperationResolutionV1.completed(TermValue(1))
+
+    assert authenticated_exceptional_resolution_count((named, nameless, completed)) == 1
+    assert not nameless.is_authenticated_exceptional_exit
+
+
+def test_nameless_halt_stays_outside_matching_boundary_end_to_end():
+    body = ExitSet(
+        (
+            Halted(
+                true_guard(),
+                RaiseEffect(occurrence="operation-origin"),
+            ),
+        )
+    )
+
+    with pytest.raises(SugarNotWritten, match="no term to state the test over"):
+        body.and_exit(
+            ExitSet.completed(object()),
+            disposition=EffectBoundaryDisposition(
+                matcher=AuthenticatedRaiseMatcher(expected=_Expected("TypeError")),
+                unmet=ExpectationNotMetEffect("raise", "assertion-site"),
+            ),
+        )
 
 
 def test_same_named_exception_keeps_distinct_operation_origins():


### PR DESCRIPTION
## What changed

- add `NativeOperationResolutionV1.is_authenticated_exceptional_exit`
- add `authenticated_exceptional_resolution_count`, which admits only resolutions carrying both exception-type and operation-occurrence coordinates
- add an end-to-end nameless-halt boundary tooth: an unauthenticated halt remains outside the matching assertion boundary
- add the two requested named-origin and nameless-projection teeth

## Evidence

Authenticated CPython 3.12.13 / NumPy 2.5.1 focused suites: 65 passed.

Mutation transaction:

- permissive `Undischarged -> Halted` projection made the nameless projection test fail
- permissive nameless boundary consumption made the end-to-end boundary test fail
- both mutations were restored before commit

This proves the tally predicate is coordinate-based, not arm-kind-based, and that nameless halted faces cannot satisfy or be consumed by an expected-type boundary.

UnaryOp and BoolOp require no additional carrier shape: they can use the existing `NativeOperationExitCarrierV1` discharge/projection API. Their remaining zero-exit state is producer wiring, outside this PR.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require named native operation exits in authenticated-exit tallies
> - Adds `is_authenticated_exceptional_exit` property to `NativeOperationResolutionV1` in [caller_parameter_contract.py](https://github.com/TSavo/sugar/pull/6585/files#diff-5136726cb5a60b48beb30152aecb6eca8ad0173bdefc676eb112b1c1b2acbf57), which is true only when `has_authenticated_exception_type` is true.
> - Adds `authenticated_exceptional_resolution_count` helper that counts authenticated exceptional exits in a resolution iterable, re-exported from the `outcome` package.
> - Adds tests verifying that only coordinate-authenticated resolutions count as exceptional exits, and that a nameless (unauthenticated) halted `RaiseEffect` raises `SugarNotWritten` when an effect boundary is enforced.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7de182d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->