### PR TITLE
Compose deferred carriers beneath exit prefixes

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -498,6 +498,9 @@ class NativeOperationExitCarrierV1:
     site: object = dataclass_field(compare=False, repr=False)
     continuations: tuple = dataclass_field(default=(), compare=False, repr=False)
     guards: tuple = dataclass_field(default=(), repr=False)
+    prefix_composition: object | None = dataclass_field(
+        default=None, compare=False, repr=False
+    )
     pre_effect_state: ReducerPreEffectStateV1 | None = dataclass_field(
         default=None, compare=False, repr=False
     )
@@ -588,6 +591,63 @@ class NativeOperationExitCarrierV1:
         del face
         return replace(self, guards=(*self.guards, guard))
 
+    @classmethod
+    def compose_prefix(cls, prefix, step):
+        """Sequence a prefix without exposing a deferred carrier to ExitSet.
+
+        Each completed prefix arm retains its own carrier instance because its
+        continuations and pre-effect state belong to that arm.  Halted and
+        already-resolved arms are retained verbatim.  Compatible carrier arms
+        share one authenticated demand; different demands are not mergeable.
+        """
+        from sugar_lift_py_tests.outcome import ExitSet, Halted
+        from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+
+        resolved = []
+        deferred = []
+        for prefix_exit in prefix.exits:
+            if isinstance(prefix_exit, Halted):
+                resolved.append(prefix_exit)
+                continue
+            following = step(prefix_exit.value)
+            if isinstance(following, cls):
+                deferred.append((prefix_exit, following))
+                continue
+            if not isinstance(following, ExitSet):
+                following = outcome_to_exitset(following)
+            sequenced = ExitSet((prefix_exit,)).sequence(
+                lambda _value, *, exits=following: exits
+            )
+            resolved.extend(sequenced.exits)
+
+        if not deferred:
+            return ExitSet(tuple(resolved)).normalize()
+
+        demand_cids = {carrier.demand.demand_cid for _, carrier in deferred}
+        if len(demand_cids) != 1:
+            from sugar_lift_py_tests.gap.info import GapKind
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="NativeOperationExitCarrierV1.compose_prefix",
+                blame=tuple(sorted(demand_cids)),
+                observed="incompatible native-operation demands beneath one prefix",
+                requested="one authenticated demand shared by every deferred prefix arm",
+                fix="keep distinct native-operation demands in separate control-flow joins",
+                gap_kind=GapKind.FLOOR,
+            )
+
+        representative = deferred[0][1]
+        return replace(
+            representative,
+            prefix_composition=(
+                tuple(resolved),
+                tuple(deferred),
+                len(representative.continuations),
+                len(representative.guards),
+            ),
+        )
+
     def discharge(self, actuals_by_formal_coordinate):
         """Evaluate against authenticated actual operands and project exits.
 
@@ -599,6 +659,29 @@ class NativeOperationExitCarrierV1:
         from sugar_lift_py_tests.floor import RaiseValue
         from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete
         from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+
+        if self.prefix_composition is not None:
+            resolved, deferred, continuation_count, guard_count = (
+                self.prefix_composition
+            )
+            exits = list(resolved)
+            for prefix_exit, carrier in deferred:
+                following = carrier.discharge(actuals_by_formal_coordinate)
+                sequenced = ExitSet((prefix_exit,)).sequence(
+                    lambda _value, *, result=following: result
+                )
+                exits.extend(sequenced.exits)
+            # Do not normalize across prefix arms: each arm's partition faces,
+            # obligations, and temporal state remain independently testified.
+            projected = ExitSet(tuple(exits))
+            for continuation in self.continuations[continuation_count:]:
+                projected = type(self).compose_prefix(projected, continuation)
+                if isinstance(projected, NativeOperationExitCarrierV1):
+                    projected = projected.discharge(actuals_by_formal_coordinate)
+            guard = _conjoin_guards(self.guards[guard_count:])
+            if guard is not None:
+                projected = projected.guarded(guard)
+            return projected
 
         def undischarged(reason):
             return NativeOperationResolutionV1.undischarged(reason).project(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -515,7 +515,10 @@ def reduce_block_to_exitset(
             # smuggle an undischarged carrier through a guard.
             exits = reduce_next(exits.exits[0].value)
         else:
-            exits = exits.sequence(reduce_next)
+            # A completed prefix may expose a deferred native operation. Keep
+            # that carrier outside ExitSet until caller actuals discharge it;
+            # ExitSet.sequence must only ever receive concrete ExitSets.
+            exits = NativeOperationExitCarrierV1.compose_prefix(exits, reduce_next)
 
     # The block boundary is where an obligation stops being in flight, so it is
     # the one door that consumes the carriers. Doing it here rather than per

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_prefix_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_prefix_carrier.py
@@ -1,0 +1,177 @@
+"""Deferred native operations compose beneath testified ExitSet prefixes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import (
+    NativeOperationExitCarrierV1,
+    ReducerPreEffectStateV1,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor import NoneValue, SymbolicValue, TermValue
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import PrimitiveSort, and_, atomic, make_var
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
+from sugar_lift_py_tests.outcome.exit_set import partition
+from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.tree import SourceFile
+
+
+@dataclass(frozen=True)
+class _Demand:
+    demand_cid: str
+
+
+@dataclass(frozen=True)
+class _Pending:
+    candidate_cid: str
+    demands: tuple[_Demand, ...]
+
+
+def _coordinate(name: str, ordinal: int) -> FormalParameterCoordinateV1:
+    source_cid = "blake3-512:" + "d" * 128
+    owner = SourceFragmentCoordinateV1(source_cid, 1, 0, 2, 20)
+    return FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=source_cid,
+        owner_definition_locus=owner,
+        declaration_locus=SourceFragmentCoordinateV1(
+            source_cid, 1, 4 + ordinal * 5, 1, 8 + ordinal * 5
+        ),
+        ordinal=ordinal,
+        parameter_kind="positional-or-keyword",
+        declared_name=name,
+        sort=PrimitiveSort("Value"),
+    )
+
+
+def _carrier(operator: str = "less_than"):
+    left = _coordinate("left", 0)
+    right = _coordinate("right", 1)
+    source = "def compare(left, right):\n    return left < right\n"
+    tree = SourceFile(
+        (source, "prefix-carrier.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    site = next(tree.functions()).fragment
+    carrier = NativeOperationExitCarrierV1.mint(
+        site=site,
+        operator=operator,
+        operands=(
+            SymbolicValue(make_var("left"), left),
+            SymbolicValue(make_var("right"), right),
+        ),
+        coordinates=(left, right),
+    )
+    return carrier, left, right
+
+
+def test_completed_prefix_arms_stay_deferred_and_retain_all_testimony() -> None:
+    carrier, left, right = _carrier()
+    pre_effect_state = _ReducedBlock((TermValue(7),), True, ())
+    carrier = carrier.and_then(
+        lambda value: Complete(value),
+        pre_effect_state=ReducerPreEffectStateV1._from_reducer(pre_effect_state),
+    )
+    tail_guard = atomic("test:carrier-tail", [])
+    carrier = carrier.guarded(tail_guard)
+    first_guard = atomic("test:prefix-first", [])
+    second_guard = atomic("test:prefix-second", [])
+    first_face, second_face = partition("test:prefix-arms")
+    first_obligation = _Pending("first", (_Demand("first-demand"),))
+    second_obligation = _Pending("second", (_Demand("second-demand"),))
+    stopped_state = object()
+    stopped_effect = RaiseEffect(blame="prefix-halt", occurrence="prefix-halt")
+    prefix = ExitSet(
+        (
+            Completed(
+                first_guard,
+                TermValue(1),
+                frozenset({first_face}),
+                (first_obligation,),
+            ),
+            Completed(
+                second_guard,
+                TermValue(2),
+                frozenset({second_face}),
+                (second_obligation,),
+            ),
+            Halted(first_guard, stopped_effect, stopped_state),
+        )
+    )
+
+    composed = NativeOperationExitCarrierV1.compose_prefix(
+        prefix, lambda _value: carrier
+    )
+
+    assert isinstance(composed, NativeOperationExitCarrierV1)
+    exits = composed.discharge(
+        {
+            left.coordinate_cid: NoneValue(),
+            right.coordinate_cid: TermValue(2),
+        }
+    )
+
+    assert len(exits.exits) == 3
+    stopped = next(exit_ for exit_ in exits.exits if exit_.effect is stopped_effect)
+    assert isinstance(stopped, Halted)
+    assert stopped.state is stopped_state
+    following = tuple(
+        exit_
+        for exit_ in exits.exits
+        if isinstance(exit_, Halted) and exit_.effect is not stopped_effect
+    )
+    assert len(following) == 2
+    assert following[0].guard == and_([first_guard, tail_guard])
+    assert following[0].faces == frozenset({first_face})
+    assert following[0].pending_contracts == (first_obligation,)
+    assert following[0].state is pre_effect_state
+    assert following[1].guard == and_([second_guard, tail_guard])
+    assert following[1].faces == frozenset({second_face})
+    assert following[1].pending_contracts == (second_obligation,)
+    assert following[1].state is pre_effect_state
+
+
+def test_incompatible_prefix_carrier_demands_refuse_loudly() -> None:
+    first, _, _ = _carrier("less_than")
+    second, _, _ = _carrier("add")
+    first_guard = atomic("test:prefix-first", [])
+    second_guard = atomic("test:prefix-second", [])
+    prefix = ExitSet(
+        (
+            Completed(first_guard, TermValue(1)),
+            Completed(second_guard, TermValue(2)),
+        )
+    )
+
+    with pytest.raises(ConstructionPanic, match="incompatible native-operation demands"):
+        NativeOperationExitCarrierV1.compose_prefix(
+            prefix,
+            lambda value: first if value == TermValue(1) else second,
+        )
+
+
+def test_prefix_composition_retains_later_carrier_continuations() -> None:
+    carrier, left, right = _carrier()
+    guard = atomic("test:prefix", [])
+    prefix = ExitSet((Completed(guard, TermValue(1)),))
+    composed = NativeOperationExitCarrierV1.compose_prefix(
+        prefix, lambda _value: carrier
+    ).and_then(lambda _predicate: Complete(TermValue(99)))
+
+    exits = composed.discharge(
+        {
+            left.coordinate_cid: TermValue(1),
+            right.coordinate_cid: TermValue(2),
+        }
+    )
+
+    assert exits.exits == (Completed(guard, TermValue(99)),)


### PR DESCRIPTION
## Capability

- retain each completed ExitSet prefix arm paired with its own deferred native-operation carrier
- bypass halted prefixes unchanged
- after authenticated discharge, conjoin prefix/tail guards and preserve partition faces, pending obligations, and temporal state
- keep distinct prefix arms distinct by avoiding cross-prefix normalization
- panic loudly when prefix arms produce incompatible native-operation demand CIDs
- route reducer prefix composition through the carrier door so `ExitSet.sequence` receives only concrete ExitSets

`exit_set.py` and `exit_disposition.py` are untouched. No undischarged carrier is wrapped as a completion. The queued `short_circuit` producer remains separately stashed.

## Tests

- `../../../bin/bpytest tests/test_native_operation_prefix_carrier.py tests/test_native_operation_exit_carrier.py tests/test_native_operation_pre_effect_state.py tests/test_function_formal_native_operation_projection.py tests/test_function_formal_native_operation_binding.py tests/test_guarded_binding_partition_carrier.py tests/test_unpack_setitem_formal_caller.py tests/test_compare_through_if_sugar.py tests/test_attribute_native_operation_demand.py` — 107 passed in 17.41s after rebase onto `origin/main` at `0a1b99ec1`
- full package `../../../bin/bpytest` — 2230 passed, 258 failed, 9 skipped, 5 errors in 374.38s; the package-wide pre-existing red surface remains loud, including the five `test_lift_coverage_harness.py` setup errors.

## Shot accounting

- Intended R axis: carrier results reaching `ExitSet.sequence` from completed prefix arms → 0 for the reducer seam.
- Predicted epsilon: one general carrier-side composition door; no ExitSet changes.
- Floors: authenticated demand identity, prefix testimony, halt bypass, partition identity, pending obligations, and temporal-state identity remain explicit and tested.