### PR TITLE
Keep pandas BinOp caller pair undischarged

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
@@ -11,6 +11,9 @@ import pytest
 from pandas import Series, Timedelta
 
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+from sugar_lift_py_tests.floor import CallSiteValue, StringValue
+from sugar_lift_py_tests.ir import ctor
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
 
 MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
@@ -133,8 +136,8 @@ def test_helper_alone_has_only_formals_so_exception_identity_is_undischarged() -
     )
 
 
-def test_real_caller_actuals_name_the_exception_from_the_operation() -> None:
-    """The actual operands, not pytest's expectation, establish TypeError."""
+def test_runtime_truth_names_the_candidate_exception_without_licensing_floor() -> None:
+    """Runtime identifies TypeError; this alone cannot authenticate the Floor."""
     _pair()
     left, right = _actuals()
 
@@ -149,8 +152,35 @@ def test_real_caller_actuals_name_the_exception_from_the_operation() -> None:
     assert assert_invalid_addsub_type(left, right) is None
 
 
-def test_wrong_expected_type_does_not_consume_the_real_caller_exception() -> None:
-    """A ValueError boundary leaves the operation's TypeError outside it."""
+def test_candidate_pair_existing_floor_remains_undischarged() -> None:
+    """The current call-result floor cannot authenticate TimedeltaArray + str.
+
+    Caller substitution constructs ``tdarr`` through ``tm.box_expected``.  Its
+    current Floor category is therefore a call result, not a source-decided
+    TimedeltaArray.  The binary law conserves both runtime faces, but its halt
+    has no exception-type coordinate.  #6588 classifies exactly this shape as
+    Undischarged; borrowing ``pytest.raises(TypeError)`` would fabricate it.
+    """
+    pair = _pair()
+    left = CallSiteValue(
+        "tm.box_expected",
+        (),
+        (),
+        ctor("call:tm.box_expected", []),
+        None,
+    )
+
+    outcome = left.add(StringValue("a"), f"{HELPER_PATH}:{pair.operation.lineno}")
+
+    halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
+    completed = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Completed))
+    assert len(halted) == 1
+    assert len(completed) == 1
+    assert halted[0].effect.exception_type_coordinate is None
+
+
+def test_runtime_wrong_expected_type_does_not_consume_candidate_exception() -> None:
+    """At runtime a ValueError boundary leaves the candidate TypeError outside."""
     _pair()
     left, right = _actuals()
 
@@ -161,8 +191,8 @@ def test_wrong_expected_type_does_not_consume_the_real_caller_exception() -> Non
     assert type(escaped.value) is TypeError
 
 
-def test_same_operation_coordinate_completes_for_normal_actuals() -> None:
-    """Changing actuals changes discharge, not the helper's BinOp identity."""
+def test_runtime_candidate_completes_for_normal_actuals() -> None:
+    """Runtime completion is a candidate twin, not authenticated Floor proof."""
     pair = _pair()
     left, _ = _actuals()
 


### PR DESCRIPTION
## Finding

No admissible pandas BinOp helper/caller pair exists yet for the current Floor. The strongest concrete pair remains:

- helper `tests/arithmetic/common.py:40`, operation `left + right` at line 55
- caller `tests/arithmetic/test_timedelta64.py:1167-1172`
- concrete arm `box_with_array=pd.array, other="a"`

CPython runtime proves this is `builtins.TypeError`, but caller construction obtains the left operand through `tm.box_expected(...)`. The existing Floor therefore sees an unresolved call result. Its binary law conserves Completed and Halted faces, but the halt has `exception_type_coordinate=None`; #6588 correctly classifies it as Undischarged. The `pytest.raises(TypeError)` expectation is verification only and is never used to create identity.

The helper-call audit found 28 real calls to `assert_cannot_add` / `assert_invalid_addsub_type`. Every call has at least one pandas Period, Datetime, Timedelta, or numeric-container operand. The other helper candidate, `_test_offset`, uses Timestamp/DateOffset. None is covered by an existing source-authenticated binary Floor law.

## Change

Adds an executable admissibility tooth to the corpus pair merged in #6590 and renames the runtime twins so they cannot be mistaken for authenticated Floor discharge. No production, carrier, ExitSet, tally, FunctionDef, comparison, or Attribute code changes.

## Validation

- CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0
- canonical 1,421-file manifest `blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530`
- `.venv-py312/bin/python -m pytest implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py -q` — 14 passed
- Black check and `git diff --check` passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test asserting pandas BinOp caller pair remains undischarged when a call-result Floor exists
> - Adds `test_candidate_pair_existing_floor_remains_undischarged` to [test_pandas_binary_caller_twins.py](https://github.com/TSavo/sugar/pull/6593/files#diff-2464628a40be2139d8a6abd5a557571ada8c5fe3e139c3c6b694b71b5ead2c96), which constructs a `CallSiteValue` for `tm.box_expected`, performs an add with a `StringValue`, and asserts the outcome has exactly one `Halted` and one `Completed` exit with no `exception_type_coordinate` on the halted effect.
> - Renames three existing tests to use "runtime/candidate" terminology and updates their docstrings without changing test logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b238e8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->