### PR TITLE
Carry formal comparisons through IfSugar

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -282,9 +282,16 @@ def reduce_block_to_exitset(
                 else:
                     linear = Complete(value)
                     contribution = linear.contribution()
-                    continues = linear.follow().continues
-                    nested_fall_through = ()
-                    nested_transforms = ()
+                    follow = linear.follow()
+                    continues = follow.continues
+                    nested_fall_through = (
+                        ()
+                        if follow.continuation_guard is None
+                        else (follow.continuation_guard,)
+                    )
+                    nested_transforms = (
+                        () if follow.transform is None else (follow.transform,)
+                    )
                     next_context = _extend_receiver_store_scope(
                         linear.value, active_ctx
                     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -127,6 +127,18 @@ class IfSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            NativeOperationExitCarrierV1,
+        )
+
+        cond = self.test.desugar(ctx)
+        if isinstance(cond, NativeOperationExitCarrierV1):
+            return cond.and_then(lambda value: self._desugar_condition(value, ctx))
+        if not isinstance(cond, Complete):
+            return cond
+        return self._desugar_condition(cond.value, ctx)
+
+    def _desugar_condition(self, condition, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.branch_result_coordinate import (
             BranchResultAuthentication,
             branch_result_guard,
@@ -144,17 +156,14 @@ class IfSugar(Sugar):
         # b`) stands as its own formula, a bare value (`if c`) emits the Python
         # `py.truthy(c)` relation. A ground bool (`if True:`) folds to a literal
         # with no formula and is not lifted yet -- LOUD, never guard by nothing.
-        cond = self.test.desugar(ctx)
-        if not isinstance(cond, Complete):
-            return cond
         # Condition expression itself raised: the if never selects a branch.
         # Do not demand truth of RaiseValue (that was force-floor:truth:RaiseValue).
         from sugar_lift_py_tests.floor import RaiseValue
         from sugar_lift_py_tests.outcome import Incomplete
 
-        if isinstance(cond.value, RaiseValue):
-            return Incomplete(cond.value.effect)
-        observed_formula = predicate_formula(cond.value, self.site)
+        if isinstance(condition, RaiseValue):
+            return Incomplete(condition.effect)
+        observed_formula = predicate_formula(condition, self.site)
         from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
 
         formula = (

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_through_if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_through_if_sugar.py
@@ -1,0 +1,142 @@
+"""Formal ordering comparisons retain their one carrier through ``IfSugar``."""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import CallSiteValue, GuardedReturn, ReturnValue, TermValue
+from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+HELPER = (
+    "def helper(left, right):\n"
+    "    if left < right:\n"
+    "        return 1\n"
+    "    return 0\n"
+)
+
+
+def _tree(calls: str = "") -> SourceFile:
+    source = f"{HELPER}\n{calls}"
+    return SourceFile(
+        (source, "compare-through-if.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _function_outcome():
+    function = next(
+        node for node in _tree().nodes() if isinstance(node, FunctionDef)
+    )
+    return function.sugar().desugar(None)
+
+
+def _call_outcomes(calls: str):
+    return tuple(
+        node.sugar().desugar(None)
+        for node in _tree(calls).nodes()
+        if isinstance(node, Call)
+    )
+
+
+def _only_completed(outcome: object) -> Completed:
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    completed = outcome.exits[0]
+    assert isinstance(completed, Completed)
+    return completed
+
+
+def _returned_term(completed: Completed) -> TermValue:
+    value = completed.value
+    if isinstance(value, CallSiteValue):
+        value = value._dig_floor_or_none(None, owner="test_compare_through_if_sugar")
+        assert value is not None
+        returns = tuple(
+            entry
+            for entry in value.statements
+            if isinstance(entry, (ReturnValue, GuardedReturn))
+        )
+        assert len(returns) == 1
+        value = returns[0]
+    if isinstance(value, GuardedReturn):
+        value = value.value
+    if isinstance(value, ReturnValue):
+        value = value.value
+    assert isinstance(value, TermValue)
+    return value
+
+
+def test_formal_ordering_condition_creates_exactly_one_carrier() -> None:
+    pending = _function_outcome()
+
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "less_than"
+    assert len(pending.demand.operand_coordinate_cids) == 2
+
+
+def test_caller_actuals_discharge_the_condition_carrier() -> None:
+    (outcome,) = _call_outcomes("helper(1, 2)\n")
+
+    completed = _only_completed(outcome)
+    assert _returned_term(completed).value == 1
+
+
+def test_completed_predicate_selects_the_correct_branch() -> None:
+    truthful, lying = _call_outcomes("helper(1, 2)\nhelper(2, 1)\n")
+
+    assert _returned_term(_only_completed(truthful)).value == 1
+    assert _returned_term(_only_completed(lying)).value == 0
+
+
+def test_exceptional_condition_bypasses_both_bodies() -> None:
+    (outcome,) = _call_outcomes("helper(None, 2)\n")
+
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    assert isinstance(outcome.exits[0], Halted)
+
+
+def test_symbolic_if_branches_keep_complementary_guards() -> None:
+    pending = _function_outcome()
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+
+    left, right = pending.coordinates
+    from sugar_lift_py_tests.floor import SymbolicValue
+    from sugar_lift_py_tests.ir import make_var
+
+    exits = pending.discharge(
+        {
+            left.coordinate_cid: SymbolicValue(make_var("actual_left")),
+            right.coordinate_cid: SymbolicValue(make_var("actual_right")),
+        }
+    )
+    assert isinstance(exits, ExitSet)
+    assert len(exits.exits) == 1
+    record = exits.exits[0].value.record
+    returns = tuple(
+        value for value in record.statements if isinstance(value, GuardedReturn)
+    )
+    assert len(returns) == 2
+    then_return, else_return = returns
+    assert then_return.value == TermValue(1)
+    assert else_return.value == TermValue(0)
+    assert then_return.guards[0].args[0].name == "python:branch_result"
+    assert else_return.guards[0].kind == "not"
+    assert else_return.guards[0].operands[0] == then_return.guards[0]
+
+
+def test_identity_condition_never_acquires_a_carrier() -> None:
+    source = HELPER.replace("left < right", "left is right")
+    tree = SourceFile(
+        (source, "identity-through-if.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+
+    assert not isinstance(
+        function.sugar().desugar(None), NativeOperationExitCarrierV1
+    )


### PR DESCRIPTION
Task 1 capability: formal ordering comparisons now retain their single native-operation carrier through `IfSugar`, resume the condition after authenticated caller discharge, select the completed branch, bypass both bodies on an exceptional comparison, and preserve complementary guards for symbolic branches. Identity comparison remains carrier-free.

Focused evidence:
- `PYTHONPATH="implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src" python3 -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_compare_through_if_sugar.py` -> `6 passed in 5.25s`
- Remote authenticated package run (`cd implementations/python/sugar-lift-py-tests && ../../../bin/bpytest`) -> new file `......`; whole package remains red: `258 failed, 2150 passed, 9 skipped, 5 errors in 331.92s`. Red was preserved, not suppressed.
- Local adjacent run on Python 3.14.4: `15 passed, 1 failed`; the one failure is the sacred runtime authentication refusal: `Python runtime authority mismatch: required cpython-3.12.13; observed cpython-3.14.4 at /usr/local/opt/python@3.14/bin/python3.14`.

No Carrier or ExitSet files changed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Carry formal comparisons through `IfSugar` via `NativeOperationExitCarrierV1`
> - `IfSugar.desugar` now detects when the if-condition desugars to a `NativeOperationExitCarrierV1` and chains branch selection via `and_then`, deferring evaluation until the carrier is discharged. Non-carrier outcomes continue to short-circuit or proceed as before.
> - A new `_desugar_condition` helper extracts the branch construction logic previously inlined in `desugar`, operating on an already-evaluated condition value rather than a `Complete` wrapper.
> - `reduce_block_to_exitset` now preserves `continuation_guard` and `transform` from `follow()` when a statement desugars to a `Complete`, threading them as `nested_fall_through` and `nested_transforms` instead of discarding them.
> - New tests in [`test_compare_through_if_sugar.py`](https://github.com/TSavo/sugar/pull/6631/files#diff-d76377737c847c7dc49d07abd5651b876be4253270db4072f464ddbf250e8ce8) verify single carrier creation, correct branch selection on discharge, exceptional bypass, complementary guards, and that identity comparisons do not produce carriers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dac24de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->