### PR TITLE
Lane 8: construct source-derived resource exit truthiness

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
@@ -72,10 +72,33 @@ class WithSourceResourceSugar(Sugar):
                     face_facts = ExitFaceBinding.from_body_exit(
                         self.exit_face_id, body_face
                     ).to_facts(site=self.site, guard=body_face.guard)
-                    routed = ExitSet((body_face,)).and_exit(
-                        exit_es,
-                        disposition=self.summary.semantics.exit.disposition,
+                    disposition = self.summary.semantics.exit.disposition
+                    from sugar_lift_py_tests.context_manager_contract import (
+                        ReturnTruthinessDispositionV1,
                     )
+
+                    if isinstance(disposition, ReturnTruthinessDispositionV1):
+                        from sugar_lift_py_tests.context_manager_contract import (
+                            NeverSuppressesDispositionV1,
+                        )
+                        from sugar_lift_py_tests.effect import RaiseEffect
+
+                        if isinstance(body_face, Halted) and not isinstance(
+                            body_face.effect, RaiseEffect
+                        ):
+                            routed = ExitSet((body_face,)).and_exit(
+                                exit_es,
+                                disposition=NeverSuppressesDispositionV1(),
+                            )
+                        else:
+                            routed = ExitSet((body_face,)).and_exit_truthiness(
+                                _exit_return_values(exit_es), site=self.site
+                            )
+                    else:
+                        routed = ExitSet((body_face,)).and_exit(
+                            exit_es,
+                            disposition=disposition,
+                        )
                     parts.append(
                         prepend_facts_to_exitset(
                             routed, (*manager_facts, *enter_facts, *face_facts)
@@ -105,6 +128,27 @@ def _returned_value(value):
         if isinstance(last, ReturnValue):
             return last.value
     return value
+
+
+def _exit_return_values(exit_es):
+    """Project each completed source method block to its real return value."""
+    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet
+
+    return ExitSet(
+        tuple(
+            (
+                Completed(
+                    face.guard,
+                    _returned_value(face.value),
+                    face.faces,
+                    face.pending_contracts,
+                )
+                if isinstance(face, Completed)
+                else face
+            )
+            for face in exit_es.exits
+        )
+    )
 
 
 def _and(left, right):

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
@@ -2,10 +2,19 @@
 
 from types import SimpleNamespace
 
-from sugar_lift_py_tests.context_manager_contract import EffectMatcher, Suppresses
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import (
+    EffectMatcher,
+    ReturnTruthinessDispositionV1,
+    Suppresses,
+)
 from sugar_lift_py_tests.effect import RaiseEffect
-from sugar_lift_py_tests.floor import BlockValue, TermValue
-from sugar_lift_py_tests.outcome import Complete, Halted, Incomplete
+from sugar_lift_py_tests.effect.loop_control_effect import LoopControlEffect
+from sugar_lift_py_tests.floor import BlockValue, ObjectValue, SymbolicValue, TermValue
+from sugar_lift_py_tests.ir import ctor, not_
+from sugar_lift_py_tests.outcome import Complete, Completed, Halted, Incomplete
+from sugar_lift_py_tests.outcome.exit_set import true_guard
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.with_source_resource_sugar import (
     WithSourceResourceSugar,
@@ -26,20 +35,44 @@ class _FixedSugar(Sugar):
 
 
 class _CompletedProtocol:
-    def __init__(self):
+    def __init__(self, *, enter_value=TermValue(2), exit_value=None):
         self.enter_calls = 0
         self.exit_calls = 0
+        self.enter_value = enter_value
+        self.exit_value = exit_value or BlockValue((), can_fall_through=True)
 
     def enter_resource_outcome(self, ctx=None):
         del ctx
         self.enter_calls += 1
-        return Complete(SimpleNamespace(enter_value=TermValue(2)))
+        return Complete(SimpleNamespace(enter_value=self.enter_value))
 
     def exit_outcome_for(self, entered, ctx=None):
-        assert entered.enter_value == TermValue(2)
+        assert entered.enter_value == self.enter_value
         del ctx
         self.exit_calls += 1
-        return Complete(BlockValue((), can_fall_through=True))
+        return Complete(self.exit_value)
+
+
+def _truthiness_resource(*, exit_value, body, enter_value=TermValue(2), slot=None):
+    summary = SimpleNamespace(
+        semantics=SimpleNamespace(
+            exit=SimpleNamespace(disposition=ReturnTruthinessDispositionV1())
+        )
+    )
+    protocol = _CompletedProtocol(enter_value=enter_value, exit_value=exit_value)
+    return (
+        WithSourceResourceSugar(
+            manager=_FixedSugar(Complete(TermValue(1))),
+            protocol=protocol,
+            summary=summary,
+            body=body,
+            manager_slot_id="manager-slot",
+            enter_slot_id=slot,
+            exit_face_id="exit-face",
+            site="resource.py:3:4",
+        ),
+        protocol,
+    )
 
 
 def test_summary_suppresses_disposition_consumes_matching_body_halt():
@@ -77,3 +110,98 @@ def test_summary_suppresses_disposition_consumes_matching_body_halt():
     )
     assert protocol.enter_calls == 1
     assert protocol.exit_calls == 1
+
+
+def test_source_true_exit_consumes_the_halted_edge():
+    effect = RaiseEffect(exception_name="ValueError", occurrence="resource.py:4:8")
+    sugar, protocol = _truthiness_resource(
+        exit_value=TermValue(True), body=(_FixedSugar(Incomplete(effect)),)
+    )
+
+    exits = sugar.desugar().exits
+
+    assert not any(isinstance(face, Halted) for face in exits)
+    assert any(isinstance(face, Completed) for face in exits)
+    assert protocol.exit_calls == 1
+
+
+def test_source_false_exit_passes_the_exact_halted_edge_through():
+    effect = RaiseEffect(exception_name="ValueError", occurrence="resource.py:4:8")
+    sugar, protocol = _truthiness_resource(
+        exit_value=TermValue(False), body=(_FixedSugar(Incomplete(effect)),)
+    )
+
+    exits = sugar.desugar().exits
+
+    halted = [face for face in exits if isinstance(face, Halted)]
+    assert len(halted) == 1
+    assert halted[0].effect == effect
+    assert protocol.exit_calls == 1
+
+
+def test_source_undecided_exit_keeps_both_suppression_faces():
+    effect = RaiseEffect(exception_name="ValueError", occurrence="resource.py:4:8")
+    result = SymbolicValue(ctor("fixture:undecided-exit", ()))
+    sugar, _ = _truthiness_resource(
+        exit_value=result, body=(_FixedSugar(Incomplete(effect)),)
+    )
+
+    exits = sugar.desugar().exits
+
+    assert len(exits) >= 2
+    assert any(isinstance(face, Completed) for face in exits)
+    halted = next(face for face in exits if isinstance(face, Halted))
+    assert halted.effect == effect
+    assert any(
+        isinstance(face, Completed) and halted.guard == not_(face.guard)
+        for face in exits
+    )
+
+
+def test_source_exit_runs_on_early_return_face():
+    from sugar_lift_py_tests.floor import ReturnValue
+
+    returned = BlockValue((ReturnValue(TermValue("early")),), can_fall_through=False)
+    sugar, protocol = _truthiness_resource(
+        exit_value=TermValue(False), body=(_FixedSugar(Complete(returned)),)
+    )
+
+    exits = sugar.desugar().exits
+
+    assert exits
+    assert protocol.exit_calls == 1
+
+
+@pytest.mark.parametrize("action", ["break", "continue"])
+def test_source_truthy_exit_runs_but_cannot_suppress_loop_transfer(action):
+    loop = LoopControlEffect(
+        action,
+        "blake3-512:" + "1" * 128,
+        "blake3-512:" + "2" * 128,
+    )
+    sugar, protocol = _truthiness_resource(
+        exit_value=TermValue(True), body=(_FixedSugar(Incomplete(loop)),)
+    )
+
+    exits = sugar.desugar().exits
+
+    halted = [face for face in exits if isinstance(face, Halted)]
+    assert len(halted) == 1
+    assert halted[0].effect == loop
+    assert protocol.exit_calls == 1
+
+
+def test_enter_as_binding_carries_object_occurrence_identity():
+    entered = ObjectValue("RenamedResource", (), identity="object-occurrence-cid")
+    sugar, _ = _truthiness_resource(
+        exit_value=TermValue(False),
+        enter_value=entered,
+        body=(_FixedSugar(Complete(BlockValue((), can_fall_through=True))),),
+        slot="enter-slot",
+    )
+
+    rendered = repr(sugar.desugar())
+
+    assert "enter_result_value" in rendered
+    assert "py.object.identity" in rendered
+    assert "object-occurrence-cid" in rendered

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -27,6 +27,7 @@ from sugar_lift_py_tests.context_manager_contract import (
     PositionalOrKeywordV1,
     ProtocolResourceSemanticsV1,
     RaiseEffectKindV1,
+    ReturnTruthinessDispositionV1,
     SuppressesModeV1,
     VariadicKeywordV1,
     VariadicPositionalV1,
@@ -154,16 +155,14 @@ def derive_manager_summary(
         return DerivedManagerSummaryGapV1(
             "exit-may-halt", protocol.protocol_construction_cid, "__exit__ ExitSet"
         )
-    for face in exit_.exits:
-        if not _exact_never_suppresses(face.value):
-            return DerivedManagerSummaryGapV1(
-                "opaque-exit-truthiness",
-                protocol.protocol_construction_cid,
-                type(face.value).__name__,
-            )
+    disposition = (
+        NeverSuppressesDispositionV1()
+        if all(_exact_never_suppresses(face.value) for face in exit_.exits)
+        else ReturnTruthinessDispositionV1()
+    )
     semantics = ProtocolResourceSemanticsV1(
         EnterResultContractV1(PrimitiveSort("Value")),
-        ExitContractV1(NeverSuppressesDispositionV1()),
+        ExitContractV1(disposition),
     )
     signature = _signature_for_behavior(behavior, semantics)
     return _sealed_summary(protocol, semantics, signature)

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -23,7 +23,10 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.context_manager_contract import ProtocolResourceSemanticsV1
+from sugar_lift_py_tests.context_manager_contract import (
+    ProtocolResourceSemanticsV1,
+    ReturnTruthinessDispositionV1,
+)
 from sugar_lift_py_tests.context_manager_resolution import (
     SourceDerivedContextManagerRefV1,
     TreeConstructionContextV1,
@@ -33,7 +36,7 @@ from sugar_lift_py_tests.fixture_resource_obligation import (
     FixtureSuppliedResourceObligationV1,
 )
 from sugar_lift_py_tests.outcome import Complete, Incomplete
-from sugar_lift_py_tests.outcome.exit_set import Halted
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
 from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
@@ -44,7 +47,6 @@ from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
 from sugar_source_tree.tree import SourceFile
-
 
 _GUARD_SOURCE = (
     "class Guard:\n"
@@ -107,7 +109,9 @@ def _with_chain(sugar):
     chain = []
 
     def walk(node):
-        if isinstance(node, (WithSourceResourceSugar, WithResourceSugar, WithEffectBoundarySugar)):
+        if isinstance(
+            node, (WithSourceResourceSugar, WithResourceSugar, WithEffectBoundarySugar)
+        ):
             chain.append(node)
             for child in getattr(node, "body", ()) or ():
                 walk(child)
@@ -242,6 +246,81 @@ def test_direct_call_returned_resource_still_constructs(tmp_path: Path):
     )
     sugar = next(node for node in tree.nodes() if node.kind == "With").sugar()
     assert isinstance(sugar, WithSourceResourceSugar)
+
+
+def test_authenticated_pandas_303_get_handle_is_real_resource_reproducer():
+    """Pinned pandas site: source IOHandles enter/exit around frame output."""
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+    corpus = authenticated_pandas_corpus()
+    frame_source = (corpus.root / "core/frame.py").read_text(encoding="utf-8")
+    manager_source = (corpus.root / "io/common.py").read_text(encoding="utf-8")
+
+    assert frame_source.splitlines()[2987].strip().startswith("with get_handle(")
+    assert "class IOHandles" in manager_source
+    assert (
+        "def __enter__(self) -> IOHandles[AnyStr]:\n        return self"
+        in manager_source
+    )
+    assert "def __exit__(\n        self," in manager_source
+    assert "    ) -> None:\n        self.close()" in manager_source
+
+
+def test_source_true_exit_publishes_truthiness_and_consumes_raise(tmp_path: Path):
+    """Source-derived ``return True`` is suppression testimony, not a name arm."""
+    implementation = _GUARD_SOURCE.replace("return False", "return True")
+    dist = _distribution(tmp_path, implementation)
+    consumer = (
+        "from arbitrary import make_guard\n"
+        "def f(x):\n"
+        "    with make_guard(x):\n"
+        "        raise ValueError('boom')\n"
+        "    return x\n"
+    )
+
+    tree, context, _ = _tree(tmp_path, consumer, dist=dist)
+    reference = next(iter(context.source_derived_contract_refs.values()))
+
+    assert isinstance(reference.semantics, ProtocolResourceSemanticsV1)
+    assert isinstance(
+        reference.semantics.exit.disposition, ReturnTruthinessDispositionV1
+    )
+    sugar = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    assert isinstance(sugar, WithSourceResourceSugar)
+    assert not any(
+        isinstance(face, Halted)
+        and getattr(face.effect, "exception_name", None) == "ValueError"
+        for face in sugar.desugar().exits
+    )
+
+
+def test_source_undecided_exit_never_silently_swallows_raise(tmp_path: Path):
+    """A source-visible symbolic return retains suppress and propagate faces."""
+    implementation = _GUARD_SOURCE.replace("return False", "return self.marker")
+    dist = _distribution(tmp_path, implementation)
+    consumer = (
+        "from arbitrary import make_guard\n"
+        "def f(x):\n"
+        "    with make_guard(x):\n"
+        "        raise ValueError('boom')\n"
+        "    return x\n"
+    )
+
+    tree, context, _ = _tree(tmp_path, consumer, dist=dist)
+    reference = next(iter(context.source_derived_contract_refs.values()))
+
+    assert isinstance(reference.semantics, ProtocolResourceSemanticsV1)
+    assert isinstance(
+        reference.semantics.exit.disposition, ReturnTruthinessDispositionV1
+    )
+    sugar = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    exits = sugar.desugar().exits
+    assert any(isinstance(face, Completed) for face in exits)
+    assert any(
+        isinstance(face, Halted)
+        and getattr(face.effect, "exception_name", None) == "ValueError"
+        for face in exits
+    )
 
 
 def test_nested_assigned_resources_compose_through_one_algebra(tmp_path: Path):
@@ -389,7 +468,9 @@ def test_fixture_supplied_formal_manager_stays_typed_loud_without_actual(
     obligation_src.write_text(
         "def use(resource):\n    return resource\n", encoding="utf-8"
     )
-    frame = next(SourceFile(path_source(str(obligation_src))).functions()).source_visible_call_frame()
+    frame = next(
+        SourceFile(path_source(str(obligation_src))).functions()
+    ).source_visible_call_frame()
     obligation = FixtureSuppliedResourceObligationV1.mint(frame.formal_coordinates[0])
     assert obligation.kind == "fixture-supplied-resource-obligation"
     assert obligation.formal_coordinate_cid == frame.formal_coordinates[0].cid

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5234,6 +5234,7 @@ class With(Statement):
             RaiseEffectKindV1,
             WarningEffectKindV1,
             NeverSuppressesDispositionV1,
+            ReturnTruthinessDispositionV1,
             ProtocolResourceSemanticsV1,
             TotalCompletionV1,
         )
@@ -5266,7 +5267,10 @@ class With(Statement):
             and isinstance(semantics.enter.sort, PrimitiveSort)
             and semantics.enter.sort.name == "Value"
             and isinstance(semantics.exit.completion, TotalCompletionV1)
-            and isinstance(semantics.exit.disposition, NeverSuppressesDispositionV1)
+            and isinstance(
+                semantics.exit.disposition,
+                (NeverSuppressesDispositionV1, ReturnTruthinessDispositionV1),
+            )
         )
         admitted_boundary = (
             isinstance(semantics, EffectBoundarySemanticsV1)
@@ -5287,7 +5291,8 @@ class With(Statement):
                     f"at {resolution.contract_cid}"
                 ),
                 requested=(
-                    "total Value/NeverSuppresses resource or typed "
+                    "total Value resource with source-derived NeverSuppresses or "
+                    "ReturnTruthiness disposition, or typed "
                     "Expects/Suppresses Raise/Warning boundary"
                 ),
                 fix="leave unsupported authenticated semantics loud; never upgrade testimony",


### PR DESCRIPTION
## Semantic law made constructible

A source-defined resource context manager now publishes its real `__enter__`/`__exit__` outcome. `__exit__` return truthiness consumes only exception exits proven truthy, restores proven-false exits, and retains both faces when truthiness is undecided. Normal completion, early return, break, and continue still execute exit; loop transfer is never suppressible. The `as` binding retains the constructed enter value including occurrence-derived object identity.

No manager/vendor spelling table and no `ExitSet`, `outcome/`, carrier, formal-seam, or generator-construction edit.

## Concrete pandas 3.0.3 reproducer

Authenticated canonical corpus `core/frame.py:2988`: `with get_handle(...) as handles`. The real manager definition is pandas `io/common.py::IOHandles`, whose `__enter__` returns `self` and whose `__exit__` calls `close()` and falls through to `None`.

## Validation

- authenticated bootstrap: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0
- `sugar-lift-py-tests`: 11 passed
- `sugar-lift-python-source`: 13 passed
- `sugar-source-tree`: 10 passed
- mutation transaction: deleting ReturnTruthiness publication makes the truthful and undecided twins fail 2/2; restored twins pass 2/2
- shared demand table consumed read-only: `blake3-512:0ce7c645...`, 107,433 rows

The wider existing `test_sole_path_manager_construction.py` has the same 14 failures on base `57a177310` and on this branch; they are inherited, with identical test names. No corpus delta, crash/timeout receipt, or battleaxe receipt is claimed from this Mac.

Rebased onto `f3703129c`. Do not merge automatically.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support source-derived `ReturnTruthinessDispositionV1` exit disposition in `with` statement desugaring
> - `derive_manager_summary` now returns `ReturnTruthinessDispositionV1` (instead of a gap) when `__exit__` return truthiness must be consulted to decide suppression.
> - `With._construct_sugar` admits resources with `ReturnTruthinessDispositionV1` exit disposition, where previously they were rejected.
> - `WithSourceResourceSugar.desugar` routes truthiness-disposition exits through a new `and_exit_truthiness` path, using `_exit_return_values` to extract actual return values; non-raise halts (e.g. loop control) remain unsuppressible.
> - Behavioral Change: `__exit__` methods that previously caused a `DerivedManagerSummaryGapV1` (and were rejected by sugar construction) now produce a fully desugared `with` block with truthiness-based suppression semantics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4c2a9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->