### PR TITLE
Finish factored message-pattern faces as guarded alternatives

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -80,11 +80,36 @@ class DerivedManagerSummaryGapV1:
     detail: str
 
 
+@dataclass(frozen=True)
+class FactoredEffectBoundarySummaryV1:
+    """Both message-pattern edges under their face guards.
+
+    Undecided ``match`` stays partitioned:
+
+    - ``match=None`` face → ``NoMessagePatternV1``
+    - ``match=pattern`` face → pattern obligation
+
+    as guarded alternatives. Faces are never recombined into one
+    ``message_pattern_operand`` and never collapsed into a uniform sealed
+    summary CID.
+    """
+
+    protocol_construction_cid: str
+    enter_testimony_cid: str
+    exit_testimony_cid: str
+    boundary_faces: object
+    import_signature: ImportSignatureV2
+
+
 def derive_manager_summary(
     protocol: ConstructedManagerProtocolV1,
     *,
     behavior=None,
-) -> DerivedManagerSummaryV1 | DerivedManagerSummaryGapV1:
+) -> (
+    DerivedManagerSummaryV1
+    | DerivedManagerSummaryGapV1
+    | FactoredEffectBoundarySummaryV1
+):
     """Derive only the theorem directly present in constructed outcomes.
 
     This first arm proves ``NeverSuppresses`` iff every enter face completes
@@ -92,6 +117,7 @@ def derive_manager_summary(
     Symbolic truthiness remains loud; it is never interpreted by target name.
     """
     from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.outcome import ExitSet
 
     from sugar_source_tree.panic import OpaqueSourceCallResolutionGap, SugarNotWritten
 
@@ -128,6 +154,8 @@ def derive_manager_summary(
         )
         if isinstance(soft, DerivedManagerSummaryGapV1):
             return soft
+        if isinstance(soft, ExitSet):
+            return _factored_effect_boundary_summary(protocol, soft, behavior)
         if soft is not None:
             signature = _signature_for_behavior(behavior, soft)
             return _sealed_summary(protocol, soft, signature)
@@ -145,6 +173,8 @@ def derive_manager_summary(
         )
         if isinstance(soft, DerivedManagerSummaryGapV1):
             return soft
+        if isinstance(soft, ExitSet):
+            return _factored_effect_boundary_summary(protocol, soft, behavior)
         if soft is not None:
             signature = _signature_for_behavior(behavior, soft)
             return _sealed_summary(protocol, soft, signature)
@@ -198,13 +228,31 @@ def _sealed_summary(protocol, semantics, signature):
     )
 
 
+def _factored_effect_boundary_summary(protocol, boundary_faces, behavior):
+    """Keep both message-pattern edges; do not seal a uniform summary."""
+    signature = _signature_for_factored_boundaries(behavior, boundary_faces)
+    return FactoredEffectBoundarySummaryV1(
+        protocol.protocol_construction_cid,
+        protocol.enter_frame_cid,
+        protocol.exit_frame_cid,
+        boundary_faces,
+        signature,
+    )
+
+
 def _construct_message_pattern_operand(
     projected_match,
     *,
     site,
     construct_message_obligation,
 ):
-    """Construct the message obligation on the source-authorized match face."""
+    """Construct the message obligation on the source-authorized match face.
+
+    ``match=None`` constructs ``NoMessagePatternV1`` without reading
+    ``.pattern``. Non-None faces project ``.pattern`` then construct the
+    regex obligation. Multi-face projections stay partitioned: each face
+    keeps its own answer under its own guard.
+    """
     from sugar_lift_py_tests.floor import NoneValue
 
     return projected_match.and_then(
@@ -221,7 +269,7 @@ def _construct_message_pattern_operand(
 def _project_receiver_match(receiver, *, site):
     """Project only source-written receiver faces that carry ``match``."""
     from sugar_lift_py_tests.floor import ObjectValue, ReceiverStatePartitionValue
-    from sugar_lift_py_tests.outcome import Completed, ExitSet
+    from sugar_lift_py_tests.outcome import ExitSet
 
     if isinstance(receiver, ObjectValue):
         if not any(field.name == "match" for field in receiver.fields):
@@ -243,23 +291,33 @@ def _project_receiver_match(receiver, *, site):
     return ExitSet(tuple(projected)) if projected else None
 
 
-def _uniform_message_operand_or_gap(
-    projected_operand,
-    *,
-    protocol_construction_cid,
-    coordinate,
-):
-    """Collapse identical message faces or return one located summary gap."""
-    projected_faces = outcome_to_exitset(projected_operand).exits
-    if projected_faces and all(
-        isinstance(face, Completed) and face.value == projected_faces[0].value
-        for face in projected_faces
-    ):
-        return projected_faces[0].value
-    return DerivedManagerSummaryGapV1(
-        "exit-may-halt",
-        protocol_construction_cid,
-        f"non-uniform-message-pattern-faces:{coordinate.cid}",
+def _message_pattern_operand_faces(projected_operand):
+    """Uniform faces collapse; non-uniform faces stay as both ExitSet edges.
+
+    Identical completed answers may share one operand. Distinct answers —
+    ``NoMessagePatternV1`` vs a pattern obligation — remain guarded
+    alternatives. There is no gap and no silent pick-one summary.
+    """
+    from sugar_lift_py_tests.outcome import ExitSet
+
+    projected = outcome_to_exitset(projected_operand)
+    completed = tuple(
+        face for face in projected.exits if isinstance(face, Completed)
+    )
+    if not completed:
+        return None
+    if all(face.value == completed[0].value for face in completed):
+        return completed[0].value
+    return ExitSet(completed)
+
+
+def _effect_boundary_for_message_operand(expected_index, message_operand):
+    return EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(expected_index),
+        message_operand,
+        ExceptionInfoBindingV1(),
     )
 
 
@@ -279,7 +337,14 @@ def _soft_effect_boundary_from_exception_formals(
     ``EffectBoundarySemanticsV1(ExpectsModeV1, …)`` dual-mode factories seal
     when their simpler exit bodies construct — without inventing a suppression
     predicate or message pattern the formals do not state.
+
+    When receiver ``match`` faces disagree (None vs pattern), both EffectBoundary
+    edges are emitted under their face guards. They are never recombined into
+    one operand and never collapsed into a uniform sealed summary.
     """
+    del protocol_construction_cid  # reserved for gap location; non-uniform is not a gap
+    from sugar_lift_py_tests.outcome import ExitSet
+
     if behavior is None:
         return None
     actuals = tuple(getattr(behavior, "formal_actual_values", ()) or ())
@@ -315,20 +380,42 @@ def _soft_effect_boundary_from_exception_formals(
             site=site,
             construct_message_obligation=lambda _pattern: Complete(message_operand),
         )
-        message_operand = _uniform_message_operand_or_gap(
-            projected_operand,
-            protocol_construction_cid=protocol_construction_cid,
-            coordinate=site,
-        )
-        if isinstance(message_operand, DerivedManagerSummaryGapV1):
-            return message_operand
-    return EffectBoundarySemanticsV1(
-        ExpectsModeV1(),
-        RaiseEffectKindV1(),
-        FormalArgumentProjectionV1(expected_index),
-        message_operand,
-        ExceptionInfoBindingV1(),
-    )
+        resolved = _message_pattern_operand_faces(projected_operand)
+        if resolved is None:
+            return None
+        if isinstance(resolved, ExitSet):
+            return ExitSet(
+                tuple(
+                    Completed(
+                        face.guard,
+                        _effect_boundary_for_message_operand(
+                            expected_index, face.value
+                        ),
+                        faces=face.faces,
+                        pending_contracts=face.pending_contracts,
+                    )
+                    for face in resolved.exits
+                    if isinstance(face, Completed)
+                )
+            )
+        message_operand = resolved
+    return _effect_boundary_for_message_operand(expected_index, message_operand)
+
+
+def _signature_for_factored_boundaries(behavior, boundary_faces):
+    """Signature for factored edges: include the message formal if any face needs it."""
+    representative = None
+    for face in boundary_faces.exits:
+        if not isinstance(face, Completed):
+            continue
+        semantics = face.value
+        if not isinstance(semantics, EffectBoundarySemanticsV1):
+            continue
+        if not isinstance(semantics.message_pattern_operand, NoMessagePatternV1):
+            return _signature_for_behavior(behavior, semantics)
+        if representative is None:
+            representative = semantics
+    return _signature_for_behavior(behavior, representative)
 
 
 def _derive_effect_boundary(exit_set, protocol, behavior):

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1372,15 +1372,13 @@ def test_none_match_branches_before_pattern_projection():
 
 
 def test_uniform_none_match_faces_collapse_to_one_no_message_summary():
-    from types import SimpleNamespace
-
     from sugar_lift_py_tests.context_manager_contract import NoMessagePatternV1
     from sugar_lift_py_tests.floor import NoneValue
     from sugar_lift_py_tests.ir import _Atomic
     from sugar_lift_py_tests.outcome import Completed, ExitSet
     from sugar_lift_python_source.manager_summary_derivation import (
         _construct_message_pattern_operand,
-        _uniform_message_operand_or_gap,
+        _message_pattern_operand_faces,
     )
 
     projected = _construct_message_pattern_operand(
@@ -1395,19 +1393,13 @@ def test_uniform_none_match_faces_collapse_to_one_no_message_summary():
             AssertionError("None faces cannot construct a regex obligation")
         ),
     )
-    result = _uniform_message_operand_or_gap(
-        projected,
-        protocol_construction_cid="uniform-none-protocol",
-        coordinate=SimpleNamespace(cid="uniform-none-coordinate"),
-    )
+    result = _message_pattern_operand_faces(projected)
 
     assert isinstance(result, NoMessagePatternV1)
 
 
 def test_uniform_pattern_faces_collapse_to_one_pattern_obligation():
     """Truthful twin: non-None faces construct one regex obligation."""
-    from types import SimpleNamespace
-
     from sugar_lift_py_tests.context_manager_contract import (
         OptionalFormalArgumentProjectionV1,
     )
@@ -1416,7 +1408,7 @@ def test_uniform_pattern_faces_collapse_to_one_pattern_obligation():
     from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet
     from sugar_lift_python_source.manager_summary_derivation import (
         _construct_message_pattern_operand,
-        _uniform_message_operand_or_gap,
+        _message_pattern_operand_faces,
     )
 
     class PatternCarrier(FloorValue):
@@ -1439,18 +1431,59 @@ def test_uniform_pattern_faces_collapse_to_one_pattern_obligation():
             else (_ for _ in ()).throw(AssertionError(pattern))
         ),
     )
-    result = _uniform_message_operand_or_gap(
-        projected,
-        protocol_construction_cid="uniform-pattern-protocol",
-        coordinate=SimpleNamespace(cid="uniform-pattern-coordinate"),
-    )
+    result = _message_pattern_operand_faces(projected)
 
     assert result == expected
 
 
-def test_non_uniform_message_faces_return_located_derived_summary_gap():
-    from types import SimpleNamespace
+def test_non_uniform_match_faces_emit_both_message_pattern_edges():
+    """Positive: match=None and match=pattern construct as both guarded edges."""
+    from sugar_lift_py_tests.context_manager_contract import (
+        NoMessagePatternV1,
+        OptionalFormalArgumentProjectionV1,
+    )
+    from sugar_lift_py_tests.floor import FloorValue, NoneValue, StringValue
+    from sugar_lift_py_tests.ir import _Atomic
+    from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet
+    from sugar_lift_python_source.manager_summary_derivation import (
+        _construct_message_pattern_operand,
+        _message_pattern_operand_faces,
+    )
 
+    class PatternCarrier(FloorValue):
+        def attribute(self, name, site):
+            assert (name, site) == ("pattern", "non-uniform-message-faces")
+            return Complete(StringValue("^needle$"))
+
+    expected = OptionalFormalArgumentProjectionV1(1)
+    projected = _construct_message_pattern_operand(
+        ExitSet(
+            (
+                Completed(_Atomic("none-message-face", ()), NoneValue()),
+                Completed(_Atomic("pattern-message-face", ()), PatternCarrier()),
+            )
+        ),
+        site="non-uniform-message-faces",
+        construct_message_obligation=lambda pattern: (
+            Complete(expected)
+            if pattern == StringValue("^needle$")
+            else (_ for _ in ()).throw(AssertionError(pattern))
+        ),
+    )
+    result = _message_pattern_operand_faces(projected)
+
+    assert isinstance(result, ExitSet)
+    completed = [face for face in result.exits if isinstance(face, Completed)]
+    assert len(completed) == 2
+    values = {face.value for face in completed}
+    assert values == {NoMessagePatternV1(), expected}
+    by_guard = {face.guard.name: face.value for face in completed}
+    assert isinstance(by_guard["none-message-face"], NoMessagePatternV1)
+    assert by_guard["pattern-message-face"] == expected
+
+
+def test_non_uniform_message_faces_do_not_collapse_to_one_operand():
+    """Discrimination: mixed faces are not a single operand and not a gap."""
     from sugar_lift_py_tests.context_manager_contract import (
         NoMessagePatternV1,
         OptionalFormalArgumentProjectionV1,
@@ -1459,11 +1492,10 @@ def test_non_uniform_message_faces_return_located_derived_summary_gap():
     from sugar_lift_py_tests.outcome import Completed, ExitSet
     from sugar_lift_python_source.manager_summary_derivation import (
         DerivedManagerSummaryGapV1,
-        _uniform_message_operand_or_gap,
+        _message_pattern_operand_faces,
     )
 
-    coordinate = SimpleNamespace(cid="non-uniform-formal-coordinate")
-    result = _uniform_message_operand_or_gap(
+    result = _message_pattern_operand_faces(
         ExitSet(
             (
                 Completed(_Atomic("none-message-face", ()), NoMessagePatternV1()),
@@ -1472,17 +1504,136 @@ def test_non_uniform_message_faces_return_located_derived_summary_gap():
                     OptionalFormalArgumentProjectionV1(1),
                 ),
             )
-        ),
-        protocol_construction_cid="non-uniform-protocol-coordinate",
-        coordinate=coordinate,
+        )
     )
 
-    assert isinstance(result, DerivedManagerSummaryGapV1)
-    assert result.kind == "exit-may-halt"
-    assert result.protocol_construction_cid == "non-uniform-protocol-coordinate"
-    assert result.detail == (
-        "non-uniform-message-pattern-faces:non-uniform-formal-coordinate"
+    assert not isinstance(result, DerivedManagerSummaryGapV1)
+    assert not isinstance(result, (NoMessagePatternV1, OptionalFormalArgumentProjectionV1))
+    assert isinstance(result, ExitSet)
+    assert len(result.exits) == 2
+
+
+def test_soft_boundary_emits_both_effect_boundary_faces_for_non_uniform_match():
+    """Soft path: both edges are full EffectBoundarySemantics under face guards."""
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        NoMessagePatternV1,
+        OptionalFormalArgumentProjectionV1,
     )
+    from sugar_lift_py_tests.floor import FloorValue, NoneValue, ObjectValue, StringValue
+    from sugar_lift_py_tests.floor.object_field import ObjectField
+    from sugar_lift_py_tests.floor.receiver_state_partition_value import (
+        ReceiverStatePartitionValue,
+    )
+    from sugar_lift_py_tests.ir import _Atomic
+    from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet
+    from sugar_lift_python_source.manager_summary_derivation import (
+        _soft_effect_boundary_from_exception_formals,
+    )
+
+    class ExceptionTypeValue(FloorValue):
+        def exception_type_identity(self):
+            return "python:ValueError"
+
+    class PatternCarrier(FloorValue):
+        def attribute(self, name, site):
+            assert name == "pattern"
+            return Complete(StringValue("^$"))
+
+    none_receiver = ObjectValue(
+        "RaisesCM",
+        (ObjectField("match", NoneValue()),),
+        identity="none-receiver",
+    )
+    pattern_receiver = ObjectValue(
+        "RaisesCM",
+        (ObjectField("match", PatternCarrier()),),
+        identity="pattern-receiver",
+    )
+    behavior = SimpleNamespace(
+        formal_actual_values=(ExceptionTypeValue(), StringValue("^$")),
+        formal_actual_bindings=(
+            SimpleNamespace(coordinate=SimpleNamespace(cid="formal-0")),
+            SimpleNamespace(coordinate=SimpleNamespace(cid="formal-1")),
+        ),
+        receiver_state=ReceiverStatePartitionValue(
+            ExitSet(
+                (
+                    Completed(_Atomic("none-face", ()), none_receiver),
+                    Completed(_Atomic("pattern-face", ()), pattern_receiver),
+                )
+            )
+        ),
+    )
+    result = _soft_effect_boundary_from_exception_formals(
+        behavior,
+        protocol_construction_cid="soft-factored-protocol",
+    )
+
+    assert isinstance(result, ExitSet)
+    completed = [face for face in result.exits if isinstance(face, Completed)]
+    assert len(completed) == 2
+    for face in completed:
+        assert isinstance(face.value, EffectBoundarySemanticsV1)
+    operands = {face.value.message_pattern_operand for face in completed}
+    assert operands == {
+        NoMessagePatternV1(),
+        OptionalFormalArgumentProjectionV1(1),
+    }
+
+
+def test_soft_boundary_uniform_none_match_stays_one_no_message_summary():
+    """Discrimination twin: uniform match=None still seals one NoMessagePattern."""
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        NoMessagePatternV1,
+    )
+    from sugar_lift_py_tests.floor import FloorValue, NoneValue, ObjectValue, StringValue
+    from sugar_lift_py_tests.floor.object_field import ObjectField
+    from sugar_lift_py_tests.floor.receiver_state_partition_value import (
+        ReceiverStatePartitionValue,
+    )
+    from sugar_lift_py_tests.ir import _Atomic
+    from sugar_lift_py_tests.outcome import Completed, ExitSet
+    from sugar_lift_python_source.manager_summary_derivation import (
+        _soft_effect_boundary_from_exception_formals,
+    )
+
+    class ExceptionTypeValue(FloorValue):
+        def exception_type_identity(self):
+            return "python:ValueError"
+
+    receiver = ObjectValue(
+        "RaisesCM",
+        (ObjectField("match", NoneValue()),),
+        identity="uniform-none-receiver",
+    )
+    behavior = SimpleNamespace(
+        formal_actual_values=(ExceptionTypeValue(), StringValue("^$")),
+        formal_actual_bindings=(
+            SimpleNamespace(coordinate=SimpleNamespace(cid="formal-0")),
+            SimpleNamespace(coordinate=SimpleNamespace(cid="formal-1")),
+        ),
+        receiver_state=ReceiverStatePartitionValue(
+            ExitSet(
+                (
+                    Completed(_Atomic("none-face-a", ()), receiver),
+                    Completed(_Atomic("none-face-b", ()), receiver),
+                )
+            )
+        ),
+    )
+    result = _soft_effect_boundary_from_exception_formals(
+        behavior,
+        protocol_construction_cid="soft-uniform-none-protocol",
+    )
+
+    assert isinstance(result, EffectBoundarySemanticsV1)
+    assert isinstance(result.message_pattern_operand, NoMessagePatternV1)
 
 
 def test_source_derived_resource_ref_selects_projection_only_with_arm(tmp_path):


### PR DESCRIPTION
## Summary

Closes the #6615 PARTIAL for non-uniform returned-manager message faces.

- `match=None` face constructs `NoMessagePatternV1` without reading `.pattern`
- `match=pattern` face projects `.pattern` then constructs the pattern obligation
- Non-uniform faces emit **both** edges as an `ExitSet` of `EffectBoundarySemanticsV1` under their face guards (`FactoredEffectBoundarySummaryV1`)
- Uniform identical faces still collapse to one operand
- No speculative attribute read; no silent pick-one summary; no non-uniform gap

## Tests

Positive + discrimination per variant:

- none-before-pattern mutation tooth (speculative `.pattern` impossible)
- uniform none → `NoMessagePatternV1`
- uniform pattern → pattern obligation
- non-uniform construct both edges (None + pattern)
- non-uniform discrimination (not a gap, not a single operand)
- soft path emits both EffectBoundary faces
- soft path uniform none stays one `NoMessagePatternV1`

```
PYTHONPATH=... python3 -m pytest implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py -k 'message_pattern or match_faces or soft_boundary or none_match_branches or uniform_none or uniform_pattern or non_uniform' -q
# 7 passed
```

`test_context_manager_semantics_v2.py`: 25 passed.

Pre-existing reds on main (carrier / undischarged native demand / exit-may-halt) are unchanged and out of scope; Carrier and ExitSet were not touched.

## Notes for merger

- Population still installs a derivation gap for `FactoredEffectBoundarySummaryV1` (not a sealed uniform `DerivedManagerSummaryV1`). Construction of both edges is the capability this PR proves; sealing a multi-face use-site ref is a separate follow-on if needed.
- No assertion consumer, carrier, outcome, ExitSet, or reserved operation floor was changed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return factored effect-boundary summaries for non-uniform message-pattern faces
> - Adds `FactoredEffectBoundarySummaryV1` dataclass to carry per-face boundary data (enter/exit testimony CIDs, boundary faces, import signature) when message-pattern operands are non-uniform across exit faces.
> - Replaces the previous gap-producing behavior in `_message_pattern_operand_faces` with an `ExitSet` of per-face operands when values differ, and returns a single operand when all faces are uniform.
> - Updates `_soft_effect_boundary_from_exception_formals` to return an `ExitSet` of `EffectBoundarySemanticsV1` (one per face) for non-uniform match faces, rather than a `DerivedManagerSummaryGapV1`.
> - `derive_manager_summary` now returns `FactoredEffectBoundarySummaryV1` instead of a gap when the soft path yields an `ExitSet`.
> - Behavioral Change: paths that previously produced a gap for non-uniform message-pattern faces now produce a structured factored summary.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c391218.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->