### PR TITLE
Project formal native operations at source calls

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -1261,6 +1261,12 @@ class CallSiteValue(FloorValue):
 
             return Complete(self)
 
+        outcome = self.reduce_source_outcome(ctx)
+        return self.project_producer_outcome(outcome)
+
+    def project_producer_outcome(self, outcome):
+        """Project a source-authenticated callee outcome onto this Call node."""
+
         from dataclasses import replace
 
         from sugar_lift_py_tests.effect import RaiseEffect
@@ -1272,7 +1278,6 @@ class CallSiteValue(FloorValue):
                 return replace(effect, producer_node_owner="Call")
             return effect
 
-        outcome = self.reduce_source_outcome(ctx)
         if isinstance(outcome, Complete):
             return Complete(self)
         exits = outcome_to_exitset(outcome)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -40,6 +40,8 @@ class CallSiteSugar(Sugar):
     exception_type_coordinate: Any = dataclass_field(default=None, compare=False)
     exception_type_mro: tuple | None = dataclass_field(default=None, compare=False)
     source_call_frame: Any = dataclass_field(default=None, compare=False)
+    formal_function_sugar: Any = dataclass_field(default=None, compare=False)
+    formal_coordinate_cids: tuple[str, ...] = dataclass_field(default=(), compare=False)
 
     @classmethod
     def witnesses(cls):
@@ -212,6 +214,25 @@ class CallSiteSugar(Sugar):
                 else ()
             ),
         )
+        if self.formal_function_sugar is not None:
+            if len(self.formal_coordinate_cids) != len(positional):
+                from sugar_source_tree.panic import SugarNotWritten
+
+                raise SugarNotWritten(
+                    owner="CallSiteSugar.desugar",
+                    blame=self.site,
+                    observed="formal projection arity mismatch",
+                    requested="one authenticated caller actual per formal coordinate",
+                    fix="bind the exact source signature or keep the call loud",
+                )
+            pending = self.formal_function_sugar.desugar(ctx)
+            from sugar_lift_py_tests.outcome import NativeOperationExitCarrierV1
+
+            if isinstance(pending, NativeOperationExitCarrierV1):
+                pending = pending.discharge(
+                    dict(zip(self.formal_coordinate_cids, positional, strict=True))
+                )
+            return callsite.project_producer_outcome(pending)
         return callsite.producer_outcome(ctx)
 
     def _collect_bridged(self, positional: tuple) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -270,6 +270,53 @@ def reduce_block_to_exitset(
             outcome = head.desugar(statement_ctx)
             from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
 
+            def project(value):
+                if isinstance(value, _ReducedBlock):
+                    contribution = value.entries
+                    continues = value.can_fall_through
+                    nested_fall_through = value.fall_through
+                    nested_transforms = value.transforms
+                    next_context = (
+                        value.context if value.context is not None else active_ctx
+                    )
+                else:
+                    linear = Complete(value)
+                    contribution = linear.contribution()
+                    continues = linear.follow().continues
+                    nested_fall_through = ()
+                    nested_transforms = ()
+                    next_context = _extend_receiver_store_scope(
+                        linear.value, active_ctx
+                    )
+                for transform in reversed(state.transforms):
+                    contribution = transform(contribution)
+                entries = (*state.entries, *contribution)
+                if not continues:
+                    return ExitSet.completed(
+                        _ReducedBlock(entries, False, (), context=next_context)
+                    )
+                return ExitSet.completed(
+                    _ReducedBlock(
+                        entries,
+                        True,
+                        (*state.fall_through, *nested_fall_through),
+                        (*state.transforms, *nested_transforms),
+                        next_context,
+                    )
+                )
+
+            from sugar_lift_py_tests.caller_parameter_contract import (
+                NativeOperationExitCarrierV1,
+            )
+
+            if isinstance(outcome, NativeOperationExitCarrierV1):
+                # A formal native operation is neither a completion nor a halt
+                # until an authenticated caller supplies its actual operands.
+                # Retain the ordinary statement projection as a continuation;
+                # discharge will feed its Completed face through this exact
+                # block seam, while its Halted face bypasses the tail.
+                return outcome.and_then(project)
+
             if (
                 isinstance(outcome, Complete)
                 and isinstance(outcome.value, GuardedFaces)
@@ -334,50 +381,6 @@ def reduce_block_to_exitset(
                         else and_(list(state.fall_through))
                     )
                     outcome = outcome.guarded(continuation)
-
-                def project(value):
-                    if isinstance(value, _ReducedBlock):
-                        # A nested block statement (a `with` whose body is
-                        # itself a routed `with` — the mixed multi-manager
-                        # site) hands back its OWN reduced block as the
-                        # completed value, not a floor value. There is no
-                        # linear `Complete` view to interrogate: the block's
-                        # contribution IS its entries and its continuation IS
-                        # its `can_fall_through`. Asking `Complete(value)` for
-                        # a contribution here is what raised a bare
-                        # AttributeError instead of routing the inner block.
-                        contribution = value.entries
-                        continues = value.can_fall_through
-                        nested_fall_through = value.fall_through
-                        nested_transforms = value.transforms
-                        next_context = (
-                            value.context if value.context is not None else active_ctx
-                        )
-                    else:
-                        linear = Complete(value)
-                        contribution = linear.contribution()
-                        continues = linear.follow().continues
-                        nested_fall_through = ()
-                        nested_transforms = ()
-                        next_context = _extend_receiver_store_scope(
-                            linear.value, active_ctx
-                        )
-                    for transform in reversed(state.transforms):
-                        contribution = transform(contribution)
-                    entries = (*state.entries, *contribution)
-                    if not continues:
-                        return ExitSet.completed(
-                            _ReducedBlock(entries, False, (), context=next_context)
-                        )
-                    return ExitSet.completed(
-                        _ReducedBlock(
-                            entries,
-                            True,
-                            (*state.fall_through, *nested_fall_through),
-                            (*state.transforms, *nested_transforms),
-                            next_context,
-                        )
-                    )
 
                 # A statement that reduces to its OWN ExitSet (a nested block:
                 # try/with, or an unpack assignment whose store leaves are
@@ -481,12 +484,38 @@ def reduce_block_to_exitset(
                 _ReducedBlock(entries, True, fall_through, transforms, next_context)
             )
 
-        exits = exits.sequence(reduce_next)
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            NativeOperationExitCarrierV1,
+        )
+
+        if isinstance(exits, NativeOperationExitCarrierV1):
+            exits = exits.and_then(reduce_next)
+        elif (
+            len(exits.exits) == 1
+            and isinstance(exits.exits[0], Completed)
+            and exits.exits[0].guard == true_guard()
+            and not exits.exits[0].faces
+            and not exits.exits[0].pending_contracts
+        ):
+            # The straight-line singleton is the only ExitSet face that can
+            # become a deferred native-operation carrier without needing a
+            # guarded carrier algebra. Preserve it directly. Branching paths
+            # continue through ExitSet.sequence and remain loud if they try to
+            # smuggle an undischarged carrier through a guard.
+            exits = reduce_next(exits.exits[0].value)
+        else:
+            exits = exits.sequence(reduce_next)
 
     # The block boundary is where an obligation stops being in flight, so it is
     # the one door that consumes the carriers. Doing it here rather than per
     # statement keeps a single owner and lets `sequence` compose obligations
     # across statements first.
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+
+    if isinstance(exits, NativeOperationExitCarrierV1):
+        return exits
     return _enrol_exit_obligations(exits)
 
 
@@ -514,6 +543,20 @@ def reduce_body(statements: tuple, ctx: object = None):
     (calls, unsupported statements) that will.
     """
     exits = reduce_block_to_exitset(statements, ctx)
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+
+    if isinstance(exits, NativeOperationExitCarrierV1):
+        return exits.and_then(
+            lambda state: Complete(
+                BlockValue(
+                    state.entries,
+                    fall_through=state.fall_through,
+                    can_fall_through=state.can_fall_through,
+                )
+            )
+        )
     collapsed = exits.collapse()
     if isinstance(collapsed, Incomplete):
         return collapsed

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_completion_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_completion_conservation.py
@@ -1,0 +1,122 @@
+"""The authenticated Compare population never escapes terminal accounting."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+from sugar_lift_py_tests.no_call_body_attribution import (
+    AttributionInvariantError,
+    AttributionOutcome,
+    BodyProbe,
+    ProducerFamily,
+    attribute_body_probe,
+    attribute_body_probes,
+    discover_no_call_body_probes,
+    pull_shared_demand_table,
+    require_expected_denominators,
+)
+from sugar_lift_py_tests.outcome import Complete
+
+PREVIOUSLY_UNACCOUNTED = frozenset(
+    {
+        "tests/arrays/categorical/test_operators.py:335:Compare",
+        "tests/arrays/categorical/test_operators.py:343:Compare",
+        "tests/frame/test_arithmetic.py:1221:Compare",
+        "tests/frame/test_arithmetic.py:1227:Compare",
+        "tests/frame/test_arithmetic.py:1679:Compare",
+        "tests/frame/test_arithmetic.py:1682:Compare",
+        "tests/frame/test_arithmetic.py:1692:Compare",
+        "tests/frame/test_arithmetic.py:1704:Compare",
+        "tests/frame/test_arithmetic.py:1707:Compare",
+        "tests/frame/test_nonunique_indexes.py:204:Compare",
+        "tests/indexes/categorical/test_equals.py:39:Compare",
+        "tests/indexes/datetimes/test_date_range.py:348:Compare",
+        "tests/indexes/datetimes/test_date_range.py:351:Compare",
+        "tests/indexes/multi/test_equivalence.py:43:Compare",
+        "tests/indexes/multi/test_equivalence.py:55:Compare",
+        "tests/indexes/multi/test_equivalence.py:65:Compare",
+        "tests/indexes/multi/test_equivalence.py:72:Compare",
+        "tests/indexes/multi/test_equivalence.py:74:Compare",
+        "tests/indexes/multi/test_equivalence.py:76:Compare",
+        "tests/indexes/multi/test_equivalence.py:79:Compare",
+        "tests/indexes/multi/test_equivalence.py:81:Compare",
+        "tests/indexes/test_old_base.py:540:Compare",
+        "tests/indexes/test_old_base.py:552:Compare",
+        "tests/indexes/test_old_base.py:562:Compare",
+        "tests/indexes/test_old_base.py:569:Compare",
+        "tests/indexes/test_old_base.py:571:Compare",
+        "tests/indexes/test_old_base.py:573:Compare",
+        "tests/indexes/test_old_base.py:576:Compare",
+        "tests/indexes/test_old_base.py:578:Compare",
+        "tests/series/test_arithmetic.py:544:Compare",
+        "tests/series/test_arithmetic.py:785:Compare",
+        "tests/series/test_arithmetic.py:787:Compare",
+        "tests/series/test_arithmetic.py:790:Compare",
+        "tests/series/test_arithmetic.py:792:Compare",
+    }
+)
+
+
+def _root_compare_has_no_call(corpus_root: Path, body_id: str) -> bool:
+    relative, line_text, _ = body_id.rsplit(":", 2)
+    tree = ast.parse((corpus_root / relative).read_text(encoding="utf-8"))
+    matches = tuple(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Compare) and node.lineno == int(line_text)
+    )
+    assert len(matches) == 1, body_id
+    return not any(isinstance(node, ast.Call) for node in ast.walk(matches[0]))
+
+
+def test_one_silent_compare_completion_is_row_level_red() -> None:
+    """Lying twin: no terminal testimony can never become an omitted row."""
+    probe = BodyProbe(
+        body_id="pandas/example.py:1:Compare",
+        family=ProducerFamily.COMPARE,
+        evaluator=lambda: Complete(object()),
+    )
+
+    with pytest.raises(AttributionInvariantError, match="completed without"):
+        attribute_body_probe(probe)
+
+
+def test_all_34_compare_completions_publish_authenticated_compare_exits(
+    tmp_path: Path,
+) -> None:
+    corpus = authenticated_pandas_corpus()
+    repo_root = Path(__file__).resolve().parents[4]
+    payload = pull_shared_demand_table(repo_root, tmp_path / "demand-table.json")
+    compare_inventory = require_expected_denominators(
+        discover_no_call_body_probes(
+            payload,
+            corpus.root,
+            families=frozenset({ProducerFamily.COMPARE}),
+        ),
+        families=frozenset({ProducerFamily.COMPARE}),
+    )
+    probes = tuple(
+        probe for probe in compare_inventory if probe.body_id in PREVIOUSLY_UNACCOUNTED
+    )
+
+    assert {probe.body_id for probe in probes} == PREVIOUSLY_UNACCOUNTED
+    assert len(probes) == 34
+    assert all(
+        _root_compare_has_no_call(corpus.root, body_id)
+        for body_id in PREVIOUSLY_UNACCOUNTED
+    )
+
+    report = attribute_body_probes(probes)
+
+    assert report.discrepancies == ()
+    assert report.outcome_total == 34
+    assert len(report.bodies) == 34
+    assert all(
+        body.outcome is AttributionOutcome.AUTHENTICATED_EXIT
+        and body.detail == "Compare"
+        for body in report.bodies
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_projection.py
@@ -1,0 +1,94 @@
+"""Ordinary source calls discharge formal native-operation demands."""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.outcome import (
+    Completed,
+    ExitSet,
+    Halted,
+    NativeOperationExitCarrierV1,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _call_outcome(actuals: str):
+    source = (
+        f"def compare(left, right):\n    return left < right\n\ncompare({actuals})\n"
+    )
+    tree = SourceFile(
+        (source, "formal_call.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    call = tuple(node for node in tree.nodes() if isinstance(node, Call))[-1]
+    return call.sugar().desugar(None)
+
+
+def _call_outcomes(*actuals: str):
+    calls = "".join(f"compare({value})\n" for value in actuals)
+    source = f"def compare(left, right):\n    return left < right\n\n{calls}"
+    tree = SourceFile(
+        (source, "formal_calls.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    nodes = tuple(node for node in tree.nodes() if isinstance(node, Call))
+    return tuple(node.sugar().desugar(None) for node in nodes)
+
+
+def test_function_definition_preserves_formal_demand_until_caller_discharge() -> None:
+    source = "def compare(left, right):\n    return left < right\n"
+    tree = SourceFile(
+        (source, "formal_definition.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+
+    assert isinstance(function.sugar().desugar(None), NativeOperationExitCarrierV1)
+
+
+def test_ordinary_function_call_discharge_can_complete() -> None:
+    outcome = _call_outcome("1, 2")
+
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    assert isinstance(outcome.exits[0], Completed)
+
+
+def test_ordinary_function_call_discharge_can_halt_with_named_identity() -> None:
+    outcome = _call_outcome("None, 2")
+
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    halted = outcome.exits[0]
+    assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate is not None
+    assert halted.effect.occurrence_id is not None
+
+
+def test_swapped_actuals_retain_the_operation_coordinate() -> None:
+    forward, swapped = _call_outcomes("None, 2", "2, None")
+
+    forward_halt = forward.exits[0]
+    swapped_halt = swapped.exits[0]
+    assert isinstance(forward_halt, Halted)
+    assert isinstance(swapped_halt, Halted)
+    assert forward_halt.effect.occurrence_id == swapped_halt.effect.occurrence_id
+
+
+def test_shadowed_function_name_does_not_borrow_module_definition() -> None:
+    source = (
+        "def compare(left, right):\n"
+        "    return left < right\n\n"
+        "def caller(compare):\n"
+        "    return compare(None, 2)\n"
+    )
+    tree = SourceFile(
+        (source, "shadowed_caller.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    call = tuple(node for node in tree.nodes() if isinstance(node, Call))[-1]
+
+    outcome = call.sugar().desugar(None)
+    assert not isinstance(outcome, ExitSet)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -409,6 +409,58 @@ class SourceUnit:
             return None
         return definition
 
+    def source_function_definition_for_call(
+        self, call: "Call"
+    ) -> "FunctionDef | AsyncFunctionDef | None":
+        """Resolve one ordinary source function at an exact lexical call site.
+
+        The name is only a lookup key. Authority is the unique typed module
+        binding plus CPython's scope classification at this occurrence. A
+        parameter, local, free, nonlocal, ambiguous, or recursive binding is
+        not silently treated as this module definition.
+        """
+        if not isinstance(call.func, Name) or self.typed_module is None:
+            return None
+        span = call.line_col_span()
+        containing = []
+        for candidate in self.function_nodes:
+            owner_span = candidate.line_col_span()
+            if (
+                (owner_span.start_line, owner_span.start_col)
+                <= (span.start_line, span.start_col)
+                <= (owner_span.end_line, owner_span.end_col)
+            ):
+                containing.append(candidate)
+        if containing:
+            owner = max(containing, key=lambda item: item.line_col_span().start_line)
+            table = self.function_symtable(owner.name, owner.line_col_span().start_line)
+            try:
+                symbol = table.lookup(call.func.id)
+            except KeyError:
+                symbol = None
+            if symbol is not None and (
+                symbol.is_parameter()
+                or symbol.is_local()
+                or symbol.is_free()
+                or symbol.is_nonlocal()
+            ):
+                return None
+
+        bindings = (self.module_direct_bindings or {}).get(call.func.id, ())
+        if len(bindings) != 1 or not isinstance(
+            bindings[0], (FunctionDef, AsyncFunctionDef)
+        ):
+            return None
+        definition = bindings[0]
+        definition_span = definition.line_col_span()
+        if (
+            (definition_span.start_line, definition_span.start_col)
+            <= (span.start_line, span.start_col)
+            <= (definition_span.end_line, definition_span.end_col)
+        ):
+            return None
+        return definition
+
     @staticmethod
     def source_class_has_authenticated_default_attribute_behavior(
         definition: "ClassDef",
@@ -784,9 +836,7 @@ class SourceUnit:
         for handler in statement.handlers:
             if handler.name == name:
                 return True
-            if any(
-                self._statement_rebinds_name(body, name) for body in handler.body
-            ):
+            if any(self._statement_rebinds_name(body, name) for body in handler.body):
                 return True
         return any(
             self._statement_rebinds_name(tail, name)
@@ -5936,9 +5986,7 @@ class Raise(Statement):
                     identity = self.unit.exception_type_identity(type_operand)
                     mro = self.unit.exception_type_mro(type_operand)
                 else:
-                    identity = self.unit.imported_exception_type_identity(
-                        type_operand
-                    )
+                    identity = self.unit.imported_exception_type_identity(type_operand)
                     mro = None
 
         with reduction_span(sugar="Raise.exc.sugar", role="construction", site=where):
@@ -8002,6 +8050,15 @@ class Call(Expression):
                 contract_ref = resolution
 
             source_call_frame = None
+            formal_function_sugar = None
+            formal_coordinate_cids = ()
+            function_definition = self.unit.source_function_definition_for_call(self)
+            if function_definition is not None:
+                formal_function_sugar = function_definition.sugar()
+                formal_coordinate_cids = tuple(
+                    coordinate.coordinate_cid
+                    for coordinate in function_definition.formal_coordinates()
+                )
             definition = self.unit.source_allocation_definition_for_call(self)
             if (
                 definition is not None
@@ -8034,6 +8091,8 @@ class Call(Expression):
                 contract_ref=contract_ref,
                 contract_resolution_gap=contract_resolution_gap,
                 source_call_frame=source_call_frame,
+                formal_function_sugar=formal_function_sugar,
+                formal_coordinate_cids=formal_coordinate_cids,
             )
         if isinstance(self.func, Attribute):
             # Lexical import binding is the ONLY door to a closed callee


### PR DESCRIPTION
## Outcome

The first missing edge was the ordinary FunctionDef block reducer: a `NativeOperationExitCarrierV1` reached `outcome.contribution()` and died before any caller could discharge it. This branch preserves that shared carrier through straight-line FunctionDef reduction, resolves a module-level helper by its unique lexical binding, maps exact caller actuals to declaration-owned formal coordinates, and projects the discharged ExitSet at the Call producer.

## Discrimination twins

- same helper with `1, 2`: one completed ExitSet face
- same helper with `None, 2`: one halted face carrying exception type and occurrence coordinates
- swapped actuals retain the same operation occurrence coordinate
- a shadowed same-name parameter cannot borrow the module FunctionDef
- mutation transaction: disabling only FunctionDef-to-call projection makes the named-halt twin fail (`MUTATION_EXIT=1`)

## Conservation ratchet retained

The exact 34 former Compare escapes and row-level silent-completion tooth from #6568 remain. The exact-34 authenticated gate is intentionally not represented as green: pytest-owned corpus bodies still lack an authenticated caller invocation in the probe, so this branch does not fabricate exception identity to force their count.

## Validation

Authenticated interpreter: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3.

- `30 passed, 1 deselected` across formal projection, Call producer, attribution, and non-corpus Compare conservation laws
- `git diff --check`: clean
- rebased onto `34cb5b7fb` (#6588); main coordinate-authenticated tally semantics retained

No comparison floor, binary floor, carrier type, outcome/ExitSet plumbing, attribution receipt workaround, or generator construction is changed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Project formal native operations at source call sites
> - Adds `source_function_definition_for_call` to `SourceUnit` to resolve the module-level function definition for a non-shadowed bare-name callee, then attaches `formal_function_sugar` and `formal_coordinate_cids` to the constructed `CallSiteSugar`.
> - `CallSiteSugar.desugar` now discharges `NativeOperationExitCarrierV1` carriers using the actual call arguments when a formal function is present, producing Completed or Halted outcomes tied to the formal operation coordinate; mismatched arity raises `SugarNotWritten`.
> - `reduce_block_to_exitset` and `reduce_body` propagate carriers through statement sequencing, deferring completion until caller discharge rather than resolving at block boundaries.
> - Adds tests verifying Compare completion conservation and that ordinary calls correctly discharge formal native-operation demands.
> - Risk: `CallSiteValue.project_producer_outcome` now raises `NameError` at runtime on the non-early-return path due to removal of `outcome = self.reduce_source_outcome(ctx)`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d78ba5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->