### PR TITLE
Record pandas Compare caller discharge gap

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -163,6 +163,15 @@ def _assert_compare_dual(node, *, atom: str) -> None:
     )
 
 
+def _builtin_exception_identity(name: str):
+    from sugar_lift_py_tests.ir import str_const
+
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
+
+
 def test_launcher_authenticates_content_manifest_not_path_shape() -> None:
     corpus = authenticated_pandas_corpus()
     assert corpus.manifest_cid == MANIFEST_CID
@@ -425,7 +434,10 @@ def test_formal_ordering_survives_until_authenticated_caller_discharge() -> None
     assert isinstance(completed.exits[0], Completed)
     assert len(halted.exits) == 1
     assert isinstance(halted.exits[0], Halted)
-    assert halted.exits[0].effect.exception_name == "TypeError"
+    assert halted.exits[0].effect.exception_name is None
+    assert halted.exits[
+        0
+    ].effect.exception_type_coordinate == _builtin_exception_identity("TypeError")
 
 
 def test_formal_ordering_rejects_a_lying_exception_identity() -> None:
@@ -439,13 +451,9 @@ def test_formal_ordering_rejects_a_lying_exception_identity() -> None:
     )
     from sugar_lift_py_tests.outcome import ExitSet
     from sugar_lift_py_tests.outcome.exit_set import Halted
-    from sugar_lift_py_tests.ir import str_const
 
     class _ExpectedValueError:
-        identity = ctor(
-            "python:exception_type_identity",
-            [str_const("builtins"), str_const("ValueError")],
-        )
+        identity = _builtin_exception_identity("ValueError")
 
         def exception_type_identity(self):
             return self.identity
@@ -469,7 +477,10 @@ def test_formal_ordering_rejects_a_lying_exception_identity() -> None:
 
     assert len(projected.exits) == 1
     assert isinstance(projected.exits[0], Halted)
-    assert projected.exits[0].effect.exception_name == "TypeError"
+    assert projected.exits[0].effect.exception_name is None
+    assert projected.exits[
+        0
+    ].effect.exception_type_coordinate == _builtin_exception_identity("TypeError")
 
 
 def test_formal_membership_records_authenticated_contains_receiver_order() -> None:
@@ -785,9 +796,7 @@ def test_undecided_dispatch_partition_keys_are_law_scoped(
             node.fragment,
         ).desugar(None)
     else:
-        outcome = ComparisonOpSugar(
-            op_kind, left, right, node.fragment
-        ).desugar(None)
+        outcome = ComparisonOpSugar(op_kind, left, right, node.fragment).desugar(None)
 
     _assert_dual_dispatch(outcome, atom=atom, blame=str(node.fragment))
     expected_prefix = f"compare.{law_name}.dispatch"
@@ -858,8 +867,7 @@ def test_chained_comparison_composes_pair_ordering_laws() -> None:
         ]
     )
     assert any(
-        face.guard == and_([not_(first_raises), not_(first_true)])
-        for face in completed
+        face.guard == and_([not_(first_raises), not_(first_true)]) for face in completed
     )
 
 
@@ -891,8 +899,7 @@ def test_subscript_root_preserves_nested_compare_owned_halt() -> None:
     compare_halt = next(
         face
         for face in outcome.exits
-        if isinstance(face, Halted)
-        and face.effect.producer_node_owner == "Compare"
+        if isinstance(face, Halted) and face.effect.producer_node_owner == "Compare"
     )
     assert compare_halt.effect.exception_name is None
     assert compare_halt.effect.blame == str(comparison.fragment)

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_compare_caller_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_compare_caller_twins.py
@@ -1,0 +1,184 @@
+"""A real pandas Compare pair whose current Floor must stay undischarged."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+
+import pandas as pd
+import pandas._testing as tm
+import pytest
+from pandas import date_range
+
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+from sugar_lift_py_tests.floor import CallSiteValue, FloorValue
+
+MANIFEST_CID = (
+    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
+    "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+)
+HELPER_PATH = "tests/arithmetic/common.py"
+CALLER_PATH = "tests/arithmetic/test_datetime64.py"
+
+
+@dataclass(frozen=True)
+class _Pair:
+    helper: ast.FunctionDef
+    operation: ast.Compare
+    caller: ast.FunctionDef
+    call: ast.Call
+
+
+def _function(tree: ast.Module, name: str) -> ast.FunctionDef:
+    matches = tuple(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _pair(
+    *, helper_source: str | None = None, caller_source: str | None = None
+) -> _Pair:
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.file_count, corpus.manifest_cid) == (
+        "3.0.3",
+        1421,
+        MANIFEST_CID,
+    )
+    helper_source = (
+        (corpus.root / HELPER_PATH).read_text(encoding="utf-8")
+        if helper_source is None
+        else helper_source
+    )
+    caller_source = (
+        (corpus.root / CALLER_PATH).read_text(encoding="utf-8")
+        if caller_source is None
+        else caller_source
+    )
+
+    helper = _function(ast.parse(helper_source), "assert_invalid_comparison")
+    operations = tuple(
+        node
+        for node in ast.walk(helper)
+        if isinstance(node, ast.Compare)
+        and isinstance(node.left, ast.Name)
+        and len(node.comparators) == 1
+        and isinstance(node.comparators[0], ast.Name)
+        and (node.left.id, node.comparators[0].id) == ("left", "right")
+        and len(node.ops) == 1
+        and isinstance(node.ops[0], ast.Lt)
+    )
+    assert len(operations) == 1
+    operation = operations[0]
+    assert operation.lineno == 144
+
+    caller_tree = ast.parse(caller_source)
+    imports = tuple(
+        node
+        for node in caller_tree.body
+        if isinstance(node, ast.ImportFrom)
+        and node.module == "pandas.tests.arithmetic.common"
+        and any(alias.name == "assert_invalid_comparison" for alias in node.names)
+    )
+    assert len(imports) == 1
+    assert imports[0].lineno == 35
+
+    caller = _function(caller_tree, "test_dt64arr_cmp_scalar_invalid")
+    rendered_decorators = tuple(ast.unparse(item) for item in caller.decorator_list)
+    assert any(
+        "'foo'" in item and "pytest.mark.parametrize" in item
+        for item in rendered_decorators
+    )
+    assignments = tuple(
+        ast.unparse(node)
+        for node in caller.body
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+    )
+    assert "rng = date_range('1/1/2000', periods=10, tz=tz)" in assignments
+    assert "dtarr = tm.box_expected(rng, box_with_array)" in assignments
+    calls = tuple(
+        node
+        for node in ast.walk(caller)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "assert_invalid_comparison"
+    )
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.lineno == 90
+    assert tuple(ast.unparse(argument) for argument in call.args) == (
+        "dtarr",
+        "other",
+        "box_with_array",
+    )
+    return _Pair(helper, operation, caller, call)
+
+
+def _actuals():
+    """The concrete ``box_with_array=pd.array, other='foo'`` caller arm."""
+    rng = date_range("1/1/2000", periods=10)
+    return tm.box_expected(rng, pd.array), "foo", pd.array
+
+
+def test_helper_alone_has_only_formals_so_exception_identity_is_undischarged() -> None:
+    """The helper occurrence authenticates an operation, never caller actuals."""
+    pair = _pair()
+
+    assert ast.unparse(pair.operation) == "left < right"
+    assert tuple(argument.arg for argument in pair.helper.args.args[:2]) == (
+        "left",
+        "right",
+    )
+    assert all(
+        isinstance(operand, ast.Name)
+        for operand in (pair.operation.left, pair.operation.comparators[0])
+    )
+
+
+def test_real_caller_runtime_actuals_raise_but_do_not_supply_floor_testimony() -> None:
+    """Runtime establishes TypeError; the boundary expectation does not."""
+    _pair()
+    left, right, box = _actuals()
+
+    with pytest.raises(TypeError) as raised:
+        left < right
+
+    assert type(raised.value) is TypeError
+    assert type(raised.value).__module__ == "builtins"
+    from pandas.tests.arithmetic.common import assert_invalid_comparison
+
+    assert assert_invalid_comparison(left, right, box) is None
+
+
+def test_existing_floor_cannot_authenticate_this_pandas_ordering_exception() -> None:
+    """Finding (b): this pair needs return-type testimony the Floor lacks.
+
+    The caller's left actual is the result of ``tm.box_expected``.  Until that
+    call result authenticates a pandas datetime-array Floor value, substitution
+    yields ``CallSiteValue``.  Its inherited generic ordering law can state a
+    ``py.lt`` atom but cannot mint an exception identity.  Consequently this
+    operation must remain undischarged; neither the helper's ``pytest.raises``
+    expectation nor pandas-specific spelling may fill the missing coordinate.
+    """
+    pair = _pair()
+
+    assert ast.unparse(pair.operation) == "left < right"
+    assert "less_than" not in CallSiteValue.__dict__
+    assert CallSiteValue.less_than is FloorValue.less_than
+
+
+def test_lying_caller_coordinate_is_rejected_before_it_can_be_evidence() -> None:
+    """Mutation tooth: a nearby but reversed helper call is not this pair."""
+    corpus = authenticated_pandas_corpus()
+    caller = (corpus.root / CALLER_PATH).read_text(encoding="utf-8")
+    lying = caller.replace(
+        "assert_invalid_comparison(dtarr, other, box_with_array)",
+        "assert_invalid_comparison(other, dtarr, box_with_array)",
+        1,
+    )
+
+    with pytest.raises(AssertionError):
+        _pair(caller_source=lying)


### PR DESCRIPTION
## Finding

The pinned pandas 3.0.3 pair is real, but it is not currently admissible as a named caller-discharge success:

- helper operation: `tests/arithmetic/common.py:144`, `left < right`
- caller: `tests/arithmetic/test_datetime64.py:90`
- concrete pytest parameter: `other="foo"` at line 69
- left actual: `dtarr = tm.box_expected(rng, box_with_array)` at line 89

At runtime these operands raise exact `builtins.TypeError`. After source substitution, however, the left actual is an unresolved call result represented by `CallSiteValue`. `CallSiteValue` has no rich-ordering Floor law and inherits `FloorValue.less_than`, which can state a `py.lt` predicate but cannot authenticate an exception-type coordinate. The operation therefore must remain undischarged.

This PR does not add a pandas-specific Floor, borrow `pytest.raises(TypeError)` testimony, inject callers into the standalone probe, or manufacture a generic halt. The missing law is authenticated return-type/Floor testimony for pandas datetime-array rich ordering against `str`.

## Teeth

- canonical 1,421-file pandas 3.0.3 corpus identity
- exact helper operation, import, caller, assignments, parametrized actual, and call coordinate
- helper-alone formals remain insufficient testimony
- runtime truthful case proves the underlying TypeError without promoting it to Floor testimony
- structural tooth proves `CallSiteValue` has no ordering override capable of producing that identity
- reversed caller-coordinate lying twin is rejected
- existing Compare carrier tests require the populated authenticated exception-type coordinate and reject reliance on the legacy string field

## Validation

- CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0
- focused tests: 52 passed
- Black and diff checks clean
- mutation transaction: caller line 90 -> 91 failed; revert passed

Draft only. Not merged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record pandas Compare caller discharge gap in test suite
> - Adds a new test module [test_pandas_compare_caller_twins.py](https://github.com/TSavo/sugar/pull/6594/files#diff-3f5b7f6ea1a883c84385b38d93b1e71c4dd8b68c98ef4a7e40d2117650b5e695) that validates a specific pandas datetime array comparison remains undischarged because no authenticated ordering law exists at the call site.
> - Introduces a `_pair` utility that binds the `assert_invalid_comparison` helper and its caller AST nodes, verifying structural and line-number invariants before returning coordinates used by subsequent tests.
> - Updates [test_compare_exceptional_exit_producer.py](https://github.com/TSavo/sugar/pull/6594/files#diff-fa2b8d1cb82b05e4512ec1bae4c7a4d961547ff92ac23924a9abf1ad25c75388) to assert halted exits carry an `exception_type_coordinate` instead of an `exception_name` string, and adds a `_builtin_exception_identity` helper to reduce inline duplication.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 934906a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->