### PR TITLE
Prove resource definition door traversal for builtin and source managers

### DIFF
--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -27,6 +27,7 @@ from sugar_lift_py_tests.context_manager_contract import (
 from sugar_lift_py_tests.context_manager_resolution import (
     ContextManagerContractRefV1,
     ContextManagerResolutionGapV1,
+    NativeDefinitionCoordinateGapV1,
     ImportSignatureV2,
     NativeProtocolSlot,
     ResolvedContractRefsV1,
@@ -81,6 +82,41 @@ def _source_with_resolution(source_identity, resolution, *, native_definitions=N
         source_identity,
         construction_context=TreeConstructionContextV1(table),
     )
+
+
+class _RecordingRefs:
+    """Construction-table wrapper proving the one producer door is traversed."""
+
+    def __init__(self, table, definitions):
+        self.table = table
+        self.definitions = definitions
+        self.calls = []
+
+    def require(self, use_site):
+        return self.table.require(use_site)
+
+    def require_native_definition(self, receiver, slot):
+        self.calls.append((receiver, slot))
+        return self.definitions[(receiver, slot)]
+
+
+def _source_with_recording_refs(source_identity, resolution, definitions):
+    first = SourceFile(source_identity)
+    with_node = next(
+        node for node in first.nodes() if node.kind in {"With", "AsyncWith"}
+    )
+    use_site = _coordinate(with_node.items[0].context_expr)
+    table = ResolvedContractRefsV1(
+        catalog_cid=_cid("c"),
+        table_cid=_cid("t"),
+        by_use_site=MappingProxyType({use_site: resolution(use_site)}),
+    )
+    recording = _RecordingRefs(table, definitions)
+    source = SourceFile(
+        source_identity,
+        construction_context=TreeConstructionContextV1(recording),
+    )
+    return source, recording, use_site
 
 
 def _resolved(use_site) -> ContextManagerContractRefV1:
@@ -190,6 +226,74 @@ def test_open_gap_is_the_builtin_authority_discrimination_arm():
     assert exit_gap.slot is NativeProtocolSlot.CONTEXT_EXIT
     assert enter_gap.reason.startswith("authenticated source definition")
     assert exit_gap.reason.startswith("authenticated source definition")
+
+
+def test_recording_door_source_defined_calls_enter_then_exit_and_desugars():
+    source = (
+        "from pandas import option_context\n"
+        "def f():\n"
+        "    with option_context('display.max_rows', 10) as resource:\n"
+        "        return resource\n"
+    )
+    source_file = SourceFile((source, "recording-source-defined.py", _cid("q")))
+    use_site = _coordinate(
+        next(node for node in source_file.nodes() if node.kind == "With")
+        .items[0]
+        .context_expr
+    )
+    enter = SourceFragmentCoordinateV1(_cid("e"), 10, 4, 11, 20)
+    exit_ = SourceFragmentCoordinateV1(_cid("x"), 20, 4, 22, 20)
+    definitions = {
+        (use_site, NativeProtocolSlot.CONTEXT_ENTER): enter,
+        (use_site, NativeProtocolSlot.CONTEXT_EXIT): exit_,
+    }
+    source, recording, _ = _source_with_recording_refs(
+        (source, "recording-source-defined.py", _cid("q")),
+        _truthiness_resolved,
+        definitions,
+    )
+    sugar = next(node for node in source.nodes() if node.kind == "With").sugar()
+    assert recording.calls == [
+        (use_site, NativeProtocolSlot.CONTEXT_ENTER),
+        (use_site, NativeProtocolSlot.CONTEXT_EXIT),
+    ]
+    assert sugar.enter_definition == enter
+    assert sugar.exit_definition == exit_
+    assert sugar.enter.native_definition_coordinate == enter
+    assert sugar.exit.native_definition_coordinate == exit_
+    assert sugar.desugar() is not None
+
+
+def test_recording_door_builtin_open_calls_both_slots_then_stays_loud():
+    source = "def f(path):\n    with open(path) as resource:\n        return resource\n"
+    source_file = SourceFile((source, "recording-open.py", _cid("q")))
+    use_site = _coordinate(
+        next(node for node in source_file.nodes() if node.kind == "With")
+        .items[0]
+        .context_expr
+    )
+    definitions = {
+        (use_site, NativeProtocolSlot.CONTEXT_ENTER): NativeDefinitionCoordinateGapV1(
+            use_site,
+            NativeProtocolSlot.CONTEXT_ENTER,
+            "authenticated source definition coordinate is not enrolled",
+        ),
+        (use_site, NativeProtocolSlot.CONTEXT_EXIT): NativeDefinitionCoordinateGapV1(
+            use_site,
+            NativeProtocolSlot.CONTEXT_EXIT,
+            "authenticated source definition coordinate is not enrolled",
+        ),
+    }
+    source, recording, _ = _source_with_recording_refs(
+        (source, "recording-open.py", _cid("q")),
+        _truthiness_resolved,
+        definitions,
+    )
+    with pytest.raises(SugarNotWritten, match="authenticated source definition"):
+        next(node for node in source.nodes() if node.kind == "With").sugar()
+    assert len(recording.calls) == 2
+    assert recording.calls[0][1] is NativeProtocolSlot.CONTEXT_ENTER
+    assert recording.calls[1][1] is NativeProtocolSlot.CONTEXT_EXIT
 
 
 def test_source_defined_coordinate_and_builtin_gap_are_distinct_door_outcomes():


### PR DESCRIPTION
## Python semantic law

The resource construction producer consults one authenticated native-definition door in a fixed order: `CONTEXT_ENTER`, then `CONTEXT_EXIT`. Source-defined testimony resolves both coordinates and builtin C `open` traverses the same door but receives typed definition gaps and stays loud. `WithResourceSugar.desugar` remains lookup-free.

## Recording twins

A recording contract table wraps the existing construction context and records calls, without changing production text or instantiating `WithResourceSugar` directly:

- source-defined `option_context`: exact ordered calls for both slots, exact coordinates attached to the prebuilt enter/exit calls, then the resulting Sugar desugars;
- builtin `open`: exact ordered calls for both slots, both native-definition gaps, construction remains typed loud.

The existing lifecycle, suppression, return/raise, and open-gap twins remain intact.

## Validation

- authenticated bootstrap: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0 (`PINS_OK`)
- focused owning-package tests: `74 passed`
- `exit_set.py` unchanged from main
- no provider/source-publication or reserved algebra edits

No battleaxe corpus delta or crash/timeout receipt is claimed from this Mac. Do not merge automatically.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prove resource definition door traversal for builtin and source managers in `With` sugar
> - Adds `_RecordingRefs`, a construction-table wrapper in [test_with_authenticated_contract_ref.py](https://github.com/TSavo/sugar/pull/6617/files#diff-24ed90dba7c15724cef255c1d44a25011bfd98f07aba873f4fa4de7241417552) that intercepts `require_native_definition` calls and logs `(receiver, slot)` pairs for assertion.
> - Adds `test_recording_door_source_defined_calls_enter_then_exit_and_desugars`: verifies that `With.sugar()` requests `CONTEXT_ENTER` then `CONTEXT_EXIT` in order and that the resulting sugar has correct `enter_definition`/`exit_definition` fields when source-defined coordinates are provided.
> - Adds `test_recording_door_builtin_open_calls_both_slots_then_stays_loud`: verifies that `With.sugar()` raises `SugarNotWritten` with an 'authenticated source definition' message when both slots return `NativeDefinitionCoordinateGapV1` (i.e. a builtin like `open`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16887c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->