### PR TITLE
Compose native carriers with guarded exits

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -413,6 +413,7 @@ class NativeOperationExitCarrierV1:
     coordinates: tuple[object | None, ...]
     site: object = dataclass_field(compare=False, repr=False)
     continuations: tuple = dataclass_field(default=(), compare=False, repr=False)
+    guards: tuple = dataclass_field(default=(), compare=False, repr=False)
 
     def __post_init__(self):
         operand_count = len(self.operands)
@@ -466,6 +467,11 @@ class NativeOperationExitCarrierV1:
     def and_then(self, step):
         """Retain enclosing expression work until the operation discharges."""
         return replace(self, continuations=(*self.continuations, step))
+
+    def guarded(self, guard, face=None):
+        """Guard the deferred operation without discharging or losing its demand."""
+        del face
+        return replace(self, guards=(*self.guards, guard))
 
     def discharge(self, actuals_by_formal_coordinate):
         """Evaluate against authenticated actual operands and project exits.
@@ -546,6 +552,8 @@ class NativeOperationExitCarrierV1:
 
         for continuation in self.continuations:
             exits = exits.and_then(continuation)
+        for guard in self.guards:
+            exits = exits.guarded(guard)
         return exits
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -34,7 +34,7 @@ from sugar_lift_py_tests.floor import (
 )
 from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
-from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var, str_const
+from sugar_lift_py_tests.ir import PrimitiveSort, atomic, ctor, make_var, str_const
 from sugar_lift_py_tests.outcome import (
     Complete,
     Completed,
@@ -192,6 +192,24 @@ def test_same_native_operation_demand_can_complete_for_authenticated_actuals():
     )
 
     assert exits.exits == (Completed(exits.exits[0].guard, TermValue(3)),)
+
+
+def test_guard_preserves_carrier_demand_until_authenticated_discharge():
+    carrier, left, right = _carrier()
+    guarded = carrier.guarded(atomic("test.guard", []))
+    assert isinstance(guarded, NativeOperationExitCarrierV1)
+    assert guarded.demand == carrier.demand
+    exits = guarded.discharge(
+        {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
+    )
+    assert isinstance(exits.exits[0], Completed)
+    assert exits.exits[0].guard is not None
+
+
+def test_guarded_but_undischarged_carrier_cannot_report_completion():
+    carrier, _, _ = _carrier()
+    with pytest.raises(ConstructionPanic, match="native operation"):
+        outcome_to_exitset(carrier.guarded(atomic("test.guard", [])))
 
 
 def test_same_native_operation_demand_can_halt_for_authenticated_actuals():


### PR DESCRIPTION
Makes NativeOperationExitCarrierV1 a first-class guarded deferred outcome: guarded() preserves the demand and accumulates guards; discharge applies guards only after caller evidence resolves the operation. Undischarged guarded carriers remain loud and cannot report completion.

Python semantic law made constructible: a native operation inside a conditional preserves its ordered demand and caller-discharge identity through the ExitSet guard algebra.

Authenticated focused validation (CPython 3.12.13 / NumPy 2.5.1 / pandas 3.0.3 / pyarrow 22.0.0): 43 passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Compose native carriers with guarded exits in `NativeOperationExitCarrierV1`
> - Adds a `guards` tuple field to `NativeOperationExitCarrierV1` and a `guarded(guard, face=None)` method that returns a new carrier with the guard appended, without discharging.
> - Updates `discharge` to apply all accumulated guards to the `ExitSet` in order, after any continuations are applied.
> - Adds tests covering guard preservation before discharge and that calling `outcome_to_exitset` on a guarded but undischarged carrier raises a `ConstructionPanic`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56e7f53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->