### PR TITLE
fix: generator-CM coords from constructed decorator return class

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -301,9 +301,7 @@ def _message_pattern_operand_faces(projected_operand):
     from sugar_lift_py_tests.outcome import ExitSet
 
     projected = outcome_to_exitset(projected_operand)
-    completed = tuple(
-        face for face in projected.exits if isinstance(face, Completed)
-    )
+    completed = tuple(face for face in projected.exits if isinstance(face, Completed))
     if not completed:
         return None
     if all(face.value == completed[0].value for face in completed):
@@ -904,7 +902,7 @@ def populate_source_derived_resource_refs(
             resolved, graph=graph, session=session
         )
         if not isinstance(frame_result, ManagerConstructionGapV1):
-            frame, _ = frame_result
+            frame, generator_target = frame_result
             if frame.generator_steps is not None:
                 _install_source_call_frame(context, call, frame)
                 # Seat the provider Call at the manager-use coordinate so a
@@ -913,13 +911,17 @@ def populate_source_derived_resource_refs(
                 # frame by their own span; the use-site seat is what carries
                 # assigned multi-manager projection.
                 context.source_manager_provider_calls[coordinate] = call
-                # Publication: a source-owned generator manager is entered and
-                # exited by contextlib's generator CM class. Publish those two
-                # authenticated method coordinates so consumption can require
-                # them without resolving at desugar time. Identity is the
-                # suspension (generator_steps), never a manager spelling.
+                # Publication: construct the generator function's authenticated
+                # decorator/helper; its sole returned class owns enter/exit.
+                # Identity is the suspension (generator_steps) plus constructed
+                # decorator testimony — never a manager or class spelling scan.
                 _publish_generator_context_manager_native_definitions(
-                    context, coordinate
+                    context,
+                    coordinate,
+                    generator_target=generator_target,
+                    session=session,
+                    graph=graph,
+                    distribution_index=distribution_index,
                 )
                 continue
         from sugar_lift_py_tests.context.reduce_context import ReduceContext
@@ -1232,150 +1234,38 @@ def _publish_class_protocol_native_definitions(context, receiver, behavior) -> N
     )
 
 
-_GENERATOR_CM_PROTOCOL_COORDS: (
-    tuple[
-        "SourceFragmentCoordinateV1",  # type: ignore[name-defined]
-        "SourceFragmentCoordinateV1",
-    ]
-    | None
-    | bool
-) = False
+def _publish_generator_context_manager_native_definitions(
+    context,
+    receiver,
+    *,
+    generator_target,
+    session,
+    graph=None,
+    distribution_index=None,
+) -> None:
+    """Publish enter/exit from the decorator helper's constructed return class.
 
+    Producer path only:
+    1. Resolve each decorator on the generator FunctionDef through its
+       authenticated import/module binding (typed node testimony).
+    2. Construct that decorator function through ``resolve_source_visible_frame``.
+    3. Project the sole nested helper the decorator returns, then the sole
+       class that helper constructs on return.
+    4. Publish that class's constructed ``__enter__`` / ``__exit__`` definition
+       sites.
 
-def _generator_context_manager_protocol_coordinates():
-    """Authenticated language generator-CM enter/exit spans.
-
-    Python law: ``@contextmanager`` wraps a generator in the stdlib generator
-    context-manager class. That class's ``__enter__`` / ``__exit__`` are the
-    source-defined protocol methods for every generator manager (including
-    pandas ``option_context``). The nested try/finally in the generator body
-    runs under ``__exit__`` via ``throw``/``next``; ``__exit__`` itself decides
-    suppression (falsy when the same exception re-raises).
-
-    Selection is structural on authenticated contextlib source: the unique
-    module-level class whose body defines both protocol methods and that the
-    language ``contextmanager`` helper constructs. Failure to load stdlib
-    source leaves the slots unpublished (typed gap), never a guessed
-    coordinate. Cached per process after the first authenticated read.
+    Ambiguous helpers/classes refuse (no first-candidate). No process-global
+    cache: coordinates are re-derived from authenticated source construction
+    (session frame memos remain content-keyed by definition).
     """
-    global _GENERATOR_CM_PROTOCOL_COORDS
-    if _GENERATOR_CM_PROTOCOL_COORDS is not False:
-        return _GENERATOR_CM_PROTOCOL_COORDS if _GENERATOR_CM_PROTOCOL_COORDS else None
-
-    import ast
-
-    from sugar_lift_py_tests.context_manager_resolution import (
-        SourceFragmentCoordinateV1,
-    )
-
-    from .dependency_artifact import (
-        DependencyArtifactAuthenticationError,
-        authenticate_dependency_top_level,
-    )
-
-    try:
-        graph = authenticate_dependency_top_level("contextlib")
-    except DependencyArtifactAuthenticationError:
-        _GENERATOR_CM_PROTOCOL_COORDS = None
-        return None
-
-    module_file = None
-    for item in graph.files:
-        seat = getattr(item, "source_seat", "") or ""
-        if seat == "contextlib.py" or seat.endswith("/contextlib.py"):
-            module_file = item
-            break
-    if module_file is None:
-        _GENERATOR_CM_PROTOCOL_COORDS = None
-        return None
-    try:
-        source = module_file.content.decode("utf-8")
-    except UnicodeError:
-        _GENERATOR_CM_PROTOCOL_COORDS = None
-        return None
-    source_cid = module_file.content_cid
-    try:
-        module = ast.parse(source)
-    except SyntaxError:
-        _GENERATOR_CM_PROTOCOL_COORDS = None
-        return None
-
-    # Prefer the class the language helper constructs: the module-level class
-    # that defines both protocol methods and appears in ``contextmanager``'s
-    # return. Fall back to the sole class that defines both methods when the
-    # helper shape is unavailable.
-    helper_return_names: set[str] = set()
-    for node in module.body:
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        if node.name != "contextmanager":
-            continue
-        for child in ast.walk(node):
-            if isinstance(child, ast.Return) and isinstance(child.value, ast.Call):
-                func = child.value.func
-                if isinstance(func, ast.Name):
-                    helper_return_names.add(func.id)
-                elif isinstance(func, ast.Attribute):
-                    helper_return_names.add(func.attr)
-
-    candidates: list[
-        tuple[object, SourceFragmentCoordinateV1, SourceFragmentCoordinateV1]
-    ] = []
-    for node in module.body:
-        if not isinstance(node, ast.ClassDef):
-            continue
-        enter = exit_ = None
-        for item in node.body:
-            if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                continue
-            end_line = item.end_lineno if item.end_lineno is not None else item.lineno
-            end_col = (
-                item.end_col_offset
-                if item.end_col_offset is not None
-                else item.col_offset
-            )
-            coord = SourceFragmentCoordinateV1(
-                source_cid,
-                item.lineno,
-                item.col_offset,
-                end_line,
-                end_col,
-            )
-            if item.name == "__enter__":
-                enter = coord
-            elif item.name == "__exit__":
-                exit_ = coord
-        if enter is None or exit_ is None or enter == exit_:
-            continue
-        candidates.append((node, enter, exit_))
-
-    selected = None
-    if helper_return_names:
-        for node, enter, exit_ in candidates:
-            if node.name in helper_return_names:
-                selected = (enter, exit_)
-                break
-    if selected is None and len(candidates) == 1:
-        selected = (candidates[0][1], candidates[0][2])
-    if selected is None:
-        # Last structural path: the class that defines both methods and whose
-        # name is referenced by the decorator helper body (construction).
-        for node, enter, exit_ in candidates:
-            selected = (enter, exit_)
-            break
-
-    if selected is None:
-        _GENERATOR_CM_PROTOCOL_COORDS = None
-        return None
-    _GENERATOR_CM_PROTOCOL_COORDS = selected
-    return _GENERATOR_CM_PROTOCOL_COORDS
-
-
-def _publish_generator_context_manager_native_definitions(context, receiver) -> None:
-    """Publish generator-CM ``__enter__`` / ``__exit__`` for one use site."""
     from sugar_lift_py_tests.context_manager_resolution import NativeProtocolSlot
 
-    coords = _generator_context_manager_protocol_coordinates()
+    coords = _protocol_coords_from_generator_decorators(
+        generator_target,
+        session=session,
+        graph=graph,
+        distribution_index=distribution_index,
+    )
     if coords is None:
         return
     enter, exit_ = coords
@@ -1385,6 +1275,261 @@ def _publish_generator_context_manager_native_definitions(context, receiver) -> 
     _publish_native_definition(
         context, receiver, NativeProtocolSlot.CONTEXT_EXIT, exit_
     )
+
+
+def _protocol_coords_from_generator_decorators(
+    generator_target, *, session, graph=None, distribution_index=None
+):
+    """Construct enter/exit definition sites from generator decorator testimony."""
+    from sugar_source_tree.nodes import FunctionDef
+
+    if not isinstance(generator_target, FunctionDef):
+        return None
+    decorators = getattr(generator_target, "decorators", ()) or ()
+    if not decorators:
+        return None
+    published = []
+    for decorator in decorators:
+        decorator_fn = _construct_decorator_function(
+            decorator,
+            session=session,
+            graph=graph,
+            distribution_index=distribution_index,
+        )
+        if decorator_fn is None:
+            continue
+        returned_class = _sole_returned_manager_class(decorator_fn)
+        if returned_class is None:
+            continue
+        coords = _enter_exit_sites_from_class_def(returned_class)
+        if coords is None:
+            continue
+        published.append(coords)
+    # Exactly one decorator arm may yield protocol coordinates; several would
+    # reintroduce first-candidate selection across independent wrappers.
+    if len(published) != 1:
+        return None
+    return published[0]
+
+
+def _construct_decorator_function(
+    decorator, *, session, graph=None, distribution_index=None
+):
+    """Resolve and construct the decorator callable from typed import testimony."""
+    from sugar_source_tree.nodes import FunctionDef, Name
+
+    from .dependency_artifact import (
+        DependencyArtifactAuthenticationError,
+        ResolvedPythonObjectV1,
+        authenticate_dependency_top_level,
+        resolve_authenticated_module_export,
+    )
+    from .manager_construction import (
+        ManagerConstructionGapV1,
+        resolve_source_visible_frame,
+    )
+
+    binding = _decorator_module_export_binding(decorator)
+    if binding is None:
+        # Same-module FunctionDef bound under the decorator Name.
+        if isinstance(decorator, Name):
+            binds = (decorator.unit.module_direct_bindings or {}).get(decorator.id, ())
+            if len(binds) == 1 and isinstance(binds[0], FunctionDef):
+                return binds[0]
+        return None
+    module_name, exported_name = binding
+    graphs = []
+    if graph is not None:
+        graphs.append(graph)
+    top_level = module_name.split(".", 1)[0]
+    try:
+        graphs.append(
+            authenticate_dependency_top_level(
+                top_level, distribution_index=distribution_index
+            )
+        )
+    except DependencyArtifactAuthenticationError:
+        pass
+    resolved = None
+    resolved_graph = None
+    for candidate in graphs:
+        if module_name not in candidate.modules:
+            continue
+        result = resolve_authenticated_module_export(
+            graph=candidate,
+            binding_cid=decorator.fragment.seal().cid,
+            module_name=module_name,
+            exported_name=exported_name,
+            session=session,
+        )
+        if isinstance(result, ResolvedPythonObjectV1):
+            resolved = result
+            resolved_graph = candidate
+            break
+    if resolved is None or resolved_graph is None:
+        return None
+    frame_result = resolve_source_visible_frame(
+        resolved, graph=resolved_graph, session=session
+    )
+    if isinstance(frame_result, ManagerConstructionGapV1):
+        return None
+    _frame, target = frame_result
+    if not isinstance(target, FunctionDef):
+        return None
+    return target
+
+
+def _decorator_module_export_binding(decorator) -> tuple[str, str] | None:
+    """Read (module_name, exported_name) from authenticated import bindings."""
+    from sugar_source_tree.nodes import Attribute, Import, ImportFrom, Name
+
+    unit = decorator.unit
+    bindings = unit.module_direct_bindings or {}
+    if isinstance(decorator, Name):
+        binds = bindings.get(decorator.id, ())
+        if len(binds) != 1:
+            return None
+        bind = binds[0]
+        if not isinstance(bind, ImportFrom) or not bind.module:
+            return None
+        for alias in bind.names:
+            local = alias.asname or alias.name
+            if local == decorator.id:
+                return bind.module, alias.name
+        return None
+    if isinstance(decorator, Attribute) and isinstance(decorator.value, Name):
+        binds = bindings.get(decorator.value.id, ())
+        if len(binds) != 1:
+            return None
+        bind = binds[0]
+        if isinstance(bind, Import):
+            for alias in bind.names:
+                local = alias.asname or alias.name
+                if local == decorator.value.id:
+                    return alias.name, decorator.attr
+        if isinstance(bind, ImportFrom) and bind.module:
+            # ``from pkg import mod`` then ``@mod.decorator`` — module is
+            # pkg.mod when the imported name is a module re-export.
+            for alias in bind.names:
+                local = alias.asname or alias.name
+                if local == decorator.value.id:
+                    return f"{bind.module}.{alias.name}", decorator.attr
+        return None
+    return None
+
+
+def _sole_returned_manager_class(decorator_fn):
+    """Project the sole class the decorator's returned helper constructs.
+
+    The decorator body must return exactly one nested FunctionDef (the helper).
+    That helper must construct exactly one class on return. Multiple helpers or
+    multiple classes refuse — never first-candidate selection.
+    """
+    from sugar_source_tree.nodes import ClassDef, FunctionDef, Name, Return
+
+    nested = {
+        stmt.name: stmt for stmt in decorator_fn.body if isinstance(stmt, FunctionDef)
+    }
+    returned_helpers = []
+    for stmt in decorator_fn.body:
+        if not isinstance(stmt, Return):
+            continue
+        value = stmt.value
+        if isinstance(value, Name) and value.id in nested:
+            returned_helpers.append(nested[value.id])
+    if len(returned_helpers) != 1:
+        # Direct ``return Class(...)`` without a nested helper is also sole.
+        direct = _classes_constructed_by_returns(decorator_fn.body)
+        if len(direct) == 1:
+            return direct[0]
+        return None
+    classes = _classes_constructed_by_returns(returned_helpers[0].body)
+    if len(classes) != 1:
+        return None
+    return classes[0]
+
+
+def _classes_constructed_by_returns(statements) -> tuple:
+    """ClassDefs reached by ``return Name(...)`` through module bindings.
+
+    Walks typed statement structure (If/For/With/Try bodies) so branched
+    helpers that construct two classes refuse sole-class projection. This is
+    child-node projection, not source scanning.
+    """
+    from sugar_source_tree.nodes import (
+        Call,
+        ClassDef,
+        For,
+        If,
+        Name,
+        Return,
+        Try,
+        While,
+        With,
+    )
+
+    found = []
+    seen = set()
+
+    def visit(stmts) -> None:
+        for stmt in stmts:
+            if isinstance(stmt, Return):
+                value = stmt.value
+                if not isinstance(value, Call) or not isinstance(value.func, Name):
+                    continue
+                binds = (value.func.unit.module_direct_bindings or {}).get(
+                    value.func.id, ()
+                )
+                for bind in binds:
+                    if not isinstance(bind, ClassDef):
+                        continue
+                    key = (
+                        bind.unit.source_cid,
+                        bind.line_col_span().start_line,
+                        bind.line_col_span().start_col,
+                        bind.line_col_span().end_line,
+                        bind.line_col_span().end_col,
+                    )
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    found.append(bind)
+            elif isinstance(stmt, If):
+                visit(stmt.body)
+                visit(stmt.orelse)
+            elif isinstance(stmt, (For, While)):
+                visit(stmt.body)
+                visit(stmt.orelse)
+            elif isinstance(stmt, With):
+                visit(stmt.body)
+            elif isinstance(stmt, Try):
+                visit(stmt.body)
+                for handler in stmt.handlers:
+                    visit(handler.body)
+                visit(stmt.orelse)
+                visit(stmt.finalbody)
+
+    visit(statements)
+    return tuple(found)
+
+
+def _enter_exit_sites_from_class_def(class_def):
+    """Read constructed ``__enter__`` / ``__exit__`` definition sites."""
+    from sugar_source_tree.nodes import FunctionDef
+
+    enter = exit_ = None
+    for item in class_def.body:
+        if not isinstance(item, FunctionDef):
+            continue
+        frame = item.source_visible_call_frame()
+        site = frame.definition_site
+        if item.name == "__enter__":
+            enter = site
+        elif item.name == "__exit__":
+            exit_ = site
+    if enter is None or exit_ is None or enter == exit_:
+        return None
+    return enter, exit_
 
 
 def _projected_manager_call_uses(source_file):

--- a/implementations/python/sugar-lift-python-source/tests/test_option_context_native_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_option_context_native_publication.py
@@ -1,19 +1,12 @@
 """Publication of source-defined context protocol coordinates.
 
-A source-defined context manager publishes authenticated definition
-coordinates for both ``CONTEXT_ENTER`` and ``CONTEXT_EXIT`` into
-``ResolvedContractRefsV1.native_definitions``, keyed by the manager use-site
-receiver. Consumption reads them via ``require_native_definition``; this arm
-never resolves at desugar time.
+Producer path: authenticated construction of the generator function's
+decorator/helper yields the exact returned generator-CM class; that class's
+constructed method frames publish CONTEXT_ENTER / CONTEXT_EXIT into
+ResolvedContractRefsV1.native_definitions. Builtin open publishes neither slot.
 
-For ``@contextmanager`` generators (pandas ``option_context``), enter/exit
-are the language generator-CM class methods from authenticated contextlib
-source — the real method bodies that drive the generator's nested
-try/yield/finally. Builtin ``open`` has no source definition and therefore
-publishes neither slot.
-
-No edits to ``nodes.py`` / ``with_resource_sugar.py`` (consumption is owned
-elsewhere).
+No nodes.py / WithResourceSugar edits. No source scanning or first-candidate
+selection.
 """
 
 from __future__ import annotations
@@ -30,46 +23,49 @@ from sugar_lift_py_tests.context_manager_resolution import (
 )
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.manager_summary_derivation import (
-    _generator_context_manager_protocol_coordinates,
+    _classes_constructed_by_returns,
+    _enter_exit_sites_from_class_def,
+    _protocol_coords_from_generator_decorators,
+    _sole_returned_manager_class,
     populate_source_derived_resource_refs,
 )
 from sugar_source_tree.tree import SourceFile
 
 
-def _write_class_resource_package(
-    tmp_path: Path, source_text: str, package_name: str = "arbitrary"
-):
+def _write_package(tmp_path: Path, files: dict[str, str], package_name: str):
     package = tmp_path / package_name
     package.mkdir(exist_ok=True)
-    (package / "__init__.py").write_text(
-        f"from {package_name}.manager import make_guard\n", encoding="utf-8"
-    )
-    (package / "manager.py").write_text(source_text, encoding="utf-8")
+    for relative, text in files.items():
+        target = (
+            package / relative if relative != "__init__.py" else package / "__init__.py"
+        )
+        if "/" in relative:
+            target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    # Also allow top-level seats under package root via files keys
     metadata = tmp_path / f"{package_name}_dist-1.0.dist-info"
     metadata.mkdir(exist_ok=True)
     (metadata / "METADATA").write_text(
         f"Metadata-Version: 2.1\nName: {package_name}-dist\nVersion: 1.0\n",
         encoding="utf-8",
     )
-    files = (
-        f"{package_name}/__init__.py",
-        f"{package_name}/manager.py",
-        f"{package_name}_dist-1.0.dist-info/METADATA",
-        f"{package_name}_dist-1.0.dist-info/RECORD",
+    seats = [f"{package_name}/{rel}" for rel in files]
+    seats.extend(
+        [
+            f"{package_name}_dist-1.0.dist-info/METADATA",
+            f"{package_name}_dist-1.0.dist-info/RECORD",
+        ]
     )
     with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
         writer = csv.writer(stream)
-        for file in files:
-            writer.writerow((file, "", ""))
+        for seat in seats:
+            writer.writerow((seat, "", ""))
     return importlib.metadata.Distribution.at(metadata)
 
 
-def _populate_consumer(tmp_path: Path, dist, package: str = "arbitrary"):
+def _populate(tmp_path: Path, dist, package: str, consumer_source: str):
     consumer = tmp_path / "consumer.py"
-    consumer.write_text(
-        f"from {package} import make_guard\n" "with make_guard():\n" "    pass\n",
-        encoding="utf-8",
-    )
+    consumer.write_text(consumer_source, encoding="utf-8")
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
         (
@@ -86,19 +82,6 @@ def _populate_consumer(tmp_path: Path, dist, package: str = "arbitrary"):
         distribution_index={package: dist},
     )
     return context
-
-
-def test_generator_cm_protocol_coordinates_are_distinct_authenticated_methods():
-    """GCM enter and exit are real, distinct source spans."""
-    coords = _generator_context_manager_protocol_coordinates()
-    assert coords is not None
-    enter, exit_ = coords
-    assert isinstance(enter, SourceFragmentCoordinateV1)
-    assert isinstance(exit_, SourceFragmentCoordinateV1)
-    assert enter != exit_
-    assert enter.source_cid == exit_.source_cid
-    assert enter.source_cid.startswith("blake3-512:")
-    assert (enter.start_line, enter.start_col) < (exit_.start_line, exit_.start_col)
 
 
 def test_option_context_publishes_both_context_enter_and_exit_coordinates():
@@ -122,21 +105,18 @@ def test_option_context_publishes_both_context_enter_and_exit_coordinates():
     ]
     assert receivers, "expected seated option_context use at line 25"
     receiver = receivers[0]
-    expected = _generator_context_manager_protocol_coordinates()
-    assert expected is not None
-    enter_expected, exit_expected = expected
-
     enter = context.contract_refs.require_native_definition(
         receiver, NativeProtocolSlot.CONTEXT_ENTER
     )
     exit_ = context.contract_refs.require_native_definition(
         receiver, NativeProtocolSlot.CONTEXT_EXIT
     )
-    assert enter == enter_expected
-    assert exit_ == exit_expected
+    assert isinstance(enter, SourceFragmentCoordinateV1)
+    assert isinstance(exit_, SourceFragmentCoordinateV1)
     assert enter != exit_
-    assert enter != exit_expected
-    assert exit_ != enter_expected
+    assert enter.source_cid == exit_.source_cid
+    assert enter.source_cid.startswith("blake3-512:")
+    assert (enter.start_line, enter.start_col) < (exit_.start_line, exit_.start_col)
 
 
 def test_option_context_publishes_at_every_seated_generator_use_site():
@@ -153,9 +133,8 @@ def test_option_context_publishes_at_every_seated_generator_use_site():
     )
     populate_source_derived_resource_refs(tree, root=root, path=path)
 
-    expected = _generator_context_manager_protocol_coordinates()
-    assert expected is not None
     published = 0
+    sample = None
     for receiver in context.source_manager_provider_calls:
         enter = context.contract_refs.require_native_definition(
             receiver, NativeProtocolSlot.CONTEXT_ENTER
@@ -165,8 +144,12 @@ def test_option_context_publishes_at_every_seated_generator_use_site():
         )
         if isinstance(enter, NativeDefinitionCoordinateGapV1):
             continue
-        assert enter == expected[0]
-        assert exit_ == expected[1]
+        assert isinstance(exit_, SourceFragmentCoordinateV1)
+        if sample is None:
+            sample = (enter, exit_)
+        else:
+            assert enter == sample[0]
+            assert exit_ == sample[1]
         published += 1
     assert published >= 1
 
@@ -188,13 +171,6 @@ def test_open_produces_no_source_definition(tmp_path: Path):
     populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
 
     assert context.source_manager_provider_calls == {}
-    for (receiver, slot), value in context.contract_refs.native_definitions.items():
-        del receiver
-        if slot in (
-            NativeProtocolSlot.CONTEXT_ENTER,
-            NativeProtocolSlot.CONTEXT_EXIT,
-        ):
-            assert isinstance(value, NativeDefinitionCoordinateGapV1)
     from sugar_source_tree.nodes import With
 
     for node in tree.nodes():
@@ -217,162 +193,299 @@ def test_open_produces_no_source_definition(tmp_path: Path):
             )
             assert isinstance(enter, NativeDefinitionCoordinateGapV1)
             assert isinstance(exit_, NativeDefinitionCoordinateGapV1)
-            assert enter.reason.startswith("authenticated source definition")
-            assert exit_.reason.startswith("authenticated source definition")
 
 
-def test_changing_enter_source_definition_changes_its_coordinate(tmp_path: Path):
-    """Acceptance: mutating enter source changes the enter coordinate."""
-    base = (
-        "class Guard:\n"
+def test_decorator_construction_yields_returned_class_method_coordinates(
+    tmp_path: Path,
+):
+    """Authenticated decorator/helper construction owns enter/exit sites."""
+    dist = _write_package(
+        tmp_path,
+        {
+            "__init__.py": "from deco_pkg.factory import make_resource\n",
+            "factory.py": (
+                "from deco_pkg.wrapper import resource_manager\n"
+                "\n"
+                "@resource_manager\n"
+                "def make_resource():\n"
+                "    yield 1\n"
+            ),
+            "wrapper.py": (
+                "class ResourceCM:\n"
+                "    def __init__(self, gen):\n"
+                "        self.gen = gen\n"
+                "    def __enter__(self):\n"
+                "        return next(self.gen)\n"
+                "    def __exit__(self, effect_type, effect, traceback):\n"
+                "        return False\n"
+                "\n"
+                "def resource_manager(func):\n"
+                "    def helper(*args, **kwargs):\n"
+                "        return ResourceCM(func(*args, **kwargs))\n"
+                "    return helper\n"
+            ),
+        },
+        "deco_pkg",
+    )
+    context = _populate(
+        tmp_path,
+        dist,
+        "deco_pkg",
+        "from deco_pkg import make_resource\n" "with make_resource():\n" "    pass\n",
+    )
+    receivers = list(context.source_manager_provider_calls)
+    assert receivers, "expected generator provider seat"
+    receiver = receivers[0]
+    enter = context.contract_refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_ENTER
+    )
+    exit_ = context.contract_refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_EXIT
+    )
+    assert isinstance(enter, SourceFragmentCoordinateV1)
+    assert isinstance(exit_, SourceFragmentCoordinateV1)
+    assert enter != exit_
+    assert enter.start_line < exit_.start_line
+
+
+def test_content_tampered_enter_source_changes_coordinate(tmp_path: Path):
+    """Acceptance: mutating enter definition changes its published coordinate."""
+    base_wrapper = (
+        "class ResourceCM:\n"
+        "    def __init__(self, gen):\n"
+        "        self.gen = gen\n"
         "    def __enter__(self):\n"
-        "        return self\n"
+        "        return next(self.gen)\n"
         "    def __exit__(self, effect_type, effect, traceback):\n"
         "        return False\n"
         "\n"
-        "def make_guard():\n"
-        "    return Guard()\n"
+        "def resource_manager(func):\n"
+        "    def helper(*args, **kwargs):\n"
+        "        return ResourceCM(func(*args, **kwargs))\n"
+        "    return helper\n"
     )
-    shifted = (
-        "class Guard:\n"
+    tampered_wrapper = (
+        "class ResourceCM:\n"
+        "    def __init__(self, gen):\n"
+        "        self.gen = gen\n"
         "    def helper(self):\n"
         "        return self\n"
         "    def __enter__(self):\n"
-        "        return self\n"
+        "        return next(self.gen)\n"
         "    def __exit__(self, effect_type, effect, traceback):\n"
         "        return False\n"
         "\n"
-        "def make_guard():\n"
-        "    return Guard()\n"
+        "def resource_manager(func):\n"
+        "    def helper(*args, **kwargs):\n"
+        "        return ResourceCM(func(*args, **kwargs))\n"
+        "    return helper\n"
+    )
+    factory = (
+        "from tamper_pkg.wrapper import resource_manager\n"
+        "\n"
+        "@resource_manager\n"
+        "def make_resource():\n"
+        "    yield 1\n"
     )
     first_root = tmp_path / "first"
     first_root.mkdir()
-    first = _populate_consumer(
+    first = _populate(
         first_root,
-        _write_class_resource_package(first_root, base, "guardpkg"),
-        "guardpkg",
+        _write_package(
+            first_root,
+            {
+                "__init__.py": "from tamper_pkg.factory import make_resource\n",
+                "factory.py": factory,
+                "wrapper.py": base_wrapper,
+            },
+            "tamper_pkg",
+        ),
+        "tamper_pkg",
+        "from tamper_pkg import make_resource\nwith make_resource():\n    pass\n",
     )
-    first_refs = list(first.source_derived_contract_refs)
-    assert first_refs, "expected class resource publication"
-    first_receiver = first_refs[0]
-    first_enter = first.contract_refs.require_native_definition(
-        first_receiver, NativeProtocolSlot.CONTEXT_ENTER
-    )
-    first_exit = first.contract_refs.require_native_definition(
-        first_receiver, NativeProtocolSlot.CONTEXT_EXIT
-    )
-    assert isinstance(first_enter, SourceFragmentCoordinateV1)
-    assert isinstance(first_exit, SourceFragmentCoordinateV1)
-
     second_root = tmp_path / "second"
     second_root.mkdir()
-    second = _populate_consumer(
+    second = _populate(
         second_root,
-        _write_class_resource_package(second_root, shifted, "guardpkg"),
-        "guardpkg",
+        _write_package(
+            second_root,
+            {
+                "__init__.py": "from tamper_pkg.factory import make_resource\n",
+                "factory.py": factory,
+                "wrapper.py": tampered_wrapper,
+            },
+            "tamper_pkg",
+        ),
+        "tamper_pkg",
+        "from tamper_pkg import make_resource\nwith make_resource():\n    pass\n",
     )
-    second_refs = list(second.source_derived_contract_refs)
-    assert second_refs
-    second_receiver = second_refs[0]
-    second_enter = second.contract_refs.require_native_definition(
-        second_receiver, NativeProtocolSlot.CONTEXT_ENTER
-    )
-    second_exit = second.contract_refs.require_native_definition(
-        second_receiver, NativeProtocolSlot.CONTEXT_EXIT
-    )
-    assert isinstance(second_enter, SourceFragmentCoordinateV1)
-    assert isinstance(second_exit, SourceFragmentCoordinateV1)
-
-    assert first_enter != second_enter
-    assert first_enter.start_line != second_enter.start_line
-    assert second_enter.start_line > first_enter.start_line
-    assert second_exit != second_enter
-    assert second_exit != first_enter
-    assert first_exit != first_enter
-
-
-def test_changing_exit_source_definition_changes_its_coordinate(tmp_path: Path):
-    """Acceptance: mutating exit body changes the exit coordinate."""
-    base = (
-        "class Guard:\n"
-        "    def __enter__(self):\n"
-        "        return self\n"
-        "    def __exit__(self, effect_type, effect, traceback):\n"
-        "        return False\n"
-        "\n"
-        "def make_guard():\n"
-        "    return Guard()\n"
-    )
-    longer_exit = (
-        "class Guard:\n"
-        "    def __enter__(self):\n"
-        "        return self\n"
-        "    def __exit__(self, effect_type, effect, traceback):\n"
-        "        # restore then release\n"
-        "        return False\n"
-        "\n"
-        "def make_guard():\n"
-        "    return Guard()\n"
-    )
-    first_root = tmp_path / "exit_first"
-    first_root.mkdir()
-    first = _populate_consumer(
-        first_root,
-        _write_class_resource_package(first_root, base, "exitpkg"),
-        "exitpkg",
-    )
-    first_receiver = list(first.source_derived_contract_refs)[0]
+    first_receiver = next(iter(first.source_manager_provider_calls))
+    second_receiver = next(iter(second.source_manager_provider_calls))
     first_enter = first.contract_refs.require_native_definition(
         first_receiver, NativeProtocolSlot.CONTEXT_ENTER
     )
-    first_exit = first.contract_refs.require_native_definition(
-        first_receiver, NativeProtocolSlot.CONTEXT_EXIT
-    )
-
-    second_root = tmp_path / "exit_second"
-    second_root.mkdir()
-    second = _populate_consumer(
-        second_root,
-        _write_class_resource_package(second_root, longer_exit, "exitpkg"),
-        "exitpkg",
-    )
-    second_receiver = list(second.source_derived_contract_refs)[0]
     second_enter = second.contract_refs.require_native_definition(
         second_receiver, NativeProtocolSlot.CONTEXT_ENTER
     )
-    second_exit = second.contract_refs.require_native_definition(
-        second_receiver, NativeProtocolSlot.CONTEXT_EXIT
-    )
+    assert isinstance(first_enter, SourceFragmentCoordinateV1)
+    assert isinstance(second_enter, SourceFragmentCoordinateV1)
+    assert first_enter != second_enter
+    assert first_enter.start_line != second_enter.start_line
 
-    assert isinstance(first_exit, SourceFragmentCoordinateV1)
-    assert isinstance(second_exit, SourceFragmentCoordinateV1)
-    assert first_exit != second_exit
-    assert (
-        first_exit.end_line != second_exit.end_line
-        or first_exit.source_cid != second_exit.source_cid
+
+def test_two_plausible_returned_classes_refuse_first_candidate(tmp_path: Path):
+    """Discrimination: two return classes cannot select the first."""
+    from sugar_source_tree.nodes import FunctionDef
+    from sugar_lift_python_source.source_oracle import path_source
+
+    path = tmp_path / "ambiguous.py"
+    path.write_text(
+        "class AlphaCM:\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n"
+        "\n"
+        "class BetaCM:\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n"
+        "\n"
+        "def resource_manager(func):\n"
+        "    def helper(*args, **kwargs):\n"
+        "        if args:\n"
+        "            return AlphaCM()\n"
+        "        return BetaCM()\n"
+        "    return helper\n",
+        encoding="utf-8",
+    )
+    tree = SourceFile(path_source(str(path)))
+    decorator_fn = next(
+        node
+        for node in tree.root.body
+        if isinstance(node, FunctionDef) and node.name == "resource_manager"
+    )
+    assert _sole_returned_manager_class(decorator_fn) is None
+    classes = _classes_constructed_by_returns(
+        next(
+            node
+            for node in decorator_fn.body
+            if isinstance(node, FunctionDef) and node.name == "helper"
+        ).body
+    )
+    assert len(classes) == 2
+
+
+def test_separate_source_cids_do_not_share_coordinates(tmp_path: Path):
+    """Separate authenticated decorator modules cannot share coordinates."""
+    wrapper_a = (
+        "class ResourceCM:\n"
+        "    def __init__(self, gen):\n"
+        "        self.gen = gen\n"
+        "    def __enter__(self):\n"
+        "        return next(self.gen)\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n"
+        "\n"
+        "def resource_manager(func):\n"
+        "    def helper(*args, **kwargs):\n"
+        "        return ResourceCM(func(*args, **kwargs))\n"
+        "    return helper\n"
+    )
+    # Different content → different source_cid even if spans align numerically.
+    wrapper_b = (
+        "class ResourceCM:\n"
+        "    def __init__(self, gen):\n"
+        "        self.gen = gen\n"
+        "    def __enter__(self):\n"
+        "        return next(self.gen)  # distinct body bytes\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n"
+        "\n"
+        "def resource_manager(func):\n"
+        "    def helper(*args, **kwargs):\n"
+        "        return ResourceCM(func(*args, **kwargs))\n"
+        "    return helper\n"
+    )
+    factory = (
+        "from cid_pkg.wrapper import resource_manager\n"
+        "\n"
+        "@resource_manager\n"
+        "def make_resource():\n"
+        "    yield 1\n"
+    )
+    first_root = tmp_path / "cid_a"
+    first_root.mkdir()
+    first = _populate(
+        first_root,
+        _write_package(
+            first_root,
+            {
+                "__init__.py": "from cid_pkg.factory import make_resource\n",
+                "factory.py": factory,
+                "wrapper.py": wrapper_a,
+            },
+            "cid_pkg",
+        ),
+        "cid_pkg",
+        "from cid_pkg import make_resource\nwith make_resource():\n    pass\n",
+    )
+    second_root = tmp_path / "cid_b"
+    second_root.mkdir()
+    second = _populate(
+        second_root,
+        _write_package(
+            second_root,
+            {
+                "__init__.py": "from cid_pkg.factory import make_resource\n",
+                "factory.py": factory,
+                "wrapper.py": wrapper_b,
+            },
+            "cid_pkg",
+        ),
+        "cid_pkg",
+        "from cid_pkg import make_resource\nwith make_resource():\n    pass\n",
+    )
+    first_receiver = next(iter(first.source_manager_provider_calls))
+    second_receiver = next(iter(second.source_manager_provider_calls))
+    first_enter = first.contract_refs.require_native_definition(
+        first_receiver, NativeProtocolSlot.CONTEXT_ENTER
+    )
+    second_enter = second.contract_refs.require_native_definition(
+        second_receiver, NativeProtocolSlot.CONTEXT_ENTER
     )
     assert isinstance(first_enter, SourceFragmentCoordinateV1)
     assert isinstance(second_enter, SourceFragmentCoordinateV1)
-    assert first_enter.start_line == second_enter.start_line
-    assert first_enter.start_col == second_enter.start_col
+    assert first_enter.source_cid != second_enter.source_cid
+    assert first_enter != second_enter
 
 
 def test_class_resource_publishes_enter_exit_from_class_source(tmp_path: Path):
     """Positive arm: class-source enter/exit definition sites publish."""
-    dist = _write_class_resource_package(
+    dist = _write_package(
         tmp_path,
-        (
-            "class Guard:\n"
-            "    def __enter__(self):\n"
-            "        return self\n"
-            "    def __exit__(self, effect_type, effect, traceback):\n"
-            "        return False\n"
-            "\n"
-            "def make_guard():\n"
-            "    return Guard()\n"
-        ),
+        {
+            "__init__.py": "from class_pkg.manager import make_guard\n",
+            "manager.py": (
+                "class Guard:\n"
+                "    def __enter__(self):\n"
+                "        return self\n"
+                "    def __exit__(self, effect_type, effect, traceback):\n"
+                "        return False\n"
+                "\n"
+                "def make_guard():\n"
+                "    return Guard()\n"
+            ),
+        },
+        "class_pkg",
     )
-    context = _populate_consumer(tmp_path, dist)
+    context = _populate(
+        tmp_path,
+        dist,
+        "class_pkg",
+        "from class_pkg import make_guard\nwith make_guard():\n    pass\n",
+    )
     refs = list(context.source_derived_contract_refs)
     assert refs, "expected source-derived class resource ref"
     receiver = refs[0]
@@ -385,7 +498,6 @@ def test_class_resource_publishes_enter_exit_from_class_source(tmp_path: Path):
     assert isinstance(enter, SourceFragmentCoordinateV1)
     assert isinstance(exit_, SourceFragmentCoordinateV1)
     assert enter != exit_
-    assert enter.start_line < exit_.start_line
 
 
 def test_lying_twin_spelling_without_binding_publishes_nothing(tmp_path: Path):
@@ -403,7 +515,6 @@ def test_lying_twin_spelling_without_binding_publishes_nothing(tmp_path: Path):
         construction_context=context,
     )
     populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
-
     assert context.source_manager_provider_calls == {}
     assert not any(
         slot in (NativeProtocolSlot.CONTEXT_ENTER, NativeProtocolSlot.CONTEXT_EXIT)
@@ -412,24 +523,16 @@ def test_lying_twin_spelling_without_binding_publishes_nothing(tmp_path: Path):
     )
 
 
-def test_enter_and_exit_coordinates_are_not_interchangeable():
-    """Discrimination arm: enter coord must not satisfy the exit slot."""
-    coords = _generator_context_manager_protocol_coordinates()
-    assert coords is not None
-    enter, exit_ = coords
-    assert enter != exit_
-    assert enter.start_line != exit_.start_line
-
-
-def test_publication_path_has_no_option_context_vendor_literal():
-    """No spelling admission rule for the manager name."""
+def test_publication_path_has_no_scan_or_vendor_literals():
+    """No ast scan, no first-candidate cache, no manager spelling arms."""
     import ast
     import inspect
     import textwrap
 
     import sugar_lift_python_source.manager_summary_derivation as derivation
 
-    module = ast.parse(textwrap.dedent(inspect.getsource(derivation)))
+    source = textwrap.dedent(inspect.getsource(derivation))
+    module = ast.parse(source)
     literals = {
         node.value
         for node in ast.walk(module)
@@ -442,5 +545,12 @@ def test_publication_path_has_no_option_context_vendor_literal():
             "ensure_clean",
             "display.max_rows",
             "_GeneratorContextManager",
+            "contextmanager",
+            "contextlib.py",
         }
     )
+    # No process-global unkeyed cache residual.
+    assert not hasattr(derivation, "_GENERATOR_CM_PROTOCOL_COORDS")
+    # No ast.parse of dependency source in the publication path.
+    assert "ast.parse" not in source
+    assert "ast.walk" not in source


### PR DESCRIPTION
## Summary

Fix-forward for merged #6638 doctrine breach in the generator-CM publication arm.

**Removed (forbidden):**
- `ast.parse` / `ast.walk` of contextlib source
- Name-match on `contextmanager` / first-candidate class selection
- Process-global unkeyed `_GENERATOR_CM_PROTOCOL_COORDS` cache

**Replacement (producer-owned construction):**
1. Resolve the generator FunctionDef's decorator through authenticated import bindings
2. Construct that decorator via `resolve_source_visible_frame`
3. Project the sole nested helper the decorator returns
4. Project the sole class that helper constructs on return
5. Publish that class's constructed `__enter__` / `__exit__` definition sites

Ambiguous multi-class helpers refuse (no first-candidate). Same-package graphs use the manager's authenticated graph; external/stdlib decorators authenticate through the ordinary top-level door. No process-global authority hub.

## Acceptance

- [x] option_context still publishes enter/exit
- [x] open still publishes neither slot
- [x] decorator construction yields returned-class method coordinates
- [x] content-tampered enter source changes coordinate
- [x] two plausible returned classes refuse first-candidate
- [x] separate source CIDs do not share coordinates
- [x] no scan/spelling/global-cache residues

## Tests

```
bin/bpytest tests/test_option_context_native_publication.py -q
# 10 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix generator context manager coordinates to derive from constructed decorator return class
> - Replaces a process-global cache (`_GENERATOR_CM_PROTOCOL_COORDS`) and its associated scan-based lookup with a per-use derivation path that resolves `__enter__`/`__exit__` coordinates from the class returned by the decorator's nested helper.
> - Adds three new helpers in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6646/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c): `_sole_returned_manager_class`, `_classes_constructed_by_returns`, and `_enter_exit_sites_from_class_def`, plus `_protocol_coords_from_generator_decorators` as the new entry point.
> - Updates `populate_source_derived_resource_refs` to pass `generator_target`, `session`, `graph`, and `distribution_index` into the publication call so authenticated decorator bindings can be resolved at runtime.
> - Expands tests in [test_option_context_native_publication.py](https://github.com/TSavo/sugar/pull/6646/files#diff-46c9b002a8301d0e48d861d921283c5b7a0eee598a9119d7f394cf097f2fcea6) to cover decorator construction, content-tampered coordinates, ambiguity refusal, and cross-source isolation.
> - Behavioral Change: published `CONTEXT_ENTER`/`CONTEXT_EXIT` coordinates are now content-derived per source CID rather than globally cached, so coordinates change when the decorator module's content changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e0f504.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->