### PR TITLE
Pin returned-manager provider-source boundary

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
@@ -36,7 +36,6 @@ from sugar_lift_py_tests.no_call_body_attribution import (
     AttributionOutcome,
     BodyProbe,
     attribute_body_probe,
-    summarize_attribution_outcomes,
 )
 from sugar_lift_python_source.canonical import blake3_512_of
 
@@ -127,13 +126,7 @@ def _with_at(line: int):
 
 
 def test_external_error_raised_follows_authenticated_returned_manager() -> None:
-    """Truthful: local import plus returned manager supplies the classification.
-
-    Construction follows the factory return into the installed RaisesExc dual-
-    mode body. Full EffectBoundary summary derivation still stops at the
-    exit-face residual (expected_exceptions / matches floor); that residual is
-    named and stage-keyed, never bridged by the helper spelling.
-    """
+    """Truthful: local import plus returned manager supplies the classification."""
     from sugar_lift_py_tests.context_manager_contract import (
         EffectBoundarySemanticsV1,
         NoMessagePatternV1,
@@ -145,41 +138,12 @@ def test_external_error_raised_follows_authenticated_returned_manager() -> None:
     with_node = _with_at(40)
     reference = with_node._prebound_manager_resolution(with_node.items[0])
 
-    if isinstance(reference, SourceDerivedContextManagerRefV1):
-        assert isinstance(reference.semantics, EffectBoundarySemanticsV1)
-        # ``match=None`` is written, constructed, and classified as no pattern.
-        assert isinstance(reference.semantics.message_pattern, NoMessagePatternV1)
-        assert isinstance(with_node.sugar(), WithEffectBoundarySugar)
-        return
-
-    # Stage-keyed residual after dual-mode return follow-through. The returned
-    # manager constructed through isinstance/tuple/len field flooring, and
-    # ``not self.matches(...)`` digs method bodies instead of refusing the
-    # CallSiteValue at the UnaryOp producer. Summary derivation still has not
-    # sealed EffectBoundary.
-    assert isinstance(reference, ContextManagerResolutionGapV1), reference
-    assert reference.kind in {
-        "exit-may-halt",
-        "enter-may-halt",
-        "force-floor",
-        "incomplete-call-actuals",
-        "no-derived-contract",
-        "method-construction",
-    }, reference
-    assert "external_error_raised" not in (reference.detail or "")
-    # Prior dead-ends drained by returned-manager construction machinery.
-    assert "binary_operation_exception_floor:SymbolicValue + CallSiteValue" not in (
-        reference.detail or ""
-    )
-    assert "SymbolicValue + CallSiteValue" not in (reference.detail or "")
-    assert "comparison_operation_exception_floor" not in (reference.detail or "")
-    assert "unary_operation_exception_floor:CallSiteValue not" not in (
-        reference.detail or ""
-    )
-    # Current residual is deeper in matches() / method-body truth after the
-    # CallSiteValue UnaryOp gate digs.
-    assert reference.kind == "exit-may-halt"
-    assert reference.detail == "truth:BlockValue"
+    assert isinstance(reference, SourceDerivedContextManagerRefV1), reference
+    assert isinstance(reference.semantics, EffectBoundarySemanticsV1)
+    # ``match=None`` is written, constructed, and remains a separate absence
+    # obligation. A speculative ``match.pattern`` face cannot replace it.
+    assert isinstance(reference.semantics.message_pattern_operand, NoMessagePatternV1)
+    assert isinstance(with_node.sugar(), WithEffectBoundarySugar)
 
 
 def test_external_error_raised_population_is_the_authenticated_47_with_sites() -> None:
@@ -333,34 +297,39 @@ def _external_error_attributions():
     return tuple(attributed)
 
 
-def test_external_error_raised_47_site_outcome_partition() -> None:
-    summary = summarize_attribution_outcomes(_external_error_attributions())
+@cache
+def _external_error_population_refusal():
+    from sugar_source_tree.panic import UnattributableRefusal
 
-    assert summary.enrolled == 47
-    # ArrowInvalid/ArrowException heads construct through import-bound export
-    # coordinates; residual is named (exit-face), never ConstructionPanic on
-    # SymbolicValue.attribute for the exception-type operand.
-    assert summary.construction_panics == 0
-    assert summary.authenticated_exceptional_exits > 0
-    assert (
-        summary.authenticated_exceptional_exits + summary.named_refusals
-        == summary.enrolled
+    try:
+        _external_error_attributions()
+    except UnattributableRefusal as refusal:
+        return refusal
+    raise AssertionError("expected the provider-source boundary to stay loud")
+
+
+def test_external_error_raised_47_site_partition_stays_loud_without_provider_source() -> (
+    None
+):
+    """The 47-site census cannot bank exits without the provider definition."""
+    refusal = _external_error_population_refusal()
+
+    assert refusal.owner == "provider_exception_type_construction"
+    assert refusal.observed == "provider artifact source absent: pyarrow"
+    assert refusal.requested == "provider-defined exception class testimony"
+    assert (refusal.blame.line, refusal.blame.col) == (1715, 34)
+
+
+def test_external_error_raised_missing_provider_source_names_the_real_site() -> None:
+    """The honest negative names source, coordinate, and required testimony."""
+    refusal = _external_error_population_refusal()
+
+    assert refusal.blame.filename.endswith("/pandas/tests/extension/test_arrow.py")
+    assert (refusal.blame.line, refusal.blame.col) == (1715, 34)
+    assert refusal.fix == (
+        "publish the named provider artifact source; never replace it with an "
+        "attribute spelling"
     )
-
-
-def test_external_error_raised_refusal_and_gap_twins_are_concrete_sites() -> None:
-    by_id = {body.body_id: body for body in _external_error_attributions()}
-
-    refusal = by_id["tests/io/test_feather.py:40"]
-    assert refusal.outcome is AttributionOutcome.NAMED_REFUSAL
-    assert refusal.detail == "With._construct_sugar"
-
-    for relative, line, _attribute in _ARROW_EXCEPTION_SITES:
-        site = by_id[f"{relative}:{line}"]
-        # Before: a named refusal after sealing the attribute spelling. After:
-        # provider-defined class testimony reaches the boundary and the real
-        # body effect is authenticated.
-        assert site.outcome is AttributionOutcome.AUTHENTICATED_EXIT, site
 
 
 def test_external_error_raised_emits_complete_consumer_testimony() -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1183,11 +1183,11 @@ def test_renamed_source_visible_exit_derives_expects_raise_boundary(tmp_path):
 
 
 def test_external_error_raised_spelling_cannot_replace_native_return_shape(tmp_path):
-    """The tempting pandas helper spelling has no assertion authority.
+    """A deferred assertion import cannot override the returned manager.
 
-    This is the lying twin for the returned-manager reproducer.  It uses the
-    exact helper name but returns an ordinary resource manager; native protocol
-    testimony must keep it out of the EffectBoundary arm.
+    This is the lying twin for the returned-manager reproducer.  It binds the
+    assertion provider at call time but returns an ordinary resource manager;
+    native return testimony must keep it out of the EffectBoundary arm.
     """
     graph, resolved, actual, call_site = _resolved_type_actual(
         tmp_path,
@@ -1199,6 +1199,7 @@ def test_external_error_raised_spelling_cannot_replace_native_return_shape(tmp_p
         "    def __exit__(self, effect_type, effect, traceback):\n"
         "        return False\n"
         "def external_error_raised(expected):\n"
+        "    import pytest\n"
         "    return OrdinaryResource(expected)\n",
         exported="external_error_raised",
     )


### PR DESCRIPTION
## Result

HONEST NEGATIVE: returned-manager construction now completes source-visibly for `external_error_raised`, but `authenticated_exceptional_exits` cannot lawfully move above zero for this population receipt. Battleaxe reaches `pandas/tests/extension/test_arrow.py:1715:34` and refuses because the authenticated provider artifact has no source for `pyarrow`; `construct_provider_exception_attribute` therefore cannot construct the requested provider-defined exception class testimony.

The stated provenance remains 51 mentions containing exactly 47 authenticated manager-demand sites.

## Changes

- require the real returned helper to produce `SourceDerivedContextManagerRefV1` and preserve written `match=None` as `NoMessagePatternV1`
- strengthen the lying twin so a deferred local `pytest` import cannot override the different manager actually returned
- keep the 47-site population loud at the exact missing provider-source coordinate instead of banking fabricated exits

## Validation

- local CPython 3.12.13: 3 returned-manager truthful/lying tests passed
- local CPython 3.12.13: 26 message-obligation and context-manager semantics tests passed
- battleaxe authenticated closure: 6 focused tests passed under CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, canonical corpus manifest
- Black check and `git diff --check` passed

No production files or reserved carrier/outcome/ExitSet seams were changed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin returned-manager provider-source boundary to raise `UnattributableRefusal` with concrete blame coordinates
> - Replaces permissive assertions (accepting either `SourceDerivedContextManagerRefV1` or `ContextManagerResolutionGapV1`) with strict assertions that only `SourceDerivedContextManagerRefV1` is returned in [test_returned_assertion_manager.py](https://github.com/TSavo/sugar/pull/6609/files#diff-ae95b2e3d9589f08dcd37a7451092b43741299d876a5c9b72987042097bfb795).
> - Removes the 47-site outcome-partition count test and the per-site refusal/gap twin test; replaces them with two focused tests that validate an `UnattributableRefusal` is raised, checking `owner`, `observed`, `requested`, blame coordinates `(1715, 34)`, and a concrete fix message naming the provider artifact source.
> - Adds a `@cache` helper `_external_error_population_refusal` to memoize the refusal captured from `_external_error_attributions()`.
> - Behavioral Change: the test suite now expects attribution to hard-fail with an `UnattributableRefusal` rather than silently producing resolution gaps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39eb5aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->