### PR TITLE
Factored faces: as-excinfo binding + refuse disagreeing face authority

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -177,23 +177,61 @@ class FactoredSourceDerivedContextManagerRefV1:
     import_signature: ImportSignatureV2
     protocol: object = field(compare=False, repr=False)
 
-    def _first_boundary_semantics(self):
+    def _completed_boundary_semantics(self):
         from sugar_lift_py_tests.outcome import Completed
 
-        for face in self.boundary_faces.exits:
-            if isinstance(face, Completed):
-                return face.value
-        raise ValueError("factored boundary has no completed EffectBoundary face")
+        return tuple(
+            face.value
+            for face in self.boundary_faces.exits
+            if isinstance(face, Completed)
+        )
+
+    def _shared_authority_field(self, field_name: str):
+        """Authority shared by every face, or refuse when faces disagree.
+
+        Expected-type and binding testimony authorize ALL message-pattern faces
+        (nodes.py observation slot / exception authentication). Face zero must
+        never speak for a sibling with different testimony.
+        """
+        from sugar_source_tree.panic import SugarNotWritten
+
+        faces = self._completed_boundary_semantics()
+        if not faces:
+            raise ValueError("factored boundary has no completed EffectBoundary face")
+        values = tuple(getattr(face, field_name) for face in faces)
+        first = values[0]
+        if any(value != first for value in values[1:]):
+            observed = ", ".join(
+                f"{type(value).__name__}={value!r}" for value in values
+            )
+            raise SugarNotWritten(
+                blame=self.use_site,
+                owner=f"FactoredSourceDerivedContextManagerRefV1.shared_{field_name}",
+                observed=(
+                    f"factored EffectBoundary faces disagree on {field_name}: "
+                    f"{observed}"
+                ),
+                requested=(
+                    f"identical {field_name} testimony on every completed "
+                    "message-pattern face"
+                ),
+                fix=(
+                    "never authorize all faces from the first completed face when "
+                    "expected-type or binding testimony differs; keep the "
+                    "disagreement loud"
+                ),
+            )
+        return first
 
     @property
     def shared_expected_type_operand(self):
         """Expected-type operand shared by every message-pattern face."""
-        return self._first_boundary_semantics().expected_type_operand
+        return self._shared_authority_field("expected_type_operand")
 
     @property
     def shared_binding(self):
         """Binding declaration shared by every message-pattern face."""
-        return self._first_boundary_semantics().binding
+        return self._shared_authority_field("binding")
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
@@ -498,3 +498,424 @@ def test_boundary_is_invariant_under_authenticated_producer_replacement():
 
     assert binop.native_shape != subscript.native_shape
     assert _route(binop.exit_set()) == _route(subscript.exit_set())
+
+
+# --- factored message-pattern faces with authenticated ``as excinfo`` binding ---
+
+
+def _factored_boundary_faces():
+    """match=None face and pattern face as guarded EffectBoundary alternatives."""
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        ExceptionInfoBindingV1,
+        ExpectsModeV1,
+        FormalArgumentProjectionV1,
+        NoMessagePatternV1,
+        OptionalFormalArgumentProjectionV1,
+        RaiseEffectKindV1,
+    )
+    from sugar_lift_py_tests.ir import _Atomic
+    from sugar_lift_py_tests.outcome import Completed
+
+    none_face = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        NoMessagePatternV1(),
+        ExceptionInfoBindingV1(),
+    )
+    pattern_face = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        OptionalFormalArgumentProjectionV1(1),
+        ExceptionInfoBindingV1(),
+    )
+    return ExitSet(
+        (
+            Completed(_Atomic("match-none-face", ()), none_face),
+            Completed(_Atomic("match-pattern-face", ()), pattern_face),
+        )
+    )
+
+
+def _factored_boundary_from_exitset(
+    body: ExitSet,
+    *,
+    expected=None,
+    pattern=None,
+    observation_slot_id: str | None = "excinfo",
+):
+    """Production WithEffectBoundarySugar over factored message-pattern faces."""
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        CallParameterV1,
+        ImportSignatureV2,
+        LiteralDefaultV1,
+        NoDefaultV1,
+        PositionalOrKeywordV1,
+    )
+    from sugar_lift_py_tests.ir import PrimitiveSort
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+
+    class Fixed(Sugar):
+        def __init__(self, outcome):
+            self.outcome = outcome
+
+        def desugar(self, ctx=None):
+            del ctx
+            return self.outcome
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    expected = expected or _Expected("ValueError")
+    if pattern is None:
+        from sugar_lift_py_tests.floor import StringValue
+
+        pattern = StringValue("needle")
+    actuals = (expected, pattern)
+    parameters = (
+        CallParameterV1(
+            "expected",
+            PrimitiveSort("Value"),
+            PositionalOrKeywordV1(),
+            True,
+            NoDefaultV1(),
+        ),
+        CallParameterV1(
+            "match",
+            PrimitiveSort("Value"),
+            PositionalOrKeywordV1(),
+            False,
+            LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
+        ),
+    )
+    manager_value = CallSiteValue(
+        target_name="expect",
+        arg_values=actuals,
+        parameters=tuple(parameter.name for parameter in parameters),
+        term=ctor("call:expect", []),
+        body=None,
+        keyword_names=(),
+    )
+    return WithEffectBoundarySugar(
+        manager=Fixed(Complete(manager_value)),
+        body=(Fixed(body),),
+        semantics=None,
+        contract_ref=SimpleNamespace(
+            import_signature=ImportSignatureV2(parameters)
+        ),
+        context_manager_edge=None,
+        boundary_faces=_factored_boundary_faces(),
+        observation_slot_id=observation_slot_id,
+        site="factored-as-binding.py:1:0",
+    )
+
+
+def _observed_binding(face):
+    from sugar_lift_py_tests.effect_router import ObservedEffectBinding
+
+    record = face.value if isinstance(face, Completed) else face.state
+    entries = getattr(record, "entries", ()) or ()
+    return next(
+        (entry for entry in entries if isinstance(entry, ObservedEffectBinding)),
+        None,
+    )
+
+
+def test_factored_none_face_consumes_matching_raise_and_binds_exact_occurrence():
+    """Positive: match=None face consumes typed raise and binds that occurrence."""
+    from sugar_lift_py_tests.floor import StringValue
+
+    occurrence = "producer.py:4:8:factored-none"
+    producer = RaiseEffect(
+        exception_name="ValueError",
+        blame=occurrence,
+        occurrence=occurrence,
+        exception_type_coordinate=_identity("ValueError"),
+        exception_type_mro=(_identity("ValueError"),),
+        raised_value=CallSiteValue(
+            "ValueError",
+            (StringValue("boom"),),
+            ("message",),
+            ctor("call:ValueError", []),
+            None,
+        ),
+        producer_node_owner="Compare.desugar",
+    )
+    body = ExitSet((Halted(true_guard(), producer, _state("none-face-body")),))
+
+    routed = _factored_boundary_from_exitset(body).desugar()
+
+    # Under match-none-face the raise is fully decided and consumed with binding.
+    none_consumed = [
+        face
+        for face in routed.exits
+        if isinstance(face, Completed)
+        and "match-none-face" in str(face.guard)
+        and _observed_binding(face) is not None
+    ]
+    assert len(none_consumed) == 1, routed.exits
+    binding = _observed_binding(none_consumed[0])
+    assert binding.slot_id == "excinfo"
+    assert binding.effect is producer
+    assert binding.effect.occurrence == occurrence
+    assert binding.effect.exception_type_coordinate is producer.exception_type_coordinate
+    assert binding.effect.producer_node_owner == "Compare.desugar"
+
+
+def test_factored_pattern_face_binds_only_on_held_arm_not_complement():
+    """Pattern face: message obligation retained; bind held only; halt has no bind."""
+    from sugar_lift_py_tests.floor import StringValue
+
+    occurrence = "producer.py:8:4:factored-pattern"
+    producer = RaiseEffect(
+        exception_name="ValueError",
+        blame=occurrence,
+        occurrence=occurrence,
+        exception_type_coordinate=_identity("ValueError"),
+        exception_type_mro=(_identity("ValueError"),),
+        raised_value=CallSiteValue(
+            "ValueError",
+            (StringValue("cannot convert"),),
+            ("message",),
+            ctor("call:ValueError", []),
+            None,
+        ),
+        producer_node_owner="BinOp.desugar",
+    )
+    # Symbolic pattern keeps the message predicate open → held + complement.
+    pattern = SymbolicValue(make_var("msg_pattern"))
+    body = ExitSet((Halted(true_guard(), producer, _state("pattern-face-body")),))
+
+    routed = _factored_boundary_from_exitset(body, pattern=pattern).desugar()
+
+    pattern_faces = [
+        face
+        for face in routed.exits
+        if "match-pattern-face" in str(face.guard)
+        and "py.re_search" in str(face.guard)
+    ]
+    assert {type(face).__name__ for face in pattern_faces} == {
+        "Completed",
+        "Halted",
+    }, routed.exits
+    held = next(face for face in pattern_faces if isinstance(face, Completed))
+    failed = next(face for face in pattern_faces if isinstance(face, Halted))
+
+    held_binding = _observed_binding(held)
+    assert held_binding is not None
+    assert held_binding.slot_id == "excinfo"
+    assert held_binding.effect is producer
+    assert held_binding.effect.occurrence == occurrence
+
+    # Complement preserves the original halt and authenticates no slot.
+    assert failed.effect is producer
+    assert _observed_binding(failed) is None
+
+
+def test_factored_as_binding_faces_keep_distinct_guards_and_identities():
+    """Discrimination: none and pattern face identities never recombine."""
+    from sugar_lift_py_tests.context_manager_contract import (
+        NoMessagePatternV1,
+        OptionalFormalArgumentProjectionV1,
+    )
+    from sugar_lift_py_tests.floor import StringValue
+
+    producer = RaiseEffect(
+        exception_name="ValueError",
+        blame="producer.py:1:0",
+        occurrence="producer.py:1:0",
+        exception_type_coordinate=_identity("ValueError"),
+        exception_type_mro=(_identity("ValueError"),),
+        raised_value=CallSiteValue(
+            "ValueError",
+            (StringValue("x"),),
+            ("message",),
+            ctor("call:ValueError", []),
+            None,
+        ),
+    )
+    body = ExitSet((Halted(true_guard(), producer, _state("dual")),))
+    pattern = SymbolicValue(make_var("open_pattern"))
+
+    sugar = _factored_boundary_from_exitset(body, pattern=pattern)
+    guarded = sugar._guarded_semantics()
+    face_ids = {guard.name for guard, _ in guarded}
+    assert face_ids == {"match-none-face", "match-pattern-face"}
+    operands = {semantics.message_pattern_operand for _, semantics in guarded}
+    assert operands == {
+        NoMessagePatternV1(),
+        OptionalFormalArgumentProjectionV1(1),
+    }
+
+    routed = sugar.desugar()
+    guard_text = " ".join(str(face.guard) for face in routed.exits)
+    # Both face identities reach the routed ExitSet (normalize may OR equal
+    # destinations, but must not drop either identity or its obligation).
+    assert "match-none-face" in guard_text
+    assert "match-pattern-face" in guard_text
+    assert "py.re_search" in guard_text
+    # Regex obligation only rides the pattern face identity.
+    for face in routed.exits:
+        text = str(face.guard)
+        if "py.re_search" in text:
+            assert "match-pattern-face" in text
+
+
+def test_factored_none_face_without_as_slot_consumes_without_binding():
+    """Discrimination twin: no observation slot means no binding testimony."""
+    from sugar_lift_py_tests.floor import StringValue
+
+    producer = RaiseEffect(
+        exception_name="ValueError",
+        blame="producer.py:2:0",
+        occurrence="producer.py:2:0",
+        exception_type_coordinate=_identity("ValueError"),
+        exception_type_mro=(_identity("ValueError"),),
+        raised_value=CallSiteValue(
+            "ValueError",
+            (StringValue("boom"),),
+            ("message",),
+            ctor("call:ValueError", []),
+            None,
+        ),
+    )
+    body = ExitSet((Halted(true_guard(), producer, _state("no-slot")),))
+
+    routed = _factored_boundary_from_exitset(
+        body, observation_slot_id=None
+    ).desugar()
+
+    none_completed = [
+        face
+        for face in routed.exits
+        if isinstance(face, Completed) and "match-none-face" in str(face.guard)
+    ]
+    assert none_completed
+    assert all(_observed_binding(face) is None for face in none_completed)
+
+
+def test_factored_disagreeing_expected_type_never_uses_face_zero():
+    """Lying twin: differing expected-type testimony must refuse, not face zero."""
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        ExceptionInfoBindingV1,
+        ExpectsModeV1,
+        FormalArgumentProjectionV1,
+        NoMessagePatternV1,
+        OptionalFormalArgumentProjectionV1,
+        RaiseEffectKindV1,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        FactoredSourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.ir import _Atomic
+    from sugar_source_tree.panic import SugarNotWritten
+    from types import SimpleNamespace
+
+    face_a = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        NoMessagePatternV1(),
+        ExceptionInfoBindingV1(),
+    )
+    face_b = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(1),  # different expected-type formal
+        OptionalFormalArgumentProjectionV1(2),
+        ExceptionInfoBindingV1(),
+    )
+    ref = FactoredSourceDerivedContextManagerRefV1(
+        SourceFragmentCoordinateV1("blake3-512:" + ("11" * 64), 1, 0, 1, 10),
+        "disagree-expected-protocol",
+        "enter-cid",
+        "exit-cid",
+        ExitSet(
+            (
+                Completed(_Atomic("face-zero", ()), face_a),
+                Completed(_Atomic("face-one", ()), face_b),
+            )
+        ),
+        SimpleNamespace(parameters=()),
+        SimpleNamespace(),
+    )
+
+    with pytest.raises(SugarNotWritten) as caught:
+        _ = ref.shared_expected_type_operand
+
+    assert "expected_type_operand" in caught.value.observed
+    assert "disagree" in caught.value.observed or "FormalArgumentProjectionV1" in (
+        caught.value.observed
+    )
+    assert "face zero" in caught.value.fix or "first completed face" in caught.value.fix
+
+
+def test_factored_disagreeing_binding_never_uses_face_zero():
+    """Lying twin: differing binding testimony must refuse, not face zero."""
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        ExceptionInfoBindingV1,
+        ExpectsModeV1,
+        FormalArgumentProjectionV1,
+        NoBindingV1,
+        NoMessagePatternV1,
+        OptionalFormalArgumentProjectionV1,
+        RaiseEffectKindV1,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        FactoredSourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.ir import _Atomic
+    from sugar_source_tree.panic import SugarNotWritten
+    from types import SimpleNamespace
+
+    face_a = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        NoMessagePatternV1(),
+        ExceptionInfoBindingV1(),
+    )
+    face_b = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        OptionalFormalArgumentProjectionV1(1),
+        NoBindingV1(),  # different binding
+    )
+    ref = FactoredSourceDerivedContextManagerRefV1(
+        SourceFragmentCoordinateV1("blake3-512:" + ("22" * 64), 1, 0, 1, 10),
+        "disagree-binding-protocol",
+        "enter-cid",
+        "exit-cid",
+        ExitSet(
+            (
+                Completed(_Atomic("bind-zero", ()), face_a),
+                Completed(_Atomic("bind-one", ()), face_b),
+            )
+        ),
+        SimpleNamespace(parameters=()),
+        SimpleNamespace(),
+    )
+
+    with pytest.raises(SugarNotWritten) as caught:
+        _ = ref.shared_binding
+
+    assert "binding" in caught.value.observed
+    assert "NoBindingV1" in caught.value.observed or "ExceptionInfoBindingV1" in (
+        caught.value.observed
+    )
+    # Must not silently return face zero's ExceptionInfoBindingV1.
+    assert caught.value.__class__.__name__ == "SugarNotWritten"

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1977,6 +1977,223 @@ def test_uniform_none_source_derived_ref_stays_single_sealed_summary():
     assert type(factored) is not type(sealed)
 
 
+def test_factored_ref_as_clause_authenticates_observation_slot(tmp_path):
+    """Production join: factored ref + ``as info`` grants the observation slot."""
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        FactoredSourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+    from sugar_source_tree.nodes import With
+
+    consumer = (
+        "def use_boundary():\n"
+        "    with boundary(ValueError, 'needle') as info:\n"
+        "        raise ValueError('needle')\n"
+    )
+    path = tmp_path / "factored-as-consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    node = next(item for item in tree.nodes() if isinstance(item, With))
+    expr = node.items[0].context_expr
+    span = expr.line_col_span()
+    coordinate = SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    context.source_derived_contract_refs[coordinate] = (
+        FactoredSourceDerivedContextManagerRefV1(
+            coordinate,
+            "factored-protocol",
+            "enter-cid",
+            "exit-cid",
+            _factored_boundary_faces(),
+            _factored_import_signature(),
+            SimpleNamespace(),
+        )
+    )
+
+    sugar = node.sugar()
+
+    assert isinstance(sugar, WithEffectBoundarySugar)
+    assert sugar.observation_slot_id is not None
+    assert sugar.observation_slot_id.endswith("#observation")
+    assert sugar.boundary_faces is not None
+    # Both faces still present after as-clause construction.
+    from sugar_lift_py_tests.context_manager_contract import (
+        NoMessagePatternV1,
+        OptionalFormalArgumentProjectionV1,
+    )
+    from sugar_lift_py_tests.outcome import Completed
+
+    operands = {
+        face.value.message_pattern_operand
+        for face in sugar.boundary_faces.exits
+        if isinstance(face, Completed)
+    }
+    assert operands == {
+        NoMessagePatternV1(),
+        OptionalFormalArgumentProjectionV1(1),
+    }
+
+
+def test_factored_ref_without_as_clause_has_no_observation_slot(tmp_path):
+    """Discrimination: no ``as`` name means factored sugar carries no slot."""
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        FactoredSourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+        WithEffectBoundarySugar,
+    )
+    from sugar_source_tree.nodes import With
+
+    consumer = (
+        "def use_boundary():\n"
+        "    with boundary(ValueError, 'needle'):\n"
+        "        raise ValueError('needle')\n"
+    )
+    path = tmp_path / "factored-no-as-consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    node = next(item for item in tree.nodes() if isinstance(item, With))
+    expr = node.items[0].context_expr
+    span = expr.line_col_span()
+    coordinate = SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    context.source_derived_contract_refs[coordinate] = (
+        FactoredSourceDerivedContextManagerRefV1(
+            coordinate,
+            "factored-protocol",
+            "enter-cid",
+            "exit-cid",
+            _factored_boundary_faces(),
+            _factored_import_signature(),
+            SimpleNamespace(),
+        )
+    )
+
+    sugar = node.sugar()
+
+    assert isinstance(sugar, WithEffectBoundarySugar)
+    assert sugar.observation_slot_id is None
+
+
+def test_factored_ref_disagreeing_binding_refuses_at_with_construction(tmp_path):
+    """Lying twin: With construction never authorizes all faces from face zero."""
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        EffectBoundarySemanticsV1,
+        ExceptionInfoBindingV1,
+        ExpectsModeV1,
+        FormalArgumentProjectionV1,
+        NoBindingV1,
+        NoMessagePatternV1,
+        OptionalFormalArgumentProjectionV1,
+        RaiseEffectKindV1,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        FactoredSourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_py_tests.ir import _Atomic
+    from sugar_lift_py_tests.outcome import Completed, ExitSet
+    from sugar_source_tree.nodes import With
+    from sugar_source_tree.panic import SugarNotWritten
+
+    consumer = (
+        "def use_boundary():\n"
+        "    with boundary(ValueError, 'needle') as info:\n"
+        "        raise ValueError('needle')\n"
+    )
+    path = tmp_path / "factored-disagree-binding.py"
+    path.write_text(consumer, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    node = next(item for item in tree.nodes() if isinstance(item, With))
+    expr = node.items[0].context_expr
+    span = expr.line_col_span()
+    coordinate = SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    disagreeing = ExitSet(
+        (
+            Completed(
+                _Atomic("bind-zero", ()),
+                EffectBoundarySemanticsV1(
+                    ExpectsModeV1(),
+                    RaiseEffectKindV1(),
+                    FormalArgumentProjectionV1(0),
+                    NoMessagePatternV1(),
+                    ExceptionInfoBindingV1(),
+                ),
+            ),
+            Completed(
+                _Atomic("bind-one", ()),
+                EffectBoundarySemanticsV1(
+                    ExpectsModeV1(),
+                    RaiseEffectKindV1(),
+                    FormalArgumentProjectionV1(0),
+                    OptionalFormalArgumentProjectionV1(1),
+                    NoBindingV1(),
+                ),
+            ),
+        )
+    )
+    context.source_derived_contract_refs[coordinate] = (
+        FactoredSourceDerivedContextManagerRefV1(
+            coordinate,
+            "disagree-binding-protocol",
+            "enter-cid",
+            "exit-cid",
+            disagreeing,
+            _factored_import_signature(),
+            SimpleNamespace(),
+        )
+    )
+
+    with pytest.raises(SugarNotWritten) as caught:
+        node.sugar()
+
+    assert "binding" in caught.value.observed
+    assert "first completed face" in caught.value.fix or "face zero" in (
+        caught.value.fix
+    )
+
+
 def test_source_derived_resource_ref_selects_projection_only_with_arm(tmp_path):
     fixture = (
         Path(__file__).parents[2]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5334,6 +5334,10 @@ class With(Statement):
                 )
                 self.reporter.report_gap(self, panic)
                 raise panic
+            # Expected-type and binding authorize every face. Disagreeing faces
+            # must refuse here — never let face zero speak for the rest.
+            _ = resolution.shared_expected_type_operand
+            _ = resolution.shared_binding
             return resolution
         if not isinstance(
             resolution, (ContextManagerContractRefV1, SourceDerivedContextManagerRefV1)


### PR DESCRIPTION
## Summary

Closes #6637's next production join: factored message-pattern faces with authenticated `as excinfo` binding, plus the advisor additive on face-zero authority.

### Binding (positive + discrimination)

- **match=None face**: consumes a matching typed raise and binds `ObservedEffectBinding` from that exact occurrence
- **pattern face**: retains `py.re_search` message obligation; binds only on the held/consumed arm; complement keeps the original halt with no binding
- Face identities (`match-none-face` / `match-pattern-face`) remain distinct; never recombined into one summary

### Face-zero authority (lying twins)

`FactoredSourceDerivedContextManagerRefV1.shared_expected_type_operand` / `shared_binding` no longer return the first completed face blindly. When completed faces disagree on expected-type or binding testimony, they raise `SugarNotWritten`. `With._require_narrow_cm_ref` checks both at admission.

### Tests (`bin/bpytest`)

```
tests/test_assertion_boundary_exitset_consumer.py -k factored  # 6 passed
tests/test_assertion_boundary_exitset_consumer.py              # 27 passed
tests/test_sole_path_manager_construction.py -k factored       # 6 passed
```

Carrier/ExitSet/manager-summary producer/spelling dispatch untouched.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse disagreeing face authority and bind `as`-excinfo slots in factored context managers
> - Replaces the single-face `_first_boundary_semantics` helper with `_completed_boundary_semantics` (all Completed faces) and `_shared_authority_field`, which enforces that all Completed faces agree on a given attribute.
> - `shared_expected_type_operand` and `shared_binding` on `FactoredSourceDerivedContextManagerRefV1` now delegate to `_shared_authority_field`, raising `SugarNotWritten` on disagreement and `ValueError` when no Completed faces exist.
> - `With._prebound_manager_resolution` explicitly reads both shared fields during construction, so disagreeing testimony is caught at `With` build time rather than silently deferred.
> - Adds support for `as`-clause observation slots in factored message-pattern faces, producing an authenticated binding when present and omitting it when absent.
> - Behavioral Change: code that previously succeeded by implicitly using the first face's testimony will now raise `SugarNotWritten` if any Completed face disagrees.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a84fc1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->