### PR TITLE
Preserve stateful halts at reduce_body boundary

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -571,6 +571,16 @@ def reduce_body(statements: tuple, ctx: object = None):
                 )
             )
         )
+    if (
+        len(exits.exits) == 1
+        and isinstance(exits.exits[0], Halted)
+        and exits.exits[0].guard == true_guard()
+        and exits.exits[0].state is not None
+    ):
+        # Incomplete has no temporal-state slot. Keep the authenticated halt
+        # face intact rather than laundering its pre-effect state through a
+        # representation that cannot carry it.
+        return exits
     collapsed = exits.collapse()
     if isinstance(collapsed, Incomplete):
         return collapsed

--- a/implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py
@@ -1,0 +1,37 @@
+"""Reducer boundary law for state-bearing exceptional exits."""
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.outcome import ExitSet, Incomplete, true_guard
+from sugar_lift_py_tests.outcome.exit_set import Halted
+from sugar_lift_py_tests.sugar import function_universe_sugar
+
+
+def test_reduce_body_retains_one_unconditional_stateful_halt(monkeypatch):
+    effect = RaiseEffect(exception_name="AttributeError")
+    pre_effect_state = object()
+    exits = ExitSet((Halted(true_guard(), effect, pre_effect_state),))
+    monkeypatch.setattr(
+        function_universe_sugar,
+        "reduce_block_to_exitset",
+        lambda statements, ctx: exits,
+    )
+
+    reduced = function_universe_sugar.reduce_body(())
+
+    assert reduced is exits
+    assert reduced.exits[0].state is pre_effect_state
+
+
+def test_reduce_body_still_collapses_one_unconditional_stateless_halt(monkeypatch):
+    effect = RaiseEffect(exception_name="AttributeError")
+    exits = ExitSet((Halted(true_guard(), effect),))
+    monkeypatch.setattr(
+        function_universe_sugar,
+        "reduce_block_to_exitset",
+        lambda statements, ctx: exits,
+    )
+
+    reduced = function_universe_sugar.reduce_body(())
+
+    assert reduced == Incomplete(effect)
+


### PR DESCRIPTION
## Capability

`reduce_body` now retains a sole unconditional `Halted(state=S)` as its authenticated `ExitSet` because `Incomplete` has no temporal-state slot. A stateless unconditional halt still follows the existing collapse path.

`exit_set.py`, `exit_disposition.py`, producers, and syntax recognition are untouched.

## Focused proof

- `../../../bin/bpytest tests/test_reduce_body_stateful_halt.py tests/test_setitem_method_caller.py tests/test_setattr_named_formal_caller.py tests/test_compare_through_if_sugar.py tests/test_unpack_setitem_formal_caller.py tests/test_native_operation_pre_effect_state.py tests/test_native_operation_prefix_carrier.py` — 64 passed in 4.60s after rebase onto `origin/main` at `baaa1c56b`
- truthful reducer seam retains the identical pre-effect-state object
- stateless discrimination arm still collapses to `Incomplete(effect)`
- merged bound-method IndexError reproducer is green

## Package telemetry

- `../../../bin/bpytest` — 2275 passed, 276 failed, 9 skipped, 5 errors in 684.66s; the repository-wide red surface remains loud, including five `test_lift_coverage_harness.py` setup errors.

## Shot accounting

- R: stateful exceptional faces losing state through `reduce_body -> collapse` becomes 0 at this boundary.
- Floors: no ExitSet changes, no default state, no producer or syntax checks, stateless behavior unchanged.

The separate `short_circuit` producer remains stashed for the next PR.