### PR TITLE
Pin formal Compare assertion-boundary join

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_through_if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_through_if_sugar.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.context_manager_contract import (
+    AuthenticatedRaiseMatcher,
+    EffectBoundaryDisposition,
+)
+from sugar_lift_py_tests.effect import ExpectationNotMetEffect
 from sugar_lift_py_tests.floor import CallSiteValue, GuardedReturn, ReturnValue, TermValue
 from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted
 from sugar_lift_python_source.canonical import blake3_512_of
@@ -48,6 +53,33 @@ def _only_completed(outcome: object) -> Completed:
     completed = outcome.exits[0]
     assert isinstance(completed, Completed)
     return completed
+
+
+def _only_halted(outcome: object) -> Halted:
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    halted = outcome.exits[0]
+    assert isinstance(halted, Halted)
+    return halted
+
+
+def _expected_exception(name: str):
+    """Resolve builtin type identity through the lexical floor, never spelling dispatch."""
+    from sugar_lift_py_tests.temporal.temporal_context import TemporalContext
+
+    return TemporalContext.empty().value_for(name)
+
+
+def _through_assertion_boundary(outcome: ExitSet, expected: str) -> ExitSet:
+    return outcome.and_exit(
+        ExitSet.completed(object()),
+        disposition=EffectBoundaryDisposition(
+            matcher=AuthenticatedRaiseMatcher(
+                expected=_expected_exception(expected), message_pattern=None
+            ),
+            unmet=ExpectationNotMetEffect("raise", "compare-through-if.py"),
+        ),
+    )
 
 
 def _returned_term(completed: Completed) -> TermValue:
@@ -95,9 +127,44 @@ def test_completed_predicate_selects_the_correct_branch() -> None:
 def test_exceptional_condition_bypasses_both_bodies() -> None:
     (outcome,) = _call_outcomes("helper(None, 2)\n")
 
-    assert isinstance(outcome, ExitSet)
-    assert len(outcome.exits) == 1
-    assert isinstance(outcome.exits[0], Halted)
+    halted = _only_halted(outcome)
+    assert (
+        halted.effect.exception_type_coordinate
+        == _expected_exception("TypeError").exception_type_identity()
+    )
+    assert halted.effect.occurrence_id is not None
+
+
+def test_matching_assertion_boundary_consumes_and_preserves_pre_effect_state() -> None:
+    """Join #6631 + #6627: the formal condition halt reaches its boundary.
+
+    RED until ``caller_parameter_contract.py`` threads the reducer's real
+    pre-effect state into ``NativeOperationResolutionV1.project``.  The
+    assertion boundary correctly refuses a matching halt with ``state=None``;
+    never fabricate that state in this test or in the boundary consumer.
+    """
+    (produced,) = _call_outcomes("helper(None, 2)\n")
+    original = _only_halted(produced)
+    assert original.state is not None, (
+        "caller_parameter_contract.py NativeOperationResolutionV1.project "
+        "omitted the formal ordering halt's real pre-effect state"
+    )
+
+    routed = _through_assertion_boundary(produced, "TypeError")
+
+    completed = _only_completed(routed)
+    assert completed.value is original.state
+
+
+def test_wrong_expected_type_retains_the_same_formal_ordering_halt() -> None:
+    (produced,) = _call_outcomes("helper(None, 2)\n")
+    original = _only_halted(produced)
+
+    routed = _through_assertion_boundary(produced, "ValueError")
+
+    remaining = _only_halted(routed)
+    assert remaining.effect is original.effect
+    assert remaining.state is original.state
 
 
 def test_symbolic_if_branches_keep_complementary_guards() -> None:


### PR DESCRIPTION
## Join claim

Proves the third composition not covered by merged #6631 or #6627: a formal `less_than` condition is carried once through `IfSugar`, discharged by `helper(None, 2)` to an authenticated TypeError halt, and routed into an assertion boundary.

## Acceptance arms

- helper alone remains one `less_than` carrier
- `helper(None, 2)` authenticates TypeError by builtin lexical type coordinate
- neither If branch executes after the condition halt
- wrong expected type retains the original effect and state objects
- identity remains carrier-free
- matching boundary must consume while preserving the exact pre-effect state

## Intentional red dependency

`test_matching_assertion_boundary_consumes_and_preserves_pre_effect_state` is red at the exact known producer defect: `caller_parameter_contract.py NativeOperationResolutionV1.project omitted the formal ordering halts real pre-effect state`.

The assertion-boundary consumer correctly refuses to consume a matching halt with `state=None`. This PR does not fabricate state or touch Carrier, ExitSet, IfSugar, comparison producers, or assertion-boundary implementation.

## Tests

`../../../bin/bpytest tests/test_compare_through_if_sugar.py -q`: 7 passed, 1 failed. The sole failure is the intentional dependency above.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin formal Compare assertion-boundary join with matching and non-matching halt tests
> - Strengthens `test_exceptional_condition_bypasses_both_bodies` to verify the specific exception type identity and non-null occurrence id on the halted effect.
> - Adds `test_matching_assertion_boundary_consumes_and_preserves_pre_effect_state`: routes a `TypeError` halt through an assertion boundary and confirms it is consumed, returning the original pre-effect state as the completed value.
> - Adds `test_wrong_expected_type_retains_the_same_formal_ordering_halt`: confirms that a boundary expecting `ValueError` leaves a `TypeError` halt and its state unchanged.
> - Introduces helpers `_only_halted`, `_expected_exception`, and `_through_assertion_boundary` in [test_compare_through_if_sugar.py](https://github.com/TSavo/sugar/pull/6635/files#diff-d76377737c847c7dc49d07abd5651b876be4253270db4072f464ddbf250e8ce8) to support these assertions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e91caa9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->