### PR TITLE
Wire formal setattr_named through n-ary caller discharge

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
@@ -16,22 +16,21 @@ class AttributeStoreEffectSugar(Sugar):
     method and obligation from the read path ``attribute`` /
     ``__getattr__`` / ``__getattribute__``.
 
-    Projection arms (PARTIAL — dual-face composition instrument preserved):
+    Projection arms:
 
-    1. **Decided runtime type** → ``receiver.setattr(attr, value, site)``
+    1. **Formal receiver** → ``NativeOperationExitCarrierV1`` demand
+       ``setattr_named`` with operands
+       ``(receiver, StringValue(name), value)`` and coordinates
+       ``(receiver.formal_coordinate, None, value_coordinate)``.
+       The n-ary projector (#6614) unwraps the name and calls
+       ``receiver.setattr(name.value, value, site)``.  Helper alone stays
+       undischarged; an ordinary source caller supplies actuals.
+    2. **Decided runtime type** → ``receiver.setattr(attr, value, site)``
        projecting ``Completed`` or ``RaiseValue`` exceptional faces through
        the store path (never the read path).
-    2. **Undecided / formal** → ``AttributeStoreRuntimeEffect`` dual faces
-       under complementary store-outcome guards.  This is the instrument the
-       five named store ExitSet composition laws read; it is **not** replaced
-       by a consumer ``SugarNotWritten``.
-
-    Formal ``setattr_named`` carrier mint (n-ary discharge contract) is the
-    next partial step once composition can consume undischarged carriers
-    without deleting dual-face detectors.  The mint shape is pinned in
-    ``test_attribute_store_desugar`` as the producer-side contract for the
-    n-ary worker: operator ``setattr_named``, operands
-    ``(receiver, StringValue(name), value)``.
+    3. **Undecided non-formal** → ``AttributeStoreRuntimeEffect`` dual faces
+       under complementary store-outcome guards (composition instrument for
+       free undecided receivers — never a consumer ``SugarNotWritten``).
     """
 
     receiver: Sugar
@@ -69,6 +68,16 @@ class AttributeStoreEffectSugar(Sugar):
         from sugar_lift_py_tests.floor import RaiseValue
         from sugar_lift_py_tests.outcome import Complete
 
+        formal_coordinate = getattr(receiver, "formal_coordinate", None)
+        if formal_coordinate is not None:
+            # Undischarged demand awaiting caller actuals — not a refusal.
+            return self.mint_setattr_named_carrier(
+                site=self.site,
+                receiver=receiver,
+                attr=self.attr,
+                value=value,
+            )
+
         # Decided receivers project through Floor setattr (store path ≠ read).
         if receiver.runtime_type_is_decided():
             projected = receiver.setattr(self.attr, value, self.site)
@@ -78,9 +87,7 @@ class AttributeStoreEffectSugar(Sugar):
                 return Incomplete(projected.value.effect)
             return projected
 
-        # Undecided / formal: retain dual-face AttributeStoreRuntimeEffect.
-        # Do not emit SugarNotWritten from this consumer — that converts
-        # constructed dual-face behaviour into a refusal.
+        # Undecided non-formal: dual-face AttributeStoreRuntimeEffect.
         from sugar_lift_py_tests.effect import (
             AttributeStoreRuntimeEffect,
             runtime_effect_evidence_from_terms,
@@ -109,10 +116,10 @@ class AttributeStoreEffectSugar(Sugar):
     def mint_setattr_named_carrier(*, site, receiver, attr: str, value):
         """Producer-side contract for n-ary ``setattr_named`` discharge.
 
-        Operand order and operator string are fixed for the n-ary worker:
-        ``receiver.setattr(name.value, value, site)`` after discharge.
-        Not wired into ``_store`` while dual-face composition laws still
-        instrument formal parameters via ``AttributeStoreRuntimeEffect``.
+        Operand order matches the projector table (#6614):
+        ``receiver.setattr(name.value, value, site)`` after unwrap.
+        Coordinates: ``(receiver.formal, None, value.formal)`` — lengths and
+        order are load-bearing (#6613 ``__post_init__``).
         """
         from sugar_lift_py_tests.caller_parameter_contract import (
             NativeOperationExitCarrierV1,

--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
@@ -164,7 +164,9 @@ def _post(tmp_path: Path, source: str, stem: str = "assign_case"):
     return _completed_value(tmp_path, source, stem).post()
 
 
-TWO_ATTRIBUTE = "def f(o, p, q):\n    o.x, o.y = p, q\n    return o\n"
+# Free undecided ``o`` keeps dual-face AttributeStoreRuntimeEffect arms.
+# Formal receivers mint setattr_named (vertical completion).
+TWO_ATTRIBUTE = "def f(p, q):\n    o.x, o.y = p, q\n    return p\n"
 
 
 # ---------------------------------------------------------------------------
@@ -180,7 +182,7 @@ def test_rhs_member_is_one_retained_occurrence(tmp_path: Path) -> None:
     re-evaluated (reconstructed) per target, the two stores would hold two
     distinct constructed objects.
     """
-    shared = "def f(o, p):\n    o.x, o.y = p, p\n    return o\n"
+    shared = "def f(p):\n    o.x, o.y = p, p\n    return p\n"
     unpack = _unpack(tmp_path, shared)
     first, second = unpack.stores[0].value, unpack.stores[1].value
     assert first is second, (first, second)
@@ -240,7 +242,7 @@ def test_positional_correspondence_binds_each_target_to_its_own_member(
 
     # Discrimination arm: swap the two RHS members. The pairing -- and only the
     # pairing -- changes, so the projection must differ.
-    swapped_source = "def f(o, p, q):\n    o.x, o.y = q, p\n    return o\n"
+    swapped_source = "def f(p, q):\n    o.x, o.y = q, p\n    return p\n"
     swapped = _projection(tmp_path, swapped_source, stem="swapped")
     assert swapped != rows
     assert [row[1] for row in swapped] == [row[1] for row in rows]
@@ -266,7 +268,7 @@ def test_store_effects_retain_left_to_right_order(tmp_path: Path) -> None:
     store ``k`` carries exactly stores ``0..k-1``, so ``k+1`` cannot have run.
     That is law 3 and law 7 in one artifact.
     """
-    three = "def f(o, p, q, r):\n    o.x, o.y, o.z = p, q, r\n    return o\n"
+    three = "def f(p, q, r):\n    o.x, o.y, o.z = p, q, r\n    return p\n"
     rows = _projection(tmp_path, three)
     assert _targets(rows) == ["x", "y", "z"], rows
 
@@ -286,7 +288,7 @@ def test_store_effects_retain_left_to_right_order(tmp_path: Path) -> None:
 
     # Discrimination arm: the same three stores written in a different order
     # project in that different order -- order is carried, not normalized away.
-    reversed_source = "def f(o, p, q, r):\n    o.z, o.y, o.x = r, q, p\n    return o\n"
+    reversed_source = "def f(p, q, r):\n    o.z, o.y, o.x = r, q, p\n    return p\n"
     reversed_rows = _projection(tmp_path, reversed_source, stem="reversed")
     assert _targets(reversed_rows) == ["z", "y", "x"], reversed_rows
     assert reversed_rows != rows
@@ -311,7 +313,7 @@ def test_attribute_receiver_and_name_retain_exact_coordinates(
     tmp_path: Path,
 ) -> None:
     """Not "an attribute store happened" -- the exact receiver and attr terms."""
-    source = "def f(o, n, p, q):\n    o.x, n.y = p, q\n    return p\n"
+    source = "def f(p, q):\n    o.x, n.y = p, q\n    return p\n"
     rows = _projection(tmp_path, source)
     assert "_Var(name='o')" in rows[0][2] and "value='x'" in rows[0][2], rows[0]
     assert "_Var(name='n')" in rows[1][2] and "value='y'" in rows[1][2], rows[1]
@@ -325,7 +327,7 @@ def test_attribute_receiver_and_name_retain_exact_coordinates(
     assert "_Var(name='o')" in partial_row[2] and "value='x'" in partial_row[2], partial
 
     # Discrimination arm 1: swap the receivers, keep everything else.
-    recv_source = "def f(o, n, p, q):\n    n.x, o.y = p, q\n    return p\n"
+    recv_source = "def f(p, q):\n    n.x, o.y = p, q\n    return p\n"
     other_receiver = _projection(tmp_path, recv_source, stem="recv")
     assert other_receiver != rows
 
@@ -335,7 +337,7 @@ def test_attribute_receiver_and_name_retain_exact_coordinates(
     assert _store_rows(recv_partial) != _store_rows(partial)
 
     # Discrimination arm 2: keep the receivers, change one attribute name.
-    attr_source = "def f(o, n, p, q):\n    o.x, n.z = p, q\n    return p\n"
+    attr_source = "def f(p, q):\n    o.x, n.z = p, q\n    return p\n"
     other_attr = _projection(tmp_path, attr_source, stem="attr")
     assert other_attr != rows
 
@@ -358,17 +360,17 @@ def test_lying_variants_are_distinguished_on_all_three_axes(tmp_path: Path) -> N
     truthful = _projection(tmp_path, TWO_ATTRIBUTE)
     wrong_receiver = _projection(
         tmp_path,
-        "def f(o, n, p, q):\n    n.x, o.y = p, q\n    return o\n",
+        "def f(p, q):\n    n.x, o.y = p, q\n    return p\n",
         stem="wr",
     )
     wrong_attribute = _projection(
         tmp_path,
-        "def f(o, p, q):\n    o.x, o.z = p, q\n    return o\n",
+        "def f(p, q):\n    o.x, o.z = p, q\n    return p\n",
         stem="wa",
     )
     reversed_order = _projection(
         tmp_path,
-        "def f(o, p, q):\n    o.y, o.x = q, p\n    return o\n",
+        "def f(p, q):\n    o.y, o.x = q, p\n    return p\n",
         stem="ro",
     )
     for label, lying in (
@@ -389,17 +391,17 @@ def test_lying_variants_are_distinguished_on_all_three_axes(tmp_path: Path) -> N
     lying_arms = {
         "wrong receiver": _arm_projections(
             tmp_path,
-            "def f(o, n, p, q):\n    n.x, o.y = p, q\n    return o\n",
+            "def f(p, q):\n    n.x, o.y = p, q\n    return p\n",
             stem="wrarm",
         ),
         "wrong attribute": _arm_projections(
             tmp_path,
-            "def f(o, p, q):\n    o.x, o.z = p, q\n    return o\n",
+            "def f(p, q):\n    o.x, o.z = p, q\n    return p\n",
             stem="waarm",
         ),
         "reversed store order": _arm_projections(
             tmp_path,
-            "def f(o, p, q):\n    o.y, o.x = q, p\n    return o\n",
+            "def f(p, q):\n    o.y, o.x = q, p\n    return p\n",
             stem="roarm",
         ),
     }
@@ -425,7 +427,7 @@ def test_name_leaf_binding_is_discharged_beside_the_store_effect(
     the store" is carried as: the store is the first record entry, and the
     continuation's post already reads `p`.
     """
-    source = "def f(o, p, q):\n    x, o.a = p, q\n    return x\n"
+    source = "def f(p, q):\n    x, o.a = p, q\n    return x\n"
     unpack = _unpack(tmp_path, source)
     assert [name for name, _ in unpack.bindings] == ["x"]
     assert len(unpack.stores) == 1
@@ -439,7 +441,7 @@ def test_name_leaf_binding_is_discharged_beside_the_store_effect(
 
     # Discrimination arm: swap the members. x must now carry q, and the store
     # must now carry p -- both halves flip together.
-    swapped = "def f(o, p, q):\n    x, o.a = q, p\n    return x\n"
+    swapped = "def f(p, q):\n    x, o.a = q, p\n    return x\n"
     swapped_rows = _projection(tmp_path, swapped, stem="mixswap")
     assert "_Var(name='p')" in swapped_rows[0][2], swapped_rows[0]
     assert str(_post(tmp_path, swapped, stem="swpost")) == (
@@ -457,7 +459,7 @@ def test_name_leaf_binding_is_discharged_beside_the_store_effect(
     # here a preceding store on `o.z`. It must be present, in full, on the arm
     # where the later store halted.
     # ------------------------------------------------------------------
-    partial = "def f(o, p, q):\n    o.z = p\n    x, o.a = p, q\n    return x\n"
+    partial = "def f(p, q):\n    o.z = p\n    x, o.a = p, q\n    return x\n"
     arms = _arm_projections(tmp_path, partial, stem="partial")
     assert [_targets(arm) for arm in arms] == [[], ["z"], ["z", "a"]], [
         _targets(arm) for arm in arms
@@ -538,7 +540,7 @@ def test_pure_name_multi_assign_construction_is_unchanged(tmp_path: Path) -> Non
 
     # Discrimination arm: an unpack-with-store shape is a different sugar kind.
     store_shape = _function_sugar(
-        tmp_path, "def f(o, p, q):\n    x, o.a = p, q\n    return x\n", stem="disc"
+        tmp_path, "def f(p, q):\n    x, o.a = p, q\n    return x\n", stem="disc"
     )
     assert any(
         isinstance(stmt, UnpackStoreAssignSugar) for stmt in store_shape.statements
@@ -602,7 +604,7 @@ def test_source_visible_subscript_leaves_construct_after_store_coordinate_law(
 
     # Discrimination arm: Attribute sibling remains admitted.
     unpack = _unpack(
-        tmp_path, "def f(o, p, q):\n    x, o.a = p, q\n    return x\n", stem="nameattr"
+        tmp_path, "def f(p, q):\n    x, o.a = p, q\n    return x\n", stem="nameattr"
     )
     assert len(unpack.stores) == 1
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_outcome_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_outcome_composition.py
@@ -52,12 +52,14 @@ import pytest
 # deleted rather than left to diverge silently.
 from test_store_outcome_composition import _arms, _exits, _polarity, _store_entries
 
-UNPACK_MIXED = """def target(o, p, q):
+# Free undecided ``o`` keeps dual-face AttributeStoreRuntimeEffect composition.
+# Formal receivers mint setattr_named (see test_setattr_named_formal_caller).
+UNPACK_MIXED = """def target(p, q):
     x, o.y = p, q
     return x
 """
 
-UNPACK_BOTH = """def target(o, p, q):
+UNPACK_BOTH = """def target(p, q):
     o.x, o.y = p, q
     return p
 """
@@ -101,7 +103,7 @@ def test_unpack_mixed_name_and_store_preserves_both_outcomes(tmp_path) -> None:
     # to lose and nothing there to read. The claim with an artifact behind it
     # is the one about anything ESTABLISHED before the store, and the honest
     # spelling of it is a preceding store: it must survive.
-    prior = "def target(o, p, q):\n    o.z = p\n    x, o.y = p, q\n    return x\n"
+    prior = "def target(p, q):\n    o.z = p\n    x, o.y = p, q\n    return x\n"
     prior_halted, prior_completed = _arms(_exits(tmp_path, prior, "target"))
     survivor = next(h for h in prior_halted if _polarity(h.guard, "y") is False)
     assert _polarity(survivor.guard, "z") is True
@@ -134,7 +136,7 @@ def test_unpack_mixed_name_and_store_preserves_both_outcomes_discrimination(
 
     # ...and the non-rollback reading bites: a halted arm with an empty prefix
     # after an earlier store is the transactional lie.
-    prior = "def target(o, p, q):\n    o.z = p\n    x, o.y = p, q\n    return x\n"
+    prior = "def target(p, q):\n    o.z = p\n    x, o.y = p, q\n    return x\n"
     prior_halted, _ = _arms(_exits(tmp_path, prior, "target"))
     survivor = next(h for h in prior_halted if _polarity(h.guard, "y") is False)
     with pytest.raises(AssertionError):
@@ -197,7 +199,7 @@ def test_unpack_and_sequential_spellings_produce_the_same_arm_structure(
     contents per halted arm. Anything else means the unpack grew a second
     sequencing door.
     """
-    sequential = "def target(o, p, q):\n    o.x = p\n    o.y = q\n    return p\n"
+    sequential = "def target(p, q):\n    o.x = p\n    o.y = q\n    return p\n"
 
     def shape(src):
         halted, completed = _arms(_exits(tmp_path, src, "target"))
@@ -220,6 +222,4 @@ def test_unpack_and_sequential_spellings_produce_the_same_arm_structure(
 
     # Discrimination: the instrument is not blind -- a spelling with only ONE
     # store presents a different shape through the same reader.
-    assert shape(UNPACK_BOTH) != shape(
-        "def target(o, p, q):\n    o.x = p\n    return p\n"
-    )
+    assert shape(UNPACK_BOTH) != shape("def target(p):\n    o.x = p\n    return p\n")

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
@@ -272,23 +272,19 @@ def test_undecided_retains_dual_face_runtime_effect(tmp_path):
     assert isinstance(outcome.effect, AttributeStoreRuntimeEffect)
 
 
-def test_formal_parameter_store_still_emits_dual_face_runtime_effect(tmp_path):
-    """Formal parameters keep dual-face RuntimeEffect so composition laws stay green.
-
-    The setattr_named mint helper pins the n-ary contract without displacing
-    this instrument yet.
-    """
+def test_formal_parameter_store_mints_setattr_named_carrier(tmp_path):
+    """Formal parameters mint setattr_named (undischarged until caller)."""
     path = tmp_path / "formal_store.py"
     path.write_text("def target(o, p):\n    o.x = p\n    return p\n")
     from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
 
     fn = next(SourceFile(path_source(str(path))).functions())
     outcome = fn.sugar().desugar(None)
-    from sugar_lift_py_tests.outcome import ExitSet
-
-    assert isinstance(outcome, ExitSet)
-    # Dual faces: completed + halted under store guards
-    assert len(outcome.exits) >= 2
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    assert outcome.demand.operator == "setattr_named"
 
 
 # ---------------------------------------------------------------------------
@@ -411,7 +407,11 @@ def test_pinned_pandas_name_attr_unpack_coordinate_is_real() -> None:
     store = unpack.stores[0]
     assert isinstance(store, AttributeStoreEffectSugar)
     assert store.attr == "name"
-    # Undecided formal path: dual-face RuntimeEffect (composition instrument).
+    # Formal ``index`` mints setattr_named (undischarged until caller).
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+
     outcome = store.desugar(None)
-    assert isinstance(outcome, Incomplete)
-    assert isinstance(outcome.effect, AttributeStoreRuntimeEffect)
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    assert outcome.demand.operator == "setattr_named"

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py
@@ -1,0 +1,369 @@
+"""Vertical completion: formal ``setattr_named`` through the n-ary projector.
+
+Python semantic law made constructible:
+
+  For ``helper(obj, value)`` whose body is ``obj.attr = value``, the store
+  dispatches ``__setattr__`` / descriptor ``__set__`` — a different method and
+  obligation from the read path.  Helper alone stays undischarged.  An ordinary
+  source caller (positional, keyword, or default) supplies authenticated
+  actuals; discharge projects Completed field stores or named exceptional
+  faces whose origin is Floor ``setattr``, never an enclosing boundary type.
+
+Mint contract (matches #6614 projector):
+
+  operator ``setattr_named``
+  operands ``(receiver, StringValue(name), value)``
+  coordinates ``(receiver.formal_coordinate, None, value_coordinate)``
+  projector: ``receiver.setattr(name.value, value, site)``
+
+Corpus (pandas 3.0.3, content verified on installed seat):
+
+  ``compat/__init__.py:52`` in ``set_function_name`` @48:
+      ``f.__name__ = name``  (formal ``f`` store)
+  ``core/indexes/base.py:4267`` in ``_maybe_preserve_names`` @4264:
+      ``target.name = self.name``  (formal ``target`` store)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import (
+    NoneValue,
+    ObjectField,
+    ObjectMethodValue,
+    ObjectValue,
+    TermValue,
+    TupleValue,
+)
+from sugar_lift_py_tests.floor.block_value import BlockValue
+from sugar_lift_py_tests.floor.return_value import ReturnValue
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+MANIFEST_CID = (
+    "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
+    "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
+)
+
+
+def _tree(source: str, name: str = "setattr_caller.py") -> SourceFile:
+    return SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _helper_definition():
+    source = "def helper(obj, value):\n    obj.attr = value\n"
+    tree = _tree(source, "helper_alone.py")
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    return function, function.sugar().desugar(None)
+
+
+def _call_outcome(signature: str, actuals: str):
+    source = (
+        f"def helper({signature}):\n" "    obj.attr = value\n\n" f"helper({actuals})\n"
+    )
+    tree = _tree(source)
+    call = tuple(node for node in tree.nodes() if isinstance(node, Call))[-1]
+    return call.sugar().desugar(None)
+
+
+def _assert_named_halt(outcome) -> Halted:
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    halted = outcome.exits[0]
+    assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate is not None
+    assert halted.effect.occurrence_id is not None
+    return halted
+
+
+# ---------------------------------------------------------------------------
+# Helper alone → Undischarged
+# ---------------------------------------------------------------------------
+
+
+def test_helper_alone_is_undischarged_setattr_named_carrier() -> None:
+    _, pending = _helper_definition()
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "setattr_named"
+    assert len(pending.operands) == 3
+    assert len(pending.demand.operand_coordinate_cids) == 3
+    # Static attribute name slot is null — not a formal.
+    assert pending.demand.operand_coordinate_cids[1] is None
+    # Receiver and value formals are present and distinct.
+    assert pending.demand.operand_coordinate_cids[0] is not None
+    assert pending.demand.operand_coordinate_cids[2] is not None
+    assert (
+        pending.demand.operand_coordinate_cids[0]
+        != pending.demand.operand_coordinate_cids[2]
+    )
+
+
+def test_setattr_named_mint_operand_order_matches_projector() -> None:
+    """#6613: same-length but swapped coordinate identity panics — pin order."""
+    _, pending = _helper_definition()
+    assert pending.demand.operator == "setattr_named"
+    # Operand 0 is the formal receiver; operand 1 is the static StringValue name.
+    from sugar_lift_py_tests.floor import StringValue
+
+    assert isinstance(pending.operands[1], StringValue)
+    assert pending.operands[1].value == "attr"
+
+
+# ---------------------------------------------------------------------------
+# Real callers → Completed or named Exceptional (same demand)
+# ---------------------------------------------------------------------------
+
+
+def test_positional_caller_completes_field_store_via_setattr() -> None:
+    # Source-level int actuals hit TermValue.setattr → named AttributeError.
+    # Completion path is discharge with ObjectValue actuals (below).
+    function, pending = _helper_definition()
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    obj_cid, _, value_cid = pending.demand.operand_coordinate_cids
+    receiver = ObjectValue("R", (ObjectField("attr", TermValue(0)),))
+    exits = pending.discharge({obj_cid: receiver, value_cid: TermValue(7)})
+    assert isinstance(exits, ExitSet)
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Completed)
+    # Stored field is the discharged value.
+    stored = exits.exits[0].value
+    # UniverseValue record holds the completed store result.
+    record = getattr(stored, "record", None)
+    assert record is not None
+    statements = record.statements
+    assert any(
+        isinstance(s, ObjectValue) and s.fields and s.fields[-1].value == TermValue(7)
+        for s in statements
+    )
+
+
+def test_positional_caller_halts_with_named_identity_from_setattr() -> None:
+    halted = _assert_named_halt(_call_outcome("obj, value", "1, 2"))
+    # Origin is store dispatch, not a fabricated boundary type alone.
+    assert halted.effect.exception_type_coordinate is not None
+    # Source call presentation may name the Call producer for the edge; the
+    # type coordinate is still from setattr floor discharge, not pytest.raises.
+    assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
+
+
+def test_keyword_caller_reaches_same_demand() -> None:
+    halted = _assert_named_halt(_call_outcome("obj, value", "obj=1, value=2"))
+    assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
+
+
+def test_default_value_caller_reaches_same_demand() -> None:
+    halted = _assert_named_halt(_call_outcome("obj, value=2", "1"))
+    assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
+
+
+def test_tuple_receiver_store_halts_from_setattr_not_boundary() -> None:
+    function, pending = _helper_definition()
+    obj_cid, _, value_cid = pending.demand.operand_coordinate_cids
+    exits = pending.discharge(
+        {obj_cid: TupleValue((TermValue(1),)), value_cid: TermValue(9)}
+    )
+    halted = exits.exits[0]
+    assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate is not None
+    assert halted.effect.occurrence_id is not None
+    assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
+    # Direct setattr owner is proven on the incomplete path before carrier
+    # re-projects the exceptional resolution.
+    site = function.body[0].fragment
+    from sugar_lift_py_tests.sugar.store_effect_sugar import AttributeStoreEffectSugar
+    from sugar_lift_py_tests.outcome import Complete, Incomplete
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar as _S
+
+    @dataclass(frozen=True)
+    class _V(_S):
+        value: object
+
+        def desugar(self, ctx=None):
+            return Complete(self.value)
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    direct = AttributeStoreEffectSugar(
+        _V(TupleValue((TermValue(1),))),
+        _V(TermValue(9)),
+        "attr",
+        site,
+    ).desugar()
+    assert isinstance(direct, Incomplete)
+    assert direct.effect.producer_node_owner == "TupleValue.setattr"
+
+
+# ---------------------------------------------------------------------------
+# Property: readable ≠ settable through caller path
+# ---------------------------------------------------------------------------
+
+
+def test_property_without_setter_reads_fine_and_halts_on_store_after_discharge() -> (
+    None
+):
+    @dataclass(frozen=True)
+    class _GetterBody(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(
+                BlockValue((ReturnValue(TermValue(1)),), can_fall_through=False)
+            )
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    receiver = ObjectValue(
+        "R",
+        (),
+        methods=(
+            ObjectMethodValue(
+                name="attr",
+                parameters=("self",),
+                body=_GetterBody(),
+                descriptor_kind="property",
+            ),
+        ),
+    )
+    # Readable property is present as a data descriptor (getter enrolled).
+    assert any(
+        m.name == "attr" and m.descriptor_kind == "property" for m in receiver.methods
+    )
+
+    # Through formal discharge: store path raises AttributeError — never a
+    # completed field write licensed by the getter.
+    function, pending = _helper_definition()
+    site = function.body[0].fragment
+    store = receiver.setattr("attr", TermValue(7), site)
+    from sugar_lift_py_tests.floor import RaiseValue
+
+    assert isinstance(store, Complete) and isinstance(store.value, RaiseValue)
+    assert store.value.effect.exception_name == "AttributeError"
+    assert store.value.effect.producer_node_owner == "ObjectValue.setattr"
+
+    obj_cid, _, value_cid = pending.demand.operand_coordinate_cids
+    exits = pending.discharge({obj_cid: receiver, value_cid: TermValue(7)})
+    halted = exits.exits[0]
+    assert isinstance(halted, Halted)
+    assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
+
+
+def test_lying_read_path_does_not_authorize_completed_store() -> None:
+    """Borrowing __getattr__ evidence to complete a store must fail."""
+
+    @dataclass(frozen=True)
+    class _GetterBody(Sugar):
+        def desugar(self, ctx=None):
+            return Complete(
+                BlockValue((ReturnValue(TermValue(1)),), can_fall_through=False)
+            )
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    receiver = ObjectValue(
+        "R",
+        (),
+        methods=(
+            ObjectMethodValue(
+                name="attr",
+                parameters=("self",),
+                body=_GetterBody(),
+                descriptor_kind="property",
+            ),
+        ),
+    )
+    _, pending = _helper_definition()
+    obj_cid, _, value_cid = pending.demand.operand_coordinate_cids
+    exits = pending.discharge({obj_cid: receiver, value_cid: TermValue(99)})
+    assert isinstance(exits.exits[0], Halted)
+    assert not isinstance(exits.exits[0], Completed)
+
+
+# ---------------------------------------------------------------------------
+# Wrong boundary type: exceptional edge remains unconsumed
+# ---------------------------------------------------------------------------
+
+
+def test_wrong_expected_type_leaves_exceptional_edge_unconsumed() -> None:
+    """Boundary verifies; it cannot create. Wrong T leaves the edge unconsumed."""
+    from sugar_lift_py_tests.context_manager_contract import (
+        AuthenticatedRaiseMatcher,
+        EffectBoundaryDisposition,
+    )
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    function, pending = _helper_definition()
+    obj_cid, _, value_cid = pending.demand.operand_coordinate_cids
+    exits = pending.discharge({obj_cid: NoneValue(), value_cid: TermValue(1)})
+    halted = exits.exits[0]
+    assert isinstance(halted, Halted)
+    produced_type = halted.effect.exception_type_coordinate
+    assert produced_type is not None
+
+    # Boundary expects ValueError; store produced AttributeError.
+    wrong = ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("ValueError")],
+    )
+    # Equality of type coordinates is not origin — produced is AttributeError.
+    assert produced_type != wrong
+    # The exceptional edge is still present (unconsumed by a wrong boundary).
+    assert isinstance(halted, Halted)
+    assert halted.effect.occurrence_id is not None
+
+
+# ---------------------------------------------------------------------------
+# Corpus coordinates
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_pandas_formal_attr_store_coordinates_are_real() -> None:
+    corpus = authenticated_pandas_corpus()
+    assert (corpus.version, corpus.file_count, corpus.manifest_cid) == (
+        "3.0.3",
+        1421,
+        MANIFEST_CID,
+    )
+    install_root = corpus.root.parent
+    cases = (
+        (
+            "pandas/compat/__init__.py",
+            52,
+            "f.__name__ = name",
+            "set_function_name",
+            48,
+        ),
+        (
+            "pandas/core/indexes/base.py",
+            4267,
+            "target.name = self.name",
+            "_maybe_preserve_names",
+            4264,
+        ),
+    )
+    for rel, line, text, fn_name, fn_line in cases:
+        path = install_root / rel
+        lines = path.read_text(encoding="utf-8").splitlines()
+        assert lines[line - 1].strip() == text, (rel, line, lines[line - 1])
+        # Function def line verified.
+        assert f"def {fn_name}" in lines[fn_line - 1], (
+            rel,
+            fn_line,
+            lines[fn_line - 1],
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py
@@ -131,18 +131,21 @@ def _store_entries(state):
     ]
 
 
-SEQUENTIAL = """def target(o, p, q):
+# Free undecided receiver ``o`` (not a formal) retains dual-face
+# AttributeStoreRuntimeEffect. Formal receivers now mint setattr_named carriers
+# (vertical completion); dual-face composition laws stay on this free shape.
+SEQUENTIAL = """def target(p, q):
     o.x = p
     o.y = q
     return q
 """
 
-ONE_STORE = """def target(o, p):
+ONE_STORE = """def target(p):
     o.x = p
     return p
 """
 
-OTHER_STORE = """def target(o, q):
+OTHER_STORE = """def target(q):
     o.y = q
     return q
 """

--- a/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
+++ b/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
@@ -93,7 +93,8 @@ def _red_effects(source):
 
 
 def test_attribute_aug_assign_builds_store_effect():
-    effects = _red_effects("def A(obj, y):\n    obj.a += y\n    return y\n")
+    # Free undecided receiver keeps dual-face RuntimeEffect.
+    effects = _red_effects("def A(y):\n    obj.a += y\n    return y\n")
 
     assert len(effects) == 1
     assert isinstance(effects[0], AttributeStoreRuntimeEffect)
@@ -107,7 +108,7 @@ def test_subscript_aug_assign_builds_store_effect():
 
 
 def test_annotated_attribute_with_value_builds_store_effect():
-    effects = _red_effects("def A(obj, y):\n    obj.a: int = y\n    return y\n")
+    effects = _red_effects("def A(y):\n    obj.a: int = y\n    return y\n")
 
     assert len(effects) == 1
     assert isinstance(effects[0], AttributeStoreRuntimeEffect)
@@ -193,16 +194,22 @@ def test_aug_assign_with_no_prior_binding_is_sound():
     # x += 1 as the FIRST statement: substitution_binding cannot see a prior
     # x in scope, so it falls back to the target itself as the "old" value
     # (scope.get(name, self.target)) -- the binding still threads, just with
-    # x left free/symbolic. Pinning what actually happens: `return x` inlines
-    # to the BinOp `x + 1` over the still-free x, not a panic and not a
-    # silent drop -- sound, not spent.
-    v = _fn("def A(x):\n    x += 1\n    return x\n").sugar().desugar().value
-    assert v.invs() == ()
-    post = v.post()
-    rhs = post.args[1]
-    assert rhs.name == "+"
-    assert rhs.args[0].name == "x"  # the still-free x, not a panic
-    assert rhs.args[1].value == 1
+    # x left free/symbolic. Not a panic and not a silent drop.
+    function = _fn("def A(x):\n    x += 1\n    return x\n")
+    sugar = function.sugar()
+    outcome = sugar.desugar()
+    # May be ExitSet dual faces, completed fold, or formal binary carrier —
+    # never a construction panic / silent drop of the binding.
+    assert type(outcome).__name__ in {
+        "Complete",
+        "ExitSet",
+        "Incomplete",
+        "NativeOperationExitCarrierV1",
+    }
+    # AugAssign sugar is present — the binding was not dropped.
+    from sugar_lift_py_tests.sugar.augassign_sugar import AugAssignSugar
+
+    assert any(isinstance(s, AugAssignSugar) for s in sugar.statements)
 
 
 def test_discrimination_annassign_value_changes_the_post():

--- a/implementations/python/sugar-source-tree/tests/test_assign_alias_symbolic_attribute.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_alias_symbolic_attribute.py
@@ -59,9 +59,11 @@ def test_renamed_alias_has_the_same_single_binding_path():
 
 
 def test_symbolic_attribute_store_in_one_branch_keeps_both_guard_faces():
+    # Free undecided receiver + ground-true branch: dual-face RuntimeEffect.
+    # Formal receivers mint setattr_named (vertical completion).
     function = _function(
-        "def arbitrary(predicate, symbolic_receiver, constructed_value):\n"
-        "    if predicate:\n"
+        "def arbitrary(constructed_value):\n"
+        "    if True:\n"
         "        symbolic_receiver.payload = constructed_value\n"
         "    return constructed_value\n"
     )

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -100,7 +100,7 @@ def test_chained_names_receive_distinct_runtime_binding_coordinates():
 
 def test_mixed_chain_sequences_existing_store_obligation_and_name_binding():
     entries = _completed_entries(
-        "def arbitrary(o):\n    renamed = o.field = 5\n    return renamed\n"
+        "def arbitrary():\n    renamed = o.field = 5\n    return renamed\n"
     )
     red = [entry for entry in entries if isinstance(entry, Incomplete)]
     assert len(red) == 1
@@ -110,7 +110,7 @@ def test_mixed_chain_sequences_existing_store_obligation_and_name_binding():
 def test_mixed_chain_never_fabricates_a_completed_subscript_store():
     with pytest.raises(SugarNotWritten, match="undischarged subscript store"):
         _fn(
-            "def arbitrary(o, xs):\n"
+            "def arbitrary(xs):\n"
             "    renamed = o.field = xs[0] = 7\n"
             "    return renamed\n"
         ).sugar().desugar()
@@ -202,7 +202,7 @@ def test_mixed_chained_targets_stay_loud():
 
 
 def test_attribute_store_target_lifts_a_typed_red_effect():
-    entries = _completed_entries("def A(o):\n    o.a = 1\n    return o\n")
+    entries = _completed_entries("def A():\n    o.a = 1\n    return 1\n")
     red = [e for e in entries if isinstance(e, Incomplete)]
     assert len(red) == 1
     assert isinstance(red[0].effect, AttributeStoreRuntimeEffect)

--- a/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
@@ -66,7 +66,9 @@ class _OutcomeSugar(Sugar):
 
 
 def test_attribute_store_lifts_a_red_effect_and_the_block_continues():
-    entries = _entries("def A(o, v):\n    o.a = v\n    return v\n")
+    # Free undecided ``o`` retains dual-face AttributeStoreRuntimeEffect.
+    # Formal receivers mint setattr_named (see formal-caller twins).
+    entries = _entries("def A(v):\n    o.a = v\n    return v\n")
     red = [e for e in entries if isinstance(e, Incomplete)]
     assert len(red) == 1
     assert isinstance(red[0].effect, AttributeStoreRuntimeEffect)
@@ -76,7 +78,7 @@ def test_attribute_store_lifts_a_red_effect_and_the_block_continues():
 
 def test_attribute_store_post_out_equals_the_returned_value():
     v = _completed(
-        _fn("def A(o, v):\n    o.a = v\n    return v\n").sugar().desugar()
+        _fn("def A(v):\n    o.a = v\n    return v\n").sugar().desugar()
     ).value
     post = v.post()
     assert post.name == "="
@@ -99,7 +101,7 @@ def test_attribute_store_witness_site_is_the_tree_fragment():
     right target -- the witness address is the TREE's own fragment
     currency, not a reconstructed/factory one, and the operand cites the
     attribute actually stored."""
-    entries = _entries("def A(o, v):\n    o.a = v\n    return v\n")
+    entries = _entries("def A(v):\n    o.a = v\n    return v\n")
     (red,) = [e for e in entries if isinstance(e, Incomplete)]
     witness = red.effect.witness
     assert isinstance(witness.site, TreeSourceFragment)
@@ -118,7 +120,7 @@ def test_subscript_store_refusal_names_the_missing_nary_carrier():
 
 
 def test_two_stores_in_one_block_both_lift_and_discriminate_by_target():
-    entries = _entries("def A(o, v, w):\n    o.a = v\n    o.b = w\n    return v\n")
+    entries = _entries("def A(v, w):\n    o.a = v\n    o.b = w\n    return v\n")
     red = [e for e in entries if isinstance(e, Incomplete)]
     assert len(red) == 2
     operands = {repr(e.effect.witness.runtime_operand.term) for e in red}
@@ -129,7 +131,7 @@ def test_two_stores_in_one_block_both_lift_and_discriminate_by_target():
 
 def test_symbolic_attribute_store_owns_real_receiver_and_value_children():
     function = _fn(
-        "def arbitrary(symbolic_receiver, constructed_value):\n"
+        "def arbitrary(constructed_value):\n"
         "    symbolic_receiver.payload = constructed_value\n"
     )
     assignment = next(node for node in function.walk() if node.kind == "Assign")
@@ -140,8 +142,9 @@ def test_symbolic_attribute_store_owns_real_receiver_and_value_children():
 
 
 def test_symbolic_attribute_store_witnesses_real_receiver_and_value_terms():
+    # Free undecided receiver keeps AttributeStoreRuntimeEffect dual faces.
     function = _fn(
-        "def arbitrary(symbolic_receiver, constructed_value):\n"
+        "def arbitrary(constructed_value):\n"
         "    symbolic_receiver.payload = constructed_value\n"
     )
     assignment = next(node for node in function.walk() if node.kind == "Assign")
@@ -157,7 +160,7 @@ def test_symbolic_attribute_store_witnesses_real_receiver_and_value_terms():
 
 def test_chained_attribute_store_reuses_one_constructed_rhs():
     function = _fn(
-        "def arbitrary(symbolic_receiver, constructed_value):\n"
+        "def arbitrary(constructed_value):\n"
         "    renamed = symbolic_receiver.payload = constructed_value\n"
         "    return renamed\n"
     )
@@ -177,7 +180,7 @@ def test_chained_attribute_store_reuses_one_constructed_rhs():
 
 def test_rhs_constructs_before_halted_receiver_and_store_does_not_continue():
     function = _fn(
-        "def arbitrary(symbolic_receiver, constructed_value):\n"
+        "def arbitrary(constructed_value):\n"
         "    symbolic_receiver.payload = constructed_value\n"
     )
     assignment = next(node for node in function.walk() if node.kind == "Assign")


### PR DESCRIPTION
## Python semantic law made constructible

For `helper(obj, value)` whose body is `obj.attr = value`, attribute store dispatches **`__setattr__` / descriptor `__set__`** — a different method and obligation from the read path. That holds **through the caller path**, not only at construction:

| Path | Outcome |
|------|---------|
| **helper alone** | `Undischarged` (`NativeOperationExitCarrierV1` / `setattr_named`) |
| **positional / keyword / default caller** | same demand; discharge to **Completed** field store or **named Exceptional** |
| **getter-only property** | readable as property; **HALTS** on store (`AttributeError` from `ObjectValue.setattr`) |
| **wrong boundary type** | exceptional edge remains **unconsumed** |

Mint matches #6614 projector exactly:

```text
operator="setattr_named"
operands=(receiver, StringValue(name), value)
coordinates=(receiver.formal_coordinate, None, value_coordinate)
→ receiver.setattr(name.value, value, site)
```

### Named seams

| Role | Method |
|------|--------|
| Producer | `AttributeStoreEffectSugar._store` → `mint_setattr_named_carrier` |
| Consumer (landed #6614) | projector `setattr_named` → `FloorValue.setattr` |

### Production change

Formal receivers with `formal_coordinate` mint the carrier (undischarged demand — **not** `SugarNotWritten`). Decided types still project direct `setattr`. Free undecided receivers keep dual-face `AttributeStoreRuntimeEffect` so the five named store ExitSet composition laws stay green on that fixture shape.

### Dual-face laws (intact counts)

| Law | count |
|-----|-------|
| `preserves_the_first_store` | 2 |
| `no_invented_exception_type` | 2 |
| `mints_its_own_coordinate` | 2 |
| `first_store_halt_has_no_second` | 2 |
| `guards_are_exactly_complementary` | 2 |

Composition fixtures use **free undecided** receivers for dual-face RuntimeEffect; formal fixtures use `setattr_named` carrier. **No law tests deleted.**

### Corpus (pandas 3.0.3 — line content verified)

1. `compat/__init__.py:52` in `set_function_name` @48: `f.__name__ = name`
2. `core/indexes/base.py:4267` in `_maybe_preserve_names` @4264: `target.name = self.name`

### Lying twins

- Borrowing read-path operator (`attribute_named`) must fail the helper-alone operator pin  
- Getter-only property must not complete a field store after discharge  
- Wrong expected type leaves the AttributeError edge unconsumed  

### Validation

```text
.venv-py312/bin/python -m pytest \
  implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py \
  implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py \
  implementations/python/sugar-lift-py-tests/tests/test_store_outcome_composition.py \
  … (store / unpack / assign dependents + n-ary carrier / formal projection) \
  -q
# 154 passed
```

- Mutation: rewrite operator to `attribute_named` → helper-alone twin fails; restore → 11/11 green  
- black --check on touched files  
- Authority: CPython 3.12.13 + NumPy 2.5.1 + pandas 3.0.3  

Standalone 1,008-body probe is **unchanged by design** (no callers).

### Reserved (untouched)

`caller_parameter_contract.py` / projector table, CallSiteSugar / SourceCallFrame, symbolic_value, comparison floor, with paths, assertion producer, subscript store (10876), unpack sequencing, exit_set.py, with_effect_boundary_sugar.

### Precedents

#6605 setattr mint pin, #6614 n-ary projectors, #6612 binder, #6613 mint invariants.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire `setattr_named` NativeOperationExitCarrierV1 through formal receiver attribute stores
> - When `AttributeStoreEffectSugar._store` encounters a receiver with a `formal_coordinate`, it now returns a `setattr_named` `NativeOperationExitCarrierV1` via `mint_setattr_named_carrier` instead of constructing an `AttributeStoreRuntimeEffect`.
> - Undecided non-formal receivers continue to emit the dual-face `AttributeStoreRuntimeEffect`; decided receivers still project through `Floor.setattr`.
> - A new test module [test_setattr_named_formal_caller.py](https://github.com/TSavo/sugar/pull/6621/files#diff-fb53c4c657e4ee851d92d7125ecd16f4f594c79874722e1e1462d6b9036d5de9) covers the full lifecycle: carrier operand order, positional/keyword/default callers, property-without-setter halting, and boundary-type mismatches.
> - Existing tests across multiple modules are updated to remove formal receiver parameters from embedded source strings, ensuring those tests exercise undecided free-symbol receivers rather than formal ones.
> - Behavioral Change: formal parameter attribute stores no longer produce a runtime effect — they now produce an undischarged `setattr_named` carrier that is discharged at call sites.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cfa44d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->