### PR TITLE
Consume source-defined resource coordinates

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
@@ -11,13 +11,31 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 @dataclass(frozen=True)
 class WithSourceResourceSugar(Sugar):
     manager: Sugar
+    enter: Sugar
+    exit: Sugar
     protocol: object
     summary: object
     body: tuple[Sugar, ...]
     manager_slot_id: str
     enter_slot_id: str | None
     exit_face_id: str
+    enter_definition: object
+    exit_definition: object
     site: object = field(compare=False, default=None)
+
+    def __post_init__(self) -> None:
+        from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+
+        for call, definition, slot in (
+            (self.enter, self.enter_definition, "context-enter"),
+            (self.exit, self.exit_definition, "context-exit"),
+        ):
+            if not isinstance(call, MethodCallSugar):
+                raise TypeError(f"source resource {slot} must be a MethodCallSugar")
+            if call.native_definition_coordinate != definition:
+                raise ValueError(
+                    f"{slot} call is not authenticated by its definition coordinate"
+                )
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
@@ -9,13 +9,27 @@ from sugar_lift_py_tests.context_manager_contract import (
     ReturnTruthinessDispositionV1,
     Suppresses,
 )
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.effect.loop_control_effect import LoopControlEffect
-from sugar_lift_py_tests.floor import BlockValue, ObjectValue, SymbolicValue, TermValue
+from sugar_lift_py_tests.floor import (
+    BlockValue,
+    ObjectValue,
+    ReturnValue,
+    SymbolicValue,
+    TermValue,
+)
 from sugar_lift_py_tests.ir import ctor, not_
 from sugar_lift_py_tests.outcome import Complete, Completed, Halted, Incomplete
 from sugar_lift_py_tests.outcome.exit_set import true_guard
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+from sugar_lift_py_tests.sugar.resource_coord_sugar import (
+    ExitTracebackRefSugar,
+    ExitTypeRefSugar,
+    ExitValueRefSugar,
+    ManagerRefSugar,
+)
 from sugar_lift_py_tests.sugar.with_source_resource_sugar import (
     WithSourceResourceSugar,
 )
@@ -53,6 +67,45 @@ class _CompletedProtocol:
         return Complete(self.exit_value)
 
 
+def _protocol_calls():
+    enter_definition = SourceFragmentCoordinateV1(
+        "blake3-512:" + "e" * 128, 1, 0, 1, 1
+    )
+    exit_definition = SourceFragmentCoordinateV1(
+        "blake3-512:" + "x" * 128, 2, 0, 2, 1
+    )
+    enter = MethodCallSugar(
+        receiver=ManagerRefSugar(slot_id="manager-slot", site=None),
+        name="__enter__",
+        args=(),
+        native_definition_coordinate=enter_definition,
+        site=None,
+    )
+    exit_ = MethodCallSugar(
+        receiver=ManagerRefSugar(slot_id="manager-slot", site=None),
+        name="__exit__",
+        args=(
+            ExitTypeRefSugar(face_id="exit-face", site=None),
+            ExitValueRefSugar(face_id="exit-face", site=None),
+            ExitTracebackRefSugar(face_id="exit-face", site=None),
+        ),
+        native_definition_coordinate=exit_definition,
+        site=None,
+    )
+    return enter, exit_, enter_definition, exit_definition
+
+
+def _source_resource(**kwargs):
+    enter, exit_, enter_definition, exit_definition = _protocol_calls()
+    return WithSourceResourceSugar(
+        enter=enter,
+        exit=exit_,
+        enter_definition=enter_definition,
+        exit_definition=exit_definition,
+        **kwargs,
+    )
+
+
 def _truthiness_resource(*, exit_value, body, enter_value=TermValue(2), slot=None):
     summary = SimpleNamespace(
         semantics=SimpleNamespace(
@@ -61,7 +114,7 @@ def _truthiness_resource(*, exit_value, body, enter_value=TermValue(2), slot=Non
     )
     protocol = _CompletedProtocol(enter_value=enter_value, exit_value=exit_value)
     return (
-        WithSourceResourceSugar(
+        _source_resource(
             manager=_FixedSugar(Complete(TermValue(1))),
             protocol=protocol,
             summary=summary,
@@ -81,7 +134,7 @@ def test_summary_suppresses_disposition_consumes_matching_body_halt():
         semantics=SimpleNamespace(exit=SimpleNamespace(disposition=disposition))
     )
     protocol = _CompletedProtocol()
-    sugar = WithSourceResourceSugar(
+    sugar = _source_resource(
         manager=_FixedSugar(Complete(TermValue(1))),
         protocol=protocol,
         summary=summary,
@@ -170,6 +223,50 @@ def test_source_exit_runs_on_early_return_face():
 
     assert exits
     assert protocol.exit_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("body_outcome", "exit_truth", "surviving_face"),
+    [
+        (
+            Complete(BlockValue((), can_fall_through=True)),
+            TermValue(True),
+            Completed,
+        ),
+        (
+            Complete(
+                BlockValue(
+                    (ReturnValue(TermValue("early")),), can_fall_through=False
+                )
+            ),
+            TermValue(True),
+            Completed,
+        ),
+        (
+            Incomplete(
+                RaiseEffect(
+                    exception_name="ValueError", occurrence="resource.py:8:8"
+                )
+            ),
+            TermValue(False),
+            Halted,
+        ),
+    ],
+    ids=("completed", "returned", "halted"),
+)
+def test_source_exit_runs_over_completed_returned_and_halted_faces(
+    body_outcome, exit_truth, surviving_face
+):
+    """Exit truth is consulted for all faces but changes only an incoming raise."""
+    sugar, protocol = _truthiness_resource(
+        exit_value=exit_truth,
+        body=(_FixedSugar(body_outcome),),
+    )
+
+    exits = sugar.desugar().exits
+
+    assert protocol.exit_calls == 1
+    assert any(isinstance(face, surviving_face) for face in exits)
 
 
 @pytest.mark.parametrize("action", ["break", "continue"])

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -28,7 +28,9 @@ from sugar_lift_py_tests.context_manager_contract import (
     ReturnTruthinessDispositionV1,
 )
 from sugar_lift_py_tests.context_manager_resolution import (
+    NativeProtocolSlot,
     SourceDerivedContextManagerRefV1,
+    SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
 from sugar_lift_py_tests.effect import RaiseEffect
@@ -38,6 +40,13 @@ from sugar_lift_py_tests.fixture_resource_obligation import (
 from sugar_lift_py_tests.outcome import Complete, Incomplete
 from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+from sugar_lift_py_tests.sugar.resource_coord_sugar import (
+    ExitTracebackRefSugar,
+    ExitTypeRefSugar,
+    ExitValueRefSugar,
+    ManagerRefSugar,
+)
 from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
 from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
 from sugar_lift_py_tests.sugar.with_source_resource_sugar import WithSourceResourceSugar
@@ -60,6 +69,40 @@ _GUARD_SOURCE = (
     "def make_guard(marker):\n"
     "    return Guard(marker)\n"
 )
+
+
+def _source_resource(**kwargs):
+    manager_slot = kwargs["manager_slot_id"]
+    face = kwargs["exit_face_id"]
+    enter_definition = SourceFragmentCoordinateV1(
+        "blake3-512:" + "e" * 128, 1, 0, 1, 1
+    )
+    exit_definition = SourceFragmentCoordinateV1(
+        "blake3-512:" + "x" * 128, 2, 0, 2, 1
+    )
+    return WithSourceResourceSugar(
+        enter=MethodCallSugar(
+            receiver=ManagerRefSugar(slot_id=manager_slot, site=None),
+            name="__enter__",
+            args=(),
+            native_definition_coordinate=enter_definition,
+            site=None,
+        ),
+        exit=MethodCallSugar(
+            receiver=ManagerRefSugar(slot_id=manager_slot, site=None),
+            name="__exit__",
+            args=(
+                ExitTypeRefSugar(face_id=face, site=None),
+                ExitValueRefSugar(face_id=face, site=None),
+                ExitTracebackRefSugar(face_id=face, site=None),
+            ),
+            native_definition_coordinate=exit_definition,
+            site=None,
+        ),
+        enter_definition=enter_definition,
+        exit_definition=exit_definition,
+        **kwargs,
+    )
 
 
 def _distribution(root: Path, source: str, *, exported: str = "make_guard"):
@@ -102,6 +145,19 @@ def _tree(root: Path, consumer: str, *, dist):
         path=path,
         distribution_index={"arbitrary": dist},
     )
+    # Inject task-2's publication boundary. These coordinates are deliberately
+    # fixture-owned; rebasing the real producer later swaps only this setup.
+    for receiver in context.source_derived_contract_refs:
+        context.contract_refs.native_definitions[
+            (receiver, NativeProtocolSlot.CONTEXT_ENTER)
+        ] = SourceFragmentCoordinateV1(
+            "blake3-512:" + "e" * 128, 1, 0, 1, 1
+        )
+        context.contract_refs.native_definitions[
+            (receiver, NativeProtocolSlot.CONTEXT_EXIT)
+        ] = SourceFragmentCoordinateV1(
+            "blake3-512:" + "x" * 128, 2, 0, 2, 1
+        )
     return tree, context, path
 
 
@@ -388,7 +444,7 @@ def test_failure_entering_inner_assigned_resource_still_exits_outer():
     """
     outer_exit, inner_exit = [], []
     halt = RaiseEffect(exception_name="OSError", occurrence="inner.py:1:0")
-    inner = WithSourceResourceSugar(
+    inner = _source_resource(
         manager=_FixedSugar(Complete(_FloorValue("inner-mgr"))),
         protocol=_ProbeProtocol(enter=Incomplete(halt), exit_probe=inner_exit),
         summary=_never_suppresses_summary(),
@@ -398,7 +454,7 @@ def test_failure_entering_inner_assigned_resource_still_exits_outer():
         exit_face_id="B#exit_face",
         site=None,
     )
-    outer = WithSourceResourceSugar(
+    outer = _source_resource(
         manager=_FixedSugar(Complete(_FloorValue("outer-mgr"))),
         protocol=_ProbeProtocol(
             enter=Complete(_Entered(_FloorValue("entered"))),
@@ -423,7 +479,7 @@ def test_discrimination_outer_exit_is_not_skipped_on_enter_halt():
     """BITE: completion-only exit would leave the outer exit probe empty."""
     outer_exit, inner_exit = [], []
     halt = RaiseEffect(exception_name="OSError", occurrence="inner.py:1:0")
-    inner = WithSourceResourceSugar(
+    inner = _source_resource(
         manager=_FixedSugar(Complete(_FloorValue("inner-mgr"))),
         protocol=_ProbeProtocol(enter=Incomplete(halt), exit_probe=inner_exit),
         summary=_never_suppresses_summary(),
@@ -433,7 +489,7 @@ def test_discrimination_outer_exit_is_not_skipped_on_enter_halt():
         exit_face_id="B#exit_face",
         site=None,
     )
-    outer = WithSourceResourceSugar(
+    outer = _source_resource(
         manager=_FixedSugar(Complete(_FloorValue("outer-mgr"))),
         protocol=_ProbeProtocol(
             enter=Complete(_Entered(_FloorValue("entered"))),

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5525,14 +5525,31 @@ class With(Statement):
                 enter_slot = (
                     f"{manager_slot}#enter_result" if binds_enter_result else None
                 )
+                enter_definition, exit_definition = (
+                    self._require_native_resource_definitions(resolved_ref)
+                )
+                from dataclasses import replace
+
+                enter_sugar = replace(
+                    item._make_enter_call().sugar(),
+                    native_definition_coordinate=enter_definition,
+                )
+                exit_sugar = replace(
+                    item._make_parametric_exit_call().sugar(),
+                    native_definition_coordinate=exit_definition,
+                )
                 return WithSourceResourceSugar(
                     manager=item.context_expr.sugar(),
+                    enter=enter_sugar,
+                    exit=exit_sugar,
                     protocol=resolved_ref.protocol,
                     summary=resolved_ref,
                     body=tuple(stmt.sugar() for stmt in self.body),
                     manager_slot_id=manager_slot,
                     enter_slot_id=enter_slot,
                     exit_face_id=item._exit_face_id(),
+                    enter_definition=enter_definition,
+                    exit_definition=exit_definition,
                     site=self.fragment,
                 )
 

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from types import MappingProxyType
+from types import MappingProxyType, SimpleNamespace
 from dataclasses import replace
 import inspect
 
@@ -31,16 +31,19 @@ from sugar_lift_py_tests.context_manager_resolution import (
     ImportSignatureV2,
     NativeProtocolSlot,
     ResolvedContractRefsV1,
+    SourceDerivedContextManagerRefV1,
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
     _hash_json,
 )
 from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.floor import TermValue
 from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete
 from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
 from sugar_lift_py_tests.effect import ExpectationNotMetEffect, RaiseEffect
 from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
 from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
+from sugar_lift_py_tests.sugar.with_source_resource_sugar import WithSourceResourceSugar
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
@@ -169,6 +172,78 @@ def _native_protocol_definitions(use_site):
             _cid("x"), 20, 4, 22, 20
         ),
     }
+
+
+class _InjectedSourceProtocol:
+    """Task-2 stand-in: lifecycle testimony only, never coordinate authority."""
+
+    def enter_resource_outcome(self, ctx=None):
+        del ctx
+        return Complete(SimpleNamespace(enter_value=TermValue(7)))
+
+    def exit_outcome_for(self, entered, ctx=None):
+        del entered, ctx
+        return Complete(TermValue(False))
+
+
+def _source_derived(use_site):
+    return SourceDerivedContextManagerRefV1(
+        use_site=use_site,
+        summary_cid=_cid("s"),
+        semantics=ProtocolResourceSemanticsV1(
+            enter=EnterResultContractV1(sort=PrimitiveSort("Value")),
+            exit=ExitContractV1(disposition=ReturnTruthinessDispositionV1()),
+        ),
+        import_signature=ImportSignatureV2(()),
+        protocol=_InjectedSourceProtocol(),
+    )
+
+
+def test_source_derived_resource_consumes_exactly_two_injected_definition_coordinates():
+    source = (
+        "from dependency import option_context\n"
+        "def f(value):\n"
+        "    with option_context('mode.key', value) as entered:\n"
+        "        return entered\n"
+    )
+    first = SourceFile((source, "injected-source-resource.py", _cid("q")))
+    use_site = _coordinate(
+        next(node for node in first.nodes() if node.kind == "With")
+        .items[0]
+        .context_expr
+    )
+    enter = SourceFragmentCoordinateV1(_cid("e"), 10, 4, 11, 20)
+    exit_ = SourceFragmentCoordinateV1(_cid("x"), 20, 4, 22, 20)
+    tree, recording, _ = _source_with_recording_refs(
+        (source, "injected-source-resource.py", _cid("q")),
+        _source_derived,
+        {
+            (use_site, NativeProtocolSlot.CONTEXT_ENTER): enter,
+            (use_site, NativeProtocolSlot.CONTEXT_EXIT): exit_,
+        },
+    )
+
+    function = next(tree.functions()).sugar()
+    resource = next(
+        statement
+        for statement in function.statements
+        if isinstance(statement, WithSourceResourceSugar)
+    )
+
+    assert recording.calls == [
+        (use_site, NativeProtocolSlot.CONTEXT_ENTER),
+        (use_site, NativeProtocolSlot.CONTEXT_EXIT),
+    ]
+    assert resource.enter.native_definition_coordinate == enter
+    assert resource.exit.native_definition_coordinate == exit_
+    assert resource.body[0].value.slot_id == resource.enter_slot_id
+    assert resource.body[0].value.projection == "enter-result"
+
+    def authority_lookup_after_construction(*args, **kwargs):
+        raise AssertionError(f"desugar authority lookup: {args!r} {kwargs!r}")
+
+    recording.require_native_definition = authority_lookup_after_construction
+    assert resource.desugar() is not None
 
 
 def test_native_resource_requires_both_authenticated_definition_coordinates():


### PR DESCRIPTION
Task 3: consume the injected source-defined resource contract.

- source-derived With construction consults the native definition door for CONTEXT_ENTER and CONTEXT_EXIT
- prebuilt enter/exit calls carry the returned coordinates
- enter binding reaches the body and exit routes Completed, Returned, and Halted faces
- truthiness affects only incoming RaiseEffect halts
- desugar is proven independent of authority lookup by a poisoned-door test

No Carrier or ExitSet changes. No provider/source derivation changes. The fixture coordinate injection is the sole swap point for task 2 publication.

Focused: 12 passed.
Package bpytest sweeps launched post-push; results will be added as telemetry.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consume source-defined resource coordinates in `WithSourceResourceSugar` for context manager sugar
> - `WithSourceResourceSugar` now requires explicit `enter`/`exit` `MethodCallSugar` instances and their authenticated `SourceFragmentCoordinate` values; construction raises `TypeError` or `ValueError` on mismatch.
> - `With._prebound_manager_resolution` in [nodes.py](https://github.com/TSavo/sugar/pull/6628/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now resolves and threads authenticated native definition coordinates for `__enter__` and `__exit__` through to the sugar constructor.
> - Desugaring no longer performs authority lookups for source-derived context managers since coordinates are now embedded at construction time.
> - Risk: any existing code constructing `WithSourceResourceSugar` without the new `enter`, `exit`, `enter_definition`, and `exit_definition` fields will now fail at instantiation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8dbfcd.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved source-derived resource handling by explicitly associating enter and exit operations with their definitions.
  - Added validation to detect invalid resource operations or mismatched definitions early.

- **Bug Fixes**
  - Ensured resource exit behavior consistently handles completed, returned, and halted outcomes.
  - Prevented unnecessary definition lookups during resource desugaring.

- **Tests**
  - Expanded coverage for source-derived resources, enter/exit behavior, nested managers, and definition resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->