### PR TITLE
Construct Python operand-selecting BoolOp short circuit

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -1,15 +1,9 @@
-"""A boolean operation `a and b`, `a or b` (n-ary: `a and b and c`).
+"""Python operand-selecting short-circuit operations ``and`` and ``or``.
 
-In a boolean context -- a condition, an assertion -- `a and b` is true exactly
-when both operands are truthy, `a or b` when either is. So the meaning is the
-conjunction / disjunction of the operands' TRUTHINESS: each operand states its
-own `truth` predicate (a comparison stands as itself, a bare value emits
-`py.truthy`), and this combines them with `and_` / `or_`. One predicate results,
-which states as an inv or guards an if exactly like any other predicate.
-
-(Python's `and`/`or` also carry a short-circuit VALUE -- `a and b` evaluates to
-`a` when `a` is falsy, else `b`. That value form is not modeled here; the boolean
-meaning is what a condition or assertion consumes, and it is what this lifts.)
+Each non-final operand is evaluated once and truth-tested once.  Its stopping
+face returns that exact operand; only its continuing face evaluates the next
+operand.  The final operand is returned without truth coercion.  A halted truth
+dispatch halts the sequence before any later operand is evaluated.
 """
 
 from __future__ import annotations
@@ -81,76 +75,87 @@ class BoolOpSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
         from sugar_lift_py_tests.outcome import Complete, ExitSet, outcome_to_exitset
         from sugar_lift_py_tests.outcome.exit_set import (
-            Completed,
-            _and_guards,
-            _or_guards,
             complement_guard,
             factored_operand,
             false_guard,
             partition,
             true_guard,
         )
-        from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
-        combine = _and_guards if self.op_kind == "And" else _or_guards
         stop_formula = false_guard() if self.op_kind == "And" else true_guard()
+        continue_formula = true_guard() if self.op_kind == "And" else false_guard()
+
+        def truth_formula(truth_value):
+            from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+            from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+                FalseBoolLiteralSugar,
+            )
+            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                TrueBoolLiteralSugar,
+            )
+
+            if isinstance(truth_value, TrueBoolLiteralSugar):
+                return true_guard()
+            if isinstance(truth_value, FalseBoolLiteralSugar):
+                return false_guard()
+            if isinstance(truth_value, PredicateValue):
+                return truth_value.formula
+
+            from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="BoolOpSugar.truth_formula",
+                blame=self.site,
+                observed=type(truth_value).__name__,
+                requested="a truth-floor boolean or PredicateValue",
+                fix=(
+                    "make the selected operand's truth floor return its native "
+                    "truth value without re-evaluating the operand"
+                ),
+                gap_kind=GapKind.FLOOR,
+                gap_locus=GapLocus.CONSTRUCTION,
+            )
 
         def reduce_from(index: int):
             operand = self.values[index]
 
+            # Python returns the final operand; it does not call bool(final).
+            if index == len(self.values) - 1:
+                return factored_operand(operand.desugar(ctx))
+
             def project_truth(value):
                 refuse_undecided_boolean_truth(value, self.site, self.op_kind)
-                return Complete(predicate_formula(value, self.site))
+                return value.truth(self.site).and_then(
+                    lambda truth_value: continue_from(value, truth_formula(truth_value))
+                )
 
-            standing = factored_operand(operand.desugar(ctx)).and_then(project_truth)
-
-            def continue_from(formula):
-                last = index == len(self.values) - 1
-                if last:
-                    return Complete(PredicateValue(formula, self.site))
-
+            def continue_from(value, formula):
                 # A decided stopping face never evaluates the RHS at all.
                 if formula == stop_formula:
-                    return Complete(PredicateValue(stop_formula, self.site))
-                if (self.op_kind == "And" and formula == true_guard()) or (
-                    self.op_kind == "Or" and formula == false_guard()
-                ):
+                    return Complete(value)
+                if formula == continue_formula:
                     return reduce_from(index + 1)
 
-                tail = reduce_from(index + 1)
-                tail_es = outcome_to_exitset(tail)
-                halted = any(not isinstance(edge, Completed) for edge in tail_es.exits)
-
-                # If construction established that every RHS face completes,
-                # its truth formula is available and the ordinary boolean
-                # formula remains a single value.  No exceptional edge is being
-                # hidden in this arm.
-                if not halted and len(tail_es.exits) == 1:
-                    tail_value = tail_es.exits[0].value
-                    return Complete(
-                        PredicateValue(combine(formula, tail_value.formula), self.site)
-                    )
-
-                # Otherwise Python evaluates the tail only on this face.  The
-                # complementary face completes with the short-circuit result;
-                # the RHS halt is conditional, never promoted to unconditional
-                # and never discarded as absent.
+                # An undecided truth result splits the sequence.  Only the
+                # continuing face evaluates the tail; the complement returns
+                # the already-evaluated operand itself.
                 rhs_guard = (
                     formula if self.op_kind == "And" else complement_guard(formula)
                 )
                 rhs_face, stop_face = partition(
                     ("BoolOpSugar", str(self.site), index, self.op_kind)
                 )
-                rhs = tail_es.guarded(rhs_guard, rhs_face)
-                stopped = ExitSet.completed(
-                    PredicateValue(stop_formula, self.site),
-                    complement_guard(rhs_guard),
-                ).guarded(true_guard(), stop_face)
+                rhs = outcome_to_exitset(reduce_from(index + 1)).guarded(
+                    rhs_guard, rhs_face
+                )
+                stopped = ExitSet.completed(value, complement_guard(rhs_guard)).guarded(
+                    true_guard(), stop_face
+                )
                 return rhs.union(stopped)
 
-            return standing.and_then(continue_from)
+            return factored_operand(operand.desugar(ctx)).and_then(project_truth)
 
         return reduce_from(0)

--- a/implementations/python/sugar-lift-py-tests/tests/test_bool_op_ground_operand.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bool_op_ground_operand.py
@@ -11,8 +11,8 @@ from dataclasses import dataclass
 
 from sugar_lift_py_tests.floor.predicate_value import PredicateValue
 from sugar_lift_py_tests.ir import make_var, num, py_eq
-from sugar_lift_py_tests.outcome import Complete
-from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
+from sugar_lift_py_tests.floor.none_value import NoneValue
+from sugar_lift_py_tests.outcome import Complete, outcome_to_exitset
 from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
 from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
 from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
@@ -39,13 +39,25 @@ class _Site:
         return _Left()
 
 
-def _bool_op(kind: str, *operands: object) -> PredicateValue:
+def _bool_op(kind: str, *operands: object):
     site = _Site()
     sugar = BoolOpSugar(op_kind=kind, values=operands, site=site)
-    out = sugar.desugar(None)
-    assert isinstance(out, Complete), out
-    assert isinstance(out.value, PredicateValue), type(out.value)
-    return out.value
+    return sugar.desugar(None)
+
+
+def _completed_values(outcome):
+    return tuple(
+        face.value
+        for face in outcome_to_exitset(outcome).exits
+        if hasattr(face, "value")
+    )
+
+
+def _has_symbolic_formula(outcome) -> bool:
+    return any(
+        isinstance(value, PredicateValue) and value.formula == _symbolic_z_eq_1()
+        for value in _completed_values(outcome)
+    )
 
 
 def _z_eq_1() -> EqualityOpSugar:
@@ -63,76 +75,93 @@ def _symbolic_z_eq_1():
 
 def test_none_and_true_is_false() -> None:
     site = _Site()
-    value = _bool_op(
+    outcome = _bool_op(
         "And",
         NoneLiteralSugar(site=site),
         TrueBoolLiteralSugar(site=site),
     )
-    assert value.formula == false_guard()
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, NoneValue)
 
 
 def test_true_and_false_is_false() -> None:
     site = _Site()
-    value = _bool_op(
+    outcome = _bool_op(
         "And",
         TrueBoolLiteralSugar(site=site),
         FalseBoolLiteralSugar(site=site),
     )
-    assert value.formula == false_guard()
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, FalseBoolLiteralSugar)
 
 
 def test_none_or_true_is_true() -> None:
     site = _Site()
-    value = _bool_op(
+    outcome = _bool_op(
         "Or",
         NoneLiteralSugar(site=site),
         TrueBoolLiteralSugar(site=site),
     )
-    assert value.formula == true_guard()
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, TrueBoolLiteralSugar)
 
 
 def test_symbolic_and_true_absorbs_to_symbolic() -> None:
     """(z == 1) and True → py.eq(z, 1); True is identity of ∧."""
     site = _Site()
-    value = _bool_op("And", _z_eq_1(), TrueBoolLiteralSugar(site=site))
-    assert value.formula == _symbolic_z_eq_1()
+    outcome = _bool_op("And", _z_eq_1(), TrueBoolLiteralSugar(site=site))
+    assert _has_symbolic_formula(outcome)
+    assert any(
+        isinstance(value, TrueBoolLiteralSugar) for value in _completed_values(outcome)
+    )
 
 
 def test_true_and_symbolic_absorbs_to_symbolic() -> None:
     """True and (z == 1) → py.eq(z, 1); order must not matter for absorption."""
     site = _Site()
-    value = _bool_op("And", TrueBoolLiteralSugar(site=site), _z_eq_1())
-    assert value.formula == _symbolic_z_eq_1()
+    outcome = _bool_op("And", TrueBoolLiteralSugar(site=site), _z_eq_1())
+    assert _has_symbolic_formula(outcome)
 
 
 def test_symbolic_or_false_absorbs_to_symbolic() -> None:
     """(z == 1) or False → py.eq(z, 1); False is identity of ∨."""
     site = _Site()
-    value = _bool_op("Or", _z_eq_1(), FalseBoolLiteralSugar(site=site))
-    assert value.formula == _symbolic_z_eq_1()
+    outcome = _bool_op("Or", _z_eq_1(), FalseBoolLiteralSugar(site=site))
+    assert _has_symbolic_formula(outcome)
+    assert any(
+        isinstance(value, FalseBoolLiteralSugar) for value in _completed_values(outcome)
+    )
 
 
 def test_false_and_symbolic_is_false() -> None:
     """False and (z == 1) → false; proves ∧ selects false, not the symbolic."""
     site = _Site()
-    value = _bool_op("And", FalseBoolLiteralSugar(site=site), _z_eq_1())
-    assert value.formula == false_guard()
+    outcome = _bool_op("And", FalseBoolLiteralSugar(site=site), _z_eq_1())
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, FalseBoolLiteralSugar)
 
 
 def test_true_or_symbolic_is_true() -> None:
     """True or (z == 1) → true; proves ∨ selects true, not the symbolic."""
     site = _Site()
-    value = _bool_op("Or", TrueBoolLiteralSugar(site=site), _z_eq_1())
-    assert value.formula == true_guard()
+    outcome = _bool_op("Or", TrueBoolLiteralSugar(site=site), _z_eq_1())
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, TrueBoolLiteralSugar)
 
 
 def test_symbolic_and_false_is_false() -> None:
     site = _Site()
-    value = _bool_op("And", _z_eq_1(), FalseBoolLiteralSugar(site=site))
-    assert value.formula == false_guard()
+    outcome = _bool_op("And", _z_eq_1(), FalseBoolLiteralSugar(site=site))
+    assert _has_symbolic_formula(outcome)
+    assert any(
+        isinstance(value, FalseBoolLiteralSugar) for value in _completed_values(outcome)
+    )
 
 
 def test_symbolic_or_true_is_true() -> None:
     site = _Site()
-    value = _bool_op("Or", _z_eq_1(), TrueBoolLiteralSugar(site=site))
-    assert value.formula == true_guard()
+    outcome = _bool_op("Or", _z_eq_1(), TrueBoolLiteralSugar(site=site))
+    assert _has_symbolic_formula(outcome)
+    assert any(
+        isinstance(value, TrueBoolLiteralSugar) for value in _completed_values(outcome)
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
@@ -1,0 +1,186 @@
+"""Python ``and``/``or`` are operand-selecting, short-circuit sequences."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor import FloorValue
+from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted, outcome_to_exitset
+from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+
+@dataclass(frozen=True)
+class _Site:
+    filename: str = "test_bool_op_operand_sequence.py"
+    line: int = 1
+    col: int = 0
+    source: str = "result = left and right"
+
+
+@dataclass(frozen=True)
+class _Operand(FloorValue):
+    label: str
+    truth_outcome: object
+    truth_calls: list[str] = field(compare=False)
+
+    def denotes_value(self) -> bool:
+        return True
+
+    def runtime_type_is_decided(self) -> bool:
+        return True
+
+    def truth(self, site):
+        del site
+        self.truth_calls.append(self.label)
+        return self.truth_outcome
+
+
+@dataclass(frozen=True)
+class _ProbeSugar(Sugar):
+    label: str
+    value: FloorValue
+    evaluations: list[str] = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        self.evaluations.append(self.label)
+        return Complete(self.value)
+
+
+def _truth(value: bool):
+    site = _Site()
+    literal = TrueBoolLiteralSugar(site) if value else FalseBoolLiteralSugar(site)
+    return Complete(literal)
+
+
+def _completed_value(outcome):
+    exits = outcome_to_exitset(outcome).exits
+    assert len(exits) == 1
+    face = exits[0]
+    assert not isinstance(face, Halted)
+    return face.value
+
+
+def test_left_operand_is_evaluated_and_truth_tested_exactly_once() -> None:
+    evaluations: list[str] = []
+    truth_calls: list[str] = []
+    left = _Operand("left", _truth(True), truth_calls)
+    right = _Operand("right", _truth(False), truth_calls)
+
+    result = BoolOpSugar(
+        "And",
+        (
+            _ProbeSugar("left", left, evaluations),
+            _ProbeSugar("right", right, evaluations),
+        ),
+        _Site(),
+    ).desugar()
+
+    assert evaluations == ["left", "right"]
+    assert truth_calls == ["left"]
+    assert _completed_value(result) is right
+
+
+def test_false_left_returns_left_without_giving_right_any_outcome() -> None:
+    evaluations: list[str] = []
+    truth_calls: list[str] = []
+    left = _Operand("left", _truth(False), truth_calls)
+    right = _Operand("right", _truth(True), truth_calls)
+
+    result = BoolOpSugar(
+        "And",
+        (
+            _ProbeSugar("left", left, evaluations),
+            _ProbeSugar("right", right, evaluations),
+        ),
+        _Site(),
+    ).desugar()
+
+    assert evaluations == ["left"]
+    assert truth_calls == ["left"]
+    assert _completed_value(result) is left
+
+
+def test_true_left_continues_to_right_without_truth_testing_final_operand() -> None:
+    evaluations: list[str] = []
+    truth_calls: list[str] = []
+    left = _Operand("left", _truth(True), truth_calls)
+    right = _Operand("right", _truth(False), truth_calls)
+
+    result = BoolOpSugar(
+        "And",
+        (
+            _ProbeSugar("left", left, evaluations),
+            _ProbeSugar("right", right, evaluations),
+        ),
+        _Site(),
+    ).desugar()
+
+    assert evaluations == ["left", "right"]
+    assert truth_calls == ["left"]
+    assert _completed_value(result) is right
+
+
+def test_halted_left_truth_test_propagates_and_never_reaches_right() -> None:
+    evaluations: list[str] = []
+    truth_calls: list[str] = []
+    effect = RaiseEffect(
+        exception_name="LeftTruthError",
+        occurrence="test_bool_op_operand_sequence.py:1:0",
+        blame="test_bool_op_operand_sequence.py:1:0",
+    )
+    left = _Operand("left", ExitSet.halted(effect), truth_calls)
+    right = _Operand("right", _truth(True), truth_calls)
+
+    result = BoolOpSugar(
+        "And",
+        (
+            _ProbeSugar("left", left, evaluations),
+            _ProbeSugar("right", right, evaluations),
+        ),
+        _Site(),
+    ).desugar()
+
+    exits = outcome_to_exitset(result).exits
+    assert evaluations == ["left"]
+    assert truth_calls == ["left"]
+    assert len(exits) == 1
+    assert isinstance(exits[0], Halted)
+    assert exits[0].effect is effect
+
+
+def test_boolop_result_is_selected_operand_never_coerced_boolean() -> None:
+    evaluations: list[str] = []
+    truth_calls: list[str] = []
+    left = _Operand("non_bool_left", _truth(False), truth_calls)
+    right = _Operand("non_bool_right", _truth(True), truth_calls)
+
+    stopped = BoolOpSugar(
+        "And",
+        (
+            _ProbeSugar("left", left, evaluations),
+            _ProbeSugar("right", right, evaluations),
+        ),
+        _Site(),
+    ).desugar()
+    continued = BoolOpSugar(
+        "Or",
+        (
+            _ProbeSugar("left", left, evaluations),
+            _ProbeSugar("right", right, evaluations),
+        ),
+        _Site(),
+    ).desugar()
+
+    assert _completed_value(stopped) is left
+    assert _completed_value(continued) is right
+    assert not isinstance(_completed_value(stopped), FalseBoolLiteralSugar)
+    assert not isinstance(_completed_value(continued), TrueBoolLiteralSugar)

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
@@ -203,7 +203,7 @@ def test_and_false_short_circuits_rhs_effect_truthful_twin() -> None:
         _EffectSugar(ExpectationNotMetEffect("rhs")),
     )
     assert result == Complete(result.value)
-    assert result.value.formula == false_guard()
+    assert isinstance(result.value, FalseBoolLiteralSugar)
 
 
 def test_or_true_short_circuits_rhs_effect_truthful_twin() -> None:
@@ -213,7 +213,7 @@ def test_or_true_short_circuits_rhs_effect_truthful_twin() -> None:
         _EffectSugar(ExpectationNotMetEffect("rhs")),
     )
     assert result == Complete(result.value)
-    assert result.value.formula == true_guard()
+    assert isinstance(result.value, TrueBoolLiteralSugar)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Python semantic law made constructible

Python `and`/`or` is an operand-selecting short-circuit sequence, not boolean coercion: each non-final operand is evaluated once and truth-tested once; a stopping face returns that exact operand; only a continuing face evaluates the next operand; the final operand is returned without truth-testing. A halted truth dispatch propagates before the right operand receives any outcome.

## What changed

- rewrite `BoolOpSugar.desugar` around `operand.desugar -> value.truth -> branch`
- retain the original operand across truth dispatch and return it on the stopping face
- evaluate the tail only under the continuing guard and return the final operand directly
- replace predicate-only expectations with operand-selection assertions while retaining symbolic formula-face checks
- pin the five independent faces: left once, false stop, true continue, halted truth stop, and operand-not-bool result

Verified pandas 3.0.3 sites: `pandas/tests/generic/test_generic.py:152` (`obj1 and obj2`) and `:154` (`obj1 or obj2`).

## Validation

- local exact environment: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0
- focused post-rebase: 43 passed
- authenticated battleaxe canonical manifest: 7 passed
- mutation transaction: truth-testing the final operand made three law tests fail; reverting returned 5 passed

## Remaining reserved attachment

The two corpus bodies remain located refusals after #6591. The exact reserved-floor attachment is `SymbolicValue.truth`: when the value carries a formal coordinate, it must return the existing native-operation carrier so this producer continuation can receive `Completed`, `Exceptional`, or `Undischarged`. This PR does not edit that reserved floor or the carrier.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement operand-selecting short-circuit semantics for Python `BoolOpSugar.desugar`
> - Rewrites `BoolOpSugar.desugar` to mirror Python's actual `and`/`or` semantics: each non-final operand is evaluated once and truth-tested once; the selected operand is returned as-is rather than coerced to a boolean formula via `PredicateValue`.
> - The final operand is returned without any truth coercion, matching Python's behavior of not calling `bool()` on the last operand.
> - When a non-final operand's truth value is undecided (symbolic), the outcome is split via `partition`: the stop face returns the already-evaluated operand, and only the continue face proceeds to evaluate the tail.
> - Halted outcomes from truth-floor evaluation propagate immediately without evaluating subsequent operands.
> - Updates all related tests in `test_bool_op_ground_operand.py`, `test_bool_op_operand_sequence.py`, and `test_unary_boolop_exception_producers.py` to assert on selected operand instances rather than boolean guard formulas.
> - Behavioral Change: `desugar` no longer produces a `PredicateValue` combining boolean formulas; completed exits now carry the selected operand value directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2293438.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->