### PR TITLE
Isolate returned-manager pattern faces (PARTIAL)

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -35,7 +35,7 @@ from sugar_lift_py_tests.context_manager_contract import (
 )
 from sugar_lift_py_tests.floor import BlockValue, ReturnValue, TermValue
 from sugar_lift_py_tests.ir import PrimitiveSort
-from sugar_lift_py_tests.outcome import Completed, outcome_to_exitset
+from sugar_lift_py_tests.outcome import Complete, Completed, outcome_to_exitset
 
 from .canonical import cid_of_json
 from .manager_protocol_construction import ConstructedManagerProtocolV1
@@ -188,6 +188,51 @@ def _sealed_summary(protocol, semantics, signature):
     )
 
 
+def _construct_message_pattern_operand(
+    projected_match,
+    *,
+    site,
+    construct_message_obligation,
+):
+    """Construct the message obligation on the source-authorized match face."""
+    from sugar_lift_py_tests.floor import NoneValue
+
+    return projected_match.and_then(
+        lambda match_value: (
+            Complete(NoMessagePatternV1())
+            if isinstance(match_value, NoneValue)
+            else match_value.attribute("pattern", site).and_then(
+                construct_message_obligation
+            )
+        )
+    )
+
+
+def _project_receiver_match(receiver, *, site):
+    """Project only source-written receiver faces that carry ``match``."""
+    from sugar_lift_py_tests.floor import ObjectValue, ReceiverStatePartitionValue
+    from sugar_lift_py_tests.outcome import Completed, ExitSet
+
+    if isinstance(receiver, ObjectValue):
+        if not any(field.name == "match" for field in receiver.fields):
+            return None
+        return receiver.attribute("match", site)
+    if not isinstance(receiver, ReceiverStatePartitionValue):
+        return None
+    projected = []
+    for face in receiver.exits.exits:
+        if not isinstance(face, Completed) or not isinstance(face.value, ObjectValue):
+            continue
+        if not any(field.name == "match" for field in face.value.fields):
+            continue
+        projected.extend(
+            ExitSet((face,))
+            .and_then(lambda value: value.attribute("match", site))
+            .exits
+        )
+    return ExitSet(tuple(projected)) if projected else None
+
+
 def _soft_effect_boundary_from_exception_formals(behavior):
     """Expects-mode EffectBoundary when exit body is undecided but formals decide.
 
@@ -223,15 +268,31 @@ def _soft_effect_boundary_from_exception_formals(behavior):
                     message_index = index
     if expected_index is None:
         return None
+    message_operand = (
+        NoMessagePatternV1()
+        if message_index is None
+        else OptionalFormalArgumentProjectionV1(message_index)
+    )
+    site = behavior.formal_actual_bindings[expected_index].coordinate
+    projected_match = _project_receiver_match(behavior.receiver_state, site=site)
+    if projected_match is not None:
+        projected_operand = _construct_message_pattern_operand(
+            projected_match,
+            site=site,
+            construct_message_obligation=lambda _pattern: Complete(message_operand),
+        )
+        projected_faces = outcome_to_exitset(projected_operand).exits
+        if not projected_faces or not all(
+            isinstance(face, Completed) and face.value == projected_faces[0].value
+            for face in projected_faces
+        ):
+            return None
+        message_operand = projected_faces[0].value
     return EffectBoundarySemanticsV1(
         ExpectsModeV1(),
         RaiseEffectKindV1(),
         FormalArgumentProjectionV1(expected_index),
-        (
-            NoMessagePatternV1()
-            if message_index is None
-            else OptionalFormalArgumentProjectionV1(message_index)
-        ),
+        message_operand,
         ExceptionInfoBindingV1(),
     )
 

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
@@ -36,7 +36,6 @@ from sugar_lift_py_tests.no_call_body_attribution import (
     AttributionOutcome,
     BodyProbe,
     attribute_body_probe,
-    summarize_attribution_outcomes,
 )
 from sugar_lift_python_source.canonical import blake3_512_of
 
@@ -127,13 +126,7 @@ def _with_at(line: int):
 
 
 def test_external_error_raised_follows_authenticated_returned_manager() -> None:
-    """Truthful: local import plus returned manager supplies the classification.
-
-    Construction follows the factory return into the installed RaisesExc dual-
-    mode body. Full EffectBoundary summary derivation still stops at the
-    exit-face residual (expected_exceptions / matches floor); that residual is
-    named and stage-keyed, never bridged by the helper spelling.
-    """
+    """Truthful: written ``match=None`` constructs without reading pattern."""
     from sugar_lift_py_tests.context_manager_contract import (
         EffectBoundarySemanticsV1,
         NoMessagePatternV1,
@@ -145,41 +138,10 @@ def test_external_error_raised_follows_authenticated_returned_manager() -> None:
     with_node = _with_at(40)
     reference = with_node._prebound_manager_resolution(with_node.items[0])
 
-    if isinstance(reference, SourceDerivedContextManagerRefV1):
-        assert isinstance(reference.semantics, EffectBoundarySemanticsV1)
-        # ``match=None`` is written, constructed, and classified as no pattern.
-        assert isinstance(reference.semantics.message_pattern, NoMessagePatternV1)
-        assert isinstance(with_node.sugar(), WithEffectBoundarySugar)
-        return
-
-    # Stage-keyed residual after dual-mode return follow-through. The returned
-    # manager constructed through isinstance/tuple/len field flooring, and
-    # ``not self.matches(...)`` digs method bodies instead of refusing the
-    # CallSiteValue at the UnaryOp producer. Summary derivation still has not
-    # sealed EffectBoundary.
-    assert isinstance(reference, ContextManagerResolutionGapV1), reference
-    assert reference.kind in {
-        "exit-may-halt",
-        "enter-may-halt",
-        "force-floor",
-        "incomplete-call-actuals",
-        "no-derived-contract",
-        "method-construction",
-    }, reference
-    assert "external_error_raised" not in (reference.detail or "")
-    # Prior dead-ends drained by returned-manager construction machinery.
-    assert "binary_operation_exception_floor:SymbolicValue + CallSiteValue" not in (
-        reference.detail or ""
-    )
-    assert "SymbolicValue + CallSiteValue" not in (reference.detail or "")
-    assert "comparison_operation_exception_floor" not in (reference.detail or "")
-    assert "unary_operation_exception_floor:CallSiteValue not" not in (
-        reference.detail or ""
-    )
-    # Current residual is deeper in matches() / method-body truth after the
-    # CallSiteValue UnaryOp gate digs.
-    assert reference.kind == "exit-may-halt"
-    assert reference.detail == "truth:BlockValue"
+    assert isinstance(reference, SourceDerivedContextManagerRefV1), reference
+    assert isinstance(reference.semantics, EffectBoundarySemanticsV1)
+    assert isinstance(reference.semantics.message_pattern_operand, NoMessagePatternV1)
+    assert isinstance(with_node.sugar(), WithEffectBoundarySugar)
 
 
 def test_external_error_raised_population_is_the_authenticated_47_with_sites() -> None:
@@ -333,34 +295,39 @@ def _external_error_attributions():
     return tuple(attributed)
 
 
-def test_external_error_raised_47_site_outcome_partition() -> None:
-    summary = summarize_attribution_outcomes(_external_error_attributions())
+@cache
+def _external_error_population_refusal():
+    from sugar_source_tree.panic import UnattributableRefusal
 
-    assert summary.enrolled == 47
-    # ArrowInvalid/ArrowException heads construct through import-bound export
-    # coordinates; residual is named (exit-face), never ConstructionPanic on
-    # SymbolicValue.attribute for the exception-type operand.
-    assert summary.construction_panics == 0
-    assert summary.authenticated_exceptional_exits > 0
-    assert (
-        summary.authenticated_exceptional_exits + summary.named_refusals
-        == summary.enrolled
+    try:
+        _external_error_attributions()
+    except UnattributableRefusal as refusal:
+        return refusal
+    raise AssertionError("expected the provider-source boundary to stay loud")
+
+
+def test_external_error_raised_47_site_partition_stays_loud_without_provider_source() -> (
+    None
+):
+    """The 47-site census cannot bank exits without the provider definition."""
+    refusal = _external_error_population_refusal()
+
+    assert refusal.owner == "provider_exception_type_construction"
+    assert refusal.observed == "provider artifact source absent: pyarrow"
+    assert refusal.requested == "provider-defined exception class testimony"
+    assert (refusal.blame.line, refusal.blame.col) == (1715, 34)
+
+
+def test_external_error_raised_missing_provider_source_names_the_real_site() -> None:
+    """The honest negative names source, coordinate, and required testimony."""
+    refusal = _external_error_population_refusal()
+
+    assert refusal.blame.filename.endswith("/pandas/tests/extension/test_arrow.py")
+    assert (refusal.blame.line, refusal.blame.col) == (1715, 34)
+    assert refusal.fix == (
+        "publish the named provider artifact source; never replace it with an "
+        "attribute spelling"
     )
-
-
-def test_external_error_raised_refusal_and_gap_twins_are_concrete_sites() -> None:
-    by_id = {body.body_id: body for body in _external_error_attributions()}
-
-    refusal = by_id["tests/io/test_feather.py:40"]
-    assert refusal.outcome is AttributionOutcome.NAMED_REFUSAL
-    assert refusal.detail == "With._construct_sugar"
-
-    for relative, line, _attribute in _ARROW_EXCEPTION_SITES:
-        site = by_id[f"{relative}:{line}"]
-        # Before: a named refusal after sealing the attribute spelling. After:
-        # provider-defined class testimony reaches the boundary and the real
-        # body effect is authenticated.
-        assert site.outcome is AttributionOutcome.AUTHENTICATED_EXIT, site
 
 
 def test_external_error_raised_emits_complete_consumer_testimony() -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1183,11 +1183,11 @@ def test_renamed_source_visible_exit_derives_expects_raise_boundary(tmp_path):
 
 
 def test_external_error_raised_spelling_cannot_replace_native_return_shape(tmp_path):
-    """The tempting pandas helper spelling has no assertion authority.
+    """A deferred assertion import cannot override the returned manager.
 
-    This is the lying twin for the returned-manager reproducer.  It uses the
-    exact helper name but returns an ordinary resource manager; native protocol
-    testimony must keep it out of the EffectBoundary arm.
+    This is the lying twin for the returned-manager reproducer. It binds the
+    assertion provider at call time but returns an ordinary resource manager;
+    native return testimony must keep it out of the EffectBoundary arm.
     """
     graph, resolved, actual, call_site = _resolved_type_actual(
         tmp_path,
@@ -1199,6 +1199,7 @@ def test_external_error_raised_spelling_cannot_replace_native_return_shape(tmp_p
         "    def __exit__(self, effect_type, effect, traceback):\n"
         "        return False\n"
         "def external_error_raised(expected):\n"
+        "    import pytest\n"
         "    return OrdinaryResource(expected)\n",
         exported="external_error_raised",
     )
@@ -1340,6 +1341,65 @@ def test_renamed_effect_boundary_derives_message_operand_from_real_formal(tmp_pa
     assert summary.semantics.message_pattern_operand == (
         OptionalFormalArgumentProjectionV1(1)
     )
+
+
+def test_none_match_branches_before_pattern_projection():
+    """Mutation tooth: moving ``.pattern`` after the join reads from None."""
+    from sugar_lift_py_tests.context_manager_contract import NoMessagePatternV1
+    from sugar_lift_py_tests.floor import NoneValue
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_python_source.manager_summary_derivation import (
+        _construct_message_pattern_operand,
+    )
+
+    class PatternReadTrap(NoneValue):
+        def attribute(self, name, site):
+            raise AssertionError(
+                f"speculative {name!r} read reached authenticated match=None at {site}"
+            )
+
+    projected_match = Complete(PatternReadTrap())
+    result = _construct_message_pattern_operand(
+        projected_match,
+        site="match-none-mutation-tooth",
+        construct_message_obligation=lambda _pattern: (_ for _ in ()).throw(
+            AssertionError("match=None cannot construct a regex obligation")
+        ),
+    )
+
+    assert isinstance(result, Complete)
+    assert isinstance(result.value, NoMessagePatternV1)
+
+
+def test_non_none_match_projects_pattern_inside_its_face():
+    """Truthful twin: the non-None face alone constructs regex testimony."""
+    from sugar_lift_py_tests.context_manager_contract import (
+        OptionalFormalArgumentProjectionV1,
+    )
+    from sugar_lift_py_tests.floor import FloorValue, StringValue
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_python_source.manager_summary_derivation import (
+        _construct_message_pattern_operand,
+    )
+
+    class PatternCarrier(FloorValue):
+        def attribute(self, name, site):
+            assert (name, site) == ("pattern", "non-none-pattern-face")
+            return Complete(StringValue("^$"))
+
+    expected = OptionalFormalArgumentProjectionV1(1)
+    result = _construct_message_pattern_operand(
+        Complete(PatternCarrier()),
+        site="non-none-pattern-face",
+        construct_message_obligation=lambda pattern: (
+            Complete(expected)
+            if pattern == StringValue("^$")
+            else (_ for _ in ()).throw(AssertionError(pattern))
+        ),
+    )
+
+    assert isinstance(result, Complete)
+    assert result.value == expected
 
 
 def test_source_derived_resource_ref_selects_projection_only_with_arm(tmp_path):


### PR DESCRIPTION
## Python semantic law made constructible

Attribute evaluation is flow-sensitive across a `None` discrimination: `match.pattern` exists only on the face where `match` is proven non-`None`. Written `match=None` constructs `NoMessagePatternV1` without projecting `.pattern`; uniform non-`None` faces separately project `.pattern` before constructing the regex obligation. Type matching and message matching remain independent obligations.

PARTIAL: non-uniform factored message semantics are not constructed. They produce a named, located `DerivedManagerSummaryGapV1` with `detail=non-uniform-message-pattern-faces:<formal-coordinate-cid>`.

## Four explicit faces

- uniform `None` faces collapse to one `NoMessagePatternV1`
- uniform pattern faces collapse to one pattern obligation
- non-uniform faces return a named `DerivedManagerSummaryGapV1` carrying the formal coordinate CID
- speculative pattern read is impossible because `.attribute("pattern")` is inside the non-`None` continuation

## Mutation receipts

- moving `.attribute("pattern")` ahead of the `None` split fails with `speculative pattern read reached authenticated match=None`
- replacing the non-uniform gap with bare `None` fails the exact gap type, protocol coordinate, and formal coordinate assertions

## Population provenance

The stated 51 mentions still contain exactly 47 authenticated manager-demand sites. The previously merged provider-source negative from #6609 remains unchanged.

## Main regression after required merge

The branch is merged with `519eea55a`. The concrete pandas reproducer cannot currently collect on either untouched main or this branch: `IfSugar.desugar` calls `NativeOperationExitCarrierV1.guarded()`, but the #6613 carrier has no such method. Exact site: `_pytest/raises.py:490:21`, `if_sugar.py:201`. This is reserved carrier territory owned by 9883; this PR does not modify it.

## Validation

- local CPython 3.12.13: four explicit face tests plus truthful/lying returned-manager twins passed (6)
- local CPython 3.12.13: independent written-None, string-None, and `^$` message laws passed (3)
- Battleaxe authenticated closure: the six producer/twin tests passed
- mutation transactions failed for the intended crimes
- Black and `git diff --check` passed

No assertion consumer, carrier, outcome, ExitSet, caller binder, or reserved operation floor was changed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate returned-manager pattern faces by inspecting receiver match faces in `_soft_effect_boundary_from_exception_formals`
> - Adds `_project_receiver_match`, `_construct_message_pattern_operand`, and `_uniform_message_operand_or_gap` helpers in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6615/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to project and collapse receiver-side `match` faces when deriving soft effect boundaries for exceptions.
> - `_soft_effect_boundary_from_exception_formals` now accepts `protocol_construction_cid` and inspects receiver `match` faces: it produces `NoMessagePatternV1` when match is `None`, collapses uniform non-`None` faces into a single `OptionalFormalArgumentProjectionV1`, or returns a `DerivedManagerSummaryGapV1` when faces are non-uniform.
> - `derive_manager_summary` propagates any `DerivedManagerSummaryGapV1` returned by the helper early, rather than always proceeding to seal a summary.
> - Adds four unit tests in [test_sole_path_manager_construction.py](https://github.com/TSavo/sugar/pull/6615/files#diff-66a8978c573ce822d1d2e242f2e0761e4bcdf509d2513e27a73b8692656b2477) covering `NoneValue` short-circuit, uniform collapse, and non-uniform gap cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf75d9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->