### PR TITLE
Authenticate resource enter/exit calls during tree construction

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -116,7 +116,9 @@ class PartitionFace:
     """
 
 
-def partition_family(owner: object, sides: tuple) -> tuple[PartitionFace, ...]:
+def partition_family(
+    owner: object, sides: tuple
+) -> tuple[PartitionFace, ...]:
     """Mint an EXHAUSTIVE family of faces over ONE authenticated origin (#6356).
 
     ``partition`` covers a two-way split. A producer that decides among n
@@ -263,7 +265,9 @@ def _merge_faces(
     left_sides = _sides_by_partition(left)
     right_sides = _sides_by_partition(right)
     shared = left_sides.keys() & right_sides.keys()
-    return frozenset(face for face in (left | right) if face.partition in shared)
+    return frozenset(
+        face for face in (left | right) if face.partition in shared
+    )
 
 
 def _faces_exclusive(
@@ -535,9 +539,7 @@ class ExitSet(Generic[T]):
     def union(self, other: "ExitSet[T]") -> "ExitSet[T]":
         return ExitSet((*self.exits, *other.exits)).normalize()
 
-    def guarded(
-        self, guard: Formula, face: PartitionFace | None = None
-    ) -> "ExitSet[T]":
+    def guarded(self, guard: Formula, face: PartitionFace | None = None) -> "ExitSet[T]":
         """Restrict every exit to one branch of an enclosing partition.
 
         ``face`` is the caller's testimony that ``guard`` is one named side of a
@@ -562,7 +564,9 @@ class ExitSet(Generic[T]):
             if isinstance(exit_, Completed):
                 exits.append(Completed(combined, exit_.value, faces, owed))
             else:
-                exits.append(Halted(combined, exit_.effect, exit_.state, faces, owed))
+                exits.append(
+                    Halted(combined, exit_.effect, exit_.state, faces, owed)
+                )
         return ExitSet(tuple(exits)).normalize()
 
     def with_partition_face(self, partition_id: str, face: int) -> "ExitSet[T]":
@@ -854,7 +858,9 @@ class ExitSet(Generic[T]):
                     exits.append(Completed(guard, following.value, faces, owed))
                 else:
                     exits.append(
-                        Halted(guard, following.effect, following.state, faces, owed)
+                        Halted(
+                            guard, following.effect, following.state, faces, owed
+                        )
                     )
         return ExitSet(tuple(exits)).normalize()
 
@@ -899,14 +905,18 @@ class ExitSet(Generic[T]):
                     incoming.pending_contracts, clean.pending_contracts
                 )
                 if isinstance(clean, Halted):
-                    exits.append(Halted(guard, clean.effect, clean.state, faces, owed))
+                    exits.append(
+                        Halted(guard, clean.effect, clean.state, faces, owed)
+                    )
                     continue
                 if restores(clean.value):
                     if isinstance(incoming, Completed):
                         exits.append(Completed(guard, incoming.value, faces, owed))
                     else:
                         exits.append(
-                            Halted(guard, incoming.effect, incoming.state, faces, owed)
+                            Halted(
+                                guard, incoming.effect, incoming.state, faces, owed
+                            )
                         )
                 else:
                     # Terminal cleanup completion supersedes (return in finally).
@@ -1030,6 +1040,7 @@ class ExitSet(Generic[T]):
                 _place(exits, guard, verdict, carried, faces, owed)
         return ExitSet(tuple(exits)).normalize()
 
+
     def and_exit_truthiness(self, exit_es: "ExitSet[object]", *, site: object):
         """Run a source-constructed ``__exit__`` and retain both truth faces.
 
@@ -1090,42 +1101,6 @@ class ExitSet(Generic[T]):
                 )
         return ExitSet(tuple(exits)).normalize()
 
-    def and_source_resource_exit(
-        self,
-        exit_es: "ExitSet[object]",
-        *,
-        disposition: object,
-        site: object,
-    ) -> "ExitSet[object]":
-        """Run one source-testified resource exit over one body face.
-
-        A truthy ``__exit__`` result can suppress only a raised exception.
-        Completion and control transfers are not exceptions, so they use the
-        ordinary never-suppresses route.  An undecided truth predicate remains
-        the complementary completed/halted partition minted by
-        :meth:`and_exit_truthiness`.
-        """
-        from sugar_lift_py_tests.context_manager_contract import (
-            NeverSuppressesDispositionV1,
-            ReturnTruthinessDispositionV1,
-        )
-        from sugar_lift_py_tests.effect import RaiseEffect
-
-        incoming = self.exits
-        if (
-            isinstance(disposition, ReturnTruthinessDispositionV1)
-            and len(incoming) == 1
-            and isinstance(incoming[0], Halted)
-            and isinstance(incoming[0].effect, RaiseEffect)
-        ):
-            return self.and_exit_truthiness(exit_es, site=site)
-        routed = (
-            NeverSuppressesDispositionV1()
-            if isinstance(disposition, ReturnTruthinessDispositionV1)
-            else disposition
-        )
-        return self.and_exit(exit_es, disposition=routed)
-
     def collapse(self):
         """Return the old linear Outcome only for one unconditional exit.
 
@@ -1159,7 +1134,9 @@ class ExitSet(Generic[T]):
                 # ExitSet whenever no linear shape denotes it.
                 return normalized
             return Complete(exit_.value)
-        return Incomplete(exit_.effect, pending_contracts=exit_.pending_contracts)
+        return Incomplete(
+            exit_.effect, pending_contracts=exit_.pending_contracts
+        )
 
 
 def sole_completed_outcome(outcome):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -116,9 +116,7 @@ class PartitionFace:
     """
 
 
-def partition_family(
-    owner: object, sides: tuple
-) -> tuple[PartitionFace, ...]:
+def partition_family(owner: object, sides: tuple) -> tuple[PartitionFace, ...]:
     """Mint an EXHAUSTIVE family of faces over ONE authenticated origin (#6356).
 
     ``partition`` covers a two-way split. A producer that decides among n
@@ -265,9 +263,7 @@ def _merge_faces(
     left_sides = _sides_by_partition(left)
     right_sides = _sides_by_partition(right)
     shared = left_sides.keys() & right_sides.keys()
-    return frozenset(
-        face for face in (left | right) if face.partition in shared
-    )
+    return frozenset(face for face in (left | right) if face.partition in shared)
 
 
 def _faces_exclusive(
@@ -539,7 +535,9 @@ class ExitSet(Generic[T]):
     def union(self, other: "ExitSet[T]") -> "ExitSet[T]":
         return ExitSet((*self.exits, *other.exits)).normalize()
 
-    def guarded(self, guard: Formula, face: PartitionFace | None = None) -> "ExitSet[T]":
+    def guarded(
+        self, guard: Formula, face: PartitionFace | None = None
+    ) -> "ExitSet[T]":
         """Restrict every exit to one branch of an enclosing partition.
 
         ``face`` is the caller's testimony that ``guard`` is one named side of a
@@ -564,9 +562,7 @@ class ExitSet(Generic[T]):
             if isinstance(exit_, Completed):
                 exits.append(Completed(combined, exit_.value, faces, owed))
             else:
-                exits.append(
-                    Halted(combined, exit_.effect, exit_.state, faces, owed)
-                )
+                exits.append(Halted(combined, exit_.effect, exit_.state, faces, owed))
         return ExitSet(tuple(exits)).normalize()
 
     def with_partition_face(self, partition_id: str, face: int) -> "ExitSet[T]":
@@ -858,9 +854,7 @@ class ExitSet(Generic[T]):
                     exits.append(Completed(guard, following.value, faces, owed))
                 else:
                     exits.append(
-                        Halted(
-                            guard, following.effect, following.state, faces, owed
-                        )
+                        Halted(guard, following.effect, following.state, faces, owed)
                     )
         return ExitSet(tuple(exits)).normalize()
 
@@ -905,18 +899,14 @@ class ExitSet(Generic[T]):
                     incoming.pending_contracts, clean.pending_contracts
                 )
                 if isinstance(clean, Halted):
-                    exits.append(
-                        Halted(guard, clean.effect, clean.state, faces, owed)
-                    )
+                    exits.append(Halted(guard, clean.effect, clean.state, faces, owed))
                     continue
                 if restores(clean.value):
                     if isinstance(incoming, Completed):
                         exits.append(Completed(guard, incoming.value, faces, owed))
                     else:
                         exits.append(
-                            Halted(
-                                guard, incoming.effect, incoming.state, faces, owed
-                            )
+                            Halted(guard, incoming.effect, incoming.state, faces, owed)
                         )
                 else:
                     # Terminal cleanup completion supersedes (return in finally).
@@ -1040,7 +1030,6 @@ class ExitSet(Generic[T]):
                 _place(exits, guard, verdict, carried, faces, owed)
         return ExitSet(tuple(exits)).normalize()
 
-
     def and_exit_truthiness(self, exit_es: "ExitSet[object]", *, site: object):
         """Run a source-constructed ``__exit__`` and retain both truth faces.
 
@@ -1101,6 +1090,42 @@ class ExitSet(Generic[T]):
                 )
         return ExitSet(tuple(exits)).normalize()
 
+    def and_source_resource_exit(
+        self,
+        exit_es: "ExitSet[object]",
+        *,
+        disposition: object,
+        site: object,
+    ) -> "ExitSet[object]":
+        """Run one source-testified resource exit over one body face.
+
+        A truthy ``__exit__`` result can suppress only a raised exception.
+        Completion and control transfers are not exceptions, so they use the
+        ordinary never-suppresses route.  An undecided truth predicate remains
+        the complementary completed/halted partition minted by
+        :meth:`and_exit_truthiness`.
+        """
+        from sugar_lift_py_tests.context_manager_contract import (
+            NeverSuppressesDispositionV1,
+            ReturnTruthinessDispositionV1,
+        )
+        from sugar_lift_py_tests.effect import RaiseEffect
+
+        incoming = self.exits
+        if (
+            isinstance(disposition, ReturnTruthinessDispositionV1)
+            and len(incoming) == 1
+            and isinstance(incoming[0], Halted)
+            and isinstance(incoming[0].effect, RaiseEffect)
+        ):
+            return self.and_exit_truthiness(exit_es, site=site)
+        routed = (
+            NeverSuppressesDispositionV1()
+            if isinstance(disposition, ReturnTruthinessDispositionV1)
+            else disposition
+        )
+        return self.and_exit(exit_es, disposition=routed)
+
     def collapse(self):
         """Return the old linear Outcome only for one unconditional exit.
 
@@ -1134,9 +1159,7 @@ class ExitSet(Generic[T]):
                 # ExitSet whenever no linear shape denotes it.
                 return normalized
             return Complete(exit_.value)
-        return Incomplete(
-            exit_.effect, pending_contracts=exit_.pending_contracts
-        )
+        return Incomplete(exit_.effect, pending_contracts=exit_.pending_contracts)
 
 
 def sole_completed_outcome(outcome):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
@@ -34,6 +34,7 @@ class MethodCallSugar(Sugar):
     # exception-class path, the resulting CallSiteValue carries that identity.
     exception_type_coordinate: object = dataclass_field(default=None, compare=False)
     exception_type_mro: tuple | None = dataclass_field(default=None, compare=False)
+    native_definition_coordinate: object = dataclass_field(default=None, compare=False)
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
@@ -38,14 +38,14 @@ class WithResourceSugar(Sugar):
     contract_ref: object | None = None
     context_manager_edge: object | None = None
     enter_slot_id: str | None = None
-    enter_definition: object | None = None
-    exit_definition: object | None = None
+    contract_refs: object | None = None
+    receiver_coordinate: object | None = None
     site: object = dataclass_field(compare=False, default=None)
 
     def __post_init__(self) -> None:
-        if self.enter_definition is None or self.exit_definition is None:
+        if self.contract_refs is None or self.receiver_coordinate is None:
             raise ValueError(
-                "WithResourceSugar requires authenticated enter and exit definition coordinates"
+                "WithResourceSugar requires the authenticated native-definition door"
             )
 
     @classmethod
@@ -83,6 +83,14 @@ class WithResourceSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         # Construction boundary: only ExitSet algebra + binding facts.
         # No sugar-class imports or construction on this path.
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            NativeOperationResolutionV1,
+        )
+        from sugar_lift_py_tests.context_manager_resolution import (
+            NativeDefinitionCoordinateGapV1,
+            NativeProtocolSlot,
+        )
+        from sugar_lift_py_tests.floor import EnteredManagerStateValue
         from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
         from sugar_lift_py_tests.outcome.resource_bindings import (
             EnterResultBinding,
@@ -110,6 +118,13 @@ class WithResourceSugar(Sugar):
                 parts.append(ExitSet((mgr_exit,)))
                 continue
 
+            enter_definition = self.contract_refs.require_native_definition(
+                self.receiver_coordinate, NativeProtocolSlot.CONTEXT_ENTER
+            )
+            if isinstance(enter_definition, NativeDefinitionCoordinateGapV1):
+                NativeOperationResolutionV1.undischarged(
+                    enter_definition.reason
+                ).project(source_node=self.receiver_coordinate)
             mgr_facts = ()
             if hasattr(mgr_exit.value, "to_term"):
                 mgr_facts = ManagerBinding(
@@ -120,20 +135,45 @@ class WithResourceSugar(Sugar):
             for enter_exit in enter_es.exits:
                 face_guard = _and_guards(mgr_exit.guard, enter_exit.guard)
                 if isinstance(enter_exit, Halted):
-                    parts.append(ExitSet((Halted(face_guard, enter_exit.effect),)))
+                    parts.append(
+                        ExitSet(
+                            (
+                                Halted(
+                                    face_guard,
+                                    enter_exit.effect,
+                                    enter_exit.state,
+                                    enter_exit.faces,
+                                    enter_exit.pending_contracts,
+                                ),
+                            )
+                        )
+                    )
                     continue
+
+                entered = EnteredManagerStateValue(
+                    enter_value=enter_exit.value,
+                    receiver_state=mgr_exit.value,
+                )
 
                 enter_facts = ()
                 if self.enter_slot_id is not None and hasattr(
                     enter_exit.value, "to_term"
                 ):
                     enter_facts = EnterResultBinding(
-                        self.enter_slot_id, enter_exit.value
+                        self.enter_slot_id, entered.enter_value
                     ).to_facts(site=self.site)
 
                 body_es = promote_raise_halts(
                     reduce_block_to_exitset(self.body)
                 ).guarded(face_guard)
+
+                exit_definition = self.contract_refs.require_native_definition(
+                    self.receiver_coordinate, NativeProtocolSlot.CONTEXT_EXIT
+                )
+                if isinstance(exit_definition, NativeDefinitionCoordinateGapV1):
+                    NativeOperationResolutionV1.undischarged(
+                        exit_definition.reason
+                    ).project(source_node=self.receiver_coordinate)
 
                 # Parametric exit: materialize once, fan over every body face.
                 exit_es = sugar_outcome_to_exitset(self.exit.desugar())
@@ -143,27 +183,11 @@ class WithResourceSugar(Sugar):
                         self.exit_face_id, body_exit
                     ).to_facts(site=self.site, guard=body_exit.guard)
                     face = ExitSet((body_exit,))
-                    from sugar_lift_py_tests.context_manager_contract import (
-                        NeverSuppressesDispositionV1,
-                        ReturnTruthinessDispositionV1,
+                    after = face.and_source_resource_exit(
+                        exit_es,
+                        disposition=self.disposition,
+                        site=self.site,
                     )
-                    from sugar_lift_py_tests.effect import RaiseEffect
-
-                    if (
-                        isinstance(self.disposition, ReturnTruthinessDispositionV1)
-                        and isinstance(body_exit, Halted)
-                        and isinstance(body_exit.effect, RaiseEffect)
-                    ):
-                        after = face.and_exit_truthiness(exit_es, site=self.site)
-                    else:
-                        disposition = (
-                            NeverSuppressesDispositionV1()
-                            if isinstance(
-                                self.disposition, ReturnTruthinessDispositionV1
-                            )
-                            else self.disposition
-                        )
-                        after = face.and_exit(exit_es, disposition=disposition)
                     after = prepend_facts_to_exitset(
                         after, (*mgr_facts, *enter_facts, *face_facts)
                     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
@@ -38,15 +38,27 @@ class WithResourceSugar(Sugar):
     contract_ref: object | None = None
     context_manager_edge: object | None = None
     enter_slot_id: str | None = None
-    contract_refs: object | None = None
-    receiver_coordinate: object | None = None
+    enter_definition: object | None = None
+    exit_definition: object | None = None
     site: object = dataclass_field(compare=False, default=None)
 
     def __post_init__(self) -> None:
-        if self.contract_refs is None or self.receiver_coordinate is None:
+        if self.enter_definition is None or self.exit_definition is None:
             raise ValueError(
-                "WithResourceSugar requires the authenticated native-definition door"
+                "WithResourceSugar requires authenticated enter and exit definition coordinates"
             )
+        from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+
+        for call, definition, slot in (
+            (self.enter, self.enter_definition, "context-enter"),
+            (self.exit, self.exit_definition, "context-exit"),
+        ):
+            if isinstance(call, MethodCallSugar) and (
+                call.native_definition_coordinate != definition
+            ):
+                raise ValueError(
+                    f"{slot} call is not authenticated by its definition coordinate"
+                )
 
     @classmethod
     def witnesses(cls):
@@ -83,13 +95,6 @@ class WithResourceSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         # Construction boundary: only ExitSet algebra + binding facts.
         # No sugar-class imports or construction on this path.
-        from sugar_lift_py_tests.caller_parameter_contract import (
-            NativeOperationResolutionV1,
-        )
-        from sugar_lift_py_tests.context_manager_resolution import (
-            NativeDefinitionCoordinateGapV1,
-            NativeProtocolSlot,
-        )
         from sugar_lift_py_tests.floor import EnteredManagerStateValue
         from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
         from sugar_lift_py_tests.outcome.resource_bindings import (
@@ -118,13 +123,6 @@ class WithResourceSugar(Sugar):
                 parts.append(ExitSet((mgr_exit,)))
                 continue
 
-            enter_definition = self.contract_refs.require_native_definition(
-                self.receiver_coordinate, NativeProtocolSlot.CONTEXT_ENTER
-            )
-            if isinstance(enter_definition, NativeDefinitionCoordinateGapV1):
-                NativeOperationResolutionV1.undischarged(
-                    enter_definition.reason
-                ).project(source_node=self.receiver_coordinate)
             mgr_facts = ()
             if hasattr(mgr_exit.value, "to_term"):
                 mgr_facts = ManagerBinding(
@@ -166,14 +164,6 @@ class WithResourceSugar(Sugar):
                 body_es = promote_raise_halts(
                     reduce_block_to_exitset(self.body)
                 ).guarded(face_guard)
-
-                exit_definition = self.contract_refs.require_native_definition(
-                    self.receiver_coordinate, NativeProtocolSlot.CONTEXT_EXIT
-                )
-                if isinstance(exit_definition, NativeDefinitionCoordinateGapV1):
-                    NativeOperationResolutionV1.undischarged(
-                        exit_definition.reason
-                    ).project(source_node=self.receiver_coordinate)
 
                 # Parametric exit: materialize once, fan over every body face.
                 exit_es = sugar_outcome_to_exitset(self.exit.desugar())

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_resource_sugar.py
@@ -173,11 +173,27 @@ class WithResourceSugar(Sugar):
                         self.exit_face_id, body_exit
                     ).to_facts(site=self.site, guard=body_exit.guard)
                     face = ExitSet((body_exit,))
-                    after = face.and_source_resource_exit(
-                        exit_es,
-                        disposition=self.disposition,
-                        site=self.site,
+                    from sugar_lift_py_tests.context_manager_contract import (
+                        NeverSuppressesDispositionV1,
+                        ReturnTruthinessDispositionV1,
                     )
+                    from sugar_lift_py_tests.effect import RaiseEffect
+
+                    if (
+                        isinstance(self.disposition, ReturnTruthinessDispositionV1)
+                        and isinstance(body_exit, Halted)
+                        and isinstance(body_exit.effect, RaiseEffect)
+                    ):
+                        after = face.and_exit_truthiness(exit_es, site=self.site)
+                    else:
+                        disposition = (
+                            NeverSuppressesDispositionV1()
+                            if isinstance(
+                                self.disposition, ReturnTruthinessDispositionV1
+                            )
+                            else self.disposition
+                        )
+                        after = face.and_exit(exit_es, disposition=disposition)
                     after = prepend_facts_to_exitset(
                         after, (*mgr_facts, *enter_facts, *face_facts)
                     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -14,10 +14,6 @@ from sugar_lift_py_tests.context_manager_contract import (
     RuntimeSelected,
 )
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
-from sugar_lift_py_tests.context_manager_resolution import (
-    NativeDefinitionCoordinateGapV1,
-    NativeProtocolSlot,
-)
 from sugar_lift_py_tests.effect import LoopControlEffect, RaiseEffect
 from sugar_lift_py_tests.floor import ObjectValue, SymbolicValue, TermValue
 from sugar_lift_py_tests.floor.block_value import BlockValue
@@ -43,7 +39,6 @@ from sugar_lift_py_tests.sugar.resource_coord_sugar import (
 )
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
-from sugar_source_tree.panic import SugarNotWritten
 
 
 def test_authenticated_pandas_303_builtin_open_resource_coordinate():
@@ -82,25 +77,6 @@ class _FixedSugar(Sugar):
     @classmethod
     def witnesses(cls):
         return ()
-
-
-class _ObservedNativeDefinitions:
-    def __init__(self, events=None, *, missing=()):
-        self.events = events if events is not None else []
-        self.missing = frozenset(missing)
-
-    def require_native_definition(self, receiver, slot):
-        self.events.append(f"require-{slot.value}")
-        if slot in self.missing:
-            return NativeDefinitionCoordinateGapV1(
-                receiver=receiver,
-                slot=slot,
-                reason="authenticated source definition coordinate is not enrolled",
-            )
-        line = 1 if slot is NativeProtocolSlot.CONTEXT_ENTER else 2
-        return SourceFragmentCoordinateV1(
-            "blake3-512:" + slot.value[0] * 128, line, 0, line, 1
-        )
 
 
 class _Pass(_FixedSugar):
@@ -152,8 +128,6 @@ def _resource(
     exit_face_id="X",
     enter_slot_id=None,
     exit_probe=None,
-    contract_refs=None,
-    receiver_coordinate=None,
 ):
     exit_sugar = exit
     if exit_sugar is None:
@@ -175,6 +149,16 @@ def _resource(
 
             exit_sugar = _ProbeExit()
 
+    from dataclasses import replace
+    from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+
+    enter_definition = SourceFragmentCoordinateV1("blake3-512:" + "e" * 128, 1, 0, 1, 1)
+    exit_definition = SourceFragmentCoordinateV1("blake3-512:" + "x" * 128, 2, 0, 2, 1)
+    if isinstance(enter, MethodCallSugar):
+        enter = replace(enter, native_definition_coordinate=enter_definition)
+    if isinstance(exit_sugar, MethodCallSugar):
+        exit_sugar = replace(exit_sugar, native_definition_coordinate=exit_definition)
+
     return WithResourceSugar(
         manager=manager
         or _FixedSugar(Complete(ObjectValue("native-resource", (), identity="mgr"))),
@@ -185,68 +169,10 @@ def _resource(
         body=body if body is not None else (_Pass(),),
         disposition=disposition or NeverSuppresses(),
         enter_slot_id=enter_slot_id,
-        contract_refs=contract_refs or _ObservedNativeDefinitions(),
-        receiver_coordinate=receiver_coordinate
-        or SourceFragmentCoordinateV1("blake3-512:" + "r" * 128, 1, 0, 1, 1),
+        enter_definition=enter_definition,
+        exit_definition=exit_definition,
         site=None,
     )
-
-
-def test_native_resource_flow_opens_enter_then_body_then_exit_definition():
-    events = []
-    refs = _ObservedNativeDefinitions(events)
-    sugar = _resource(
-        manager=_FixedSugar(
-            Complete(ObjectValue("native-resource", (), identity="mgr")),
-            probe=events,
-        ),
-        enter=_FixedSugar(Complete(_FloorValue("entered")), probe=events),
-        body=(_FixedSugar(Complete(BlockValue((), True)), probe=events),),
-        exit=_FixedSugar(Complete(TermValue(0)), probe=events),
-        contract_refs=refs,
-        disposition=ReturnTruthinessDispositionV1(),
-    )
-    sugar.desugar()
-    assert events == [
-        1,
-        "require-context-enter",
-        1,
-        1,
-        "require-context-exit",
-        1,
-    ]
-
-
-def test_missing_native_exit_definition_stays_typed_loud_after_body_reduction():
-    events = []
-    refs = _ObservedNativeDefinitions(
-        events, missing=(NativeProtocolSlot.CONTEXT_EXIT,)
-    )
-    with pytest.raises(
-        SugarNotWritten,
-        match="authenticated source definition coordinate is not enrolled",
-    ):
-        _resource(
-            body=(_FixedSugar(Complete(BlockValue((), True)), probe=events),),
-            contract_refs=refs,
-        ).desugar()
-    assert events == ["require-context-enter", 1, "require-context-exit"]
-
-
-def test_source_defined_coordinate_and_builtin_gap_are_distinct_door_outcomes():
-    """Discrimination twin: source testimony resolves; C-builtin testimony gaps."""
-    receiver = SourceFragmentCoordinateV1("blake3-512:" + "z" * 128, 7, 0, 7, 5)
-    source_refs = _ObservedNativeDefinitions()
-    source_sugar = _resource(contract_refs=source_refs, receiver_coordinate=receiver)
-    source_sugar.desugar()
-    assert source_refs.events == ["require-context-enter", "require-context-exit"]
-
-    builtin_refs = _ObservedNativeDefinitions(
-        missing=(NativeProtocolSlot.CONTEXT_ENTER, NativeProtocolSlot.CONTEXT_EXIT)
-    )
-    with pytest.raises(SugarNotWritten, match="authenticated source definition"):
-        _resource(contract_refs=builtin_refs, receiver_coordinate=receiver).desugar()
-    assert builtin_refs.events == ["require-context-enter"]
 
 
 def test_manager_expression_evaluated_exactly_once():

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -1,7 +1,4 @@
-"""Unit twins for resource ``WithResourceSugar`` — parametric exit, no desugar builds.
-
-Production ``open(...)`` stays RuntimeSelected.
-"""
+"""Unit twins for the authenticated builtin resource lifecycle."""
 
 from __future__ import annotations
 
@@ -17,8 +14,12 @@ from sugar_lift_py_tests.context_manager_contract import (
     RuntimeSelected,
 )
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.context_manager_resolution import (
+    NativeDefinitionCoordinateGapV1,
+    NativeProtocolSlot,
+)
 from sugar_lift_py_tests.effect import LoopControlEffect, RaiseEffect
-from sugar_lift_py_tests.floor import SymbolicValue, TermValue
+from sugar_lift_py_tests.floor import ObjectValue, SymbolicValue, TermValue
 from sugar_lift_py_tests.floor.block_value import BlockValue
 from sugar_lift_py_tests.floor.call_site_value import ExitSuppressionContract
 from sugar_lift_py_tests.floor.manager_coordinate import (
@@ -42,6 +43,7 @@ from sugar_lift_py_tests.sugar.resource_coord_sugar import (
 )
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
+from sugar_source_tree.panic import SugarNotWritten
 
 
 def test_authenticated_pandas_303_builtin_open_resource_coordinate():
@@ -80,6 +82,25 @@ class _FixedSugar(Sugar):
     @classmethod
     def witnesses(cls):
         return ()
+
+
+class _ObservedNativeDefinitions:
+    def __init__(self, events=None, *, missing=()):
+        self.events = events if events is not None else []
+        self.missing = frozenset(missing)
+
+    def require_native_definition(self, receiver, slot):
+        self.events.append(f"require-{slot.value}")
+        if slot in self.missing:
+            return NativeDefinitionCoordinateGapV1(
+                receiver=receiver,
+                slot=slot,
+                reason="authenticated source definition coordinate is not enrolled",
+            )
+        line = 1 if slot is NativeProtocolSlot.CONTEXT_ENTER else 2
+        return SourceFragmentCoordinateV1(
+            "blake3-512:" + slot.value[0] * 128, line, 0, line, 1
+        )
 
 
 class _Pass(_FixedSugar):
@@ -131,6 +152,8 @@ def _resource(
     exit_face_id="X",
     enter_slot_id=None,
     exit_probe=None,
+    contract_refs=None,
+    receiver_coordinate=None,
 ):
     exit_sugar = exit
     if exit_sugar is None:
@@ -153,7 +176,8 @@ def _resource(
             exit_sugar = _ProbeExit()
 
     return WithResourceSugar(
-        manager=manager or _FixedSugar(Complete(_FloorValue("mgr"))),
+        manager=manager
+        or _FixedSugar(Complete(ObjectValue("native-resource", (), identity="mgr"))),
         manager_slot_id=manager_slot_id,
         enter=enter or _FixedSugar(Complete(_FloorValue("entered"))),
         exit=exit_sugar,
@@ -161,20 +185,60 @@ def _resource(
         body=body if body is not None else (_Pass(),),
         disposition=disposition or NeverSuppresses(),
         enter_slot_id=enter_slot_id,
-        enter_definition=SourceFragmentCoordinateV1(
-            "blake3-512:" + "e" * 128, 1, 0, 1, 1
-        ),
-        exit_definition=SourceFragmentCoordinateV1(
-            "blake3-512:" + "x" * 128, 2, 0, 2, 1
-        ),
+        contract_refs=contract_refs or _ObservedNativeDefinitions(),
+        receiver_coordinate=receiver_coordinate
+        or SourceFragmentCoordinateV1("blake3-512:" + "r" * 128, 1, 0, 1, 1),
         site=None,
     )
+
+
+def test_native_resource_flow_opens_enter_then_body_then_exit_definition():
+    events = []
+    refs = _ObservedNativeDefinitions(events)
+    sugar = _resource(
+        manager=_FixedSugar(
+            Complete(ObjectValue("native-resource", (), identity="mgr")),
+            probe=events,
+        ),
+        enter=_FixedSugar(Complete(_FloorValue("entered")), probe=events),
+        body=(_FixedSugar(Complete(BlockValue((), True)), probe=events),),
+        exit=_FixedSugar(Complete(TermValue(0)), probe=events),
+        contract_refs=refs,
+        disposition=ReturnTruthinessDispositionV1(),
+    )
+    sugar.desugar()
+    assert events == [
+        1,
+        "require-context-enter",
+        1,
+        1,
+        "require-context-exit",
+        1,
+    ]
+
+
+def test_missing_native_exit_definition_stays_typed_loud_after_body_reduction():
+    events = []
+    refs = _ObservedNativeDefinitions(
+        events, missing=(NativeProtocolSlot.CONTEXT_EXIT,)
+    )
+    with pytest.raises(
+        SugarNotWritten,
+        match="authenticated source definition coordinate is not enrolled",
+    ):
+        _resource(
+            body=(_FixedSugar(Complete(BlockValue((), True)), probe=events),),
+            contract_refs=refs,
+        ).desugar()
+    assert events == ["require-context-enter", 1, "require-context-exit"]
 
 
 def test_manager_expression_evaluated_exactly_once():
     seen = []
     sugar = _resource(
-        manager=_FixedSugar(Complete(_FloorValue("mgr")), probe=seen),
+        manager=_FixedSugar(
+            Complete(ObjectValue("native-resource", (), identity="mgr")), probe=seen
+        ),
         body=(_Pass(),),
     )
     sugar.desugar()
@@ -225,6 +289,102 @@ def test_enter_halt_skips_body_and_exit():
     reds = [e for e in out.value.contribution() if isinstance(e, Incomplete)]
     assert len(reds) == 1
     assert reds[0].effect == enter_halt
+
+
+def test_completed_body_runs_exit_with_three_explicit_none_coordinates():
+    """Face 2: normal completion authenticates all three None arguments."""
+    out = _resource(body=(_Pass(),), exit=_FixedSugar(Complete(TermValue(0)))).desugar()
+    invs = [entry for entry in out.value.contribution() if isinstance(entry, InvValue)]
+    exit_facts = [
+        inv
+        for inv in invs
+        if getattr(getattr(inv.formula, "args", (None,))[0], "name", None)
+        in {"exit_type", "exit_value", "exit_traceback"}
+    ]
+    assert len(exit_facts) == 3
+    assert {fact.formula.args[0].name for fact in exit_facts} == {
+        "exit_type",
+        "exit_value",
+        "exit_traceback",
+    }
+    assert all(fact.formula.args[1].value == "None" for fact in exit_facts)
+
+
+def test_raised_body_routes_exact_face_coordinates_to_exit():
+    """Face 3: type/value/traceback coordinates share the exact raised face."""
+    face_id = "raised-face-17"
+    effect = RaiseEffect(
+        exception_name="ValueError",
+        occurrence="source.py:17:8",
+    )
+    exit_sugar = _parametric_exit(face_id=face_id)
+    type_coord, value_coord, traceback_coord = (
+        argument.desugar().value for argument in exit_sugar.args
+    )
+    assert type_coord == ExitTypeCoordinate(face_id, None)
+    assert value_coord == ExitValueCoordinate(face_id, None)
+    assert traceback_coord == ExitTracebackCoordinate(face_id, None)
+
+    binding = ExitFaceBinding.from_body_exit(face_id, Halted(true_guard(), effect))
+    assert binding.face_id == face_id
+    facts = binding.to_facts()
+    assert {fact.formula.args[0].args[0].value for fact in facts} == {face_id}
+    assert any(
+        getattr(fact.formula.args[1], "value", None) == "ValueError" for fact in facts
+    )
+    assert any(
+        getattr(fact.formula.args[1], "name", None) == "python:raise_effect_occurrence"
+        and fact.formula.args[1].args[0].value == "source.py:17:8"
+        for fact in facts
+    )
+
+
+def test_falsy_source_exit_preserves_the_exact_original_halt():
+    """Face 4: falsity restores the same effect and pre-effect state objects."""
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    effect = RaiseEffect(exception_name="ValueError", occurrence="body.py:4:2")
+    state = ObjectValue("native-resource", (), identity="before-raise")
+    incoming = Halted(true_guard(), effect, state)
+    routed = ExitSet((incoming,)).and_source_resource_exit(
+        ExitSet.completed(TermValue(False)),
+        disposition=ReturnTruthinessDispositionV1(),
+        site="exit-site",
+    )
+    assert len(routed.exits) == 1
+    surviving = routed.exits[0]
+    assert isinstance(surviving, Halted)
+    assert surviving.effect is effect
+    assert surviving.state is state
+
+
+def test_truthy_source_exit_suppresses_the_original_raise():
+    """Face 5: source-testified truth consumes the raised edge."""
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    effect = RaiseEffect(exception_name="ValueError", occurrence="body.py:5:2")
+    routed = ExitSet((Halted(true_guard(), effect),)).and_source_resource_exit(
+        ExitSet.completed(TermValue(True)),
+        disposition=ReturnTruthinessDispositionV1(),
+        site="exit-site",
+    )
+    assert all(not isinstance(face, Halted) for face in routed.exits)
+
+
+def test_undecided_source_exit_keeps_both_faces_factored():
+    """Face 6: UNKNOWN truth is neither false nor true; both arms survive."""
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    effect = RaiseEffect(exception_name="ValueError", occurrence="body.py:6:2")
+    routed = ExitSet((Halted(true_guard(), effect),)).and_source_resource_exit(
+        ExitSet.completed(SymbolicValue(make_var("exit_result"))),
+        disposition=ReturnTruthinessDispositionV1(),
+        site="exit-site",
+    )
+    assert {type(face) for face in routed.exits} == {Completed, Halted}
+    halted = next(face for face in routed.exits if isinstance(face, Halted))
+    assert halted.effect is effect
+    assert len({partition for face in routed.exits for partition in face.faces}) == 2
 
 
 def test_never_suppresses_restores_body_halt():
@@ -521,8 +681,12 @@ def test_enter_result_and_manager_binding_facts():
     sugar = _resource(
         body=(_Pass(),),
         enter_slot_id="E",
-        enter=_FixedSugar(Complete(_FloorValue("entered-val"))),
-        manager=_FixedSugar(Complete(_FloorValue("mgr-val"))),
+        enter=_FixedSugar(
+            Complete(ObjectValue("native-resource", (), identity="entered-val"))
+        ),
+        manager=_FixedSugar(
+            Complete(ObjectValue("native-resource", (), identity="mgr-val"))
+        ),
     )
     out = sugar.desugar()
     invs = [e for e in out.value.contribution() if isinstance(e, InvValue)]
@@ -536,6 +700,13 @@ def test_enter_result_and_manager_binding_facts():
     assert "manager_slot_value" in names
     assert "enter_result_value" in names
     assert "exit_type" in names  # completed face testimony
+    enter_fact = next(
+        inv
+        for inv in invs
+        if getattr(inv.formula.args[0], "name", None) == "enter_result_value"
+    )
+    assert enter_fact.formula.args[1].name == "py.object.identity"
+    assert enter_fact.formula.args[1].args[1].value == "entered-val"
 
 
 def test_parametric_exit_args_are_exit_refs():

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -233,6 +233,22 @@ def test_missing_native_exit_definition_stays_typed_loud_after_body_reduction():
     assert events == ["require-context-enter", 1, "require-context-exit"]
 
 
+def test_source_defined_coordinate_and_builtin_gap_are_distinct_door_outcomes():
+    """Discrimination twin: source testimony resolves; C-builtin testimony gaps."""
+    receiver = SourceFragmentCoordinateV1("blake3-512:" + "z" * 128, 7, 0, 7, 5)
+    source_refs = _ObservedNativeDefinitions()
+    source_sugar = _resource(contract_refs=source_refs, receiver_coordinate=receiver)
+    source_sugar.desugar()
+    assert source_refs.events == ["require-context-enter", "require-context-exit"]
+
+    builtin_refs = _ObservedNativeDefinitions(
+        missing=(NativeProtocolSlot.CONTEXT_ENTER, NativeProtocolSlot.CONTEXT_EXIT)
+    )
+    with pytest.raises(SugarNotWritten, match="authenticated source definition"):
+        _resource(contract_refs=builtin_refs, receiver_coordinate=receiver).desugar()
+    assert builtin_refs.events == ["require-context-enter"]
+
+
 def test_manager_expression_evaluated_exactly_once():
     seen = []
     sugar = _resource(

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -288,10 +288,8 @@ def test_falsy_source_exit_preserves_the_exact_original_halt():
     effect = RaiseEffect(exception_name="ValueError", occurrence="body.py:4:2")
     state = ObjectValue("native-resource", (), identity="before-raise")
     incoming = Halted(true_guard(), effect, state)
-    routed = ExitSet((incoming,)).and_source_resource_exit(
-        ExitSet.completed(TermValue(False)),
-        disposition=ReturnTruthinessDispositionV1(),
-        site="exit-site",
+    routed = ExitSet((incoming,)).and_exit_truthiness(
+        ExitSet.completed(TermValue(False)), site="exit-site"
     )
     assert len(routed.exits) == 1
     surviving = routed.exits[0]
@@ -305,10 +303,8 @@ def test_truthy_source_exit_suppresses_the_original_raise():
     from sugar_lift_py_tests.outcome.exit_set import ExitSet
 
     effect = RaiseEffect(exception_name="ValueError", occurrence="body.py:5:2")
-    routed = ExitSet((Halted(true_guard(), effect),)).and_source_resource_exit(
-        ExitSet.completed(TermValue(True)),
-        disposition=ReturnTruthinessDispositionV1(),
-        site="exit-site",
+    routed = ExitSet((Halted(true_guard(), effect),)).and_exit_truthiness(
+        ExitSet.completed(TermValue(True)), site="exit-site"
     )
     assert all(not isinstance(face, Halted) for face in routed.exits)
 
@@ -318,10 +314,8 @@ def test_undecided_source_exit_keeps_both_faces_factored():
     from sugar_lift_py_tests.outcome.exit_set import ExitSet
 
     effect = RaiseEffect(exception_name="ValueError", occurrence="body.py:6:2")
-    routed = ExitSet((Halted(true_guard(), effect),)).and_source_resource_exit(
-        ExitSet.completed(SymbolicValue(make_var("exit_result"))),
-        disposition=ReturnTruthinessDispositionV1(),
-        site="exit-site",
+    routed = ExitSet((Halted(true_guard(), effect),)).and_exit_truthiness(
+        ExitSet.completed(SymbolicValue(make_var("exit_result"))), site="exit-site"
     )
     assert {type(face) for face in routed.exits} == {Completed, Halted}
     halted = next(face for face in routed.exits if isinstance(face, Halted))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5607,11 +5607,24 @@ class With(Statement):
 
             manager_slot = item._manager_slot_id()
             enter_slot = f"{manager_slot}#enter_result" if binds_enter_result else None
+            enter_definition, exit_definition = (
+                self._require_native_resource_definitions(resolved_ref)
+            )
+            from dataclasses import replace
+
+            enter_sugar = replace(
+                item._make_enter_call().sugar(),
+                native_definition_coordinate=enter_definition,
+            )
+            exit_sugar = replace(
+                item._make_parametric_exit_call().sugar(),
+                native_definition_coordinate=exit_definition,
+            )
             return WithResourceSugar(
                 manager=item.context_expr.sugar(),
                 manager_slot_id=manager_slot,
-                enter=item._make_enter_call().sugar(),
-                exit=item._make_parametric_exit_call().sugar(),
+                enter=enter_sugar,
+                exit=exit_sugar,
                 exit_face_id=item._exit_face_id(),
                 body=tuple(stmt.sugar() for stmt in self.body),
                 disposition=resolved_ref.semantics.exit.disposition,
@@ -5620,8 +5633,8 @@ class With(Statement):
                     resolved_ref, resolved_ref.use_site
                 ),
                 enter_slot_id=enter_slot,
-                contract_refs=self.unit.construction_context.contract_refs,
-                receiver_coordinate=resolved_ref.use_site,
+                enter_definition=enter_definition,
+                exit_definition=exit_definition,
                 site=self.fragment,
             )
         panic = RuntimeSelectedContextManager(
@@ -5633,6 +5646,39 @@ class With(Statement):
         )
         self.reporter.report_gap(self, panic)
         raise panic
+
+    def _require_native_resource_definitions(self, resolved_ref):
+        """Require both protocol methods through the one authenticated door."""
+        from sugar_lift_py_tests.context_manager_resolution import (
+            NativeDefinitionCoordinateGapV1,
+            NativeProtocolSlot,
+        )
+        from .panic import SugarNotWritten
+
+        refs = self.unit.construction_context.contract_refs
+        receiver = resolved_ref.use_site
+        enter = refs.require_native_definition(
+            receiver, NativeProtocolSlot.CONTEXT_ENTER
+        )
+        exit_ = refs.require_native_definition(
+            receiver, NativeProtocolSlot.CONTEXT_EXIT
+        )
+        for resolution in (enter, exit_):
+            if isinstance(resolution, NativeDefinitionCoordinateGapV1):
+                raise SugarNotWritten(
+                    blame=self.fragment,
+                    owner="With._require_native_resource_definitions",
+                    observed=resolution.reason,
+                    requested=(
+                        "authenticated source definition coordinates for both "
+                        "context-enter and context-exit"
+                    ),
+                    fix=(
+                        "retain this native resource as undischarged until the "
+                        "shared definition door resolves the missing slot"
+                    ),
+                )
+        return enter, exit_
 
     def _authenticate_expected_exception_type(self, manager, manager_sugar, reference):
         """Attach the floor-owned identity to the selected real call operand."""

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5607,9 +5607,6 @@ class With(Statement):
 
             manager_slot = item._manager_slot_id()
             enter_slot = f"{manager_slot}#enter_result" if binds_enter_result else None
-            enter_definition, exit_definition = (
-                self._require_native_resource_definitions(resolved_ref)
-            )
             return WithResourceSugar(
                 manager=item.context_expr.sugar(),
                 manager_slot_id=manager_slot,
@@ -5623,8 +5620,8 @@ class With(Statement):
                     resolved_ref, resolved_ref.use_site
                 ),
                 enter_slot_id=enter_slot,
-                enter_definition=enter_definition,
-                exit_definition=exit_definition,
+                contract_refs=self.unit.construction_context.contract_refs,
+                receiver_coordinate=resolved_ref.use_site,
                 site=self.fragment,
             )
         panic = RuntimeSelectedContextManager(
@@ -5636,39 +5633,6 @@ class With(Statement):
         )
         self.reporter.report_gap(self, panic)
         raise panic
-
-    def _require_native_resource_definitions(self, resolved_ref):
-        """Require both protocol methods through the one authenticated door."""
-        from sugar_lift_py_tests.context_manager_resolution import (
-            NativeDefinitionCoordinateGapV1,
-            NativeProtocolSlot,
-        )
-        from .panic import SugarNotWritten
-
-        refs = self.unit.construction_context.contract_refs
-        receiver = resolved_ref.use_site
-        enter = refs.require_native_definition(
-            receiver, NativeProtocolSlot.CONTEXT_ENTER
-        )
-        exit_ = refs.require_native_definition(
-            receiver, NativeProtocolSlot.CONTEXT_EXIT
-        )
-        for resolution in (enter, exit_):
-            if isinstance(resolution, NativeDefinitionCoordinateGapV1):
-                raise SugarNotWritten(
-                    blame=self.fragment,
-                    owner="With._require_native_resource_definitions",
-                    observed=resolution.reason,
-                    requested=(
-                        "authenticated source definition coordinates for both "
-                        "context-enter and context-exit"
-                    ),
-                    fix=(
-                        "retain this native resource as undischarged until the "
-                        "shared definition door resolves the missing slot"
-                    ),
-                )
-        return enter, exit_
 
     def _authenticate_expected_exception_type(self, manager, manager_sugar, reference):
         """Attach the floor-owned identity to the selected real call operand."""

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -161,15 +161,33 @@ def test_open_name_without_native_definition_stays_typed_loud():
     tree = _source_with_resolution(
         (source, "native-resource-gap.py", _cid("q")),
         _truthiness_resolved,
-        native_definitions=lambda use_site: {
-            (use_site, NativeProtocolSlot.CONTEXT_ENTER): SourceFragmentCoordinateV1(
-                _cid("e"), 10, 4, 11, 20
-            )
-        },
+        native_definitions=lambda use_site: {},
     )
     boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
     with pytest.raises(SugarNotWritten, match="authenticated source definition"):
         boundary.desugar()
+
+
+def test_open_gap_is_the_builtin_authority_discrimination_arm():
+    """The real C builtin asks the door; it is not admitted by spelling."""
+    source = "def f(path):\n    with open(path) as resource:\n        return resource\n"
+    tree = _source_with_resolution(
+        (source, "builtin-open-gap.py", _cid("q")),
+        _truthiness_resolved,
+        native_definitions=lambda use_site: {},
+    )
+    boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    receiver = boundary.receiver_coordinate
+    enter_gap = boundary.contract_refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_ENTER
+    )
+    exit_gap = boundary.contract_refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_EXIT
+    )
+    assert enter_gap.slot is NativeProtocolSlot.CONTEXT_ENTER
+    assert exit_gap.slot is NativeProtocolSlot.CONTEXT_EXIT
+    assert enter_gap.reason.startswith("authenticated source definition")
+    assert exit_gap.reason.startswith("authenticated source definition")
 
 
 def _function_sugar(source_identity, resolution):

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -144,12 +144,13 @@ def test_native_resource_requires_both_authenticated_definition_coordinates():
     )
     boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
     assert isinstance(boundary, WithResourceSugar)
-    assert boundary.enter_definition == SourceFragmentCoordinateV1(
-        _cid("e"), 10, 4, 11, 20
-    )
-    assert boundary.exit_definition == SourceFragmentCoordinateV1(
-        _cid("x"), 20, 4, 22, 20
-    )
+    assert boundary.receiver_coordinate == boundary.contract_ref.use_site
+    assert boundary.contract_refs.require_native_definition(
+        boundary.receiver_coordinate, NativeProtocolSlot.CONTEXT_ENTER
+    ) == SourceFragmentCoordinateV1(_cid("e"), 10, 4, 11, 20)
+    assert boundary.contract_refs.require_native_definition(
+        boundary.receiver_coordinate, NativeProtocolSlot.CONTEXT_EXIT
+    ) == SourceFragmentCoordinateV1(_cid("x"), 20, 4, 22, 20)
     assert boundary.enter_slot_id is not None
     assert boundary.enter_slot_id.startswith(boundary.manager_slot_id)
 
@@ -166,8 +167,9 @@ def test_open_name_without_native_definition_stays_typed_loud():
             )
         },
     )
+    boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
     with pytest.raises(SugarNotWritten, match="authenticated source definition"):
-        next(node for node in tree.nodes() if node.kind == "With").sugar()
+        boundary.desugar()
 
 
 def _function_sugar(source_identity, resolution):

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -192,6 +192,29 @@ def test_open_gap_is_the_builtin_authority_discrimination_arm():
     assert exit_gap.reason.startswith("authenticated source definition")
 
 
+def test_source_defined_coordinate_and_builtin_gap_are_distinct_door_outcomes():
+    """Both authorities use With.sugar; only source testimony constructs."""
+    source = (
+        "from pandas import option_context\n"
+        "def f():\n"
+        "    with option_context('display.max_rows', 10) as resource:\n"
+        "        return resource\n"
+    )
+    tree = _source_with_resolution(
+        (source, "source-defined-resource.py", _cid("q")),
+        _truthiness_resolved,
+        native_definitions=_native_protocol_definitions,
+    )
+    boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    expected_enter = SourceFragmentCoordinateV1(_cid("e"), 10, 4, 11, 20)
+    expected_exit = SourceFragmentCoordinateV1(_cid("x"), 20, 4, 22, 20)
+    assert boundary.enter_definition == expected_enter
+    assert boundary.exit_definition == expected_exit
+    assert boundary.enter.native_definition_coordinate == expected_enter
+    assert boundary.exit.native_definition_coordinate == expected_exit
+    assert boundary.desugar() is not None
+
+
 @pytest.mark.parametrize(
     "missing_slot", [NativeProtocolSlot.CONTEXT_ENTER, NativeProtocolSlot.CONTEXT_EXIT]
 )

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from types import MappingProxyType
+from dataclasses import replace
+import inspect
 
 import pytest
 
@@ -144,13 +146,12 @@ def test_native_resource_requires_both_authenticated_definition_coordinates():
     )
     boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
     assert isinstance(boundary, WithResourceSugar)
-    assert boundary.receiver_coordinate == boundary.contract_ref.use_site
-    assert boundary.contract_refs.require_native_definition(
-        boundary.receiver_coordinate, NativeProtocolSlot.CONTEXT_ENTER
-    ) == SourceFragmentCoordinateV1(_cid("e"), 10, 4, 11, 20)
-    assert boundary.contract_refs.require_native_definition(
-        boundary.receiver_coordinate, NativeProtocolSlot.CONTEXT_EXIT
-    ) == SourceFragmentCoordinateV1(_cid("x"), 20, 4, 22, 20)
+    enter_definition = SourceFragmentCoordinateV1(_cid("e"), 10, 4, 11, 20)
+    exit_definition = SourceFragmentCoordinateV1(_cid("x"), 20, 4, 22, 20)
+    assert boundary.enter_definition == enter_definition
+    assert boundary.exit_definition == exit_definition
+    assert boundary.enter.native_definition_coordinate == enter_definition
+    assert boundary.exit.native_definition_coordinate == exit_definition
     assert boundary.enter_slot_id is not None
     assert boundary.enter_slot_id.startswith(boundary.manager_slot_id)
 
@@ -163,9 +164,8 @@ def test_open_name_without_native_definition_stays_typed_loud():
         _truthiness_resolved,
         native_definitions=lambda use_site: {},
     )
-    boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
     with pytest.raises(SugarNotWritten, match="authenticated source definition"):
-        boundary.desugar()
+        next(node for node in tree.nodes() if node.kind == "With").sugar()
 
 
 def test_open_gap_is_the_builtin_authority_discrimination_arm():
@@ -176,18 +176,62 @@ def test_open_gap_is_the_builtin_authority_discrimination_arm():
         _truthiness_resolved,
         native_definitions=lambda use_site: {},
     )
-    boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
-    receiver = boundary.receiver_coordinate
-    enter_gap = boundary.contract_refs.require_native_definition(
+    with_node = next(node for node in tree.nodes() if node.kind == "With")
+    receiver = _coordinate(with_node.items[0].context_expr)
+    refs = with_node.unit.construction_context.contract_refs
+    enter_gap = refs.require_native_definition(
         receiver, NativeProtocolSlot.CONTEXT_ENTER
     )
-    exit_gap = boundary.contract_refs.require_native_definition(
-        receiver, NativeProtocolSlot.CONTEXT_EXIT
-    )
+    exit_gap = refs.require_native_definition(receiver, NativeProtocolSlot.CONTEXT_EXIT)
     assert enter_gap.slot is NativeProtocolSlot.CONTEXT_ENTER
     assert exit_gap.slot is NativeProtocolSlot.CONTEXT_EXIT
     assert enter_gap.reason.startswith("authenticated source definition")
     assert exit_gap.reason.startswith("authenticated source definition")
+
+
+@pytest.mark.parametrize(
+    "missing_slot", [NativeProtocolSlot.CONTEXT_ENTER, NativeProtocolSlot.CONTEXT_EXIT]
+)
+def test_missing_one_native_definition_is_typed_loud(missing_slot):
+    source = (
+        "def f(path):\n    with acquire(path) as resource:\n        return resource\n"
+    )
+
+    def definitions(use_site):
+        values = _native_protocol_definitions(use_site)
+        values.pop((use_site, missing_slot))
+        return values
+
+    tree = _source_with_resolution(
+        (source, "missing-one-native-definition.py", _cid("q")),
+        _truthiness_resolved,
+        native_definitions=definitions,
+    )
+    with pytest.raises(SugarNotWritten, match="authenticated source definition"):
+        next(node for node in tree.nodes() if node.kind == "With").sugar()
+
+
+def test_swapped_definition_coordinates_are_rejected_by_authenticated_calls():
+    source = (
+        "def f(path):\n    with acquire(path) as resource:\n        return resource\n"
+    )
+    tree = _source_with_resolution(
+        (source, "swapped-native-definition.py", _cid("q")),
+        _truthiness_resolved,
+        native_definitions=_native_protocol_definitions,
+    )
+    boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    with pytest.raises(ValueError, match="not authenticated"):
+        replace(
+            boundary,
+            enter_definition=boundary.exit_definition,
+            exit_definition=boundary.enter_definition,
+        )
+
+
+def test_resource_desugar_has_no_second_native_definition_lookup():
+    source = inspect.getsource(WithResourceSugar.desugar)
+    assert "require_native_definition" not in source
 
 
 def _function_sugar(source_identity, resolution):

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -137,7 +137,10 @@ def _native_protocol_definitions(use_site):
 
 def test_native_resource_requires_both_authenticated_definition_coordinates():
     source = (
-        "def f(path):\n    with acquire(path) as resource:\n        return resource\n"
+        "from pandas import option_context\n"
+        "def f():\n"
+        "    with option_context('display.max_rows', 10) as resource:\n"
+        "        return resource\n"
     )
     tree = _source_with_resolution(
         (source, "native-resource.py", _cid("q")),

--- a/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
@@ -339,8 +339,12 @@ def _resource(*, enter=None, body=None, slot="M", exit_probe=None):
         exit_face_id=f"{slot}#exit_face",
         body=body if body is not None else (),
         disposition=NeverSuppresses(),
-        contract_refs=_NativeDefinitions(),
-        receiver_coordinate=receiver,
+        enter_definition=SourceFragmentCoordinateV1(
+            "blake3-512:" + "e" * 128, 1, 0, 1, 1
+        ),
+        exit_definition=SourceFragmentCoordinateV1(
+            "blake3-512:" + "x" * 128, 2, 0, 2, 1
+        ),
         site=None,
     )
 

--- a/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
@@ -310,8 +310,25 @@ class _FloorValue:
 
 def _resource(*, enter=None, body=None, slot="M", exit_probe=None):
     from sugar_lift_py_tests.context_manager_resolution import (
+        NativeProtocolSlot,
         SourceFragmentCoordinateV1,
     )
+
+    receiver = SourceFragmentCoordinateV1(
+        "blake3-512:" + slot.lower() * 128, 1, 0, 1, 1
+    )
+
+    class _NativeDefinitions:
+        def require_native_definition(self, requested_receiver, protocol_slot):
+            assert requested_receiver == receiver
+            line = 1 if protocol_slot is NativeProtocolSlot.CONTEXT_ENTER else 2
+            return SourceFragmentCoordinateV1(
+                "blake3-512:" + protocol_slot.value[0] * 128,
+                line,
+                0,
+                line,
+                1,
+            )
 
     exit_sugar = _FixedSugar(Complete(_FloorValue("exited")), probe=exit_probe)
     return WithResourceSugar(
@@ -322,12 +339,8 @@ def _resource(*, enter=None, body=None, slot="M", exit_probe=None):
         exit_face_id=f"{slot}#exit_face",
         body=body if body is not None else (),
         disposition=NeverSuppresses(),
-        enter_definition=SourceFragmentCoordinateV1(
-            "blake3-512:" + "e" * 128, 1, 0, 1, 1
-        ),
-        exit_definition=SourceFragmentCoordinateV1(
-            "blake3-512:" + "x" * 128, 2, 0, 2, 1
-        ),
+        contract_refs=_NativeDefinitions(),
+        receiver_coordinate=receiver,
         site=None,
     )
 


### PR DESCRIPTION
## Python semantic law

Builtin C resource managers such as `open` remain loud when the authenticated native-definition door has no Python source coordinate. Definition authority stays solely in `With._construct_sugar`; `WithResourceSugar.desugar` performs no resolution lookup. Source-defined testimony uses the same construction path and carries exact enter/exit coordinates into the prebuilt calls.

## Concrete pinned site

- pandas 3.0.3: `tests/series/methods/test_to_csv.py:57`
- `with open(path, "w", encoding="utf-8") as outfile:`
- authenticated use-site CID `blake3-512:e7fe0726…f960343a0`, columns 13–46
- canonical corpus `blake3-512:6f317a5a…563530`, 1,421 files

The real C builtin has no authenticated Python definition. Both slots therefore produce `NativeDefinitionCoordinateGapV1` and construction remains a named `SugarNotWritten` refusal.

## Construction authority

`With._require_native_resource_definitions` resolves both slots exactly once. The resulting coordinates are attached to the prebuilt `MethodCallSugar` enter/exit calls and stored as the matching `enter_definition`/`exit_definition` fields. `WithResourceSugar.__post_init__` rejects a call/coordinate mismatch. Its `desugar` source contains no `require_native_definition` lookup.

Tests cover:

- missing enter row -> typed loud;
- missing exit row -> typed loud;
- swapped definition fields -> rejected because the prebuilt calls carry the opposite coordinates;
- real `open` gap versus source-defined resolved-coordinate discrimination;
- enter halt, completed None triple, raised-face identity, false preservation, true suppression, undecided factoring, return/loop non-suppression, and early-return cleanup.

## Validation

- authenticated bootstrap: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0 (`PINS_OK`)
- focused owning-package tests: `71 passed`
- mutation: removing the producer `_require_native_resource_definitions` call makes the positive construction test fail; restored afterward
- Black check clean

No battleaxe corpus delta or crash/timeout receipt is claimed from this Mac. Do not merge automatically.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate resource enter/exit calls during `WithResourceSugar` tree construction
> - Adds a `native_definition_coordinate` field to `MethodCallSugar` to carry an authenticated definition coordinate for native method calls.
> - `WithResourceSugar.__post_init__` now validates that enter/exit `MethodCallSugar` instances carry matching authenticated coordinates, raising `ValueError` if they don't.
> - `With._prebound_manager_resolution` stamps the synthesized enter/exit `MethodCallSugar` instances with the resolved `enter_definition`/`exit_definition` coordinates before passing them to `WithResourceSugar`.
> - Fixes `WithResourceSugar.desugar` to preserve original state, faces, and pending contracts when the enter call halts, and binds the enter result via `EnteredManagerStateValue` coupled with manager state.
> - Behavioral Change: `WithResourceSugar` construction now rejects mismatched or missing authenticated coordinates, which was previously not enforced.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a35d0e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->