### PR TITLE
Enforce native carrier coordinate identity

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -265,6 +265,39 @@ class NativeOperationExitCarrierV1:
     site: object = dataclass_field(compare=False, repr=False)
     continuations: tuple = dataclass_field(default=(), compare=False, repr=False)
 
+    def __post_init__(self):
+        operand_count = len(self.operands)
+        coordinate_count = len(self.coordinates)
+        demand_count = len(self.demand.operand_coordinate_cids)
+        if len({operand_count, coordinate_count, demand_count}) != 1:
+            from sugar_lift_py_tests.gap.info import GapKind
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="NativeOperationExitCarrierV1.__post_init__",
+                blame=self.demand.source_node,
+                observed=(operand_count, coordinate_count, demand_count),
+                requested="one authenticated coordinate slot per ordered operand",
+                fix="rebuild the carrier with aligned operands and coordinates",
+                gap_kind=GapKind.FLOOR,
+            )
+        stored_cids = tuple(
+            None if coordinate is None else coordinate.coordinate_cid
+            for coordinate in self.coordinates
+        )
+        if stored_cids != self.demand.operand_coordinate_cids:
+            from sugar_lift_py_tests.gap.info import GapKind
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="NativeOperationExitCarrierV1.__post_init__",
+                blame=self.demand.source_node,
+                observed=(stored_cids, self.demand.operand_coordinate_cids),
+                requested="stored coordinates authenticating to the demand CID tuple",
+                fix="preserve ordered coordinate identity when constructing the carrier",
+                gap_kind=GapKind.FLOOR,
+            )
+
     @classmethod
     def mint(cls, *, site, operator, operands, coordinates):
         operands = tuple(operands)

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -222,28 +222,36 @@ def test_unavailable_native_operation_is_undischarged_not_a_construction_panic()
 
 
 def test_unsupported_native_arity_is_undischarged_not_a_construction_panic():
+    carrier, left, right = _carrier()
+    third = left
+    three = NativeOperationExitCarrierV1.mint(
+        site=_site(),
+        operator="add",
+        operands=carrier.operands + (carrier.operands[0],),
+        coordinates=(left, right, third),
+    )
+    with pytest.raises(SugarNotWritten, match="arity is unavailable"):
+        three.discharge({left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)})
+
+    # The construction invariant remains independently loud for mismatched rows.
+    from dataclasses import replace
+    demand = replace(
+        carrier.demand,
+        operand_coordinate_cids=carrier.demand.operand_coordinate_cids + (left.coordinate_cid,),
+    )
+    with pytest.raises(ConstructionPanic, match="one authenticated coordinate slot"):
+        replace(
+            carrier,
+            demand=demand,
+        )
+
+
+def test_same_length_swapped_coordinate_identities_panic_at_construction():
     from dataclasses import replace
 
     carrier, left, right = _carrier()
-    demand = replace(
-        carrier.demand,
-        operand_terms=carrier.demand.operand_terms + (carrier.demand.operand_terms[0],),
-        operand_coordinate_cids=carrier.demand.operand_coordinate_cids
-        + (left.coordinate_cid,),
-    )
-    malformed = replace(
-        carrier,
-        demand=demand,
-        operands=carrier.operands + (carrier.operands[0],),
-        coordinates=carrier.coordinates + (left,),
-    )
-    with pytest.raises(SugarNotWritten, match="arity is unavailable"):
-        malformed.discharge(
-            {
-                left.coordinate_cid: TermValue(1),
-                right.coordinate_cid: TermValue(2),
-            }
-        )
+    with pytest.raises(ConstructionPanic, match="ordered coordinate identity"):
+        replace(carrier, coordinates=(right, left))
 
 
 def test_swapped_operands_retain_distinct_demand_coordinates():


### PR DESCRIPTION
Adds carrier-local __post_init__ invariants: operand, coordinate, and demand slot counts must agree, and stored coordinate CIDs must exactly equal the ordered demand CID tuple. Mismatches are construction panics; valid carriers with missing actual evidence remain named Undischarged.

Python semantic law made constructible: an ordered native operation cannot be constructed unless each operand has exactly one authenticated coordinate slot preserving identity.

Authenticated focused validation (CPython 3.12.13 / NumPy 2.5.1 / pandas 3.0.3 / pyarrow 22.0.0): 31 passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce coordinate identity invariants on `NativeOperationExitCarrierV1` construction
> - Adds `__post_init__` to `NativeOperationExitCarrierV1` that validates two invariants at construction time: operand, coordinate, and `demand.operand_coordinate_cids` lengths must match, and the stored coordinate CIDs must exactly equal the demand's coordinate CID tuple.
> - Violations trigger `construction_panic_gap` with `GapKind.FLOOR`, so mismatches are caught when calling `mint` or `dataclasses.replace`.
> - Updates `test_unsupported_native_arity_is_undischarged_not_a_construction_panic` to use a three-operand carrier and adds `test_same_length_swapped_coordinate_identities_panic_at_construction` to cover reordered coordinates.
> - Behavioral Change: constructing a carrier with mismatched or reordered coordinate identities now raises a `ConstructionPanic` instead of silently succeeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f82a2b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->