### PR TITLE
Seal generator bound entries with ConstructedValueTestimonyV1

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -122,6 +122,18 @@ def _generator_value_testimony(value: object, *, owner: str) -> dict:
             "resumeCoordinate": value.resume_coordinate,
             "value": _generator_value_testimony(value.resume_value, owner=owner),
         }
+    # Sealed BindingEntryV1: require producer-minted ConstructedValueTestimonyV1.
+    # Consumer never fabricates testimony; unsealed entries refuse here.
+    from sugar_source_tree.binding_state import BindingEntryV1
+
+    if isinstance(value, BindingEntryV1):
+        testimony = value.require_constructed_value_testimony()
+        return {
+            "kind": "sealed-bound-binding",
+            "coordinateCid": value.coordinate.cid,
+            "constructedValueTestimonyCid": testimony.cid,
+            "entry": value.wire(),
+        }
     to_term = getattr(value, "to_term", None)
     if callable(to_term):
         from sugar_lift_py_tests.ir import _term_content_cid
@@ -156,11 +168,6 @@ def _generator_value_testimony(value: object, *, owner: str) -> dict:
         return {"kind": "wire", "payload": wire()}
     if isinstance(value, (str, int, bool)):
         return {"kind": "primitive", "value": value}
-    # Typed binding entries may project through coordinate CID.
-    coordinate = getattr(value, "coordinate", None)
-    coordinate_cid = getattr(coordinate, "cid", None)
-    if isinstance(coordinate_cid, str):
-        return {"kind": "binding-coordinate", "coordinateCid": coordinate_cid}
     raise TypeError(
         f"{owner} cannot content-address value of type {type(value).__name__}; "
         "project authenticated construction testimony, never object identity"
@@ -260,6 +267,12 @@ class GeneratorConstructionV1:
         binding_state: tuple[object, ...],
         steps: tuple[GeneratorStepV1, ...],
     ) -> "GeneratorConstructionV1":
+        from sugar_source_tree.binding_state import seal_generator_binding_state_v1
+
+        # Producer seal: every BindingEntryV1 carries ConstructedValueTestimonyV1
+        # before the instance exists. Unavailable testimony gaps here, never as
+        # a delayed BindingStateWireGap on a "successfully" sealed state.
+        binding_state = seal_generator_binding_state_v1(binding_state)
         instance_coordinate = cid_of_json(
             {
                 "kind": "python-generator-instance",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -214,7 +214,7 @@ class SourceVisibleCallFrameV1:
             BindingEntryV1(
                 coordinate,
                 node,
-                BoundBindingStateV1(testimony),
+                BoundBindingStateV1(testimony) if testimony is not None else None,
             )
             for coordinate, node, testimony in zip(
                 self.formal_coordinates, bound, supplied_testimonies, strict=True

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_binding_testimony_term.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_binding_testimony_term.py
@@ -1,0 +1,150 @@
+"""Consumer proof: GeneratorConstructionV1.to_term reads sealed binding testimony.
+
+Producer seals BindingEntryV1 at allocate. The term preimage carries
+constructed-value testimony CIDs from sealed entries — never coordinate-only
+fallback, never consumer-fabricated testimony.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    ReturnStepV1,
+    YieldStepV1,
+)
+from sugar_lift_py_tests.ir import num
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
+from sugar_source_tree.binding_state import (
+    BindingStateWireGap,
+    RuntimeBindingEntryFactoryV1,
+    seal_bound_binding_entry_v1,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _entry_pair(source_a: str, source_b: str | None = None):
+    def _one(source: str):
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+            handle.write(source)
+            path = handle.name
+        function = next(SourceFile(path_source(path)).functions())
+        assignment = next(node for node in function.walk() if node.kind == "Assign")
+        factory = RuntimeBindingEntryFactoryV1(
+            cid_of_json({"scope": function.fragment.seal().to_dict()})
+        )
+        return factory.mint_entry(
+            binding_site=assignment.targets[0].fragment,
+            projection_path=("targets", 0),
+            state=assignment.value,
+        )
+
+    left = _one(source_a)
+    right = _one(source_b or source_a)
+    return left, right
+
+
+def _machine(binding):
+    return GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:gen:1",
+        frame_coordinate="frame:gen",
+        binding_state=binding,
+        steps=(YieldStepV1(num(1)), ReturnStepV1(num(2))),
+    )
+
+
+def test_allocate_seals_binding_entries_with_constructed_value_testimony():
+    entry, _ = _entry_pair("def gen():\n    bound = 7\n    yield bound\n")
+    assert entry.constructed_value_testimony is None
+    machine = _machine((entry,))
+    sealed = machine.binding_state[0]
+    testimony = sealed.require_constructed_value_testimony()
+    assert isinstance(testimony, ConstructedValueTestimonyV1)
+    # Successfully sealed: wire does not delay a gap.
+    assert sealed.wire()["state"]["kind"] == "bound"
+
+
+def test_to_term_preimage_carries_sealed_testimony_not_coordinate_only():
+    entry, _ = _entry_pair("def gen():\n    bound = 7\n    yield bound\n")
+    machine = _machine((entry,))
+    sealed = machine.binding_state[0]
+    preimage = machine.construction_term_preimage()
+    item = preimage["bindingState"][0]
+    assert item["kind"] == "sealed-bound-binding"
+    assert item["coordinateCid"] == sealed.coordinate.cid
+    assert (
+        item["constructedValueTestimonyCid"]
+        == sealed.require_constructed_value_testimony().cid
+    )
+    assert item["entry"] == sealed.wire()
+
+
+def test_identical_sealed_bindings_yield_identical_terms():
+    left_entry, right_entry = _entry_pair(
+        "def gen():\n    bound = 7\n    yield bound\n"
+    )
+    # Same source text → same value content; coordinates differ by occurrence.
+    # Seal with the same semantic path through allocate.
+    left = _machine((left_entry,))
+    right = _machine((right_entry,))
+    # Different factory occurrences → different coordinates → different terms.
+    # Same sealed entry reused twice must match.
+    same = _machine((left_entry,))
+    assert left.to_term(owner="test") == same.to_term(owner="test")
+    assert left.construction_term_cid() == same.construction_term_cid()
+    # Distinct coordinates still differ.
+    assert left.to_term(owner="test") != right.to_term(owner="test")
+
+
+def test_changed_value_content_changes_term():
+    left_entry, _ = _entry_pair("def gen():\n    bound = 1\n    yield bound\n")
+    right_entry, _ = _entry_pair("def gen():\n    bound = 2\n    yield bound\n")
+    left = _machine((left_entry,))
+    right = _machine((right_entry,))
+    assert left.to_term(owner="test") != right.to_term(owner="test")
+    assert (
+        left.binding_state[0].require_constructed_value_testimony().cid
+        != right.binding_state[0].require_constructed_value_testimony().cid
+    )
+
+
+def test_unsealed_entry_cannot_project_term_without_producer_seal():
+    """Lying twin: stripping sealed_state after allocate is not the live path.
+
+    Allocate always seals; force an unsealed entry into construction_term_preimage
+    via a hand-built machine to prove the consumer refuses fabrication.
+    """
+    entry, _ = _entry_pair("def gen():\n    bound = 7\n    yield bound\n")
+    # Bypass allocate seal by constructing the frozen dataclass directly.
+    machine = GeneratorConstructionV1(
+        allocation_coordinate="call:gen:1",
+        frame_coordinate="frame:gen",
+        binding_state=(entry,),  # unsealed
+        steps=(YieldStepV1(num(1)),),
+        instance_coordinate="blake3-512:" + "a" * 128,
+    )
+    with pytest.raises(BindingStateWireGap, match="testimony unavailable"):
+        machine.construction_term_preimage()
+
+
+def test_mismatched_supplied_testimony_refuses_before_allocate():
+    entry, _ = _entry_pair("def gen():\n    bound = 7\n    yield bound\n")
+    lying = ConstructedValueTestimonyV1.mint(
+        entry.state.fragment,
+        cid_of_json({"kind": "lying", "value": -1}),
+    )
+    with pytest.raises(BindingStateWireGap, match="does not match"):
+        seal_bound_binding_entry_v1(entry, testimony=lying)
+
+
+def test_primitive_binding_stubs_still_allocate_without_entry_seal():
+    """Existing non-entry binding stubs remain valid allocate inputs."""
+    machine = _machine(("bound:x",))
+    assert machine.binding_state == ("bound:x",)
+    preimage = machine.construction_term_preimage()
+    assert preimage["bindingState"] == [{"kind": "primitive", "value": "bound:x"}]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
@@ -191,7 +191,18 @@ class ConstructedValueTestimonyV1:
 
 @dataclass(frozen=True)
 class BoundBindingStateV1:
-    testimony: ConstructedValueTestimonyV1 | None
+    """Sealed bound state: constructed-value testimony is mandatory.
+
+    Unsealed intermediate bindings use ``sealed_state=None`` on the runtime
+    carrier. A bound sealed projection without testimony is unrepresentable.
+    """
+
+    testimony: ConstructedValueTestimonyV1
+
+    def __post_init__(self) -> None:
+        if self.testimony is None:
+            raise BindingProvenanceGap("constructed-value testimony unavailable")
+        ConstructedValueTestimonyV1.decode(self.testimony.wire())
 
 
 @dataclass(frozen=True)
@@ -267,8 +278,6 @@ class BindingEntryV1:
     def constructed_value_testimony_cid(self) -> str:
         if not isinstance(self.state, BoundBindingStateV1):
             raise BindingProvenanceGap("binding entry is not a bound value")
-        if self.state.testimony is None:
-            raise BindingProvenanceGap("constructed-value testimony unavailable")
         ConstructedValueTestimonyV1.decode(self.state.testimony.wire())
         return self.state.testimony.cid
 
@@ -406,8 +415,6 @@ def _decode_source_memento(raw: object) -> dict[str, Any]:
 
 def _state_wire(state: BindingStateV1) -> dict[str, Any]:
     if isinstance(state, BoundBindingStateV1):
-        if state.testimony is None:
-            raise BindingProvenanceGap("constructed-value testimony unavailable")
         return {"kind": "bound", "testimony": state.testimony.wire()}
     if isinstance(state, UnboundBindingStateV1):
         return {

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -160,6 +160,10 @@ class BindingEntryV1:
     def with_testimony(
         self, testimony: ConstructedValueTestimonyV1
     ) -> "BindingEntryV1":
+        if testimony is None:
+            raise BindingStateWireGap("constructed-value testimony unavailable")
+        # Re-authenticate: a stale or fabricated CID cannot seal.
+        ConstructedValueTestimonyV1.decode(testimony.wire())
         return replace(self, sealed_state=BoundBindingStateV1(testimony))
 
     def require_constructed_value_testimony(self) -> ConstructedValueTestimonyV1:
@@ -180,11 +184,7 @@ class BindingEntryV1:
             raise BindingStateWireGap(
                 "runtime binding state has no authenticated sealed projection"
             )
-        if (
-            isinstance(self.sealed_state, BoundBindingStateV1)
-            and self.sealed_state.testimony is None
-        ):
-            raise RuntimeBindingEntryGap("constructed-value testimony unavailable")
+        # BoundBindingStateV1 requires testimony at construction; no delayed gap.
         return SealedBindingEntryV1.decode(
             SealedBindingEntryV1(self.coordinate, self.sealed_state).wire()
         ).wire()
@@ -553,11 +553,13 @@ class _ResolvedSourceFragment:
         return _Memento(self._source)
 
 
-def _initial_sealed_state(state: BindingState) -> SealedBindingStateV1:
+def _initial_sealed_state(state: BindingState) -> SealedBindingStateV1 | None:
     from sugar_source_tree.nodes import Node
 
     if isinstance(state, Node):
-        return BoundBindingStateV1(None)
+        # Unsealed bound value: optionality lives on the carrier (None), never
+        # as BoundBindingStateV1 without testimony.
+        return None
     if isinstance(state, UnboundBinding):
         return UnboundBindingStateV1(state.cause.seal().cid)
     if isinstance(state, GuardedBinding):
@@ -565,6 +567,115 @@ def _initial_sealed_state(state: BindingState) -> SealedBindingStateV1:
     if isinstance(state, LoopProjectedBinding):
         return None
     raise BindingStateWireGap(f"unknown runtime binding state {type(state).__name__}")
+
+
+def _semantic_value_cid_for_bound_node(node: "Node") -> str:
+    """Content CID of one bound Node's actual value.
+
+    Prefers an already-authenticated construction testimony on the node, then
+    the closed constructed-value envelope of its sugar, then the node shape
+    CID. Genuinely unavailable content refuses loud.
+    """
+    construction = getattr(node, "construction_testimony", None)
+    if construction is not None:
+        semantic = getattr(construction, "semantic_value_cid", None)
+        if isinstance(semantic, str) and semantic.startswith("blake3-512:"):
+            return semantic
+        cid = getattr(construction, "cid", None)
+        if isinstance(cid, str) and cid.startswith("blake3-512:"):
+            # construction_testimony may itself be ConstructedValueTestimonyV1.
+            return construction.semantic_value_cid
+    try:
+        constructed = node.sugar()
+        return cid_of_json(_constructed_preimage(constructed))
+    except BindingStateWireGap:
+        raise
+    except Exception as cause:  # noqa: BLE001 -- map any construction miss to seal gap
+        try:
+            return node_construction_shape_cid(node)
+        except (TypeError, ValueError) as shape_cause:
+            raise BindingStateWireGap(
+                "constructed-value testimony unavailable: "
+                f"{type(cause).__name__}: {cause}; "
+                f"shape: {type(shape_cause).__name__}: {shape_cause}"
+            ) from cause
+
+
+def seal_bound_binding_entry_v1(
+    entry: BindingEntryV1,
+    *,
+    testimony: ConstructedValueTestimonyV1 | None = None,
+    semantic_value_cid: str | None = None,
+) -> BindingEntryV1:
+    """Seal one bound runtime entry with mandatory ConstructedValueTestimonyV1.
+
+    Producer door for generator (and other) bound entries that must wire
+    without a delayed :class:`BindingStateWireGap`. Testimony is derived from
+    the bound Node's source fragment and actual value content, or accepted only
+    when it re-authenticates against that content.
+
+    Returns a successfully sealed entry whose :meth:`BindingEntryV1.wire`
+    succeeds. Unavailable testimony or value/testimony mismatch refuse here.
+    """
+    from sugar_source_tree.nodes import Node
+
+    if not isinstance(entry.state, Node):
+        raise BindingStateWireGap(
+            "binding state is not a constructed bound value; "
+            "only constructed Node bound entries seal with constructed-value testimony"
+        )
+    if cid_of_json(entry.coordinate.preimage) != entry.coordinate.cid:
+        raise BindingStateWireGap("binding coordinate CID mismatch")
+
+    derived_semantic = (
+        semantic_value_cid
+        if semantic_value_cid is not None
+        else _semantic_value_cid_for_bound_node(entry.state)
+    )
+    _require_runtime_cid(derived_semantic, "semanticValueCid")
+    derived = mint_constructed_value_testimony_v1(
+        source_fragment=entry.state.fragment,
+        semantic_value_cid=derived_semantic,
+    )
+
+    if testimony is None:
+        sealed_testimony = derived
+    else:
+        ConstructedValueTestimonyV1.decode(testimony.wire())
+        if testimony.cid != derived.cid:
+            raise BindingStateWireGap(
+                "constructed-value testimony does not match bound value content"
+            )
+        sealed_testimony = testimony
+
+    existing = entry.constructed_value_testimony
+    if existing is not None and existing.cid != sealed_testimony.cid:
+        raise BindingStateWireGap(
+            "constructed-value testimony does not match bound value content"
+        )
+
+    sealed = entry.with_testimony(sealed_testimony)
+    # Prove the seal: a successfully sealed state never delays wire refusal.
+    sealed.wire()
+    return sealed
+
+
+def seal_generator_binding_state_v1(
+    binding_state: tuple[object, ...],
+) -> tuple[object, ...]:
+    """Seal every bound BindingEntryV1 in a generator binding-state tuple.
+
+    Non-entry items (resume bindings, primitive test stubs) pass through.
+    Each bound entry exits with mandatory ConstructedValueTestimonyV1, or the
+    producer gaps loud before the generator instance is allocated.
+    """
+    sealed: list[object] = []
+    for item in binding_state:
+        if isinstance(item, BindingEntryV1):
+            sealed.append(seal_bound_binding_entry_v1(item))
+        else:
+            sealed.append(item)
+    return tuple(sealed)
 
 
 def node_construction_shape_cid(node: Node) -> str:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -311,7 +311,7 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
             replace(
                 entry,
                 state=_make_loop_ref(loop, entry, completion_kind),
-                sealed_state=BoundBindingStateV1(None),
+                sealed_state=None,  # unsealed until face testimony is sealed
             )
             for entry in pre_entries
         )
@@ -346,7 +346,7 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
             replace(
                 halted_scope.get(name, entry),
                 coordinate=entry.coordinate,
-                sealed_state=BoundBindingStateV1(None),
+                sealed_state=None,  # unsealed until face testimony is sealed
             )
             for name, entry in zip(carried_names, pre_entries, strict=True)
         )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3275,10 +3275,7 @@ class ClassDef(Statement):
         from sugar_lift_py_tests.sugar.class_constructor_body_sugar import (
             ClassConstructorBodySugar,
         )
-        from sugar_source_tree.binding_provenance import (
-            BindingCoordinateV1,
-            BoundBindingStateV1,
-        )
+        from sugar_source_tree.binding_provenance import BindingCoordinateV1
         from sugar_source_tree.binding_state import BindingEntryV1
 
         initializer = next(
@@ -3302,7 +3299,7 @@ class ClassDef(Statement):
             receiver_coordinate_cid = coordinate.cid
             initializer_scope = {
                 receiver_param.name: BindingEntryV1(
-                    coordinate, receiver, BoundBindingStateV1(None)
+                    coordinate, receiver, None  # unsealed; seal when testified
                 ),
                 **scope,
             }

--- a/implementations/python/sugar-source-tree/tests/test_binding_provenance_v1.py
+++ b/implementations/python/sugar-source-tree/tests/test_binding_provenance_v1.py
@@ -59,15 +59,21 @@ def test_constructed_value_testimony_is_authenticated_and_unavailable_is_loud():
         value.fragment, cid_of_json({"kind": "IntLiteralSugar", "value": 1})
     )
     assert ConstructedValueTestimonyV1.decode(testimony.wire()) == testimony
+    # Bound sealed state requires testimony at construction; None is unrepresentable.
+    with pytest.raises(BindingProvenanceGap, match="testimony unavailable"):
+        BoundBindingStateV1(None)
+    # Sealed wire entry without a bound state cannot project testimony.
+    from sugar_source_tree.binding_provenance import UnboundBindingStateV1
+
     entry = BindingEntryV1(
         BindingCoordinateV1.mint(
             cid_of_json({"scope": "arbitrary"}),
             assignments[0].targets[0].fragment,
             ("targets", 0),
         ),
-        BoundBindingStateV1(None),
+        UnboundBindingStateV1(value.fragment.seal().cid),
     )
-    with pytest.raises(BindingProvenanceGap, match="testimony unavailable"):
+    with pytest.raises(BindingProvenanceGap, match="not a bound value"):
         entry.constructed_value_testimony_cid()
 
 

--- a/implementations/python/sugar-source-tree/tests/test_generator_binding_testimony.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_binding_testimony.py
@@ -1,0 +1,177 @@
+"""Generator bound entries seal with mandatory ConstructedValueTestimonyV1.
+
+Producer (seal_bound_binding_entry_v1 / seal_generator_binding_state_v1) mints
+testimony from the bound Node's source fragment and actual value content.
+Successfully sealed entries wire without delayed BindingStateWireGap.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from dataclasses import replace
+
+import pytest
+
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.binding_provenance import (
+    BoundBindingStateV1,
+    ConstructedValueTestimonyV1,
+)
+from sugar_source_tree.binding_state import (
+    BindingEntryV1,
+    BindingStateWireGap,
+    RuntimeBindingEntryFactoryV1,
+    seal_bound_binding_entry_v1,
+    seal_generator_binding_state_v1,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _bound_entry(source: str = "def gen():\n    bound = 7\n    yield bound\n"):
+    function = _function(source)
+    assignments = [node for node in function.walk() if node.kind == "Assign"]
+    assert assignments, "need an assignment to bind"
+    value_node = assignments[0].value
+    site = assignments[0].targets[0].fragment
+    factory = RuntimeBindingEntryFactoryV1(
+        cid_of_json({"scope": function.fragment.seal().to_dict()})
+    )
+    entry = factory.mint_entry(
+        binding_site=site,
+        projection_path=("formal", 0),
+        state=value_node,
+    )
+    return function, value_node, entry
+
+
+def test_bound_binding_state_requires_testimony_at_construction():
+    with pytest.raises(Exception, match="testimony unavailable"):
+        BoundBindingStateV1(None)
+
+
+def test_unsealed_entry_has_no_bound_projection():
+    _fn, _value, entry = _bound_entry()
+    assert entry.sealed_state is None
+    assert entry.constructed_value_testimony is None
+    with pytest.raises(BindingStateWireGap, match="no authenticated sealed"):
+        entry.wire()
+
+
+def test_seal_mints_testimony_from_value_content_and_wires():
+    _fn, value_node, entry = _bound_entry(
+        "def gen():\n    bound = 7\n    yield bound\n"
+    )
+    sealed = seal_bound_binding_entry_v1(entry)
+    testimony = sealed.require_constructed_value_testimony()
+    assert isinstance(testimony, ConstructedValueTestimonyV1)
+    assert testimony.source_fragment_cid == value_node.fragment.seal().cid
+    # Wire succeeds now — no delayed gap after successful seal.
+    projected = sealed.wire()
+    assert projected["state"]["kind"] == "bound"
+    assert (
+        projected["state"]["testimony"]["constructedValueTestimonyCid"] == testimony.cid
+    )
+
+
+def test_identical_source_and_value_yield_identical_testimony():
+    _fn, value_node, entry = _bound_entry(
+        "def gen():\n    bound = 7\n    yield bound\n"
+    )
+    left = seal_bound_binding_entry_v1(entry)
+    right = seal_bound_binding_entry_v1(entry)
+    assert (
+        left.require_constructed_value_testimony().cid
+        == right.require_constructed_value_testimony().cid
+    )
+    assert left.wire() == right.wire()
+    # Explicit mint of the same content matches the producer.
+    semantic = left.require_constructed_value_testimony().semantic_value_cid
+    reminted = ConstructedValueTestimonyV1.mint(value_node.fragment, semantic)
+    assert reminted.cid == left.require_constructed_value_testimony().cid
+
+
+def test_changed_value_content_changes_testimony():
+    _fn_a, _va, entry_a = _bound_entry("def gen():\n    bound = 1\n    yield bound\n")
+    _fn_b, _vb, entry_b = _bound_entry("def gen():\n    bound = 2\n    yield bound\n")
+    sealed_a = seal_bound_binding_entry_v1(entry_a)
+    sealed_b = seal_bound_binding_entry_v1(entry_b)
+    assert (
+        sealed_a.require_constructed_value_testimony().cid
+        != sealed_b.require_constructed_value_testimony().cid
+    )
+
+
+def test_changed_binding_coordinate_changes_entry_wire():
+    function = _function("def gen():\n    a = 1\n    b = 1\n")
+    assignments = [node for node in function.walk() if node.kind == "Assign"]
+    factory = RuntimeBindingEntryFactoryV1(
+        cid_of_json({"scope": function.fragment.seal().to_dict()})
+    )
+    first = factory.mint_entry(
+        binding_site=assignments[0].targets[0].fragment,
+        projection_path=("targets", 0),
+        state=assignments[0].value,
+    )
+    second = factory.mint_entry(
+        binding_site=assignments[1].targets[0].fragment,
+        projection_path=("targets", 0),
+        state=assignments[1].value,
+    )
+    sealed_first = seal_bound_binding_entry_v1(first)
+    sealed_second = seal_bound_binding_entry_v1(second)
+    assert sealed_first.coordinate.cid != sealed_second.coordinate.cid
+    assert sealed_first.wire() != sealed_second.wire()
+
+
+def test_mismatched_testimony_refuses_at_seal():
+    _fn, value_node, entry = _bound_entry(
+        "def gen():\n    bound = 7\n    yield bound\n"
+    )
+    lying = ConstructedValueTestimonyV1.mint(
+        value_node.fragment,
+        cid_of_json({"kind": "lying-value", "value": 99}),
+    )
+    with pytest.raises(BindingStateWireGap, match="does not match bound value content"):
+        seal_bound_binding_entry_v1(entry, testimony=lying)
+
+
+def test_stale_coordinate_refuses_at_seal():
+    _fn, _value, entry = _bound_entry("def gen():\n    bound = 7\n    yield bound\n")
+    stale = replace(
+        entry,
+        coordinate=replace(entry.coordinate, cid="blake3-512:" + "0" * 128),
+    )
+    with pytest.raises(BindingStateWireGap, match="coordinate CID mismatch"):
+        seal_bound_binding_entry_v1(stale)
+
+
+def test_seal_generator_binding_state_seals_entries_only():
+    _fn, _value, entry = _bound_entry("def gen():\n    bound = 7\n    yield bound\n")
+    resume = ("resume-stub",)
+    sealed = seal_generator_binding_state_v1((entry, "bound:x", *resume))
+    assert len(sealed) == 3
+    assert isinstance(sealed[0], BindingEntryV1)
+    assert sealed[0].require_constructed_value_testimony() is not None
+    assert sealed[0].wire()["state"]["kind"] == "bound"
+    assert sealed[1] == "bound:x"
+    assert sealed[2] == "resume-stub"
+
+
+def test_successfully_sealed_entry_never_delays_wire_gap():
+    _fn, _value, entry = _bound_entry("def gen():\n    bound = 7\n    yield bound\n")
+    sealed = seal_bound_binding_entry_v1(entry)
+    # Round-trip wire is stable and never raises BindingStateWireGap.
+    first = sealed.wire()
+    second = sealed.wire()
+    assert first == second
+    assert first["state"]["testimony"]["constructedValueTestimonyCid"] == (
+        sealed.require_constructed_value_testimony().cid
+    )

--- a/implementations/python/sugar-source-tree/tests/test_runtime_binding_entry_v1.py
+++ b/implementations/python/sugar-source-tree/tests/test_runtime_binding_entry_v1.py
@@ -48,7 +48,9 @@ def test_runtime_entry_keeps_live_node_and_projects_only_pure_wire():
     assignment, live_state, entry = _entry()
     assert entry.state is live_state
     assert "renamed" not in entry.coordinate.preimage
-    with pytest.raises(RuntimeBindingEntryGap, match="testimony unavailable"):
+    # Unsealed bound entry: sealed_state is None until producer testimony seals.
+    assert entry.sealed_state is None
+    with pytest.raises(RuntimeBindingEntryGap, match="no authenticated sealed"):
         entry.wire()
 
     testimony = ConstructedValueTestimonyV1.mint(


### PR DESCRIPTION
## Summary

Priority dispatch: every sealed bound entry used by `GeneratorConstructionV1.to_term()` carries producer-minted `ConstructedValueTestimonyV1` from authenticated binding coordinate + actual value content.

- **`BoundBindingStateV1`**: testimony is mandatory at construction. Unsealed intermediate states use `sealed_state=None` on the runtime carrier — not a half-sealed `BoundBindingStateV1(None)`.
- **Producer** (`seal_bound_binding_entry_v1` / `seal_generator_binding_state_v1` in `binding_state.py`): mints testimony from the bound Node's source fragment and value content; re-authenticates supplied testimony; refuses mismatch and unavailability with `BindingStateWireGap` at seal time; proves `wire()` succeeds before return.
- **`GeneratorConstructionV1.allocate`**: seals every `BindingEntryV1` before the instance exists.
- **Consumer** (`_generator_value_testimony`): projects sealed entries via coordinate + constructed-value testimony CID + full `entry.wire()`; never fabricates testimony; unsealed entries refuse.

## Acceptance

| Check | |
| --- | --- |
| Sealed bound entry carries ConstructedValueTestimonyV1 | green |
| Identical source/value → identical testimony/terms | green |
| Changed value or coordinate → different testimony/term | green |
| Mismatched value/testimony refuses at seal | green |
| Unavailable testimony prevents sealing (typed-loud gap) | green |
| Successfully sealed state wires without delayed BindingStateWireGap | green |
| to_term reads sealed testimony (not coordinate-only / consumer-fabricated) | green |
| Primitive binding stubs still allocate | green |

## Must not touch (held)

ManagerBinding, BindingEntryV1.wire() weakening, None fallback in to_term(), identity/repr/spelling, carrier/ExitSet, consumer-fabricated testimony.

## Shell deleted

`BoundBindingStateV1(testimony=None)` half-seal — illegal at type construction. Unsealed optionality is `sealed_state=None`.

## Tests

```
bin/bpytest tests/test_generator_binding_testimony_term.py tests/test_generator_manager_binding_term.py tests/test_generator_construction_v1.py -q
# 27 passed

bin/bpytest tests/test_generator_binding_testimony.py tests/test_runtime_binding_entry_v1.py tests/test_binding_provenance_v1.py -q
# 21 passed (sugar-source-tree)

local: 48 passed across producer + consumer focused suites
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seal generator bound binding entries with `ConstructedValueTestimonyV1`
> - Introduces `seal_bound_binding_entry_v1` and `seal_generator_binding_state_v1` in [`binding_state.py`](https://github.com/TSavo/sugar/pull/6661/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40) to authenticate and seal `BindingEntryV1` items with minted `ConstructedValueTestimonyV1` before generator allocation.
> - `GeneratorConstructionV1.allocate` now seals the provided `binding_state` before computing the instance preimage and coordinate, so the sealed testimony is reflected in the construction term.
> - `_generator_value_testimony` in [`generator_construction.py`](https://github.com/TSavo/sugar/pull/6661/files#diff-35db5b3e2bf70dbb9aa1b5a6d30899e84d402ab203905605799dbd5855b1f072) now returns a `sealed-bound-binding` record with testimony CID instead of a `binding-coordinate` projection.
> - `BoundBindingStateV1` in [`binding_provenance.py`](https://github.com/TSavo/sugar/pull/6661/files#diff-31a51c7781695c73ae1a14807ce7047e4b99d195b5d82fed68253687a818e78a) now requires testimony at construction; passing `None` raises `BindingProvenanceGap`.
> - Risk: Unsealed or mismatched binding entries that previously succeeded will now raise at allocation time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06cfe9f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->