### PR TITLE
Make carrier guard conjunction explicit

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -393,6 +393,17 @@ def _native_operation_projector_arity(projector) -> int:
     return len(inspect.signature(projector).parameters) - 1
 
 
+def _conjoin_guards(guards):
+    guards = tuple(guards)
+    if not guards:
+        return None
+    if len(guards) == 1:
+        return guards[0]
+    from sugar_lift_py_tests.ir import and_
+
+    return and_(list(guards))
+
+
 @dataclass(frozen=True)
 class NativeOperationExitCarrierV1:
     """Deferred native operation whose discharge codomain is an ``ExitSet``.
@@ -413,7 +424,7 @@ class NativeOperationExitCarrierV1:
     coordinates: tuple[object | None, ...]
     site: object = dataclass_field(compare=False, repr=False)
     continuations: tuple = dataclass_field(default=(), compare=False, repr=False)
-    guards: tuple = dataclass_field(default=(), compare=False, repr=False)
+    guards: tuple = dataclass_field(default=(), repr=False)
 
     def __post_init__(self):
         operand_count = len(self.operands)
@@ -551,14 +562,15 @@ class NativeOperationExitCarrierV1:
             exits = outcome_to_exitset(projected)
 
         for continuation in self.continuations:
-            def resume(value, continuation=continuation):
-                next_outcome = continuation(value)
+            def resume(value, *, step=continuation):
+                next_outcome = step(value)
                 if isinstance(next_outcome, NativeOperationExitCarrierV1):
                     return next_outcome.discharge(actuals_by_formal_coordinate)
                 return next_outcome
 
             exits = exits.and_then(resume)
-        for guard in self.guards:
+        guard = _conjoin_guards(self.guards)
+        if guard is not None:
             exits = exits.guarded(guard)
         return exits
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -206,6 +206,43 @@ def test_guard_preserves_carrier_demand_until_authenticated_discharge():
     assert exits.exits[0].guard is not None
 
 
+def test_guarded_exceptional_face_retains_guard():
+    carrier, left, right = _carrier()
+    guarded = carrier.guarded(atomic("test.guard", []))
+    exits = guarded.discharge(
+        {left.coordinate_cid: NoneValue(), right.coordinate_cid: TermValue(2)}
+    )
+    assert isinstance(exits.exits[0], Halted)
+    assert exits.exits[0].guard is not None
+
+
+def test_same_demand_under_complementary_guards_keeps_distinct_carriers():
+    carrier, left, right = _carrier()
+    positive = atomic("test.guard", [])
+    negative = atomic("test.not_guard", [])
+    left_carrier = carrier.guarded(positive)
+    right_carrier = carrier.guarded(negative)
+    assert left_carrier.demand.demand_cid == right_carrier.demand.demand_cid
+    assert left_carrier != right_carrier
+    assert left_carrier.discharge(
+        {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
+    ).exits[0].guard is not None
+    assert right_carrier.discharge(
+        {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
+    ).exits[0].guard is not None
+
+
+def test_multiple_guards_are_explicitly_conjoined():
+    carrier, left, right = _carrier()
+    exits = carrier.guarded(atomic("outer", [])).guarded(
+        atomic("inner", [])
+    ).discharge(
+        {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
+    )
+    assert exits.exits[0].guard.kind == "and"
+    assert len(exits.exits[0].guard.operands) == 2
+
+
 def test_nested_carrier_continuation_reuses_original_actual_map():
     outer, left, right = _carrier()
     inner, inner_left, inner_right = _carrier()

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -224,12 +224,24 @@ def test_same_demand_under_complementary_guards_keeps_distinct_carriers():
     right_carrier = carrier.guarded(negative)
     assert left_carrier.demand.demand_cid == right_carrier.demand.demand_cid
     assert left_carrier != right_carrier
-    assert left_carrier.discharge(
-        {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
-    ).exits[0].guard is not None
-    assert right_carrier.discharge(
-        {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
-    ).exits[0].guard is not None
+    actuals = {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
+    discharged_left = left_carrier.discharge(actuals)
+    discharged_right = right_carrier.discharge(actuals)
+    assert discharged_left.exits[0].guard == positive
+    assert discharged_right.exits[0].guard == negative
+    assert actuals == {
+        left.coordinate_cid: TermValue(1),
+        right.coordinate_cid: TermValue(2),
+    }
+
+
+def test_complementary_guard_tooth_rejects_same_guard_mutation():
+    carrier, left, right = _carrier()
+    positive = atomic("test.guard", [])
+    negative = atomic("test.not_guard", [])
+    lying = carrier.guarded(positive)
+    actuals = {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
+    assert lying.discharge(actuals).exits[0].guard != negative
 
 
 def test_multiple_guards_are_explicitly_conjoined():


### PR DESCRIPTION
Completes the remaining carrier guard laws: keyword-only continuation capture, explicit conjunction of accumulated guards, guarded exceptional-face coverage, complementary-guard identity, and guard isolation from caller actual maps. Guard state participates in carrier equality while demand CID remains unchanged.

Python semantic law made constructible: one native operation occurrence may inhabit complementary control contexts without changing its demand identity, and all resolved faces inherit the conjunction of those contexts.

Authenticated focused validation (CPython 3.12.13 / NumPy 2.5.1 / pandas 3.0.3 / pyarrow 22.0.0): 48 passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Conjoin multiple carrier guards into a single `ir.and_` node before applying
> - Introduces `_conjoin_guards` in [caller_parameter_contract.py](https://github.com/TSavo/sugar/pull/6626/files#diff-5136726cb5a60b48beb30152aecb6eca8ad0173bdefc676eb112b1c1b2acbf57) to normalize an iterable of guards: returns `None` for empty, the guard itself for a single guard, or an `ir.and_` node for multiple guards.
> - Updates `NativeOperationExitCarrierV1.discharge()` to apply one combined guard via a single `.guarded()` call instead of chaining multiple sequential calls.
> - Enables the `guards` field to participate in dataclass equality comparisons by removing `compare=False`.
> - Adds tests covering guard retention on halted exits, complementary guard distinctness, and the `ir.and_` structure when two guards are present.
> - Behavioral Change: discharging a carrier with multiple guards now produces an exit with one conjoint `and` guard rather than multiple independently chained guards, which changes the resulting IR structure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33cd099.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->