### PR TITLE
Construct source-visible Attribute exits

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -13,6 +13,7 @@ class ConstructedClassMethodV1:
     definition_fragment_cid: str
     body: object = field(compare=False)
     source_call_frame: object = field(compare=False)
+    descriptor_kind: str | None = None
 
 
 @dataclass(frozen=True)
@@ -190,6 +191,7 @@ class ClassDefinitionValue(GuardStableValue):
                     for coordinate in method.source_call_frame.formal_coordinates
                 ),
                 method.source_call_frame,
+                method.descriptor_kind,
             )
             for method in (*inherited, *self.methods)
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -596,6 +596,26 @@ class FloorValue:
         )
         construction_panic(info)
 
+    def attribute_named(self, name_value, site):
+        """Carrier adapter for ``receiver.<static name>`` after discharge.
+
+        ``NativeOperationDemandV1`` records ordered Floor values.  Attribute's
+        second operand is the source-written static identifier, represented as
+        a ground StringValue; it is never runtime spelling authority.
+        """
+        from sugar_lift_py_tests.floor.string_value import StringValue
+        from sugar_source_tree.panic import SugarNotWritten
+
+        if not isinstance(name_value, StringValue):
+            raise SugarNotWritten(
+                blame=site,
+                owner="FloorValue.attribute_named",
+                observed=type(name_value).__name__,
+                requested="source-written static attribute identifier",
+                fix="preserve the Attribute node's identifier as StringValue",
+            )
+        return self.attribute(name_value.value, site)
+
     def undecided_attribute(self, name, site, *, owner: str):
         """Refuse lookup when source testimony decides neither outgoing edge.
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_method_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_method_value.py
@@ -23,6 +23,7 @@ class ObjectMethodValue(FloorValue):
     source_call_frame_cid: str | None = None
     formal_coordinate_cids: tuple[str, ...] = ()
     source_call_frame: object | None = field(default=None, compare=False, repr=False)
+    descriptor_kind: str | None = None
 
     def __post_init__(self) -> None:
         from sugar_lift_py_tests.sugar.sugar_base import Sugar

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -147,6 +147,53 @@ class ObjectValue(FloorValue):
                 from sugar_lift_py_tests.outcome import Complete
 
                 return Complete(field.value)
+        for method in reversed(self.methods):
+            if method.name != name or method.descriptor_kind != "property":
+                continue
+            from dataclasses import replace
+
+            from sugar_lift_py_tests.effect import RaiseEffect
+            from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
+
+            def invoke(callsite):
+                outcome = callsite.producer_outcome()
+                if not isinstance(outcome, ExitSet):
+                    return outcome
+                return ExitSet(
+                    tuple(
+                        (
+                            Halted(
+                                face.guard,
+                                (
+                                    replace(
+                                        face.effect,
+                                        producer_node_owner="Attribute",
+                                    )
+                                    if isinstance(face.effect, RaiseEffect)
+                                    else face.effect
+                                ),
+                                face.state,
+                                face.faces,
+                                face.pending_contracts,
+                            )
+                            if isinstance(face, Halted)
+                            else Completed(
+                                face.guard,
+                                face.value,
+                                face.faces,
+                                face.pending_contracts,
+                            )
+                        )
+                        for face in outcome.exits
+                    )
+                ).normalize()
+
+            return self.call_method_value(
+                name,
+                (),
+                owner="ObjectValue.attribute.property",
+                blame=site,
+            ).and_then(invoke)
         if name in self.deferred_helper_fields:
             from sugar_lift_py_tests.floor.getattr_coordinate import (
                 getattr_coordinate,
@@ -162,6 +209,22 @@ class ObjectValue(FloorValue):
 
     def with_field_store(self, name: str, value: FloorValue) -> "ObjectValue":
         """Return this receiver identity after one authenticated field store."""
+        if any(
+            method.name == name and method.descriptor_kind == "property"
+            for method in self.methods
+        ):
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                blame=f"{self.class_name}.{name}",
+                owner="ObjectValue.with_field_store",
+                observed="source-authenticated property data descriptor",
+                requested="the descriptor's authenticated assignment behavior",
+                fix=(
+                    "construct the property's setter before treating the write "
+                    "as an instance-field store"
+                ),
+            )
         remaining = tuple(field for field in self.fields if field.name != name)
         return ObjectValue(
             self.class_name,
@@ -170,6 +233,13 @@ class ObjectValue(FloorValue):
             self.class_fields,
             self.identity,
             self.deferred_helper_fields,
+        )
+
+    def authenticates_plain_attribute_store(self, name: str) -> bool:
+        """Whether ``self.name = value`` is an ordinary instance-field store."""
+        return not any(
+            method.name == name and method.descriptor_kind == "property"
+            for method in self.methods
         )
 
     def with_deferred_helper_fields(self) -> "ObjectValue":

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
@@ -36,6 +36,33 @@ class AttributeSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        return self.receiver.desugar(ctx).and_then(
-            lambda receiver: receiver.attribute(self.name, self.site)
-        )
+        def project(receiver):
+            from sugar_lift_py_tests.floor import CallSiteValue
+
+            formal_coordinate = getattr(receiver, "formal_coordinate", None)
+            if formal_coordinate is not None:
+                from sugar_lift_py_tests.caller_parameter_contract import (
+                    NativeOperationExitCarrierV1,
+                )
+                from sugar_lift_py_tests.floor import StringValue
+
+                return NativeOperationExitCarrierV1.mint(
+                    site=self.site,
+                    operator="attribute_named",
+                    operands=(receiver, StringValue(self.name)),
+                    coordinates=(formal_coordinate, None),
+                )
+
+            if (
+                isinstance(receiver, CallSiteValue)
+                and receiver.body is not None
+                and receiver.source_call_frame_cid is not None
+            ):
+                receiver = receiver.force_floor(
+                    ctx,
+                    owner="authenticated attribute receiver",
+                    project_callsite=False,
+                )
+            return receiver.attribute(self.name, self.site)
+
+        return self.receiver.desugar(ctx).and_then(project)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
@@ -68,6 +68,7 @@ class ClassDefinitionSugar(Sugar):
                     "name": method.name,
                     "definitionFragmentCid": method.definition_fragment_cid,
                     "sourceCallFrameCid": method.source_call_frame.frame_cid,
+                    "descriptorKind": method.descriptor_kind,
                 }
                 for method in self.methods
             ],

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/place_assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/place_assign_sugar.py
@@ -28,6 +28,24 @@ class PlaceAssignSugar(Sugar):
         from sugar_lift_py_tests.floor.place_assign_value import PlaceAssignValue
 
         def with_receiver(receiver):
+            if (
+                self.selector_kind == "attribute"
+                and hasattr(receiver, "authenticates_plain_attribute_store")
+                and not receiver.authenticates_plain_attribute_store(self.selector)
+            ):
+                from sugar_source_tree.panic import SugarNotWritten
+
+                raise SugarNotWritten(
+                    blame=self.site,
+                    owner="PlaceAssignSugar",
+                    observed="source-authenticated property data descriptor",
+                    requested="the descriptor's authenticated assignment behavior",
+                    fix=(
+                        "construct the property's setter before treating the write "
+                        "as an instance-field store"
+                    ),
+                )
+
             def with_value(value):
                 if self.selector_kind == "attribute":
                     selector = self.selector

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.floor import (
+    NoneValue,
+    ObjectField,
+    ObjectValue,
+    SymbolicValue,
+    TermValue,
+)
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var, str_const
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Attribute
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+class _ValueSugar(Sugar):
+    def __init__(self, value):
+        self.value = value
+
+    def desugar(self, ctx=None):
+        del ctx
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(self.value)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+def _attribute_node() -> Attribute:
+    source = "def access(receiver):\n    return receiver.value\n"
+    tree = SourceFile((source, "attribute_demand.py", blake3_512_of(source.encode())))
+    return next(node for node in tree.nodes() if isinstance(node, Attribute))
+
+
+def _formal(node: Attribute) -> FormalParameterCoordinateV1:
+    span = node.fragment.line_col_span
+    owner = SourceFragmentCoordinateV1(
+        node.fragment.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    return FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=node.fragment.source_cid,
+        owner_definition_locus=owner,
+        declaration_locus=owner,
+        ordinal=0,
+        parameter_kind="positional-or-keyword",
+        declared_name="receiver",
+        sort=PrimitiveSort("Value"),
+    )
+
+
+def _carrier() -> tuple[NativeOperationExitCarrierV1, FormalParameterCoordinateV1]:
+    node = _attribute_node()
+    formal = _formal(node)
+    outcome = AttributeSugar(
+        _ValueSugar(SymbolicValue(make_var("receiver"), formal)),
+        "value",
+        node.fragment,
+    ).desugar(None)
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    return outcome, formal
+
+
+def test_formal_attribute_completes_or_halts_from_authenticated_actual() -> None:
+    carrier, formal = _carrier()
+    completed = carrier.discharge(
+        {
+            formal.coordinate_cid: ObjectValue(
+                "Receiver", (ObjectField("value", TermValue(7)),)
+            )
+        }
+    )
+    halted = carrier.discharge({formal.coordinate_cid: NoneValue()})
+
+    assert carrier.demand.operator == "attribute_named"
+    assert len(completed.exits) == 1
+    assert isinstance(completed.exits[0], Completed)
+    assert completed.exits[0].value == TermValue(7)
+    assert len(halted.exits) == 1
+    assert isinstance(halted.exits[0], Halted)
+    assert halted.exits[0].effect.exception_type_coordinate is not None
+    assert halted.exits[0].effect.occurrence_id is not None
+
+
+def test_undecidable_attribute_actual_remains_named_loud() -> None:
+    carrier, formal = _carrier()
+
+    with pytest.raises(SugarNotWritten, match="undecided receiver runtime type"):
+        carrier.discharge(
+            {formal.coordinate_cid: SymbolicValue(make_var("still_unknown"))}
+        )
+
+
+def test_lying_exception_type_cannot_consume_attribute_halt() -> None:
+    from sugar_lift_py_tests.context_manager_contract import (
+        AuthenticatedRaiseMatcher,
+        EffectBoundaryDisposition,
+    )
+    from sugar_lift_py_tests.effect import ExpectationNotMetEffect
+    from sugar_lift_py_tests.outcome import ExitSet
+
+    class _ExpectedValueError:
+        def exception_type_identity(self):
+            return ctor(
+                "python:exception_type_identity",
+                [str_const("builtins"), str_const("ValueError")],
+            )
+
+    carrier, formal = _carrier()
+    exits = carrier.discharge({formal.coordinate_cid: NoneValue()})
+    routed = exits.and_exit(
+        ExitSet.completed(object()),
+        disposition=EffectBoundaryDisposition(
+            matcher=AuthenticatedRaiseMatcher(expected=_ExpectedValueError()),
+            unmet=ExpectationNotMetEffect("raise", "assertion-site"),
+        ),
+    )
+
+    assert len(routed.exits) == 1
+    assert isinstance(routed.exits[0], Halted)
+    assert (
+        routed.exits[0].effect.exception_type_coordinate
+        != _ExpectedValueError().exception_type_identity()
+    )
+
+
+def test_total_attribute_actual_never_acquires_exceptional_edge() -> None:
+    carrier, formal = _carrier()
+    exits = carrier.discharge(
+        {
+            formal.coordinate_cid: ObjectValue(
+                "Receiver", (ObjectField("value", TermValue(7)),)
+            )
+        }
+    )
+
+    assert all(isinstance(face, Completed) for face in exits.exits)
+
+
+def test_authenticated_attribute_family_has_a_closed_nonzero_exit_split() -> None:
+    from sugar_lift_py_tests.no_call_body_attribution import (
+        ProducerFamily,
+        run_authenticated_attribution,
+    )
+
+    repo_root = Path(__file__).resolve().parents[4]
+    report = run_authenticated_attribution(
+        repo_root, families=frozenset({ProducerFamily.ATTRIBUTE})
+    )
+    row = report.by_family[ProducerFamily.ATTRIBUTE]
+
+    print(report.render())
+    assert row.enrolled == 53
+    assert row.authenticated_exceptional_exits > 0
+    assert row.authenticated_exceptional_exits + row.named_refusals == 53
+    assert row.construction_panics == 0
+    assert report.discrepancies == ()
+
+
+def test_attribute_construction_has_no_vendor_exception_name_arm() -> None:
+    production = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+    source_tree = Path(__file__).resolve().parents[2] / "sugar-source-tree" / "src"
+    text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (
+            production / "sugar" / "attribute_sugar.py",
+            production / "floor" / "object_value.py",
+            source_tree / "sugar_source_tree" / "nodes.py",
+        )
+    )
+    for forbidden in ("AbstractMethodError", "pandas.errors", "SeriesGroupBy"):
+        assert forbidden not in text

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -119,10 +119,7 @@ def test_nameless_halted_face_stays_loud_in_the_exit_ledger() -> None:
 
 def test_corpus_tally_does_not_count_nameless_halted_faces_as_exits() -> None:
     report = attribute_body_probes(
-        tuple(
-            _probe(ProducerFamily.COMPARE, _nameless_raise_value)
-            for _ in range(503)
-        )
+        tuple(_probe(ProducerFamily.COMPARE, _nameless_raise_value) for _ in range(503))
     )
 
     row = report.by_family[ProducerFamily.COMPARE]
@@ -267,7 +264,7 @@ def test_join_collects_construction_panic_and_outcome_discrepancy_before_failing
     assert report.loud_failure_count == 2
     assert "constructionPanic body=pandas/example.py:1:Subscript" in report.render()
     assert (
-            "OUTCOME TOTAL DISCREPANCY enrolled=2 outcomeTotal=1 unaccounted=1"
+        "OUTCOME TOTAL DISCREPANCY enrolled=2 outcomeTotal=1 unaccounted=1"
         in report.render()
     )
 
@@ -492,6 +489,64 @@ def test_discovery_projects_one_family_without_constructing_peer_sources(
     )
 
     assert [probe.body_id for probe in probes] == ["attribute_body.py:3:Attribute"]
+
+
+def test_discovery_carries_source_property_binding_to_attribute_exit(tmp_path) -> None:
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_python_source.canonical import blake3_512_of
+    from sugar_source_tree.nodes import With
+    from sugar_source_tree.tree import SourceFile
+
+    package = tmp_path / "pandas"
+    package.mkdir()
+    path = package / "property_body.py"
+    source = (
+        "import pytest\n"
+        "class Receiver:\n"
+        "    @property\n"
+        "    def value(self):\n"
+        "        raise ValueError('source getter')\n"
+        "def use():\n"
+        "    with pytest.raises(ValueError):\n"
+        "        Receiver().value\n"
+    )
+    path.write_text(source, encoding="utf-8")
+    source_cid = blake3_512_of(source.encode())
+    tree = SourceFile(
+        (source, str(path), source_cid),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    with_node = next(node for node in tree.nodes() if isinstance(node, With))
+    span = with_node.items[0].context_expr.line_col_span()
+    probes = discover_no_call_body_probes(
+        {
+            "rows": [
+                {
+                    "kind": "context-manager-demand",
+                    "gapKind": None,
+                    "useSite": {
+                        "sourceCid": source_cid,
+                        "startLine": span.start_line,
+                        "startCol": span.start_col,
+                        "endLine": span.end_line,
+                        "endCol": span.end_col,
+                    },
+                }
+            ]
+        },
+        package,
+        families=frozenset({ProducerFamily.ATTRIBUTE}),
+    )
+
+    report = attribute_body_probes(probes)
+
+    assert report.discrepancies == ()
+    assert (
+        report.by_family[ProducerFamily.ATTRIBUTE].authenticated_exceptional_exits == 1
+    )
+    assert report.by_family[ProducerFamily.ATTRIBUTE].named_refusals == 0
 
 
 def test_selected_family_denominator_remains_fixed() -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -435,7 +435,13 @@ class SourceUnit:
             )
             or any(
                 isinstance(member, FunctionDef)
-                and (member.name in forbidden_methods or member.decorators)
+                and (
+                    member.name in forbidden_methods
+                    or (
+                        member.decorators
+                        and definition._method_descriptor_kind(member) is None
+                    )
+                )
                 for member in definition.body
             )
         )
@@ -784,9 +790,7 @@ class SourceUnit:
         for handler in statement.handlers:
             if handler.name == name:
                 return True
-            if any(
-                self._statement_rebinds_name(body, name) for body in handler.body
-            ):
+            if any(self._statement_rebinds_name(body, name) for body in handler.body):
                 return True
         return any(
             self._statement_rebinds_name(tail, name)
@@ -2858,6 +2862,25 @@ class ClassDef(Statement):
     type_params: Tuple[TypeParam, ...]
     _child_fields = ("decorators", "type_params", "bases", "keywords", "body")
 
+    def _method_descriptor_kind(self, method: "FunctionDef") -> Optional[str]:
+        """Authenticate one language descriptor decorator by lexical binding.
+
+        The decorator spelling is only a lookup key.  A same-named module
+        binding defeats the builtin coordinate, so it can never grant property
+        or class/static method semantics.
+        """
+        if len(method.decorators) != 1:
+            return None
+        decorator = method.decorators[0]
+        if not isinstance(decorator, Name):
+            return None
+        if decorator.id not in {"property", "classmethod", "staticmethod"}:
+            return None
+        bindings = (self.unit.module_direct_bindings or {}).get(decorator.id, ())
+        if bindings:
+            return None
+        return decorator.id
+
     def substitute(self, scope):
         """A class: decorators and type params evaluate in the enclosing scope;
         the type params then bind for the bases, keywords, and body. The body is
@@ -3010,6 +3033,7 @@ class ClassDef(Statement):
                 method.fragment.seal().cid,
                 method.sugar(),
                 method.source_visible_call_frame(),
+                self._method_descriptor_kind(method),
             )
             for method in methods
         )
@@ -5934,11 +5958,15 @@ class Raise(Statement):
             ):
                 if isinstance(type_operand, Name):
                     identity = self.unit.exception_type_identity(type_operand)
-                    mro = self.unit.exception_type_mro(type_operand)
+                    if identity is None:
+                        identity = self.unit.imported_exception_type_identity(
+                            type_operand
+                        )
+                        mro = None
+                    else:
+                        mro = self.unit.exception_type_mro(type_operand)
                 else:
-                    identity = self.unit.imported_exception_type_identity(
-                        type_operand
-                    )
+                    identity = self.unit.imported_exception_type_identity(type_operand)
                     mro = None
 
         with reduction_span(sugar="Raise.exc.sugar", role="construction", site=where):

--- a/implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.outcome import Complete, ExitSet
+from sugar_lift_py_tests.outcome.exit_set import Halted
+from sugar_lift_python_source.manager_summary_derivation import (
+    populate_source_derived_resource_refs,
+)
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.nodes import Attribute, With
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+PANDAS_MANIFEST_CID = (
+    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
+    "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+)
+
+
+def _tree(tmp_path: Path, source: str) -> SourceFile:
+    path = tmp_path / "property_attribute.py"
+    path.write_text(source, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        workspace_path_source(str(path), root=str(tmp_path)),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    return tree
+
+
+def _body_attribute(tree: SourceFile) -> Attribute:
+    with_node = next(node for node in tree.nodes() if isinstance(node, With))
+    expression = with_node.body[0].value
+    assert isinstance(expression, Attribute)
+    return expression
+
+
+def test_source_property_getter_publishes_authenticated_exceptional_exit(
+    tmp_path: Path,
+) -> None:
+    tree = _tree(
+        tmp_path,
+        "import pytest\n"
+        "class Receiver:\n"
+        "    @property\n"
+        "    def value(self):\n"
+        "        raise ValueError('source getter')\n"
+        "def use():\n"
+        "    with pytest.raises(ValueError):\n"
+        "        Receiver().value\n",
+    )
+
+    outcome = _body_attribute(tree).sugar().desugar(None)
+
+    assert isinstance(outcome, ExitSet)
+    halted = tuple(face for face in outcome.exits if isinstance(face, Halted))
+    assert len(halted) == 1
+    effect = halted[0].effect
+    assert isinstance(effect, RaiseEffect)
+    assert effect.exception_name == "ValueError"
+    assert effect.exception_type_coordinate is not None
+    assert effect.occurrence_id is not None
+    assert effect.producer_node_owner == "Attribute"
+
+
+def test_property_getter_raise_keeps_imported_bare_exception_coordinate(
+    tmp_path: Path,
+) -> None:
+    tree = _tree(
+        tmp_path,
+        "import pytest\n"
+        "from provider.errors import CustomError\n"
+        "class Receiver:\n"
+        "    @property\n"
+        "    def value(self):\n"
+        "        raise CustomError('source getter')\n"
+        "def use():\n"
+        "    with pytest.raises(CustomError):\n"
+        "        Receiver().value\n",
+    )
+
+    outcome = _body_attribute(tree).sugar().desugar(None)
+
+    assert isinstance(outcome, ExitSet)
+    halted = next(face for face in outcome.exits if isinstance(face, Halted))
+    assert isinstance(halted.effect, RaiseEffect)
+    assert halted.effect.exception_name == "CustomError"
+    assert halted.effect.exception_type_coordinate is not None
+    assert halted.effect.occurrence_id is not None
+
+
+def test_source_property_getter_that_returns_completes_without_a_raise(
+    tmp_path: Path,
+) -> None:
+    tree = _tree(
+        tmp_path,
+        "import pytest\n"
+        "class Receiver:\n"
+        "    @property\n"
+        "    def value(self):\n"
+        "        return 7\n"
+        "def use():\n"
+        "    with pytest.raises(ValueError):\n"
+        "        Receiver().value\n",
+    )
+
+    outcome = _body_attribute(tree).sugar().desugar(None)
+
+    assert isinstance(outcome, Complete)
+
+
+def test_shadowed_property_spelling_does_not_authorize_descriptor_dispatch(
+    tmp_path: Path,
+) -> None:
+    tree = _tree(
+        tmp_path,
+        "import pytest\n"
+        "def property(fn):\n"
+        "    return fn\n"
+        "class Receiver:\n"
+        "    @property\n"
+        "    def value(self):\n"
+        "        raise ValueError('not a descriptor')\n"
+        "def use():\n"
+        "    with pytest.raises(ValueError):\n"
+        "        Receiver().value\n",
+    )
+
+    with pytest.raises(SugarNotWritten):
+        _body_attribute(tree).sugar().desugar(None)
+
+
+def test_pandas_303_abstract_method_property_is_the_concrete_reproducer() -> None:
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.manifest_cid, corpus.file_count) == (
+        "3.0.3",
+        PANDAS_MANIFEST_CID,
+        1421,
+    )
+    path = corpus.root / "tests/test_errors.py"
+    tree = SourceFile(
+        workspace_path_source(str(path), root=str(corpus.root.parent)),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    matches = tuple(
+        node
+        for node in tree.nodes()
+        if isinstance(node, Attribute)
+        and node.attr == "property"
+        and node.line_col_span().start_line == 108
+    )
+    assert len(matches) == 1
+
+    outcome = matches[0].sugar().desugar(None)
+
+    assert isinstance(outcome, ExitSet)
+    halted = next(face for face in outcome.exits if isinstance(face, Halted))
+    effect = halted.effect
+    assert isinstance(effect, RaiseEffect)
+    assert effect.exception_name == "AbstractMethodError"
+    assert effect.exception_type_coordinate is not None
+    assert effect.occurrence_id is not None
+    assert effect.producer_node_owner == "Attribute"


### PR DESCRIPTION
## What changed

- authenticate builtin descriptor decorators by lexical binding and carry descriptor kind through constructed class methods
- construct property getter bodies for Attribute access, preserving exception-type and raise-occurrence coordinates
- defer formal Attribute operations through the shared `NativeOperationExitCarrierV1` and reject undecidable or lying actuals
- keep property stores named-loud until an authenticated setter exists

## Why

The authenticated Attribute family was conserved but entirely refused (`0 exits + 53 refusals + 0 panics`). Source-visible property getters already testify to both completion and specific raised exceptions; the lift stopped at the receiver call instead of following that binding.

The verified pandas 3.0.3 reproducer is `pandas/tests/test_errors.py:108` (`Foo().property`), whose getter raises `pandas.errors.AbstractMethodError` at line 95. The new path carries `python:exception_type_identity(import, pandas.errors.AbstractMethodError)` and the concrete raise occurrence while attributing the producer edge to `Attribute`. No pandas or exception spelling is present in production dispatch.

## Authenticated result

Under CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, and pyarrow 22.0.0:

```text
family=Attribute enrolled=53 authenticatedExceptionalExit=1 namedRefusal=52 constructionPanic=0
```

Conservation remains exact: `53 = 1 + 52 + 0`. This is a local authenticated family measurement, not a Battleaxe corpus-wide crash/timeout receipt.

## Teeth

- raising property / completing property twins
- shadowed `property` spelling refuses, proving lexical binding rather than name authority
- formal actual completes or raises; undecidable actual stays loud
- lying expected exception type cannot consume the real AttributeError edge
- total Attribute access gains no fabricated exceptional edge
- mutation of the property-dispatch condition makes the truthful reproducer fail, then restoration returns green

## Validation

```text
79 passed in 133.00s
black --check: 11 files unchanged
git diff --check: exit 0
Attribute family: 1 exit + 52 refusals + 0 panics = 53
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct source-visible Attribute exits for property descriptors on formal receivers
> - Attribute access on formal receivers now emits a `NativeOperationExitCarrierV1` demand with operator `attribute_named` instead of projecting immediately, enabling source-visible exit construction for properties.
> - `ObjectValue.attribute` invokes the property getter when the attribute resolves to a method with `descriptor_kind == 'property'`, marking any propagated `RaiseEffect` with `producer_node_owner='Attribute'`.
> - `ClassDef._method_descriptor_kind` detects recognized unshadowed `property`, `classmethod`, and `staticmethod` decorators; this metadata flows through `ConstructedClassMethodV1` and `ObjectMethodValue` to consumers.
> - Plain attribute stores to properties are refused with `SugarNotWritten` in both `ObjectValue.with_field_store` and `PlaceAssignSugar.desugar`, requiring explicit setter construction.
> - `Raise.exception_type_identity` falls back to `imported_exception_type_identity` when local resolution returns `None`, retaining exception coordinates for imported bare exception names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ae1759.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->