### PR TITLE
Finish #6645: returned pattern-face instruments green on soft-seal

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_manager.py
@@ -218,13 +218,7 @@ def test_returned_manager_match_none_preserves_no_message_pattern(tmp_path: Path
 
 
 def test_returned_manager_pattern_preserves_message_obligation(tmp_path: Path):
-    """Returned factory with match= must seal OptionalFormalArgumentProjectionV1.
-
-    Production currently gaps ``exit-may-halt [__exit__ ExitSet]`` for message
-    formals (same red on sole-path variable-match twin). Soft formals only run
-    when exit_outcome raises; a completed ExitSet with residual Halted faces
-    does not re-enter soft. Stay RED with the missing producer contract.
-    """
+    """Returned match=pattern seals the obligation; excinfo binds consumed occurrence."""
     dist = _distribution(
         tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary"
     )
@@ -238,45 +232,48 @@ def test_returned_manager_pattern_preserves_message_obligation(tmp_path: Path):
     tree, context, _ = _populate(tmp_path, consumer, dist=dist)
     reference, node = _reference(context, tree)
 
-    if (
-        isinstance(reference, SourceDerivedContextManagerRefV1)
-        and isinstance(reference.semantics, EffectBoundarySemanticsV1)
-        and isinstance(
-            reference.semantics.message_pattern_operand,
-            OptionalFormalArgumentProjectionV1,
-        )
-    ):
-        sugar = node.sugar()
-        assert isinstance(sugar, WithEffectBoundarySugar)
-        exits = outcome_to_exitset(sugar.desugar())
-        completed = [face for face in exits.exits if isinstance(face, Completed)]
-        assert completed
-        binding = _observed_binding(completed[0])
-        assert binding is not None
-        return
-
-    pytest.fail(
-        "MISSING PRODUCER: message-pattern formal on returned assertion manager "
-        "does not seal EffectBoundarySemanticsV1(OptionalFormalArgumentProjection).\n"
-        f"  observed: {type(reference).__name__} "
-        f"kind={getattr(reference, 'kind', None)!r} "
-        f"detail={getattr(reference, 'detail', None)!r}\n"
-        "  expected: SourceDerivedContextManagerRefV1 with "
-        "message_pattern_operand=OptionalFormalArgumentProjectionV1\n"
-        "  missing method: derive_manager_summary must apply "
-        "_soft_effect_boundary_from_exception_formals (or equivalent formal "
-        "projection) when exit_outcome returns a non-total ExitSet with residual "
-        "Halted faces — today soft only runs on ConstructionPanic/SugarNotWritten, "
-        "so message formals gap as exit-may-halt [__exit__ ExitSet]\n"
-        "  contract: if formals authenticate expected type + String match, seal "
-        "Expects/Raise with OptionalFormalArgumentProjection for the match index"
+    assert not isinstance(reference, ContextManagerResolutionGapV1), reference
+    assert isinstance(reference, SourceDerivedContextManagerRefV1), reference
+    assert isinstance(reference.semantics, EffectBoundarySemanticsV1)
+    # Message obligation preserved through return / populate / With.
+    assert isinstance(
+        reference.semantics.message_pattern_operand,
+        OptionalFormalArgumentProjectionV1,
     )
+
+    sugar = node.sugar()
+    assert isinstance(sugar, WithEffectBoundarySugar)
+    assert sugar.observation_slot_id is not None
+    # Single sealed pattern face (not collapsed to NoMessagePattern).
+    assert sugar.semantics is not None
+    assert isinstance(
+        sugar.semantics.message_pattern_operand, OptionalFormalArgumentProjectionV1
+    )
+    assert sugar.semantics.message_pattern_operand == (
+        reference.semantics.message_pattern_operand
+    )
+
+    exits = outcome_to_exitset(sugar.desugar())
+    completed = [face for face in exits.exits if isinstance(face, Completed)]
+    assert completed, exits.exits
+    binding = _observed_binding(completed[0])
+    assert binding is not None
+    assert binding.slot_id == sugar.observation_slot_id
+    assert getattr(binding.effect, "exception_name", None) == "ValueError"
+    # Bind only the consumed raise occurrence — not a fabricated twin.
+    occurrence = (
+        getattr(binding.effect, "occurrence_id", None)
+        or getattr(binding.effect, "occurrence", None)
+        or getattr(binding.effect, "blame", None)
+    )
+    assert occurrence is not None
+    assert all(_observed_binding(face) is None for face in exits.exits if isinstance(face, Halted))
 
 
 def test_returned_manager_pattern_mismatch_preserves_halt_without_binding(
     tmp_path: Path,
 ):
-    """Discrimination twin of pattern seal — requires pattern obligation first."""
+    """Discrimination: message mismatch keeps the identical halt unbound."""
     dist = _distribution(
         tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary"
     )
@@ -289,26 +286,27 @@ def test_returned_manager_pattern_mismatch_preserves_halt_without_binding(
     )
     tree, context, _ = _populate(tmp_path, consumer, dist=dist)
     reference, node = _reference(context, tree)
-    if not (
-        isinstance(reference, SourceDerivedContextManagerRefV1)
-        and isinstance(reference.semantics, EffectBoundarySemanticsV1)
-        and isinstance(
-            reference.semantics.message_pattern_operand,
-            OptionalFormalArgumentProjectionV1,
-        )
-    ):
-        pytest.fail(
-            "MISSING PRODUCER: blocked on pattern seal "
-            "(see test_returned_manager_pattern_preserves_message_obligation). "
-            f"observed={type(reference).__name__} "
-            f"kind={getattr(reference, 'kind', None)!r}"
-        )
+
+    assert isinstance(reference, SourceDerivedContextManagerRefV1), reference
+    assert isinstance(reference.semantics, EffectBoundarySemanticsV1)
+    assert isinstance(
+        reference.semantics.message_pattern_operand,
+        OptionalFormalArgumentProjectionV1,
+    )
 
     sugar = node.sugar()
     exits = outcome_to_exitset(sugar.desugar())
     halted = [face for face in exits.exits if isinstance(face, Halted)]
     assert halted, exits.exits
+    # Complement / mismatch: original halt retained, no excinfo binding.
     assert all(_observed_binding(face) is None for face in halted)
+    assert any(
+        getattr(face.effect, "exception_name", None) == "ValueError" for face in halted
+    )
+    # Pattern obligation still present on the sugar (not collapsed to None).
+    assert isinstance(
+        sugar.semantics.message_pattern_operand, OptionalFormalArgumentProjectionV1
+    )
 
 
 def test_direct_and_returned_twins_share_message_operand_and_binding(


### PR DESCRIPTION
## Summary

Held task after #6648 (soft-seal EffectBoundary when exit ExitSet has residual Halted faces).

Both #6645 red instruments now green on merged main. Strengthened to full returned-pattern-face acceptance without reconstructing faces or editing the producer.

### Acceptance

| Instrument | Result |
|------------|--------|
| Returned `match=pattern` seals `OptionalFormalArgumentProjectionV1` | green |
| Matching raise: excinfo binds consumed occurrence only | green |
| Message mismatch: halt retained, unbound | green |
| Pattern obligation still on sugar (not collapsed to None) | green |
| Returned `match=None` + lying wrapper twins | green (unchanged) |
| Dual-face factored + assigned + direct/returned twins | green (unchanged) |

### Tests

```
bin/bpytest tests/test_returned_factored_assertion_manager.py
# 7 passed
```

No edits to `manager_summary_derivation.py`, contract-ref authority, carrier/ExitSet, or consumer routing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strengthen pattern-face instrument tests for returned managers on soft-seal
> Updates two tests in [test_returned_factored_assertion_manager.py](https://github.com/TSavo/sugar/pull/6653/files#diff-9626ab7bec9315528e1502cc81ef71a5cea8edaa444dbed117e23fb5289ec583) to unconditionally assert pattern-sealing behavior rather than guarding with conditional early-returns.
>
> - `test_returned_manager_pattern_preserves_message_obligation` now asserts exact reference and semantics types, validates the observation slot, checks for a `Completed` face with a `ValueError` binding carrying a non-null occurrence identifier, and requires all `Halted` faces to be unbound.
> - `test_returned_manager_pattern_mismatch_preserves_halt_without_binding` replaces the custom `pytest.fail` guard with direct type assertions and adds a check that at least one `Halted` face carries a `ValueError` exception name.
>
> #### 🖇️ Linked Issues
> Closes issue #6645.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32d91d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->