### PR TITLE
Route formal BinOp dispatch through caller carrier

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -352,6 +352,19 @@ class SymbolicValue(FloorValue):
             for method, coordinate in _BINARY_OPERATOR_COORDINATE.items()
             if coordinate == operator
         )
+        left_coordinate = self.formal_coordinate
+        right_coordinate = getattr(other, "formal_coordinate", None)
+        if left_coordinate is not None or right_coordinate is not None:
+            from sugar_lift_py_tests.caller_parameter_contract import (
+                NativeOperationExitCarrierV1,
+            )
+
+            return NativeOperationExitCarrierV1.mint(
+                site=site,
+                operator=owner,
+                operands=(self, other),
+                coordinates=(left_coordinate, right_coordinate),
+            )
         if isinstance(other, GuardedValue):
             return other.map_from_left(owner, self, site)
         denotes_other = getattr(other, "denotes_value", None)

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -76,6 +76,98 @@ def _carrier(operator: str = "add"):
     return carrier, left_coordinate, right_coordinate
 
 
+@pytest.mark.parametrize(
+    ("method", "operator"),
+    (
+        ("add", "add"),
+        ("subtract", "subtract"),
+        ("multiply", "multiply"),
+        ("divide", "divide"),
+        ("floor_divide", "floor_divide"),
+        ("modulo", "modulo"),
+        ("power", "power"),
+        ("matrix_multiply", "matrix_multiply"),
+        ("bitwise_and", "bitwise_and"),
+        ("bitwise_or", "bitwise_or"),
+        ("bitwise_xor", "bitwise_xor"),
+        ("left_shift", "left_shift"),
+        ("right_shift", "right_shift"),
+    ),
+)
+def test_formal_binary_dispatch_mints_caller_discharge_carrier(method, operator):
+    left_coordinate = _coordinate("left", 0)
+    right_coordinate = _coordinate("right", 1)
+    left = SymbolicValue(make_var("left"), left_coordinate)
+    right = SymbolicValue(make_var("right"), right_coordinate)
+
+    outcome = getattr(left, method)(right, _site())
+
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    assert outcome.demand.operator == operator
+    assert outcome.operands == (left, right)
+    assert outcome.demand.operand_coordinate_cids == (
+        left_coordinate.coordinate_cid,
+        right_coordinate.coordinate_cid,
+    )
+
+
+def test_swapped_formal_binary_operands_retain_distinct_ordered_demands():
+    left_coordinate = _coordinate("left", 0)
+    right_coordinate = _coordinate("right", 1)
+    left = SymbolicValue(make_var("left"), left_coordinate)
+    right = SymbolicValue(make_var("right"), right_coordinate)
+
+    forward = left.subtract(right, _site())
+    reverse = right.subtract(left, _site())
+
+    assert isinstance(forward, NativeOperationExitCarrierV1)
+    assert isinstance(reverse, NativeOperationExitCarrierV1)
+    assert forward.demand.operator == reverse.demand.operator == "subtract"
+    assert forward.demand.operand_coordinate_cids == (
+        left_coordinate.coordinate_cid,
+        right_coordinate.coordinate_cid,
+    )
+    assert reverse.demand.operand_coordinate_cids == (
+        right_coordinate.coordinate_cid,
+        left_coordinate.coordinate_cid,
+    )
+    assert forward.demand.demand_cid != reverse.demand.demand_cid
+
+
+@pytest.mark.parametrize("formal_side", ("left", "right"))
+def test_either_formal_operand_is_enough_to_defer_binary_dispatch(formal_side):
+    coordinate = _coordinate(formal_side, 0)
+    left = SymbolicValue(
+        make_var("left"), coordinate if formal_side == "left" else None
+    )
+    right = SymbolicValue(
+        make_var("right"), coordinate if formal_side == "right" else None
+    )
+
+    outcome = left.add(right, _site())
+
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    assert outcome.coordinates == (
+        coordinate if formal_side == "left" else None,
+        coordinate if formal_side == "right" else None,
+    )
+
+
+def test_coordinate_free_binary_dispatch_retains_existing_symbolic_faces():
+    outcome = SymbolicValue(make_var("left")).add(
+        SymbolicValue(make_var("right")), _site()
+    )
+
+    assert isinstance(outcome, ExitSet)
+    assert (
+        len(tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Completed)))
+        == 1
+    )
+    assert (
+        len(tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))) == 1
+    )
+
+
 def test_same_native_operation_demand_can_complete_for_authenticated_actuals():
     carrier, left, right = _carrier()
 


### PR DESCRIPTION
## What changed

- make `SymbolicValue._runtime_binary_dispatch` mint `NativeOperationExitCarrierV1` whenever either operand carries a formal coordinate
- record the Floor method name (`add`, `subtract`, etc.), ordered operands, and ordered formal coordinates
- preserve the existing coordinate-free symbolic completed/halted partition

## Corpus evidence

Pinned pandas 3.0.3 pair:
- helper operation: `tests/arithmetic/common.py:55` (`left + right`)
- real caller: `tests/arithmetic/test_timedelta64.py:1172` (`assert_invalid_addsub_type(tdarr, other)`)

That pair remains honestly Undischarged under #6593 because the existing Floor sees the left actual as the `tm.box_expected` call result and cannot authenticate a concrete exception type. This PR adds no pandas-specific Floor law and borrows nothing from the assertion expected type.

## Landing order

**Draft / do not land yet.** This is merge-order position 3 and depends on:
1. `carrier-undischarged-gaps` (`a3541d175`) so absent authenticated actuals remain Undischarged rather than becoming construction panics
2. the `SourceCallFrame.bind_actuals` formal binding seam (`4e2da4317`, with its preserved-law follow-up)

## Verification

Authenticated local environment: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0.

```
.venv-py312/bin/python -m pytest \
  implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py \
  implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py \
  implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py -q
# 104 passed
```

The teeth cover all 13 binary Floor method names, either formal side, ordered/swapped coordinates, and the unchanged coordinate-free path.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route formal BinOp dispatch through a `NativeOperationExitCarrierV1` when either operand has a formal coordinate
> - Updates `SymbolicValue._runtime_binary_dispatch` in [symbolic_value.py](https://github.com/TSavo/sugar/pull/6610/files#diff-20ac3864063391c0ae09b701dfd27a9311b941b1de39a4aa18390907dcb1be42) to check for `formal_coordinate` on either operand before the existing `GuardedValue`/`ExitSet` path.
> - When at least one formal coordinate is found, the method mints and returns a `NativeOperationExitCarrierV1` via its `mint` factory, capturing the operator owner, both operands, and their coordinate CIDs.
> - Coordinate-free binary dispatch retains the existing `ExitSet`-based behavior unchanged.
> - Four new parametrized tests in [test_native_operation_exit_carrier.py](https://github.com/TSavo/sugar/pull/6610/files#diff-1f11ed61160a89cc13f7f8660fd6936e828ac1510feeedc6c90119db53970fe0) cover the minted carrier's operator, operand ordering, single-sided formal coordinates, and the coordinate-free fallback path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 585c48b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Python semantic law made constructible

Binary operator dispatch over helper formals is caller-dependent: helper construction preserves the native operation as a coordinate-keyed demand, and authenticated Python argument binding (positional, keyword, or default) lets the existing operand Floor select completion or a named exceptional result. An assertion boundary may verify that result but never create its exception identity.