### PR TITLE
Keep missing native evidence undischarged

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -288,10 +288,13 @@ class NativeOperationExitCarrierV1:
     def discharge(self, actuals_by_formal_coordinate):
         """Evaluate against authenticated actual operands and project exits."""
         from sugar_lift_py_tests.floor import RaiseValue
-        from sugar_lift_py_tests.gap.info import GapKind
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
         from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete
         from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+
+        def undischarged(reason):
+            return NativeOperationResolutionV1.undischarged(reason).project(
+                source_node=self.demand.source_node
+            )
 
         actual_operands = []
         for original, coordinate_cid in zip(
@@ -301,35 +304,23 @@ class NativeOperationExitCarrierV1:
                 actual_operands.append(original)
                 continue
             if coordinate_cid not in actuals_by_formal_coordinate:
-                construction_panic_gap(
-                    owner="NativeOperationExitCarrierV1.discharge",
-                    blame=self.demand.source_node,
-                    observed=(
-                        "native operation discharge omitted authenticated actual "
-                        f"for {coordinate_cid}"
-                    ),
-                    requested="one authenticated actual for every formal operand",
-                    fix=(
-                        "preserve the operation demand until caller discharge can "
-                        "supply the missing formal-to-actual binding"
-                    ),
-                    gap_kind=GapKind.FLOOR,
+                return undischarged(
+                    "authenticated caller actual absent for "
+                    f"{coordinate_cid}"
                 )
             actual_operands.append(actuals_by_formal_coordinate[coordinate_cid])
 
+        if len(actual_operands) not in {1, 2}:
+            return undischarged(
+                "native operation arity is unavailable until a unary or binary "
+                f"producer is authenticated (arity={len(actual_operands)})"
+            )
         left = actual_operands[0]
         operation = getattr(left, self.demand.operator, None)
         if not callable(operation):
-            construction_panic_gap(
-                owner="NativeOperationExitCarrierV1.discharge",
-                blame=self.demand.source_node,
-                observed=(
-                    f"{type(left).__name__} has no native Floor operation "
-                    f"{self.demand.operator}"
-                ),
-                requested="an operator named by the authenticated producer Floor",
-                fix="wire the producer's existing Floor method into the carrier",
-                gap_kind=GapKind.FLOOR,
+            return undischarged(
+                "native producer operation unavailable on authenticated actual: "
+                f"{self.demand.operator}"
             )
 
         if len(actual_operands) == 1:
@@ -337,14 +328,7 @@ class NativeOperationExitCarrierV1:
         elif len(actual_operands) == 2:
             projected = operation(actual_operands[1], self.site)
         else:
-            construction_panic_gap(
-                owner="NativeOperationExitCarrierV1.discharge",
-                blame=self.demand.source_node,
-                observed="native operation has unsupported operand arity",
-                requested="a unary or binary native operation",
-                fix="retain the operation demand until its native arity is supported",
-                gap_kind=GapKind.FLOOR,
-            )
+            return undischarged("native operation arity is unavailable")
         if isinstance(projected, Complete) and isinstance(projected.value, RaiseValue):
             effect = projected.value.effect
             if effect.exception_type_coordinate is None or effect.occurrence_id is None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -114,11 +114,44 @@ def test_undischarged_native_operation_is_typed_loud_not_completed():
         outcome_to_exitset(carrier)
 
 
-def test_missing_authenticated_actual_remains_typed_loud():
+def test_missing_authenticated_actual_is_undischarged_not_a_construction_panic():
     carrier, left, _ = _carrier()
 
-    with pytest.raises(ConstructionPanic, match="authenticated actual"):
+    with pytest.raises(SugarNotWritten, match="caller actual absent"):
         carrier.discharge({left.coordinate_cid: TermValue(1)})
+
+
+def test_unavailable_native_operation_is_undischarged_not_a_construction_panic():
+    carrier, left, right = _carrier(operator="not_a_floor_operation")
+    with pytest.raises(SugarNotWritten, match="producer operation unavailable"):
+        carrier.discharge(
+            {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
+        )
+
+
+def test_unsupported_native_arity_is_undischarged_not_a_construction_panic():
+    from dataclasses import replace
+
+    carrier, left, right = _carrier()
+    demand = replace(
+        carrier.demand,
+        operand_terms=carrier.demand.operand_terms + (carrier.demand.operand_terms[0],),
+        operand_coordinate_cids=carrier.demand.operand_coordinate_cids
+        + (left.coordinate_cid,),
+    )
+    malformed = replace(
+        carrier,
+        demand=demand,
+        operands=carrier.operands + (carrier.operands[0],),
+        coordinates=carrier.coordinates + (left,),
+    )
+    with pytest.raises(SugarNotWritten, match="arity is unavailable"):
+        malformed.discharge(
+            {
+                left.coordinate_cid: TermValue(1),
+                right.coordinate_cid: TermValue(2),
+            }
+        )
 
 
 def test_swapped_operands_retain_distinct_demand_coordinates():


### PR DESCRIPTION
Carrier semantics repair, first in merge order. Missing caller actuals, unsupported unary/binary arity, and unavailable producer methods now return named Undischarged projections rather than construction panics. Genuine invariant failures remain loud through the existing exit-set conversion path.

Authenticated focused validation: CPython 3.12.13 / NumPy 2.5.1 / pandas 3.0.3 / pyarrow 22.0.0; test_native_operation_exit_carrier.py: 13 passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep missing native evidence undischarged instead of panicking in `NativeOperationExitCarrierV1.discharge`
> - Replaces `construction_panic_gap` failure paths in [`caller_parameter_contract.py`](https://github.com/TSavo/sugar/pull/6608/files#diff-5136726cb5a60b48beb30152aecb6eca8ad0173bdefc676eb112b1c1b2acbf57) with `undischarged(reason)` projections that raise `SugarNotWritten`.
> - Covers three cases: a missing authenticated caller actual for a formal operand, a named native operation absent from the authenticated left operand, and unsupported arity (anything other than unary or binary).
> - Tests in [`test_native_operation_exit_carrier.py`](https://github.com/TSavo/sugar/pull/6608/files#diff-1f11ed61160a89cc13f7f8660fd6936e828ac1510feeedc6c90119db53970fe0) are updated or added to assert `SugarNotWritten` rather than `ConstructionPanic` for each case.
> - Behavioral Change: callers that previously received a `ConstructionPanic` for these conditions will now receive `SugarNotWritten`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3541d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->