### PR TITLE
Discharge formal subscript stores

### DIFF
--- a/docs/superpowers/plans/2026-07-27-setitem-formal-caller-plan.md
+++ b/docs/superpowers/plans/2026-07-27-setitem-formal-caller-plan.md
@@ -1,0 +1,56 @@
+# Setitem Formal Caller Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `obj[key] = value` inside a source-defined helper defer over formal operands and discharge to the actual caller's completed or named exceptional `setitem` outcome.
+
+**Architecture:** Preserve Python source evaluation as RHS, receiver, index in `SubscriptStoreEffectSugar.desugar`. When any evaluated operand carries a formal coordinate, mint `NativeOperationExitCarrierV1` in projector order `(receiver, index, value)` with exactly aligned coordinate slots; otherwise retain the ground `receiver.setitem(index, value, site)` path. Existing `CallSiteSugar`, `SourceCallFrame`, carrier, projector, ExitSet, and assertion boundary consume the result unchanged.
+
+**Tech Stack:** Python 3.12.13, pytest, Sugar source tree and shared ExitSet/native-operation carrier.
+
+## Global Constraints
+
+- Do not edit reserved carrier, projector, binder, CallSiteSugar, SymbolicValue, ExitSet, With, AttributeStore, or standalone attribution-probe files.
+- Never manufacture an exception identity or completion; unresolved helper-only operations remain deferred.
+- Source evaluation order is value, receiver, index; discharge order is receiver, index, value.
+- Commit as `T Savo <evilgenius@nefariousplan.com>`.
+
+---
+
+### Task 1: Pin the production vertical
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py`
+
+**Interfaces:**
+- Consumes: `NativeOperationExitCarrierV1.mint(site, operator, operands, coordinates)` and the `setitem` projector.
+- Produces: deferred `setitem` carrier from `SubscriptStoreEffectSugar._store`.
+
+- [ ] Add a failing helper-only test asserting one carrier with operands and coordinates ordered receiver, index, value.
+- [ ] Run that test and verify the existing `SugarNotWritten` refusal is the failure.
+- [ ] Add the minimal formal-coordinate detection and carrier mint in `_store`.
+- [ ] Run the helper-only test and all existing SubscriptStore laws green.
+
+### Task 2: Prove caller outcomes and boundary typing
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_projection.py`
+
+**Interfaces:**
+- Consumes: ordinary source-call binder and native-operation discharge.
+- Produces: positional, keyword, and default caller twins for completed and named exceptional store exits.
+
+- [ ] Add failing source-call tests for positional, keyword, and default callers reaching the same demand coordinate.
+- [ ] Add completion, immutable-receiver named halt, and wrong-boundary-type non-consumption assertions.
+- [ ] Run the tests red before production wiring and green afterward.
+
+### Task 3: Mutation and focused verification
+
+**Files:**
+- Test: both files above plus existing carrier and assertion-boundary focused suites.
+
+- [ ] Swap index and value in the production mint, run the lying twin, and record its failure.
+- [ ] Restore receiver, index, value order and rerun focused tests for every touched package.
+- [ ] Verify the authenticated pandas coordinates, format, diff, exact author, push, and open an unmerged PR naming the Python assignment evaluation and setitem-discharge laws.
+

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
@@ -172,6 +172,21 @@ class SubscriptStoreEffectSugar(Sugar):
         )
 
     def _store(self, receiver, index, value) -> Outcome:
+        coordinates = tuple(
+            getattr(operand, "formal_coordinate", None)
+            for operand in (receiver, index, value)
+        )
+        if any(coordinate is not None for coordinate in coordinates):
+            from sugar_lift_py_tests.caller_parameter_contract import (
+                NativeOperationExitCarrierV1,
+            )
+
+            return NativeOperationExitCarrierV1.mint(
+                site=self.site,
+                operator="setitem",
+                operands=(receiver, index, value),
+                coordinates=coordinates,
+            )
         if not receiver.runtime_type_is_decided():
             from sugar_source_tree.panic import SugarNotWritten
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_formal_call_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_formal_call_projection.py
@@ -1,0 +1,151 @@
+"""Source-defined subscript stores discharge through authenticated callers."""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.context_manager_contract import (
+    AuthenticatedRaiseMatcher,
+    EffectBoundaryDisposition,
+)
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.effect.expectation_not_met_effect import (
+    ExpectationNotMetEffect,
+)
+from sugar_lift_py_tests.floor import TermValue, TupleValue
+from sugar_lift_py_tests.outcome import (
+    Completed,
+    ExitSet,
+    Halted,
+    NativeOperationExitCarrierV1,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _tree(source: str) -> SourceFile:
+    return SourceFile(
+        (source, "setitem_formal_call.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _helper_and_calls(source: str):
+    tree = _tree(source)
+    helper = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    calls = tuple(node for node in tree.nodes() if isinstance(node, Call))
+    return helper, calls
+
+
+def _one_face(outcome):
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    return outcome.exits[0]
+
+
+def _identity(name: str):
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
+
+
+class _Expected:
+    def __init__(self, name: str):
+        self.identity = _identity(name)
+
+    def exception_type_identity(self):
+        return self.identity
+
+
+def test_helper_alone_retains_setitem_demand_in_projector_order() -> None:
+    helper, _calls = _helper_and_calls(
+        "def helper(obj, key, value):\n    obj[key] = value\n"
+    )
+
+    pending = helper.sugar().desugar(None)
+
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "setitem"
+    assert tuple(value.term.name for value in pending.operands) == (
+        "obj",
+        "key",
+        "value",
+    )
+    assert pending.demand.operand_coordinate_cids == tuple(
+        value.formal_coordinate.coordinate_cid for value in pending.operands
+    )
+
+
+def test_positional_keyword_and_default_callers_complete_same_store_demand() -> None:
+    _helper, calls = _helper_and_calls(
+        "def helper(obj, key=0, value=9):\n"
+        "    obj[key] = value\n\n"
+        "helper([0], 0, 9)\n"
+        "helper([0], key=0, value=9)\n"
+        "helper([0])\n"
+    )
+
+    faces = tuple(_one_face(call.sugar().desugar(None)) for call in calls)
+
+    assert len(faces) == 3
+    assert all(isinstance(face, Completed) for face in faces)
+    values = tuple(face.value for face in faces)
+    assert values[0].arg_values == values[1].arg_values == values[2].arg_values
+    assert (
+        values[0].formal_coordinate_cids
+        == values[1].formal_coordinate_cids
+        == values[2].formal_coordinate_cids
+    )
+    assert (
+        values[0].source_call_frame_cid
+        == values[1].source_call_frame_cid
+        == values[2].source_call_frame_cid
+    )
+
+
+def test_immutable_receiver_reads_but_formal_store_halts_with_named_type() -> None:
+    helper, calls = _helper_and_calls(
+        "def helper(obj, key, value):\n"
+        "    obj[key] = value\n\n"
+        "helper((0,), 0, 9)\n"
+    )
+    readable = TupleValue((TermValue(0),)).subscript(TermValue(0), "read.py:1")
+    assert readable.value == TermValue(0)
+    assert isinstance(helper.sugar().desugar(None), NativeOperationExitCarrierV1)
+
+    halted = _one_face(calls[-1].sugar().desugar(None))
+
+    assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _identity("TypeError")
+    assert halted.effect.occurrence_id is not None
+    assert "'startLine': 2" in halted.effect.occurrence
+    assert "assertion" not in halted.effect.occurrence
+
+
+def test_wrong_expected_type_leaves_setitem_exception_unconsumed() -> None:
+    _helper, calls = _helper_and_calls(
+        "def helper(obj, key, value):\n"
+        "    obj[key] = value\n\n"
+        "helper((0,), 0, 9)\n"
+    )
+    produced = calls[-1].sugar().desugar(None)
+    original = _one_face(produced)
+    assert isinstance(original, Halted)
+
+    routed = produced.and_exit(
+        ExitSet.completed(object()),
+        disposition=EffectBoundaryDisposition(
+            matcher=AuthenticatedRaiseMatcher(expected=_Expected("IndexError")),
+            unmet=ExpectationNotMetEffect("raise", "assertion-site"),
+        ),
+    )
+
+    remaining = [
+        face
+        for face in routed.exits
+        if isinstance(face, Halted) and face.effect is original.effect
+    ]
+    assert remaining == [original]
+    assert remaining[0].effect.exception_type_coordinate == _identity("TypeError")

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -208,9 +208,15 @@ def test_attribute_store_target_lifts_a_typed_red_effect():
     assert isinstance(red[0].effect, AttributeStoreRuntimeEffect)
 
 
-def test_subscript_store_target_stays_loud_without_setitem_testimony():
-    with pytest.raises(SugarNotWritten, match="undischarged subscript store"):
-        _fn("def A(xs):\n    xs[0] = 1\n    return xs\n").sugar().desugar()
+def test_subscript_store_target_retains_setitem_demand_without_caller():
+    from sugar_lift_py_tests.outcome import NativeOperationExitCarrierV1
+
+    pending = _fn("def A(xs):\n    xs[0] = 1\n    return xs\n").sugar().desugar()
+
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "setitem"
+    assert pending.demand.operand_coordinate_cids[0] is not None
+    assert pending.demand.operand_coordinate_cids[1:] == (None, None)
 
 
 def test_subscript_store_producer_retains_receiver_key_and_rhs():
@@ -236,7 +242,7 @@ if __name__ == "__main__":
     test_non_display_rhs_stays_loud()
     test_mixed_chained_targets_stay_loud()
     test_attribute_store_target_lifts_a_typed_red_effect()
-    test_subscript_store_target_stays_loud_without_setitem_testimony()
+    test_subscript_store_target_retains_setitem_demand_without_caller()
     print(
         "ok: tuple/chained assign destructures; starred/nested stay loud; "
         "subscript stores require setitem testimony"

--- a/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
@@ -84,14 +84,27 @@ def test_attribute_store_post_out_equals_the_returned_value():
     assert post.args[1].name == "v"
 
 
-def test_subscript_store_stays_loud_without_setitem_testimony():
-    with pytest.raises(SugarNotWritten, match="undischarged subscript store"):
-        _fn("def A(xs, i, v):\n    xs[i] = v\n    return v\n").sugar().desugar()
+def _pending_subscript_store():
+    from sugar_lift_py_tests.outcome import NativeOperationExitCarrierV1
+
+    pending = _fn("def A(xs, i, v):\n    xs[i] = v\n    return v\n").sugar().desugar()
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    return pending
+
+
+def test_subscript_store_retains_setitem_demand_without_caller():
+    pending = _pending_subscript_store()
+
+    assert pending.demand.operator == "setitem"
+    assert all(pending.demand.operand_coordinate_cids)
 
 
 def test_subscript_store_does_not_borrow_the_read_path():
-    with pytest.raises(SugarNotWritten, match="undischarged subscript store"):
-        _fn("def A(xs, i, v):\n    xs[i] = v\n    return v\n").sugar().desugar()
+    pending = _pending_subscript_store()
+
+    assert pending.demand.operator == "setitem"
+    assert len(pending.operands) == 3
+    assert len(pending.demand.operand_coordinate_cids) == 3
 
 
 def test_attribute_store_witness_site_is_the_tree_fragment():
@@ -112,9 +125,11 @@ def test_attribute_store_witness_site_is_the_tree_fragment():
     assert "store_target" not in operand
 
 
-def test_subscript_store_refusal_names_the_missing_nary_carrier():
-    with pytest.raises(SugarNotWritten, match="n-ary setitem demand"):
-        _fn("def A(xs, i, v):\n    xs[i] = v\n    return v\n").sugar().desugar()
+def test_subscript_store_demand_names_all_three_formal_coordinates():
+    pending = _pending_subscript_store()
+
+    assert len(pending.demand.operand_coordinate_cids) == 3
+    assert len(set(pending.demand.operand_coordinate_cids)) == 3
 
 
 def test_two_stores_in_one_block_both_lift_and_discriminate_by_target():


### PR DESCRIPTION
## Python semantic law made constructible

For `obj[key] = value`, Python evaluates source expressions in `value, obj, key` order exactly once, then calls the resolved operation in `receiver.setitem(index, value)` order. A source-defined helper must retain that operation until authenticated positional, keyword, or default caller actuals select its completed or named exceptional face.

## What changed

- mint the merged n-ary `setitem` carrier from `SubscriptStoreEffectSugar` when any operand carries a formal coordinate
- preserve three ordered operands and three aligned coordinate slots as `receiver, index, value`
- keep ground and non-formal undecided store behavior unchanged
- supersede the old missing-projector refusal tests with stronger pending-demand laws
- prove helper-only deferral, positional/keyword/default completion, immutable-reader store halt, and wrong expected-type non-consumption

## Authenticated pandas reproducer

Canonical pandas 3.0.3 contains `_normalize_json` at `pandas/io/json/_normalize.py:153`, the formal store `normalized_dict[key_string] = data` at line 190, the recursive keyword caller at lines 183-188, and the top-level keyword caller at lines 210-214. Verified under CPython 3.12.13, NumPy 2.5.1, pandas 3.0.3, pyarrow 22.0.0 and corpus BLAKE3-512 `6f317a5a...563530`.

## Validation

- focused vertical: 133 passed
- mutation transaction: swapping index/value made both the ordered-demand twin and real caller-completion twin fail; restoration returned green
- Black: 4 files unchanged
- `git diff --check`: exit 0

## Scope

No edits to the carrier/projector table, binder, CallSiteSugar, SymbolicValue, ExitSet, With paths, AttributeStore, or standalone 1,008-body probe. The no-caller attribution population therefore remains intentionally outside this vertical.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Discharge formal subscript stores via `NativeOperationExitCarrierV1` instead of raising `SugarNotWritten`
> - When any operand (receiver, index, or value) of a subscript store (`obj[key] = value`) carries a formal coordinate, `SubscriptStoreEffectSugar._store` now returns a `NativeOperationExitCarrierV1` for `'setitem'` rather than raising `SugarNotWritten`.
> - The carrier preserves projector order (receiver, index, value) and aligns operand coordinate CIDs with the formal coordinates of each operand.
> - Ground cases (all operands resolved, receiver type decided) continue to call `receiver.setitem` directly as before.
> - Tests in [test_subscript_store_formal_call_projection.py](https://github.com/TSavo/sugar/pull/6623/files#diff-fe0270ae366a0620d5fafc1d499aa13e188823fee5a7f86072b98488c48f1fda) cover positional, keyword, and defaulted callers completing the demand, as well as immutable-receiver halt and mismatched exception-type routing.
> - Behavioral Change: existing tests expecting `SugarNotWritten` for formal subscript stores are updated to expect a `setitem` demand instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8f7ab9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->