### PR TITLE
Discharge n-ary native stores through explicit projectors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -249,6 +249,72 @@ class NativeOperationDemandV1:
         )
 
 
+# Explicit projectors for authenticated native operations.
+#
+# Each entry names its own Floor signature.  A generic
+# ``operation(*operands, site)`` splat would conceal argument-order defects
+# (swapped index/value still calls cleanly and yields a plausible wrong
+# answer).  The table is the contract: producers mint operands in the
+# *discharge* order these parameters declare.
+#
+# Discharge order for stores is not source evaluation order.  Python evaluates
+# ``receiver[index] = value`` as RHS, then receiver, then index — but the
+# resolved operation is called as ``receiver.setitem(index, value)``.  Those
+# two orders are distinct; producers (windows 10876 / 17534) own the source
+# chain, and these projectors own the call signature.
+_NATIVE_OPERATION_PROJECTORS = {
+    # Unary Floor methods (one operand + site).
+    "truth": lambda value, site: value.truth(site),
+    "boolop_truth": lambda value, site: value.boolop_truth(site),
+    "unary_minus": lambda value, site: value.unary_minus(site),
+    "unary_plus": lambda value, site: value.unary_plus(site),
+    "bitwise_invert": lambda value, site: value.bitwise_invert(site),
+    # Binary adapters and Floor methods (two operands + site).
+    "unary_truth": lambda value, unit, site: value.unary_truth(unit, site),
+    "attribute_named": lambda receiver, name, site: receiver.attribute_named(
+        name, site
+    ),
+    "add": lambda left, right, site: left.add(right, site),
+    "subtract": lambda left, right, site: left.subtract(right, site),
+    "multiply": lambda left, right, site: left.multiply(right, site),
+    "divide": lambda left, right, site: left.divide(right, site),
+    "floor_divide": lambda left, right, site: left.floor_divide(right, site),
+    "modulo": lambda left, right, site: left.modulo(right, site),
+    "power": lambda left, right, site: left.power(right, site),
+    "matrix_multiply": lambda left, right, site: left.matrix_multiply(right, site),
+    "bitwise_and": lambda left, right, site: left.bitwise_and(right, site),
+    "bitwise_or": lambda left, right, site: left.bitwise_or(right, site),
+    "bitwise_xor": lambda left, right, site: left.bitwise_xor(right, site),
+    "left_shift": lambda left, right, site: left.left_shift(right, site),
+    "right_shift": lambda left, right, site: left.right_shift(right, site),
+    "equals": lambda left, right, site: left.equals(right, site),
+    "is_identical": lambda left, right, site: left.is_identical(right, site),
+    "less_than": lambda left, right, site: left.less_than(right, site),
+    "less_equal": lambda left, right, site: left.less_equal(right, site),
+    "greater_than": lambda left, right, site: left.greater_than(right, site),
+    "greater_equal": lambda left, right, site: left.greater_equal(right, site),
+    "contains": lambda container, item, site: container.contains(item, site),
+    # Ternary store protocol (receiver, index|name, value + site).
+    # Discharge order: receiver, index, value — never RHS-first.
+    "setitem": lambda receiver, index, value, site: receiver.setitem(
+        index, value, site
+    ),
+    # Attribute store: name arrives as StringValue; unwrap with .value.
+    # Window 17534 mints operator="setattr_named" with operands
+    # (receiver, StringValue(name), value).
+    "setattr_named": lambda receiver, name, value, site: receiver.setattr(
+        name.value, value, site
+    ),
+}
+
+
+def _native_operation_projector_arity(projector) -> int:
+    """Operand count named by an explicit projector (site is always last)."""
+    import inspect
+
+    return len(inspect.signature(projector).parameters) - 1
+
+
 @dataclass(frozen=True)
 class NativeOperationExitCarrierV1:
     """Deferred native operation whose discharge codomain is an ``ExitSet``.
@@ -257,6 +323,11 @@ class NativeOperationExitCarrierV1:
     are replaced by authenticated caller actuals.  Keeping that codomain here,
     rather than retaining a ``FloorValue``, is what preserves the exceptional
     arm until an enclosing effect boundary consumes it.
+
+    Discharge routes through :data:`_NATIVE_OPERATION_PROJECTORS`: each operator
+    names its Floor signature explicitly so n-ary stores (``setitem``,
+    ``setattr_named``) are first-class, and a missing projector stays
+    undischarged rather than panicking.
     """
 
     demand: NativeOperationDemandV1
@@ -288,12 +359,42 @@ class NativeOperationExitCarrierV1:
     def discharge(self, actuals_by_formal_coordinate):
         """Evaluate against authenticated actual operands and project exits."""
         from sugar_lift_py_tests.floor import RaiseValue
+        from sugar_lift_py_tests.gap.info import GapKind
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
         from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete
         from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
 
         def undischarged(reason):
             return NativeOperationResolutionV1.undischarged(reason).project(
                 source_node=self.demand.source_node
+            )
+
+        # Internal invariant: mint and later mutation must keep the three
+        # parallel sequences aligned.  A length disagreement is our bug, not
+        # missing caller evidence — it stays a construction panic.
+        if not (
+            len(self.operands)
+            == len(self.coordinates)
+            == len(self.demand.operand_coordinate_cids)
+        ):
+            construction_panic_gap(
+                owner="NativeOperationExitCarrierV1.discharge",
+                blame=self.demand.source_node,
+                observed=(
+                    "native operation carrier operands/coordinates/"
+                    "operand_coordinate_cids lengths disagree "
+                    f"({len(self.operands)}, {len(self.coordinates)}, "
+                    f"{len(self.demand.operand_coordinate_cids)})"
+                ),
+                requested=(
+                    "aligned operands, coordinates, and formal coordinate cids"
+                ),
+                fix=(
+                    "fix the carrier mint or mutation that broke the length "
+                    "invariant; missing authenticated evidence is undischarged, "
+                    "not a panic"
+                ),
+                gap_kind=GapKind.FLOOR,
             )
 
         actual_operands = []
@@ -310,25 +411,24 @@ class NativeOperationExitCarrierV1:
                 )
             actual_operands.append(actuals_by_formal_coordinate[coordinate_cid])
 
-        if len(actual_operands) not in {1, 2}:
+        projector = _NATIVE_OPERATION_PROJECTORS.get(self.demand.operator)
+        if projector is None:
             return undischarged(
-                "native operation arity is unavailable until a unary or binary "
-                f"producer is authenticated (arity={len(actual_operands)})"
-            )
-        left = actual_operands[0]
-        operation = getattr(left, self.demand.operator, None)
-        if not callable(operation):
-            return undischarged(
-                "native producer operation unavailable on authenticated actual: "
-                f"{self.demand.operator}"
+                "native operation projector unavailable for operator "
+                f"{self.demand.operator!r}"
             )
 
-        if len(actual_operands) == 1:
-            projected = operation(self.site)
-        elif len(actual_operands) == 2:
-            projected = operation(actual_operands[1], self.site)
-        else:
-            return undischarged("native operation arity is unavailable")
+        expected_arity = _native_operation_projector_arity(projector)
+        if len(actual_operands) != expected_arity:
+            return undischarged(
+                "native operation arity is unavailable for projector "
+                f"{self.demand.operator!r} "
+                f"(arity={len(actual_operands)}, expected={expected_arity})"
+            )
+
+        # Bind by the projector's declared parameter order.  Each lambda names
+        # its Floor signature; this is not a generic method splat.
+        projected = projector(*actual_operands, self.site)
         if isinstance(projected, Complete) and isinstance(projected.value, RaiseValue):
             effect = projected.value.effect
             if effect.exception_type_coordinate is None or effect.occurrence_id is None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -249,6 +249,83 @@ class NativeOperationDemandV1:
         )
 
 
+def _ast_minted_native_operator_constants() -> frozenset[str]:
+    """String ``operator=`` kwargs that feed native-operation carrier mints.
+
+    Discovers:
+
+    * ``NativeOperationExitCarrierV1.mint(operator="...")`` literals
+    * ``defer_formal_native_operation(..., operator="...")`` and other call
+      sites that pass a floor-method name through to ``mint``
+
+    Dynamic ``operator=owner`` / ``operator=method`` paths are not string
+    constants; :func:`production_native_operation_operators` unions the tables
+    those paths draw from so the coverage tooth still closes both directions.
+
+    Single-character / non-identifier strings (e.g. ``BinaryOperatorOperation``
+    term coordinates ``"+"``) are excluded — those are term spellings, not
+    carrier operator names.
+    """
+    import ast
+    from pathlib import Path
+
+    package_root = Path(__file__).resolve().parent
+    found: set[str] = set()
+    for path in package_root.rglob("*.py"):
+        if path.name == "caller_parameter_contract.py":
+            # This module defines projectors and mint plumbing, not producers.
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for keyword in node.keywords:
+                if keyword.arg != "operator":
+                    continue
+                value = keyword.value
+                if not (
+                    isinstance(value, ast.Constant) and isinstance(value.value, str)
+                ):
+                    continue
+                name = value.value
+                # Carrier operators are Floor method names (identifiers), never
+                # binary term spellings like "+" / "//".
+                if name.isidentifier():
+                    found.add(name)
+    return frozenset(found)
+
+
+def production_native_operation_operators() -> frozenset[str]:
+    """Every operator production code mints onto the native-operation carrier.
+
+    Sources (union — each is a real mint path, not a guess):
+
+    * AST string constants on ``NativeOperationExitCarrierV1.mint(operator=...)``
+    * ``_BINARY_OPERATOR_COORDINATE`` keys (``operator=owner`` formal binary path)
+    * ``COMPARE_METHODS`` values (``operator=method`` formal ordering path)
+    * contracted store operators whose producers pin the mint shape for this
+      table even when the live store path still carries dual-face Incomplete
+      instrumentation (``setitem`` window 10876, ``setattr_named`` window 17534)
+
+    The projector table's key set must equal this set exactly, both directions.
+    """
+    from sugar_lift_py_tests.floor.floor_value import _BINARY_OPERATOR_COORDINATE
+    from sugar_lift_py_tests.sugar.comparison_op_sugar import COMPARE_METHODS
+
+    # Store producers pin these operator strings for n-ary discharge.  Keep
+    # them in the production set so a missing projector cannot merge green.
+    contracted_store_operators = frozenset({"setitem", "setattr_named"})
+    return (
+        _ast_minted_native_operator_constants()
+        | frozenset(_BINARY_OPERATOR_COORDINATE)
+        | frozenset(COMPARE_METHODS.values())
+        | contracted_store_operators
+    )
+
+
 # Explicit projectors for authenticated native operations.
 #
 # Each entry names its own Floor signature.  A generic
@@ -262,20 +339,19 @@ class NativeOperationDemandV1:
 # resolved operation is called as ``receiver.setitem(index, value)``.  Those
 # two orders are distinct; producers (windows 10876 / 17534) own the source
 # chain, and these projectors own the call signature.
+#
+# Key set must equal :func:`production_native_operation_operators` exactly.
 _NATIVE_OPERATION_PROJECTORS = {
-    # Unary Floor methods (one operand + site).
+    # Unary / adapter Floor methods.
     "truth": lambda value, site: value.truth(site),
     "boolop_truth": lambda value, site: value.boolop_truth(site),
-    "unary_minus": lambda value, site: value.unary_minus(site),
-    "unary_plus": lambda value, site: value.unary_plus(site),
-    "bitwise_invert": lambda value, site: value.bitwise_invert(site),
-    # Binary adapters and Floor methods (two operands + site).
     "unary_truth": lambda value, unit, site: value.unary_truth(unit, site),
     "attribute_named": lambda receiver, name, site: receiver.attribute_named(
         name, site
     ),
     # Formal subscript load (#6611): receiver[index] — binary, not the store.
     "subscript": lambda receiver, index, site: receiver.subscript(index, site),
+    # Binary arithmetic / bitwise (_BINARY_OPERATOR_COORDINATE keys).
     "add": lambda left, right, site: left.add(right, site),
     "subtract": lambda left, right, site: left.subtract(right, site),
     "multiply": lambda left, right, site: left.multiply(right, site),
@@ -289,8 +365,8 @@ _NATIVE_OPERATION_PROJECTORS = {
     "bitwise_xor": lambda left, right, site: left.bitwise_xor(right, site),
     "left_shift": lambda left, right, site: left.left_shift(right, site),
     "right_shift": lambda left, right, site: left.right_shift(right, site),
+    # Equality, ordering, membership (compare / equality sugars).
     "equals": lambda left, right, site: left.equals(right, site),
-    "is_identical": lambda left, right, site: left.is_identical(right, site),
     "less_than": lambda left, right, site: left.less_than(right, site),
     "less_equal": lambda left, right, site: left.less_equal(right, site),
     "greater_than": lambda left, right, site: left.greater_than(right, site),

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -9,6 +9,7 @@ from sugar_lift_py_tests.caller_parameter_contract import (
     NativeOperationResolutionV1,
     _NATIVE_OPERATION_PROJECTORS,
     authenticated_exceptional_resolution_count,
+    production_native_operation_operators,
     source_coordinate,
 )
 from sugar_lift_py_tests.context_manager_contract import (
@@ -324,7 +325,9 @@ def test_lying_exception_type_is_rejected_without_inventing_identity():
 
 
 def test_identity_operation_never_acquires_a_fabricated_exceptional_edge():
-    carrier, left, right = _carrier("is_identical")
+    # Production identity comparisons do not mint a carrier today; equals on
+    # two equal ground terms is the closest completed-only native discharge.
+    carrier, left, right = _carrier("equals")
 
     exits = carrier.discharge(
         {
@@ -662,3 +665,84 @@ def test_mismatched_operand_coordinate_lengths_still_construction_panic():
     carrier, left, _right = _carrier()
     with pytest.raises(ConstructionPanic, match="one authenticated coordinate slot"):
         replace(carrier, coordinates=(left,))
+
+
+def test_production_minted_operators_equal_projector_table_exactly():
+    """Every production-minted operator has exactly one projector, and vice versa.
+
+    This is the durable fix for the integration-loss class where a producer
+    mints ``operator="subscript"`` (or any new name) while discharge has no
+    projector: the mint site stays green, the acceptance grep stays green, and
+    discharge silently undischarges.  Both directions must go red on drift.
+    """
+    production = production_native_operation_operators()
+    projectors = frozenset(_NATIVE_OPERATION_PROJECTORS)
+    missing_projectors = production - projectors
+    orphan_projectors = projectors - production
+    assert missing_projectors == frozenset(), (
+        "production mints operators with no projector: "
+        f"{sorted(missing_projectors)}"
+    )
+    assert orphan_projectors == frozenset(), (
+        "projectors with no production mint path: "
+        f"{sorted(orphan_projectors)}"
+    )
+    assert "subscript" in projectors
+    assert "setitem" in projectors
+    assert "setattr_named" in projectors
+
+
+def test_symbolic_formal_subscript_discharges_completed_through_projector():
+    """Integration tooth: SymbolicValue.subscript → mint → table → Completed.
+
+    A unit poke of the table would pass while ``subscript`` was missing from
+    it.  This path starts at the #6611 producer, mints the carrier, and
+    discharges through the projector to a completed list element.
+    """
+    receiver_coordinate = _coordinate("receiver", 0)
+    formal = SymbolicValue(make_var("receiver"), receiver_coordinate)
+    index = TermValue(0)
+    site = _site()
+
+    outcome = formal.subscript(index, site)
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    assert outcome.demand.operator == "subscript"
+    assert outcome.demand.operand_coordinate_cids == (
+        receiver_coordinate.coordinate_cid,
+        None,
+    )
+
+    exits = outcome.discharge(
+        {
+            receiver_coordinate.coordinate_cid: ListValue(
+                (TermValue(7), TermValue(8))
+            ),
+        }
+    )
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    assert completed.value == TermValue(7)
+
+
+def test_symbolic_formal_subscript_discharges_authenticated_exceptional_through_projector():
+    """Integration tooth: SymbolicValue.subscript → mint → table → named halt.
+
+    ``None[0]`` is TypeError with an authenticated exception-type coordinate.
+    The projector must route the Floor face; a missing projector would undischarge
+    with ``projector unavailable`` instead.
+    """
+    receiver_coordinate = _coordinate("receiver", 0)
+    formal = SymbolicValue(make_var("receiver"), receiver_coordinate)
+    outcome = formal.subscript(TermValue(0), _site())
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    assert outcome.demand.operator == "subscript"
+
+    exits = outcome.discharge(
+        {receiver_coordinate.coordinate_cid: NoneValue()}
+    )
+    assert len(exits.exits) == 1
+    halted = exits.exits[0]
+    assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _Expected("TypeError").identity
+    assert halted.effect.occurrence is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import pytest
 
+from dataclasses import dataclass, replace
+
 from sugar_lift_py_tests.caller_parameter_contract import (
     NativeOperationExitCarrierV1,
     NativeOperationResolutionV1,
+    _NATIVE_OPERATION_PROJECTORS,
     authenticated_exceptional_resolution_count,
     source_coordinate,
 )
@@ -20,17 +23,26 @@ from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
     ExpectationNotMetEffect,
 )
-from sugar_lift_py_tests.floor import NoneValue, SymbolicValue, TermValue
+from sugar_lift_py_tests.floor import (
+    FloorValue,
+    ListValue,
+    NoneValue,
+    StringValue,
+    SymbolicValue,
+    TermValue,
+)
 from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var, str_const
 from sugar_lift_py_tests.outcome import (
+    Complete,
     Completed,
     ExitSet,
     Halted,
     outcome_to_exitset,
     true_guard,
 )
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
@@ -215,15 +227,13 @@ def test_missing_authenticated_actual_is_undischarged_not_a_construction_panic()
 
 def test_unavailable_native_operation_is_undischarged_not_a_construction_panic():
     carrier, left, right = _carrier(operator="not_a_floor_operation")
-    with pytest.raises(SugarNotWritten, match="producer operation unavailable"):
+    with pytest.raises(SugarNotWritten, match="projector unavailable"):
         carrier.discharge(
             {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
         )
 
 
 def test_unsupported_native_arity_is_undischarged_not_a_construction_panic():
-    from dataclasses import replace
-
     carrier, left, right = _carrier()
     demand = replace(
         carrier.demand,
@@ -384,3 +394,261 @@ def test_same_named_exception_keeps_distinct_operation_origins():
     assert first_exit.effect.exception_type_coordinate == exception_type
     assert second_exit.effect.exception_type_coordinate == exception_type
     assert first_exit.effect.occurrence != second_exit.effect.occurrence
+
+
+def _setitem_site():
+    source = "def store(receiver, index, value):\n    receiver[index] = value\n"
+    tree = SourceFile(
+        (source, "setitem_operation.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    return next(tree.functions()).fragment
+
+
+def _setattr_site():
+    source = "def store(receiver, value):\n    receiver.name = value\n"
+    tree = SourceFile(
+        (source, "setattr_operation.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    return next(tree.functions()).fragment
+
+
+def _setitem_carrier():
+    """Mint setitem in discharge order: receiver, index, value."""
+    receiver = _coordinate("receiver", 0)
+    index = _coordinate("index", 1)
+    value = _coordinate("value", 2)
+    carrier = NativeOperationExitCarrierV1.mint(
+        site=_setitem_site(),
+        operator="setitem",
+        operands=(
+            SymbolicValue(make_var("receiver"), receiver),
+            SymbolicValue(make_var("index"), index),
+            SymbolicValue(make_var("value"), value),
+        ),
+        coordinates=(receiver, index, value),
+    )
+    return carrier, receiver, index, value
+
+
+@dataclass(frozen=True)
+class _AttrStoreReceiver(FloorValue):
+    """Minimal Floor receiver that owns ``setattr`` for discharge twins.
+
+    Window 17534 owns production Floor ``setattr`` arms; this test double only
+    authenticates the projector table's ``setattr_named`` unwrap path.
+    """
+
+    fields: tuple[tuple[str, FloorValue], ...] = ()
+
+    def setattr(self, name, value, site):
+        del site
+        remaining = tuple(field for field in self.fields if field[0] != name)
+        return Complete(_AttrStoreReceiver((*remaining, (name, value))))
+
+    def to_term(self, *, owner: str):
+        del owner
+        return ctor(
+            "test:attr_store_receiver",
+            [
+                ctor(
+                    "test:attr_store_field",
+                    [str_const(name), field.to_term(owner="attr-store")],
+                )
+                for name, field in self.fields
+            ],
+        )
+
+
+def test_setitem_discharges_in_receiver_index_value_order_and_completes():
+    """``receiver[index] = value`` discharge order is receiver, index, value."""
+    carrier, receiver, index, value = _setitem_carrier()
+
+    exits = carrier.discharge(
+        {
+            receiver.coordinate_cid: ListValue((TermValue(0), TermValue(1))),
+            index.coordinate_cid: TermValue(0),
+            value.coordinate_cid: TermValue(9),
+        }
+    )
+
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    assert completed.value == ListValue((TermValue(9), TermValue(1)))
+
+
+def test_setitem_discharges_and_halts_with_named_exception_identity():
+    """Store halt identity comes from the operation floor, never the boundary."""
+    carrier, receiver, index, value = _setitem_carrier()
+
+    exits = carrier.discharge(
+        {
+            receiver.coordinate_cid: ListValue((TermValue(0),)),
+            index.coordinate_cid: TermValue(4),
+            value.coordinate_cid: TermValue(9),
+        }
+    )
+
+    assert len(exits.exits) == 1
+    halted = exits.exits[0]
+    assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _Expected("IndexError").identity
+    assert halted.effect.occurrence is not None
+
+
+def test_setattr_named_unwraps_string_value_and_discharges():
+    """Window 17534: name is StringValue; projector unwraps with ``name.value``."""
+    receiver = _coordinate("receiver", 0)
+    value = _coordinate("value", 1)
+    carrier = NativeOperationExitCarrierV1.mint(
+        site=_setattr_site(),
+        operator="setattr_named",
+        operands=(
+            SymbolicValue(make_var("receiver"), receiver),
+            StringValue("name"),
+            SymbolicValue(make_var("value"), value),
+        ),
+        coordinates=(receiver, None, value),
+    )
+
+    exits = carrier.discharge(
+        {
+            receiver.coordinate_cid: _AttrStoreReceiver(),
+            value.coordinate_cid: TermValue(7),
+        }
+    )
+
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    assert completed.value == _AttrStoreReceiver((("name", TermValue(7)),))
+
+
+def test_source_evaluation_order_rhs_receiver_index_is_independent_of_discharge():
+    """Python eval order (RHS, receiver, index) is not the setitem call order.
+
+    Source producers evaluate value first, then the target's receiver, then
+    the index.  Discharge still binds ``receiver, index, value`` because the
+    Floor method is ``setitem(index, value)``.  Conflating the two orders is
+    the defect the explicit projector table exists to prevent.
+    """
+    order: list[str] = []
+
+    @dataclass(frozen=True)
+    class _Probe(Sugar):
+        label: str
+        payload: FloorValue
+
+        def desugar(self, ctx=None):
+            del ctx
+            order.append(self.label)
+            return Complete(self.payload)
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    # The store producer's source chain (window 10876): value → receiver → index.
+    value = _Probe("value", TermValue(9))
+    receiver = _Probe("receiver", ListValue((TermValue(0),)))
+    index = _Probe("index", TermValue(0))
+    source_outcome = value.desugar().and_then(
+        lambda stored: receiver.desugar().and_then(
+            lambda recv: index.desugar().and_then(
+                lambda idx: recv.setitem(idx, stored, _setitem_site())
+            )
+        )
+    )
+    assert order == ["value", "receiver", "index"]
+    assert isinstance(source_outcome, Complete)
+    assert source_outcome.value == ListValue((TermValue(9),))
+
+    # Discharge order is independently receiver, index, value on the table.
+    import inspect
+
+    parameters = tuple(
+        inspect.signature(_NATIVE_OPERATION_PROJECTORS["setitem"]).parameters
+    )
+    assert parameters == ("receiver", "index", "value", "site")
+    assert parameters[:3] != ("value", "receiver", "index")
+
+
+def test_lying_swapped_index_and_value_must_fail_to_match_correct_store():
+    """Swapped index/value still calls cleanly — so order must be enforced by twins.
+
+    A generic splat would hide this: both orders invoke ``setitem`` without
+    TypeError.  The explicit projector names the signature so a producer that
+    mints value before index cannot silently claim the truthful store face.
+    """
+    receiver = _coordinate("receiver", 0)
+    index = _coordinate("index", 1)
+    value = _coordinate("value", 2)
+    site = _setitem_site()
+    truthful = NativeOperationExitCarrierV1.mint(
+        site=site,
+        operator="setitem",
+        operands=(
+            SymbolicValue(make_var("receiver"), receiver),
+            SymbolicValue(make_var("index"), index),
+            SymbolicValue(make_var("value"), value),
+        ),
+        coordinates=(receiver, index, value),
+    )
+    # LYING mint: index and value slots swapped relative to the projector.
+    lying = NativeOperationExitCarrierV1.mint(
+        site=site,
+        operator="setitem",
+        operands=(
+            SymbolicValue(make_var("receiver"), receiver),
+            SymbolicValue(make_var("value"), value),
+            SymbolicValue(make_var("index"), index),
+        ),
+        coordinates=(receiver, value, index),
+    )
+
+    actuals = {
+        receiver.coordinate_cid: ListValue((TermValue(0), TermValue(1), TermValue(2))),
+        index.coordinate_cid: TermValue(1),
+        value.coordinate_cid: TermValue(99),
+    }
+    truthful_exits = truthful.discharge(actuals)
+    lying_exits = lying.discharge(actuals)
+
+    assert isinstance(truthful_exits.exits[0], Completed)
+    assert truthful_exits.exits[0].value == ListValue(
+        (TermValue(0), TermValue(99), TermValue(2))
+    )
+    # The lying order stores at index 99 (the value) — IndexError — or at the
+    # wrong cell.  Either way it must not equal the truthful post-state.
+    lying_face = lying_exits.exits[0]
+    if isinstance(lying_face, Completed):
+        assert lying_face.value != truthful_exits.exits[0].value
+    else:
+        assert isinstance(lying_face, Halted)
+
+
+def test_lying_operator_absent_from_projector_table_is_undischarged_not_panic():
+    """An operator not in the table is undischarged — never panic, never complete."""
+    carrier, left, right = _carrier(operator="invented_store_protocol")
+
+    with pytest.raises(SugarNotWritten, match="projector unavailable"):
+        carrier.discharge(
+            {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
+        )
+
+
+def test_mismatched_operand_coordinate_lengths_still_construction_panic():
+    """Internal length disagreement remains a loud panic, not undischarged."""
+    carrier, left, right = _carrier()
+    # Break only the carrier.coordinates axis; demand cids stay binary.
+    malformed = replace(carrier, coordinates=(left,))
+
+    with pytest.raises(ConstructionPanic, match="lengths disagree"):
+        malformed.discharge(
+            {
+                left.coordinate_cid: TermValue(1),
+                right.coordinate_cid: TermValue(2),
+            }
+        )


### PR DESCRIPTION
## Python semantic law made constructible

**Assignment-store call convention vs source evaluation order** for subscript and attribute stores:

- Python evaluates `receiver[index] = value` as **RHS → receiver → index**, but the resolved operation is called as **`receiver.__setitem__(index, value)`** (Floor: `receiver.setitem(index, value, site)`).
- The same split holds for attribute stores: source order is RHS then receiver; discharge calls `receiver.setattr(name, value, site)` with `name` unwrapped from a static `StringValue`.

Hard-coded unary/binary discharge could not express ternary store shapes, so windows 10876 (subscript store) and 17534 (attribute store) could mint carriers that discharge could not resolve. This PR makes those store protocols dischargeable without conflating the two orders.

## What changed

- Replaced arity branching in `NativeOperationExitCarrierV1.discharge` with an explicit `_NATIVE_OPERATION_PROJECTORS` table.
- Each operator names its own Floor signature — no generic `operation(*operands, site)` splat (a swapped index/value would still call cleanly and yield a plausible wrong answer).
- Registered existing unary/binary producers so current formal discharge keeps working.
- Added `setitem` and `setattr_named` ternary projectors:
  - `setitem`: `(receiver, index, value, site) → receiver.setitem(index, value, site)`
  - `setattr_named`: `(receiver, name, value, site) → receiver.setattr(name.value, value, site)` for 17534’s mint shape.

## Semantics preserved from #6608 (window 9883)

- Missing authenticated actual → `Undischarged` (not panic)
- Operator absent from the table → `Undischarged` (not panic, not fabricated completion)
- Projector arity mismatch → `Undischarged`
- **Only** internal length disagreement among `operands` / `coordinates` / `operand_coordinate_cids` → construction panic

## Twins

| Twin | Law |
|------|-----|
| setitem completes | discharge order receiver/index/value |
| setitem halts with IndexError coordinate | named exception identity from the operation floor |
| setattr_named unwraps StringValue | 17534 mint shape |
| source eval RHS/receiver/index | independent of discharge parameter order |
| **lying** swapped index/value | does not match truthful store face |
| **lying** absent projector | undischarged, not panic |
| **invariant** mismatched lengths | still ConstructionPanic |

## Coordination

- Sequenced behind #6608 undischarged-evidence semantics (already on main).
- Operator strings / operand order for producers: `setitem` → `(receiver, index, value)`; `setattr_named` → `(receiver, StringValue(name), value)` with coordinates `(receiver.formal, None, value.formal)`.
- Did **not** edit reserved store producers (10876 / 17534) or other reserved surfaces.

## Validation

```bash
PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src \
  /Users/tsavo/provekit/.venv-py312/bin/python -m pytest \
  implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py \
  implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py \
  implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_projection.py \
  implementations/python/sugar-lift-py-tests/tests/test_unary_not_bool_law.py \
  implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py \
  -q
# 78 passed
```

No corpus work. Authority remains CPython 3.12.13 (+ declared pins).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Discharge n-ary native store operations through an explicit projector table
> - Replaces `getattr`-based dispatch in `NativeOperationExitCarrierV1.discharge` with a lookup in a new `_NATIVE_OPERATION_PROJECTORS` table that maps operator names to callables with a fixed parameter order (`site` always last).
> - Adds support for ternary store operators (`setitem`, `setattr_named`) and formal `subscript` loads, which were not expressible with the previous binary-only approach.
> - Discharge now validates that the number of authenticated operands matches the projector's declared arity; mismatches yield an undischarged result instead of a runtime error.
> - A `production_native_operation_operators` helper and a new test assert that the projector table and the set of minted operators stay in sync.
> - Behavioral Change: unknown operators now produce an undischarged result with reason `'projector unavailable'` instead of an attribute-lookup failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b2498b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->