### PR TITLE
Project decided attribute stores through Floor setattr (PARTIAL: dual-face formals retained; setattr_named mint pinned for n-ary)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -756,6 +756,28 @@ class FloorValue:
         )
         construction_panic(info)
 
+    def setattr(self, name, value, site):
+        """``receiver.name = value`` — the store path, never the read path.
+
+        Distinct from :meth:`attribute` / ``__getattr__`` / ``__getattribute__``.
+        A readable name does not license a write. Default: loud floor gap.
+        """
+        del name, value
+        from sugar_lift_py_tests.gap.panic import construction_panic
+        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+
+        observed = type(self).__name__
+        info = ConstructionGap(
+            owner="setattr",
+            blame=str(site),
+            observed=observed,
+            requested="stand on the attribute-store floor",
+            fix=f"write more Floor: implement {observed}.setattr",
+            gap_kind=GapKind.FLOOR,
+            gap_locus=GapLocus.CONSTRUCTION,
+        )
+        construction_panic(info)
+
     def delitem(self, index, site):
         del index
         from sugar_lift_py_tests.gap.panic import construction_panic

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -34,6 +34,19 @@ class ListValue(FloorValue):
 
         return getattr_coordinate(self, name, owner="ListValue.attribute")
 
+    def setattr(self, name, value, site):
+        """Lists have no instance ``__dict__``; attribute store is AttributeError.
+
+        Distinct from the read path: ``xs.append`` may resolve as a bound method
+        coordinate while ``xs.append = f`` still raises AttributeError.
+        """
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="ListValue.setattr"
+        )
+
     def to_term(self, *, owner: str):
         # Project elements into FOL — assert equality / dig return faces.
         from sugar_lift_py_tests.ir import ctor

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
@@ -72,6 +72,17 @@ class NoneValue(FloorValue):
 
         return getattr_coordinate(self, name, owner="NoneValue.attribute")
 
+    def setattr(self, name, value, site):
+        """``None.name = value`` is always AttributeError — store, not read."""
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="NoneValue.setattr",
+        )
+
     def subscript(self, index, site):
         """Construct Python's exact ground ``None[...]`` exceptional exit."""
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -242,6 +242,28 @@ class ObjectValue(FloorValue):
             for method in self.methods
         )
 
+    def setattr(self, name, value, site):
+        """``self.name = value`` via instance-field store or property refusal.
+
+        Properties are data descriptors: a getter without an authenticated
+        setter raises ``AttributeError`` on the **store** path — never by
+        consulting :meth:`attribute` / the read path.
+        """
+        from sugar_lift_py_tests.outcome import Complete
+
+        if any(
+            method.name == name and method.descriptor_kind == "property"
+            for method in self.methods
+        ):
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+            return ground_exceptional_exit(
+                exception_name="AttributeError",
+                site=site,
+                owner="ObjectValue.setattr",
+            )
+        return Complete(self.with_field_store(name, value))
+
     def with_deferred_helper_fields(self) -> "ObjectValue":
         names = self.helper_receiver_field_names()
         return ObjectValue(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -156,9 +156,7 @@ class TermValue(FloorValue):
                 else FalseBoolLiteralSugar(site=site)
             )
         if self._unorderable_ground_peer(other):
-            return self._ground_ordering_type_error(
-                site, owner="TermValue.less_than"
-            )
+            return self._ground_ordering_type_error(site, owner="TermValue.less_than")
         return super().less_than(other, site)
 
     def less_equal(self, other, site):
@@ -177,9 +175,7 @@ class TermValue(FloorValue):
                 else FalseBoolLiteralSugar(site=site)
             )
         if self._unorderable_ground_peer(other):
-            return self._ground_ordering_type_error(
-                site, owner="TermValue.less_equal"
-            )
+            return self._ground_ordering_type_error(site, owner="TermValue.less_equal")
         return super().less_equal(other, site)
 
     def greater_than(self, other, site):
@@ -303,9 +299,7 @@ class TermValue(FloorValue):
 
         if type(other) is ComplexValue:
             return super().subtract(other, site)
-        return self._decided_binary_type_error(
-            other, site, owner="TermValue.subtract"
-        )
+        return self._decided_binary_type_error(other, site, owner="TermValue.subtract")
 
     def multiply(self, other, site):
         # A number stands on the multiplication floor: two numbers multiply, and the
@@ -345,9 +339,7 @@ class TermValue(FloorValue):
 
         if type(other) is ComplexValue:
             return super().multiply(other, site)
-        return self._decided_binary_type_error(
-            other, site, owner="TermValue.multiply"
-        )
+        return self._decided_binary_type_error(other, site, owner="TermValue.multiply")
 
     def power(self, other, site):
         if type(other) is TermValue:
@@ -668,6 +660,15 @@ class TermValue(FloorValue):
             exception_name="TypeError",
             site=site,
             owner="TermValue.bitwise_invert",
+        )
+
+    def setattr(self, name, value, site):
+        """``(1).x = v`` raises AttributeError — store path, not read path."""
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="TermValue.setattr"
         )
 
     def subscript(self, index, site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -357,3 +357,12 @@ class TupleValue(FloorValue):
         return ground_exceptional_exit(
             exception_name="TypeError", site=site, owner="TupleValue.setitem"
         )
+
+    def setattr(self, name, value, site):
+        """Tuples have no ``__dict__``; attribute store is AttributeError."""
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="TupleValue.setattr"
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
@@ -9,21 +9,29 @@ from sugar_lift_py_tests.sugar.witnesses import typed_red_effect_witness
 
 @dataclass(frozen=True)
 class AttributeStoreEffectSugar(Sugar):
-    """`<receiver>.<attr> = <value>` -- an attribute store whose receiver
-    identity belongs to the runtime: Python attribute assignment can invoke
-    descriptors and ``__setattr__`` at runtime, so the exact post-state is not
-    lift-time decidable.
+    """`receiver.attr = value` — evaluate once, then project the store face.
 
-    Unlike ``AssignSugar`` (a plain-Name target, spent by substitute), a
-    store target is never bound -- it is read AND written, so it carries no
-    inert-meaning arm. This desugars straight to typed red: ``Incomplete``
-    wrapping an ``AttributeStoreRuntimeEffect``, witnessed at the TREE
-    fragment site (``site``, the statement's own fragment -- the sole site
-    type on this hot path; see ``effect/runtime_effect.py``'s
-    ``RuntimeEffectSite`` protocol). The store completed (Python continues
-    to the next statement), so ``Incomplete.follow()`` treats this effect as
-    continue-with-red, not halt (outcome/incomplete.py::
-    _effect_continues_control_flow) -- the block keeps reducing past it.
+    Python order: RHS first, then the receiver, each exactly once.  Dispatch is
+    ``__setattr__`` / descriptor ``__set__`` via Floor ``setattr`` — a different
+    method and obligation from the read path ``attribute`` /
+    ``__getattr__`` / ``__getattribute__``.
+
+    Projection arms (PARTIAL — dual-face composition instrument preserved):
+
+    1. **Decided runtime type** → ``receiver.setattr(attr, value, site)``
+       projecting ``Completed`` or ``RaiseValue`` exceptional faces through
+       the store path (never the read path).
+    2. **Undecided / formal** → ``AttributeStoreRuntimeEffect`` dual faces
+       under complementary store-outcome guards.  This is the instrument the
+       five named store ExitSet composition laws read; it is **not** replaced
+       by a consumer ``SugarNotWritten``.
+
+    Formal ``setattr_named`` carrier mint (n-ary discharge contract) is the
+    next partial step once composition can consume undischarged carriers
+    without deleting dual-face detectors.  The mint shape is pinned in
+    ``test_attribute_store_desugar`` as the producer-side contract for the
+    n-ary worker: operator ``setattr_named``, operands
+    ``(receiver, StringValue(name), value)``.
     """
 
     receiver: Sugar
@@ -58,6 +66,21 @@ class AttributeStoreEffectSugar(Sugar):
         )
 
     def _store(self, receiver, value) -> Outcome:
+        from sugar_lift_py_tests.floor import RaiseValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        # Decided receivers project through Floor setattr (store path ≠ read).
+        if receiver.runtime_type_is_decided():
+            projected = receiver.setattr(self.attr, value, self.site)
+            if isinstance(projected, Complete) and isinstance(
+                projected.value, RaiseValue
+            ):
+                return Incomplete(projected.value.effect)
+            return projected
+
+        # Undecided / formal: retain dual-face AttributeStoreRuntimeEffect.
+        # Do not emit SugarNotWritten from this consumer — that converts
+        # constructed dual-face behaviour into a refusal.
         from sugar_lift_py_tests.effect import (
             AttributeStoreRuntimeEffect,
             runtime_effect_evidence_from_terms,
@@ -80,6 +103,33 @@ class AttributeStoreEffectSugar(Sugar):
                 f"attr={self.attr} site={self.site}",
                 **runtime_effect_evidence_from_terms(operation, operation, self.site),
             )
+        )
+
+    @staticmethod
+    def mint_setattr_named_carrier(*, site, receiver, attr: str, value):
+        """Producer-side contract for n-ary ``setattr_named`` discharge.
+
+        Operand order and operator string are fixed for the n-ary worker:
+        ``receiver.setattr(name.value, value, site)`` after discharge.
+        Not wired into ``_store`` while dual-face composition laws still
+        instrument formal parameters via ``AttributeStoreRuntimeEffect``.
+        """
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            NativeOperationExitCarrierV1,
+        )
+        from sugar_lift_py_tests.floor import StringValue
+
+        formal_coordinate = getattr(receiver, "formal_coordinate", None)
+        if formal_coordinate is None:
+            raise ValueError(
+                "setattr_named carrier requires a receiver formal_coordinate"
+            )
+        value_coordinate = getattr(value, "formal_coordinate", None)
+        return NativeOperationExitCarrierV1.mint(
+            site=site,
+            operator="setattr_named",
+            operands=(receiver, StringValue(attr), value),
+            coordinates=(formal_coordinate, None, value_coordinate),
         )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
@@ -1,0 +1,417 @@
+"""ADDED laws for source-visible attribute store faces.
+
+Does **not** delete or rewrite store ExitSet composition laws
+(``test_store_outcome_composition``, unpack twins). Those five named laws
+remain the dual-face instrument for undecided formal stores via
+``AttributeStoreRuntimeEffect``.
+
+Python semantic law made constructible (PARTIAL):
+
+  For ``obj.attr = value``, when the receiver runtime type is decided, project
+  through Floor ``setattr`` (not the read path). Evaluate RHS then receiver
+  once. Store halt preserves earlier state. Exception type originates in the
+  store dispatch owner.
+
+  Formal ``setattr_named`` carrier mint is pinned as the n-ary discharge
+  contract (operator + operand order) but is not yet the sole formal arm —
+  wiring it into ``_store`` would convert dual-face ExitSet composition into
+  undischarged carriers and red the five named store laws without an
+  individual per-test restatement. That switch is a separate partial step.
+
+Named seams (``test_producer_and_consumer_methods_are_the_named_seams``):
+
+  producer: ``AttributeStoreEffectSugar.desugar`` / ``_store``
+  consumer: ``FloorValue.setattr`` / ``ObjectValue.setattr``
+
+Pinned pandas 3.0.3 (line content verified on installed seat):
+
+  ``pandas/tests/indexes/test_any_index.py:113``
+  ``original_name, index.name = index.name, "foo"``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.effect import AttributeStoreRuntimeEffect
+from sugar_lift_py_tests.floor import (
+    FloorValue,
+    ListValue,
+    NoneValue,
+    ObjectField,
+    ObjectMethodValue,
+    ObjectValue,
+    SymbolicValue,
+    TermValue,
+    TupleValue,
+)
+from sugar_lift_py_tests.floor.block_value import BlockValue
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.ir import PrimitiveSort, make_var, str_const
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.outcome.exit_set import Halted
+from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
+from sugar_lift_py_tests.sugar.store_effect_sugar import AttributeStoreEffectSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+MANIFEST_CID = (
+    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
+    "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+)
+
+CORPUS_RELATIVE = "pandas/tests/indexes/test_any_index.py"
+CORPUS_LINE = 113
+CORPUS_TEXT = 'original_name, index.name = index.name, "foo"'
+
+
+def _site(tmp_path: Path):
+    path = tmp_path / "attr_store.py"
+    path.write_text("def f(obj, value):\n    obj.attr = value\n")
+    function = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    )
+    return function.body[0].fragment
+
+
+@dataclass(frozen=True)
+class _ObservedSugar(Sugar):
+    label: str
+    value: object
+    log: list[str]
+
+    @classmethod
+    def witnesses(cls):
+        raise AssertionError("test helper has no witness")
+
+    def desugar(self, ctx=None):
+        del ctx
+        self.log.append(self.label)
+        return Complete(self.value)
+
+
+def _store(receiver, value, log, site, attr: str = "attr"):
+    return AttributeStoreEffectSugar(
+        receiver=_ObservedSugar("receiver", receiver, log),
+        value=_ObservedSugar("value", value, log),
+        attr=attr,
+        site=site,
+    )
+
+
+def _formal(site) -> FormalParameterCoordinateV1:
+    span = site.line_col_span
+    owner = SourceFragmentCoordinateV1(
+        site.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    return FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=site.source_cid,
+        owner_definition_locus=owner,
+        declaration_locus=owner,
+        ordinal=0,
+        parameter_kind="positional-or-keyword",
+        declared_name="obj",
+        sort=PrimitiveSort("Value"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Named seams
+# ---------------------------------------------------------------------------
+
+
+def test_producer_and_consumer_methods_are_the_named_seams() -> None:
+    assert hasattr(AttributeStoreEffectSugar, "desugar")
+    assert hasattr(AttributeStoreEffectSugar, "_store")
+    assert hasattr(AttributeStoreEffectSugar, "desugar_store")
+    assert hasattr(AttributeStoreEffectSugar, "mint_setattr_named_carrier")
+    assert hasattr(FloorValue, "setattr")
+    assert hasattr(ObjectValue, "setattr")
+    assert FloorValue.setattr is not FloorValue.attribute
+
+
+# ---------------------------------------------------------------------------
+# Evaluate-once / left-to-right
+# ---------------------------------------------------------------------------
+
+
+def test_attribute_store_evaluates_rhs_and_receiver_once_in_python_order(tmp_path):
+    log: list[str] = []
+    receiver = ObjectValue("R", (ObjectField("attr", TermValue(1)),))
+    outcome = _store(receiver, TermValue(7), log, _site(tmp_path)).desugar()
+
+    assert log == ["value", "receiver"]
+    assert isinstance(outcome, Complete)
+    assert outcome.value.fields[-1].value == TermValue(7)
+
+
+def test_rhs_halt_wins_before_receiver_evaluation(tmp_path):
+    from sugar_lift_py_tests.effect import RaiseEffect
+    from sugar_lift_py_tests.floor import RaiseValue
+
+    log: list[str] = []
+
+    @dataclass(frozen=True)
+    class _RaisingValue(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            log.append("value")
+            return Complete(
+                RaiseValue(
+                    RaiseEffect(
+                        exception_type_coordinate=str_const("ValueError"),
+                        occurrence="attr_store.py:2:16",
+                    )
+                )
+            )
+
+        @classmethod
+        def witnesses(cls):
+            raise AssertionError
+
+    store = AttributeStoreEffectSugar(
+        receiver=_ObservedSugar("receiver", ObjectValue("R", ()), log),
+        value=_RaisingValue(),
+        attr="attr",
+        site=_site(tmp_path),
+    )
+    outcome = store.desugar()
+
+    assert log == ["value"]
+    assert outcome.value.effect.exception_type_coordinate == str_const("ValueError")
+
+
+# ---------------------------------------------------------------------------
+# Decided faces — store path ≠ read path
+# ---------------------------------------------------------------------------
+
+
+def test_ground_object_field_store_completes(tmp_path):
+    receiver = ObjectValue("R", (ObjectField("attr", TermValue(0)),))
+    outcome = _store(receiver, TermValue(9), [], _site(tmp_path)).desugar()
+    assert isinstance(outcome, Complete)
+    assert outcome.value.fields[-1].value == TermValue(9)
+
+
+def test_readable_immutable_receiver_raises_on_store(tmp_path):
+    receiver = TupleValue((TermValue(1),))
+    outcome = _store(receiver, TermValue(7), [], _site(tmp_path)).desugar()
+
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect.exception_name == "AttributeError"
+    assert outcome.effect.producer_node_owner == "TupleValue.setattr"
+
+
+def test_none_setattr_is_attribute_error_on_store_path(tmp_path):
+    outcome = _store(NoneValue(), TermValue(1), [], _site(tmp_path)).desugar()
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect.exception_name == "AttributeError"
+    assert outcome.effect.producer_node_owner == "NoneValue.setattr"
+
+
+def test_list_read_path_does_not_license_list_setattr(tmp_path):
+    receiver = ListValue((TermValue(1),))
+    outcome = _store(
+        receiver, TermValue(7), [], _site(tmp_path), attr="append"
+    ).desugar()
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect.exception_name == "AttributeError"
+    assert outcome.effect.producer_node_owner == "ListValue.setattr"
+
+
+def test_property_without_setter_raises_attribute_error_not_completed(tmp_path):
+    from sugar_lift_py_tests.floor.return_value import ReturnValue
+
+    @dataclass(frozen=True)
+    class _GetterBody(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(
+                BlockValue((ReturnValue(TermValue(1)),), can_fall_through=False)
+            )
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    receiver = ObjectValue(
+        "R",
+        (),
+        methods=(
+            ObjectMethodValue(
+                name="attr",
+                parameters=("self",),
+                body=_GetterBody(),
+                descriptor_kind="property",
+            ),
+        ),
+    )
+    outcome = _store(receiver, TermValue(7), [], _site(tmp_path)).desugar()
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect.exception_name == "AttributeError"
+    assert outcome.effect.producer_node_owner == "ObjectValue.setattr"
+
+
+def test_undecided_retains_dual_face_runtime_effect(tmp_path):
+    """Dual-face instrument intact — not replaced by SugarNotWritten."""
+    outcome = _store(
+        SymbolicValue(make_var("obj")), TermValue(7), [], _site(tmp_path)
+    ).desugar()
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, AttributeStoreRuntimeEffect)
+
+
+def test_formal_parameter_store_still_emits_dual_face_runtime_effect(tmp_path):
+    """Formal parameters keep dual-face RuntimeEffect so composition laws stay green.
+
+    The setattr_named mint helper pins the n-ary contract without displacing
+    this instrument yet.
+    """
+    path = tmp_path / "formal_store.py"
+    path.write_text("def target(o, p):\n    o.x = p\n    return p\n")
+    from sugar_lift_python_source.source_oracle import path_source
+
+    fn = next(SourceFile(path_source(str(path))).functions())
+    outcome = fn.sugar().desugar(None)
+    from sugar_lift_py_tests.outcome import ExitSet
+
+    assert isinstance(outcome, ExitSet)
+    # Dual faces: completed + halted under store guards
+    assert len(outcome.exits) >= 2
+
+
+# ---------------------------------------------------------------------------
+# setattr_named mint contract (n-ary worker producer side)
+# ---------------------------------------------------------------------------
+
+
+def test_setattr_named_carrier_mint_contract(tmp_path):
+    """Operator string and operand order for the n-ary discharge worker."""
+    site = _site(tmp_path)
+    formal = _formal(site)
+    receiver = SymbolicValue(make_var("obj"), formal)
+    value = TermValue(7)
+    carrier = AttributeStoreEffectSugar.mint_setattr_named_carrier(
+        site=site, receiver=receiver, attr="attr", value=value
+    )
+    assert isinstance(carrier, NativeOperationExitCarrierV1)
+    assert carrier.demand.operator == "setattr_named"
+    assert len(carrier.operands) == 3
+    assert carrier.demand.operand_coordinate_cids[0] == formal.coordinate_cid
+    assert carrier.demand.operand_coordinate_cids[1] is None
+
+
+# ---------------------------------------------------------------------------
+# Preservation
+# ---------------------------------------------------------------------------
+
+
+def test_store_halt_preserves_state_completed_before_it(tmp_path):
+    prior = _ObservedSugar(
+        "prior", BlockValue((TermValue(99),), can_fall_through=True), []
+    )
+    store = _store(
+        TupleValue((TermValue(1),)),
+        TermValue(7),
+        [],
+        _site(tmp_path),
+    )
+    outcome = reduce_block_to_exitset((prior, store), None)
+
+    halted = [exit_ for exit_ in outcome.exits if isinstance(exit_, Halted)]
+    assert len(halted) == 1
+    assert TermValue(99) in halted[0].state.entries
+
+
+# ---------------------------------------------------------------------------
+# Lying twins
+# ---------------------------------------------------------------------------
+
+
+def test_property_read_does_not_license_completed_store(tmp_path):
+    from sugar_lift_py_tests.floor.return_value import ReturnValue
+
+    @dataclass(frozen=True)
+    class _GetterBody(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(
+                BlockValue((ReturnValue(TermValue(1)),), can_fall_through=False)
+            )
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    receiver = ObjectValue(
+        "R",
+        (),
+        methods=(
+            ObjectMethodValue(
+                name="attr",
+                parameters=("self",),
+                body=_GetterBody(),
+                descriptor_kind="property",
+            ),
+        ),
+    )
+    outcome = _store(receiver, TermValue(7), [], _site(tmp_path)).desugar()
+    assert not (
+        isinstance(outcome, Complete) and isinstance(outcome.value, ObjectValue)
+    )
+
+
+def test_exception_type_originates_in_store_dispatch_not_boundary(tmp_path):
+    outcome = _store(NoneValue(), TermValue(1), [], _site(tmp_path)).desugar()
+    assert outcome.effect.exception_name == "AttributeError"
+    assert outcome.effect.producer_node_owner == "NoneValue.setattr"
+    assert "setattr" in outcome.effect.producer_node_owner
+
+
+# ---------------------------------------------------------------------------
+# Corpus coordinate
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_pandas_name_attr_unpack_coordinate_is_real() -> None:
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.file_count, corpus.manifest_cid) == (
+        "3.0.3",
+        1421,
+        MANIFEST_CID,
+    )
+    install_root = corpus.root.parent
+    path = install_root / CORPUS_RELATIVE
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert lines[CORPUS_LINE - 1].strip() == CORPUS_TEXT
+
+    tree = SourceFile(workspace_path_source(str(path), root=str(install_root)))
+    function = next(
+        fn for fn in tree.functions() if fn.name == "test_pickle_preserves_name"
+    )
+    from sugar_lift_py_tests.sugar.assign_sugar import UnpackStoreAssignSugar
+
+    unpack = next(
+        stmt
+        for stmt in function.sugar().statements
+        if isinstance(stmt, UnpackStoreAssignSugar)
+    )
+    assert unpack.bindings[0][0] == "original_name"
+    store = unpack.stores[0]
+    assert isinstance(store, AttributeStoreEffectSugar)
+    assert store.attr == "name"
+    # Undecided formal path: dual-face RuntimeEffect (composition instrument).
+    outcome = store.desugar(None)
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, AttributeStoreRuntimeEffect)


### PR DESCRIPTION
## Python semantic law made constructible (PARTIAL)

For `obj.attr = value`, Python evaluates **value then obj** each exactly once. When the receiver runtime type is **decided**, dispatch is **`setattr` / descriptor `__set__`** — a different method and obligation from the read path `attribute` / `__getattr__` / `__getattribute__`. Exception type originates in the store floor owner (`*.setattr`), never an enclosing boundary.

Undecided receivers (including formal parameters that currently drive dual-face composition) **retain** `AttributeStoreRuntimeEffect` under complementary store-outcome guards. That instrument is **not** replaced by a consumer `SugarNotWritten`.

### Why PARTIAL

Formal `setattr_named` carrier mint is the correct next demand shape (n-ary discharge worker maps `setattr_named` → `receiver.setattr(name.value, value, site)`). Wiring formals off dual-face RuntimeEffect **now** would red the five named store ExitSet composition laws without an individual per-test restatement of those fixtures. This PR:

- **keeps those five laws intact and green**
- **adds** decided `setattr` projection
- **pins** the `setattr_named` mint contract via `AttributeStoreEffectSugar.mint_setattr_named_carrier` for the n-ary producer/consumer handshake

### Named seams

| Role | Method |
|------|--------|
| **Producer** | `AttributeStoreEffectSugar.desugar` / `_store` |
| **Consumer** | `FloorValue.setattr` / `ObjectValue.setattr` |

`test_producer_and_consumer_methods_are_the_named_seams` enforces these.

### Production seam

```
AttributeStoreEffectSugar._store
  → if decided: receiver.setattr(name, value, site)
       → Completed | Incomplete(RaiseEffect from store floor)
  → else: Incomplete(AttributeStoreRuntimeEffect)  # dual-face instrument intact
```

### Store laws restored / intact (measured)

| Law | main count | branch count |
|-----|------------|--------------|
| `preserves_the_first_store` | 2 | 2 |
| `no_invented_exception_type` | 2 | 2 |
| `mints_its_own_coordinate` | 2 | 2 |
| `first_store_halt_has_no_second` | 2 | 2 |
| `guards_are_exactly_complementary` | 2 | 2 |
| `test_mixed_chain_never_fabricates_a_completed_subscript_store` | present | present |

**Zero store-law tests deleted.** New module only adds laws.

### Corpus coordinate (pandas 3.0.3 — content verified)

`pandas/tests/indexes/test_any_index.py:113`

```python
original_name, index.name = index.name, "foo"
```

Undecided formal path still dual-face RuntimeEffect (composition instrument). Decided ground faces project through setattr.

### Lying twins (must not complete / wrong origin)

1. Property with getter, no setter → completed field store  
2. Exception type from boundary rather than `*.setattr` producer owner  
3. List/tuple readable attribute licensing a completed store  

### Validation

```text
.venv-py312/bin/python -m pytest \
  implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py \
  implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py \
  implementations/python/sugar-source-tree/tests/test_store_target_effect.py \
  implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_outcome_composition.py \
  -q
# 46 passed
```

- Five named laws: 10 passed  
- Mutation: reverse RHS/receiver order → order twin fails; restore → 15/15 green  
- black --check clean on touched files  
- Authority: CPython 3.12.13 + NumPy 2.5.1 + pandas 3.0.3  

### Follow-up (not this PR)

Wire formal receivers to `mint_setattr_named_carrier` only with **individual** restatement of dual-face composition fixtures that currently use formal parameters — never a group deletion of detectors.

### Reserved (untouched)

carrier / outcome / ExitSet / tally / definition door (9883), seam/binder (9864), binary floor (10035), comparison (9015), Attribute read (9008), Subscript read (8865), assertion-with (10052), resource-with (269), source-defined manager (17515), **subscript store (10876)**, BoolOp (10732), UnaryOp (17512), exit_set.py, generator construction.

### Precedents

#6604 PARTIAL unpack sequencing (laws added, old intact); #6599 subscript store sibling; #6602 native definition door.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` to Floor value types and dispatch attribute stores through Floor
> - Adds `setattr` to `FloorValue`, `ListValue`, `NoneValue`, `TermValue`, and `TupleValue`; all raise `AttributeError` via a ground exceptional exit except `FloorValue`, which triggers a `construction_panic` with a `FLOOR` `ConstructionGap`.
> - Adds `setattr` to `ObjectValue` with full attribute-store semantics: plain field stores return `Complete` with the updated object; attempts to set a property without a setter raise `AttributeError`.
> - Adds `mint_setattr_named_carrier` to `AttributeStoreEffectSugar`, which mints a `setattr_named` `NativeOperationExitCarrierV1`; raises `ValueError` if the receiver lacks a `formal_coordinate`.
> - Adds a new test module covering desugaring semantics, decided/undecided faces, property behavior, and formal parameter carrier minting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab94044.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->