### PR TITLE
Add authenticated native protocol definition coordinates

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -198,9 +198,9 @@ class NativeOperationDemandV1:
             raise ValueError("native operation requires a nonempty operator")
         operands = tuple(operands)
         coordinates = tuple(coordinates)
-        if len(operands) != 2 or len(coordinates) != len(operands):
+        if not operands or len(coordinates) != len(operands):
             raise ValueError(
-                "native operation requires two ordered operands and aligned coordinates"
+                "native operation requires ordered operands and aligned coordinates"
             )
 
         source_node = source_coordinate(site)
@@ -317,7 +317,7 @@ class NativeOperationExitCarrierV1:
                 )
             actual_operands.append(actuals_by_formal_coordinate[coordinate_cid])
 
-        left, right = actual_operands
+        left = actual_operands[0]
         operation = getattr(left, self.demand.operator, None)
         if not callable(operation):
             construction_panic_gap(
@@ -332,7 +332,19 @@ class NativeOperationExitCarrierV1:
                 gap_kind=GapKind.FLOOR,
             )
 
-        projected = operation(right, self.site)
+        if len(actual_operands) == 1:
+            projected = operation(self.site)
+        elif len(actual_operands) == 2:
+            projected = operation(actual_operands[1], self.site)
+        else:
+            construction_panic_gap(
+                owner="NativeOperationExitCarrierV1.discharge",
+                blame=self.demand.source_node,
+                observed="native operation has unsupported operand arity",
+                requested="a unary or binary native operation",
+                fix="retain the operation demand until its native arity is supported",
+                gap_kind=GapKind.FLOOR,
+            )
         if isinstance(projected, Complete) and isinstance(projected.value, RaiseValue):
             effect = projected.value.effect
             if effect.exception_type_coordinate is None or effect.occurrence_id is None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from types import MappingProxyType
+from enum import Enum
 from typing import Any, Mapping
 
 from .canonicalizer import blake3_512_of, encode_jcs
@@ -20,6 +21,16 @@ from .ir import Sort
 
 class ContractRefProtocolError(ValueError):
     pass
+
+
+class NativeProtocolSlot(str, Enum):
+    """Closed source protocol slots, independent of vendor member spelling."""
+
+    CONTEXT_ENTER = "context-enter"
+    CONTEXT_EXIT = "context-exit"
+    TRUTH = "truth"
+    SET_ITEM = "set-item"
+    GET_ITEM = "get-item"
 
 
 @dataclass(frozen=True, order=True)
@@ -122,6 +133,18 @@ ContextManagerResolutionV1 = ContextManagerContractRefV1 | ContextManagerResolut
 
 
 @dataclass(frozen=True)
+class NativeDefinitionCoordinateGapV1:
+    receiver: SourceFragmentCoordinateV1
+    slot: NativeProtocolSlot
+    reason: str
+
+
+NativeDefinitionCoordinateResolutionV1 = (
+    SourceFragmentCoordinateV1 | NativeDefinitionCoordinateGapV1
+)
+
+
+@dataclass(frozen=True)
 class SourceDerivedContextManagerRefV1:
     """Live protocol testimony plus its immutable h=h(p) summary coordinate."""
 
@@ -137,6 +160,10 @@ class ResolvedContractRefsV1:
     catalog_cid: str
     table_cid: str
     by_use_site: Mapping[SourceFragmentCoordinateV1, ContextManagerResolutionV1]
+    native_definitions: Mapping[
+        tuple[SourceFragmentCoordinateV1, NativeProtocolSlot],
+        NativeDefinitionCoordinateResolutionV1,
+    ] = field(default_factory=dict)
 
     def require(
         self, use_site: SourceFragmentCoordinateV1
@@ -147,6 +174,19 @@ class ResolvedContractRefsV1:
             raise ContractRefProtocolError(
                 "BackendDefect: enrolled context-manager demand missing from resolution table"
             ) from exc
+
+    def require_native_definition(
+        self, receiver: SourceFragmentCoordinateV1, slot: NativeProtocolSlot
+    ) -> NativeDefinitionCoordinateResolutionV1:
+        """Resolve one authenticated source definition, or retain UNDECIDED."""
+        result = self.native_definitions.get((receiver, slot))
+        if result is None:
+            return NativeDefinitionCoordinateGapV1(
+                receiver=receiver,
+                slot=slot,
+                reason="authenticated source definition coordinate is not enrolled",
+            )
+        return result
 
 
 # Placeholder table for construction that does not enroll context-manager

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -183,6 +183,17 @@ class SymbolicValue(FloorValue):
         return self.term
 
     def truth(self, site):
+        if self.formal_coordinate is not None:
+            from sugar_lift_py_tests.caller_parameter_contract import (
+                NativeOperationExitCarrierV1,
+            )
+
+            return NativeOperationExitCarrierV1.mint(
+                site=site,
+                operator="truth",
+                operands=(self,),
+                coordinates=(self.formal_coordinate,),
+            )
         # A symbolic value EMITS the Python truth relation; the sort adjudicates later.
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
         from sugar_lift_py_tests.ir import py_truthy

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_protocol_definition_refs.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_protocol_definition_refs.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.context_manager_resolution import (
+    NativeDefinitionCoordinateGapV1,
+    NativeProtocolSlot,
+    ResolvedContractRefsV1,
+    SourceFragmentCoordinateV1,
+)
+from sugar_lift_py_tests.floor import SymbolicValue, TermValue
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.ir import PrimitiveSort, make_var
+from sugar_lift_py_tests.outcome import Completed
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.tree import SourceFile
+
+
+def _coord(start: int) -> SourceFragmentCoordinateV1:
+    return SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 1, start, 1, start + 1)
+
+
+def test_native_protocol_slots_share_one_authenticated_definition_door():
+    receiver, definition = _coord(2), _coord(20)
+    refs = ResolvedContractRefsV1(
+        "blake3-512:" + "b" * 128,
+        "blake3-512:" + "c" * 128,
+        {},
+        {(receiver, NativeProtocolSlot.CONTEXT_EXIT): definition},
+    )
+    assert refs.require_native_definition(receiver, NativeProtocolSlot.CONTEXT_EXIT) == definition
+    gap = refs.require_native_definition(receiver, NativeProtocolSlot.TRUTH)
+    assert isinstance(gap, NativeDefinitionCoordinateGapV1)
+    assert gap.reason.startswith("authenticated source definition")
+
+
+def test_formal_truth_is_a_deferred_native_operation_with_unary_discharge():
+    source = "def truth(receiver):\n    return bool(receiver)\n"
+    tree = SourceFile((source, "truth.py", blake3_512_of(source.encode())))
+    site = next(tree.functions()).fragment
+    locus = _coord(0)
+    formal = FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=locus.source_cid,
+        owner_definition_locus=locus,
+        declaration_locus=locus,
+        ordinal=0,
+        parameter_kind="positional-or-keyword",
+        declared_name="receiver",
+        sort=PrimitiveSort("Value"),
+    )
+    outcome = SymbolicValue(make_var("receiver"), formal).truth(site)
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    exits = outcome.discharge({formal.coordinate_cid: TermValue(1)})
+    assert isinstance(exits.exits[0], Completed)


### PR DESCRIPTION
Adds one shared source-authenticated lookup door for native protocol definition coordinates (context enter/exit, truth, item get/set), with explicit undecided gaps. Formal SymbolicValue.truth now emits a unary NativeOperationExitCarrier demand and discharges through the existing caller seam.

Validation: PYTHONPATH=... python3 -m pytest .../test_native_protocol_definition_refs.py .../test_native_operation_exit_carrier.py (13 passed). Authenticated bootstrap was held by another process and was not bypassed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add authenticated native protocol definition coordinates with unary operation support
> - Introduces `NativeProtocolSlot` enum and `NativeDefinitionCoordinateGapV1` dataclass in [context_manager_resolution.py](https://github.com/TSavo/sugar/pull/6602/files#diff-b8737b72b8d926d37e380cf04e1422e0060a034091ae459fda0450dc4c08191a) to represent typed protocol slots and missing native definition coordinates.
> - Extends `ResolvedContractRefsV1` with a `native_definitions` map and `require_native_definition(receiver, slot)` method that returns a gap object instead of raising when a coordinate is absent.
> - Updates `NativeOperationDemandV1.mint` and `NativeOperationExitCarrierV1.discharge` in [caller_parameter_contract.py](https://github.com/TSavo/sugar/pull/6602/files#diff-5136726cb5a60b48beb30152aecb6eca8ad0173bdefc676eb112b1c1b2acbf57) to support unary (and other non-binary) operation arities; discharge now emits a `construction_panic_gap` for arities outside 1 or 2.
> - `SymbolicValue.truth` in [symbolic_value.py](https://github.com/TSavo/sugar/pull/6602/files#diff-20ac3864063391c0ae09b701dfd27a9311b941b1de39a4aa18390907dcb1be42) now defers evaluation by returning a `NativeOperationExitCarrierV1` when the value has a formal coordinate, rather than immediately completing with a predicate.
> - Behavioral Change: `discharge` previously only handled binary operations; it now handles unary and produces a floor gap for anything else.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64ecbd3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->