### PR TITLE
GeneratorConstructionV1.to_term from authenticated construction preimage

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -112,6 +112,106 @@ GeneratorStepV1 = (
 )
 
 
+def _generator_value_testimony(value: object, *, owner: str) -> dict:
+    """Content-addressed testimony for one binding-state or step payload value."""
+    if value is None:
+        return {"kind": "null"}
+    if isinstance(value, ResumeBindingV1):
+        return {
+            "kind": "resume-binding",
+            "resumeCoordinate": value.resume_coordinate,
+            "value": _generator_value_testimony(value.resume_value, owner=owner),
+        }
+    to_term = getattr(value, "to_term", None)
+    if callable(to_term):
+        from sugar_lift_py_tests.ir import _term_content_cid
+
+        return {
+            "kind": "term-cid",
+            "contentCid": _term_content_cid(to_term(owner=owner)),
+        }
+    # IR Terms are already content-addressable without a FloorValue wrapper.
+    from sugar_lift_py_tests.ir import (
+        _ConstBool,
+        _ConstInt,
+        _ConstReal,
+        _ConstStr,
+        _Ctor,
+        _Lambda,
+        _Var,
+        _term_content_cid,
+    )
+
+    if isinstance(
+        value, (_Ctor, _ConstInt, _ConstStr, _ConstBool, _ConstReal, _Var, _Lambda)
+    ):
+        return {"kind": "term-cid", "contentCid": _term_content_cid(value)}
+    fragment = getattr(value, "fragment", None)
+    if fragment is not None:
+        seal = getattr(fragment, "seal", None)
+        if callable(seal):
+            return {"kind": "fragment-cid", "contentCid": seal().cid}
+    wire = getattr(value, "wire", None)
+    if callable(wire):
+        return {"kind": "wire", "payload": wire()}
+    if isinstance(value, (str, int, bool)):
+        return {"kind": "primitive", "value": value}
+    # Typed binding entries may project through coordinate CID.
+    coordinate = getattr(value, "coordinate", None)
+    coordinate_cid = getattr(coordinate, "cid", None)
+    if isinstance(coordinate_cid, str):
+        return {"kind": "binding-coordinate", "coordinateCid": coordinate_cid}
+    raise TypeError(
+        f"{owner} cannot content-address value of type {type(value).__name__}; "
+        "project authenticated construction testimony, never object identity"
+    )
+
+
+def _generator_step_testimony(step: object, *, owner: str) -> dict:
+    """Content-addressed testimony for one generator step."""
+    if isinstance(step, YieldStepV1):
+        return {
+            "kind": "yield",
+            "value": _generator_value_testimony(step.value, owner=owner),
+        }
+    if isinstance(step, ReturnStepV1):
+        return {
+            "kind": "return",
+            "value": _generator_value_testimony(step.value, owner=owner),
+        }
+    if isinstance(step, OpaqueStepV1):
+        return {
+            "kind": "opaque",
+            "observed": step.observed,
+            "carriesSuspension": step.carries_suspension,
+        }
+    if isinstance(step, InertStepV1):
+        return {"kind": "inert", "observed": step.observed}
+    if isinstance(step, FinallyStepV1):
+        return {
+            "kind": "finally",
+            "statements": [
+                _generator_value_testimony(item, owner=owner)
+                for item in step.statements
+            ],
+        }
+    if isinstance(step, IfStepV1):
+        return {
+            "kind": "if",
+            "fragmentCid": step.fragment_cid,
+            "guard": _generator_value_testimony(step.guard, owner=owner),
+            "thenSteps": [
+                _generator_step_testimony(item, owner=owner) for item in step.then_steps
+            ],
+            "elseSteps": [
+                _generator_step_testimony(item, owner=owner) for item in step.else_steps
+            ],
+        }
+    raise TypeError(
+        f"{owner} cannot content-address step of type {type(step).__name__}"
+    )
+
+
 @dataclass(frozen=True)
 class ResumeBindingV1:
     resume_coordinate: str
@@ -175,6 +275,51 @@ class GeneratorConstructionV1:
             binding_state=binding_state,
             steps=tuple(steps),
             instance_coordinate=instance_coordinate,
+        )
+
+    def construction_term_preimage(self) -> dict:
+        """Authenticated construction + lifecycle content for term projection.
+
+        Derives solely from construction coordinates (allocation/frame/instance),
+        step testimony, binding-state testimony, and lifecycle (cursor /
+        suspended resume). Never object identity, class spelling, or a
+        fabricated generic manager DTO disconnected from this preimage.
+        """
+        return {
+            "kind": "python-generator-construction-term",
+            "schemaVersion": "1",
+            "allocationCoordinate": self.allocation_coordinate,
+            "frameCoordinate": self.frame_coordinate,
+            "instanceCoordinate": self.instance_coordinate,
+            "cursor": self.cursor,
+            "suspendedResumeCoordinate": self.suspended_resume_coordinate,
+            "bindingState": [
+                _generator_value_testimony(item, owner="GeneratorConstructionV1")
+                for item in self.binding_state
+            ],
+            "steps": [
+                _generator_step_testimony(step, owner="GeneratorConstructionV1")
+                for step in self.steps
+            ],
+        }
+
+    def construction_term_cid(self) -> str:
+        return cid_of_json(self.construction_term_preimage())
+
+    def to_term(self, *, owner: str):
+        """Canonical term for ManagerBinding and other record testimony.
+
+        Content-addressed over :meth:`construction_term_preimage`. Identical
+        construction and lifecycle yield identical terms; any change to
+        generator/frame/state testimony changes the term.
+        """
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:generator-construction",
+            [str_const(self.construction_term_cid())],
+            symbol_kind="coordinate",
         )
 
     def resume(self):

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_manager_binding_term.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_manager_binding_term.py
@@ -1,0 +1,140 @@
+"""GeneratorConstructionV1.to_term — producer-owned manager binding testimony.
+
+ManagerBinding.to_facts() projects manager_value.to_term unchanged. Generator
+managers must supply a content-addressed term from authenticated construction
+and lifecycle state — never object identity, class spelling, or a fabricated
+generic manager DTO.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    ReturnStepV1,
+    YieldStepV1,
+)
+from sugar_lift_py_tests.ir import ctor, num, str_const
+from sugar_lift_py_tests.outcome.resource_bindings import ManagerBinding
+
+
+def _machine(
+    *, allocation="call:m:1", frame="frame:m", binding=("bound:x",), steps=None
+):
+    if steps is None:
+        steps = (YieldStepV1(num(7)), ReturnStepV1(num(9)))
+    return GeneratorConstructionV1.allocate(
+        allocation_coordinate=allocation,
+        frame_coordinate=frame,
+        binding_state=binding,
+        steps=steps,
+    )
+
+
+def test_identical_construction_preimages_yield_identical_terms():
+    left = _machine()
+    right = _machine()
+    assert left is not right
+    assert left.to_term(owner="test") == right.to_term(owner="test")
+    assert left.construction_term_cid() == right.construction_term_cid()
+
+
+def test_changed_frame_coordinate_changes_term():
+    left = _machine(frame="frame:a")
+    right = _machine(frame="frame:b")
+    assert left.to_term(owner="test") != right.to_term(owner="test")
+
+
+def test_changed_allocation_coordinate_changes_term():
+    left = _machine(allocation="call:a:1")
+    right = _machine(allocation="call:b:1")
+    assert left.to_term(owner="test") != right.to_term(owner="test")
+
+
+def test_changed_binding_state_changes_term():
+    left = _machine(binding=("bound:x",))
+    right = _machine(binding=("bound:y",))
+    assert left.to_term(owner="test") != right.to_term(owner="test")
+
+
+def test_lifecycle_cursor_after_resume_changes_term():
+    machine = _machine()
+    before = machine.to_term(owner="test")
+    yielded = machine.resume()
+    after = yielded.machine.to_term(owner="test")
+    assert before != after
+    assert yielded.machine.cursor == 1
+
+
+def test_lifecycle_suspended_resume_is_in_term_preimage():
+    machine = _machine()
+    yielded = machine.resume()
+    preimage = yielded.machine.construction_term_preimage()
+    assert preimage["cursor"] == 1
+    assert preimage["suspendedResumeCoordinate"] == yielded.resume_coordinate
+    assert preimage["instanceCoordinate"] == machine.instance_coordinate
+
+
+def test_manager_binding_to_facts_carries_exact_generator_term():
+    machine = _machine()
+    facts = ManagerBinding(slot_id="M0", manager_value=machine).to_facts()
+    assert len(facts) == 1
+    formula = facts[0].formula
+    # eq(manager_slot_value(M0), generator_term)
+    assert formula.args[0] == ctor("manager_slot_value", [str_const("M0")])
+    assert formula.args[1] == machine.to_term(owner="ManagerBinding")
+
+
+def test_term_is_coordinate_not_object_identity_or_class_spelling():
+    machine = _machine()
+    term = machine.to_term(owner="test")
+    assert term == ctor(
+        "python:generator-construction",
+        [str_const(machine.construction_term_cid())],
+        symbol_kind="coordinate",
+    )
+    # Reject twins that would key on object identity or class name spelling.
+    rendered = repr(term)
+    assert str(id(machine)) not in rendered
+    assert "GeneratorConstructionV1" not in rendered
+    assert "option_context" not in rendered
+    assert "contextmanager" not in rendered
+
+
+def test_fabricated_generic_manager_term_is_not_the_generator_term():
+    """Lying twin: a generic manager DTO cannot impersonate generator testimony."""
+    machine = _machine()
+    genuine = machine.to_term(owner="test")
+    fabricated = ctor(
+        "python:manager",
+        [str_const(machine.instance_coordinate)],
+        symbol_kind="coordinate",
+    )
+    assert genuine != fabricated
+    facts = ManagerBinding(slot_id="M0", manager_value=machine).to_facts()
+    assert facts[0].formula.args[1] != fabricated
+
+
+def test_omitted_lifecycle_state_is_not_the_live_term():
+    """Lying twin: instance coordinate alone omits cursor/suspension lifecycle."""
+    machine = _machine().resume().machine
+    live = machine.to_term(owner="test")
+    omitted = ctor(
+        "python:generator-construction",
+        [str_const(machine.instance_coordinate)],
+        symbol_kind="coordinate",
+    )
+    assert live != omitted
+
+
+def test_ordinary_object_manager_to_term_unchanged():
+    """Ordinary Floor managers still project through their own to_term."""
+    from sugar_lift_py_tests.floor.object_value import ObjectValue
+
+    obj = ObjectValue("Guard", (), (), (), "identity:guard")
+    term = obj.to_term(owner="ManagerBinding")
+    assert term == ctor(
+        "py.object.identity",
+        [str_const("Guard"), str_const("identity:guard")],
+    )
+    facts = ManagerBinding(slot_id="M1", manager_value=obj).to_facts()
+    assert facts[0].formula.args[1] == term


### PR DESCRIPTION
## Summary

Priority interrupt: producer-owned canonical term projection for `GeneratorConstructionV1`, unblocking codex-2 / option_context vertical manager binding.

`ManagerBinding.to_facts()` calls `manager_value.to_term(owner=...)` unchanged. Generators now project a content-addressed term over authenticated construction + lifecycle state:

- allocation / frame / instance coordinates
- step testimony (yield/return/opaque/inert/finally/if)
- binding-state testimony (including resume bindings)
- lifecycle cursor + suspended resume coordinate

Term shape: `python:generator-construction(contentCid)` with `symbol_kind="coordinate"`.

## Acceptance

| Check | |
| --- | --- |
| Identical construction preimages → identical terms | green |
| Changed frame/allocation/binding/lifecycle → different term | green |
| ManagerBinding.to_facts carries exact generator term | green |
| Twins reject object identity, class/provider spelling, omitted lifecycle, fabricated generic manager terms | green |
| Ordinary ObjectValue managers unchanged | green |

## Must not touch (held)

resource_bindings.py, ManagerBinding dispatch, CM factory selection, carrier/ExitSet.

## Tests

```
bin/bpytest tests/test_generator_manager_binding_term.py tests/test_generator_construction_v1.py -q
# 20 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `GeneratorConstructionV1.to_term` from authenticated construction preimage
> - Adds `construction_term_preimage()` to `GeneratorConstructionV1` that captures authenticated construction and lifecycle state (allocation/frame/instance coordinates, cursor, binding state, steps) as a content-addressed dict.
> - Adds `construction_term_cid()` that hashes the preimage via `cid_of_json` to produce a stable CID string.
> - Implements `to_term()` returning a coordinate IR term `ctor('python:generator-construction', [str_const(cid)])`, replacing any object-identity-based representation.
> - Adds two helpers, `_generator_value_testimony` and `_generator_step_testimony`, that recursively project binding values and step types into canonical testimony dicts; unsupported types raise `TypeError`.
> - Adds tests in [`test_generator_manager_binding_term.py`](https://github.com/TSavo/sugar/pull/6655/files#diff-cc1359db50230101eeec1cace61f6b027a9049171f72ec60ac86e847be17fb9f) verifying CID stability, sensitivity to state changes, and correct propagation through `ManagerBinding.to_facts()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3ed45f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->