### PR TITLE
Retain innermost carrier pre-effect state

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -560,7 +560,7 @@ class NativeOperationExitCarrierV1:
                     "pre_effect_state must be reducer-issued testimony; raw "
                     f"{type(pre_effect_state).__name__} is not admissible"
                 )
-            if testimony is not None and testimony.state is not pre_effect_state.state:
+            if testimony is not None and testimony.state != pre_effect_state.state:
                 from sugar_lift_py_tests.gap.info import GapKind
                 from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
@@ -575,7 +575,8 @@ class NativeOperationExitCarrierV1:
                     ),
                     gap_kind=GapKind.FLOOR,
                 )
-            testimony = pre_effect_state
+            if testimony is None:
+                testimony = pre_effect_state
         return replace(
             self,
             continuations=(*self.continuations, step),

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_pre_effect_state.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_pre_effect_state.py
@@ -154,3 +154,26 @@ def test_second_conflicting_state_enrollment_panics() -> None:
             lambda value: Complete(value),
             pre_effect_state=conflicting,
         )
+
+
+def test_equal_state_reenrollment_retains_original_testimony() -> None:
+    pending, _ = _pending_and_receiver()
+    original = pending.pre_effect_state
+    assert original is not None
+    state = original.state
+    equal_state = _ReducedBlock(
+        state.entries,
+        state.can_fall_through,
+        state.fall_through,
+        state.transforms,
+        state.context,
+    )
+    assert equal_state == state
+    assert equal_state is not state
+
+    retained = pending.and_then(
+        lambda value: Complete(value),
+        pre_effect_state=ReducerPreEffectStateV1._from_reducer(equal_state),
+    )
+
+    assert retained.pre_effect_state is original


### PR DESCRIPTION
## Capability

- make equal reducer-state re-enrollment a lawful no-op while retaining the original sealed testimony
- keep genuinely unequal state re-enrollment on the existing `ConstructionPanic` arm
- allow nested `reduce_body` setitem carriers to pass through their repeated equal state without suppressing the conflict discriminator

This is the separate preempting carrier repair. The queued `short_circuit` producer remains stashed and is not part of this PR.

## Tests

- `../../../bin/bpytest tests/test_unpack_setitem_formal_caller.py` — 13 passed (was 11 failed / 2 passed on merged main)
- `../../../bin/bpytest tests/test_native_operation_pre_effect_state.py tests/test_unpack_setitem_formal_caller.py tests/test_compare_through_if_sugar.py tests/test_native_operation_exit_carrier.py` — 78 passed; #6635 and #6636 joins green
- `../../../bin/bpytest` — 2212 passed, 259 failed, 9 skipped, 5 errors in 323.34s; loud package instruments remain unsuppressed

## Floors

Unequal state still panics. No ExitSet, exit disposition, store producer, matcher, timeout, or skipped-test changes.