### PR TITLE
Bind formal native operations through Python calls

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -10,6 +10,14 @@ from .context_manager_resolution import SourceFragmentCoordinateV1
 
 
 @dataclass(frozen=True)
+class BoundNativeOperationActualsV1:
+    """The one Python binder's ordered result, indexed by formal coordinate."""
+
+    actuals: tuple
+    by_formal_coordinate: dict[str, object]
+
+
+@dataclass(frozen=True)
 class SourceVisibleCallFrameV1:
     """A body constructed by FunctionDef through the ordinary tree door."""
 
@@ -25,6 +33,8 @@ class SourceVisibleCallFrameV1:
     default_fragment_cids: tuple[str | None, ...]
     body: object = field(compare=False)
     owner: object = field(compare=False, repr=False)
+    native_operation_formal_coordinates: tuple = field(default=(), compare=False)
+    pending_native_operation: object | None = field(default=None, compare=False)
     runtime_entries: tuple[BindingEntryV1, ...] = field(
         default=(), compare=False, repr=False
     )
@@ -69,9 +79,7 @@ class SourceVisibleCallFrameV1:
                     )
                 for entry_key, entry_value in value.entries:
                     if type(entry_key) is not StringValue:
-                        raise SourceCallBindingGap(
-                            "non-string keyword expansion key"
-                        )
+                        raise SourceCallBindingGap("non-string keyword expansion key")
                     if entry_key.value in named:
                         raise SourceCallBindingGap(
                             "duplicate keyword actual from expansion"
@@ -126,6 +134,31 @@ class SourceVisibleCallFrameV1:
         if remaining or named:
             raise SourceCallBindingGap("unconsumed call actual")
         return tuple(bound)
+
+    def bind_native_operation_actuals(
+        self, positional: tuple, keywords: tuple, ctx=None
+    ) -> BoundNativeOperationActualsV1:
+        """Bind once, then key that exact result by formal coordinates."""
+        bound = self.bind_actuals(positional, keywords, ctx)
+        return BoundNativeOperationActualsV1(
+            actuals=bound,
+            by_formal_coordinate={
+                coordinate.coordinate_cid: actual
+                for coordinate, actual in zip(
+                    self.native_operation_formal_coordinates,
+                    bound,
+                    strict=True,
+                )
+            },
+        )
+
+    def with_native_operation_projection(self, formal_coordinates, pending):
+        """Seat one already-constructed formal operation on this call frame."""
+        return replace(
+            self,
+            native_operation_formal_coordinates=tuple(formal_coordinates),
+            pending_native_operation=pending,
+        )
 
     def bind_node_actuals(
         self,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -120,6 +120,7 @@ class CallSiteSugar(Sugar):
             return self._collect_bridged(positional)
         source_body = None
         source_frame_cid = None
+        native_operation_actuals = None
         if self.source_call_frame is not None:
             from sugar_lift_py_tests.source_call_frame import SourceVisibleCallFrameV1
             from sugar_source_tree.panic import SugarNotWritten
@@ -135,9 +136,17 @@ class CallSiteSugar(Sugar):
             from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
             try:
-                positional = self.source_call_frame.bind_actuals(
-                    positional, kw_values, ctx
-                )
+                if self.source_call_frame.pending_native_operation is None:
+                    positional = self.source_call_frame.bind_actuals(
+                        positional, kw_values, ctx
+                    )
+                else:
+                    native_operation_actuals = (
+                        self.source_call_frame.bind_native_operation_actuals(
+                            positional, kw_values, ctx
+                        )
+                    )
+                    positional = native_operation_actuals.actuals
             except SourceCallBindingGap as exc:
                 raise SugarNotWritten(
                     owner="CallSiteSugar.desugar",
@@ -214,24 +223,13 @@ class CallSiteSugar(Sugar):
                 else ()
             ),
         )
+        if native_operation_actuals is not None:
+            pending = self.source_call_frame.pending_native_operation.discharge(
+                native_operation_actuals.by_formal_coordinate
+            )
+            return callsite.project_producer_outcome(pending)
         if self.formal_function_sugar is not None:
-            if len(self.formal_coordinate_cids) != len(positional):
-                from sugar_source_tree.panic import SugarNotWritten
-
-                raise SugarNotWritten(
-                    owner="CallSiteSugar.desugar",
-                    blame=self.site,
-                    observed="formal projection arity mismatch",
-                    requested="one authenticated caller actual per formal coordinate",
-                    fix="bind the exact source signature or keep the call loud",
-                )
             pending = self.formal_function_sugar.desugar(ctx)
-            from sugar_lift_py_tests.outcome import NativeOperationExitCarrierV1
-
-            if isinstance(pending, NativeOperationExitCarrierV1):
-                pending = pending.discharge(
-                    dict(zip(self.formal_coordinate_cids, positional, strict=True))
-                )
             return callsite.project_producer_outcome(pending)
         return callsite.producer_outcome(ctx)
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
@@ -1,0 +1,70 @@
+"""Formal native operations use the one Python call binder."""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.outcome import ExitSet, Halted, NativeOperationExitCarrierV1
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _tree(source: str) -> SourceFile:
+    return SourceFile(
+        (source, "formal_binding.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _call_outcome(signature: str, actuals: str):
+    source = (
+        f"def helper({signature}):\n"
+        "    return left + right\n\n"
+        f"helper({actuals})\n"
+    )
+    tree = _tree(source)
+    call = tuple(node for node in tree.nodes() if isinstance(node, Call))[-1]
+    return call.sugar().desugar(None)
+
+
+def _assert_named_halt(outcome) -> None:
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    halted = outcome.exits[0]
+    assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate is not None
+    assert halted.effect.occurrence_id is not None
+
+
+def test_positional_actuals_discharge_through_python_binder() -> None:
+    _assert_named_halt(_call_outcome("left, right", "None, 2"))
+
+
+def test_keyword_actuals_discharge_through_python_binder() -> None:
+    _assert_named_halt(_call_outcome("left, right", "left=None, right=2"))
+
+
+def test_default_actual_is_keyed_to_its_formal_coordinate() -> None:
+    _assert_named_halt(_call_outcome("left, right=2", "None"))
+
+
+def test_wrong_coordinate_actual_cannot_discharge_pending_operation() -> None:
+    source = "def helper(left, right):\n    return left + right\n"
+    function = next(
+        node for node in _tree(source).nodes() if isinstance(node, FunctionDef)
+    )
+    pending = function.sugar().desugar(None)
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    left, right = function.formal_coordinates()
+
+    with pytest.raises(SugarNotWritten, match="caller actual absent"):
+        pending.discharge(
+            {
+                f"wrong:{left.coordinate_cid}": TermValue(1),
+                right.coordinate_cid: TermValue(2),
+            }
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -8182,10 +8182,17 @@ class Call(Expression):
             function_definition = self.unit.source_function_definition_for_call(self)
             if function_definition is not None:
                 formal_function_sugar = function_definition.sugar()
+                formal_coordinates = function_definition.formal_coordinates()
                 formal_coordinate_cids = tuple(
-                    coordinate.coordinate_cid
-                    for coordinate in function_definition.formal_coordinates()
+                    coordinate.coordinate_cid for coordinate in formal_coordinates
                 )
+                pending = formal_function_sugar.desugar(None)
+                from sugar_lift_py_tests.outcome import NativeOperationExitCarrierV1
+
+                if isinstance(pending, NativeOperationExitCarrierV1):
+                    source_call_frame = function_definition.source_visible_call_frame().with_native_operation_projection(
+                        formal_coordinates, pending
+                    )
             definition = self.unit.source_allocation_definition_for_call(self)
             if (
                 definition is not None


### PR DESCRIPTION
## What changed

- seat the already-constructed pending native operation on the ordinary source-call frame
- run positional, keyword, default, positional-only, keyword-only, and variadic inputs through `SourceVisibleCallFrameV1.bind_actuals` exactly once
- key that binder result by formal coordinates before discharge
- remove the call-site arity check and positional `dict(zip(...))` mapper
- retain binding-based source-function resolution and the shadowed-name refusal law

## Why

The merged caller seam mapped raw positional call-site values directly to formal coordinates. Keyword and default actuals never reached discharge, even though the repository already has the complete Python binder.

## Validation

- authenticated environment: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0
- red before production: keyword/default arity failures and wrong-coordinate construction panic, exit 1
- mutation: disabling the binder projection makes the default-coordinate tooth fail, exit 1
- `58 passed`: four binder twins plus formal projection, carrier, Call producer, and corpus authentication
- source-tree focused file: `10 passed, 1 failed`; the same `test_formula_operand_carries_the_substituted_actual` failure reproduces on current `origin/main` and is not changed or hidden here

Predicted effect: keyword/default source callers reach the same formal-coordinate discharge door as positional callers; no census denominator changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind formal native operations through Python calls using coordinate-keyed actuals
> - Adds `BoundNativeOperationActualsV1` dataclass to carry both the ordered actuals tuple and a dict keyed by formal coordinate CID after binding native operation actuals.
> - Extends `SourceVisibleCallFrameV1` with `native_operation_formal_coordinates` and `pending_native_operation` fields, plus `bind_native_operation_actuals` and `with_native_operation_projection` methods.
> - Updates `nodes.Call.sugar` to attach a pending native operation and its formal coordinates to the source call frame when desugaring yields a `NativeOperationExitCarrierV1`.
> - Updates `CallSiteSugar.desugar` to discharge the pending native operation earlier using the coordinate-keyed binding from the Python binder, replacing the previous arity-check and post-desugar discharge path.
> - Behavioral Change: the arity mismatch check against `formal_coordinate_cids` and the conditional discharge based on `formal_function_sugar.desugar` result are removed; discharge now happens via the source call frame's pending projection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68e01f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->