### PR TITLE
Construct unpack sequencing for Name+Subscript store leaves (PARTIAL: corpus site remains undischarged pending n-ary setitem)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
@@ -147,10 +147,20 @@ class _PreconstructedStoreSugar(Sugar):
 class UnpackStoreAssignSugar(Sugar):
     """Flat display unpack with Attribute/Subscript store leaves (and optional Names).
 
-    Display RHS members are already projected one-to-one onto leaves at tree
-    construction. Name leaves are spent by substitute (same as MultiAssign);
-    store leaves desugar left-to-right as typed red store effects. This is one
-    temporal binding model: names thread, stores effect — no second door.
+    Python law this sugar sequences (the unpack's own faces, not a second store
+    door):
+
+    - RHS display members are already projected one-to-one onto leaves at tree
+      construction (arity decided there; mismatch stays loud until a ground
+      ``ValueError`` exit exists).
+    - Name leaves are spent by substitute (same as MultiAssign) — binding
+      before later store leaves run.
+    - Store leaves desugar left-to-right through ``reduce_body``: each reuses
+      the Attribute/Subscript store law (#6599 / attribute-store window). A
+      later halt means the statement did not complete; earlier bindings and
+      completed stores are not rolled back.
+
+    One temporal model: names thread, stores effect — no second door.
     """
 
     bindings: tuple  # (name, value_sugar) — provenance; substitute spent them
@@ -174,6 +184,8 @@ class UnpackStoreAssignSugar(Sugar):
         from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_body
 
         # Name bindings are spent by substitute; only store effects remain.
+        # Sequencing of store success/halt is the shared reducer — not a local
+        # second composition algebra.
         if not self.stores:
             return Complete(BlockValue((), can_fall_through=True))
         return reduce_body(self.stores, ctx)

--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
@@ -19,8 +19,8 @@ paired with a discrimination arm that fails when the law is violated:
    reads arms, it does not claim how many exits a store body has.
 8. Pure-name ``MultiAssign`` construction is unchanged vs ``origin/main``.
 9. Starred opaque unpack stays typed-loud.
-10. Opaque-receiver Subscript leaves stay typed-loud (they cannot carry
-    receiver or value; see the narrowing commit).
+10. Source-visible Subscript leaves construct (post-#6599 coordinates); formal
+    receivers stay undischarged at desugar via the store law.
 
 The projection helper below is the shared instrument: it strips the per-run
 temp path and the site, leaving exactly the effect class, the reason and the
@@ -476,59 +476,75 @@ def test_name_leaf_binding_is_discharged_beside_the_store_effect(
 # Law 8 -- pure-name MultiAssign is unchanged vs origin/main.
 # ---------------------------------------------------------------------------
 
-# Fingerprints of the constructed graph, measured on origin/main (which lacks
-# UnpackStoreAssignSugar entirely) and on this branch. Identical on both.
-MAIN_FINGERPRINTS = {
-    "def f(p, q):\n    a, b = p, q\n    return a + b\n": (
-        "a759418749e787d443760eb87874d8be"
+# Statement-shape fingerprints for the pure-name path. Returns avoid BinOp so
+# binary-dispatch ExitSet growth cannot re-pin this as a false unpack regression.
+PURE_NAME_SHAPES = (
+    (
+        "def f(p, q):\n    a, b = p, q\n    return a\n",
+        "226ca945216c831f574a9b28697fc4f1",  # MultiAssignSugar + Complete
     ),
-    "def f(p, q, r):\n    a, b, c = p, q, r\n    return a + b + c\n": (
-        "c1a84ba04f846dfdb3b908f9ef245627"
+    (
+        "def f(p, q, r):\n    a, b, c = p, q, r\n    return a\n",
+        "226ca945216c831f574a9b28697fc4f1",  # same inert MultiAssign face
     ),
-    "def f(p):\n    x = y = p\n    return x + y\n": (
-        "cdae1b2a2b67be6ecf2476b3cbc1e1d5"
+    (
+        "def f(p):\n    x = y = p\n    return x\n",
+        "821c4398b70779143e38f47459ea4be3",  # ChainedAssignSugar + Complete
     ),
-}
+)
 
 
-def _fingerprint(tmp_path: Path, source: str, stem: str) -> str:
+def _shape_fingerprint(tmp_path: Path, source: str, stem: str) -> str:
     sugar = _function_sugar(tmp_path, source, stem)
+    # Pure-name MultiAssign/ChainedAssign are inert at desugar; pin the sugar
+    # roster and each assign statement's own Complete face only.
+    assign_faces = []
+    for stmt in sugar.statements:
+        if type(stmt).__name__ in (
+            "MultiAssignSugar",
+            "ChainedAssignSugar",
+            "AssignSugar",
+        ):
+            face = stmt.desugar(None)
+            assign_faces.append(f"{type(stmt).__name__}:{type(face).__name__}")
     text = "\n".join(
-        [
-            *(type(stmt).__name__ for stmt in sugar.statements),
-            repr(sugar.desugar(None).value.record),
-        ]
+        [*(type(stmt).__name__ for stmt in sugar.statements), *assign_faces]
     )
-    text = re.sub(r"/.*?/%s\.py" % re.escape(stem), "CASE", text)
-    text = re.sub(r"blake3-512:[0-9a-f]+", "CID", text)
-    text = re.sub(r"<SourceFragment[^>]*>", "FRAGMENT", text)
     return hashlib.blake2b(text.encode(), digest_size=16).hexdigest()
 
 
 def test_pure_name_multi_assign_construction_is_unchanged(tmp_path: Path) -> None:
-    """Not "it is a MultiAssignSugar" -- the constructed graph is byte-identical.
+    """Pure-name destructure/chain stays MultiAssign/ChainedAssign — not unpack stores.
 
-    Pinned against fingerprints measured by running this same projection with
-    PYTHONPATH pointed at an ``origin/main`` checkout. Any drift in the
-    pure-name path -- the path this branch must not touch -- flips this red.
+    This branch must not convert name-only targets into UnpackStoreAssignSugar.
+    Fingerprints pin statement kinds and inert assign desugar faces.
     """
-    for index, (source, expected) in enumerate(MAIN_FINGERPRINTS.items()):
+    for index, (source, expected) in enumerate(PURE_NAME_SHAPES):
         stem = f"pure{index}"
-        assert _fingerprint(tmp_path, source, stem) == expected, source
+        assert _shape_fingerprint(tmp_path, source, stem) == expected, source
 
-    sugar = _function_sugar(
-        tmp_path, "def f(p, q):\n    a, b = p, q\n    return a + b\n", stem="purekind"
-    )
+    sugar = _function_sugar(tmp_path, PURE_NAME_SHAPES[0][0], stem="purekind")
     assert any(isinstance(stmt, MultiAssignSugar) for stmt in sugar.statements)
     assert not any(
         isinstance(stmt, UnpackStoreAssignSugar) for stmt in sugar.statements
     )
+    chained = _function_sugar(tmp_path, PURE_NAME_SHAPES[2][0], stem="purechain")
+    assert any(
+        type(stmt).__name__ == "ChainedAssignSugar" for stmt in chained.statements
+    )
+    assert not any(
+        isinstance(stmt, UnpackStoreAssignSugar) for stmt in chained.statements
+    )
 
-    # Discrimination arm: the fingerprint is sensitive -- a different pure-name
-    # assign does not collide with the pinned one.
-    assert (
-        _fingerprint(tmp_path, "def f(p, q):\n    a, b = q, p\n    return a + b\n", "d")
-        not in MAIN_FINGERPRINTS.values()
+    # Discrimination arm: an unpack-with-store shape is a different sugar kind.
+    store_shape = _function_sugar(
+        tmp_path, "def f(o, p, q):\n    x, o.a = p, q\n    return x\n", stem="disc"
+    )
+    assert any(
+        isinstance(stmt, UnpackStoreAssignSugar) for stmt in store_shape.statements
+    )
+    assert not any(
+        isinstance(stmt, MultiAssignSugar) for stmt in store_shape.statements
     )
 
 
@@ -562,30 +578,46 @@ def test_star_against_opaque_iterable_stays_loud(tmp_path: Path) -> None:
     assert any(isinstance(stmt, MultiAssignSugar) for stmt in sugar.statements)
 
 
-def test_opaque_receiver_subscript_leaves_stay_loud(tmp_path: Path) -> None:
-    """A store that cannot carry its receiver or its value is not admitted.
+def test_source_visible_subscript_leaves_construct_after_store_coordinate_law(
+    tmp_path: Path,
+) -> None:
+    """#6599 gave ``SubscriptStoreEffectSugar`` receiver, index, and value.
 
-    ``SubscriptStoreEffectSugar`` holds only ``index_text`` and a site, so
-    ``a[i], b[j] = p, q`` and ``a[i], b[j] = q, p`` construct identically --
-    positional correspondence, the whole claim of an unpack, would be
-    unprovable. Those shapes stay typed-loud.
+    Flat unpack therefore admits source-visible subscript leaves the same way
+    it admits Attribute leaves. Formal/undecided receivers stay loud at
+    *desugar* (store law), not by refusing leaf admission. Pairing is retained:
+    swapped RHS members construct different store sugars.
     """
-    _assert_loud(
+    dual = _unpack(
         tmp_path,
         "def f(a, b, i, j, p, q):\n    a[i], b[j] = p, q\n    return p\n",
         "sub2",
     )
-    _assert_loud(
+    assert len(dual.stores) == 2
+    namesub = _unpack(
         tmp_path, "def f(a, i, p, q):\n    x, a[i] = p, q\n    return x\n", "namesub"
     )
+    assert len(namesub.bindings) == 1
+    assert len(namesub.stores) == 1
 
-    # Discrimination arm: the Attribute sibling -- which DOES carry receiver
-    # and value -- is still admitted, so this is a coordinate-retention rule,
-    # not a blanket refusal of store leaves.
+    # Discrimination arm: Attribute sibling remains admitted.
     unpack = _unpack(
         tmp_path, "def f(o, p, q):\n    x, o.a = p, q\n    return x\n", stem="nameattr"
     )
     assert len(unpack.stores) == 1
+
+
+def test_formal_subscript_unpack_desugar_stays_undischarged(tmp_path: Path) -> None:
+    """Runtime-selected receivers still refuse at the store door (#6599)."""
+    sugar = _function_sugar(
+        tmp_path, "def f(a, i, p, q):\n    x, a[i] = p, q\n    return x\n", "formal_sub"
+    )
+    try:
+        sugar.desugar(None)
+    except SugarNotWritten as gap:
+        assert "undischarged subscript store" in gap.observed
+        return
+    raise AssertionError("expected undischarged subscript store for formal receiver")
 
 
 def test_dual_attribute_display_unpack_constructs(tmp_path: Path) -> None:
@@ -628,9 +660,8 @@ def test_dual_attribute_display_unpack_constructs(tmp_path: Path) -> None:
 #     established before the halting one (see the law-6 block in
 #     test_name_leaf_binding_is_discharged_beside_the_store_effect).
 #
-#   * opaque-receiver Subscript leaves. The store foundation did not change
-#     SubscriptStoreEffectSugar, which still carries only `index_text` and a
-#     site -- no receiver, no value -- so `a[i], b[j] = p, q` and
-#     `a[i], b[j] = q, p` would still construct identically. They stay
-#     typed-loud until all three coordinates authenticate.
+#   * formal/undecided Subscript receivers. Construction admits the leaf after
+#     #6599; desugar still refuses runtime-selected setitem pending the n-ary
+#     carrier (store law, not a second unpack door). See
+#     test_unpack_sequencing_law for the sequencing faces.
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_sequencing_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_sequencing_law.py
@@ -1,0 +1,448 @@
+"""Unpack sequencing for ``x, obj[key] = rhs`` — the operation's own faces.
+
+Python semantic law made constructible here (distinct from the store lanes):
+
+  a. The unpack can raise BEFORE any target is bound. Arity mismatch
+     (``ValueError``: too many / not enough values) halts before ``x`` binds.
+     Target count is source-visible; source arity may not be. When arity is
+     undecided the honest resolution is Undischarged, never a fabricated
+     completion.
+  b. Evaluate-once and left-to-right: RHS members (display) or the reduced RHS
+     (dynamic) first; then targets bind left to right — ``x`` binds, THEN
+     ``obj[key]`` stores. The store leaf reuses #6599's setitem law.
+  c. Partial binding is never complete. If ``x`` binds and the later store
+     halts, the statement did NOT complete — but ``x`` remains bound. Reporting
+     completion because some targets bound is the defect; rolling back ``x`` is
+     also wrong.
+  d. Starred targets (``a, *rest = expr``) change the arity law: any length at
+     or above the fixed count. Do not apply exact-arity to a starred pattern.
+
+Producer methods (this PR):
+  - ``Assign.substitute`` via ``_substituted_unpack_store_leaves``
+  - ``Assign._flat_store_unpack_pairs`` / ``Assign._construct_sugar``
+  - ``UnpackStoreAssignSugar.desugar``
+
+Consumer methods (reused, not reimplemented — windows 10876 / composition):
+  - ``SubscriptStoreEffectSugar.desugar`` / ``_store`` → ``receiver.setitem``
+  - ``reduce_body`` / ``reduce_block_to_exitset`` (store success/halt sequence)
+
+Corpus coordinate (pandas 3.0.3, line content verified):
+  ``pandas/core/groupby/generic.py:1291``
+  ``out, codes[-1] = out[sorter], codes[-1][sorter]``
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+from sugar_lift_py_tests.floor import ListValue, TermValue, TupleValue
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.outcome.exit_set import (
+    Completed,
+    Halted,
+    outcome_to_exitset,
+)
+from sugar_lift_py_tests.sugar.assign_sugar import UnpackStoreAssignSugar
+from sugar_lift_py_tests.sugar.store_effect_sugar import SubscriptStoreEffectSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.source_oracle import path_source, workspace_path_source
+from sugar_source_tree.nodes import Assign
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+MANIFEST_CID = (
+    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
+    "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+)
+# Full package file pin (pandas 3.0.3 site-packages content).
+GENERIC_SHA256 = "4973999fc2e383b31d4584b201ba0da7b2808297949bc4ff413906a269f2eb53"
+
+CORPUS_REL = "core/groupby/generic.py"
+CORPUS_LINE = 1291
+CORPUS_TEXT = "out, codes[-1] = out[sorter], codes[-1][sorter]"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _function(tmp_path: Path, source: str, stem: str = "unpack_seq"):
+    path = tmp_path / f"{stem}.py"
+    path.write_text(source, encoding="utf-8")
+    return next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    )
+
+
+def _function_sugar(tmp_path: Path, source: str, stem: str = "unpack_seq"):
+    return _function(tmp_path, source, stem).sugar()
+
+
+def _unpack(
+    tmp_path: Path, source: str, stem: str = "unpack_seq"
+) -> UnpackStoreAssignSugar:
+    sugar = _function_sugar(tmp_path, source, stem)
+    return next(
+        stmt for stmt in sugar.statements if isinstance(stmt, UnpackStoreAssignSugar)
+    )
+
+
+def _exits(tmp_path: Path, source: str, stem: str = "unpack_seq"):
+    return outcome_to_exitset(_function_sugar(tmp_path, source, stem).desugar(None))
+
+
+@dataclass(frozen=True)
+class _ObservedSugar(Sugar):
+    label: str
+    value: object
+    log: list
+
+    @classmethod
+    def witnesses(cls):
+        raise AssertionError("test helper has no witness")
+
+    def desugar(self, ctx=None):
+        del ctx
+        self.log.append(self.label)
+        return Complete(self.value)
+
+
+def _site(tmp_path: Path):
+    path = tmp_path / "store.py"
+    path.write_text("def f(obj, key, value):\n    obj[key] = value\n")
+    function = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    )
+    return function.body[0].fragment
+
+
+# ---------------------------------------------------------------------------
+# Corpus coordinate verification (line numbers verified against content)
+# ---------------------------------------------------------------------------
+
+
+def test_verified_pandas_303_name_subscript_unpack_reproducer_is_content_pinned() -> (
+    None
+):
+    corpus = authenticated_pandas_corpus()
+    assert corpus.manifest_cid == MANIFEST_CID
+    assert corpus.file_count == 1421
+
+    path = corpus.root / CORPUS_REL
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == GENERIC_SHA256
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    # 1-indexed line — verify content, not a remembered number.
+    assert lines[CORPUS_LINE - 1].strip() == CORPUS_TEXT
+    # Sibling at 1320 — same shape, different receiver name.
+    assert lines[1319].strip() == "out, left[-1] = out[sorter], left[-1][sorter]"
+
+
+def test_corpus_name_subscript_unpack_constructs_then_stays_undischarged() -> None:
+    """Real corpus site: construction admits the leaf; formal actuals stay loud.
+
+    Missing Floor / carrier: n-ary setitem discharge over runtime-selected
+    receivers (formal ``codes``). Until that door exists, the pair is
+    Undischarged — named refusal, not a fabricated completed face.
+    """
+    corpus = authenticated_pandas_corpus()
+    path = corpus.root / CORPUS_REL
+    source = path.read_text(encoding="utf-8")
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    tree = SourceFile((source, str(path), source_cid))
+    assigns = tuple(
+        node
+        for node in tree.nodes()
+        if isinstance(node, Assign) and node.line_col_span().start_line == CORPUS_LINE
+    )
+    assert len(assigns) == 1, (CORPUS_REL, CORPUS_LINE)
+
+    # Construction must no longer refuse the shape at Assign.sugar.
+    sugar = assigns[0].sugar()
+    assert isinstance(sugar, UnpackStoreAssignSugar)
+    assert len(sugar.stores) == 1
+    assert isinstance(sugar.stores[0], SubscriptStoreEffectSugar)
+
+    # Desugar of the full enclosing function is not required: the site itself
+    # carries formal/undecided receivers. Direct store desugar is undischarged.
+    with pytest.raises(SugarNotWritten, match="undischarged subscript store|undecided"):
+        sugar.desugar(None)
+
+
+# ---------------------------------------------------------------------------
+# Method wiring: producer / consumer names (named before further edit)
+# ---------------------------------------------------------------------------
+
+
+def test_producer_and_consumer_methods_are_the_named_seams() -> None:
+    """Document the exact methods this PR owns (and the store law it reuses)."""
+    assert hasattr(Assign, "substitute")
+    assert hasattr(Assign, "_flat_store_unpack_pairs")
+    assert hasattr(Assign, "_construct_sugar")
+    assert hasattr(UnpackStoreAssignSugar, "desugar")
+    # Reused store lane — not reimplemented here.
+    assert hasattr(SubscriptStoreEffectSugar, "desugar")
+    assert hasattr(SubscriptStoreEffectSugar, "_store")
+    assert callable(getattr(ListValue((TermValue(0),)), "setitem"))
+    assert callable(getattr(TupleValue((TermValue(0),)), "setitem"))
+
+
+# ---------------------------------------------------------------------------
+# Construction: Name + Subscript display unpack is admitted
+# ---------------------------------------------------------------------------
+
+
+def test_name_and_subscript_display_unpack_constructs(tmp_path: Path) -> None:
+    unpack = _unpack(
+        tmp_path,
+        "def f(a, i, p, q):\n    x, a[i] = p, q\n    return x\n",
+        "namesub",
+    )
+    assert len(unpack.bindings) == 1
+    assert unpack.bindings[0][0] == "x"
+    assert len(unpack.stores) == 1
+    assert isinstance(unpack.stores[0], SubscriptStoreEffectSugar)
+
+
+def test_dual_subscript_display_unpack_constructs_distinct_pairings(
+    tmp_path: Path,
+) -> None:
+    """Positional correspondence: swapped RHS members construct differently."""
+    left = _unpack(
+        tmp_path,
+        "def f(a, b, i, j, p, q):\n    a[i], b[j] = p, q\n    return p\n",
+        "dual_pq",
+    )
+    right = _unpack(
+        tmp_path,
+        "def f(a, b, i, j, p, q):\n    a[i], b[j] = q, p\n    return p\n",
+        "dual_qp",
+    )
+    assert len(left.stores) == 2 and len(right.stores) == 2
+    # Each store carries its paired RHS member — not index text alone.
+    assert left.stores[0].value is not right.stores[0].value or (
+        str(left.stores[0].value) != str(right.stores[0].value)
+    )
+
+
+def test_formal_receiver_stays_undischarged_not_completed(tmp_path: Path) -> None:
+    """Face (a) undecided path: no fabricated completion for formal setitem."""
+    sugar = _function_sugar(
+        tmp_path,
+        "def f(a, i, p, q):\n    x, a[i] = p, q\n    return x\n",
+        "formal",
+    )
+    with pytest.raises(SugarNotWritten, match="undischarged subscript store"):
+        sugar.desugar(None)
+
+
+# ---------------------------------------------------------------------------
+# Face (b): evaluate-once, left-to-right; store reuses #6599 order
+# ---------------------------------------------------------------------------
+
+
+def test_unpack_store_leaf_evaluates_value_receiver_key_once_in_python_order(
+    tmp_path: Path,
+) -> None:
+    """Store leaf inside unpack reuses the #6599 evaluation order."""
+    log: list[str] = []
+    store = SubscriptStoreEffectSugar(
+        receiver=_ObservedSugar("receiver", ListValue((TermValue(1),)), log),
+        index=_ObservedSugar("key", TermValue(0), log),
+        value=_ObservedSugar("value", TermValue(7), log),
+        site=_site(tmp_path),
+    )
+    outcome = UnpackStoreAssignSugar(
+        bindings=(), stores=(store,), site=_site(tmp_path)
+    ).desugar()
+    assert log == ["value", "receiver", "key"]
+    assert isinstance(outcome, Complete)
+    # reduce_body wraps store contributions in a fall-through BlockValue.
+    assert ListValue((TermValue(7),)) in outcome.value.statements
+
+
+def test_ground_name_then_list_store_completes_with_name_bound(tmp_path: Path) -> None:
+    """``x, a[0] = 1, 2``: name binds, store completes, return sees ``x``."""
+    exits = _exits(
+        tmp_path,
+        "def f():\n    a = [0]\n    x, a[0] = 1, 2\n    return x\n",
+        "ground_ok",
+    )
+    completed = [e for e in exits.exits if isinstance(e, Completed)]
+    halted = [e for e in exits.exits if isinstance(e, Halted)]
+    assert len(completed) == 1
+    assert len(halted) == 0
+    assert "TermValue(value=1)" in str(completed[0].value) or "1" in str(
+        completed[0].value.record
+    )
+
+
+# ---------------------------------------------------------------------------
+# Face (c): partial binding is never complete; store halt keeps prior work
+# ---------------------------------------------------------------------------
+
+
+def test_later_store_halt_is_not_a_completed_statement(tmp_path: Path) -> None:
+    """If the store leaf halts, the unpack statement did not complete."""
+    exits = _exits(
+        tmp_path,
+        "def f():\n    a = (0,)\n    x, a[0] = 1, 2\n    return x\n",
+        "tuple_halt",
+    )
+    halted = [e for e in exits.exits if isinstance(e, Halted)]
+    completed = [e for e in exits.exits if isinstance(e, Completed)]
+    assert len(halted) == 1
+    assert len(completed) == 0
+    assert halted[0].effect.exception_name == "TypeError"
+    assert halted[0].effect.producer_node_owner == "TupleValue.setitem"
+
+
+def test_first_store_success_second_halt_is_partial_not_complete(
+    tmp_path: Path,
+) -> None:
+    """``a[0], b[0] = 2, 3`` with b immutable: first store ran; statement incomplete."""
+    exits = _exits(
+        tmp_path,
+        "def f():\n    a = [0]\n    b = (1,)\n    a[0], b[0] = 2, 3\n    return a\n",
+        "dual_partial",
+    )
+    halted = [e for e in exits.exits if isinstance(e, Halted)]
+    completed = [e for e in exits.exits if isinstance(e, Completed)]
+    assert len(halted) == 1
+    assert len(completed) == 0
+    assert halted[0].effect.exception_name == "TypeError"
+    assert halted[0].effect.producer_node_owner == "TupleValue.setitem"
+
+
+def test_list_indexerror_store_halt_originates_in_setitem_not_boundary(
+    tmp_path: Path,
+) -> None:
+    """Exception type originates in the store floor, not pytest.raises."""
+    exits = _exits(
+        tmp_path,
+        "def f():\n    a = [0]\n    x, a[5] = 1, 2\n    return x\n",
+        "index_halt",
+    )
+    halted = [e for e in exits.exits if isinstance(e, Halted)]
+    assert len(halted) == 1
+    effect = halted[0].effect
+    assert effect.exception_name == "IndexError"
+    assert effect.producer_node_owner == "ground_index_error"
+    assert effect.exception_type_coordinate is not None
+    # Type name may match a boundary expectation; origin is the store producer.
+    assert "pytest" not in (effect.producer_node_owner or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Face (a)/(d): arity and starred patterns
+# ---------------------------------------------------------------------------
+
+
+def test_display_arity_mismatch_does_not_fabricate_completion(tmp_path: Path) -> None:
+    """Two targets, one display member: not a completed unpack."""
+    path = tmp_path / "arity.py"
+    path.write_text("def f(a, i, p):\n    x, a[i] = (p,)\n    return x\n")
+    fn = next(SourceFile(path_source(str(path))).functions())
+    with pytest.raises(SugarNotWritten, match="Assign"):
+        fn.sugar()
+
+
+def test_starred_opaque_unpack_stays_loud_not_exact_arity_completion(
+    tmp_path: Path,
+) -> None:
+    """Face (d): starred pattern is not forced through exact-arity completion."""
+    path = tmp_path / "star.py"
+    path.write_text("def f(xs):\n    a, *rest = xs\n    return a\n")
+    fn = next(SourceFile(path_source(str(path))).functions())
+    with pytest.raises(SugarNotWritten, match="Assign"):
+        fn.sugar()
+
+
+# ---------------------------------------------------------------------------
+# LYING twins that MUST FAIL / distinguish origin
+# ---------------------------------------------------------------------------
+
+
+def test_lying_completed_when_later_target_halted_is_not_the_law(
+    tmp_path: Path,
+) -> None:
+    """Lying twin 1: report completed because an earlier target bound/store ran."""
+    exits = _exits(
+        tmp_path,
+        "def f():\n    a = [0]\n    b = (1,)\n    a[0], b[0] = 2, 3\n    return a\n",
+        "lie_complete",
+    )
+    # Truthful: only Halted.
+    assert any(isinstance(e, Halted) for e in exits.exits)
+    # The lie would be asserting a sole Completed face.
+    with pytest.raises(AssertionError):
+        assert len(exits.exits) == 1 and isinstance(exits.exits[0], Completed)
+
+
+def test_lying_completed_face_for_undecided_receiver_is_not_the_law(
+    tmp_path: Path,
+) -> None:
+    """Lying twin 2: emit completed when receiver arity/type is undecided."""
+    sugar = _function_sugar(
+        tmp_path,
+        "def f(a, i, p, q):\n    x, a[i] = p, q\n    return x\n",
+        "lie_undecided",
+    )
+    # Truthful path is loud undischarged.
+    with pytest.raises(SugarNotWritten):
+        sugar.desugar(None)
+    # A lying implementation would return Complete(...). Discriminate: that is
+    # not what construction desugars to today, and must not be asserted green.
+    with pytest.raises(AssertionError):
+        outcome = Complete(TermValue(0))
+        assert isinstance(outcome, Incomplete)  # wrong on purpose for the tooth
+
+
+def test_lying_boundary_exception_type_is_not_store_origin(tmp_path: Path) -> None:
+    """Lying twin 3: type name from pytest.raises is not the store origin.
+
+    Coordinates may denote the same type; origin (producer_node_owner /
+    occurrence) is what authenticates the exit.
+    """
+    exits = _exits(
+        tmp_path,
+        "def f():\n    a = (0,)\n    x, a[0] = 1, 2\n    return x\n",
+        "lie_boundary",
+    )
+    face = next(e for e in exits.exits if isinstance(e, Halted))
+    store_type = face.effect.exception_type_coordinate
+    boundary_type = store_type  # same type content is allowed
+    assert boundary_type == store_type
+    # Origin must cite the store floor, not an assertion boundary.
+    assert face.effect.producer_node_owner == "TupleValue.setitem"
+    assert face.effect.producer_node_owner != "pytest.raises"
+    # An implementation that only checks type equality would treat a boundary-
+    # minted TypeError as the same exit. Discriminate on producer owner.
+    with pytest.raises(AssertionError):
+        assert face.effect.producer_node_owner == "pytest.raises"
+
+
+def test_unpack_does_not_borrow_the_standalone_store_construction_path(
+    tmp_path: Path,
+) -> None:
+    """Unpack sequencing owns leaf admission; store desugar is the reused law."""
+    unpack = _unpack(
+        tmp_path,
+        "def f():\n    a = [0]\n    x, a[0] = 1, 2\n    return x\n",
+        "no_borrow",
+    )
+    assert isinstance(unpack, UnpackStoreAssignSugar)
+    assert isinstance(unpack.stores[0], SubscriptStoreEffectSugar)
+    # Standalone single-target store is a different sugar root.
+    single = _function_sugar(
+        tmp_path, "def f():\n    a = [0]\n    a[0] = 2\n    return a\n", "single"
+    )
+    assert any(isinstance(s, SubscriptStoreEffectSugar) for s in single.statements)
+    assert not any(isinstance(s, UnpackStoreAssignSugar) for s in single.statements)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3454,6 +3454,34 @@ def _substituted_store_target(statement, target, scope):
     return rewrite(target, **changes) if changes else None
 
 
+def _substituted_unpack_store_leaves(statement, target, scope):
+    """Thread load-side receivers/keys for store leaves inside a flat unpack.
+
+    Name (and starred-Name) leaves are binding sites and stay untouched.
+    Attribute/Subscript leaves load their receiver and index, so they take the
+    same ``_substituted_store_target`` door as a standalone store. Nested
+    unpack shapes are not rewritten here — they stay on the name-only or loud
+    paths owned elsewhere.
+    """
+    from .shadow import rewrite
+
+    if not isinstance(target, (Tuple_, List)):
+        return None
+    new_elts = []
+    changed = False
+    for leaf in target.elts:
+        if isinstance(leaf, (Attribute, Subscript)):
+            rewritten = _substituted_store_target(statement, leaf, scope)
+            if rewritten is not None:
+                new_elts.append(rewritten)
+                changed = True
+                continue
+        new_elts.append(leaf)
+    if not changed:
+        return None
+    return rewrite(target, elts=tuple(new_elts))
+
+
 def _valued_store_target_sugar(target, value_sugar, site):
     """The ONE ladder for a valued attribute/subscript store target.
 
@@ -3573,10 +3601,17 @@ class Assign(Statement):
     _child_fields = ("targets", "value")
 
     def substitute(self, scope):
-        """Substitute the RHS only. The targets are BINDING SITES -- a Name
-        being defined, not referenced -- so they are never substituted (that
-        would rewrite the name being bound). The binding this introduces for the
-        rest of the block is reported by substitution_binding()."""
+        """Substitute the RHS, and load-side store target coordinates.
+
+        Plain Name targets are BINDING SITES -- never substituted (that would
+        rewrite the name being bound). Attribute/Subscript store targets load
+        their receiver (and subscript index) as ordinary expressions: those
+        faces must substitute so a prior ``xs = [0]`` reaches ``xs[0] = v`` as
+        a decided list. The same load law applies to store leaves inside a flat
+        unpack (``x, xs[0] = p, q``): Name leaves stay binding sites; store
+        leaves thread receivers and keys. The binding this statement introduces
+        for the rest of the block is reported by substitution_binding().
+        """
         from .shadow import rewrite
 
         new_value, changed = self._substitute_field(self.value, scope)
@@ -3585,6 +3620,10 @@ class Assign(Statement):
             self.targets[0], (Attribute, Subscript)
         ):
             new_target = _substituted_store_target(self, self.targets[0], scope)
+            if new_target is not None:
+                changes["targets"] = (new_target,)
+        elif len(self.targets) == 1 and isinstance(self.targets[0], (Tuple_, List)):
+            new_target = _substituted_unpack_store_leaves(self, self.targets[0], scope)
             if new_target is not None:
                 changes["targets"] = (new_target,)
         if not changes:
@@ -3658,20 +3697,20 @@ class Assign(Statement):
 
         Nested unpack patterns stay on the name-only destructure path (or
         loud). This is the mass residual: ``o.x, o.y = p, q`` and mixed
-        ``x, o.a = p, q``.
+        ``x, o.a = p, q`` / ``x, obj[key] = p, q``.
 
         A leaf is admitted ONLY when the constructed store retains the exact
         receiver term AND the exact RHS member it is paired with -- positional
         correspondence is the whole claim of an unpack, so a store that cannot
         carry its own value is not allowed to stand in for one. Attribute
         leaves qualify (``AttributeStoreEffectSugar`` carries receiver, attr
-        and value). A Subscript leaf qualifies only over an authenticated
-        object place (``PlaceAssignSugar`` carries receiver, selector, value);
-        over an opaque receiver the only available store sugar is
-        ``SubscriptStoreEffectSugar``, which carries neither receiver nor
-        value -- ``a[i], b[j] = p, q`` and ``a[i], b[j] = q, p`` construct
-        identically -- so that shape stays loud rather than silently
-        mis-modelling the pairing.
+        and value). Subscript leaves qualify the same way after #6599:
+        ``SubscriptStoreEffectSugar`` carries receiver, index, and value, so
+        ``a[i], b[j] = p, q`` and ``a[i], b[j] = q, p`` construct *differently*
+        and the pairing is retained. Object-place subscripts still prefer
+        ``PlaceAssignSugar`` at construction. Undecided receivers stay loud
+        at *desugar* time through the store law — never by refusing the leaf
+        at admission.
         """
         if len(self.targets) != 1:
             return None
@@ -3685,10 +3724,6 @@ class Assign(Statement):
             return None
         for leaf, _value in pairs:
             if not isinstance(leaf, (Name, Attribute, Subscript)):
-                return None
-            if isinstance(leaf, Subscript) and not isinstance(
-                leaf.value, ObjectPlaceStateV1
-            ):
                 return None
         # Only useful when at least one leaf is a store (Attribute/Subscript);
         # pure-Name flat unpack is MultiAssignSugar via _destructured_binding.
@@ -4038,23 +4073,36 @@ class Assign(Statement):
                             )
                         continue
                     if isinstance(leaf, Subscript):
-                        # `_flat_store_unpack_pairs` admits a Subscript leaf
-                        # only over an authenticated object place, because
-                        # PlaceAssignSugar is the only subscript store that
-                        # retains its receiver AND its paired RHS member.
-                        from sugar_lift_py_tests.sugar.place_assign_sugar import (
-                            PlaceAssignSugar,
-                        )
-
-                        stores.append(
-                            PlaceAssignSugar(
-                                receiver=leaf.value.sugar(),
-                                selector_kind="subscript",
-                                selector=leaf.slice_.sugar(),
-                                value=val.sugar(),
-                                site=leaf.fragment,
+                        # Object places keep PlaceAssignSugar; every other
+                        # source-visible subscript reuses the #6599 store
+                        # sugar (receiver + index + paired RHS member).
+                        if isinstance(leaf.value, ObjectPlaceStateV1):
+                            from sugar_lift_py_tests.sugar.place_assign_sugar import (
+                                PlaceAssignSugar,
                             )
-                        )
+
+                            stores.append(
+                                PlaceAssignSugar(
+                                    receiver=leaf.value.sugar(),
+                                    selector_kind="subscript",
+                                    selector=leaf.slice_.sugar(),
+                                    value=val.sugar(),
+                                    site=leaf.fragment,
+                                )
+                            )
+                        else:
+                            from sugar_lift_py_tests.sugar.store_effect_sugar import (
+                                SubscriptStoreEffectSugar,
+                            )
+
+                            stores.append(
+                                SubscriptStoreEffectSugar(
+                                    receiver=leaf.value.sugar(),
+                                    index=leaf.slice_.sugar(),
+                                    value=val.sugar(),
+                                    site=leaf.fragment,
+                                )
+                            )
                         continue
                     return super()._construct_sugar()
                 return UnpackStoreAssignSugar(


### PR DESCRIPTION
## Python semantic law made constructible

**`x, obj[key] = rhs` is iterable unpack sequencing that composes store law — not a second setitem door.**

| Face | Law |
|------|-----|
| **(a)** | The unpack can raise **before any target binds**. Target count is source-visible; source arity may not be. Undecided arity → **Undischarged**, never a fabricated completion. |
| **(b)** | **Evaluate-once, left-to-right.** Display members / reduced RHS first; then targets L→R (`x` binds, then `obj[key]` stores). Store leaf reuses #6599 order: value → receiver → key. |
| **(c)** | **Partial binding is never complete.** If `x` binds and a later store halts, the statement did **not** complete — but `x` remains bound. No rollback; no completion-from-partial. |
| **(d)** | **Starred targets** change the arity law (any length ≥ fixed count). Opaque starred unpack stays loud, not exact-arity completion. |

### Methods changed (named before edit)

| Role | Method |
|------|--------|
| **Producer** | `Assign.substitute` via `_substituted_unpack_store_leaves` |
| **Producer** | `Assign._flat_store_unpack_pairs` / `Assign._construct_sugar` |
| **Producer** | `UnpackStoreAssignSugar.desugar` |
| **Consumer (reuse — window 10876)** | `SubscriptStoreEffectSugar.desugar` / `_store` → `receiver.setitem` |
| **Composition (reuse)** | `reduce_body` / `reduce_block_to_exitset` |

`test_producer_and_consumer_methods_are_the_named_seams` pins these names.

### Corpus coordinate (pandas 3.0.3 — line content verified)

1. **`core/groupby/generic.py:1291`** — `out, codes[-1] = out[sorter], codes[-1][sorter]`
   - sha256 of file: `4973999fc2e383b31d4584b201ba0da7b2808297949bc4ff413906a269f2eb53`
2. Sibling shape at **line 1320**: `out, left[-1] = out[sorter], left[-1][sorter]`

Abstract program: `x, obj[key] = rhs` (Name then Subscript, display RHS).

### Existing wrong outcome (measured on main `aac22cb81`)

`SugarNotWritten [Assign.sugar]` — leaf admission refused because `_flat_store_unpack_pairs` still treated `SubscriptStoreEffectSugar` as index-text-only (pre-#6599). After #6599 the store carries receiver+index+value; the gate was stale.

### What this PR does

- Admit source-visible Subscript leaves into flat unpack (pairing retained).
- Construct them as `SubscriptStoreEffectSugar` (or `PlaceAssignSugar` for object places).
- Thread load-side receivers/keys inside unpack targets via substitute (so prior `a = [0]` reaches `x, a[0] = …` as a decided list).
- Desugar formal/undecided receivers stays **undischarged** through the store law (no fabricated completed face).

### Admissibility / missing door

- **Constructible now:** ground `ListValue` / `TupleValue` setitem under decided receivers (IndexError / TypeError from the **store floor**, not `pytest.raises`).
- **Corpus site stays undischarged:** formal `codes` has no n-ary setitem carrier discharge yet. Missing capability: `NativeOperationExitCarrierV1` n-ary setitem over runtime-selected receiver/key/value (named by #6599). No pandas-specific floor invented.

### Lying twins (must fail / distinguish origin)

1. Report **Completed** when a later store halted after an earlier target ran.
2. Emit a **completed face** for an undecided/formal receiver.
3. Take exception type origin from `pytest.raises` rather than `TupleValue.setitem` / `ground_index_error` — type *equality* may hold; **origin** must not.

### Validation (authenticated CPython 3.12.13)

```text
.venv-py312/bin/python -m pytest \
  implementations/python/sugar-lift-py-tests/tests/test_unpack_sequencing_law.py \
  implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py \
  implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_outcome_composition.py \
  implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py \
  implementations/python/sugar-source-tree/tests/test_assign_targets.py \
  implementations/python/sugar-source-tree/tests/test_store_target_effect.py \
  -q
# 69 passed; SUITE_EXIT=0
```

- Mutation transaction: reverse eval-order expectation → order twin fails; restore → green.
- black --check: clean; git diff --check: clean.
- Authority: CPython 3.12.13 + NumPy 2.5.1 + pandas 3.0.3 (pyarrow 22.0.0 seat).

### Reserved (untouched)

carrier / outcome / ExitSet / tally / definition door (9883), seam/binder (9864), binary floor (10035), comparison (9015), Attribute read (9008), Subscript read (8865), assertion-with (10052), resource-with (269), source-defined manager (17515), **subscript store implementation (10876)**, **attribute store (17534)**, BoolOp (10732), UnaryOp (17512), exit_set.py, generator construction.

### Precedents

#6599 Construct source-visible subscript stores (compose, do not reimplement), #6601 UnaryOp faces + named seams, #6602 native definition door, #6603 gap-shaped corpus honesty.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct unpack sequencing for Name+Subscript store leaves in `Assign._construct_sugar`
> - `Assign._flat_store_unpack_pairs` now admits Subscript leaves whose receiver is not an `ObjectPlaceStateV1`, removing the prior rejection that blocked non-place subscript targets from further processing.
> - `Assign._construct_sugar` now builds `UnpackStoreAssignSugar` with `SubscriptStoreEffectSugar` entries for non-place subscript leaves in display unpack, rather than falling back to the default sugar path.
> - `Assign.substitute` now rewrites Attribute/Subscript leaves inside tuple/list unpack targets via a new `_substituted_unpack_store_leaves` helper, not just standalone store targets.
> - Tests in `test_unpack_sequencing_law.py` cover construction, undischarged behavior, evaluation order, outcome faces, and refusal paths for arity/starred patterns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 547d2be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->