### PR TITLE
Construct source-visible subscript stores

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -349,3 +349,11 @@ class TupleValue(FloorValue):
                 exception_name="TypeError", site=site, owner="TupleValue.subscript"
             )
         return self.undecided_subscript(index, site, owner="TupleValue.subscript")
+
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="TupleValue.setitem"
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
@@ -85,32 +85,78 @@ class AttributeStoreEffectSugar(Sugar):
 
 @dataclass(frozen=True)
 class SubscriptStoreEffectSugar(Sugar):
-    """`<receiver>[<index>] = <value>` -- a subscript store whose dispatch
-    (``__setitem__``) belongs to the runtime.
+    """`receiver[index] = value`, evaluated and dispatched as ``__setitem__``.
 
-    Same shape as ``AttributeStoreEffectSugar``: a store target is read and
-    written, never bound, so it desugars straight to typed red --
-    ``Incomplete`` wrapping a ``SubscriptStoreRuntimeEffect``, witnessed at
-    the TREE fragment site. The store completed, so the block continues past
-    it (outcome/incomplete.py::_effect_continues_control_flow).
+    Ground receivers project their native completed or exceptional store face.
+    A runtime-selected receiver stays loud until the n-ary native-operation
+    carrier can preserve receiver, key, value, and the original occurrence.
     """
+
+    receiver: Sugar
+    index: Sugar
+    value: Sugar
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        # The source-visible completed/exceptional and loud-refusal laws are
+        # discrimination tests in test_subscript_store_desugar.py. The former
+        # typed-runtime-effect witness asserted the superseded generic effect.
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        # Python evaluates the RHS before the target receiver and key.
+        return self.value.desugar(ctx).and_then(
+            lambda value: self.receiver.desugar(ctx).and_then(
+                lambda receiver: self.index.desugar(ctx).and_then(
+                    lambda index: self._store(receiver, index, value)
+                )
+            )
+        )
+
+    def desugar_store(self, ctx: object, value) -> Outcome:
+        return self.receiver.desugar(ctx).and_then(
+            lambda receiver: self.index.desugar(ctx).and_then(
+                lambda index: self._store(receiver, index, value)
+            )
+        )
+
+    def _store(self, receiver, index, value) -> Outcome:
+        if not receiver.runtime_type_is_decided():
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                owner="SubscriptStoreEffectSugar._store",
+                blame=self.site,
+                observed="undischarged subscript store over runtime-selected receiver",
+                requested=(
+                    "NativeOperationExitCarrierV1 n-ary setitem demand over "
+                    "receiver, key, and value formal coordinates"
+                ),
+                fix="attach the three-operand carrier seam owned by 9883",
+            )
+        projected = receiver.setitem(index, value, self.site)
+        from sugar_lift_py_tests.floor import RaiseValue
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+        if isinstance(projected, Complete) and isinstance(projected.value, RaiseValue):
+            return Incomplete(projected.value.effect)
+        return projected
+
+
+@dataclass(frozen=True)
+class LegacyAugmentedSubscriptStoreEffectSugar(Sugar):
+    """Preserve AugAssign without pretending its raw RHS is the stored value."""
 
     index_text: str
     site: object = dataclass_field(compare=False)
 
     @classmethod
     def witnesses(cls):
-        return typed_red_effect_witness(
-            name="subscript_store_runtime_effect",
-            owner_sugar="SubscriptStoreEffectSugar",
-            source="def A(xs, i, v):\n    xs[i] = v\n    return v\n",
-            effect_class="SubscriptStoreRuntimeEffect",
-            reason_needle="subscript store",
-            blame_needle="index=i",
-            wrong_reason_needle="subscript store target `[j]`",
-        )
+        return ()
 
     def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
         from sugar_lift_py_tests.effect import (
             SubscriptStoreRuntimeEffect,
             runtime_effect_evidence,
@@ -120,15 +166,8 @@ class SubscriptStoreEffectSugar(Sugar):
         operand = make_var(f"store_target[{self.index_text}]")
         return Incomplete(
             SubscriptStoreRuntimeEffect(
-                "subscript assignment runtime boundary: subscript store "
-                f"target `[{self.index_text}]` -- receiver dispatch belongs "
-                "to Python's runtime __setitem__; "
-                f"index={self.index_text} site={self.site}",
+                "augmented subscript assignment runtime boundary: subscript store "
+                f"target `[{self.index_text}]`; index={self.index_text} site={self.site}",
                 **runtime_effect_evidence("py.setitem", operand, self.site),
             )
         )
-
-    def desugar_store(self, ctx: object, value) -> Outcome:
-        """Compatibility with chained store sequencing; subscript is separately owned."""
-        del value
-        return self.desugar(ctx)

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.floor import ListValue, SymbolicValue, TermValue, TupleValue
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.store_effect_sugar import SubscriptStoreEffectSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_source_tree.panic import SugarNotWritten
+
+
+def _site(tmp_path):
+    from sugar_lift_python_source.source_oracle import workspace_path_source
+    from sugar_source_tree.tree import SourceFile
+
+    path = tmp_path / "store.py"
+    path.write_text("def f(obj, key, value):\n    obj[key] = value\n")
+    function = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    )
+    return function.body[0].fragment
+
+
+@dataclass(frozen=True)
+class _ObservedSugar(Sugar):
+    label: str
+    value: object
+    log: list[str]
+
+    @classmethod
+    def witnesses(cls):
+        raise AssertionError("test helper has no witness")
+
+    def desugar(self, ctx=None):
+        del ctx
+        self.log.append(self.label)
+        return Complete(self.value)
+
+
+def _store(receiver, key, value, log, site):
+    return SubscriptStoreEffectSugar(
+        receiver=_ObservedSugar("receiver", receiver, log),
+        index=_ObservedSugar("key", key, log),
+        value=_ObservedSugar("value", value, log),
+        site=site,
+    )
+
+
+def test_subscript_store_evaluates_rhs_receiver_and_key_once_in_python_order(tmp_path):
+    log: list[str] = []
+    outcome = _store(
+        ListValue((TermValue(1),)), TermValue(0), TermValue(7), log, _site(tmp_path)
+    ).desugar()
+
+    assert log == ["value", "receiver", "key"]
+    assert outcome == Complete(ListValue((TermValue(7),)))
+
+
+def test_readable_immutable_receiver_raises_on_store(tmp_path):
+    receiver = TupleValue((TermValue(1),))
+    assert receiver.subscript(TermValue(0), "read.py:1").value == TermValue(1)
+
+    outcome = _store(
+        receiver, TermValue(0), TermValue(7), [], _site(tmp_path)
+    ).desugar()
+
+    assert type(outcome).__name__ == "Incomplete"
+    assert outcome.effect.exception_name == "TypeError"
+    assert "TypeError" in repr(outcome.effect.exception_type_coordinate)
+    assert "ValueError" not in repr(outcome.effect.exception_type_coordinate)
+    assert outcome.effect.producer_node_owner == "TupleValue.setitem"
+
+
+def test_undecided_store_never_claims_a_completed_face(tmp_path):
+    store = _store(
+        SymbolicValue(make_var("obj")),
+        TermValue(0),
+        TermValue(7),
+        [],
+        _site(tmp_path),
+    )
+
+    with pytest.raises(SugarNotWritten, match="undischarged subscript store"):
+        store.desugar()
+
+
+def test_rhs_halt_wins_before_receiver_or_key_evaluation(tmp_path):
+    from sugar_lift_py_tests.effect import RaiseEffect
+    from sugar_lift_py_tests.floor import RaiseValue
+    from sugar_lift_py_tests.ir import str_const
+
+    log: list[str] = []
+
+    @dataclass(frozen=True)
+    class _RaisingValue(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            log.append("value")
+            return Complete(
+                RaiseValue(
+                    RaiseEffect(
+                        exception_type_coordinate=str_const("ValueError"),
+                        occurrence="store.py:4:12",
+                    )
+                )
+            )
+
+        @classmethod
+        def witnesses(cls):
+            raise AssertionError
+
+    store = SubscriptStoreEffectSugar(
+        receiver=_ObservedSugar("receiver", ListValue(()), log),
+        index=_ObservedSugar("key", TermValue(0), log),
+        value=_RaisingValue(),
+        site=_site(tmp_path),
+    )
+    outcome = store.desugar()
+
+    assert log == ["value"]
+    assert outcome.value.effect.exception_type_coordinate == str_const("ValueError")
+
+
+def test_receiver_halt_wins_before_key_after_rhs_completed(tmp_path):
+    from sugar_lift_py_tests.effect import RaiseEffect
+    from sugar_lift_py_tests.floor import RaiseValue
+    from sugar_lift_py_tests.ir import str_const
+
+    log: list[str] = []
+
+    @dataclass(frozen=True)
+    class _RaisingReceiver(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            log.append("receiver")
+            return Complete(
+                RaiseValue(
+                    RaiseEffect(
+                        exception_type_coordinate=str_const("LookupError"),
+                        occurrence="store.py:4:4",
+                    )
+                )
+            )
+
+        @classmethod
+        def witnesses(cls):
+            raise AssertionError
+
+    store = SubscriptStoreEffectSugar(
+        receiver=_RaisingReceiver(),
+        index=_ObservedSugar("key", TermValue(0), log),
+        value=_ObservedSugar("value", TermValue(7), log),
+        site=_site(tmp_path),
+    )
+
+    outcome = store.desugar()
+
+    assert log == ["value", "receiver"]
+    assert outcome.value.effect.exception_type_coordinate == str_const("LookupError")
+
+
+def test_store_halt_preserves_state_completed_before_it(tmp_path):
+    from sugar_lift_py_tests.floor.block_value import BlockValue
+    from sugar_lift_py_tests.outcome import Halted
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        reduce_block_to_exitset,
+    )
+
+    prior = _ObservedSugar(
+        "prior", BlockValue((TermValue(99),), can_fall_through=True), []
+    )
+    store = _store(
+        TupleValue((TermValue(1),)),
+        TermValue(0),
+        TermValue(7),
+        [],
+        _site(tmp_path),
+    )
+
+    outcome = reduce_block_to_exitset((prior, store), None)
+
+    halted = [exit_ for exit_ in outcome.exits if isinstance(exit_, Halted)]
+    assert len(halted) == 1
+    assert TermValue(99) in halted[0].state.entries

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3511,7 +3511,9 @@ def _valued_store_target_sugar(target, value_sugar, site):
         )
 
         return SubscriptStoreEffectSugar(
-            index_text=target.slice_.fragment.text,
+            receiver=target.value.sugar(),
+            index=target.slice_.sugar(),
+            value=value_sugar,
             site=site,
         )
     return None
@@ -4116,7 +4118,9 @@ class Assign(Statement):
 
                     stores.append(
                         SubscriptStoreEffectSugar(
-                            index_text=target.slice_.fragment.text,
+                            receiver=target.value.sugar(),
+                            index=target.slice_.sugar(),
+                            value=value_sugar,
                             site=target.fragment,
                         )
                     )
@@ -4229,10 +4233,10 @@ class AugAssign(Statement):
             )
         if isinstance(self.target, Subscript):
             from sugar_lift_py_tests.sugar.store_effect_sugar import (
-                SubscriptStoreEffectSugar,
+                LegacyAugmentedSubscriptStoreEffectSugar,
             )
 
-            return SubscriptStoreEffectSugar(
+            return LegacyAugmentedSubscriptStoreEffectSugar(
                 index_text=self.target.slice_.fragment.text,
                 site=self.fragment,
             )

--- a/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
+++ b/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
@@ -7,6 +7,8 @@ bare non-Name annotations remain loud gaps."""
 
 import tempfile
 
+import pytest
+
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_lift_py_tests.effect import (
     AttributeStoreRuntimeEffect,
@@ -17,6 +19,7 @@ from sugar_lift_py_tests.sugar.expr_statement_sugar import ExprStatementSugar
 from sugar_lift_py_tests.sugar.augassign_sugar import AugAssignSugar
 from sugar_lift_py_tests.sugar.binop_sugar import BinOpSugar
 from sugar_lift_py_tests.sugar.store_effect_sugar import AttributeStoreEffectSugar
+from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
@@ -110,11 +113,9 @@ def test_annotated_attribute_with_value_builds_store_effect():
     assert isinstance(effects[0], AttributeStoreRuntimeEffect)
 
 
-def test_annotated_subscript_with_value_builds_store_effect():
-    effects = _red_effects("def A(d, k, y):\n    d[k]: int = y\n    return y\n")
-
-    assert len(effects) == 1
-    assert isinstance(effects[0], SubscriptStoreRuntimeEffect)
+def test_annotated_subscript_store_stays_loud_without_setitem_testimony():
+    with pytest.raises(SugarNotWritten, match="undischarged subscript store"):
+        _fn("def A(d, k, y):\n    d[k]: int = y\n    return y\n").sugar().desugar()
 
 
 _CONSTRUCTED_RECEIVER_SOURCE = (

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -11,10 +11,7 @@ import tempfile
 
 import pytest
 
-from sugar_lift_py_tests.effect import (
-    AttributeStoreRuntimeEffect,
-    SubscriptStoreRuntimeEffect,
-)
+from sugar_lift_py_tests.effect import AttributeStoreRuntimeEffect
 from sugar_lift_py_tests.outcome import Incomplete
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.panic import SugarNotWritten
@@ -110,17 +107,13 @@ def test_mixed_chain_sequences_existing_store_obligation_and_name_binding():
     assert isinstance(red[0].effect, AttributeStoreRuntimeEffect)
 
 
-def test_mixed_chain_preserves_each_store_face_in_source_order():
-    entries = _completed_entries(
-        "def arbitrary(o, xs):\n"
-        "    renamed = o.field = xs[0] = 7\n"
-        "    return renamed\n"
-    )
-    red = [entry for entry in entries if isinstance(entry, Incomplete)]
-    assert [type(entry.effect) for entry in red] == [
-        AttributeStoreRuntimeEffect,
-        SubscriptStoreRuntimeEffect,
-    ]
+def test_mixed_chain_never_fabricates_a_completed_subscript_store():
+    with pytest.raises(SugarNotWritten, match="undischarged subscript store"):
+        _fn(
+            "def arbitrary(o, xs):\n"
+            "    renamed = o.field = xs[0] = 7\n"
+            "    return renamed\n"
+        ).sugar().desugar()
 
 
 def test_nested_tuple_target_binds_each_structural_projection():
@@ -215,11 +208,21 @@ def test_attribute_store_target_lifts_a_typed_red_effect():
     assert isinstance(red[0].effect, AttributeStoreRuntimeEffect)
 
 
-def test_subscript_store_target_lifts_a_typed_red_effect():
-    entries = _completed_entries("def A(xs):\n    xs[0] = 1\n    return xs\n")
-    red = [e for e in entries if isinstance(e, Incomplete)]
-    assert len(red) == 1
-    assert isinstance(red[0].effect, SubscriptStoreRuntimeEffect)
+def test_subscript_store_target_stays_loud_without_setitem_testimony():
+    with pytest.raises(SugarNotWritten, match="undischarged subscript store"):
+        _fn("def A(xs):\n    xs[0] = 1\n    return xs\n").sugar().desugar()
+
+
+def test_subscript_store_producer_retains_receiver_key_and_rhs():
+    function = _fn("def A(xs, key, value):\n    xs[key] = value\n")
+    assignment = next(node for node in function.walk() if node.kind == "Assign")
+
+    store = assignment.sugar()
+
+    assert type(store).__name__ == "SubscriptStoreEffectSugar"
+    assert store.receiver.site.text == "xs"
+    assert store.index.site.text == "key"
+    assert store.value.site.text == "value"
 
 
 if __name__ == "__main__":
@@ -233,8 +236,8 @@ if __name__ == "__main__":
     test_non_display_rhs_stays_loud()
     test_mixed_chained_targets_stay_loud()
     test_attribute_store_target_lifts_a_typed_red_effect()
-    test_subscript_store_target_lifts_a_typed_red_effect()
+    test_subscript_store_target_stays_loud_without_setitem_testimony()
     print(
         "ok: tuple/chained assign destructures; starred/nested stay loud; "
-        "store targets lift typed red"
+        "subscript stores require setitem testimony"
     )

--- a/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
@@ -1,28 +1,21 @@
-"""Store-target assignments (`obj.a = e`, `xs[i] = e`) attach a typed red
-runtime-effect witness at the TREE fragment site (the fragment-type seam,
-#5994-adjacent).
+"""Store-target assignments preserve their target-specific obligations.
 
-A store has TWO outcomes, runtime-selected: it completes (Python continues to
-the next statement) or it halts. So the body reduces to an `ExitSet`, not to one
-linear outcome. Everything asserted below is a fact about the COMPLETED arm --
-the block kept reducing, the returned value is unaffected, the witness names the
-real target -- and the assertions are unchanged; only the navigation to that arm
-is explicit now. The halt arm and the composition laws are asserted in
-sugar-lift-py-tests/tests/test_store_outcome_composition.py."""
+Attribute-store coverage here retains its runtime-effect witness. Subscript
+store coverage pins the stronger rule: absent ``__setitem__`` testimony it
+stays loud and cannot borrow ``__getitem__`` or a generic completed arm."""
 
 import tempfile
 from dataclasses import replace
 
+import pytest
+
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_lift_py_tests.effect import (
-    AttributeStoreRuntimeEffect,
-    RaiseEffect,
-    SubscriptStoreRuntimeEffect,
-)
+from sugar_lift_py_tests.effect import AttributeStoreRuntimeEffect, RaiseEffect
 from sugar_lift_py_tests.outcome import Incomplete
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
 from sugar_source_tree.fragment import SourceFragment as TreeSourceFragment
+from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
@@ -91,22 +84,14 @@ def test_attribute_store_post_out_equals_the_returned_value():
     assert post.args[1].name == "v"
 
 
-def test_subscript_store_lifts_a_red_effect_and_the_block_continues():
-    entries = _entries("def A(xs, i, v):\n    xs[i] = v\n    return v\n")
-    red = [e for e in entries if isinstance(e, Incomplete)]
-    assert len(red) == 1
-    assert isinstance(red[0].effect, SubscriptStoreRuntimeEffect)
-    assert any(type(e).__name__ == "ReturnValue" for e in entries)
-
-
-def test_subscript_store_post_out_equals_the_returned_value():
-    v = _completed(
+def test_subscript_store_stays_loud_without_setitem_testimony():
+    with pytest.raises(SugarNotWritten, match="undischarged subscript store"):
         _fn("def A(xs, i, v):\n    xs[i] = v\n    return v\n").sugar().desugar()
-    ).value
-    post = v.post()
-    assert post.name == "="
-    assert post.args[0].name == "out"
-    assert post.args[1].name == "v"
+
+
+def test_subscript_store_does_not_borrow_the_read_path():
+    with pytest.raises(SugarNotWritten, match="undischarged subscript store"):
+        _fn("def A(xs, i, v):\n    xs[i] = v\n    return v\n").sugar().desugar()
 
 
 def test_attribute_store_witness_site_is_the_tree_fragment():
@@ -127,12 +112,9 @@ def test_attribute_store_witness_site_is_the_tree_fragment():
     assert "store_target" not in operand
 
 
-def test_subscript_store_witness_names_the_index():
-    entries = _entries("def A(xs, i, v):\n    xs[i] = v\n    return v\n")
-    (red,) = [e for e in entries if isinstance(e, Incomplete)]
-    witness = red.effect.witness
-    assert isinstance(witness.site, TreeSourceFragment)
-    assert "store_target[i]" in repr(witness.runtime_operand.term)
+def test_subscript_store_refusal_names_the_missing_nary_carrier():
+    with pytest.raises(SugarNotWritten, match="n-ary setitem demand"):
+        _fn("def A(xs, i, v):\n    xs[i] = v\n    return v\n").sugar().desugar()
 
 
 def test_two_stores_in_one_block_both_lift_and_discriminate_by_target():


### PR DESCRIPTION
## What changed

- retain receiver, key, and RHS sugar for plain subscript assignment
- evaluate RHS, receiver, and key exactly once in Python order before dispatching setitem
- project ground completed and exceptional faces through the shared block-to-ExitSet reducer
- keep runtime-selected setitem obligations loudly refused pending the n-ary native-operation carrier owned by 9883
- preserve the pre-existing AugAssign runtime path separately so raw RHS is never mistaken for the augmented stored value

## Python semantic law made constructible

For obj[key] = value, Python evaluates value first, then obj, then key, each exactly once, and dispatches setitem independently of the readable getitem obligation. A store halt retains state completed before the store.

Pinned pandas reproducer: pandas/tests/arrays/numpy_/test_numpy.py:293, arr[0] = "t".

## Validation

- authenticated local runtime: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0
- focused suites: 78 passed, 2 deselected; both deselections independently reproduce unchanged on origin/main due to pre-existing ExitSet.value assumptions
- mutation transaction: reversing RHS/receiver order made the order twin fail; restoring returned the focused suite green
- black check: 7 files unchanged
- git diff --check: exit 0

## Named dependency

NativeOperationExitCarrierV1.mint currently requires exactly two operands and discharge invokes left.operator(right, site). Runtime-selected SubscriptStore needs three aligned operands and receiver.setitem(key, value, original_site), preserving all formal-coordinate CIDs and the original occurrence. This PR refuses that unresolved case rather than fabricating a completed or generic halted face.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct source-visible subscript stores with receiver, key, and value sugar
> - `SubscriptStoreEffectSugar` now carries receiver, index, and value sugar instead of only index text, enabling downstream evaluation and refusal logic based on runtime receiver selection.
> - Subscript stores over runtime-selected receivers now raise `SugarNotWritten` with an 'undischarged subscript store over runtime-selected receiver' observation requesting an n-ary setitem carrier, rather than producing a typed red effect.
> - Augmented subscript assignments are routed through a new `LegacyAugmentedSubscriptStoreEffectSugar` path in [nodes.py](https://github.com/TSavo/sugar/pull/6599/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0).
> - `TupleValue.setitem` is added in [tuple_value.py](https://github.com/TSavo/sugar/pull/6599/files#diff-ee02935e29cc93521433e8c8341cbad2b784d9c95c3a9cee1451a2e504318945) and emits a `TypeError` via a ground exceptional exit on any subscript store attempt.
> - Behavioral Change: tests that previously expected `SubscriptStoreRuntimeEffect` now expect `SugarNotWritten`; the `desugar_store()` compatibility method is removed from `SubscriptStoreEffectSugar`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53791c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->