### PR TITLE
Align formal unpack setitem tooth with undischarged carrier

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
@@ -34,6 +34,8 @@ import hashlib
 import re
 from pathlib import Path
 
+import pytest
+
 from sugar_lift_py_tests.outcome.exit_set import (
     Completed,
     Halted,
@@ -610,16 +612,24 @@ def test_source_visible_subscript_leaves_construct_after_store_coordinate_law(
 
 
 def test_formal_subscript_unpack_desugar_stays_undischarged(tmp_path: Path) -> None:
-    """Runtime-selected receivers still refuse at the store door (#6599)."""
+    """Formal receivers mint undischarged setitem carrier (not Completed).
+
+    Runtime-selected non-formal receivers still refuse at the store door
+    (#6599 SugarNotWritten).  Formal operands are the n-ary setitem vertical:
+    ``NativeOperationExitCarrierV1`` awaiting caller actuals.
+    """
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+
     sugar = _function_sugar(
         tmp_path, "def f(a, i, p, q):\n    x, a[i] = p, q\n    return x\n", "formal_sub"
     )
-    try:
-        sugar.desugar(None)
-    except SugarNotWritten as gap:
-        assert "undischarged subscript store" in gap.observed
-        return
-    raise AssertionError("expected undischarged subscript store for formal receiver")
+    outcome = sugar.desugar(None)
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    assert outcome.demand.operator == "setitem"
+    with pytest.raises(SugarNotWritten, match="caller actual absent"):
+        outcome.discharge({})
 
 
 def test_dual_attribute_display_unpack_constructs(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #6630. Full `bin/bpytest` on `sugar-lift-py-tests` surfaced a stale formal-unpack tooth that still expected `SugarNotWritten` for formal `a[i]` stores. That path is the n-ary setitem carrier (undischarged without caller actuals).

## Test plan

- [x] `bin/bpytest` from `implementations/python/sugar-lift-py-tests`:
  - `tests/test_assign_unpack_store_leaves.py::test_formal_subscript_unpack_desugar_stays_undischarged`
  - `tests/test_setitem_formal_caller.py`
  - `tests/test_unpack_sequencing_law.py`
  - `tests/test_subscript_store_formal_call_projection.py`
  - `tests/test_subscript_store_desugar.py`
  - `tests/test_native_operation_exit_carrier.py`
  → **96 passed** (cpython-3.12.13 on bx)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `test_formal_subscript_unpack_desugar_stays_undischarged` to expect undischarged carrier from `desugar`
> Updates the test in [test_assign_unpack_store_leaves.py](https://github.com/TSavo/sugar/pull/6634/files#diff-e630f2aab4b0527d1ebf628b3dec8ccb52890b651aa9a5008f9f9890a8aa5088) to reflect that `sugar.desugar(None)` now returns a `NativeOperationExitCarrierV1` with `demand.operator == 'setitem'` rather than raising `SugarNotWritten` immediately. The `SugarNotWritten` exception (matching `'caller actual absent'`) is now expected only when `outcome.discharge({})` is called on the returned carrier.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized abcc01c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->