### PR TITLE
Preserve native-operation pre-effect state

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -32,6 +32,8 @@ class NativeOperationResolutionV1:
         "value",
         "exception_type_coordinate",
         "raise_occurrence_coordinate",
+        "effect",
+        "pre_effect_state",
         "reason",
     )
 
@@ -42,6 +44,8 @@ class NativeOperationResolutionV1:
         value=None,
         exception_type_coordinate=None,
         raise_occurrence_coordinate=None,
+        effect=None,
+        pre_effect_state=None,
         reason=None,
     ):
         if kind not in {"completed", "exceptional", "undischarged"}:
@@ -67,6 +71,8 @@ class NativeOperationResolutionV1:
         self.value = value
         self.exception_type_coordinate = exception_type_coordinate
         self.raise_occurrence_coordinate = raise_occurrence_coordinate
+        self.effect = effect
+        self.pre_effect_state = pre_effect_state
         self.reason = reason
 
     @classmethod
@@ -74,11 +80,27 @@ class NativeOperationResolutionV1:
         return cls(kind="completed", value=value)
 
     @classmethod
-    def exceptional(cls, *, exception_type_coordinate, operation_occurrence):
+    def exceptional(
+        cls,
+        *,
+        exception_type_coordinate,
+        operation_occurrence,
+        effect=None,
+        pre_effect_state=None,
+    ):
+        if pre_effect_state is not None and not isinstance(
+            pre_effect_state, ReducerPreEffectStateV1
+        ):
+            raise TypeError(
+                "exceptional native operation requires reducer-issued "
+                "pre-effect-state testimony"
+            )
         return cls(
             kind="exceptional",
             exception_type_coordinate=exception_type_coordinate,
             raise_occurrence_coordinate=operation_occurrence,
+            effect=effect,
+            pre_effect_state=pre_effect_state,
         )
 
     @classmethod
@@ -125,12 +147,23 @@ class NativeOperationResolutionV1:
         if self.has_authenticated_exception_type:
             occurrence = self.raise_occurrence_coordinate
             assert occurrence is not None
-            return ExitSet.halted(
-                RaiseEffect(
+            testimony = self.pre_effect_state
+            effect = self.effect
+            if testimony is None:
+                effect = RaiseEffect(
                     exception_type_coordinate=self.exception_type_coordinate,
                     occurrence=str(occurrence.wire()),
                     blame=str(occurrence.wire()),
                 )
+            if not isinstance(effect, RaiseEffect):
+                raise TypeError("exceptional native operation effect must be RaiseEffect")
+            return ExitSet.halted(
+                effect,
+                state=(
+                    None
+                    if testimony is None
+                    else testimony.state
+                ),
             )
         raise SugarNotWritten(
             blame=str(source_node),
@@ -139,6 +172,43 @@ class NativeOperationResolutionV1:
             requested="authenticated exception type and operation occurrence coordinates",
             fix="retain the operation as undischarged until both coordinates are proven",
         )
+
+
+_REDUCER_PRE_EFFECT_STATE_SEAL = object()
+
+
+@dataclass(frozen=True)
+class ReducerPreEffectStateV1:
+    """Reducer-issued testimony for the exact state preceding one operation.
+
+    The constructor is sealed: callers cannot pass a raw empty block, receiver,
+    or post-store value and have it mistaken for temporal testimony.  The sole
+    mint is called by ``reduce_block_to_exitset`` at carrier enrollment.
+    """
+
+    state: object
+    _seal: object = dataclass_field(repr=False, compare=False)
+
+    def __post_init__(self):
+        if self._seal is not _REDUCER_PRE_EFFECT_STATE_SEAL:
+            raise TypeError(
+                "pre-effect state must be issued by reduce_block_to_exitset"
+            )
+
+    @classmethod
+    def _from_reducer(cls, state):
+        if state is None:
+            raise TypeError("reducer pre-effect state cannot be absent")
+        if (
+            type(state).__name__ != "_ReducedBlock"
+            or type(state).__module__
+            != "sugar_lift_py_tests.sugar.function_universe_sugar"
+        ):
+            raise TypeError(
+                "reducer pre-effect state must be the live _ReducedBlock, not "
+                f"{type(state).__name__}"
+            )
+        return cls(state=state, _seal=_REDUCER_PRE_EFFECT_STATE_SEAL)
 
 
 def authenticated_exceptional_resolution_count(resolutions) -> int:
@@ -404,6 +474,9 @@ def _conjoin_guards(guards):
     return and_(list(guards))
 
 
+_PRE_EFFECT_STATE_UNSET = object()
+
+
 @dataclass(frozen=True)
 class NativeOperationExitCarrierV1:
     """Deferred native operation whose discharge codomain is an ``ExitSet``.
@@ -425,6 +498,9 @@ class NativeOperationExitCarrierV1:
     site: object = dataclass_field(compare=False, repr=False)
     continuations: tuple = dataclass_field(default=(), compare=False, repr=False)
     guards: tuple = dataclass_field(default=(), repr=False)
+    pre_effect_state: ReducerPreEffectStateV1 | None = dataclass_field(
+        default=None, compare=False, repr=False
+    )
 
     def __post_init__(self):
         operand_count = len(self.operands)
@@ -475,9 +551,36 @@ class NativeOperationExitCarrierV1:
             site=site,
         )
 
-    def and_then(self, step):
-        """Retain enclosing expression work until the operation discharges."""
-        return replace(self, continuations=(*self.continuations, step))
+    def and_then(self, step, *, pre_effect_state=_PRE_EFFECT_STATE_UNSET):
+        """Retain work and, at the reducer seam, the exact pre-effect state."""
+        testimony = self.pre_effect_state
+        if pre_effect_state is not _PRE_EFFECT_STATE_UNSET:
+            if not isinstance(pre_effect_state, ReducerPreEffectStateV1):
+                raise TypeError(
+                    "pre_effect_state must be reducer-issued testimony; raw "
+                    f"{type(pre_effect_state).__name__} is not admissible"
+                )
+            if testimony is not None and testimony.state is not pre_effect_state.state:
+                from sugar_lift_py_tests.gap.info import GapKind
+                from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+                construction_panic_gap(
+                    owner="NativeOperationExitCarrierV1.and_then",
+                    blame=self.demand.source_node,
+                    observed="a second conflicting reducer pre-effect state",
+                    requested="one reducer enrollment carrying one exact state",
+                    fix=(
+                        "enroll the carrier once at reduce_block_to_exitset; "
+                        "later expression continuations must omit pre_effect_state"
+                    ),
+                    gap_kind=GapKind.FLOOR,
+                )
+            testimony = pre_effect_state
+        return replace(
+            self,
+            continuations=(*self.continuations, step),
+            pre_effect_state=testimony,
+        )
 
     def guarded(self, guard, face=None):
         """Guard the deferred operation without discharging or losing its demand."""
@@ -543,6 +646,8 @@ class NativeOperationExitCarrierV1:
                 resolution = NativeOperationResolutionV1.exceptional(
                     exception_type_coordinate=effect.exception_type_coordinate,
                     operation_occurrence=self.demand.source_node,
+                    effect=effect,
+                    pre_effect_state=self.pre_effect_state,
                 )
             exits = resolution.project(source_node=self.demand.source_node)
         elif isinstance(projected, Complete):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -314,6 +314,7 @@ def reduce_block_to_exitset(
 
             from sugar_lift_py_tests.caller_parameter_contract import (
                 NativeOperationExitCarrierV1,
+                ReducerPreEffectStateV1,
             )
 
             if isinstance(outcome, NativeOperationExitCarrierV1):
@@ -322,7 +323,10 @@ def reduce_block_to_exitset(
                 # Retain the ordinary statement projection as a continuation;
                 # discharge will feed its Completed face through this exact
                 # block seam, while its Halted face bypasses the tail.
-                return outcome.and_then(project)
+                return outcome.and_then(
+                    project,
+                    pre_effect_state=ReducerPreEffectStateV1._from_reducer(state),
+                )
 
             if (
                 isinstance(outcome, Complete)

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_pre_effect_state.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_pre_effect_state.py
@@ -1,0 +1,156 @@
+"""Discharged native-operation halts retain reducer-owned temporal state."""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import (
+    NativeOperationExitCarrierV1,
+    ReducerPreEffectStateV1,
+)
+from sugar_lift_py_tests.context_manager_contract import (
+    AuthenticatedRaiseMatcher,
+    EffectBoundaryDisposition,
+)
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.effect.expectation_not_met_effect import (
+    ExpectationNotMetEffect,
+)
+from sugar_lift_py_tests.floor import ObjectValue, TermValue
+from sugar_lift_py_tests.floor.class_definition_value import ClassDefinitionValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import ctor, str_const
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
+from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import ClassDef, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+SOURCE = (
+    "class Widget:\n"
+    "    @property\n"
+    "    def field(self):\n"
+    "        return 1\n"
+    "\n"
+    "def helper(obj, value):\n"
+    "    obj.field = value\n"
+)
+
+
+def _pending_and_receiver():
+    tree = SourceFile(
+        (SOURCE, "native-operation-state.py", blake3_512_of(SOURCE.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    class_def = next(node for node in tree.nodes() if isinstance(node, ClassDef))
+    helper = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == "helper"
+    )
+    class_outcome = class_def.sugar().desugar(None)
+    assert isinstance(class_outcome, Complete)
+    assert isinstance(class_outcome.value, ClassDefinitionValue)
+    receiver = class_outcome.value.construct_receiver_state_from_block(
+        None, class_outcome.value.class_definition_cid
+    )
+    pending = helper.sugar().desugar(None)
+    assert isinstance(receiver, ObjectValue)
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    return pending, receiver
+
+
+def _attribute_error_discharge():
+    pending, receiver = _pending_and_receiver()
+    obj_cid, _, value_cid = pending.demand.operand_coordinate_cids
+    exits = pending.discharge({obj_cid: receiver, value_cid: TermValue(7)})
+    assert isinstance(exits, ExitSet)
+    assert len(exits.exits) == 1
+    halted = exits.exits[0]
+    assert isinstance(halted, Halted)
+    return pending, receiver, halted
+
+
+class _Expected:
+    def __init__(self, name: str):
+        self.identity = ctor(
+            "python:exception_type_identity",
+            [str_const("builtins"), str_const(name)],
+        )
+
+    def exception_type_identity(self):
+        return self.identity
+
+
+def _route(exits: ExitSet, expected: str):
+    return exits.and_exit(
+        ExitSet.completed(object()),
+        disposition=EffectBoundaryDisposition(
+            matcher=AuthenticatedRaiseMatcher(expected=_Expected(expected)),
+            unmet=ExpectationNotMetEffect("raise", "assertion-site"),
+        ),
+    )
+
+
+def test_setattr_exception_and_boundary_share_exact_pre_effect_state() -> None:
+    pending, _, halted = _attribute_error_discharge()
+    testimony = pending.pre_effect_state
+    assert testimony is not None
+    assert halted.state is testimony.state
+    assert halted.effect.exception_name == "AttributeError"
+    assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
+    assert halted.effect.occurrence_id is not None
+
+    routed = _route(ExitSet((halted,)), "AttributeError")
+    assert len(routed.exits) == 1
+    completed = routed.exits[0]
+    assert isinstance(completed, Completed)
+    assert completed.value is testimony.state
+
+
+def test_wrong_boundary_retains_identical_halt_effect_and_state() -> None:
+    _, _, halted = _attribute_error_discharge()
+
+    routed = _route(ExitSet((halted,)), "ValueError")
+    assert len(routed.exits) == 1
+    retained = routed.exits[0]
+    assert isinstance(retained, Halted)
+    assert retained.effect is halted.effect
+    assert retained.state is halted.state
+
+
+@pytest.mark.parametrize("lie", ["empty", "receiver", "post-store"])
+def test_raw_state_substitutes_are_rejected_at_carrier_enrollment(lie: str) -> None:
+    pending, receiver = _pending_and_receiver()
+    if lie == "empty":
+        substitute = _ReducedBlock((), True, ())
+    elif lie == "receiver":
+        substitute = receiver
+    else:
+        completed = receiver.setattr("other", TermValue(9), pending.site)
+        assert isinstance(completed, Complete)
+        substitute = completed.value
+
+    with pytest.raises(TypeError, match="reducer-issued testimony"):
+        pending.and_then(lambda value: Complete(value), pre_effect_state=substitute)
+
+
+def test_explicit_none_is_rejected_at_carrier_enrollment() -> None:
+    pending, _ = _pending_and_receiver()
+
+    with pytest.raises(TypeError, match="reducer-issued testimony"):
+        pending.and_then(lambda value: Complete(value), pre_effect_state=None)
+
+
+def test_second_conflicting_state_enrollment_panics() -> None:
+    pending, _ = _pending_and_receiver()
+    conflicting = ReducerPreEffectStateV1._from_reducer(
+        _ReducedBlock((TermValue(99),), True, ())
+    )
+
+    with pytest.raises(ConstructionPanic, match="second conflicting"):
+        pending.and_then(
+            lambda value: Complete(value),
+            pre_effect_state=conflicting,
+        )


### PR DESCRIPTION
## Capability

- enroll the exact current `_ReducedBlock` once at the reducer carrier seam
- retain reducer-issued testimony across expression continuations and panic on conflicting re-enrollment
- stamp authenticated exceptional exits with the original named raise effect and exact pre-effect state before continuations run
- prove matching-boundary resume, wrong-boundary identity retention, and rejection of absent/empty/receiver/post-store substitutes

`ExitSet`, `exit_disposition.py`, store producers, and matcher semantics are untouched.

## Tests

- `../../../bin/bpytest tests/test_native_operation_pre_effect_state.py tests/test_setattr_named_formal_caller.py tests/test_native_operation_exit_carrier.py tests/test_compare_through_if_sugar.py` — 81 passed (including compare/IfSugar join 8/8)
- `../../../bin/bpytest` — 2189 passed, 261 failed, 9 skipped, 5 errors; existing loud package instruments remain red and are not suppressed

## Shot accounting

- predicted epsilon: the stateless authenticated exceptional face becomes an exact pre-effect-state halt; matching boundary resumes without panic
- floors preserved: no invented default state, no vendor spelling arms, no timeout/test suppression, frozen exit machinery untouched

The separately specified `NativeOperationExitCarrierV1.short_circuit` producer is intentionally excluded and will be a follow-on PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve native-operation pre-effect state through halt and effect-boundary routing
> - Introduces `ReducerPreEffectStateV1`, a sealed testimony type in [`caller_parameter_contract.py`](https://github.com/TSavo/sugar/pull/6640/files#diff-5136726cb5a60b48beb30152aecb6eca8ad0173bdefc676eb112b1c1b2acbf57) that carries reducer-owned pre-effect state; construction without the internal seal raises `TypeError`.
> - Extends `NativeOperationExitCarrierV1.and_then` to accept and retain a `ReducerPreEffectStateV1` during enrollment, rejecting non-testimony values and panicking on conflicting second enrollment.
> - Updates `NativeOperationResolutionV1.exceptional` and `project` to accept and forward pre-effect state so that a discharged halt produces an `ExitSet.halted` carrying both the `RaiseEffect` and the reducer state.
> - Updates [`function_universe_sugar.py`](https://github.com/TSavo/sugar/pull/6640/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b) to enroll the live reducer state via `ReducerPreEffectStateV1._from_reducer` at the `NativeOperationExitCarrierV1` seam.
> - Risk: `and_then` now panics via `construction_panic_gap` if the same carrier is enrolled with two different underlying states, which is a new failure mode for callers that reuse carriers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fc5510.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->