### PR TITLE
Render authenticated exit coordinates

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -79,6 +79,7 @@ class BodyAttribution:
     family: ProducerFamily | str
     outcome: AttributionOutcome
     detail: str
+    exceptional_exit_coordinates: tuple[tuple[object | None, object | None], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -86,6 +87,12 @@ class AttributionDiscrepancy:
     body_id: str
     family: ProducerFamily | str
     detail: str
+
+
+@dataclass(frozen=True)
+class ExceptionalExitIdentityDiscrepancy:
+    body_id: str
+    missing: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -101,6 +108,14 @@ class FamilyAttribution:
         """Only the hard construction-panic axis is a harness failure."""
         return self.construction_panics
 
+    @property
+    def outcome_total(self) -> int:
+        return (
+            self.authenticated_exceptional_exits
+            + self.named_refusals
+            + self.construction_panics
+        )
+
 
 @dataclass(frozen=True)
 class AttributionOutcomeSummary:
@@ -114,6 +129,9 @@ class AttributionOutcomeSummary:
 class AttributionReport:
     bodies: tuple[BodyAttribution, ...]
     discrepancies: tuple[AttributionDiscrepancy, ...]
+    exceptional_exit_identity_discrepancies: tuple[
+        ExceptionalExitIdentityDiscrepancy, ...
+    ]
     by_family: Mapping[ProducerFamily, FamilyAttribution]
 
     def rows(self) -> tuple[FamilyAttribution, ...]:
@@ -134,7 +152,11 @@ class AttributionReport:
 
     @property
     def loud_failure_count(self) -> int:
-        return self.construction_panic_count + len(self.discrepancies)
+        return (
+            self.construction_panic_count
+            + len(self.discrepancies)
+            + len(self.exceptional_exit_identity_discrepancies)
+        )
 
     def render(self) -> str:
         lines = []
@@ -150,8 +172,25 @@ class AttributionReport:
                     )
                 )
             )
+            if row.outcome_total != row.enrolled:
+                lines.append(
+                    "FAMILY OUTCOME DISCREPANCY "
+                    f"family={row.family.value} enrolled={row.enrolled} "
+                    f"threeOutcomeTotal={row.outcome_total} "
+                    f"unaccounted={row.enrolled - row.outcome_total}"
+                )
         for body in self.bodies:
-            if body.outcome is AttributionOutcome.NAMED_REFUSAL:
+            if body.outcome is AttributionOutcome.AUTHENTICATED_EXIT:
+                for (
+                    exception_type_coordinate,
+                    raise_occurrence,
+                ) in body.exceptional_exit_coordinates:
+                    lines.append(
+                        f"authenticatedExceptionalExit body={body.body_id} "
+                        f"exceptionTypeCoordinate={exception_type_coordinate!r} "
+                        f"raiseOccurrence={raise_occurrence}"
+                    )
+            elif body.outcome is AttributionOutcome.NAMED_REFUSAL:
                 lines.append(
                     f"namedRefusal body={body.body_id} coordinate={body.detail}"
                 )
@@ -161,6 +200,11 @@ class AttributionReport:
                     f"node={getattr(body.family, 'value', body.family)} "
                     f"owner={body.detail}"
                 )
+        for discrepancy in self.exceptional_exit_identity_discrepancies:
+            lines.append(
+                f"NAMELESS HALTED FACE body={discrepancy.body_id} "
+                f"missing={','.join(discrepancy.missing)}"
+            )
         for discrepancy in self.discrepancies:
             lines.append(
                 f"unaccounted body={discrepancy.body_id} "
@@ -239,6 +283,10 @@ def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
             probe.family,
             AttributionOutcome.AUTHENTICATED_EXIT,
             detail,
+            tuple(
+                (effect.exception_type_coordinate, effect.occurrence_id)
+                for effect in exceptional_effects
+            ),
         )
     raise AttributionInvariantError(
         f"{probe.body_id} "
@@ -272,9 +320,27 @@ def attribute_body_probes(probes: Iterable[BodyProbe]) -> AttributionReport:
     materialized = tuple(probes)
     bodies = []
     discrepancies = []
+    identity_discrepancies = []
     for probe in materialized:
         try:
-            bodies.append(attribute_body_probe(probe))
+            body = attribute_body_probe(probe)
+            bodies.append(body)
+            for (
+                exception_type_coordinate,
+                raise_occurrence,
+            ) in body.exceptional_exit_coordinates:
+                missing = tuple(
+                    name
+                    for name, coordinate in (
+                        ("exceptionTypeCoordinate", exception_type_coordinate),
+                        ("raiseOccurrence", raise_occurrence),
+                    )
+                    if coordinate is None
+                )
+                if missing:
+                    identity_discrepancies.append(
+                        ExceptionalExitIdentityDiscrepancy(body.body_id, missing)
+                    )
         except AttributionInvariantError as error:
             discrepancies.append(
                 AttributionDiscrepancy(probe.body_id, probe.family, str(error))
@@ -301,6 +367,7 @@ def attribute_body_probes(probes: Iterable[BodyProbe]) -> AttributionReport:
     return AttributionReport(
         bodies=attributed,
         discrepancies=tuple(discrepancies),
+        exceptional_exit_identity_discrepancies=tuple(identity_discrepancies),
         by_family=rows,
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -4,6 +4,7 @@ import pytest
 
 from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.floor import RaiseValue
+from sugar_lift_py_tests.ir import str_const
 from sugar_lift_py_tests.no_call_body_attribution import (
     CANONICAL_CORPUS_MANIFEST_CID,
     FAMILY_DENOMINATORS,
@@ -33,13 +34,28 @@ def _probe(family: ProducerFamily, evaluator) -> BodyProbe:
 
 
 def _raise_value():
-    return Complete(RaiseValue(RaiseEffect(exception_name="TypeError")))
+    return Complete(
+        RaiseValue(
+            RaiseEffect(
+                exception_type_coordinate=str_const("TypeError"),
+                occurrence="pandas/example.py:1:4",
+            )
+        )
+    )
+
+
+def _nameless_raise_value():
+    return Complete(RaiseValue(RaiseEffect()))
 
 
 def _call_owned_raise_value():
     return Complete(
         RaiseValue(
-            RaiseEffect(exception_name="TypeError", producer_node_owner="Call")
+            RaiseEffect(
+                exception_type_coordinate=str_const("TypeError"),
+                occurrence="pandas/example.py:1:4",
+                producer_node_owner="Call",
+            )
         )
     )
 
@@ -74,6 +90,36 @@ def test_truthful_authenticated_body_is_counted_as_an_exceptional_exit() -> None
     assert row.named_refusals == 0
     assert row.construction_panics == 0
     assert report.bodies[0].outcome is AttributionOutcome.AUTHENTICATED_EXIT
+
+
+def test_authenticated_exit_ledger_projects_both_source_coordinates() -> None:
+    report = attribute_body_probes((_probe(ProducerFamily.SUBSCRIPT, _raise_value),))
+
+    assert (
+        "authenticatedExceptionalExit body=pandas/example.py:1:Subscript "
+        f"exceptionTypeCoordinate={str_const('TypeError')!r} "
+        "raiseOccurrence=pandas/example.py:1:4"
+    ) in report.render()
+
+
+def test_nameless_halted_face_stays_loud_in_the_exit_ledger() -> None:
+    """Lying twin: a Halted face cannot borrow authenticated identity."""
+    report = attribute_body_probes(
+        (_probe(ProducerFamily.SUBSCRIPT, _nameless_raise_value),)
+    )
+
+    assert (
+        report.by_family[ProducerFamily.SUBSCRIPT].authenticated_exceptional_exits == 1
+    )
+    assert report.loud_failure_count == 1
+    assert (
+        "authenticatedExceptionalExit body=pandas/example.py:1:Subscript "
+        "exceptionTypeCoordinate=None raiseOccurrence=None"
+    ) in report.render()
+    assert (
+        "NAMELESS HALTED FACE body=pandas/example.py:1:Subscript "
+        "missing=exceptionTypeCoordinate,raiseOccurrence"
+    ) in report.render()
 
 
 def test_declared_typed_gap_is_a_named_refusal_not_a_failure() -> None:
@@ -169,6 +215,10 @@ def test_silent_completion_stays_a_separate_loud_discrepancy() -> None:
         in report.render()
     )
     assert (
+        "FAMILY OUTCOME DISCREPANCY family=BoolOp enrolled=1 "
+        "threeOutcomeTotal=0 unaccounted=1" in report.render()
+    )
+    assert (
         "OUTCOME TOTAL DISCREPANCY enrolled=1 threeOutcomeTotal=0 unaccounted=1"
         in report.render()
     )
@@ -186,7 +236,9 @@ def test_construction_panics_are_rendered_with_site_and_failing_node_owner() -> 
     assert report.construction_panic_count == 1
 
 
-def test_join_collects_construction_panic_and_outcome_discrepancy_before_failing() -> None:
+def test_join_collects_construction_panic_and_outcome_discrepancy_before_failing() -> (
+    None
+):
     """#6540 + #6541: both loud axes survive one report transaction."""
     report = attribute_body_probes(
         (


### PR DESCRIPTION
## What changed

- render one `authenticatedExceptionalExit` ledger row for every projected halted effect, carrying both the exception-type coordinate and raise-occurrence coordinate
- keep a nameless halted face in the existing exit tally while making its missing identity a separate loud discrepancy
- render per-family outcome conservation discrepancies alongside the existing corpus-wide discrepancy

## Why

The 1,008-body receipt counted 503 authenticated exceptional exits but emitted no exit ledger rows. That asymmetry hid whether each counted exit carried source-authenticated type and occurrence testimony. This change reports the existing testimony without changing producer or consumer semantics.

## Validation

Exact local authority: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0.

- `PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-lift-python-source/src .venv-py312/bin/python -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py` — 19 passed
- `.venv-py312/bin/python -m black --check .../no_call_body_attribution.py .../test_no_call_body_attribution.py` — clean
- mutation transaction: clean 19 passed; removing identity-discrepancy collection made the nameless lying twin fail; restoring it returned 19 passed

No semantic producer, boundary-consumer, ExitSet, outcome, or generator-construction code changed. The authenticated 1,008-body measurement remains a follow-up after the Battleaxe pyarrow closure is republished.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render authenticated exit coordinates in body attribution reports
> - `BodyAttribution` now stores `exceptional_exit_coordinates` — a tuple of `(exception_type_coordinate, raise_occurrence)` pairs — for bodies with authenticated exceptional exits.
> - `AttributionReport.render()` emits `authenticatedExceptionalExit` lines with `exceptionTypeCoordinate` and `raiseOccurrence` for each coordinate, and a `FAMILY OUTCOME DISCREPANCY` line when a family's enrolled count differs from `outcome_total`.
> - A new `ExceptionalExitIdentityDiscrepancy` type is recorded when an authenticated exit is missing identity fields; these are surfaced as `NAMELESS HALTED FACE` lines and counted in `loud_failure_count`.
> - `FamilyAttribution` gains an `outcome_total` property summing authenticated exceptional exits, named refusals, and construction panics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13c71be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->