### PR TITLE
Prove BinOp keyword and default caller discharge

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
@@ -4,9 +4,22 @@ from __future__ import annotations
 
 import pytest
 
+from sugar_lift_py_tests.context_manager_contract import (
+    AuthenticatedRaiseMatcher,
+    EffectBoundaryDisposition,
+)
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.effect.expectation_not_met_effect import (
+    ExpectationNotMetEffect,
+)
 from sugar_lift_py_tests.floor import TermValue
-from sugar_lift_py_tests.outcome import ExitSet, Halted, NativeOperationExitCarrierV1
+from sugar_lift_py_tests.ir import ctor, str_const
+from sugar_lift_py_tests.outcome import (
+    Completed,
+    ExitSet,
+    Halted,
+    NativeOperationExitCarrierV1,
+)
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import Call, FunctionDef
 from sugar_source_tree.panic import SugarNotWritten
@@ -31,6 +44,14 @@ def _call_outcome(signature: str, actuals: str):
     return call.sugar().desugar(None)
 
 
+def _call_outcomes(signature: str, *actuals: str):
+    calls = "".join(f"helper({value})\n" for value in actuals)
+    source = f"def helper({signature}):\n    return left + right\n\n{calls}"
+    tree = _tree(source)
+    nodes = tuple(node for node in tree.nodes() if isinstance(node, Call))
+    return tuple(node.sugar().desugar(None) for node in nodes)
+
+
 def _assert_named_halt(outcome) -> None:
     assert isinstance(outcome, ExitSet)
     assert len(outcome.exits) == 1
@@ -50,6 +71,78 @@ def test_keyword_actuals_discharge_through_python_binder() -> None:
 
 def test_default_actual_is_keyed_to_its_formal_coordinate() -> None:
     _assert_named_halt(_call_outcome("left, right=2", "None"))
+
+
+def test_helper_alone_retains_the_undischarged_binary_carrier() -> None:
+    source = "def helper(left, right=2):\n    return left + right\n"
+    function = next(
+        node for node in _tree(source).nodes() if isinstance(node, FunctionDef)
+    )
+    pending = function.sugar().desugar(None)
+
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "add"
+    assert all(pending.demand.operand_coordinate_cids)
+
+
+def test_positional_keyword_and_default_calls_reach_the_same_binary_demand() -> None:
+    positional, keyword, default = _call_outcomes(
+        "left, right=2", "None, 2", "None, right=2", "None"
+    )
+
+    halted = []
+    for outcome in (positional, keyword, default):
+        _assert_named_halt(outcome)
+        halted.append(outcome.exits[0])
+    assert {exit_.effect.exception_type_coordinate for exit_ in halted} == {
+        halted[0].effect.exception_type_coordinate
+    }
+    assert {exit_.effect.occurrence_id for exit_ in halted} == {
+        halted[0].effect.occurrence_id
+    }
+
+
+def test_keyword_and_default_calls_can_complete_from_the_existing_floor() -> None:
+    keyword, default = _call_outcomes("left, right=2", "1, right=2", "1")
+
+    assert all(
+        isinstance(outcome, ExitSet)
+        and len(outcome.exits) == 1
+        and isinstance(outcome.exits[0], Completed)
+        for outcome in (keyword, default)
+    )
+
+
+class _Expected:
+    def __init__(self, name: str):
+        self.identity = ctor(
+            "python:exception_type_identity",
+            [str_const("builtins"), str_const(name)],
+        )
+
+    def exception_type_identity(self):
+        return self.identity
+
+
+def test_wrong_boundary_type_leaves_named_binary_exception_unconsumed() -> None:
+    outcome = _call_outcome("left, right=2", "None")
+    _assert_named_halt(outcome)
+    original = outcome.exits[0]
+
+    routed = outcome.and_exit(
+        ExitSet.completed(object()),
+        disposition=EffectBoundaryDisposition(
+            matcher=AuthenticatedRaiseMatcher(expected=_Expected("ValueError")),
+            unmet=ExpectationNotMetEffect("raise", "assertion-site"),
+        ),
+    )
+
+    assert len(routed.exits) == 1
+    escaped = routed.exits[0]
+    assert isinstance(escaped, Halted)
+    assert escaped.effect.exception_type_coordinate == _Expected("TypeError").identity
+    assert escaped.effect.exception_type_coordinate != _Expected("ValueError").identity
+    assert escaped.effect.occurrence_id == original.effect.occurrence_id
 
 
 def test_wrong_coordinate_actual_cannot_discharge_pending_operation() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
@@ -21,6 +21,7 @@ MANIFEST_CID = (
 )
 HELPER_PATH = "tests/arithmetic/common.py"
 CALLER_PATH = "tests/arithmetic/test_timedelta64.py"
+KEYWORD_CALLER_PATH = "tests/arithmetic/test_datetime64.py"
 
 
 @dataclass(frozen=True)
@@ -121,6 +122,37 @@ def _actuals():
     return tm.box_expected(tdser, pd.array), "a"
 
 
+def _keyword_call(*, caller_source: str | None = None) -> ast.Call:
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.file_count, corpus.manifest_cid) == (
+        "3.0.3",
+        1421,
+        MANIFEST_CID,
+    )
+    source = (
+        (corpus.root / KEYWORD_CALLER_PATH).read_text(encoding="utf-8")
+        if caller_source is None
+        else caller_source
+    )
+    caller = _function(ast.parse(source), "test_dt64arr_addsub_time_objects_raises")
+    calls = tuple(
+        node
+        for node in ast.walk(caller)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "assert_invalid_addsub_type"
+        and any(keyword.arg == "msg" for keyword in node.keywords)
+    )
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.lineno == 1221
+    assert tuple(ast.unparse(arg) for arg in call.args) == ("obj1", "obj2")
+    assert tuple((item.arg, ast.unparse(item.value)) for item in call.keywords) == (
+        ("msg", "msg"),
+    )
+    return call
+
+
 def test_helper_alone_has_only_formals_so_exception_identity_is_undischarged() -> None:
     """The helper occurrence authenticates an operation, never caller actuals."""
     pair = _pair()
@@ -134,6 +166,29 @@ def test_helper_alone_has_only_formals_so_exception_identity_is_undischarged() -
         isinstance(operand, ast.Name)
         for operand in (pair.operation.left, pair.operation.right)
     )
+
+
+def test_real_omitted_and_keyword_helper_call_coordinates_are_pinned() -> None:
+    default_pair = _pair()
+    keyword_call = _keyword_call()
+
+    assert default_pair.call.lineno == 1172
+    assert not default_pair.call.keywords
+    assert keyword_call.lineno == 1221
+    assert keyword_call.keywords[0].arg == "msg"
+
+
+def test_lying_keyword_caller_coordinate_is_rejected() -> None:
+    corpus = authenticated_pandas_corpus()
+    caller = (corpus.root / KEYWORD_CALLER_PATH).read_text(encoding="utf-8")
+    lying = caller.replace(
+        "assert_invalid_addsub_type(obj1, obj2, msg=msg)",
+        "assert_invalid_addsub_type(obj1, obj2, expected=msg)",
+        1,
+    )
+
+    with pytest.raises(AssertionError):
+        _keyword_call(caller_source=lying)
 
 
 def test_runtime_truth_names_the_candidate_exception_without_licensing_floor() -> None:


### PR DESCRIPTION
## Python semantic law made constructible

Python argument binding selects a formal native operation by formal-coordinate identity, not argument position: positional, keyword, and default-bound operands must reach the same BinOp demand. The authenticated operand Floor alone chooses completion or a named exceptional result; an assertion boundary may verify that result but cannot create its exception identity.

## What this proves

- a helper with only formal operands retains `NativeOperationExitCarrierV1`
- positional, keyword, and default calls all reach the same operation occurrence
- `None + 2` projects a named `TypeError` edge through every call spelling
- `1 + 2` projects a completed edge through keyword and default binding
- a `ValueError` boundary leaves the named `TypeError` edge unconsumed and preserves its operation origin
- wrong formal coordinates and swapped operand order remain covered by the carrier teeth

## Authenticated pandas coordinates

Canonical pandas 3.0.3 corpus (`blake3-512:6f317a5a...`, 1,421 files):

- helper BinOp: `tests/arithmetic/common.py:55`
- omitted optional `msg` caller: `tests/arithmetic/test_timedelta64.py:1172`
- keyword `msg=msg` caller: `tests/arithmetic/test_datetime64.py:1221`

The `tm.box_expected` pair remains honestly Undischarged: the existing Floor still cannot authenticate the call result exception type. No pandas-specific Floor law is added.

The corpus also has a defaulted-operand direct helper at `tests/util/test_deprecate_nonkeyword_arguments.py:18-19`, with callers at lines 28, 33, and 38, but its nested BinOp chain exposes a separate carrier-continuation actual-map gap in reserved carrier plumbing. This PR does not hide or widen into that mechanism.

## Verification

Authenticated environment: CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0.

```
.venv-py312/bin/python -m pytest \
  implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py \
  implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py \
  implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py \
  implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py -q
# 127 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prove BinOp keyword and default caller discharge via new test coverage
> - Adds tests in [test_function_formal_native_operation_binding.py](https://github.com/TSavo/sugar/pull/6620/files#diff-5b050a9643e404a48ae60d62e30e55262cb9f48af95fc990d05df91b54b2d5e7) verifying that positional, keyword, and defaulted call forms reach the same named binary demand identity and occurrence, and that keyword/default calls can complete from the existing floor.
> - Adds a `_call_outcomes` helper to reduce boilerplate for generating and desugaring multiple call forms in a single test.
> - Adds a test asserting that a mismatched effect boundary type does not consume a named binary exception and preserves occurrence identity.
> - Adds tests in [test_pandas_binary_caller_twins.py](https://github.com/TSavo/sugar/pull/6620/files#diff-2464628a40be2139d8a6abd5a557571ada8c5fe3e139c3c6b694b71b5ead2c96) that pin coordinates of omitted-arg and keyword-arg call sites in the pandas corpus and reject callers with mismatched keyword names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 236326f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->