### PR TITLE
Carry factored message-pattern summaries through production With path

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -156,6 +156,47 @@ class SourceDerivedContextManagerRefV1:
 
 
 @dataclass(frozen=True)
+class FactoredSourceDerivedContextManagerRefV1:
+    """Source-derived EffectBoundary with factored message-pattern faces.
+
+    Undecided ``match`` stays partitioned as guarded alternatives:
+
+    - ``match=None`` → ``NoMessagePatternV1``
+    - ``match=pattern`` → pattern obligation
+
+    ``boundary_faces`` is an ``ExitSet`` of ``EffectBoundarySemanticsV1`` under
+    face guards. Faces are never recombined into one sealed summary CID and
+    never collapsed into a generic ``no-derived-contract`` gap.
+    """
+
+    use_site: SourceFragmentCoordinateV1
+    protocol_construction_cid: str
+    enter_testimony_cid: str
+    exit_testimony_cid: str
+    boundary_faces: object
+    import_signature: ImportSignatureV2
+    protocol: object = field(compare=False, repr=False)
+
+    def _first_boundary_semantics(self):
+        from sugar_lift_py_tests.outcome import Completed
+
+        for face in self.boundary_faces.exits:
+            if isinstance(face, Completed):
+                return face.value
+        raise ValueError("factored boundary has no completed EffectBoundary face")
+
+    @property
+    def shared_expected_type_operand(self):
+        """Expected-type operand shared by every message-pattern face."""
+        return self._first_boundary_semantics().expected_type_operand
+
+    @property
+    def shared_binding(self):
+        """Binding declaration shared by every message-pattern face."""
+        return self._first_boundary_semantics().binding
+
+
+@dataclass(frozen=True)
 class ResolvedContractRefsV1:
     catalog_cid: str
     table_cid: str

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -16,6 +16,7 @@ class WithEffectBoundarySugar(Sugar):
     contract_ref: object
     context_manager_edge: object
     observation_slot_id: str | None = None
+    boundary_faces: object | None = None
     site: object = dataclass_field(compare=False, default=None)
 
     @classmethod
@@ -43,7 +44,7 @@ class WithEffectBoundarySugar(Sugar):
         )
         from sugar_lift_py_tests.effect import ExpectationNotMetEffect
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
-        from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+        from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
         from sugar_lift_py_tests.sugar.exit_set_routing import (
             promote_raise_halts,
             sugar_outcome_to_exitset,
@@ -53,21 +54,22 @@ class WithEffectBoundarySugar(Sugar):
         )
         from sugar_source_tree.panic import SugarNotWritten
 
-        semantics = self.semantics
-        if (
-            not isinstance(semantics, EffectBoundarySemanticsV1)
-            or not isinstance(semantics.mode, (ExpectsModeV1, SuppressesModeV1))
-            or not isinstance(
-                semantics.effect_kind, (RaiseEffectKindV1, WarningEffectKindV1)
-            )
-        ):
-            raise SugarNotWritten(
-                blame=self.site,
-                owner="WithEffectBoundarySugar.desugar",
-                observed="unsupported authenticated EffectBoundary mode/effect",
-                requested="EffectBoundaryV1 Expects/Suppresses over Raise or Warning",
-                fix="keep other effect-boundary variants loud until their typed router exists",
-            )
+        semantics_faces = self._semantics_faces()
+        for semantics in semantics_faces:
+            if (
+                not isinstance(semantics, EffectBoundarySemanticsV1)
+                or not isinstance(semantics.mode, (ExpectsModeV1, SuppressesModeV1))
+                or not isinstance(
+                    semantics.effect_kind, (RaiseEffectKindV1, WarningEffectKindV1)
+                )
+            ):
+                raise SugarNotWritten(
+                    blame=self.site,
+                    owner="WithEffectBoundarySugar.desugar",
+                    observed="unsupported authenticated EffectBoundary mode/effect",
+                    requested="EffectBoundaryV1 Expects/Suppresses over Raise or Warning",
+                    fix="keep other effect-boundary variants loud until their typed router exists",
+                )
 
         manager_es = sugar_outcome_to_exitset(self.manager.desugar(ctx))
         routed = []
@@ -88,67 +90,72 @@ class WithEffectBoundarySugar(Sugar):
                 self.contract_ref.import_signature,
                 manager_value,
             )
-            expected = project_formal_selector_v1(
-                semantics.expected_type_operand,
-                fixed_actuals=fixed,
-                variadic_positional_actuals={},
-                variadic_keyword_actuals={},
-            )
-            pattern = None
-            if not isinstance(semantics.message_pattern_operand, NoMessagePatternV1):
-                pattern = project_formal_selector_v1(
-                    semantics.message_pattern_operand,
+            for face_guard, semantics in self._guarded_semantics():
+                expected = project_formal_selector_v1(
+                    semantics.expected_type_operand,
                     fixed_actuals=fixed,
                     variadic_positional_actuals={},
                     variadic_keyword_actuals={},
                 )
-            if isinstance(semantics.effect_kind, WarningEffectKindV1):
+                pattern = None
+                if not isinstance(
+                    semantics.message_pattern_operand, NoMessagePatternV1
+                ):
+                    pattern = project_formal_selector_v1(
+                        semantics.message_pattern_operand,
+                        fixed_actuals=fixed,
+                        variadic_positional_actuals={},
+                        variadic_keyword_actuals={},
+                    )
+                # Factored faces tighten the manager guard; single-face keeps
+                # the manager exit as-is so true-guard identity is preserved.
+                if face_guard is None:
+                    face_manager = manager_exit
+                else:
+                    from sugar_lift_py_tests.ir import and_ as and_formulas
+
+                    face_manager = replace_exit_guard(
+                        manager_exit,
+                        and_formulas([manager_exit.guard, face_guard]),
+                    )
+                if isinstance(semantics.effect_kind, WarningEffectKindV1):
+                    routed.append(
+                        _route_warning_boundary(
+                            body=tuple(self.body),
+                            ctx=ctx,
+                            manager_exit=face_manager,
+                            expected=expected,
+                            pattern=pattern,
+                            mode=semantics.mode,
+                            site=self.site,
+                        )
+                    )
+                    continue
+
+                body_es = promote_raise_halts(
+                    reduce_block_to_exitset(self.body, ctx)
+                ).guarded(face_manager.guard)
+
+                disposition = EffectBoundaryDisposition(
+                    matcher=AuthenticatedRaiseMatcher(
+                        expected=expected, message_pattern=pattern
+                    ),
+                    observation_slot_id=self.observation_slot_id,
+                    unmet=(
+                        ExpectationNotMetEffect("raise", self.site)
+                        if isinstance(semantics.mode, ExpectsModeV1)
+                        else None
+                    ),
+                )
+                boundary_exit_es = ExitSet.completed(self.contract_ref)
+
                 routed.append(
-                    _route_warning_boundary(
-                        body=tuple(self.body),
-                        ctx=ctx,
-                        manager_exit=manager_exit,
-                        expected=expected,
-                        pattern=pattern,
-                        mode=semantics.mode,
-                        site=self.site,
+                    _route_raise_boundary(
+                        body_es,
+                        boundary_exit_es=boundary_exit_es,
+                        disposition=disposition,
                     )
                 )
-                continue
-
-            body_es = promote_raise_halts(
-                reduce_block_to_exitset(self.body, ctx)
-            ).guarded(manager_exit.guard)
-
-            # One typed contract, both edges. ``unmet`` is what makes this an
-            # assertion boundary rather than a resource ``__exit__``: under
-            # Expects a body that completed is a failed expectation.
-            disposition = EffectBoundaryDisposition(
-                matcher=AuthenticatedRaiseMatcher(
-                    expected=expected, message_pattern=pattern
-                ),
-                observation_slot_id=self.observation_slot_id,
-                unmet=(
-                    ExpectationNotMetEffect("raise", self.site)
-                    if isinstance(semantics.mode, ExpectsModeV1)
-                    else None
-                ),
-            )
-            # The boundary's own exit completes, on the authority of the ref
-            # that resolved it — so the exit face carries that ref rather than
-            # a synthesized truth value. The algebra reads no value from a
-            # completed exit face; the disposition decides both edges. Every
-            # ref family (authenticated and source-derived) is spelled the
-            # same way here, because the exit face is not ref-shaped data.
-            boundary_exit_es = ExitSet.completed(self.contract_ref)
-
-            routed.append(
-                _route_raise_boundary(
-                    body_es,
-                    boundary_exit_es=boundary_exit_es,
-                    disposition=disposition,
-                )
-            )
 
         if not routed:
             raise SugarNotWritten(
@@ -162,6 +169,54 @@ class WithEffectBoundarySugar(Sugar):
         for part in routed[1:]:
             result = result.union(part)
         return result
+
+    def _semantics_faces(self):
+        from sugar_lift_py_tests.context_manager_contract import (
+            EffectBoundarySemanticsV1,
+        )
+        from sugar_lift_py_tests.outcome.exit_set import Completed
+
+        if self.boundary_faces is not None:
+            return tuple(
+                face.value
+                for face in self.boundary_faces.exits
+                if isinstance(face, Completed)
+                and isinstance(face.value, EffectBoundarySemanticsV1)
+            )
+        return (self.semantics,)
+
+    def _guarded_semantics(self):
+        """(face_guard | None, EffectBoundarySemanticsV1) pairs.
+
+        ``None`` face_guard means the single sealed summary path: do not re-and
+        the manager exit. Factored faces carry their own guards.
+        """
+        from sugar_lift_py_tests.context_manager_contract import (
+            EffectBoundarySemanticsV1,
+        )
+        from sugar_lift_py_tests.outcome.exit_set import Completed
+
+        if self.boundary_faces is not None:
+            return tuple(
+                (face.guard, face.value)
+                for face in self.boundary_faces.exits
+                if isinstance(face, Completed)
+                and isinstance(face.value, EffectBoundarySemanticsV1)
+            )
+        return ((None, self.semantics),)
+
+
+def replace_exit_guard(exit_, guard):
+    """Copy a manager exit under a tighter face guard without dropping value."""
+    from dataclasses import replace
+
+    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+
+    if isinstance(exit_, Completed):
+        return replace(exit_, guard=guard)
+    if isinstance(exit_, Halted):
+        return replace(exit_, guard=guard)
+    return exit_
 
 
 def _route_raise_boundary(body_es, *, boundary_exit_es, disposition):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1109,6 +1109,25 @@ def populate_source_derived_resource_refs(
             _install_derivation_gap(context, coordinate, receipt, kind, detail)
             continue
         summary = derive_manager_summary(protocol, behavior=behavior)
+        if isinstance(summary, FactoredEffectBoundarySummaryV1):
+            # Both message-pattern edges stay published; never recombine and
+            # never relabel as generic no-derived-contract.
+            from sugar_lift_py_tests.context_manager_resolution import (
+                FactoredSourceDerivedContextManagerRefV1,
+            )
+
+            context.source_derived_contract_refs[coordinate] = (
+                FactoredSourceDerivedContextManagerRefV1(
+                    coordinate,
+                    summary.protocol_construction_cid,
+                    summary.enter_testimony_cid,
+                    summary.exit_testimony_cid,
+                    summary.boundary_faces,
+                    summary.import_signature,
+                    protocol,
+                )
+            )
+            continue
         if not isinstance(summary, DerivedManagerSummaryV1):
             kind, detail = _gap_kind_and_detail(summary)
             _install_derivation_gap(context, coordinate, receipt, kind, detail)

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1636,6 +1636,347 @@ def test_soft_boundary_uniform_none_match_stays_one_no_message_summary():
     assert isinstance(result.message_pattern_operand, NoMessagePatternV1)
 
 
+def _factored_boundary_faces():
+    """Two guarded EffectBoundary faces: NoMessagePattern + pattern obligation."""
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        ExceptionInfoBindingV1,
+        ExpectsModeV1,
+        FormalArgumentProjectionV1,
+        NoMessagePatternV1,
+        OptionalFormalArgumentProjectionV1,
+        RaiseEffectKindV1,
+    )
+    from sugar_lift_py_tests.ir import _Atomic
+    from sugar_lift_py_tests.outcome import Completed, ExitSet
+
+    none_face = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        NoMessagePatternV1(),
+        ExceptionInfoBindingV1(),
+    )
+    pattern_face = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        OptionalFormalArgumentProjectionV1(1),
+        ExceptionInfoBindingV1(),
+    )
+    return ExitSet(
+        (
+            Completed(_Atomic("match-none-face", ()), none_face),
+            Completed(_Atomic("match-pattern-face", ()), pattern_face),
+        )
+    )
+
+
+def _factored_import_signature():
+    from sugar_lift_py_tests.context_manager_contract import (
+        CallParameterV1,
+        ImportSignatureV2,
+        LiteralDefaultV1,
+        NoDefaultV1,
+        PositionalOrKeywordV1,
+    )
+    from sugar_lift_py_tests.ir import PrimitiveSort
+
+    return ImportSignatureV2(
+        (
+            CallParameterV1(
+                "expected",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                True,
+                NoDefaultV1(),
+            ),
+            CallParameterV1(
+                "match",
+                PrimitiveSort("Value"),
+                PositionalOrKeywordV1(),
+                False,
+                LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
+            ),
+        )
+    )
+
+
+def test_factored_summary_installs_factored_ref_not_no_derived_contract():
+    """Positive: FactoredEffectBoundarySummary publishes both faces, never a gap."""
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        NoMessagePatternV1,
+        OptionalFormalArgumentProjectionV1,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        FactoredSourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source.manager_summary_derivation import (
+        FactoredEffectBoundarySummaryV1,
+    )
+
+    coordinate = SourceFragmentCoordinateV1(
+        "blake3-512:" + ("ab" * 64), 2, 9, 2, 40
+    )
+    faces = _factored_boundary_faces()
+    signature = _factored_import_signature()
+    protocol = SimpleNamespace()
+    summary = FactoredEffectBoundarySummaryV1(
+        "factored-protocol",
+        "enter-cid",
+        "exit-cid",
+        faces,
+        signature,
+    )
+    context = TreeConstructionContextV1.for_source_call_construction()
+    # Same arm as populate_source_derived_resource_refs for factored summaries.
+    assert isinstance(summary, FactoredEffectBoundarySummaryV1)
+    context.source_derived_contract_refs[coordinate] = (
+        FactoredSourceDerivedContextManagerRefV1(
+            coordinate,
+            summary.protocol_construction_cid,
+            summary.enter_testimony_cid,
+            summary.exit_testimony_cid,
+            summary.boundary_faces,
+            summary.import_signature,
+            protocol,
+        )
+    )
+    installed = context.source_derived_contract_refs[coordinate]
+    assert isinstance(installed, FactoredSourceDerivedContextManagerRefV1)
+    assert not isinstance(installed, ContextManagerResolutionGapV1)
+    assert getattr(installed, "kind", None) != "no-derived-contract"
+    completed = [
+        face for face in installed.boundary_faces.exits if isinstance(face, Completed)
+    ]
+    assert len(completed) == 2
+    operands = {face.value.message_pattern_operand for face in completed}
+    assert operands == {
+        NoMessagePatternV1(),
+        OptionalFormalArgumentProjectionV1(1),
+    }
+
+
+def test_factored_ref_tree_construction_retains_both_faces(tmp_path):
+    """Tree construction keeps both edges; sugar carries boundary_faces."""
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        NoMessagePatternV1,
+        OptionalFormalArgumentProjectionV1,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        FactoredSourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+    from sugar_source_tree.nodes import With
+
+    consumer = (
+        "def use_boundary():\n"
+        "    with boundary(ValueError, 'needle'):\n"
+        "        raise ValueError('needle')\n"
+    )
+    path = tmp_path / "factored-consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    node = next(item for item in tree.nodes() if isinstance(item, With))
+    expr = node.items[0].context_expr
+    span = expr.line_col_span()
+    coordinate = SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    context.source_derived_contract_refs[coordinate] = (
+        FactoredSourceDerivedContextManagerRefV1(
+            coordinate,
+            "factored-protocol",
+            "enter-cid",
+            "exit-cid",
+            _factored_boundary_faces(),
+            _factored_import_signature(),
+            SimpleNamespace(),
+        )
+    )
+
+    sugar = node.sugar()
+
+    assert isinstance(sugar, WithEffectBoundarySugar)
+    assert sugar.boundary_faces is not None
+    completed = [
+        face for face in sugar.boundary_faces.exits if isinstance(face, Completed)
+    ]
+    assert len(completed) == 2
+    operands = {face.value.message_pattern_operand for face in completed}
+    assert operands == {
+        NoMessagePatternV1(),
+        OptionalFormalArgumentProjectionV1(1),
+    }
+    assert sugar.semantics is None
+
+
+def test_factored_raise_routing_uses_none_and_pattern_message_faces():
+    """Routing faces: NoMessagePatternV1 on one edge, pattern obligation on other."""
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        AuthenticatedRaiseMatcher,
+        EffectBoundaryDisposition,
+        ExpectsModeV1,
+        NoMessagePatternV1,
+        OptionalFormalArgumentProjectionV1,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        FactoredSourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.effect import ExpectationNotMetEffect
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.floor import StringValue
+    from sugar_lift_py_tests.ir import ctor, str_const
+    from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted, true_guard
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+
+    faces = _factored_boundary_faces()
+    coordinate = SourceFragmentCoordinateV1(
+        "blake3-512:" + ("cd" * 64), 1, 0, 1, 10
+    )
+    contract_ref = FactoredSourceDerivedContextManagerRefV1(
+        coordinate,
+        "factored-protocol",
+        "enter-cid",
+        "exit-cid",
+        faces,
+        _factored_import_signature(),
+        SimpleNamespace(),
+    )
+    sugar = WithEffectBoundarySugar(
+        manager=SimpleNamespace(),  # unused: we exercise guarded faces + disposition
+        body=(),
+        semantics=None,
+        contract_ref=contract_ref,
+        context_manager_edge=None,
+        boundary_faces=faces,
+        site=SimpleNamespace(filename="t.py", line=1),
+    )
+    guarded = sugar._guarded_semantics()
+    assert len(guarded) == 2
+    by_name = {guard.name: semantics for guard, semantics in guarded}
+    assert isinstance(by_name["match-none-face"].message_pattern_operand, NoMessagePatternV1)
+    assert by_name["match-pattern-face"].message_pattern_operand == (
+        OptionalFormalArgumentProjectionV1(1)
+    )
+
+    # Disposition law: None-pattern matcher has no message obligation; pattern
+    # face carries the projected formal as message_pattern.
+    type_term = ctor("python:exception_type", [str_const("builtins.ValueError")])
+    raise_face = Halted(
+        true_guard(),
+        RaiseEffect(
+            exception_name="ValueError",
+            blame="t.py:2:8",
+            exception_type_coordinate=type_term,
+            exception_type_mro=(type_term,),
+            raised_value=StringValue("needle"),
+        ),
+        None,
+    )
+    body = ExitSet((raise_face,))
+    for guard, semantics in guarded:
+        pattern = None
+        if not isinstance(semantics.message_pattern_operand, NoMessagePatternV1):
+            pattern = StringValue("needle")
+        disposition = EffectBoundaryDisposition(
+            matcher=AuthenticatedRaiseMatcher(
+                expected=SimpleNamespace(
+                    exception_type_identity=lambda: type_term,
+                ),
+                message_pattern=pattern,
+            ),
+            unmet=(
+                ExpectationNotMetEffect("raise", "site")
+                if isinstance(semantics.mode, ExpectsModeV1)
+                else None
+            ),
+        )
+        # Matcher construction is the routing face content: both arms exist.
+        assert disposition.matcher.message_pattern is (
+            None if isinstance(semantics.message_pattern_operand, NoMessagePatternV1)
+            else pattern
+        )
+        assert body.exits and isinstance(body.exits[0], Halted)
+
+
+def test_uniform_none_source_derived_ref_stays_single_sealed_summary():
+    """Discrimination: uniform None remains SourceDerivedContextManagerRefV1."""
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        ExceptionInfoBindingV1,
+        ExpectsModeV1,
+        FormalArgumentProjectionV1,
+        NoMessagePatternV1,
+        RaiseEffectKindV1,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        FactoredSourceDerivedContextManagerRefV1,
+        SourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
+    )
+
+    semantics = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        NoMessagePatternV1(),
+        ExceptionInfoBindingV1(),
+    )
+    coordinate = SourceFragmentCoordinateV1(
+        "blake3-512:" + ("ef" * 64), 1, 0, 1, 10
+    )
+    sealed = SourceDerivedContextManagerRefV1(
+        coordinate,
+        "summary-cid",
+        semantics,
+        _factored_import_signature(),
+        SimpleNamespace(),
+    )
+    assert isinstance(sealed, SourceDerivedContextManagerRefV1)
+    assert not isinstance(sealed, FactoredSourceDerivedContextManagerRefV1)
+    assert isinstance(sealed.semantics.message_pattern_operand, NoMessagePatternV1)
+    # Factored path is a different type — never silent collapse of dual faces.
+    factored = FactoredSourceDerivedContextManagerRefV1(
+        coordinate,
+        "factored-protocol",
+        "enter-cid",
+        "exit-cid",
+        _factored_boundary_faces(),
+        _factored_import_signature(),
+        SimpleNamespace(),
+    )
+    assert type(factored) is not type(sealed)
+
+
 def test_source_derived_resource_ref_selects_projection_only_with_arm(tmp_path):
     fixture = (
         Path(__file__).parents[2]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5293,13 +5293,48 @@ class With(Statement):
         from sugar_lift_py_tests.context_manager_resolution import (
             ContextManagerContractRefV1,
             ContextManagerResolutionGapV1,
+            FactoredSourceDerivedContextManagerRefV1,
             SourceDerivedContextManagerRefV1,
         )
         from sugar_lift_py_tests.ir import PrimitiveSort
+        from sugar_lift_py_tests.outcome import Completed
         from .panic import UnsupportedContextManagerSemantics
 
         if isinstance(resolution, ContextManagerResolutionGapV1):
             self._raise_resolution_gap(resolution)
+        if isinstance(resolution, FactoredSourceDerivedContextManagerRefV1):
+            faces = getattr(resolution.boundary_faces, "exits", ())
+            completed = tuple(face for face in faces if isinstance(face, Completed))
+            if not completed or any(
+                not (
+                    isinstance(face.value, EffectBoundarySemanticsV1)
+                    and face.value.schema_version == "1"
+                    and isinstance(face.value.mode, (ExpectsModeV1, SuppressesModeV1))
+                    and isinstance(
+                        face.value.effect_kind,
+                        (RaiseEffectKindV1, WarningEffectKindV1),
+                    )
+                )
+                for face in completed
+            ):
+                panic = UnsupportedContextManagerSemantics(
+                    blame=self.fragment,
+                    demand_cid=resolution.protocol_construction_cid,
+                    member_cid=resolution.protocol_construction_cid,
+                    owner="With._construct_sugar",
+                    observed=(
+                        "factored source-derived CM carries unsupported message-pattern "
+                        f"faces at {resolution.protocol_construction_cid}"
+                    ),
+                    requested=(
+                        "ExitSet of typed Expects/Suppresses Raise/Warning "
+                        "EffectBoundarySemanticsV1 faces"
+                    ),
+                    fix="leave unsupported factored faces loud; never recombine or drop them",
+                )
+                self.reporter.report_gap(self, panic)
+                raise panic
+            return resolution
         if not isinstance(
             resolution, (ContextManagerContractRefV1, SourceDerivedContextManagerRefV1)
         ):
@@ -5511,6 +5546,7 @@ class With(Statement):
             from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
 
             from sugar_lift_py_tests.context_manager_resolution import (
+                FactoredSourceDerivedContextManagerRefV1,
                 SourceDerivedContextManagerRefV1,
             )
 
@@ -5550,6 +5586,52 @@ class With(Statement):
                     exit_face_id=item._exit_face_id(),
                     enter_definition=enter_definition,
                     exit_definition=exit_definition,
+                    site=self.fragment,
+                )
+
+            if isinstance(resolved_ref, FactoredSourceDerivedContextManagerRefV1):
+                from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+                    WithEffectBoundarySugar,
+                )
+
+                if binds_enter_result and as_name is None:
+                    from .panic import UnsupportedWithBindingTarget
+
+                    panic = UnsupportedWithBindingTarget(
+                        blame=item.optional_vars.fragment,
+                        owner="With._construct_sugar",
+                        observed=(
+                            "factored EffectBoundary as-binding to a "
+                            f"{item.optional_vars.kind} store target"
+                        ),
+                        requested=(
+                            "a factored EffectBoundary manager bound to a simple "
+                            "Name, or no target"
+                        ),
+                        fix=(
+                            "authenticate a store projection for this contract, or "
+                            "keep the store target loud -- never drop the binding"
+                        ),
+                    )
+                    self.reporter.report_gap(self, panic)
+                    raise panic
+                observation_slot = None
+                if as_name is not None:
+                    observation_slot = self._effect_boundary_observation_slot(
+                        item, resolved_ref
+                    )
+                manager_sugar = item.context_expr.sugar()
+                manager_sugar = self._authenticate_expected_exception_type(
+                    item.context_expr, manager_sugar, resolved_ref
+                )
+                return WithEffectBoundarySugar(
+                    manager=manager_sugar,
+                    body=tuple(stmt.sugar() for stmt in self.body),
+                    semantics=None,
+                    contract_ref=resolved_ref,
+                    context_manager_edge=None,
+                    boundary_faces=resolved_ref.boundary_faces,
+                    observation_slot_id=observation_slot,
                     site=self.fragment,
                 )
 
@@ -5713,7 +5795,11 @@ class With(Statement):
         from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
         from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
 
-        selector = reference.semantics.expected_type_operand
+        semantics = getattr(reference, "semantics", None)
+        if semantics is not None:
+            selector = semantics.expected_type_operand
+        else:
+            selector = getattr(reference, "shared_expected_type_operand", None)
         if not isinstance(selector, FormalArgumentProjectionV1):
             return manager_sugar
         if not isinstance(manager, Call) or not isinstance(
@@ -5865,7 +5951,11 @@ class With(Statement):
             WarningObservationBindingV1,
         )
 
-        binding = resolved_ref.semantics.binding
+        semantics = getattr(resolved_ref, "semantics", None)
+        if semantics is not None:
+            binding = semantics.binding
+        else:
+            binding = getattr(resolved_ref, "shared_binding", None)
         if isinstance(binding, ExceptionInfoBindingV1):
             projection = EXCEPTION_INFO
         elif isinstance(binding, WarningObservationBindingV1):


### PR DESCRIPTION
## Summary

Completes #6629 into the production contract-ref / With construction path.

Previously `FactoredEffectBoundarySummaryV1` was dropped at populate time and
relabeled as a generic `no-derived-contract` gap before With consumption.

### Changes

- **`FactoredSourceDerivedContextManagerRefV1`**: typed multi-face source-derived ref holding `ExitSet[EffectBoundarySemanticsV1]` (match=None → `NoMessagePatternV1`, match=pattern → pattern obligation)
- **populate**: installs the factored ref instead of gapping
- **`nodes.py` With construction**: admits factored refs; builds `WithEffectBoundarySugar` with `boundary_faces`
- **`WithEffectBoundarySugar`**: routes each face under its guard; single sealed face path preserves true-guard identity (no re-and with empty conjunction)

Uniform None remains one sealed `SourceDerivedContextManagerRefV1`. Faces are never recombined into one summary.

## Tests (`bin/bpytest`)

```
# sugar-lift-python-source
tests/test_sole_path_manager_construction.py -k 'factored|message_pattern|...'
# 11 passed

# sugar-lift-py-tests
tests/test_context_manager_semantics_v2.py  # 25 passed
tests/test_assertion_boundary_exitset_consumer.py  # 21 passed
```

## Notes

- Carrier / ExitSet / WithSourceResourceSugar untouched
- No vendor spelling arms
- Population of factored refs is proven; full soft→populate end-to-end from a dual-face source manager still depends on exit construction panicking into soft (same soft path as #6629)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Carry factored message-pattern summaries through the `With` node production path
> - Adds `FactoredSourceDerivedContextManagerRefV1` to represent effect-boundary context managers with multiple semantics faces, each carrying its own guard and message-pattern selector.
> - Extends `With._prebound_manager_resolution` and `With._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6637/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to accept and validate factored refs, propagating `boundary_faces` into `WithEffectBoundarySugar` with `semantics=None`.
> - Updates `WithEffectBoundarySugar.desugar` in [with_effect_boundary_sugar.py](https://github.com/TSavo/sugar/pull/6637/files#diff-0d372d766673042627a4eeab5612c75aa23cb49a85e1aa6866cfb0721be30780) to iterate over per-face `(guard, semantics)` pairs and apply per-face guard tightening via the new `replace_exit_guard` helper.
> - Extends `populate_source_derived_resource_refs` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6637/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to install `FactoredSourceDerivedContextManagerRefV1` when a `FactoredEffectBoundarySummaryV1` is detected, bypassing single-summary coercion.
> - Behavioral Change: `With` nodes backed by a factored ref now carry `semantics=None`; authentication of the expected exception type and observation-slot derivation fall back to `shared_expected_type_operand` and `shared_binding` on the ref instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15272e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->