### PR TITLE
Pin pandas BinOp caller discharge twins

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
@@ -1,0 +1,187 @@
+"""Corpus teeth for discharging a formal BinOp at a real pandas caller."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+
+import pandas as pd
+import pandas._testing as tm
+import pytest
+from pandas import Series, Timedelta
+
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+MANIFEST_CID = (
+    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
+    "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+)
+HELPER_PATH = "tests/arithmetic/common.py"
+CALLER_PATH = "tests/arithmetic/test_timedelta64.py"
+
+
+@dataclass(frozen=True)
+class _Pair:
+    helper: ast.FunctionDef
+    operation: ast.BinOp
+    caller: ast.FunctionDef
+    call: ast.Call
+
+
+def _function(tree: ast.Module, name: str) -> ast.FunctionDef:
+    matches = tuple(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _pair(
+    *, helper_source: str | None = None, caller_source: str | None = None
+) -> _Pair:
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.file_count, corpus.manifest_cid) == (
+        "3.0.3",
+        1421,
+        MANIFEST_CID,
+    )
+    helper_source = (
+        (corpus.root / HELPER_PATH).read_text(encoding="utf-8")
+        if helper_source is None
+        else helper_source
+    )
+    caller_source = (
+        (corpus.root / CALLER_PATH).read_text(encoding="utf-8")
+        if caller_source is None
+        else caller_source
+    )
+
+    helper = _function(ast.parse(helper_source), "assert_invalid_addsub_type")
+    operations = tuple(
+        node
+        for node in ast.walk(helper)
+        if isinstance(node, ast.BinOp)
+        and isinstance(node.left, ast.Name)
+        and isinstance(node.right, ast.Name)
+        and (node.left.id, node.right.id) == ("left", "right")
+        and isinstance(node.op, ast.Add)
+    )
+    assert len(operations) == 1
+    operation = operations[0]
+    assert operation.lineno == 55
+
+    caller_tree = ast.parse(caller_source)
+    imports = tuple(
+        node
+        for node in caller_tree.body
+        if isinstance(node, ast.ImportFrom)
+        and node.module == "pandas.tests.arithmetic.common"
+        and any(alias.name == "assert_invalid_addsub_type" for alias in node.names)
+    )
+    assert len(imports) == 1
+    assert imports[0].lineno == 31
+
+    caller = _function(caller_tree, "test_td64arr_addsub_numeric_scalar_invalid")
+    rendered_decorators = tuple(ast.unparse(item) for item in caller.decorator_list)
+    assert any(
+        "pytest.mark.parametrize('other', ['a', 1, 1.5, np.array(2)])" == item
+        for item in rendered_decorators
+    )
+    assignments = tuple(
+        ast.unparse(node)
+        for node in caller.body
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+    )
+    assert any(
+        "tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='m8[ns]')" == assignment
+        for assignment in assignments
+    )
+    calls = tuple(
+        node
+        for node in ast.walk(caller)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "assert_invalid_addsub_type"
+    )
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.lineno == 1172
+    assert tuple(ast.unparse(arg) for arg in call.args) == ("tdarr", "other")
+    return _Pair(helper, operation, caller, call)
+
+
+def _actuals():
+    """The concrete ``box_with_array=pd.array, other='a'`` caller arm."""
+    tdser = Series(["59 Days", "59 Days", "NaT"], dtype="m8[ns]")
+    return tm.box_expected(tdser, pd.array), "a"
+
+
+def test_helper_alone_has_only_formals_so_exception_identity_is_undischarged() -> None:
+    """The helper occurrence authenticates an operation, never caller actuals."""
+    pair = _pair()
+
+    assert ast.unparse(pair.operation) == "left + right"
+    assert tuple(argument.arg for argument in pair.helper.args.args[:2]) == (
+        "left",
+        "right",
+    )
+    assert all(
+        isinstance(operand, ast.Name)
+        for operand in (pair.operation.left, pair.operation.right)
+    )
+
+
+def test_real_caller_actuals_name_the_exception_from_the_operation() -> None:
+    """The actual operands, not pytest's expectation, establish TypeError."""
+    _pair()
+    left, right = _actuals()
+
+    with pytest.raises(TypeError) as raised:
+        left + right
+
+    assert type(raised.value) is TypeError
+    assert type(raised.value).__module__ == "builtins"
+    # The real helper consumes the same operation at the real caller arm.
+    from pandas.tests.arithmetic.common import assert_invalid_addsub_type
+
+    assert assert_invalid_addsub_type(left, right) is None
+
+
+def test_wrong_expected_type_does_not_consume_the_real_caller_exception() -> None:
+    """A ValueError boundary leaves the operation's TypeError outside it."""
+    _pair()
+    left, right = _actuals()
+
+    with pytest.raises(TypeError) as escaped:
+        with pytest.raises(ValueError):
+            left + right
+
+    assert type(escaped.value) is TypeError
+
+
+def test_same_operation_coordinate_completes_for_normal_actuals() -> None:
+    """Changing actuals changes discharge, not the helper's BinOp identity."""
+    pair = _pair()
+    left, _ = _actuals()
+
+    result = left + Timedelta("1D")
+
+    assert ast.unparse(pair.operation) == "left + right"
+    assert result.dtype == left.dtype
+    assert result[0] == Timedelta("60D")
+
+
+def test_lying_caller_coordinate_is_rejected_before_it_can_be_evidence() -> None:
+    """Mutation tooth: a nearby but different helper call is not this pair."""
+    corpus = authenticated_pandas_corpus()
+    caller = (corpus.root / CALLER_PATH).read_text(encoding="utf-8")
+    lying = caller.replace(
+        "assert_invalid_addsub_type(tdarr, other)",
+        "assert_invalid_addsub_type(other, tdarr)",
+        1,
+    )
+
+    with pytest.raises(AssertionError):
+        _pair(caller_source=lying)


### PR DESCRIPTION
## What

Pins one authenticated pandas 3.0.3 helper/caller pair for future BinOp caller discharge:

- helper `tests/arithmetic/common.py:40`, operation `left + right` at line 55
- import binding `tests/arithmetic/test_timedelta64.py:31-32`
- caller `test_td64arr_addsub_numeric_scalar_invalid` and call at line 1172
- concrete actual arm `box_with_array=pd.array, other="a"`

The teeth cover helper-only formal evidence, the real TypeError-producing caller actuals, a wrong ValueError boundary that does not consume TypeError, a completing actual pair at the same operation coordinate, and a reversed-argument mutation that the coordinate locator rejects.

## Why

The standalone no-call probe intentionally has no caller actuals and therefore cannot authenticate an exception identity. These tests provide corpus coordinates and runtime twins for the FunctionDef/formal-discharge seam without changing the carrier, ExitSet, tally, or substitution implementations. The exception identity is observed from the operation itself; the pytest expectation only verifies it.

## Validation

- CPython 3.12.13
- NumPy 2.5.1
- pandas 3.0.3
- pyarrow 22.0.0
- canonical 1,421-file manifest `blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530`
- `.venv-py312/bin/python -m pytest implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py -q` (13 passed)
- `.venv-py312/bin/python -m black --check implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin pandas BinOp caller discharge twins with AST-based corpus tests
> Adds a new test module [test_pandas_binary_caller_twins.py](https://github.com/TSavo/sugar/pull/6590/files#diff-2464628a40be2139d8a6abd5a557571ada8c5fe3e139c3c6b694b71b5ead2c96) that authenticates the structure of the pandas `assert_invalid_addsub_type` helper and its caller `test_td64arr_addsub_numeric_scalar_invalid` using AST inspection.
>
> - Walks the authenticated pandas corpus to locate the helper BinOp (`left + right`) and the call site in the caller, asserting their shape and argument order.
> - Runs concrete operand tests confirming the operation raises `TypeError`, that the helper consumes it returning `None`, and that valid Timedelta operands succeed with expected dtype/value.
> - Includes a mutation test that swaps call argument order and expects `_pair` to reject the forged caller via `AssertionError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b45ffe3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->