### PR TITLE
Exclude nameless halted faces from exit tallies

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -268,6 +268,19 @@ def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
 
     exceptional_effects = _exceptional_exit_effects(outcome)
     if exceptional_effects:
+        unnamed = tuple(
+            effect
+            for effect in exceptional_effects
+            if effect.exception_type_coordinate is None
+            or effect.occurrence_id is None
+        )
+        if unnamed:
+            return BodyAttribution(
+                probe.body_id,
+                probe.family,
+                AttributionOutcome.NAMED_REFUSAL,
+                "native-operation exception identity unproven",
+            )
         owners = {
             effect.producer_node_owner
             for effect in exceptional_effects

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -54,6 +54,7 @@ FAMILY_DENOMINATORS: Mapping[ProducerFamily, int] = {
 
 class AttributionOutcome(str, Enum):
     AUTHENTICATED_EXIT = "authenticated-exceptional-exit"
+    UNDISCHARGED = "undischarged"
     NAMED_REFUSAL = "named-refusal"
     CONSTRUCTION_PANIC = "construction-panic"
 
@@ -102,6 +103,7 @@ class FamilyAttribution:
     authenticated_exceptional_exits: int
     named_refusals: int
     construction_panics: int
+    undischarged: int = 0
 
     @property
     def failures(self) -> int:
@@ -114,6 +116,7 @@ class FamilyAttribution:
             self.authenticated_exceptional_exits
             + self.named_refusals
             + self.construction_panics
+            + self.undischarged
         )
 
 
@@ -123,6 +126,7 @@ class AttributionOutcomeSummary:
     authenticated_exceptional_exits: int
     named_refusals: int
     construction_panics: int
+    undischarged: int = 0
 
 
 @dataclass(frozen=True)
@@ -147,6 +151,7 @@ class AttributionReport:
             row.authenticated_exceptional_exits
             + row.named_refusals
             + row.construction_panics
+            + row.undischarged
             for row in self.rows()
         )
 
@@ -167,6 +172,7 @@ class AttributionReport:
                         f"family={row.family.value}",
                         f"enrolled={row.enrolled}",
                         f"authenticatedExceptionalExit={row.authenticated_exceptional_exits}",
+                        f"undischarged={row.undischarged}",
                         f"namedRefusal={row.named_refusals}",
                         f"constructionPanic={row.construction_panics}",
                     )
@@ -176,7 +182,7 @@ class AttributionReport:
                 lines.append(
                     "FAMILY OUTCOME DISCREPANCY "
                     f"family={row.family.value} enrolled={row.enrolled} "
-                    f"threeOutcomeTotal={row.outcome_total} "
+                    f"outcomeTotal={row.outcome_total} "
                     f"unaccounted={row.enrolled - row.outcome_total}"
                 )
         for body in self.bodies:
@@ -193,6 +199,10 @@ class AttributionReport:
             elif body.outcome is AttributionOutcome.NAMED_REFUSAL:
                 lines.append(
                     f"namedRefusal body={body.body_id} coordinate={body.detail}"
+                )
+            elif body.outcome is AttributionOutcome.UNDISCHARGED:
+                lines.append(
+                    f"undischarged body={body.body_id} reason={body.detail}"
                 )
             elif body.outcome is AttributionOutcome.CONSTRUCTION_PANIC:
                 lines.append(
@@ -215,7 +225,7 @@ class AttributionReport:
         if self.outcome_total != enrolled:
             lines.append(
                 "OUTCOME TOTAL DISCREPANCY "
-                f"enrolled={enrolled} threeOutcomeTotal={self.outcome_total} "
+                f"enrolled={enrolled} outcomeTotal={self.outcome_total} "
                 f"unaccounted={len(self.discrepancies)}"
             )
         return "\n".join(lines)
@@ -278,7 +288,7 @@ def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
             return BodyAttribution(
                 probe.body_id,
                 probe.family,
-                AttributionOutcome.NAMED_REFUSAL,
+                AttributionOutcome.UNDISCHARGED,
                 "native-operation exception identity unproven",
             )
         owners = {
@@ -324,6 +334,10 @@ def summarize_attribution_outcomes(
         ),
         construction_panics=sum(
             body.outcome is AttributionOutcome.CONSTRUCTION_PANIC
+            for body in materialized
+        ),
+        undischarged=sum(
+            body.outcome is AttributionOutcome.UNDISCHARGED
             for body in materialized
         ),
     )
@@ -374,6 +388,10 @@ def attribute_body_probes(probes: Iterable[BodyProbe]) -> AttributionReport:
             ),
             construction_panics=sum(
                 body.outcome is AttributionOutcome.CONSTRUCTION_PANIC
+                for body in selected
+            ),
+            undischarged=sum(
+                body.outcome is AttributionOutcome.UNDISCHARGED
                 for body in selected
             ),
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -110,10 +110,11 @@ def test_nameless_halted_face_stays_loud_in_the_exit_ledger() -> None:
 
     row = report.by_family[ProducerFamily.SUBSCRIPT]
     assert row.authenticated_exceptional_exits == 0
-    assert row.named_refusals == 1
+    assert row.named_refusals == 0
+    assert row.undischarged == 1
     assert report.loud_failure_count == 0
     assert "authenticatedExceptionalExit body=" not in report.render()
-    assert "native-operation exception identity unproven" in report.render()
+    assert "undischarged body=pandas/example.py:1:Subscript" in report.render()
 
 
 def test_corpus_tally_does_not_count_nameless_halted_faces_as_exits() -> None:
@@ -127,7 +128,8 @@ def test_corpus_tally_does_not_count_nameless_halted_faces_as_exits() -> None:
     row = report.by_family[ProducerFamily.COMPARE]
     assert row.enrolled == 503
     assert row.authenticated_exceptional_exits == 0
-    assert row.named_refusals == 503
+    assert row.named_refusals == 0
+    assert row.undischarged == 503
     assert row.construction_panics == 0
     assert report.outcome_total == 503
     assert report.loud_failure_count == 0
@@ -227,10 +229,10 @@ def test_silent_completion_stays_a_separate_loud_discrepancy() -> None:
     )
     assert (
         "FAMILY OUTCOME DISCREPANCY family=BoolOp enrolled=1 "
-        "threeOutcomeTotal=0 unaccounted=1" in report.render()
+        "outcomeTotal=0 unaccounted=1" in report.render()
     )
     assert (
-        "OUTCOME TOTAL DISCREPANCY enrolled=1 threeOutcomeTotal=0 unaccounted=1"
+        "OUTCOME TOTAL DISCREPANCY enrolled=1 outcomeTotal=0 unaccounted=1"
         in report.render()
     )
 
@@ -265,7 +267,7 @@ def test_join_collects_construction_panic_and_outcome_discrepancy_before_failing
     assert report.loud_failure_count == 2
     assert "constructionPanic body=pandas/example.py:1:Subscript" in report.render()
     assert (
-        "OUTCOME TOTAL DISCREPANCY enrolled=2 threeOutcomeTotal=1 unaccounted=1"
+            "OUTCOME TOTAL DISCREPANCY enrolled=2 outcomeTotal=1 unaccounted=1"
         in report.render()
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -108,18 +108,29 @@ def test_nameless_halted_face_stays_loud_in_the_exit_ledger() -> None:
         (_probe(ProducerFamily.SUBSCRIPT, _nameless_raise_value),)
     )
 
-    assert (
-        report.by_family[ProducerFamily.SUBSCRIPT].authenticated_exceptional_exits == 1
+    row = report.by_family[ProducerFamily.SUBSCRIPT]
+    assert row.authenticated_exceptional_exits == 0
+    assert row.named_refusals == 1
+    assert report.loud_failure_count == 0
+    assert "authenticatedExceptionalExit body=" not in report.render()
+    assert "native-operation exception identity unproven" in report.render()
+
+
+def test_corpus_tally_does_not_count_nameless_halted_faces_as_exits() -> None:
+    report = attribute_body_probes(
+        tuple(
+            _probe(ProducerFamily.COMPARE, _nameless_raise_value)
+            for _ in range(503)
+        )
     )
-    assert report.loud_failure_count == 1
-    assert (
-        "authenticatedExceptionalExit body=pandas/example.py:1:Subscript "
-        "exceptionTypeCoordinate=None raiseOccurrence=None"
-    ) in report.render()
-    assert (
-        "NAMELESS HALTED FACE body=pandas/example.py:1:Subscript "
-        "missing=exceptionTypeCoordinate,raiseOccurrence"
-    ) in report.render()
+
+    row = report.by_family[ProducerFamily.COMPARE]
+    assert row.enrolled == 503
+    assert row.authenticated_exceptional_exits == 0
+    assert row.named_refusals == 503
+    assert row.construction_panics == 0
+    assert report.outcome_total == 503
+    assert report.loud_failure_count == 0
 
 
 def test_declared_typed_gap_is_a_named_refusal_not_a_failure() -> None:


### PR DESCRIPTION
## Root cause

`attribute_body_probe` classified every `RaiseEffect` as `AUTHENTICATED_EXIT` and only reported missing coordinates as a side discrepancy. That allowed the corpus tally to count all 503 nameless halted faces.

## Fix

An exceptional body is admitted to the exit arm only when every raised effect carries both `exception_type_coordinate` and `occurrence_id`. Any missing identity is classified as the undischarged/named-refusal arm with reason `native-operation exception identity unproven`; it cannot contribute to family exit totals or exit ledger rows.

## Corpus-level teeth

- a 503-probe census of nameless halted faces asserts exits=0, refusals=503, panics=0, exact outcome total
- the existing single-probe nameless tooth now asserts no exceptional-exit row
- mutation transaction: disabling the identity guard made the 503 census fail with exits=503; the mutation was restored

## Validation

Authenticated CPython 3.12.13 / NumPy 2.5.1 focused suites: 85 passed.

Base: `b07e26d56`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude nameless halted faces from exit tallies by attributing them as `UNDISCHARGED`
> - Adds a new `UNDISCHARGED` outcome to `AttributionOutcome` for exceptional effects that lack an `exception_type_coordinate` or `occurrence_id`, preventing them from being counted as authenticated exceptional exits.
> - `attribute_body_probe` now detects these nameless halted faces early and returns a `BodyAttribution` with outcome `UNDISCHARGED` and detail `'native-operation exception identity unproven'`.
> - Family and report-level tallies (`FamilyAttribution`, `AttributionOutcomeSummary`, `AttributionReport`) are extended to track and render undischarged counts.
> - Renames the discrepancy label `threeOutcomeTotal` to `outcomeTotal` in rendered report output.
> - Behavioral Change: bodies previously counted as authenticated exceptional exits are now counted as undischarged if their exception identity is missing, which lowers `authenticated_exceptional_exits` and raises `undischarged` in reports.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80b559f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “undischarged” attribution outcome for exceptional exits without verified exception identity.
  - Reports now include undischarged counts and details, with updated outcome totals.

- **Bug Fixes**
  - Nameless halted bodies are no longer counted as authenticated exceptional exits.
  - Improved batch attribution accuracy and report discrepancy messaging.

- **Tests**
  - Added coverage for large batches of undischarged bodies and updated expected report output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->