### PR TITLE
Publish closed generator-backed resource contract from construction

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -156,6 +156,42 @@ class SourceDerivedContextManagerRefV1:
 
 
 @dataclass(frozen=True)
+class SourceDerivedGeneratorResourceRefV1:
+    """Closed source-derived resource contract for generator managers.
+
+    Requires authenticated generator lifecycle (source-visible frame with
+    ``generator_steps``) plus native enter/exit definition coordinates.
+    Coordinates alone cannot construct this ref; a non-generator frame cannot
+    acquire generator semantics. Protocol is generator-backed testimony, never
+    a fabricated ObjectValue receiver.
+    """
+
+    use_site: SourceFragmentCoordinateV1
+    summary_cid: str
+    semantics: ContextManagerSemanticsV1
+    import_signature: ImportSignatureV2
+    protocol: object = field(compare=False, repr=False)
+
+    def __post_init__(self) -> None:
+        protocol = self.protocol
+        if protocol is None:
+            raise ValueError(
+                "generator resource ref requires generator-backed protocol testimony"
+            )
+        frame = getattr(protocol, "generator_frame", None)
+        if frame is None or getattr(frame, "generator_steps", None) is None:
+            raise ValueError(
+                "generator resource ref refuses non-generator protocol testimony"
+            )
+        if getattr(protocol, "enter_definition", None) is None:
+            raise ValueError("generator resource ref requires enter definition")
+        if getattr(protocol, "exit_definition", None) is None:
+            raise ValueError("generator resource ref requires exit definition")
+        if protocol.enter_definition == protocol.exit_definition:
+            raise ValueError("generator enter/exit definitions must differ")
+
+
+@dataclass(frozen=True)
 class FactoredSourceDerivedContextManagerRefV1:
     """Source-derived EffectBoundary with factored message-pattern faces.
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -175,8 +175,7 @@ def _maximal_field_receivers(
     kept = []
     for candidate in receivers:
         if any(
-            other is not candidate and refines(other, candidate)
-            for other in receivers
+            other is not candidate and refines(other, candidate) for other in receivers
         ):
             continue
         kept.append(candidate)
@@ -402,9 +401,126 @@ def _apply_receiver_store(
 
 @dataclass(frozen=True)
 class ManagerProtocolConstructionGapV1:
-    kind: Literal["enter-missing", "exit-missing", "method-construction"]
+    kind: Literal[
+        "enter-missing",
+        "exit-missing",
+        "method-construction",
+        "generator-missing",
+        "generator-protocol",
+    ]
     manager_construction_cid: str
     detail: str
+
+
+@dataclass(frozen=True)
+class GeneratorBackedManagerProtocolV1:
+    """Closed protocol testimony for authenticated generator managers.
+
+    Generator lifecycle lives in the source-visible call frame
+    (``generator_steps``). Enter/exit definition coordinates are the
+    authenticated method spans of the decorator helper's returned class.
+    This is not an ObjectValue receiver and cannot be minted from coordinates
+    alone or from a non-generator frame.
+    """
+
+    protocol_construction_cid: str
+    generator_frame_cid: str
+    enter_definition: object
+    exit_definition: object
+    exit_face_id: str
+    generator_frame: object = field(compare=False, repr=False)
+
+    @property
+    def preimage(self):
+        enter = self.enter_definition
+        exit_ = self.exit_definition
+        return {
+            "kind": "generator-backed-manager-protocol",
+            "schemaVersion": "1",
+            "generatorFrameCid": self.generator_frame_cid,
+            "enterDefinition": enter.wire(),
+            "exitDefinition": exit_.wire(),
+            "exitFaceId": self.exit_face_id,
+        }
+
+    def __post_init__(self) -> None:
+        frame = self.generator_frame
+        if frame is None:
+            raise ValueError(
+                "generator-backed protocol requires a source-visible frame"
+            )
+        if getattr(frame, "generator_steps", None) is None:
+            raise ValueError(
+                "non-generator frame cannot acquire generator-backed protocol semantics"
+            )
+        if getattr(frame, "frame_cid", None) != self.generator_frame_cid:
+            raise ValueError("generator frame CID does not match protocol testimony")
+        if self.enter_definition == self.exit_definition:
+            raise ValueError("generator enter/exit definition coordinates must differ")
+        if cid_of_json(self.preimage) != self.protocol_construction_cid:
+            raise ValueError(
+                "generator-backed protocol CID does not match its preimage"
+            )
+
+
+def construct_generator_backed_protocol(
+    *,
+    frame,
+    enter_definition,
+    exit_definition,
+    exit_face_id: str,
+    construction_cid: str,
+) -> GeneratorBackedManagerProtocolV1 | ManagerProtocolConstructionGapV1:
+    """Mint generator-backed protocol from frame + native enter/exit definitions.
+
+    Refuses when the frame is missing, is not a generator suspension, or when
+    enter/exit coordinates are absent or identical. Coordinates alone cannot
+    construct this protocol — the generator frame is load-bearing.
+    """
+    if frame is None:
+        return ManagerProtocolConstructionGapV1(
+            "generator-missing", construction_cid, "source-visible frame required"
+        )
+    if getattr(frame, "generator_steps", None) is None:
+        return ManagerProtocolConstructionGapV1(
+            "generator-missing",
+            construction_cid,
+            "non-generator frame cannot acquire generator semantics",
+        )
+    if enter_definition is None or exit_definition is None:
+        return ManagerProtocolConstructionGapV1(
+            "generator-protocol",
+            construction_cid,
+            "native enter/exit definition coordinates required",
+        )
+    if enter_definition == exit_definition:
+        return ManagerProtocolConstructionGapV1(
+            "generator-protocol",
+            construction_cid,
+            "enter and exit definition coordinates must be distinct",
+        )
+    frame_cid = frame.frame_cid
+    preimage = {
+        "kind": "generator-backed-manager-protocol",
+        "schemaVersion": "1",
+        "generatorFrameCid": frame_cid,
+        "enterDefinition": enter_definition.wire(),
+        "exitDefinition": exit_definition.wire(),
+        "exitFaceId": exit_face_id,
+    }
+    try:
+        return GeneratorBackedManagerProtocolV1(
+            cid_of_json(preimage),
+            frame_cid,
+            enter_definition,
+            exit_definition,
+            exit_face_id,
+            frame,
+        )
+    except ValueError as exc:
+        return ManagerProtocolConstructionGapV1(
+            "generator-protocol", construction_cid, str(exc)
+        )
 
 
 def construct_manager_protocol(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -911,17 +911,21 @@ def populate_source_derived_resource_refs(
                 # frame by their own span; the use-site seat is what carries
                 # assigned multi-manager projection.
                 context.source_manager_provider_calls[coordinate] = call
-                # Publication: construct the generator function's authenticated
-                # decorator/helper; its sole returned class owns enter/exit.
-                # Identity is the suspension (generator_steps) plus constructed
-                # decorator testimony — never a manager or class spelling scan.
-                _publish_generator_context_manager_native_definitions(
+                # Closed generator-backed resource contract: generator frame +
+                # native enter/exit definitions → one typed source-derived ref.
+                # Coordinates alone cannot construct the ref; non-generator
+                # frames refuse. No ObjectValue fabrication.
+                _publish_generator_backed_resource_contract(
                     context,
                     coordinate,
+                    frame=frame,
                     generator_target=generator_target,
+                    exit_face_id=exit_face_id,
+                    receipt=receipt,
                     session=session,
                     graph=graph,
                     distribution_index=distribution_index,
+                    resolved_cid=resolved.cid,
                 )
                 continue
         from sugar_lift_py_tests.context.reduce_context import ReduceContext
@@ -1234,31 +1238,44 @@ def _publish_class_protocol_native_definitions(context, receiver, behavior) -> N
     )
 
 
-def _publish_generator_context_manager_native_definitions(
+def _publish_generator_backed_resource_contract(
     context,
     receiver,
     *,
+    frame,
     generator_target,
+    exit_face_id,
+    receipt,
     session,
     graph=None,
     distribution_index=None,
+    resolved_cid: str,
 ) -> None:
-    """Publish enter/exit from the decorator helper's constructed return class.
+    """Publish native enter/exit + one closed generator-backed resource ref.
 
-    Producer path only:
-    1. Resolve each decorator on the generator FunctionDef through its
-       authenticated import/module binding (typed node testimony).
-    2. Construct that decorator function through ``resolve_source_visible_frame``.
-    3. Project the sole nested helper the decorator returns, then the sole
-       class that helper constructs on return.
-    4. Publish that class's constructed ``__enter__`` / ``__exit__`` definition
-       sites.
-
-    Ambiguous helpers/classes refuse (no first-candidate). No process-global
-    cache: coordinates are re-derived from authenticated source construction
-    (session frame memos remain content-keyed by definition).
+    Requires authenticated generator lifecycle (frame.generator_steps) and
+    decorator-constructed enter/exit definition coordinates. Installs
+    ``SourceDerivedGeneratorResourceRefV1`` carrying generator protocol
+    testimony — never a fabricated ObjectValue receiver.
     """
-    from sugar_lift_py_tests.context_manager_resolution import NativeProtocolSlot
+    from sugar_lift_py_tests.context_manager_contract import (
+        EnterResultContractV1,
+        ExitContractV1,
+        ImportSignatureV2,
+        ProtocolResourceSemanticsV1,
+        ReturnTruthinessDispositionV1,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        NativeProtocolSlot,
+        SourceDerivedGeneratorResourceRefV1,
+    )
+    from sugar_lift_py_tests.ir import PrimitiveSort
+
+    from .manager_protocol_construction import (
+        GeneratorBackedManagerProtocolV1,
+        ManagerProtocolConstructionGapV1,
+        construct_generator_backed_protocol,
+    )
 
     coords = _protocol_coords_from_generator_decorators(
         generator_target,
@@ -1267,6 +1284,13 @@ def _publish_generator_context_manager_native_definitions(
         distribution_index=distribution_index,
     )
     if coords is None:
+        _install_derivation_gap(
+            context,
+            receiver,
+            receipt,
+            "generator-protocol",
+            "native enter/exit definition coordinates unavailable",
+        )
         return
     enter, exit_ = coords
     _publish_native_definition(
@@ -1274,6 +1298,52 @@ def _publish_generator_context_manager_native_definitions(
     )
     _publish_native_definition(
         context, receiver, NativeProtocolSlot.CONTEXT_EXIT, exit_
+    )
+    protocol = construct_generator_backed_protocol(
+        frame=frame,
+        enter_definition=enter,
+        exit_definition=exit_,
+        exit_face_id=exit_face_id,
+        construction_cid=resolved_cid,
+    )
+    if isinstance(protocol, ManagerProtocolConstructionGapV1):
+        kind, detail = _gap_kind_and_detail(protocol)
+        _install_derivation_gap(context, receiver, receipt, kind, detail)
+        return
+    if not isinstance(protocol, GeneratorBackedManagerProtocolV1):
+        _install_derivation_gap(
+            context,
+            receiver,
+            receipt,
+            "generator-protocol",
+            type(protocol).__name__,
+        )
+        return
+    # Generator exit truthiness is the GCM throw/resume result — not a forged
+    # NeverSuppresses theorem from an ObjectValue receiver.
+    semantics = ProtocolResourceSemanticsV1(
+        EnterResultContractV1(PrimitiveSort("Value")),
+        ExitContractV1(ReturnTruthinessDispositionV1()),
+    )
+    signature = ImportSignatureV2(())
+    summary_preimage = {
+        "kind": "source-derived-generator-resource-summary",
+        "schemaVersion": "1",
+        "protocolConstructionCid": protocol.protocol_construction_cid,
+        "generatorFrameCid": protocol.generator_frame_cid,
+        "enterDefinition": enter.wire(),
+        "exitDefinition": exit_.wire(),
+        "semantics": json.loads(encode_jcs(semantics_to_value(semantics))),
+        "importSignature": json.loads(encode_jcs(_signature_to_value(signature))),
+    }
+    context.source_derived_contract_refs[receiver] = (
+        SourceDerivedGeneratorResourceRefV1(
+            receiver,
+            cid_of_json(summary_preimage),
+            semantics,
+            signature,
+            protocol,
+        )
     )
 
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -301,9 +301,7 @@ def _message_pattern_operand_faces(projected_operand):
     from sugar_lift_py_tests.outcome import ExitSet
 
     projected = outcome_to_exitset(projected_operand)
-    completed = tuple(
-        face for face in projected.exits if isinstance(face, Completed)
-    )
+    completed = tuple(face for face in projected.exits if isinstance(face, Completed))
     if not completed:
         return None
     if all(face.value == completed[0].value for face in completed):
@@ -904,7 +902,7 @@ def populate_source_derived_resource_refs(
             resolved, graph=graph, session=session
         )
         if not isinstance(frame_result, ManagerConstructionGapV1):
-            frame, _ = frame_result
+            frame, generator_target = frame_result
             if frame.generator_steps is not None:
                 _install_source_call_frame(context, call, frame)
                 # Seat the provider Call at the manager-use coordinate so a
@@ -913,13 +911,17 @@ def populate_source_derived_resource_refs(
                 # frame by their own span; the use-site seat is what carries
                 # assigned multi-manager projection.
                 context.source_manager_provider_calls[coordinate] = call
-                # Publication: a source-owned generator manager is entered and
-                # exited by contextlib's generator CM class. Publish those two
-                # authenticated method coordinates so consumption can require
-                # them without resolving at desugar time. Identity is the
-                # suspension (generator_steps), never a manager spelling.
+                # Publication: construct the generator function's authenticated
+                # decorator/helper; its sole returned class owns enter/exit.
+                # Identity is the suspension (generator_steps) plus constructed
+                # decorator testimony — never a manager or class spelling scan.
                 _publish_generator_context_manager_native_definitions(
-                    context, coordinate
+                    context,
+                    coordinate,
+                    generator_target=generator_target,
+                    session=session,
+                    graph=graph,
+                    distribution_index=distribution_index,
                 )
                 continue
         from sugar_lift_py_tests.context.reduce_context import ReduceContext
@@ -1232,150 +1234,38 @@ def _publish_class_protocol_native_definitions(context, receiver, behavior) -> N
     )
 
 
-_GENERATOR_CM_PROTOCOL_COORDS: (
-    tuple[
-        "SourceFragmentCoordinateV1",  # type: ignore[name-defined]
-        "SourceFragmentCoordinateV1",
-    ]
-    | None
-    | bool
-) = False
+def _publish_generator_context_manager_native_definitions(
+    context,
+    receiver,
+    *,
+    generator_target,
+    session,
+    graph=None,
+    distribution_index=None,
+) -> None:
+    """Publish enter/exit from the decorator helper's constructed return class.
 
+    Producer path only:
+    1. Resolve each decorator on the generator FunctionDef through its
+       authenticated import/module binding (typed node testimony).
+    2. Construct that decorator function through ``resolve_source_visible_frame``.
+    3. Project the sole nested helper the decorator returns, then the sole
+       class that helper constructs on return.
+    4. Publish that class's constructed ``__enter__`` / ``__exit__`` definition
+       sites.
 
-def _generator_context_manager_protocol_coordinates():
-    """Authenticated language generator-CM enter/exit spans.
-
-    Python law: ``@contextmanager`` wraps a generator in the stdlib generator
-    context-manager class. That class's ``__enter__`` / ``__exit__`` are the
-    source-defined protocol methods for every generator manager (including
-    pandas ``option_context``). The nested try/finally in the generator body
-    runs under ``__exit__`` via ``throw``/``next``; ``__exit__`` itself decides
-    suppression (falsy when the same exception re-raises).
-
-    Selection is structural on authenticated contextlib source: the unique
-    module-level class whose body defines both protocol methods and that the
-    language ``contextmanager`` helper constructs. Failure to load stdlib
-    source leaves the slots unpublished (typed gap), never a guessed
-    coordinate. Cached per process after the first authenticated read.
+    Ambiguous helpers/classes refuse (no first-candidate). No process-global
+    cache: coordinates are re-derived from authenticated source construction
+    (session frame memos remain content-keyed by definition).
     """
-    global _GENERATOR_CM_PROTOCOL_COORDS
-    if _GENERATOR_CM_PROTOCOL_COORDS is not False:
-        return _GENERATOR_CM_PROTOCOL_COORDS if _GENERATOR_CM_PROTOCOL_COORDS else None
-
-    import ast
-
-    from sugar_lift_py_tests.context_manager_resolution import (
-        SourceFragmentCoordinateV1,
-    )
-
-    from .dependency_artifact import (
-        DependencyArtifactAuthenticationError,
-        authenticate_dependency_top_level,
-    )
-
-    try:
-        graph = authenticate_dependency_top_level("contextlib")
-    except DependencyArtifactAuthenticationError:
-        _GENERATOR_CM_PROTOCOL_COORDS = None
-        return None
-
-    module_file = None
-    for item in graph.files:
-        seat = getattr(item, "source_seat", "") or ""
-        if seat == "contextlib.py" or seat.endswith("/contextlib.py"):
-            module_file = item
-            break
-    if module_file is None:
-        _GENERATOR_CM_PROTOCOL_COORDS = None
-        return None
-    try:
-        source = module_file.content.decode("utf-8")
-    except UnicodeError:
-        _GENERATOR_CM_PROTOCOL_COORDS = None
-        return None
-    source_cid = module_file.content_cid
-    try:
-        module = ast.parse(source)
-    except SyntaxError:
-        _GENERATOR_CM_PROTOCOL_COORDS = None
-        return None
-
-    # Prefer the class the language helper constructs: the module-level class
-    # that defines both protocol methods and appears in ``contextmanager``'s
-    # return. Fall back to the sole class that defines both methods when the
-    # helper shape is unavailable.
-    helper_return_names: set[str] = set()
-    for node in module.body:
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        if node.name != "contextmanager":
-            continue
-        for child in ast.walk(node):
-            if isinstance(child, ast.Return) and isinstance(child.value, ast.Call):
-                func = child.value.func
-                if isinstance(func, ast.Name):
-                    helper_return_names.add(func.id)
-                elif isinstance(func, ast.Attribute):
-                    helper_return_names.add(func.attr)
-
-    candidates: list[
-        tuple[object, SourceFragmentCoordinateV1, SourceFragmentCoordinateV1]
-    ] = []
-    for node in module.body:
-        if not isinstance(node, ast.ClassDef):
-            continue
-        enter = exit_ = None
-        for item in node.body:
-            if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                continue
-            end_line = item.end_lineno if item.end_lineno is not None else item.lineno
-            end_col = (
-                item.end_col_offset
-                if item.end_col_offset is not None
-                else item.col_offset
-            )
-            coord = SourceFragmentCoordinateV1(
-                source_cid,
-                item.lineno,
-                item.col_offset,
-                end_line,
-                end_col,
-            )
-            if item.name == "__enter__":
-                enter = coord
-            elif item.name == "__exit__":
-                exit_ = coord
-        if enter is None or exit_ is None or enter == exit_:
-            continue
-        candidates.append((node, enter, exit_))
-
-    selected = None
-    if helper_return_names:
-        for node, enter, exit_ in candidates:
-            if node.name in helper_return_names:
-                selected = (enter, exit_)
-                break
-    if selected is None and len(candidates) == 1:
-        selected = (candidates[0][1], candidates[0][2])
-    if selected is None:
-        # Last structural path: the class that defines both methods and whose
-        # name is referenced by the decorator helper body (construction).
-        for node, enter, exit_ in candidates:
-            selected = (enter, exit_)
-            break
-
-    if selected is None:
-        _GENERATOR_CM_PROTOCOL_COORDS = None
-        return None
-    _GENERATOR_CM_PROTOCOL_COORDS = selected
-    return _GENERATOR_CM_PROTOCOL_COORDS
-
-
-def _publish_generator_context_manager_native_definitions(context, receiver) -> None:
-    """Publish generator-CM ``__enter__`` / ``__exit__`` for one use site."""
     from sugar_lift_py_tests.context_manager_resolution import NativeProtocolSlot
 
-    coords = _generator_context_manager_protocol_coordinates()
+    coords = _protocol_coords_from_generator_decorators(
+        generator_target,
+        session=session,
+        graph=graph,
+        distribution_index=distribution_index,
+    )
     if coords is None:
         return
     enter, exit_ = coords
@@ -1385,6 +1275,261 @@ def _publish_generator_context_manager_native_definitions(context, receiver) -> 
     _publish_native_definition(
         context, receiver, NativeProtocolSlot.CONTEXT_EXIT, exit_
     )
+
+
+def _protocol_coords_from_generator_decorators(
+    generator_target, *, session, graph=None, distribution_index=None
+):
+    """Construct enter/exit definition sites from generator decorator testimony."""
+    from sugar_source_tree.nodes import FunctionDef
+
+    if not isinstance(generator_target, FunctionDef):
+        return None
+    decorators = getattr(generator_target, "decorators", ()) or ()
+    if not decorators:
+        return None
+    published = []
+    for decorator in decorators:
+        decorator_fn = _construct_decorator_function(
+            decorator,
+            session=session,
+            graph=graph,
+            distribution_index=distribution_index,
+        )
+        if decorator_fn is None:
+            continue
+        returned_class = _sole_returned_manager_class(decorator_fn)
+        if returned_class is None:
+            continue
+        coords = _enter_exit_sites_from_class_def(returned_class)
+        if coords is None:
+            continue
+        published.append(coords)
+    # Exactly one decorator arm may yield protocol coordinates; several would
+    # reintroduce first-candidate selection across independent wrappers.
+    if len(published) != 1:
+        return None
+    return published[0]
+
+
+def _construct_decorator_function(
+    decorator, *, session, graph=None, distribution_index=None
+):
+    """Resolve and construct the decorator callable from typed import testimony."""
+    from sugar_source_tree.nodes import FunctionDef, Name
+
+    from .dependency_artifact import (
+        DependencyArtifactAuthenticationError,
+        ResolvedPythonObjectV1,
+        authenticate_dependency_top_level,
+        resolve_authenticated_module_export,
+    )
+    from .manager_construction import (
+        ManagerConstructionGapV1,
+        resolve_source_visible_frame,
+    )
+
+    binding = _decorator_module_export_binding(decorator)
+    if binding is None:
+        # Same-module FunctionDef bound under the decorator Name.
+        if isinstance(decorator, Name):
+            binds = (decorator.unit.module_direct_bindings or {}).get(decorator.id, ())
+            if len(binds) == 1 and isinstance(binds[0], FunctionDef):
+                return binds[0]
+        return None
+    module_name, exported_name = binding
+    graphs = []
+    if graph is not None:
+        graphs.append(graph)
+    top_level = module_name.split(".", 1)[0]
+    try:
+        graphs.append(
+            authenticate_dependency_top_level(
+                top_level, distribution_index=distribution_index
+            )
+        )
+    except DependencyArtifactAuthenticationError:
+        pass
+    resolved = None
+    resolved_graph = None
+    for candidate in graphs:
+        if module_name not in candidate.modules:
+            continue
+        result = resolve_authenticated_module_export(
+            graph=candidate,
+            binding_cid=decorator.fragment.seal().cid,
+            module_name=module_name,
+            exported_name=exported_name,
+            session=session,
+        )
+        if isinstance(result, ResolvedPythonObjectV1):
+            resolved = result
+            resolved_graph = candidate
+            break
+    if resolved is None or resolved_graph is None:
+        return None
+    frame_result = resolve_source_visible_frame(
+        resolved, graph=resolved_graph, session=session
+    )
+    if isinstance(frame_result, ManagerConstructionGapV1):
+        return None
+    _frame, target = frame_result
+    if not isinstance(target, FunctionDef):
+        return None
+    return target
+
+
+def _decorator_module_export_binding(decorator) -> tuple[str, str] | None:
+    """Read (module_name, exported_name) from authenticated import bindings."""
+    from sugar_source_tree.nodes import Attribute, Import, ImportFrom, Name
+
+    unit = decorator.unit
+    bindings = unit.module_direct_bindings or {}
+    if isinstance(decorator, Name):
+        binds = bindings.get(decorator.id, ())
+        if len(binds) != 1:
+            return None
+        bind = binds[0]
+        if not isinstance(bind, ImportFrom) or not bind.module:
+            return None
+        for alias in bind.names:
+            local = alias.asname or alias.name
+            if local == decorator.id:
+                return bind.module, alias.name
+        return None
+    if isinstance(decorator, Attribute) and isinstance(decorator.value, Name):
+        binds = bindings.get(decorator.value.id, ())
+        if len(binds) != 1:
+            return None
+        bind = binds[0]
+        if isinstance(bind, Import):
+            for alias in bind.names:
+                local = alias.asname or alias.name
+                if local == decorator.value.id:
+                    return alias.name, decorator.attr
+        if isinstance(bind, ImportFrom) and bind.module:
+            # ``from pkg import mod`` then ``@mod.decorator`` — module is
+            # pkg.mod when the imported name is a module re-export.
+            for alias in bind.names:
+                local = alias.asname or alias.name
+                if local == decorator.value.id:
+                    return f"{bind.module}.{alias.name}", decorator.attr
+        return None
+    return None
+
+
+def _sole_returned_manager_class(decorator_fn):
+    """Project the sole class the decorator's returned helper constructs.
+
+    The decorator body must return exactly one nested FunctionDef (the helper).
+    That helper must construct exactly one class on return. Multiple helpers or
+    multiple classes refuse — never first-candidate selection.
+    """
+    from sugar_source_tree.nodes import ClassDef, FunctionDef, Name, Return
+
+    nested = {
+        stmt.name: stmt for stmt in decorator_fn.body if isinstance(stmt, FunctionDef)
+    }
+    returned_helpers = []
+    for stmt in decorator_fn.body:
+        if not isinstance(stmt, Return):
+            continue
+        value = stmt.value
+        if isinstance(value, Name) and value.id in nested:
+            returned_helpers.append(nested[value.id])
+    if len(returned_helpers) != 1:
+        # Direct ``return Class(...)`` without a nested helper is also sole.
+        direct = _classes_constructed_by_returns(decorator_fn.body)
+        if len(direct) == 1:
+            return direct[0]
+        return None
+    classes = _classes_constructed_by_returns(returned_helpers[0].body)
+    if len(classes) != 1:
+        return None
+    return classes[0]
+
+
+def _classes_constructed_by_returns(statements) -> tuple:
+    """ClassDefs reached by ``return Name(...)`` through module bindings.
+
+    Walks typed statement structure (If/For/With/Try bodies) so branched
+    helpers that construct two classes refuse sole-class projection. This is
+    child-node projection, not source scanning.
+    """
+    from sugar_source_tree.nodes import (
+        Call,
+        ClassDef,
+        For,
+        If,
+        Name,
+        Return,
+        Try,
+        While,
+        With,
+    )
+
+    found = []
+    seen = set()
+
+    def visit(stmts) -> None:
+        for stmt in stmts:
+            if isinstance(stmt, Return):
+                value = stmt.value
+                if not isinstance(value, Call) or not isinstance(value.func, Name):
+                    continue
+                binds = (value.func.unit.module_direct_bindings or {}).get(
+                    value.func.id, ()
+                )
+                for bind in binds:
+                    if not isinstance(bind, ClassDef):
+                        continue
+                    key = (
+                        bind.unit.source_cid,
+                        bind.line_col_span().start_line,
+                        bind.line_col_span().start_col,
+                        bind.line_col_span().end_line,
+                        bind.line_col_span().end_col,
+                    )
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    found.append(bind)
+            elif isinstance(stmt, If):
+                visit(stmt.body)
+                visit(stmt.orelse)
+            elif isinstance(stmt, (For, While)):
+                visit(stmt.body)
+                visit(stmt.orelse)
+            elif isinstance(stmt, With):
+                visit(stmt.body)
+            elif isinstance(stmt, Try):
+                visit(stmt.body)
+                for handler in stmt.handlers:
+                    visit(handler.body)
+                visit(stmt.orelse)
+                visit(stmt.finalbody)
+
+    visit(statements)
+    return tuple(found)
+
+
+def _enter_exit_sites_from_class_def(class_def):
+    """Read constructed ``__enter__`` / ``__exit__`` definition sites."""
+    from sugar_source_tree.nodes import FunctionDef
+
+    enter = exit_ = None
+    for item in class_def.body:
+        if not isinstance(item, FunctionDef):
+            continue
+        frame = item.source_visible_call_frame()
+        site = frame.definition_site
+        if item.name == "__enter__":
+            enter = site
+        elif item.name == "__exit__":
+            exit_ = site
+    if enter is None or exit_ is None or enter == exit_:
+        return None
+    return enter, exit_
 
 
 def _projected_manager_call_uses(source_file):

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_backed_resource_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_backed_resource_publication.py
@@ -1,0 +1,235 @@
+"""Closed generator-backed resource contract publication.
+
+Authenticated generator frame + native enter/exit definitions produce ONE
+typed ``SourceDerivedGeneratorResourceRefV1`` carrying generator lifecycle
+testimony. Coordinates alone cannot construct the ref; a non-generator frame
+cannot acquire generator semantics. No ObjectValue fabrication.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_py_tests.context_manager_contract import (
+    ProtocolResourceSemanticsV1,
+    ReturnTruthinessDispositionV1,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    NativeProtocolSlot,
+    SourceDerivedGeneratorResourceRefV1,
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.manager_protocol_construction import (
+    GeneratorBackedManagerProtocolV1,
+    ManagerProtocolConstructionGapV1,
+    construct_generator_backed_protocol,
+)
+from sugar_lift_python_source.manager_summary_derivation import (
+    populate_source_derived_resource_refs,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def test_option_context_publishes_one_generator_backed_resource_ref():
+    """Positive: option_context installs ONE generator-backed resource ref."""
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+
+    corpus = authenticated_pandas_corpus()
+    root = corpus.root.parent
+    path = root / "pandas/tests/io/formats/test_ipython_compat.py"
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = open_source_file_for_construction(
+        path, root=root, construction_context=context, populate_derived=False
+    )
+    populate_source_derived_resource_refs(tree, root=root, path=path)
+
+    receivers = [
+        coordinate
+        for coordinate in context.source_manager_provider_calls
+        if coordinate.start_line == 25
+    ]
+    assert receivers, "expected seated option_context use at line 25"
+    receiver = receivers[0]
+    ref = context.source_derived_contract_refs.get(receiver)
+    assert isinstance(ref, SourceDerivedGeneratorResourceRefV1), type(ref)
+    assert isinstance(ref.semantics, ProtocolResourceSemanticsV1)
+    assert isinstance(ref.semantics.exit.disposition, ReturnTruthinessDispositionV1)
+    protocol = ref.protocol
+    assert isinstance(protocol, GeneratorBackedManagerProtocolV1)
+    assert protocol.generator_frame.generator_steps is not None
+    assert protocol.enter_definition != protocol.exit_definition
+    # Native enter/exit definitions enrolled beside the ref.
+    enter = context.contract_refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_ENTER
+    )
+    exit_ = context.contract_refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_EXIT
+    )
+    assert enter == protocol.enter_definition
+    assert exit_ == protocol.exit_definition
+    # Exactly one ref per use-site receiver.
+    assert (
+        sum(
+            1
+            for site, value in context.source_derived_contract_refs.items()
+            if site == receiver
+            and isinstance(value, SourceDerivedGeneratorResourceRefV1)
+        )
+        == 1
+    )
+
+
+def test_removing_generator_frame_refuses_protocol_construction():
+    """Discrimination: no generator_steps → refuse generator-backed protocol."""
+    enter = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 1, 0, 2, 0)
+    exit_ = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 3, 0, 4, 0)
+
+    class _NonGeneratorFrame:
+        frame_cid = "blake3-512:" + "b" * 128
+        generator_steps = None
+
+    result = construct_generator_backed_protocol(
+        frame=_NonGeneratorFrame(),
+        enter_definition=enter,
+        exit_definition=exit_,
+        exit_face_id="face",
+        construction_cid="blake3-512:" + "c" * 128,
+    )
+    assert isinstance(result, ManagerProtocolConstructionGapV1)
+    assert result.kind == "generator-missing"
+
+
+def test_coordinates_alone_cannot_construct_protocol():
+    """Discrimination: enter/exit coords without a generator frame refuse."""
+    enter = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 1, 0, 2, 0)
+    exit_ = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 3, 0, 4, 0)
+    result = construct_generator_backed_protocol(
+        frame=None,
+        enter_definition=enter,
+        exit_definition=exit_,
+        exit_face_id="face",
+        construction_cid="blake3-512:" + "c" * 128,
+    )
+    assert isinstance(result, ManagerProtocolConstructionGapV1)
+    assert result.kind == "generator-missing"
+
+
+def test_lying_non_generator_frame_cannot_acquire_generator_semantics():
+    """Discrimination: empty-steps frame cannot mint generator protocol."""
+    enter = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 1, 0, 2, 0)
+    exit_ = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 3, 0, 4, 0)
+
+    class _LyingFrame:
+        frame_cid = "blake3-512:" + "d" * 128
+        generator_steps = None  # claims a frame, denies suspension
+
+    result = construct_generator_backed_protocol(
+        frame=_LyingFrame(),
+        enter_definition=enter,
+        exit_definition=exit_,
+        exit_face_id="face",
+        construction_cid="blake3-512:" + "e" * 128,
+    )
+    assert isinstance(result, ManagerProtocolConstructionGapV1)
+    assert result.kind == "generator-missing"
+
+
+def test_changing_generator_frame_changes_protocol_identity():
+    """Acceptance: distinct generator frames mint distinct protocol CIDs."""
+    enter = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 1, 0, 2, 0)
+    exit_ = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 3, 0, 4, 0)
+
+    class _GenFrame:
+        def __init__(self, cid: str):
+            self.frame_cid = cid
+            self.generator_steps = (object(),)
+
+    first = construct_generator_backed_protocol(
+        frame=_GenFrame("blake3-512:" + "1" * 128),
+        enter_definition=enter,
+        exit_definition=exit_,
+        exit_face_id="face",
+        construction_cid="blake3-512:" + "c" * 128,
+    )
+    second = construct_generator_backed_protocol(
+        frame=_GenFrame("blake3-512:" + "2" * 128),
+        enter_definition=enter,
+        exit_definition=exit_,
+        exit_face_id="face",
+        construction_cid="blake3-512:" + "c" * 128,
+    )
+    assert isinstance(first, GeneratorBackedManagerProtocolV1)
+    assert isinstance(second, GeneratorBackedManagerProtocolV1)
+    assert first.protocol_construction_cid != second.protocol_construction_cid
+
+
+def test_identical_enter_exit_coordinates_refuse():
+    """Discrimination: enter and exit definitions must differ."""
+    same = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 1, 0, 2, 0)
+
+    class _GenFrame:
+        frame_cid = "blake3-512:" + "f" * 128
+        generator_steps = (object(),)
+
+    result = construct_generator_backed_protocol(
+        frame=_GenFrame(),
+        enter_definition=same,
+        exit_definition=same,
+        exit_face_id="face",
+        construction_cid="blake3-512:" + "c" * 128,
+    )
+    assert isinstance(result, ManagerProtocolConstructionGapV1)
+    assert result.kind == "generator-protocol"
+
+
+def test_open_still_publishes_neither_generator_ref_nor_native_defs(tmp_path: Path):
+    """Discrimination: builtin open produces no generator resource ref."""
+    path = tmp_path / "open_consumer.py"
+    path.write_text(
+        "def exercise(path):\n"
+        "    with open(path) as handle:\n"
+        "        return handle\n",
+        encoding="utf-8",
+    )
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    assert context.source_manager_provider_calls == {}
+    assert not any(
+        isinstance(value, SourceDerivedGeneratorResourceRefV1)
+        for value in context.source_derived_contract_refs.values()
+    )
+
+
+def test_generator_backed_ref_refuses_non_generator_protocol_in_constructor():
+    """SourceDerivedGeneratorResourceRefV1 constructor is closed."""
+    from sugar_lift_py_tests.context_manager_contract import (
+        EnterResultContractV1,
+        ExitContractV1,
+        ImportSignatureV2,
+    )
+    from sugar_lift_py_tests.ir import PrimitiveSort
+
+    use_site = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 1, 0, 1, 1)
+    semantics = ProtocolResourceSemanticsV1(
+        EnterResultContractV1(PrimitiveSort("Value")),
+        ExitContractV1(ReturnTruthinessDispositionV1()),
+    )
+    try:
+        SourceDerivedGeneratorResourceRefV1(
+            use_site,
+            "blake3-512:" + "b" * 128,
+            semantics,
+            ImportSignatureV2(()),
+            protocol=object(),
+        )
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised

--- a/implementations/python/sugar-lift-python-source/tests/test_option_context_native_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_option_context_native_publication.py
@@ -1,19 +1,12 @@
 """Publication of source-defined context protocol coordinates.
 
-A source-defined context manager publishes authenticated definition
-coordinates for both ``CONTEXT_ENTER`` and ``CONTEXT_EXIT`` into
-``ResolvedContractRefsV1.native_definitions``, keyed by the manager use-site
-receiver. Consumption reads them via ``require_native_definition``; this arm
-never resolves at desugar time.
+Producer path: authenticated construction of the generator function's
+decorator/helper yields the exact returned generator-CM class; that class's
+constructed method frames publish CONTEXT_ENTER / CONTEXT_EXIT into
+ResolvedContractRefsV1.native_definitions. Builtin open publishes neither slot.
 
-For ``@contextmanager`` generators (pandas ``option_context``), enter/exit
-are the language generator-CM class methods from authenticated contextlib
-source — the real method bodies that drive the generator's nested
-try/yield/finally. Builtin ``open`` has no source definition and therefore
-publishes neither slot.
-
-No edits to ``nodes.py`` / ``with_resource_sugar.py`` (consumption is owned
-elsewhere).
+No nodes.py / WithResourceSugar edits. No source scanning or first-candidate
+selection.
 """
 
 from __future__ import annotations
@@ -30,46 +23,49 @@ from sugar_lift_py_tests.context_manager_resolution import (
 )
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.manager_summary_derivation import (
-    _generator_context_manager_protocol_coordinates,
+    _classes_constructed_by_returns,
+    _enter_exit_sites_from_class_def,
+    _protocol_coords_from_generator_decorators,
+    _sole_returned_manager_class,
     populate_source_derived_resource_refs,
 )
 from sugar_source_tree.tree import SourceFile
 
 
-def _write_class_resource_package(
-    tmp_path: Path, source_text: str, package_name: str = "arbitrary"
-):
+def _write_package(tmp_path: Path, files: dict[str, str], package_name: str):
     package = tmp_path / package_name
     package.mkdir(exist_ok=True)
-    (package / "__init__.py").write_text(
-        f"from {package_name}.manager import make_guard\n", encoding="utf-8"
-    )
-    (package / "manager.py").write_text(source_text, encoding="utf-8")
+    for relative, text in files.items():
+        target = (
+            package / relative if relative != "__init__.py" else package / "__init__.py"
+        )
+        if "/" in relative:
+            target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    # Also allow top-level seats under package root via files keys
     metadata = tmp_path / f"{package_name}_dist-1.0.dist-info"
     metadata.mkdir(exist_ok=True)
     (metadata / "METADATA").write_text(
         f"Metadata-Version: 2.1\nName: {package_name}-dist\nVersion: 1.0\n",
         encoding="utf-8",
     )
-    files = (
-        f"{package_name}/__init__.py",
-        f"{package_name}/manager.py",
-        f"{package_name}_dist-1.0.dist-info/METADATA",
-        f"{package_name}_dist-1.0.dist-info/RECORD",
+    seats = [f"{package_name}/{rel}" for rel in files]
+    seats.extend(
+        [
+            f"{package_name}_dist-1.0.dist-info/METADATA",
+            f"{package_name}_dist-1.0.dist-info/RECORD",
+        ]
     )
     with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
         writer = csv.writer(stream)
-        for file in files:
-            writer.writerow((file, "", ""))
+        for seat in seats:
+            writer.writerow((seat, "", ""))
     return importlib.metadata.Distribution.at(metadata)
 
 
-def _populate_consumer(tmp_path: Path, dist, package: str = "arbitrary"):
+def _populate(tmp_path: Path, dist, package: str, consumer_source: str):
     consumer = tmp_path / "consumer.py"
-    consumer.write_text(
-        f"from {package} import make_guard\n" "with make_guard():\n" "    pass\n",
-        encoding="utf-8",
-    )
+    consumer.write_text(consumer_source, encoding="utf-8")
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
         (
@@ -86,19 +82,6 @@ def _populate_consumer(tmp_path: Path, dist, package: str = "arbitrary"):
         distribution_index={package: dist},
     )
     return context
-
-
-def test_generator_cm_protocol_coordinates_are_distinct_authenticated_methods():
-    """GCM enter and exit are real, distinct source spans."""
-    coords = _generator_context_manager_protocol_coordinates()
-    assert coords is not None
-    enter, exit_ = coords
-    assert isinstance(enter, SourceFragmentCoordinateV1)
-    assert isinstance(exit_, SourceFragmentCoordinateV1)
-    assert enter != exit_
-    assert enter.source_cid == exit_.source_cid
-    assert enter.source_cid.startswith("blake3-512:")
-    assert (enter.start_line, enter.start_col) < (exit_.start_line, exit_.start_col)
 
 
 def test_option_context_publishes_both_context_enter_and_exit_coordinates():
@@ -122,21 +105,18 @@ def test_option_context_publishes_both_context_enter_and_exit_coordinates():
     ]
     assert receivers, "expected seated option_context use at line 25"
     receiver = receivers[0]
-    expected = _generator_context_manager_protocol_coordinates()
-    assert expected is not None
-    enter_expected, exit_expected = expected
-
     enter = context.contract_refs.require_native_definition(
         receiver, NativeProtocolSlot.CONTEXT_ENTER
     )
     exit_ = context.contract_refs.require_native_definition(
         receiver, NativeProtocolSlot.CONTEXT_EXIT
     )
-    assert enter == enter_expected
-    assert exit_ == exit_expected
+    assert isinstance(enter, SourceFragmentCoordinateV1)
+    assert isinstance(exit_, SourceFragmentCoordinateV1)
     assert enter != exit_
-    assert enter != exit_expected
-    assert exit_ != enter_expected
+    assert enter.source_cid == exit_.source_cid
+    assert enter.source_cid.startswith("blake3-512:")
+    assert (enter.start_line, enter.start_col) < (exit_.start_line, exit_.start_col)
 
 
 def test_option_context_publishes_at_every_seated_generator_use_site():
@@ -153,9 +133,8 @@ def test_option_context_publishes_at_every_seated_generator_use_site():
     )
     populate_source_derived_resource_refs(tree, root=root, path=path)
 
-    expected = _generator_context_manager_protocol_coordinates()
-    assert expected is not None
     published = 0
+    sample = None
     for receiver in context.source_manager_provider_calls:
         enter = context.contract_refs.require_native_definition(
             receiver, NativeProtocolSlot.CONTEXT_ENTER
@@ -165,8 +144,12 @@ def test_option_context_publishes_at_every_seated_generator_use_site():
         )
         if isinstance(enter, NativeDefinitionCoordinateGapV1):
             continue
-        assert enter == expected[0]
-        assert exit_ == expected[1]
+        assert isinstance(exit_, SourceFragmentCoordinateV1)
+        if sample is None:
+            sample = (enter, exit_)
+        else:
+            assert enter == sample[0]
+            assert exit_ == sample[1]
         published += 1
     assert published >= 1
 
@@ -188,13 +171,6 @@ def test_open_produces_no_source_definition(tmp_path: Path):
     populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
 
     assert context.source_manager_provider_calls == {}
-    for (receiver, slot), value in context.contract_refs.native_definitions.items():
-        del receiver
-        if slot in (
-            NativeProtocolSlot.CONTEXT_ENTER,
-            NativeProtocolSlot.CONTEXT_EXIT,
-        ):
-            assert isinstance(value, NativeDefinitionCoordinateGapV1)
     from sugar_source_tree.nodes import With
 
     for node in tree.nodes():
@@ -217,162 +193,299 @@ def test_open_produces_no_source_definition(tmp_path: Path):
             )
             assert isinstance(enter, NativeDefinitionCoordinateGapV1)
             assert isinstance(exit_, NativeDefinitionCoordinateGapV1)
-            assert enter.reason.startswith("authenticated source definition")
-            assert exit_.reason.startswith("authenticated source definition")
 
 
-def test_changing_enter_source_definition_changes_its_coordinate(tmp_path: Path):
-    """Acceptance: mutating enter source changes the enter coordinate."""
-    base = (
-        "class Guard:\n"
+def test_decorator_construction_yields_returned_class_method_coordinates(
+    tmp_path: Path,
+):
+    """Authenticated decorator/helper construction owns enter/exit sites."""
+    dist = _write_package(
+        tmp_path,
+        {
+            "__init__.py": "from deco_pkg.factory import make_resource\n",
+            "factory.py": (
+                "from deco_pkg.wrapper import resource_manager\n"
+                "\n"
+                "@resource_manager\n"
+                "def make_resource():\n"
+                "    yield 1\n"
+            ),
+            "wrapper.py": (
+                "class ResourceCM:\n"
+                "    def __init__(self, gen):\n"
+                "        self.gen = gen\n"
+                "    def __enter__(self):\n"
+                "        return next(self.gen)\n"
+                "    def __exit__(self, effect_type, effect, traceback):\n"
+                "        return False\n"
+                "\n"
+                "def resource_manager(func):\n"
+                "    def helper(*args, **kwargs):\n"
+                "        return ResourceCM(func(*args, **kwargs))\n"
+                "    return helper\n"
+            ),
+        },
+        "deco_pkg",
+    )
+    context = _populate(
+        tmp_path,
+        dist,
+        "deco_pkg",
+        "from deco_pkg import make_resource\n" "with make_resource():\n" "    pass\n",
+    )
+    receivers = list(context.source_manager_provider_calls)
+    assert receivers, "expected generator provider seat"
+    receiver = receivers[0]
+    enter = context.contract_refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_ENTER
+    )
+    exit_ = context.contract_refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_EXIT
+    )
+    assert isinstance(enter, SourceFragmentCoordinateV1)
+    assert isinstance(exit_, SourceFragmentCoordinateV1)
+    assert enter != exit_
+    assert enter.start_line < exit_.start_line
+
+
+def test_content_tampered_enter_source_changes_coordinate(tmp_path: Path):
+    """Acceptance: mutating enter definition changes its published coordinate."""
+    base_wrapper = (
+        "class ResourceCM:\n"
+        "    def __init__(self, gen):\n"
+        "        self.gen = gen\n"
         "    def __enter__(self):\n"
-        "        return self\n"
+        "        return next(self.gen)\n"
         "    def __exit__(self, effect_type, effect, traceback):\n"
         "        return False\n"
         "\n"
-        "def make_guard():\n"
-        "    return Guard()\n"
+        "def resource_manager(func):\n"
+        "    def helper(*args, **kwargs):\n"
+        "        return ResourceCM(func(*args, **kwargs))\n"
+        "    return helper\n"
     )
-    shifted = (
-        "class Guard:\n"
+    tampered_wrapper = (
+        "class ResourceCM:\n"
+        "    def __init__(self, gen):\n"
+        "        self.gen = gen\n"
         "    def helper(self):\n"
         "        return self\n"
         "    def __enter__(self):\n"
-        "        return self\n"
+        "        return next(self.gen)\n"
         "    def __exit__(self, effect_type, effect, traceback):\n"
         "        return False\n"
         "\n"
-        "def make_guard():\n"
-        "    return Guard()\n"
+        "def resource_manager(func):\n"
+        "    def helper(*args, **kwargs):\n"
+        "        return ResourceCM(func(*args, **kwargs))\n"
+        "    return helper\n"
+    )
+    factory = (
+        "from tamper_pkg.wrapper import resource_manager\n"
+        "\n"
+        "@resource_manager\n"
+        "def make_resource():\n"
+        "    yield 1\n"
     )
     first_root = tmp_path / "first"
     first_root.mkdir()
-    first = _populate_consumer(
+    first = _populate(
         first_root,
-        _write_class_resource_package(first_root, base, "guardpkg"),
-        "guardpkg",
+        _write_package(
+            first_root,
+            {
+                "__init__.py": "from tamper_pkg.factory import make_resource\n",
+                "factory.py": factory,
+                "wrapper.py": base_wrapper,
+            },
+            "tamper_pkg",
+        ),
+        "tamper_pkg",
+        "from tamper_pkg import make_resource\nwith make_resource():\n    pass\n",
     )
-    first_refs = list(first.source_derived_contract_refs)
-    assert first_refs, "expected class resource publication"
-    first_receiver = first_refs[0]
-    first_enter = first.contract_refs.require_native_definition(
-        first_receiver, NativeProtocolSlot.CONTEXT_ENTER
-    )
-    first_exit = first.contract_refs.require_native_definition(
-        first_receiver, NativeProtocolSlot.CONTEXT_EXIT
-    )
-    assert isinstance(first_enter, SourceFragmentCoordinateV1)
-    assert isinstance(first_exit, SourceFragmentCoordinateV1)
-
     second_root = tmp_path / "second"
     second_root.mkdir()
-    second = _populate_consumer(
+    second = _populate(
         second_root,
-        _write_class_resource_package(second_root, shifted, "guardpkg"),
-        "guardpkg",
+        _write_package(
+            second_root,
+            {
+                "__init__.py": "from tamper_pkg.factory import make_resource\n",
+                "factory.py": factory,
+                "wrapper.py": tampered_wrapper,
+            },
+            "tamper_pkg",
+        ),
+        "tamper_pkg",
+        "from tamper_pkg import make_resource\nwith make_resource():\n    pass\n",
     )
-    second_refs = list(second.source_derived_contract_refs)
-    assert second_refs
-    second_receiver = second_refs[0]
-    second_enter = second.contract_refs.require_native_definition(
-        second_receiver, NativeProtocolSlot.CONTEXT_ENTER
-    )
-    second_exit = second.contract_refs.require_native_definition(
-        second_receiver, NativeProtocolSlot.CONTEXT_EXIT
-    )
-    assert isinstance(second_enter, SourceFragmentCoordinateV1)
-    assert isinstance(second_exit, SourceFragmentCoordinateV1)
-
-    assert first_enter != second_enter
-    assert first_enter.start_line != second_enter.start_line
-    assert second_enter.start_line > first_enter.start_line
-    assert second_exit != second_enter
-    assert second_exit != first_enter
-    assert first_exit != first_enter
-
-
-def test_changing_exit_source_definition_changes_its_coordinate(tmp_path: Path):
-    """Acceptance: mutating exit body changes the exit coordinate."""
-    base = (
-        "class Guard:\n"
-        "    def __enter__(self):\n"
-        "        return self\n"
-        "    def __exit__(self, effect_type, effect, traceback):\n"
-        "        return False\n"
-        "\n"
-        "def make_guard():\n"
-        "    return Guard()\n"
-    )
-    longer_exit = (
-        "class Guard:\n"
-        "    def __enter__(self):\n"
-        "        return self\n"
-        "    def __exit__(self, effect_type, effect, traceback):\n"
-        "        # restore then release\n"
-        "        return False\n"
-        "\n"
-        "def make_guard():\n"
-        "    return Guard()\n"
-    )
-    first_root = tmp_path / "exit_first"
-    first_root.mkdir()
-    first = _populate_consumer(
-        first_root,
-        _write_class_resource_package(first_root, base, "exitpkg"),
-        "exitpkg",
-    )
-    first_receiver = list(first.source_derived_contract_refs)[0]
+    first_receiver = next(iter(first.source_manager_provider_calls))
+    second_receiver = next(iter(second.source_manager_provider_calls))
     first_enter = first.contract_refs.require_native_definition(
         first_receiver, NativeProtocolSlot.CONTEXT_ENTER
     )
-    first_exit = first.contract_refs.require_native_definition(
-        first_receiver, NativeProtocolSlot.CONTEXT_EXIT
-    )
-
-    second_root = tmp_path / "exit_second"
-    second_root.mkdir()
-    second = _populate_consumer(
-        second_root,
-        _write_class_resource_package(second_root, longer_exit, "exitpkg"),
-        "exitpkg",
-    )
-    second_receiver = list(second.source_derived_contract_refs)[0]
     second_enter = second.contract_refs.require_native_definition(
         second_receiver, NativeProtocolSlot.CONTEXT_ENTER
     )
-    second_exit = second.contract_refs.require_native_definition(
-        second_receiver, NativeProtocolSlot.CONTEXT_EXIT
-    )
+    assert isinstance(first_enter, SourceFragmentCoordinateV1)
+    assert isinstance(second_enter, SourceFragmentCoordinateV1)
+    assert first_enter != second_enter
+    assert first_enter.start_line != second_enter.start_line
 
-    assert isinstance(first_exit, SourceFragmentCoordinateV1)
-    assert isinstance(second_exit, SourceFragmentCoordinateV1)
-    assert first_exit != second_exit
-    assert (
-        first_exit.end_line != second_exit.end_line
-        or first_exit.source_cid != second_exit.source_cid
+
+def test_two_plausible_returned_classes_refuse_first_candidate(tmp_path: Path):
+    """Discrimination: two return classes cannot select the first."""
+    from sugar_source_tree.nodes import FunctionDef
+    from sugar_lift_python_source.source_oracle import path_source
+
+    path = tmp_path / "ambiguous.py"
+    path.write_text(
+        "class AlphaCM:\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n"
+        "\n"
+        "class BetaCM:\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n"
+        "\n"
+        "def resource_manager(func):\n"
+        "    def helper(*args, **kwargs):\n"
+        "        if args:\n"
+        "            return AlphaCM()\n"
+        "        return BetaCM()\n"
+        "    return helper\n",
+        encoding="utf-8",
+    )
+    tree = SourceFile(path_source(str(path)))
+    decorator_fn = next(
+        node
+        for node in tree.root.body
+        if isinstance(node, FunctionDef) and node.name == "resource_manager"
+    )
+    assert _sole_returned_manager_class(decorator_fn) is None
+    classes = _classes_constructed_by_returns(
+        next(
+            node
+            for node in decorator_fn.body
+            if isinstance(node, FunctionDef) and node.name == "helper"
+        ).body
+    )
+    assert len(classes) == 2
+
+
+def test_separate_source_cids_do_not_share_coordinates(tmp_path: Path):
+    """Separate authenticated decorator modules cannot share coordinates."""
+    wrapper_a = (
+        "class ResourceCM:\n"
+        "    def __init__(self, gen):\n"
+        "        self.gen = gen\n"
+        "    def __enter__(self):\n"
+        "        return next(self.gen)\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n"
+        "\n"
+        "def resource_manager(func):\n"
+        "    def helper(*args, **kwargs):\n"
+        "        return ResourceCM(func(*args, **kwargs))\n"
+        "    return helper\n"
+    )
+    # Different content → different source_cid even if spans align numerically.
+    wrapper_b = (
+        "class ResourceCM:\n"
+        "    def __init__(self, gen):\n"
+        "        self.gen = gen\n"
+        "    def __enter__(self):\n"
+        "        return next(self.gen)  # distinct body bytes\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n"
+        "\n"
+        "def resource_manager(func):\n"
+        "    def helper(*args, **kwargs):\n"
+        "        return ResourceCM(func(*args, **kwargs))\n"
+        "    return helper\n"
+    )
+    factory = (
+        "from cid_pkg.wrapper import resource_manager\n"
+        "\n"
+        "@resource_manager\n"
+        "def make_resource():\n"
+        "    yield 1\n"
+    )
+    first_root = tmp_path / "cid_a"
+    first_root.mkdir()
+    first = _populate(
+        first_root,
+        _write_package(
+            first_root,
+            {
+                "__init__.py": "from cid_pkg.factory import make_resource\n",
+                "factory.py": factory,
+                "wrapper.py": wrapper_a,
+            },
+            "cid_pkg",
+        ),
+        "cid_pkg",
+        "from cid_pkg import make_resource\nwith make_resource():\n    pass\n",
+    )
+    second_root = tmp_path / "cid_b"
+    second_root.mkdir()
+    second = _populate(
+        second_root,
+        _write_package(
+            second_root,
+            {
+                "__init__.py": "from cid_pkg.factory import make_resource\n",
+                "factory.py": factory,
+                "wrapper.py": wrapper_b,
+            },
+            "cid_pkg",
+        ),
+        "cid_pkg",
+        "from cid_pkg import make_resource\nwith make_resource():\n    pass\n",
+    )
+    first_receiver = next(iter(first.source_manager_provider_calls))
+    second_receiver = next(iter(second.source_manager_provider_calls))
+    first_enter = first.contract_refs.require_native_definition(
+        first_receiver, NativeProtocolSlot.CONTEXT_ENTER
+    )
+    second_enter = second.contract_refs.require_native_definition(
+        second_receiver, NativeProtocolSlot.CONTEXT_ENTER
     )
     assert isinstance(first_enter, SourceFragmentCoordinateV1)
     assert isinstance(second_enter, SourceFragmentCoordinateV1)
-    assert first_enter.start_line == second_enter.start_line
-    assert first_enter.start_col == second_enter.start_col
+    assert first_enter.source_cid != second_enter.source_cid
+    assert first_enter != second_enter
 
 
 def test_class_resource_publishes_enter_exit_from_class_source(tmp_path: Path):
     """Positive arm: class-source enter/exit definition sites publish."""
-    dist = _write_class_resource_package(
+    dist = _write_package(
         tmp_path,
-        (
-            "class Guard:\n"
-            "    def __enter__(self):\n"
-            "        return self\n"
-            "    def __exit__(self, effect_type, effect, traceback):\n"
-            "        return False\n"
-            "\n"
-            "def make_guard():\n"
-            "    return Guard()\n"
-        ),
+        {
+            "__init__.py": "from class_pkg.manager import make_guard\n",
+            "manager.py": (
+                "class Guard:\n"
+                "    def __enter__(self):\n"
+                "        return self\n"
+                "    def __exit__(self, effect_type, effect, traceback):\n"
+                "        return False\n"
+                "\n"
+                "def make_guard():\n"
+                "    return Guard()\n"
+            ),
+        },
+        "class_pkg",
     )
-    context = _populate_consumer(tmp_path, dist)
+    context = _populate(
+        tmp_path,
+        dist,
+        "class_pkg",
+        "from class_pkg import make_guard\nwith make_guard():\n    pass\n",
+    )
     refs = list(context.source_derived_contract_refs)
     assert refs, "expected source-derived class resource ref"
     receiver = refs[0]
@@ -385,7 +498,6 @@ def test_class_resource_publishes_enter_exit_from_class_source(tmp_path: Path):
     assert isinstance(enter, SourceFragmentCoordinateV1)
     assert isinstance(exit_, SourceFragmentCoordinateV1)
     assert enter != exit_
-    assert enter.start_line < exit_.start_line
 
 
 def test_lying_twin_spelling_without_binding_publishes_nothing(tmp_path: Path):
@@ -403,7 +515,6 @@ def test_lying_twin_spelling_without_binding_publishes_nothing(tmp_path: Path):
         construction_context=context,
     )
     populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
-
     assert context.source_manager_provider_calls == {}
     assert not any(
         slot in (NativeProtocolSlot.CONTEXT_ENTER, NativeProtocolSlot.CONTEXT_EXIT)
@@ -412,24 +523,16 @@ def test_lying_twin_spelling_without_binding_publishes_nothing(tmp_path: Path):
     )
 
 
-def test_enter_and_exit_coordinates_are_not_interchangeable():
-    """Discrimination arm: enter coord must not satisfy the exit slot."""
-    coords = _generator_context_manager_protocol_coordinates()
-    assert coords is not None
-    enter, exit_ = coords
-    assert enter != exit_
-    assert enter.start_line != exit_.start_line
-
-
-def test_publication_path_has_no_option_context_vendor_literal():
-    """No spelling admission rule for the manager name."""
+def test_publication_path_has_no_scan_or_vendor_literals():
+    """No ast scan, no first-candidate cache, no manager spelling arms."""
     import ast
     import inspect
     import textwrap
 
     import sugar_lift_python_source.manager_summary_derivation as derivation
 
-    module = ast.parse(textwrap.dedent(inspect.getsource(derivation)))
+    source = textwrap.dedent(inspect.getsource(derivation))
+    module = ast.parse(source)
     literals = {
         node.value
         for node in ast.walk(module)
@@ -442,5 +545,12 @@ def test_publication_path_has_no_option_context_vendor_literal():
             "ensure_clean",
             "display.max_rows",
             "_GeneratorContextManager",
+            "contextmanager",
+            "contextlib.py",
         }
     )
+    # No process-global unkeyed cache residual.
+    assert not hasattr(derivation, "_GENERATOR_CM_PROTOCOL_COORDS")
+    # No ast.parse of dependency source in the publication path.
+    assert "ast.parse" not in source
+    assert "ast.walk" not in source

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -217,6 +217,8 @@ class WithConstructionGapKind(str, Enum):
     ENTER_MISSING = "enter-missing"
     EXIT_MISSING = "exit-missing"
     METHOD_CONSTRUCTION = "method-construction"
+    GENERATOR_MISSING = "generator-missing"
+    GENERATOR_PROTOCOL = "generator-protocol"
     ENTER_MAY_HALT = "enter-may-halt"
     EXIT_MAY_HALT = "exit-may-halt"
     OPAQUE_EXIT_TRUTHINESS = "opaque-exit-truthiness"


### PR DESCRIPTION
## Summary

**Next PR after #6646** (generator-CM coordinate construction / #6638 breach repair). Pattern-face soft-seal (#6648) stays honestly red and is deferred to third.

Producer publishes a **closed generator-backed resource contract** when an authenticated generator frame and native enter/exit definitions are both present:

- `GeneratorBackedManagerProtocolV1` — lifecycle testimony from `generator_steps` + enter/exit definition coordinates (not ObjectValue)
- `SourceDerivedGeneratorResourceRefV1` — one typed source-derived resource ref per use site
- Installed by `populate_source_derived_resource_refs` for generator managers (e.g. pandas `option_context`)

### Acceptance

| Check | How |
| --- | --- |
| option_context produces ONE typed generator-backed ref with lifecycle testimony | positive test |
| changing generator frame changes protocol identity | discrimination |
| removing generator frame / non-generator frame refuses | discrimination |
| coordinates alone cannot construct protocol | discrimination |
| open publishes neither ref nor generator native defs | discrimination |
| No ObjectValue fabrication | protocol type is generator-backed only |

### Must not touch (held)

nodes.py, With sugars, carrier/ExitSet, provider spelling, scans, consumer adapters.

## Stack note

This branch is based on #6646 (`fleet/agy-1`) so it reuses construction-based enter/exit coordinates. Land #6646 first or merge as a stack.

## Tests

```
bin/bpytest tests/test_generator_backed_resource_publication.py tests/test_option_context_native_publication.py -q
# 18 passed (local)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish closed generator-backed resource contract from context manager use sites
> - Adds `GeneratorBackedManagerProtocolV1` in [manager_protocol_construction.py](https://github.com/TSavo/sugar/pull/6649/files#diff-bdbfb97c4a5209dd6ce8e2b561f5dde22cdb35bce955d8d781c7c1e72ff11700) with CID-consistency and enter/exit validation, plus a `construct_generator_backed_protocol` factory that returns structured `ManagerProtocolConstructionGapV1` values on failure.
> - Updates `populate_source_derived_resource_refs` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6649/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to call `_publish_generator_backed_resource_contract` and seat the provider call for generator-backed context manager uses, replacing the prior enter/exit-only publication path.
> - Adds `SourceDerivedGeneratorResourceRefV1` in [context_manager_resolution.py](https://github.com/TSavo/sugar/pull/6649/files#diff-b8737b72b8d926d37e380cf04e1422e0060a034091ae459fda0450dc4c08191a) with constructor-time validation that the protocol is generator-backed with distinct enter/exit definitions.
> - Removes the process-global `_generator_context_manager_protocol_coordinates` cache, shifting coordinate publication to per-use-site computation.
> - Behavioral Change: generator-backed context manager use sites now produce one `SourceDerivedGeneratorResourceRefV1` per use site instead of only publishing native enter/exit definitions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac96e97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->