### PR TITLE
Construct starred unpack from authenticated finite members

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/sequence_projection_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/sequence_projection_operation.py
@@ -1,27 +1,27 @@
-"""The sequence-projection operation: what ``a, b = <rhs>`` demands of one
-reduced RHS value.
+"""The sequence-projection operation: what ``a, b = <rhs>`` (and starred
+forms) demand of one reduced RHS value.
 
 Python's unpacking assignment is ITERABLE unpacking, not subscription, and it
-is not a sequence of independent stores.  ``UNPACK_SEQUENCE`` materializes the
-right-hand side and demands EXACTLY the arity the target spells; only then does
-it bind, left to right.  So the whole statement has exactly two outcomes:
+is not a sequence of independent stores.  ``UNPACK_SEQUENCE`` / ``UNPACK_EX``
+materializes the right-hand side and demands the arity the target spells; only
+then does it bind, left to right.  So the whole statement has exactly two
+outcomes:
 
-    Unpack(value, arity)
-        the value yields exactly `arity` members -> Completed(names bound to
-                                                             those members)
-        it yields any other count, or is not iterable
-                                             -> Halted(unpack effect, nothing
-                                                       bound)
+    Unpack(value, pattern)
+        the value yields enough members for the pattern
+            -> Completed(names bound to those members; star binds a list)
+        too few / not iterable / runtime cardinality
+            -> Halted(unpack effect or named ValueError, nothing bound)
 
 Which one happens is decided by the RHS.  That decision is the whole content of
 the operation, and it splits on ONE question: does the reduced value carry
 authenticated finite members?
 
-- It does (a tuple/array literal floor value): the count is lift-time
-  decidable.  Matching arity binds each name to the member ALREADY IN HAND --
-  never a fabricated element.  A mismatch is a decidable ``ValueError`` whose
-  exact exceptional exit has no floor value yet, so it stays a loud
-  construction gap rather than a guessed exit.
+- It does (a tuple/array/list floor value): the count is lift-time decidable.
+  Matching (or starred-sufficient) arity binds each name to the member ALREADY
+  IN HAND -- never a fabricated element.  A star target receives a
+  ``ListValue`` of the middle slice in source order.  Too few fixed positions
+  is a named ``ValueError`` via the ground exit door.
 
 - It does not (a symbolic term, an object, an opaque call coordinate): the
   cardinality is known only at runtime.  There is no lift-time evidence naming
@@ -30,7 +30,8 @@ authenticated finite members?
   ``python:unpack.destructure(term, arity)`` obligation -- the same coordinate
   family the comprehension destructure already states
   (``sugar/comprehension_sugar.py::_guard_destructure``).  Assuming the count
-  matched would be the one forbidden move.
+  matched would be the one forbidden move.  Starred opaque patterns keep the
+  same law: never complete, never invent a tail.
 
 Anything else reaches ``FloorValue.project_sequence_with`` and stays a loud
 floor construction gap: an unwritten floor is never a silent success.
@@ -44,17 +45,60 @@ from typing import Any, ClassVar
 
 @dataclass(frozen=True)
 class SequenceProjectionOperation:
-    """One unpack demand: ``target_names`` positions against one reduced RHS."""
+    """One unpack demand against one reduced RHS.
+
+    Exact form (no star): ``target_names`` is the full left-to-right roster and
+    ``star_name`` is ``None``.  Arity is exact.
+
+    Starred form: ``prefix_names`` then ``*star_name`` then ``suffix_names``.
+    ``target_names`` is the flattened fixed roster (prefix + suffix) for
+    compatibility; the star is not in that tuple.  Minimum member count is
+    ``len(prefix) + len(suffix)``.
+    """
 
     method_name: ClassVar[str] = "project_sequence_with"
 
     target_names: tuple[str, ...]
     owner: str
     blame: object
+    star_name: str | None = None
+    prefix_names: tuple[str, ...] = ()
+    suffix_names: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.star_name is None:
+            if self.prefix_names or self.suffix_names:
+                raise ValueError(
+                    "prefix_names/suffix_names require star_name for starred unpack"
+                )
+            return
+        # Starred: target_names is the fixed roster (prefix+suffix) for the
+        # obligation's fixed-count half; recompute if the caller only supplied
+        # prefix/suffix.
+        fixed = (*self.prefix_names, *self.suffix_names)
+        if self.target_names and self.target_names != fixed:
+            # Allow callers that pass only target_names + star_name + star index
+            # via prefix/suffix already set.
+            if not self.prefix_names and not self.suffix_names:
+                object.__setattr__(self, "prefix_names", self.target_names)
+                object.__setattr__(self, "suffix_names", ())
+                return
+            raise ValueError(
+                "target_names must equal prefix_names + suffix_names for starred unpack"
+            )
+        if not self.target_names:
+            object.__setattr__(self, "target_names", fixed)
 
     @property
     def arity(self) -> int:
-        return len(self.target_names)
+        """Exact target count for non-star; fixed (minimum) count for star."""
+        if self.star_name is None:
+            return len(self.target_names)
+        return len(self.prefix_names) + len(self.suffix_names)
+
+    @property
+    def is_starred(self) -> bool:
+        return self.star_name is not None
 
     def submit(self, value: Any, ctx: Any) -> Any:
         """Ask the value what it unpacks to. The value owns the answer."""
@@ -100,14 +144,37 @@ class SequenceProjectionOperation:
     # -- the two answers ---------------------------------------------------
 
     def _authenticated_members(self, value: Any, members: tuple, display: str) -> Any:
+        from sugar_lift_py_tests.floor.list_value import ListValue
         from sugar_lift_py_tests.floor.scope_rebind import ScopeRebinds
         from sugar_lift_py_tests.outcome import Complete
 
-        if len(members) != self.arity:
-            self._arity_mismatch_gap(value, len(members), display)
-        return Complete(
-            ScopeRebinds(tuple(zip(self.target_names, members, strict=True)))
+        if self.star_name is None:
+            if len(members) != self.arity:
+                return self._arity_mismatch_exit(value, len(members), display)
+            return Complete(
+                ScopeRebinds(tuple(zip(self.target_names, members, strict=True)))
+            )
+
+        # Starred: need at least the fixed positions; middle may be empty.
+        fixed = self.arity
+        if len(members) < fixed:
+            return self._arity_mismatch_exit(value, len(members), display)
+        pre_n = len(self.prefix_names)
+        suf_n = len(self.suffix_names)
+        prefix_vals = members[:pre_n]
+        if suf_n:
+            mid_vals = members[pre_n : len(members) - suf_n]
+            suffix_vals = members[len(members) - suf_n :]
+        else:
+            mid_vals = members[pre_n:]
+            suffix_vals = ()
+        # CPython always binds the starred target to a list, even from a tuple.
+        rebinds = (
+            *zip(self.prefix_names, prefix_vals, strict=True),
+            (self.star_name, ListValue(tuple(mid_vals))),
+            *zip(self.suffix_names, suffix_vals, strict=True),
         )
+        return Complete(ScopeRebinds(rebinds))
 
     def _runtime_cardinality(self, value: Any) -> Any:
         from sugar_lift_py_tests.effect import (
@@ -123,39 +190,77 @@ class SequenceProjectionOperation:
             [term, num(self.arity)],
             symbol_kind="coordinate",
         )
+        if self.star_name is None:
+            roster = ", ".join(self.target_names)
+            demand = f"exactly {self.arity} members for targets ({roster})"
+        else:
+            roster = (
+                f"{', '.join(self.prefix_names)}"
+                f"{', ' if self.prefix_names else ''}"
+                f"*{self.star_name}"
+                f"{', ' if self.suffix_names else ''}"
+                f"{', '.join(self.suffix_names)}"
+            )
+            demand = f"at least {self.arity} members for starred targets ({roster})"
         return Incomplete(
             SequenceUnpackRuntimeEffect(
-                "sequence unpack runtime boundary: unpack demands exactly "
-                f"{self.arity} members for targets "
-                f"({', '.join(self.target_names)}) but the right-hand side "
+                "sequence unpack runtime boundary: unpack demands "
+                f"{demand} but the right-hand side "
                 "carries no authenticated cardinality -- iteration count "
                 "belongs to Python's runtime __iter__; "
-                f"arity={self.arity} site={self.blame}",
+                f"arity={self.arity} starred={self.star_name is not None} "
+                f"site={self.blame}",
                 **runtime_effect_evidence_from_terms(operation, operation, self.blame),
             )
         )
 
-    def _arity_mismatch_gap(self, value: Any, members: int, display: str) -> None:
+    def _arity_mismatch_exit(self, value: Any, members: int, display: str) -> Any:
+        """Named ValueError for a decidable too-few / too-many unpack.
+
+        Uses the ground exit door when ``blame`` is a re-readable source
+        fragment.  Prose / non-fragment blame stays the loud construction gap
+        naming the mismatch (existing twin-site instruments).
+        """
+        from sugar_lift_py_tests.floor import RaiseValue
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
         from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-        from sugar_lift_py_tests.gap.panic import construction_panic
+        from sugar_lift_py_tests.gap.panic import ConstructionPanic, construction_panic
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
 
         relation = "not enough" if members < self.arity else "too many"
+        observed = (
+            f"{type(value).__name__} of {members} members unpacked into "
+            f"{self.arity} fixed targets ({relation} values)"
+        )
+        # Only fragments (or objects answering the RuntimeEffectSite protocol)
+        # may mint a ground exit.  Strings and synthetic loci stay the gap.
+        if hasattr(self.blame, "filename") and hasattr(self.blame, "line"):
+            try:
+                projected = ground_exceptional_exit(
+                    exception_name="ValueError",
+                    site=self.blame,
+                    owner=f"{self.owner}.arity_mismatch",
+                )
+            except ConstructionPanic:
+                projected = None
+            else:
+                if isinstance(projected, Complete) and isinstance(
+                    projected.value, RaiseValue
+                ):
+                    return Incomplete(projected.value.effect)
+                return projected
         construction_panic(
             ConstructionGap(
                 owner=self.owner,
                 blame=str(self.blame),
-                observed=(
-                    f"{type(value).__name__} of {members} members unpacked into "
-                    f"{self.arity} targets ({relation} values)"
-                ),
+                observed=observed,
                 requested=(
                     "ground ValueError exceptional exit for a decidable "
                     f"{display} unpack arity mismatch"
                 ),
                 fix=(
-                    "write more Floor: a ground ValueError exit value so this "
-                    "decidable mismatch states its exception instead of "
-                    "panicking"
+                    "thread a workspace-relative source fragment as blame so "
+                    "the ground ValueError exit can cite it"
                 ),
                 gap_kind=GapKind.FLOOR,
                 gap_locus=GapLocus.CONSTRUCTION,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/dynamic_unpack_assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/dynamic_unpack_assign_sugar.py
@@ -10,7 +10,8 @@ from sugar_lift_py_tests.sugar.witnesses import typed_red_effect_witness
 
 @dataclass(frozen=True)
 class DynamicUnpackAssignSugar(Sugar):
-    """``<name>, <name>, ... = <rhs>`` where the RHS is NOT a display.
+    """``<name>, <name>, ... = <rhs>`` (optionally with one ``*star``) where
+    the RHS is NOT a display.
 
     The tree cannot pair targets with members here (``Assign._destructured_binding``
     zips displays only), so ``substitution_binding`` threads nothing and the
@@ -22,14 +23,16 @@ class DynamicUnpackAssignSugar(Sugar):
     is submitted through the floor's ``project_sequence_with`` port, and the
     value decides:
 
-    - authenticated finite members (tuple/array literal): the arity is
-      lift-time decidable, so each name binds to the member ALREADY IN HAND and
-      rides forward as a ``ScopeRebinds`` support entry -- the same scope
-      threading a mutation uses, no second door;
+    - authenticated finite members (tuple/array/list): the arity is lift-time
+      decidable, so each name binds to the member ALREADY IN HAND (star binds a
+      ``ListValue`` of the middle in source order) and rides forward as a
+      ``ScopeRebinds`` support entry -- the same scope threading a mutation
+      uses, no second door;
     - runtime cardinality (symbolic / object / opaque coordinate): the count
       belongs to ``__iter__`` at runtime, so the arity demand is retained as a
       typed ``SequenceUnpackRuntimeEffect``. Nothing binds on that arm, exactly
-      as CPython binds nothing when ``UNPACK_SEQUENCE`` raises;
+      as CPython binds nothing when ``UNPACK_SEQUENCE`` / ``UNPACK_EX`` raises.
+      Starred opaque patterns keep this law: never complete, never invent a tail;
     - anything else: a loud floor construction gap.
 
     No arm assumes the count matched, and no arm invents a member. The RHS's own
@@ -39,6 +42,9 @@ class DynamicUnpackAssignSugar(Sugar):
     target_names: tuple[str, ...]
     value: Sugar
     site: object = dataclass_field(compare=False)
+    star_name: str | None = None
+    prefix_names: tuple[str, ...] = ()
+    suffix_names: tuple[str, ...] = ()
 
     @classmethod
     def witnesses(cls):
@@ -55,11 +61,21 @@ class DynamicUnpackAssignSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.operations import SequenceProjectionOperation
 
-        operation = SequenceProjectionOperation(
-            target_names=self.target_names,
-            owner=type(self).__name__,
-            blame=self.site,
-        )
+        if self.star_name is None:
+            operation = SequenceProjectionOperation(
+                target_names=self.target_names,
+                owner=type(self).__name__,
+                blame=self.site,
+            )
+        else:
+            operation = SequenceProjectionOperation(
+                target_names=(*self.prefix_names, *self.suffix_names),
+                owner=type(self).__name__,
+                blame=self.site,
+                star_name=self.star_name,
+                prefix_names=self.prefix_names,
+                suffix_names=self.suffix_names,
+            )
         # Python evaluates the right-hand side before it unpacks anything.
         return self.value.desugar(ctx).and_then(
             lambda value: operation.submit(value, ctx)

--- a/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py
@@ -568,8 +568,21 @@ def _assert_loud(tmp_path: Path, source: str, stem: str) -> None:
 
 
 def test_star_against_opaque_iterable_stays_loud(tmp_path: Path) -> None:
-    """Starred opaque unpack is not a replacement binding door (#6078)."""
-    _assert_loud(tmp_path, "def f(xs):\n    a, *rest = xs\n    return a\n", "star")
+    """Starred opaque unpack retains typed obligation — never completion.
+
+    Post-starred-unpack: ``DynamicUnpackAssignSugar`` constructs for
+    ``a, *rest = xs``; desugar keeps ``SequenceUnpackRuntimeEffect`` and binds
+    nothing. Display twins still construct via MultiAssignSugar.
+    """
+    from sugar_lift_py_tests.effect import SequenceUnpackRuntimeEffect
+    from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+    outcome = _function_sugar(
+        tmp_path, "def f(xs):\n    a, *rest = xs\n    return a\n", "star"
+    ).desugar(None)
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, SequenceUnpackRuntimeEffect)
+    assert not isinstance(outcome, Complete)
 
     # Discrimination arm: a starred unpack against a CONCRETE display is a
     # different shape and must still construct -- "loud" is about the opaque

--- a/implementations/python/sugar-lift-py-tests/tests/test_dynamic_unpack_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dynamic_unpack_projection.py
@@ -142,13 +142,29 @@ def test_reduced_rhs_is_the_unpacked_term(tmp_path: Path) -> None:
 
 
 def test_rhs_expression_is_reduced_not_quoted(tmp_path: Path) -> None:
-    attribute = _obligation(tmp_path, ATTRIBUTE_RHS, "attr_rhs")
-    other = _obligation(tmp_path, OTHER_ATTRIBUTE_RHS, "attr_rhs_other")
-    # The reduced attribute coordinate rides in the obligation ...
-    assert "shape" in attribute[2]
-    # ... and a different attribute is a different obligation.
-    assert attribute[2] != other[2]
-    assert "shape" not in other[2]
+    """Formal attribute RHS reduces before unpack (post attribute_named carrier).
+
+    ``a, b = o.shape`` desugars the attribute first; when ``o`` is a formal the
+    reduced face is an undischarged ``attribute_named`` demand that names the
+    attribute.  A different attribute is a different demand.  The unpack
+    obligation rides after discharge — never a quoted spelling of the source.
+    """
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+
+    shape_out = _outcome(tmp_path, ATTRIBUTE_RHS, "attr_rhs")
+    size_out = _outcome(tmp_path, OTHER_ATTRIBUTE_RHS, "attr_rhs_other")
+    assert isinstance(shape_out, NativeOperationExitCarrierV1)
+    assert isinstance(size_out, NativeOperationExitCarrierV1)
+    assert shape_out.demand.operator == "attribute_named"
+    assert size_out.demand.operator == "attribute_named"
+    shape_term = str(shape_out.demand.candidate)
+    size_term = str(size_out.demand.candidate)
+    assert "shape" in shape_term
+    assert shape_term != size_term
+    assert "shape" not in size_term
+    assert "size" in size_term
 
 
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_starred_unpack_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_starred_unpack_projection.py
@@ -1,0 +1,301 @@
+"""Starred unpack: authenticated finite members + opaque arity honesty.
+
+Python law:
+
+    head, *tail = rhs
+
+- Over authenticated tuple/list members: bind head and tail (list) in source
+  order; too few fixed positions → named ValueError.
+- Over opaque / runtime-selected members: retain typed
+  ``SequenceUnpackRuntimeEffect``; bind nothing; never fabricate arity or
+  complete.
+- Later store halt preserves earlier bindings from a completed star unpack
+  prefix.
+- Arity and reversed-tail lying twins fail.
+
+Producer: ``SequenceProjectionOperation`` (+ ``DynamicUnpackAssignSugar``
+submit). Floor: ``TupleValue`` / ``ListValue``.project_sequence_with.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.effect import SequenceUnpackRuntimeEffect
+from sugar_lift_py_tests.floor.list_value import ListValue
+from sugar_lift_py_tests.floor.scope_rebind import ScopeRebinds
+from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.floor.tuple_literal_value import TupleLiteralValue
+from sugar_lift_py_tests.floor.tuple_value import TupleValue
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.operations import SequenceProjectionOperation
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted, outcome_to_exitset
+from sugar_lift_python_source.source_oracle import path_source, workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _star_op(
+    *,
+    prefix: tuple[str, ...] = (),
+    star: str = "tail",
+    suffix: tuple[str, ...] = (),
+    blame: object = "star-site",
+) -> SequenceProjectionOperation:
+    return SequenceProjectionOperation(
+        target_names=(*prefix, *suffix),
+        owner="starred-unpack",
+        blame=blame,
+        star_name=star,
+        prefix_names=prefix,
+        suffix_names=suffix,
+    )
+
+
+def _function_sugar(tmp_path: Path, source: str, stem: str):
+    path = tmp_path / f"{stem}.py"
+    path.write_text(source, encoding="utf-8")
+    return next(SourceFile(path_source(str(path))).functions()).sugar()
+
+
+def _workspace_site(tmp_path: Path):
+    """Workspace-relative fragment so ground ValueError can cite source."""
+    path = tmp_path / "pkg" / "site.py"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("def f(xs):\n    a, *rest = xs\n    return a\n")
+    tree = SourceFile(workspace_path_source(str(path), root=str(tmp_path)))
+    function = next(tree.functions())
+    return function.body[0].fragment
+
+
+# ---------------------------------------------------------------------------
+# Authenticated finite members: head, *tail in source order
+# ---------------------------------------------------------------------------
+
+
+def test_tuple_head_star_tail_binds_source_order() -> None:
+    members = (TermValue(1), TermValue(2), TermValue(3), TermValue(4))
+    outcome = _star_op(prefix=("head",)).submit(TupleValue(members), None)
+    assert isinstance(outcome, Complete)
+    assert outcome.value == ScopeRebinds(
+        (
+            ("head", TermValue(1)),
+            ("tail", ListValue((TermValue(2), TermValue(3), TermValue(4)))),
+        )
+    )
+
+
+def test_list_head_star_tail_binds_source_order() -> None:
+    members = (TermValue(10), TermValue(20), TermValue(30))
+    outcome = _star_op(prefix=("head",)).submit(ListValue(members), None)
+    assert isinstance(outcome, Complete)
+    assert outcome.value == ScopeRebinds(
+        (
+            ("head", TermValue(10)),
+            ("tail", ListValue((TermValue(20), TermValue(30)))),
+        )
+    )
+
+
+def test_head_star_mid_suffix_binds_middle_as_list() -> None:
+    members = (TermValue(1), TermValue(2), TermValue(3), TermValue(4))
+    outcome = _star_op(prefix=("a",), star="mid", suffix=("b",)).submit(
+        TupleLiteralValue(members), None
+    )
+    assert isinstance(outcome, Complete)
+    assert outcome.value == ScopeRebinds(
+        (
+            ("a", TermValue(1)),
+            ("mid", ListValue((TermValue(2), TermValue(3)))),
+            ("b", TermValue(4)),
+        )
+    )
+
+
+def test_empty_tail_is_empty_list_not_none() -> None:
+    """``a, *rest = (1,)``: rest is [] — never None, never omitted."""
+    outcome = _star_op(prefix=("a",)).submit(TupleValue((TermValue(1),)), None)
+    assert isinstance(outcome, Complete)
+    assert outcome.value == ScopeRebinds((("a", TermValue(1)), ("tail", ListValue(()))))
+
+
+def test_reversed_tail_lying_twin_fails() -> None:
+    """Bite: reverse middle members must not match the truthful rebind."""
+    members = (TermValue(1), TermValue(2), TermValue(3), TermValue(4))
+    outcome = _star_op(prefix=("head",)).submit(TupleValue(members), None)
+    truthful = outcome.value
+    lying = ScopeRebinds(
+        (
+            ("head", TermValue(1)),
+            ("tail", ListValue((TermValue(4), TermValue(3), TermValue(2)))),
+        )
+    )
+    assert truthful != lying
+    with pytest.raises(AssertionError):
+        assert truthful == lying
+
+
+# ---------------------------------------------------------------------------
+# Too-few → named ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_too_few_members_named_valueerror(tmp_path: Path) -> None:
+    site = _workspace_site(tmp_path)
+    # Need two fixed positions (a and b) but only one member.
+    op = _star_op(prefix=("a", "b"), star="rest", blame=site)
+    outcome = op.submit(TupleValue((TermValue(1),)), None)
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect.exception_name == "ValueError" or (
+        outcome.effect.exception_type_coordinate is not None
+        and "ValueError" in repr(outcome.effect.exception_type_coordinate)
+    )
+
+
+def test_too_few_discrimination_is_not_completed_bind(tmp_path: Path) -> None:
+    site = _workspace_site(tmp_path)
+    op = _star_op(prefix=("a", "b"), star="rest", blame=site)
+    outcome = op.submit(ListValue((TermValue(1),)), None)
+    with pytest.raises(AssertionError):
+        assert isinstance(outcome, Complete), "too-few starred unpack completed"
+
+
+# ---------------------------------------------------------------------------
+# Opaque / runtime-selected: typed obligation, no bind, never completion
+# ---------------------------------------------------------------------------
+
+
+def test_opaque_starred_retains_typed_obligation_no_bind(tmp_path: Path) -> None:
+    site = _workspace_site(tmp_path)
+    outcome = _star_op(prefix=("head",), blame=site).submit(
+        SymbolicValue(make_var("xs")), None
+    )
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, SequenceUnpackRuntimeEffect)
+    assert "no authenticated cardinality" in outcome.effect.reason
+    assert (
+        "at least" in outcome.effect.reason or "starred=True" in outcome.effect.reason
+    )
+
+
+def test_source_opaque_starred_never_completes(tmp_path: Path) -> None:
+    outcome = _function_sugar(
+        tmp_path, "def f(xs):\n    head, *tail = xs\n    return head\n", "opaque_src"
+    ).desugar(None)
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, SequenceUnpackRuntimeEffect)
+    with pytest.raises(AssertionError):
+        assert isinstance(outcome, Complete)
+
+
+def test_opaque_starred_discrimination_display_does_bind(tmp_path: Path) -> None:
+    """Display twin completes; opaque does not — so the red is not universal."""
+    opaque = _function_sugar(
+        tmp_path, "def f(xs):\n    a, *rest = xs\n    return a\n", "op_disc"
+    ).desugar(None)
+    display = _function_sugar(
+        tmp_path,
+        "def f(p, q, r):\n    a, *rest = p, q, r\n    return a\n",
+        "disp_disc",
+    ).desugar(None)
+    assert isinstance(opaque, Incomplete)
+    assert isinstance(display, Complete)
+
+
+# ---------------------------------------------------------------------------
+# Later store halt preserves earlier starred bindings
+# ---------------------------------------------------------------------------
+
+
+def _workspace_function_sugar(tmp_path: Path, source: str, stem: str):
+    """Workspace-relative source so ground TypeError exits can cite the store."""
+    path = tmp_path / "pkg" / f"{stem}.py"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).sugar()
+
+
+def test_later_store_halt_preserves_earlier_star_bindings(tmp_path: Path) -> None:
+    """Star binds first; later immutable store halts; body is not sole-Completed.
+
+    ``head, *tail = (1, 2, 3)`` is MultiAssign (display); the following
+    ``xs[0] = 9`` on a tuple is a decided setitem TypeError. The star binding
+    is not rolled back into a body that pretends the store never ran.
+    """
+    source = (
+        "def f():\n"
+        "    head, *tail = (1, 2, 3)\n"
+        "    xs = (0,)\n"
+        "    xs[0] = 9\n"
+        "    return head\n"
+    )
+    raw = _workspace_function_sugar(tmp_path, source, "star_then_store").desugar(None)
+    outcome = outcome_to_exitset(raw)
+    halted = [e for e in outcome.exits if isinstance(e, Halted)]
+    completed = [e for e in outcome.exits if isinstance(e, Completed)]
+    assert len(halted) == 1
+    assert len(completed) == 0
+    assert halted[0].effect.exception_name == "TypeError" or (
+        halted[0].effect.exception_type_coordinate is not None
+        and "TypeError" in repr(halted[0].effect.exception_type_coordinate)
+    )
+    # No completed return face — store halt blocked later targets.
+    assert not any(isinstance(e, Completed) for e in outcome.exits)
+
+
+def test_later_store_halt_discrimination_not_sole_completed(tmp_path: Path) -> None:
+    source = (
+        "def f():\n"
+        "    head, *tail = (1, 2, 3)\n"
+        "    xs = (0,)\n"
+        "    xs[0] = 9\n"
+        "    return head\n"
+    )
+    outcome = outcome_to_exitset(
+        _workspace_function_sugar(tmp_path, source, "star_then_store_d").desugar(None)
+    )
+    with pytest.raises(AssertionError):
+        assert len(outcome.exits) == 1 and isinstance(
+            outcome.exits[0], Completed
+        ), "store halt erased by sole Completed"
+
+
+# ---------------------------------------------------------------------------
+# Arity lying twin
+# ---------------------------------------------------------------------------
+
+
+def test_arity_lying_twin_exact_count_is_not_star_minimum() -> None:
+    """Exact-arity of 1 is not the same demand as head,*tail over 3 members."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    exact = SequenceProjectionOperation(
+        target_names=("head",), owner="exact", blame="x"
+    )
+    starred = _star_op(prefix=("head",))
+    members = (TermValue(1), TermValue(2), TermValue(3))
+    star_ok = starred.submit(TupleValue(members), None)
+    assert isinstance(star_ok, Complete)
+    # Exact one-name against three members is a mismatch (too many) → gap on prose site.
+    with pytest.raises(ConstructionPanic):
+        exact.submit(TupleValue(members), None)
+    with pytest.raises(AssertionError):
+        assert star_ok.value == ScopeRebinds((("head", TermValue(1)),))
+
+
+def test_source_authenticated_star_binds_through_local_display(tmp_path: Path) -> None:
+    """``xs = (1,2,3); head, *tail = xs`` via substitution MultiAssign."""
+    outcome = _function_sugar(
+        tmp_path,
+        "def f():\n    xs = (1, 2, 3)\n    head, *tail = xs\n    return head\n",
+        "local_star",
+    ).desugar(None)
+    assert isinstance(outcome, Complete)
+    assert "1" in str(outcome.value.record) or "TermValue(value=1)" in str(
+        outcome.value
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_sequencing_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_sequencing_law.py
@@ -372,12 +372,19 @@ def test_display_arity_mismatch_does_not_fabricate_completion(tmp_path: Path) ->
 def test_starred_opaque_unpack_stays_loud_not_exact_arity_completion(
     tmp_path: Path,
 ) -> None:
-    """Face (d): starred pattern is not forced through exact-arity completion."""
+    """Face (d): starred pattern retains typed unpack; never exact-arity completion."""
+    from sugar_lift_py_tests.effect import SequenceUnpackRuntimeEffect
+    from sugar_lift_py_tests.outcome import Complete, Incomplete
+
     path = tmp_path / "star.py"
     path.write_text("def f(xs):\n    a, *rest = xs\n    return a\n")
     fn = next(SourceFile(path_source(str(path))).functions())
-    with pytest.raises(SugarNotWritten, match="Assign"):
-        fn.sugar()
+    outcome = fn.sugar().desugar(None)
+    assert isinstance(outcome, Incomplete)
+    assert isinstance(outcome.effect, SequenceUnpackRuntimeEffect)
+    assert not isinstance(outcome, Complete)
+    with pytest.raises(AssertionError):
+        assert isinstance(outcome, Complete), "opaque starred unpack completed"
 
 
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3692,6 +3692,38 @@ class Assign(Statement):
             pairs.extend(zip(target.elts[-suffix:], value.elts[-suffix:]))
         return pairs
 
+    def _flat_starred_name_parts(self, target):
+        """Parse a flat ``Name | *Name`` target into (prefix, star_name, suffix).
+
+        Used for non-display RHS dynamic unpack. Nested stars, non-Name leaves,
+        or more than one star stay unadmitted (``None``).
+        """
+        if not isinstance(target, (Tuple_, List)):
+            return None
+        star_indices = [
+            index
+            for index, element in enumerate(target.elts)
+            if isinstance(element, Starred)
+        ]
+        if len(star_indices) != 1:
+            return None
+        star_index = star_indices[0]
+        star = target.elts[star_index]
+        if not isinstance(star.value, Name):
+            return None
+        prefix: list[str] = []
+        suffix: list[str] = []
+        for index, element in enumerate(target.elts):
+            if index == star_index:
+                continue
+            if not isinstance(element, Name):
+                return None
+            if index < star_index:
+                prefix.append(element.id)
+            else:
+                suffix.append(element.id)
+        return (tuple(prefix), star.value.id, tuple(suffix))
+
     def _flat_store_unpack_pairs(self):
         """Flat Name|Attribute|Subscript leaves against a display RHS.
 
@@ -4111,20 +4143,32 @@ class Assign(Statement):
                     site=self.fragment,
                 )
             target = self.targets[0]
-            if (
-                not isinstance(self.value, (Tuple_, List))
-                and target.elts
-                and all(isinstance(item, Name) for item in target.elts)
-            ):
+            if not isinstance(self.value, (Tuple_, List)) and target.elts:
                 from sugar_lift_py_tests.sugar.dynamic_unpack_assign_sugar import (
                     DynamicUnpackAssignSugar,
                 )
 
-                return DynamicUnpackAssignSugar(
-                    tuple(item.id for item in target.elts),
-                    self.value.sugar(),
-                    self.fragment,
-                )
+                # Exact-arity: every leaf is a plain Name.
+                if all(isinstance(item, Name) for item in target.elts):
+                    return DynamicUnpackAssignSugar(
+                        tuple(item.id for item in target.elts),
+                        self.value.sugar(),
+                        self.fragment,
+                    )
+                # Starred: at most one *Name among flat Name leaves. Opaque /
+                # runtime-selected RHS keeps the typed unpack obligation via
+                # SequenceProjectionOperation (never a fabricated completion).
+                star_parts = self._flat_starred_name_parts(target)
+                if star_parts is not None:
+                    prefix, star_name, suffix = star_parts
+                    return DynamicUnpackAssignSugar(
+                        target_names=(*prefix, *suffix),
+                        value=self.value.sugar(),
+                        site=self.fragment,
+                        star_name=star_name,
+                        prefix_names=prefix,
+                        suffix_names=suffix,
+                    )
             return super()._construct_sugar()
 
         if len(self.targets) > 1 and all(isinstance(t, Name) for t in self.targets):


### PR DESCRIPTION
## Summary

Wave 3: starred unpack (`head, *tail = rhs`) from authenticated finite members, with opaque arity honesty.

| Face | Pin |
|------|-----|
| Authenticated tuple/list | `head` + `ListValue` tail in **source order** |
| Too few fixed positions | named **ValueError** (ground exit when blame is a workspace-relative fragment) |
| Opaque / runtime-selected | `SequenceUnpackRuntimeEffect` — **never** completion, no fabricated arity |
| Later store halt | not sole-Completed; TypeError store after star prefix |
| Lying twins | reversed-tail rebind ≠ truthful; exact-arity ≠ star minimum |

### Owned surface
- `SequenceProjectionOperation` — star prefix/suffix + ValueError mismatch
- `DynamicUnpackAssignSugar` — star_name / prefix / suffix
- `Assign._flat_starred_name_parts` + construct door for flat `Name|*Name` non-display RHS
- Floor ports unchanged (still `project_tuple` / `project_array`)

### Must not touch (honored)
carrier/ExitSet, store projectors, corpus instruments, vendor spelling arms.

### Standing interrupt (#6636)
Carrier prefix-state fix not yet on main: formal unpack+setitem invalid-index halt still has `state is None`. No extra commit; re-check when codex-1 lands.

## Tests (`bin/bpytest`)

```
bin/bpytest \
  implementations/python/sugar-lift-py-tests/tests/test_starred_unpack_projection.py \
  implementations/python/sugar-lift-py-tests/tests/test_dynamic_unpack_projection.py \
  implementations/python/sugar-lift-py-tests/tests/test_assign_unpack_store_leaves.py \
  implementations/python/sugar-lift-py-tests/tests/test_unpack_sequencing_law.py -q
```

→ **55 passed**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add starred unpack support to `SequenceProjectionOperation` from authenticated finite members
> - [`SequenceProjectionOperation`](https://github.com/TSavo/sugar/pull/6642/files#diff-9be349b5e190d0d25eea1243b590d33cad0994bfaf442e9c32851518f50a31a4) gains `star_name`, `prefix_names`, and `suffix_names` fields; for starred patterns, arity reports the fixed minimum (prefix + suffix count) and the starred name is bound to a `ListValue` of the middle slice.
> - Arity mismatches now yield a named `ValueError` exceptional exit when a ground site is available, falling back to a construction panic gap otherwise.
> - [`Assign._construct_sugar`](https://github.com/TSavo/sugar/pull/6642/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) detects a single `Starred` name among flat `Name` leaves and routes to `DynamicUnpackAssignSugar` with starred configuration instead of falling through to the superclass.
> - Opaque starred RHS yields an `Incomplete` `SequenceUnpackRuntimeEffect` rather than a fabricated completion.
> - A new test suite in [`test_starred_unpack_projection.py`](https://github.com/TSavo/sugar/pull/6642/files#diff-5e94ddd27bb289f6c387a3dfc7fb72509fb600c16e30bcad8df743b99def186a) covers binding order, empty middle, arity mismatch exits, opaque RHS, and local display substitution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce65c9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->