### PR TITLE
Discharge BoolOp truth through caller actuals

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .array_literal import ArrayLiteral
 from .async_function_callable import AsyncFunctionCallable
 from .block_value import BlockValue
+from .boolop_truth_selection import BoolOpTruthSelection
 from .branch_result_coordinate import (
     BranchResultAuthentication,
     BranchResultCoordinate,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/boolop_truth_selection.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/boolop_truth_selection.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+
+@dataclass(frozen=True)
+class BoolOpTruthSelection(FloorValue):
+    """One evaluation's operand and its completed native truth result.
+
+    BoolOp needs both: truth selects the next face, while Python returns the
+    original operand on the short-circuit face.  Keeping them together lets a
+    caller-discharge continuation return the substituted actual rather than
+    the definition-time formal symbol.
+    """
+
+    operand: object
+    truth_value: object

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -652,6 +652,50 @@ class FloorValue:
                 )
         return self.truth(site)
 
+    def boolop_truth(self, site):
+        """Truth-test once while retaining the actual operand BoolOp returns.
+
+        This unary carrier adapter is deliberately distinct from ``truth``:
+        ``a and b`` / ``a or b`` select using ``bool(a)`` but return ``a`` on
+        the stopping face.  After formal-coordinate discharge, ``self`` is the
+        authenticated caller actual, so packaging it here prevents the
+        definition-time formal from leaking into the result.
+
+        An actual whose runtime type remains undecided stays a named refusal;
+        neither a generic halt nor a total symbolic truth is invented.
+        """
+        denotes = getattr(self, "denotes_value", None)
+        decided = getattr(self, "runtime_type_is_decided", None)
+        if callable(denotes) and callable(decided) and denotes() and not decided():
+            from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+            from sugar_source_tree.panic import SugarNotWritten
+
+            if not isinstance(self, CallSiteValue):
+                raise SugarNotWritten(
+                    blame=site,
+                    owner="boolean_operation_exception_floor",
+                    observed=f"{type(self).__name__} BoolOp truth",
+                    requested=(
+                        "source-visible native truth testimony selecting completion "
+                        "or an authenticated exceptional exit"
+                    ),
+                    fix=(
+                        "preserve the undecided third value at boolop_truth discharge; "
+                        "resolve the actual's runtime type and __bool__/__len__ from "
+                        "source before completing or halting"
+                    ),
+                )
+
+        from sugar_lift_py_tests.floor.boolop_truth_selection import (
+            BoolOpTruthSelection,
+        )
+
+        from sugar_lift_py_tests.outcome import Complete
+
+        return self.truth(site).and_then(
+            lambda truth_value: Complete(BoolOpTruthSelection(self, truth_value))
+        )
+
     def undecided_attribute(self, name, site, *, owner: str):
         """Refuse lookup when source testimony decides neither outgoing edge.
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -127,9 +127,26 @@ class BoolOpSugar(Sugar):
                 return factored_operand(operand.desugar(ctx))
 
             def project_truth(value):
-                refuse_undecided_boolean_truth(value, self.site, self.op_kind)
-                return value.truth(self.site).and_then(
-                    lambda truth_value: continue_from(value, truth_formula(truth_value))
+                formal_coordinate = getattr(value, "formal_coordinate", None)
+                if formal_coordinate is not None:
+                    from sugar_lift_py_tests.caller_parameter_contract import (
+                        NativeOperationExitCarrierV1,
+                    )
+
+                    tested = NativeOperationExitCarrierV1.mint(
+                        site=self.site,
+                        operator="boolop_truth",
+                        operands=(value,),
+                        coordinates=(formal_coordinate,),
+                    )
+                else:
+                    refuse_undecided_boolean_truth(value, self.site, self.op_kind)
+                    tested = value.boolop_truth(self.site)
+
+                return tested.and_then(
+                    lambda selection: continue_from(
+                        selection.operand, truth_formula(selection.truth_value)
+                    )
                 )
 
             def continue_from(value, formula):

--- a/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
@@ -4,13 +4,28 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.context_manager_contract import (
+    AuthenticatedRaiseMatcher,
+    EffectBoundaryDisposition,
+)
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.effect import RaiseEffect
-from sugar_lift_py_tests.floor import FloorValue
+from sugar_lift_py_tests.floor import FloorValue, SymbolicValue, TermValue
+from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var, str_const
 from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted, outcome_to_exitset
 from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
 from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import BoolOp
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
 
 
 @dataclass(frozen=True)
@@ -55,6 +70,24 @@ class _ProbeSugar(Sugar):
         return Complete(self.value)
 
 
+@dataclass(frozen=True)
+class _ExceptionalTruth(FloorValue):
+    def denotes_value(self) -> bool:
+        return True
+
+    def runtime_type_is_decided(self) -> bool:
+        return True
+
+    def truth(self, site):
+        return ground_type_error(site=site, owner="_ExceptionalTruth.truth")
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor("python:boolop_exceptional_truth_probe", [])
+
+
 def _truth(value: bool):
     site = _Site()
     literal = TrueBoolLiteralSugar(site) if value else FalseBoolLiteralSugar(site)
@@ -67,6 +100,59 @@ def _completed_value(outcome):
     face = exits[0]
     assert not isinstance(face, Halted)
     return face.value
+
+
+def _formal_carrier():
+    source = "def choose(left, right):\n    return left and right\n"
+    node = next(
+        item
+        for item in SourceFile(
+            (source, "boolop_caller.py", blake3_512_of(source.encode()))
+        ).nodes()
+        if isinstance(item, BoolOp)
+    )
+    span = node.fragment.line_col_span
+    locus = SourceFragmentCoordinateV1(
+        node.fragment.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    formal = FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=locus.source_cid,
+        owner_definition_locus=locus,
+        declaration_locus=locus,
+        ordinal=0,
+        parameter_kind="positional-or-keyword",
+        declared_name="left",
+        sort=PrimitiveSort("Value"),
+    )
+    evaluations: list[str] = []
+    right = _Operand("right", _truth(True), [])
+    outcome = BoolOpSugar(
+        "And",
+        (
+            _ProbeSugar(
+                "left", SymbolicValue(make_var("left"), formal), evaluations
+            ),
+            _ProbeSugar("right", right, evaluations),
+        ),
+        node.fragment,
+    ).desugar()
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    return outcome, formal, evaluations, right
+
+
+class _ExpectedType:
+    def __init__(self, name: str):
+        self._identity = ctor(
+            "python:exception_type_identity",
+            [str_const("builtins"), str_const(name)],
+        )
+
+    def exception_type_identity(self):
+        return self._identity
 
 
 def test_left_operand_is_evaluated_and_truth_tested_exactly_once() -> None:
@@ -184,3 +270,76 @@ def test_boolop_result_is_selected_operand_never_coerced_boolean() -> None:
     assert _completed_value(continued) is right
     assert not isinstance(_completed_value(stopped), FalseBoolLiteralSugar)
     assert not isinstance(_completed_value(continued), TrueBoolLiteralSugar)
+
+
+def test_formal_boolop_defers_truth_to_existing_unary_carrier() -> None:
+    carrier, formal, evaluations, _ = _formal_carrier()
+    assert carrier.demand.operator == "boolop_truth"
+    assert carrier.demand.operand_coordinate_cids == (formal.coordinate_cid,)
+    assert evaluations == ["left"]
+
+
+def test_false_caller_actual_returns_that_actual_and_never_reaches_right() -> None:
+    carrier, formal, evaluations, _ = _formal_carrier()
+    actual = TermValue(0)
+    exits = carrier.discharge({formal.coordinate_cid: actual})
+    assert evaluations == ["left"]
+    assert len(exits.exits) == 1
+    assert not isinstance(exits.exits[0], Halted)
+    assert exits.exits[0].value is actual
+
+
+def test_true_caller_actual_reaches_and_returns_right_operand() -> None:
+    carrier, formal, evaluations, right = _formal_carrier()
+    exits = carrier.discharge({formal.coordinate_cid: TermValue(1)})
+    assert evaluations == ["left", "right"]
+    assert len(exits.exits) == 1
+    assert exits.exits[0].value is right
+
+
+def test_halted_caller_truth_propagates_and_never_reaches_right() -> None:
+    carrier, formal, evaluations, _ = _formal_carrier()
+    exits = carrier.discharge({formal.coordinate_cid: _ExceptionalTruth()})
+    assert evaluations == ["left"]
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Halted)
+    assert exits.exits[0].effect.exception_type_coordinate is not None
+
+
+def test_wrong_boundary_type_does_not_consume_caller_truth_halt() -> None:
+    """The assertion expectation verifies; it never creates the producer type."""
+    carrier, formal, _, _ = _formal_carrier()
+    produced = carrier.discharge({formal.coordinate_cid: _ExceptionalTruth()})
+    original = produced.exits[0]
+    assert isinstance(original, Halted)
+
+    routed = produced.and_exit(
+        ExitSet.completed(object()),
+        disposition=EffectBoundaryDisposition(
+            matcher=AuthenticatedRaiseMatcher(_ExpectedType("ValueError"))
+        ),
+    )
+    surviving = [
+        face
+        for face in routed.exits
+        if isinstance(face, Halted) and face.effect is original.effect
+    ]
+    assert len(surviving) == 1
+
+
+def test_undecided_caller_actual_remains_named_refusal() -> None:
+    carrier, formal, _, _ = _formal_carrier()
+    with pytest.raises(SugarNotWritten) as caught:
+        carrier.discharge(
+            {formal.coordinate_cid: SymbolicValue(make_var("still_unknown"))}
+        )
+    assert caught.value.owner == "boolean_operation_exception_floor"
+
+
+def test_lying_bool_coercion_cannot_replace_selected_operand() -> None:
+    carrier, formal, evaluations, _ = _formal_carrier()
+    actual = TermValue(0)
+    selected = carrier.discharge({formal.coordinate_cid: actual}).exits[0].value
+    assert selected is actual
+    assert not isinstance(selected, FalseBoolLiteralSugar)
+    assert evaluations == ["left"]

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
@@ -281,7 +281,10 @@ def test_pandas_series_boolop_sites_stay_source_undecided() -> None:
     BoolOp, so the producer cannot mint ValueError — only the named refusal.
     """
     from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_py_tests.caller_parameter_contract import source_coordinate
     from sugar_lift_py_tests.context_manager_resolution import (
+        NativeDefinitionCoordinateGapV1,
+        NativeProtocolSlot,
         TreeConstructionContextV1,
     )
     from sugar_lift_python_source.canonical import blake3_512_of
@@ -307,9 +310,10 @@ def test_pandas_series_boolop_sites_stay_source_undecided() -> None:
     with pytest.raises(ValueError, match="ambiguous"):
         obj1 or obj2
 
+    construction_context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
         (source, str(path), source_cid),
-        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        construction_context=construction_context,
     )
     for line, operator in ((152, "and"), (154, "or")):
         matches = tuple(
@@ -318,6 +322,12 @@ def test_pandas_series_boolop_sites_stay_source_undecided() -> None:
             if isinstance(node, BoolOp) and node.line_col_span().start_line == line
         )
         assert len(matches) == 1
+        receiver = source_coordinate(matches[0].values[0].fragment)
+        definition = construction_context.contract_refs.require_native_definition(
+            receiver, NativeProtocolSlot.TRUTH
+        )
+        assert isinstance(definition, NativeDefinitionCoordinateGapV1)
+        assert definition.reason.startswith("authenticated source definition")
         with pytest.raises(SugarNotWritten) as raised:
             matches[0].sugar().desugar(None)
         refusal = raised.value


### PR DESCRIPTION
## What

- carry a formal BoolOp left operand through the existing unary native-operation carrier
- preserve the substituted caller operand alongside its completed truth result
- propagate authenticated truth-test halts without evaluating the right operand
- keep undecided actual truth dispatch as a located named refusal

## Python law made constructible

`a and b` / `a or b` truth-test the left operand exactly once, short-circuit without evaluating the right operand, and return the selected operand rather than its coerced boolean.

The real pandas 3.0.3 sites remain honest named refusals at `tests/generic/test_generic.py:152` and `:154`: the sole native-definition door reports an authenticated-source-definition coordinate gap. Synthetic caller actuals exercise the carrier completion and exceptional faces.

## Validation

- CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0
- `.venv-py312/bin/python -m pytest implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py implementations/python/sugar-lift-py-tests/tests/test_native_protocol_definition_refs.py -q` (44 passed)
- mutation: replacing the selected operand with the truth value failed 4 tests; reverted state passed 44/44

No corpus-wide delta is claimed from the shared Mac.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Discharge BoolOp truth through caller actuals for formal parameter operands
> - When desugaring a boolean operation, operands bound to a formal parameter now yield a `NativeOperationExitCarrierV1` with operator `boolop_truth`, deferring truth testing to the caller rather than evaluating it inline.
> - For non-formal operands, truth testing goes through the new `FloorValue.boolop_truth` method, which raises `SugarNotWritten` with owner `'boolean_operation_exception_floor'` for undecided runtime types.
> - Adds a new `BoolOpTruthSelection` dataclass pairing the tested operand with its resolved truth value; the continuation uses this to preserve operand identity for short-circuit semantics.
> - Behavioral Change: non-final bool-op operands now take a different code path depending on whether they carry a `formal_coordinate`, changing when and where truth is resolved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f453ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->