### PR TITLE
Exercise rich ordering through keyword and default binding

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_keyword_default_vertical.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_keyword_default_vertical.py
@@ -1,0 +1,199 @@
+"""Ordering comparison demands cross Python keyword/default call binding."""
+
+from __future__ import annotations
+
+import ast
+
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.context_manager_contract import (
+    AuthenticatedRaiseMatcher,
+    EffectBoundaryDisposition,
+)
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.effect.expectation_not_met_effect import ExpectationNotMetEffect
+from sugar_lift_py_tests.ir import ctor, str_const
+from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+MANIFEST_CID = (
+    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
+    "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+)
+PANDAS_HELPER = "tests/arithmetic/common.py"
+PANDAS_CALLER = "tests/arithmetic/test_datetime64.py"
+MATCH_PARTS = (
+    "Invalid comparison between",
+    "Cannot compare type",
+    "not supported between",
+    "invalid type promotion",
+    "The DTypes <class 'numpy.dtype\\[datetime64\\]'> and "
+    "<class 'numpy.dtype\\[int64\\]'> do not have a common DType. For example "
+    "they cannot be stored in a single array unless the dtype is `object`.",
+)
+
+
+def _tree(source: str) -> SourceFile:
+    return SourceFile(
+        (source, "compare-keyword-default.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _exception_identity(name: str):
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
+
+
+class _Expected:
+    def __init__(self, name: str):
+        self.identity = _exception_identity(name)
+
+    def exception_type_identity(self):
+        return self.identity
+
+
+def _program_outcomes():
+    source = (
+        "def helper(left, right=2):\n"
+        "    return left < right\n\n"
+        "helper(None, 2)\n"
+        "helper(None, right=2)\n"
+        "helper(None)\n"
+        "helper(1, right=2)\n"
+    )
+    nodes = tuple(_tree(source).nodes())
+    function = next(node for node in nodes if isinstance(node, FunctionDef))
+    calls = tuple(node for node in nodes if isinstance(node, Call))
+    return function.sugar().desugar(None), tuple(
+        call.sugar().desugar(None) for call in calls
+    )
+
+
+def _named_type_error(outcome: object) -> Halted:
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    halted = outcome.exits[0]
+    assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _exception_identity("TypeError")
+    assert halted.effect.occurrence_id is not None
+    return halted
+
+
+def test_real_pandas_ordering_helper_and_positional_caller_are_content_pinned() -> None:
+    """The corpus evidence is real; keyword/default are binder-shape twins."""
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.manifest_cid, corpus.file_count) == (
+        "3.0.3",
+        MANIFEST_CID,
+        1421,
+    )
+    helper_source = (corpus.root / PANDAS_HELPER).read_text(encoding="utf-8")
+    helper_tree = ast.parse(helper_source)
+    helper = next(
+        node
+        for node in ast.walk(helper_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "assert_invalid_comparison"
+    )
+    assert helper.lineno == 89
+    with_node = next(node for node in ast.walk(helper) if isinstance(node, ast.With))
+    manager = with_node.items[0].context_expr
+    assert with_node.lineno == 143
+    assert isinstance(manager, ast.Call)
+    assert ast.unparse(manager.args[0]) == "TypeError"
+    assert [(keyword.arg, ast.unparse(keyword.value)) for keyword in manager.keywords] == [
+        ("match", "msg")
+    ]
+    msg = next(
+        node
+        for node in helper.body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "msg" for target in node.targets)
+    )
+    assert isinstance(msg.value, ast.Call)
+    assert ast.unparse(msg.value.func) == "'|'.join"
+    assert len(msg.value.args) == 1 and isinstance(msg.value.args[0], ast.List)
+    assert tuple(ast.literal_eval(item) for item in msg.value.args[0].elts) == MATCH_PARTS
+    comparison = next(
+        node
+        for node in ast.walk(with_node)
+        if isinstance(node, ast.Compare) and ast.unparse(node) == "left < right"
+    )
+    assert comparison.lineno == 144
+
+    caller_source = (corpus.root / PANDAS_CALLER).read_text(encoding="utf-8")
+    calls = [
+        node
+        for node in ast.walk(ast.parse(caller_source))
+        if isinstance(node, ast.Call)
+        and ast.unparse(node.func).endswith("assert_invalid_comparison")
+    ]
+    assert any(node.lineno == 90 and len(node.args) == 3 and not node.keywords for node in calls)
+
+
+def test_helper_alone_is_undischarged_and_all_three_bindings_reach_one_demand() -> None:
+    pending, (positional, keyword, default, normal) = _program_outcomes()
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "less_than"
+
+    halted = tuple(_named_type_error(outcome) for outcome in (positional, keyword, default))
+    assert len({face.effect.occurrence_id for face in halted}) == 1
+    assert isinstance(normal, ExitSet)
+    assert len(normal.exits) == 1
+    assert not any(isinstance(face, Halted) for face in normal.exits)
+
+
+def test_wrong_boundary_type_does_not_consume_or_create_the_exception_identity() -> None:
+    _, (_, keyword, _, _) = _program_outcomes()
+    producer_halt = _named_type_error(keyword)
+    separately_minted_expected = _Expected("TypeError")
+    assert producer_halt.effect.exception_type_coordinate == separately_minted_expected.identity
+    assert producer_halt.effect.exception_type_coordinate is not separately_minted_expected.identity
+
+    projected = keyword.and_exit(
+        ExitSet.completed(object()),
+        disposition=EffectBoundaryDisposition(
+            matcher=AuthenticatedRaiseMatcher(expected=_Expected("ValueError")),
+            unmet=ExpectationNotMetEffect("raise", "assertion-site"),
+        ),
+    )
+    assert len(projected.exits) == 1
+    assert isinstance(projected.exits[0], Halted)
+    assert projected.exits[0].effect is producer_halt.effect
+
+
+def test_swapped_ordering_retains_distinct_ordered_coordinates() -> None:
+    forward_source = "def helper(left, right=2):\n    return left < right\n"
+    swapped_source = "def helper(left, right=2):\n    return right < left\n"
+    forward_function = next(
+        node for node in _tree(forward_source).nodes() if isinstance(node, FunctionDef)
+    )
+    swapped_function = next(
+        node for node in _tree(swapped_source).nodes() if isinstance(node, FunctionDef)
+    )
+    forward = forward_function.sugar().desugar(None)
+    swapped = swapped_function.sugar().desugar(None)
+    assert isinstance(forward, NativeOperationExitCarrierV1)
+    assert isinstance(swapped, NativeOperationExitCarrierV1)
+    assert forward.demand.operand_coordinate_cids == tuple(
+        coordinate.coordinate_cid for coordinate in forward_function.formal_coordinates()
+    )
+    assert swapped.demand.operand_coordinate_cids == tuple(
+        coordinate.coordinate_cid
+        for coordinate in reversed(swapped_function.formal_coordinates())
+    )
+    assert forward.demand.demand_cid != swapped.demand.demand_cid
+
+
+def test_identity_law_never_acquires_a_native_operation_carrier() -> None:
+    source = "def helper(left, right=2):\n    return left is right\n"
+    outcome = next(
+        node for node in _tree(source).nodes() if isinstance(node, FunctionDef)
+    ).sugar().desugar(None)
+    assert isinstance(outcome, Complete)
+    assert not isinstance(outcome, NativeOperationExitCarrierV1)


### PR DESCRIPTION
## What changed

Adds an end-to-end Python lift vertical for the rich-ordering law through `SourceCallFrame.bind_actuals`:

- pins the authenticated pandas 3.0.3 `assert_invalid_comparison` helper at `tests/arithmetic/common.py:89`, its `pytest.raises(TypeError, match=msg)` boundary at line 143, and `left < right` at line 144
- pins a real positional caller at `tests/arithmetic/test_datetime64.py:90`
- proves positional, keyword, and default actual binding discharge the same formal ordering occurrence to a named `TypeError`
- proves a normal actual pair completes, a wrong expected type does not consume the halt, swapped operands retain their own formal-coordinate order, and identity remains non-raising without a carrier

## Assumption and corpus finding

The pinned pandas 3.0.3 corpus contains no ordering-under-`pytest.raises(TypeError, match=...)` helper with a defaulted formal and no keyword invocation of `assert_invalid_comparison`. Therefore the pandas evidence is the real helper and positional caller above; keyword/default are source-level binder-shape twins of that same Python rich-ordering law. This PR does not add a pandas-specific Floor law or claim nonexistent pandas call coordinates.

## Validation

- red-first failures read and corrected for AST join construction and source-owned formal coordinate comparison
- mutation transaction: changing the keyword caller from `None` to `1` made the named-`TypeError` tooth fail; reverted; focused set returned green
- `.venv-py312/bin/python -m pytest implementations/python/sugar-lift-py-tests/tests/test_compare_keyword_default_vertical.py implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py -q` — 57 passed

Runtime: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0. No corpus-wide count or crash/timeout claim is made.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests exercising keyword and default argument binding for rich ordering desugaring
> - Adds a new test module [`test_compare_keyword_default_vertical.py`](https://github.com/TSavo/sugar/pull/6618/files#diff-fe38488cac8559e28970e52cfbaff1e7652a8e61f789570fb3bb1419e9152f5c) with helpers and tests for the `<` operator desugaring path.
> - Verifies that positional, keyword, and default argument bindings all produce the same `TypeError` halt with a shared `occurrence_id` for invalid comparisons, while a valid numeric comparison completes normally.
> - Confirms that swapping operand order produces distinct `demand_cid` values, and that `is` (identity) comparisons do not produce a `NativeOperationExitCarrierV1`.
> - Validates effect boundary behavior: projecting through an `EffectBoundaryDisposition` expecting a different exception type preserves the original `TypeError` effect.
> - Content-pins structure and call-site shape against an authenticated pandas corpus (`assert_invalid_comparison` in `tests/arithmetic/common.py`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 288871d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->