### PR TITLE
Preserve caller actuals through nested carriers

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -551,7 +551,13 @@ class NativeOperationExitCarrierV1:
             exits = outcome_to_exitset(projected)
 
         for continuation in self.continuations:
-            exits = exits.and_then(continuation)
+            def resume(value, continuation=continuation):
+                next_outcome = continuation(value)
+                if isinstance(next_outcome, NativeOperationExitCarrierV1):
+                    return next_outcome.discharge(actuals_by_formal_coordinate)
+                return next_outcome
+
+            exits = exits.and_then(resume)
         for guard in self.guards:
             exits = exits.guarded(guard)
         return exits

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -206,6 +206,40 @@ def test_guard_preserves_carrier_demand_until_authenticated_discharge():
     assert exits.exits[0].guard is not None
 
 
+def test_nested_carrier_continuation_reuses_original_actual_map():
+    outer, left, right = _carrier()
+    inner, inner_left, inner_right = _carrier()
+    chained = outer.and_then(lambda _value: inner)
+    exits = chained.discharge(
+        {
+            left.coordinate_cid: TermValue(1),
+            right.coordinate_cid: TermValue(2),
+            inner_left.coordinate_cid: TermValue(3),
+            inner_right.coordinate_cid: TermValue(4),
+        }
+    )
+    assert exits.exits[0].value == TermValue(7)
+
+
+def test_nested_carrier_missing_its_formal_actual_stays_undischarged():
+    outer, left, right = _carrier()
+    inner_left = _coordinate("inner_left", 2)
+    inner_right = _coordinate("inner_right", 3)
+    inner = NativeOperationExitCarrierV1.mint(
+        site=_site(),
+        operator="add",
+        operands=(
+            SymbolicValue(make_var("inner_left"), inner_left),
+            SymbolicValue(make_var("inner_right"), inner_right),
+        ),
+        coordinates=(inner_left, inner_right),
+    )
+    with pytest.raises(SugarNotWritten, match="caller actual absent"):
+        outer.and_then(lambda _value: inner).discharge(
+            {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
+        )
+
+
 def test_guarded_but_undischarged_carrier_cannot_report_completion():
     carrier, _, _ = _carrier()
     with pytest.raises(ConstructionPanic, match="native operation"):


### PR DESCRIPTION
Completes the carrier algebra repair: every continuation is wrapped so a nested NativeOperationExitCarrierV1 discharges with the original authenticated caller-actual map. Nested operations therefore complete or remain named Undischarged without inventing evidence. Guards remain control context and are applied after continuation discharge.

Python semantic law made constructible: caller actual bindings are transitive through nested native-operation evaluation under conditional ExitSet context.

Authenticated focused validation (CPython 3.12.13 / NumPy 2.5.1 / pandas 3.0.3 / pyarrow 22.0.0): 45 passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve caller actuals through nested carriers in `NativeOperationExitCarrierV1.discharge`
> When a continuation passed to `discharge` returns another `NativeOperationExitCarrierV1`, the nested carrier is now automatically discharged using the same `actuals_by_formal_coordinate` map from the outer call, rather than passing the unresolved carrier through.
>
> - The `discharge` method in [caller_parameter_contract.py](https://github.com/TSavo/sugar/pull/6624/files#diff-5136726cb5a60b48beb30152aecb6eca8ad0173bdefc676eb112b1c1b2acbf57) wraps each continuation in a `resume` helper that detects and resolves nested carriers inline.
> - If the nested carrier's formals are missing from the actuals map, `discharge` raises `SugarNotWritten` as expected.
> - Behavioral Change: Continuations that previously returned a raw `NativeOperationExitCarrierV1` now return resolved exits instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a229448.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nested operation handling so chained operations correctly reuse available inputs and produce expected results.
  * Operations with missing required inputs now remain undischarged and report the missing input clearly.

* **Tests**
  * Added coverage for nested operation chains and missing-input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->