### PR TITLE
Select PyArrow authenticated closure

### DIFF
--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -60,7 +60,7 @@ reference = "ghcr.io/tsavo/sugar-env@sha256:0cdfae5249ffbd4232f4675230b4e414bfe8
 [images."core,vampire"]
 reference = "ghcr.io/tsavo/sugar-env@sha256:d5a3076102ad9e57a0022f52de95f8047df448ba689b1d9afc96d519a35ebe86"
 [images."core,python-scientific,python-test,solver-z3"]
-reference = "ghcr.io/tsavo/sugar-env@sha256:f96731de7b4eb9a5660a6f8a14fc37f23ead4a0a9221667e9073ee0853070db3"
+reference = "ghcr.io/tsavo/sugar-env@sha256:da7ea2ff7359fd1d8590a84fece1f3ee98a576d0527ded196d24c27a4262c0f6"
 [images."core,java,node,python-scientific,python-test,solver-coq,solver-z3,vampire"]
 reference = "ghcr.io/tsavo/sugar-env@sha256:f3474a1e1badba67f3daaf5c589f2844da28a7be6beda929ca5f7f2e5d95785e"
 


### PR DESCRIPTION
## What changed

Select the published `core,python-scientific,python-test,solver-z3` closure that includes the exact PyArrow authority added by #6572.

## Authority receipt

Direct execution of the immutable digest on Battleaxe reported and asserted:

- CPython 3.12.13
- NumPy 2.5.1
- pandas 3.0.3
- PyArrow 22.0.0
- PyArrow load path `/usr/local/lib/python3.12/site-packages/pyarrow/__init__.py`
- exit 0

Digest: `sha256:da7ea2ff7359fd1d8590a84fece1f3ee98a576d0527ded196d24c27a4262c0f6`

This is intentionally separate from draft #6587 so authenticated consumers are not blocked on the unfinished Arrow mechanism.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update container image digest for PyArrow authenticated closure build
> Updates the container image digest in [sugar-build.toml](https://github.com/TSavo/sugar/pull/6589/files#diff-b714a26a105f372af4929844b95deb54b1e2701396f192e8761d975086b49835) for the `core,python-scientific,python-test,solver-z3` image group to `sha256:da7ea2ff...`. Builds targeting this group will now pull the new image version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d2a733e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->