### PR TITLE
Authenticate nested attribute source calls

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import ast
+import csv
 from dataclasses import dataclass
+import importlib.metadata
+from pathlib import Path
 
 import pandas as pd
 import pandas._testing as tm
@@ -13,11 +16,16 @@ from pandas import Series, Timedelta
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import CallSiteValue, StringValue
-from sugar_lift_py_tests.ir import ctor
+from sugar_lift_py_tests.ir import ctor, str_const
 from sugar_lift_py_tests.outcome import ExitSet
 from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
 from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.source_call_preconstruction import (
+    populate_source_visible_call_frames,
+)
+from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.nodes import Call as SourceCall
+from sugar_source_tree.nodes import BinOp as SourceBinOp
 from sugar_source_tree.tree import SourceFile
 
 MANIFEST_CID = (
@@ -330,6 +338,112 @@ def test_candidate_pair_existing_floor_remains_undischarged() -> None:
     assert len(halted) == 1
     assert len(completed) == 1
     assert halted[0].effect.exception_type_coordinate is None
+
+
+def test_authenticated_box_expected_actual_names_type_error_edge(
+    tmp_path: Path,
+) -> None:
+    """An authenticated attributed producer supplies the real helper's Floor."""
+    pair = _pair()
+    package = tmp_path / "unprivileged"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from unprivileged.helpers import box_expected\n", encoding="utf-8"
+    )
+    (package / "helpers.py").write_text(
+        "def box_expected(expected):\n    return expected\n", encoding="utf-8"
+    )
+    metadata = tmp_path / "unprivileged_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: unprivileged-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(("unprivileged/__init__.py", "", ""))
+        writer.writerow(("unprivileged/helpers.py", "", ""))
+        writer.writerow(("unprivileged_dist-1.0.dist-info/METADATA", "", ""))
+        writer.writerow(("unprivileged_dist-1.0.dist-info/RECORD", "", ""))
+    distribution = importlib.metadata.Distribution.at(metadata)
+
+    actual_source = (
+        "import unprivileged as tm\n"
+        "def actual():\n"
+        "    return tm.box_expected((1,))\n"
+        "actual()\n"
+    )
+    actual_path = tmp_path / "real-binop-actual.py"
+    actual_path.write_text(actual_source, encoding="utf-8")
+    actual_context = TreeConstructionContextV1.for_source_call_construction(
+        workspace_root=str(tmp_path)
+    )
+    actual_tree = SourceFile(
+        workspace_path_source(str(actual_path), root=str(tmp_path)),
+        construction_context=actual_context,
+    )
+    calls = tuple(node for node in actual_tree.nodes() if isinstance(node, SourceCall))
+    actual_call = next(
+        call for call in calls if getattr(call.func, "attr", None) == "box_expected"
+    )
+    populate_source_visible_call_frames(
+        actual_tree,
+        root=tmp_path,
+        path=actual_path,
+        distribution_index={"unprivileged": distribution},
+    )
+
+    actual_outcome = actual_call.sugar().desugar(None)
+    assert hasattr(actual_outcome, "value")
+    actual_return = actual_outcome.value.force_floor(
+        None, owner="authenticated attributed producer", project_callsite=False
+    ).statements[0]
+    assert type(actual_return.value).__name__ == "TupleValue"
+    corpus = authenticated_pandas_corpus()
+    helper_path = corpus.root / HELPER_PATH
+    helper_tree = SourceFile(
+        workspace_path_source(str(helper_path), root=str(corpus.root.parent)),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    helper_operation = next(
+        node
+        for node in helper_tree.nodes()
+        if isinstance(node, SourceBinOp)
+        and node.line_col_span().start_line == pair.operation.lineno
+    )
+    produced = actual_return.value.add(
+        StringValue("a"), helper_operation.fragment
+    )
+    raised = produced.value
+    assert raised.effect.exception_type_coordinate == ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("TypeError")],
+    )
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        AuthenticatedRaiseMatcher,
+        EffectBoundaryDisposition,
+    )
+    from sugar_lift_py_tests.effect import ExpectationNotMetEffect
+    from sugar_lift_py_tests.outcome.exit_set import true_guard
+    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+
+    class _WrongExpected:
+        def exception_type_identity(self):
+            return ctor(
+                "python:exception_type_identity",
+                [str_const("builtins"), str_const("ValueError")],
+            )
+
+    original = Halted(true_guard(), raised.effect, _ReducedBlock((), False, ()))
+    routed = ExitSet((original,)).and_exit(
+        ExitSet.completed(object()),
+        disposition=EffectBoundaryDisposition(
+            matcher=AuthenticatedRaiseMatcher(_WrongExpected()),
+            unmet=ExpectationNotMetEffect("raise", helper_operation.fragment),
+        ),
+    )
+    assert routed.exits == (original,)
 
 
 def test_runtime_wrong_expected_type_does_not_consume_candidate_exception() -> None:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
@@ -122,14 +122,7 @@ def populate_source_visible_call_frames(
             )
             continue
         frame, target = frame_result
-        opaque = _unsupported_call(target)
-        if opaque is not None:
-            context.source_call_resolutions[coordinate] = (
-                SourceCallPreconstructionGapV1(
-                    "dynamic-call-target", coordinate, opaque
-                )
-            )
-            continue
+        _preconstruct_authenticated_attribute_calls(target, graph=graph, session=session)
         from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
         try:
@@ -189,19 +182,68 @@ def populate_source_visible_call_frames(
         )
 
 
-def _unsupported_call(target) -> str | None:
-    """Keep method/computed dispatch loud until receiver identity is authenticated."""
+def _preconstruct_authenticated_attribute_calls(
+    target, *, graph, session, visited: frozenset[tuple] = frozenset()
+) -> None:
+    """Install exact frames for attributed callees authenticated in this artifact.
+
+    The outer import receipt authenticates ``target``.  This second lexical
+    pass reads receipts from those same retained module bytes and admits only
+    exact attributed call coordinates whose targets resolve through the same
+    dependency-artifact graph.  No receiver or member spelling is consulted.
+    """
     if not isinstance(target, FunctionDef):
-        return None
-    stack = list(reversed(target.body))
-    while stack:
-        node = stack.pop()
-        if isinstance(node, FunctionDef):
+        return
+    context = target.unit.construction_context
+    if context is None:
+        return
+    target_key = (target.unit.source_cid, _span_key(target))
+    if target_key in visited:
+        return
+    visited = visited | {target_key}
+
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+
+    receipts, _ = authenticated_import_use_receipts(
+        Path("."),
+        Path(target.unit.filename),
+        target.unit.source,
+        target.unit.source_cid,
+        module_identities={},
+    )
+    calls = tuple(
+        node
+        for node in target.walk()
+        if isinstance(node, Call) and isinstance(node.func, Attribute)
+    )
+    calls_by_span = {
+        span: call
+        for call in calls
+        for span in (_span_key(call), _span_key(call.func))
+    }
+    for receipt in receipts:
+        raw = receipt.use["useSite"]
+        key = (raw["startLine"], raw["startCol"], raw["endLine"], raw["endCol"])
+        call = calls_by_span.get(key)
+        if call is None:
             continue
-        if isinstance(node, Call) and not isinstance(node.func, Name):
-            return node.func.kind
-        stack.extend(reversed([child for _, _, child in node.children()]))
-    return None
+        # The lexical pass authenticated this exact attributed use against its
+        # import binding. That is sufficient to distinguish it from runtime
+        # receiver dispatch; the call's ordinary factory/definition door still
+        # owns whether the target can construct a Floor.
+        resolved = resolve_import_binding(receipt, graph=graph, session=session)
+        if not isinstance(resolved, ResolvedPythonObjectV1):
+            continue
+        projected = resolve_source_visible_frame(
+            resolved, graph=graph, session=session
+        )
+        if isinstance(projected, ManagerConstructionGapV1):
+            continue
+        frame, nested_target = projected
+        _preconstruct_authenticated_attribute_calls(
+            nested_target, graph=graph, session=session, visited=visited
+        )
+        context.source_call_frames[_coordinate(call)] = frame
 
 
 def _span_key(node):

--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -12,6 +12,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     TreeConstructionContextV1,
 )
 from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, ReturnValue, TermValue
+from sugar_lift_py_tests.gap import ConstructionPanic
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_py_tests.source_call_resolution import (
     SourceCallPreconstructionGapV1,
@@ -49,6 +50,18 @@ def _distribution(root: Path, implementation: str) -> importlib.metadata.Distrib
         for file in files:
             writer.writerow((file, "", ""))
     return importlib.metadata.Distribution.at(metadata)
+
+
+def _distribution_with_nested_module(
+    root: Path, implementation: str, nested: str
+) -> importlib.metadata.Distribution:
+    distribution = _distribution(root, implementation)
+    package = root / "unprivileged"
+    (package / "nested.py").write_text(nested, encoding="utf-8")
+    record = root / "unprivileged_dist-1.0.dist-info" / "RECORD"
+    with record.open("a", newline="", encoding="utf-8") as stream:
+        csv.writer(stream).writerow(("unprivileged/nested.py", "", ""))
+    return distribution
 
 
 def _coordinate(call: Call) -> SourceFragmentCoordinateV1:
@@ -119,6 +132,91 @@ def test_renamed_cross_file_call_installs_source_frame_and_constructs_return(
     )
     assert isinstance(nested_result, BlockValue)
     assert nested_result.statements == (ReturnValue(TermValue(17)),)
+
+
+def test_authenticated_nested_attribute_call_installs_recursive_source_frame(
+    tmp_path: Path,
+) -> None:
+    """An attributed callee with authenticated defining bytes is not dynamic."""
+    distribution = _distribution_with_nested_module(
+        tmp_path,
+        "import unprivileged.nested as nested\n\n"
+        "def arbitrary_helper(value=17):\n"
+        "    return nested.project(value)\n",
+        "def project(value):\n"
+        "    return value\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as renamed\nrenamed()\n",
+    )
+    call = next(node for node in source_file.nodes() if isinstance(node, Call))
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+
+    coordinate = _coordinate(call)
+    assert isinstance(
+        context.source_call_resolutions[coordinate], SourceCallPreconstructionRefV1
+    )
+    value = call.sugar().desugar().value
+    assert isinstance(value, CallSiteValue)
+    result = value.force_floor(
+        None, owner="authenticated nested attribute call", project_callsite=False
+    )
+    returned = result.statements[0]
+    assert isinstance(returned, ReturnValue)
+    assert isinstance(returned.value, CallSiteValue)
+    nested_result = returned.value.force_floor(
+        None, owner="authenticated attributed callee", project_callsite=False
+    )
+    assert nested_result.statements == (ReturnValue(TermValue(17)),)
+
+
+def test_runtime_receiver_attribute_call_remains_dynamic_and_loud(
+    tmp_path: Path,
+) -> None:
+    """A formal receiver supplies no authenticated identity for its method."""
+    distribution = _distribution(
+        tmp_path,
+        "def arbitrary_helper(receiver, value):\n"
+        "    return receiver.project(value)\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as renamed\n"
+        "renamed(subject, 17)\n",
+    )
+    call = next(node for node in source_file.nodes() if isinstance(node, Call))
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+
+    coordinate = _coordinate(call)
+    row = context.source_call_resolutions[coordinate]
+    assert isinstance(row, SourceCallPreconstructionRefV1)
+    assert coordinate in context.source_call_frames
+    value = call.sugar().desugar().value
+    assert isinstance(value, CallSiteValue)
+    outer = value.force_floor(
+        None, owner="runtime receiver attribute call", project_callsite=False
+    )
+    returned = outer.statements[0]
+    assert isinstance(returned, ReturnValue)
+    assert isinstance(returned.value, CallSiteValue)
+    with pytest.raises(ConstructionPanic) as raised:
+        returned.value.force_floor(
+            None, owner="runtime receiver attribute call", project_callsite=False
+        )
+    assert "blame=project observed=missing callsite body" in str(raised.value)
 
 
 def test_source_visible_function_with_opaque_child_stays_typed_loud(


### PR DESCRIPTION
## Capability

- recursively follows authenticated import-use receipts for attributed call targets inside authenticated function definitions
- installs exact nested source-call frames without vendor/name dispatch
- preserves genuinely dynamic receiver calls as a loud ConstructionPanic
- projects an attributed caller result to a concrete Floor for the real pandas assert_invalid_addsub_type BinOp locus, including TypeError and wrong-expected discrimination

## Evidence

- `../../../bin/bpytest tests/test_source_call_preconstruction.py::test_authenticated_nested_attribute_call_installs_recursive_source_frame tests/test_source_call_preconstruction.py::test_runtime_receiver_attribute_call_remains_dynamic_and_loud ../sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py::test_candidate_pair_existing_floor_remains_undischarged ../sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py::test_authenticated_box_expected_actual_names_type_error_edge -q` — 4 passed
- `../../../bin/bpytest tests/test_source_call_preconstruction.py -q` — 2 failed, 11 passed (two inherited reds retained)
- `../../../bin/bpytest ../sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py -q` — 1 failed, 11 passed (inherited nested-default carrier red retained)
- source package full `../../../bin/bpytest -q` — 39 failed, 753 passed, 2 warnings
- py-tests package full `../../../bin/bpytest -q` — 258 failed, 2145 passed, 9 skipped, 5 errors

No Carrier or ExitSet production code changed. No vendor-spelling recognition arm added.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate nested attribute source calls by recursively installing source-visible frames at preconstruction time
> - Replaces the `_unsupported_call` dynamic-call-target gap marker in `populate_source_visible_call_frames` with a new `_preconstruct_authenticated_attribute_calls` helper in [source_call_preconstruction.py](https://github.com/TSavo/sugar/pull/6643/files#diff-74b4be0d0a335267f0783561ba4419e3981f34d4d03f9d4d72678b66d4e94cbf).
> - The new helper walks attributed `Call` sites within a resolved target's `FunctionDef`, resolves their import bindings via the dependency-artifact graph, and installs exact source-visible frames recursively into the construction context.
> - A visited set keyed by `(unit.source_cid, span)` prevents cycles during recursion.
> - Receiver-based (runtime-dispatch) attribute calls are unaffected and remain dynamic, raising `ConstructionPanic` when forced.
> - Behavioral Change: calls that previously produced dynamic-call-target gap markers now resolve to exact preconstructed frames when the receiver is an authenticated import.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 258b7a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->