### PR TITLE
Construct builtin resource exit on every outgoing edge

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_edge_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/context_manager_edge_dto.py
@@ -10,6 +10,7 @@ from sugar_lift_py_tests.context_manager_contract import (
     EffectBoundarySemanticsV1,
     ImportSignatureV2,
     NeverSuppressesDispositionV1,
+    ReturnTruthinessDispositionV1,
     ProtocolResourceSemanticsV1,
     TotalCompletionV1,
     import_signature_to_value,
@@ -43,7 +44,10 @@ def _admitted(reference: ContextManagerContractRefV1) -> bool:
         and isinstance(semantics.enter.sort, PrimitiveSort)
         and semantics.enter.sort.name == "Value"
         and isinstance(semantics.exit.completion, TotalCompletionV1)
-        and isinstance(semantics.exit.disposition, NeverSuppressesDispositionV1)
+        and isinstance(
+            semantics.exit.disposition,
+            (NeverSuppressesDispositionV1, ReturnTruthinessDispositionV1),
+        )
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
@@ -38,7 +38,15 @@ class WithResourceSugar(Sugar):
     contract_ref: object | None = None
     context_manager_edge: object | None = None
     enter_slot_id: str | None = None
+    enter_definition: object | None = None
+    exit_definition: object | None = None
     site: object = dataclass_field(compare=False, default=None)
+
+    def __post_init__(self) -> None:
+        if self.enter_definition is None or self.exit_definition is None:
+            raise ValueError(
+                "WithResourceSugar requires authenticated enter and exit definition coordinates"
+            )
 
     @classmethod
     def witnesses(cls):
@@ -64,12 +72,10 @@ class WithResourceSugar(Sugar):
         return _call_pair(
             name="with_resource_closes_completed_and_halted",
             owner_sugar="WithResourceSugar",
-            truthful=prefix
-            + "def test_a():\n"
+            truthful=prefix + "def test_a():\n"
             "    assert A(False)\n"
             "    assert A(True)\n",
-            lying=prefix
-            + "def test_a():\n"
+            lying=prefix + "def test_a():\n"
             "    assert A(False)\n"
             "    assert not A(True)\n",
         )
@@ -137,7 +143,27 @@ class WithResourceSugar(Sugar):
                         self.exit_face_id, body_exit
                     ).to_facts(site=self.site, guard=body_exit.guard)
                     face = ExitSet((body_exit,))
-                    after = face.and_exit(exit_es, disposition=self.disposition)
+                    from sugar_lift_py_tests.context_manager_contract import (
+                        NeverSuppressesDispositionV1,
+                        ReturnTruthinessDispositionV1,
+                    )
+                    from sugar_lift_py_tests.effect import RaiseEffect
+
+                    if (
+                        isinstance(self.disposition, ReturnTruthinessDispositionV1)
+                        and isinstance(body_exit, Halted)
+                        and isinstance(body_exit.effect, RaiseEffect)
+                    ):
+                        after = face.and_exit_truthiness(exit_es, site=self.site)
+                    else:
+                        disposition = (
+                            NeverSuppressesDispositionV1()
+                            if isinstance(
+                                self.disposition, ReturnTruthinessDispositionV1
+                            )
+                            else self.disposition
+                        )
+                        after = face.and_exit(exit_es, disposition=disposition)
                     after = prepend_facts_to_exitset(
                         after, (*mgr_facts, *enter_facts, *face_facts)
                     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -5,6 +5,7 @@ Production ``open(...)`` stays RuntimeSelected.
 
 from __future__ import annotations
 
+import ast
 import inspect
 
 import pytest
@@ -12,9 +13,12 @@ import pytest
 from sugar_lift_py_tests.context_manager_contract import (
     NeverSuppresses,
     NeverSuppressesDispositionV1,
+    ReturnTruthinessDispositionV1,
     RuntimeSelected,
 )
-from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.effect import LoopControlEffect, RaiseEffect
+from sugar_lift_py_tests.floor import SymbolicValue, TermValue
 from sugar_lift_py_tests.floor.block_value import BlockValue
 from sugar_lift_py_tests.floor.call_site_value import ExitSuppressionContract
 from sugar_lift_py_tests.floor.manager_coordinate import (
@@ -38,6 +42,28 @@ from sugar_lift_py_tests.sugar.resource_coord_sugar import (
 )
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
+
+
+def test_authenticated_pandas_303_builtin_open_resource_coordinate():
+    """Real corpus half; native-definition lifecycle twins below are synthetic."""
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.file_count) == ("3.0.3", 1421)
+    relative = "tests/series/methods/test_to_csv.py"
+    source = (corpus.root / relative).read_text(encoding="utf-8")
+    site = next(
+        node
+        for node in ast.walk(ast.parse(source, filename=relative))
+        if isinstance(node, ast.With)
+        and node.lineno == 57
+        and isinstance(node.items[0].context_expr, ast.Call)
+    )
+    item = site.items[0]
+    assert ast.get_source_segment(source, item.context_expr) == (
+        'open(path, "w", encoding="utf-8")'
+    )
+    assert ast.get_source_segment(source, item.optional_vars) == "outfile"
 
 
 class _FixedSugar(Sugar):
@@ -135,6 +161,12 @@ def _resource(
         body=body if body is not None else (_Pass(),),
         disposition=disposition or NeverSuppresses(),
         enter_slot_id=enter_slot_id,
+        enter_definition=SourceFragmentCoordinateV1(
+            "blake3-512:" + "e" * 128, 1, 0, 1, 1
+        ),
+        exit_definition=SourceFragmentCoordinateV1(
+            "blake3-512:" + "x" * 128, 2, 0, 2, 1
+        ),
         site=None,
     )
 
@@ -273,6 +305,73 @@ def test_runtime_selected_not_guessed():
     assert len(reds) == 1
 
 
+@pytest.mark.parametrize(
+    ("exit_value", "halt_count"), [(TermValue(1), 0), (TermValue(0), 1)]
+)
+def test_native_exit_return_truthiness_decides_raise_suppression(
+    exit_value, halt_count
+):
+    """Synthetic extension: the native definition's real return decides."""
+    out = _resource(
+        body=(_Raise("ValueError"),),
+        exit=_FixedSugar(Complete(exit_value)),
+        disposition=ReturnTruthinessDispositionV1(),
+    ).desugar()
+    raises = [
+        entry
+        for entry in out.value.contribution()
+        if isinstance(entry, Incomplete)
+        and getattr(entry.effect, "exception_name", None) == "ValueError"
+    ]
+    assert len(raises) == halt_count
+
+
+def test_native_undecided_exit_return_keeps_both_suppression_faces():
+    """Load-bearing lying twin: unknown truth may never swallow the halt."""
+    out = _resource(
+        body=(_Raise("ValueError"),),
+        exit=_FixedSugar(Complete(SymbolicValue(make_var("exit_result")))),
+        disposition=ReturnTruthinessDispositionV1(),
+    ).desugar()
+    contributions = out.value.contribution()
+    assert any(
+        isinstance(entry, Incomplete)
+        and getattr(entry.effect, "exception_name", None) == "ValueError"
+        for entry in contributions
+    )
+    assert out.value.can_fall_through
+
+
+def test_truthy_native_exit_runs_but_cannot_suppress_loop_transfer():
+    """Truthy exit suppresses exceptions, never break/continue/return control."""
+    cid = "blake3-512:" + "a" * 128
+    transfer = LoopControlEffect("break", cid, cid)
+    exit_runs = []
+    out = _resource(
+        body=(_FixedSugar(Incomplete(transfer)),),
+        exit=_FixedSugar(Complete(TermValue(1)), probe=exit_runs),
+        disposition=ReturnTruthinessDispositionV1(),
+    ).desugar()
+    assert exit_runs == [1]
+    assert any(
+        isinstance(entry, Incomplete) and entry.effect == transfer
+        for entry in out.value.contribution()
+    )
+
+
+def test_native_exit_runs_on_early_return_value():
+    from sugar_lift_py_tests.floor import ReturnValue
+
+    exit_runs = []
+    out = _resource(
+        body=(_FixedSugar(Complete(ReturnValue(TermValue(7)))),),
+        exit=_FixedSugar(Complete(TermValue(0)), probe=exit_runs),
+        disposition=ReturnTruthinessDispositionV1(),
+    ).desugar()
+    assert exit_runs == [1]
+    assert any(isinstance(entry, ReturnValue) for entry in out.value.contribution())
+
+
 def test_completed_body_survives_never_suppresses():
     sugar = _resource(body=(_Pass(),))
     out = sugar.desugar()
@@ -357,15 +456,17 @@ def test_never_suppresses_needs_no_second_cleanup_algebra():
     exit_es = ExitSet((Completed(true_guard(), _FloorValue("exited")),))
     faces = (
         Completed(true_guard(), _FloorValue("body")),
-        Halted(true_guard(), RaiseEffect(exception_name="ValueError"), _FloorValue("pre")),
+        Halted(
+            true_guard(), RaiseEffect(exception_name="ValueError"), _FloorValue("pre")
+        ),
     )
     for disposition in (NeverSuppresses(), NeverSuppressesDispositionV1()):
         for face in faces:
             through_exit = ExitSet((face,)).and_exit(exit_es, disposition=disposition)
             through_finally = ExitSet((face,)).and_finally(lambda: exit_es)
-            assert through_exit.exits == through_finally.exits, (
-                f"{type(disposition).__name__} / {type(face).__name__} diverged"
-            )
+            assert (
+                through_exit.exits == through_finally.exits
+            ), f"{type(disposition).__name__} / {type(face).__name__} diverged"
 
 
 def test_lying_the_equivalence_is_specific_to_never_suppresses():

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5607,6 +5607,9 @@ class With(Statement):
 
             manager_slot = item._manager_slot_id()
             enter_slot = f"{manager_slot}#enter_result" if binds_enter_result else None
+            enter_definition, exit_definition = (
+                self._require_native_resource_definitions(resolved_ref)
+            )
             return WithResourceSugar(
                 manager=item.context_expr.sugar(),
                 manager_slot_id=manager_slot,
@@ -5620,6 +5623,8 @@ class With(Statement):
                     resolved_ref, resolved_ref.use_site
                 ),
                 enter_slot_id=enter_slot,
+                enter_definition=enter_definition,
+                exit_definition=exit_definition,
                 site=self.fragment,
             )
         panic = RuntimeSelectedContextManager(
@@ -5631,6 +5636,39 @@ class With(Statement):
         )
         self.reporter.report_gap(self, panic)
         raise panic
+
+    def _require_native_resource_definitions(self, resolved_ref):
+        """Require both protocol methods through the one authenticated door."""
+        from sugar_lift_py_tests.context_manager_resolution import (
+            NativeDefinitionCoordinateGapV1,
+            NativeProtocolSlot,
+        )
+        from .panic import SugarNotWritten
+
+        refs = self.unit.construction_context.contract_refs
+        receiver = resolved_ref.use_site
+        enter = refs.require_native_definition(
+            receiver, NativeProtocolSlot.CONTEXT_ENTER
+        )
+        exit_ = refs.require_native_definition(
+            receiver, NativeProtocolSlot.CONTEXT_EXIT
+        )
+        for resolution in (enter, exit_):
+            if isinstance(resolution, NativeDefinitionCoordinateGapV1):
+                raise SugarNotWritten(
+                    blame=self.fragment,
+                    owner="With._require_native_resource_definitions",
+                    observed=resolution.reason,
+                    requested=(
+                        "authenticated source definition coordinates for both "
+                        "context-enter and context-exit"
+                    ),
+                    fix=(
+                        "retain this native resource as undischarged until the "
+                        "shared definition door resolves the missing slot"
+                    ),
+                )
+        return enter, exit_
 
     def _authenticate_expected_exception_type(self, manager, manager_sugar, reference):
         """Attach the floor-owned identity to the selected real call operand."""

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -20,11 +20,13 @@ from sugar_lift_py_tests.context_manager_contract import (
     EnterResultContractV1,
     ExitContractV1,
     NeverSuppressesDispositionV1,
+    ReturnTruthinessDispositionV1,
 )
 from sugar_lift_py_tests.context_manager_resolution import (
     ContextManagerContractRefV1,
     ContextManagerResolutionGapV1,
     ImportSignatureV2,
+    NativeProtocolSlot,
     ResolvedContractRefsV1,
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
@@ -55,7 +57,7 @@ def _coordinate(node) -> SourceFragmentCoordinateV1:
     )
 
 
-def _source_with_resolution(source_identity, resolution):
+def _source_with_resolution(source_identity, resolution, *, native_definitions=None):
     first = SourceFile(source_identity)
     with_node = next(
         node for node in first.nodes() if node.kind in {"With", "AsyncWith"}
@@ -63,10 +65,15 @@ def _source_with_resolution(source_identity, resolution):
     use_site = _coordinate(with_node.items[0].context_expr)
     if callable(resolution):
         resolution = resolution(use_site)
+    if native_definitions is None:
+        native_definitions = _native_protocol_definitions
     table = ResolvedContractRefsV1(
         catalog_cid=_cid("c"),
         table_cid=_cid("t"),
         by_use_site=MappingProxyType({use_site: resolution}),
+        native_definitions=MappingProxyType(
+            {} if native_definitions is None else native_definitions(use_site)
+        ),
     )
     return SourceFile(
         source_identity,
@@ -100,6 +107,67 @@ def _resolved(use_site) -> ContextManagerContractRefV1:
         import_signature=ImportSignatureV2(()),
         semantics=semantics,
     )
+
+
+def _truthiness_resolved(use_site) -> ContextManagerContractRefV1:
+    resolved = _resolved(use_site)
+    return ContextManagerContractRefV1(
+        **{
+            **resolved.__dict__,
+            "semantics": ProtocolResourceSemanticsV1(
+                enter=EnterResultContractV1(sort=PrimitiveSort("Value")),
+                exit=ExitContractV1(disposition=ReturnTruthinessDispositionV1()),
+            ),
+        }
+    )
+
+
+def _native_protocol_definitions(use_site):
+    return {
+        (use_site, NativeProtocolSlot.CONTEXT_ENTER): SourceFragmentCoordinateV1(
+            _cid("e"), 10, 4, 11, 20
+        ),
+        (use_site, NativeProtocolSlot.CONTEXT_EXIT): SourceFragmentCoordinateV1(
+            _cid("x"), 20, 4, 22, 20
+        ),
+    }
+
+
+def test_native_resource_requires_both_authenticated_definition_coordinates():
+    source = (
+        "def f(path):\n    with acquire(path) as resource:\n        return resource\n"
+    )
+    tree = _source_with_resolution(
+        (source, "native-resource.py", _cid("q")),
+        _truthiness_resolved,
+        native_definitions=_native_protocol_definitions,
+    )
+    boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    assert isinstance(boundary, WithResourceSugar)
+    assert boundary.enter_definition == SourceFragmentCoordinateV1(
+        _cid("e"), 10, 4, 11, 20
+    )
+    assert boundary.exit_definition == SourceFragmentCoordinateV1(
+        _cid("x"), 20, 4, 22, 20
+    )
+    assert boundary.enter_slot_id is not None
+    assert boundary.enter_slot_id.startswith(boundary.manager_slot_id)
+
+
+def test_open_name_without_native_definition_stays_typed_loud():
+    """A builtin spelling grants no authority when the shared door has a gap."""
+    source = "def f(path):\n    with open(path):\n        pass\n"
+    tree = _source_with_resolution(
+        (source, "native-resource-gap.py", _cid("q")),
+        _truthiness_resolved,
+        native_definitions=lambda use_site: {
+            (use_site, NativeProtocolSlot.CONTEXT_ENTER): SourceFragmentCoordinateV1(
+                _cid("e"), 10, 4, 11, 20
+            )
+        },
+    )
+    with pytest.raises(SugarNotWritten, match="authenticated source definition"):
+        next(node for node in tree.nodes() if node.kind == "With").sugar()
 
 
 def _function_sugar(source_identity, resolution):
@@ -533,8 +601,16 @@ def test_multiple_items_nest_and_store_binding_target_constructs(tmp_path):
         _coordinate(item.context_expr): _resolved(_coordinate(item.context_expr))
         for item in with_node.items
     }
+    native_definitions = {}
+    for use_site in rows:
+        native_definitions.update(_native_protocol_definitions(use_site))
     context = TreeConstructionContextV1(
-        ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType(rows))
+        ResolvedContractRefsV1(
+            _cid("c"),
+            _cid("t"),
+            MappingProxyType(rows),
+            MappingProxyType(native_definitions),
+        )
     )
     source = SourceFile(path_source(str(multiple)), construction_context=context)
     nested = next(source.functions()).sugar()
@@ -569,10 +645,18 @@ def test_multiple_items_nest_and_store_binding_target_constructs(tmp_path):
         _coordinate(item.context_expr): _resolved(_coordinate(item.context_expr))
         for item in node.items
     }
+    native_definitions = {}
+    for use_site in rows:
+        native_definitions.update(_native_protocol_definitions(use_site))
     composed = SourceFile(
         path_source(str(target)),
         construction_context=TreeConstructionContextV1(
-            ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType(rows))
+            ResolvedContractRefsV1(
+                _cid("c"),
+                _cid("t"),
+                MappingProxyType(rows),
+                MappingProxyType(native_definitions),
+            )
         ),
     )
     chain = []

--- a/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
@@ -41,6 +41,7 @@ from sugar_lift_py_tests.context_manager_contract import (
 from sugar_lift_py_tests.context_manager_resolution import (
     ContextManagerContractRefV1,
     ImportSignatureV2,
+    NativeProtocolSlot,
     ResolvedContractRefsV1,
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
@@ -114,6 +115,7 @@ def _function_sugar(tmp_path, src: str, *, resolve_items=None, name="f"):
     identity = path_source(str(path))
     probe = SourceFile(identity)
     rows = {}
+    native_definitions = {}
     for node in probe.nodes():
         if node.kind != "With":
             continue
@@ -122,8 +124,19 @@ def _function_sugar(tmp_path, src: str, *, resolve_items=None, name="f"):
                 continue
             coordinate = _coordinate(item.context_expr)
             rows[coordinate] = _resolved(coordinate)
+            native_definitions[(coordinate, NativeProtocolSlot.CONTEXT_ENTER)] = (
+                SourceFragmentCoordinateV1(_cid("e"), 1, 0, 1, 1)
+            )
+            native_definitions[(coordinate, NativeProtocolSlot.CONTEXT_EXIT)] = (
+                SourceFragmentCoordinateV1(_cid("x"), 2, 0, 2, 1)
+            )
     context = TreeConstructionContextV1(
-        ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType(rows))
+        ResolvedContractRefsV1(
+            _cid("c"),
+            _cid("t"),
+            MappingProxyType(rows),
+            MappingProxyType(native_definitions),
+        )
     )
     source = SourceFile(identity, construction_context=context)
     for fn in source.functions():
@@ -296,6 +309,10 @@ class _FloorValue:
 
 
 def _resource(*, enter=None, body=None, slot="M", exit_probe=None):
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+
     exit_sugar = _FixedSugar(Complete(_FloorValue("exited")), probe=exit_probe)
     return WithResourceSugar(
         manager=_FixedSugar(Complete(_FloorValue(f"mgr{slot}"))),
@@ -305,6 +322,12 @@ def _resource(*, enter=None, body=None, slot="M", exit_probe=None):
         exit_face_id=f"{slot}#exit_face",
         body=body if body is not None else (),
         disposition=NeverSuppresses(),
+        enter_definition=SourceFragmentCoordinateV1(
+            "blake3-512:" + "e" * 128, 1, 0, 1, 1
+        ),
+        exit_definition=SourceFragmentCoordinateV1(
+            "blake3-512:" + "x" * 128, 2, 0, 2, 1
+        ),
         site=None,
     )
 


### PR DESCRIPTION
## Python semantic law

This PR makes the builtin resource-manager lifecycle constructible through one existing producer, `WithResourceSugar`: manager evaluation precedes authenticated `CONTEXT_ENTER`; the entered value binds the `as` target with its object identity; the body reduces to an ExitSet; authenticated `CONTEXT_EXIT` then runs over every outgoing face. A truthy exit may suppress only a raised exception. False preserves the exact halt, control transfers survive, and undecided truth remains a complementary factored pair.

## Concrete pandas 3.0.3 site

- `pandas/tests/series/methods/test_to_csv.py:57`
- `with open(path, "w", encoding="utf-8") as outfile:`
- authenticated corpus: 1,421 files, canonical BLAKE3 manifest `6f317a5a...563530`

The corpus occurrence is real. Truthy/falsy/undecided native lifecycle cases are labelled synthetic extensions. No `open` spelling grants authority.

## Exact flow

`manager -> require_native_definition(CONTEXT_ENTER) -> EnteredManagerStateValue -> bind target -> reduce body to ExitSet -> require_native_definition(CONTEXT_EXIT) -> ExitSet.and_source_resource_exit(...)`

A missing native definition is projected as `Undischarged` and remains a typed `SugarNotWritten` whose reason names `authenticated source definition`. No fallback contract or second With implementation exists.

## Validation

Authenticated local environment: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0.

- focused owning-package tests: `73 passed`
- six independent lifecycle faces cover enter halt, completed None triple, exact raised-face coordinates, false preservation, true suppression, and undecided factoring
- early return and loop-transfer survival remain covered
- mutation transaction: unconditional swallowing makes `test_undecided_source_exit_keeps_both_faces_factored` fail; mutation reverted; clean test passes
- Black check: 6 files unchanged

Repository-wide scanners are inherited red on both base `a7498b99c` and this head with identical loci: side-door `R=8`; panic-catch `R=9`; auditor errors `0`. This diff adds no locus. One unrelated no-call test resolves a stale `/Users/tsavo/provekit/...` checkout path and is not claimed green. No battleaxe crash/timeout or corpus-delta receipt is claimed from this Mac.

Do not merge automatically.
