### PR TITLE
Factored assertion: try/finally, source-resource stack, returned stack

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -90,6 +90,13 @@ class WithEffectBoundarySugar(Sugar):
                 self.contract_ref.import_signature,
                 manager_value,
             )
+            # Reduce the body suite ONCE per manager face. Factored message
+            # faces are alternative guards over the same body occurrence —
+            # re-reducing would re-enter nested resources and invent a second
+            # evaluation of the same source suite under each message face.
+            body_es_once = promote_raise_halts(
+                reduce_block_to_exitset(self.body, ctx)
+            )
             for face_guard, semantics in self._guarded_semantics():
                 expected = project_formal_selector_v1(
                     semantics.expected_type_operand,
@@ -132,9 +139,7 @@ class WithEffectBoundarySugar(Sugar):
                     )
                     continue
 
-                body_es = promote_raise_halts(
-                    reduce_block_to_exitset(self.body, ctx)
-                ).guarded(face_manager.guard)
+                body_es = body_es_once.guarded(face_manager.guard)
 
                 disposition = EffectBoundaryDisposition(
                     matcher=AuthenticatedRaiseMatcher(

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_source_resource_stack.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_source_resource_stack.py
@@ -1,0 +1,595 @@
+"""Stack a factored assertion manager with a source-resource manager.
+
+Source order is nesting order: first manager is outer (enter first, exit last).
+Each outgoing body face runs both required exits exactly once. Assertion
+suppression (consume matching raise / unmet / residual) stays separate from
+resource disposition (NeverSuppresses / truthiness).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sugar_lift_py_tests.context_manager_contract import (
+    CallParameterV1,
+    EffectBoundarySemanticsV1,
+    ExceptionInfoBindingV1,
+    ExpectsModeV1,
+    FormalArgumentProjectionV1,
+    ImportSignatureV2,
+    LiteralDefaultV1,
+    NeverSuppressesDispositionV1,
+    NoDefaultV1,
+    NoMessagePatternV1,
+    OptionalFormalArgumentProjectionV1,
+    PositionalOrKeywordV1,
+    RaiseEffectKindV1,
+    ReturnTruthinessDispositionV1,
+)
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.effect.expectation_not_met_effect import (
+    ExpectationNotMetEffect,
+)
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor import StringValue, TermValue
+from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+from sugar_lift_py_tests.ir import PrimitiveSort, _Atomic, ctor
+from sugar_lift_py_tests.outcome import Complete, Completed, Halted, Incomplete
+from sugar_lift_py_tests.outcome.exit_set import ExitSet
+from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+from sugar_lift_py_tests.sugar.resource_coord_sugar import (
+    ExitTracebackRefSugar,
+    ExitTypeRefSugar,
+    ExitValueRefSugar,
+    ManagerRefSugar,
+)
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+    WithEffectBoundarySugar,
+)
+from sugar_lift_py_tests.sugar.with_source_resource_sugar import (
+    WithSourceResourceSugar,
+)
+
+
+def _identity(name: str):
+    from sugar_lift_py_tests.ir import str_const
+
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
+
+
+class _Expected:
+    def __init__(self, name: str):
+        self.identity = _identity(name)
+
+    def exception_type_identity(self):
+        return self.identity
+
+
+def _state(marker: str):
+    return _ReducedBlock(
+        entries=(marker,), can_fall_through=False, fall_through=()
+    )
+
+
+class Fixed(Sugar):
+    def __init__(self, outcome):
+        self.outcome = outcome
+
+    def desugar(self, ctx=None):
+        del ctx
+        return self.outcome
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+class _RecordingProtocol:
+    """Records enter/exit order and count."""
+
+    def __init__(self, *, name: str, exit_value=None, exit_outcome=None):
+        self.name = name
+        self.enter_calls = 0
+        self.exit_calls = 0
+        self.order = []
+        self.exit_value = exit_value if exit_value is not None else TermValue(False)
+        self._exit_outcome = exit_outcome
+        self.enter_value = TermValue(f"enter-{name}")
+
+    def enter_resource_outcome(self, ctx=None):
+        del ctx
+        self.enter_calls += 1
+        self.order.append(f"enter:{self.name}")
+        return Complete(SimpleNamespace(enter_value=self.enter_value))
+
+    def exit_outcome_for(self, entered, ctx=None):
+        del ctx
+        self.exit_calls += 1
+        self.order.append(f"exit:{self.name}")
+        if self._exit_outcome is not None:
+            return self._exit_outcome
+        return Complete(self.exit_value)
+
+
+def _protocol_calls(slot: str, face_id: str):
+    enter_definition = SourceFragmentCoordinateV1(
+        "blake3-512:" + "e" * 128, 1, 0, 1, 1
+    )
+    exit_definition = SourceFragmentCoordinateV1(
+        "blake3-512:" + "x" * 128, 2, 0, 2, 1
+    )
+    enter = MethodCallSugar(
+        receiver=ManagerRefSugar(slot_id=slot, site=None),
+        name="__enter__",
+        args=(),
+        native_definition_coordinate=enter_definition,
+        site=None,
+    )
+    exit_ = MethodCallSugar(
+        receiver=ManagerRefSugar(slot_id=slot, site=None),
+        name="__exit__",
+        args=(
+            ExitTypeRefSugar(face_id=face_id, site=None),
+            ExitValueRefSugar(face_id=face_id, site=None),
+            ExitTracebackRefSugar(face_id=face_id, site=None),
+        ),
+        native_definition_coordinate=exit_definition,
+        site=None,
+    )
+    return enter, exit_, enter_definition, exit_definition
+
+
+def _source_resource(*, protocol, summary, body, slot="resource-slot", face_id="res-exit"):
+    enter, exit_, enter_def, exit_def = _protocol_calls(slot, face_id)
+    return WithSourceResourceSugar(
+        manager=Fixed(Complete(TermValue(1))),
+        enter=enter,
+        exit=exit_,
+        enter_definition=enter_def,
+        exit_definition=exit_def,
+        protocol=protocol,
+        summary=summary,
+        body=body,
+        manager_slot_id=slot,
+        enter_slot_id=None,
+        exit_face_id=face_id,
+        site="stack-resource.py:1:0",
+    )
+
+
+def _never_summary():
+    return SimpleNamespace(
+        semantics=SimpleNamespace(
+            exit=SimpleNamespace(disposition=NeverSuppressesDispositionV1())
+        )
+    )
+
+
+def _truthiness_summary():
+    return SimpleNamespace(
+        semantics=SimpleNamespace(
+            exit=SimpleNamespace(disposition=ReturnTruthinessDispositionV1())
+        )
+    )
+
+
+def _factored_boundary_faces():
+    none_face = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        NoMessagePatternV1(),
+        ExceptionInfoBindingV1(),
+    )
+    pattern_face = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        OptionalFormalArgumentProjectionV1(1),
+        ExceptionInfoBindingV1(),
+    )
+    return ExitSet(
+        (
+            Completed(_Atomic("match-none-face", ()), none_face),
+            Completed(_Atomic("match-pattern-face", ()), pattern_face),
+        )
+    )
+
+
+def _factored_boundary(body: ExitSet, *, pattern=None, observation_slot_id="excinfo"):
+    expected = _Expected("ValueError")
+    if pattern is None:
+        pattern = StringValue("needle")
+    parameters = (
+        CallParameterV1(
+            "expected",
+            PrimitiveSort("Value"),
+            PositionalOrKeywordV1(),
+            True,
+            NoDefaultV1(),
+        ),
+        CallParameterV1(
+            "match",
+            PrimitiveSort("Value"),
+            PositionalOrKeywordV1(),
+            False,
+            LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
+        ),
+    )
+    manager_value = CallSiteValue(
+        target_name="expect",
+        arg_values=(expected, pattern),
+        parameters=tuple(p.name for p in parameters),
+        term=ctor("call:expect", []),
+        body=None,
+        keyword_names=(),
+    )
+    return WithEffectBoundarySugar(
+        manager=Fixed(Complete(manager_value)),
+        body=(Fixed(body),),
+        semantics=None,
+        contract_ref=SimpleNamespace(
+            import_signature=ImportSignatureV2(parameters)
+        ),
+        context_manager_edge=None,
+        boundary_faces=_factored_boundary_faces(),
+        observation_slot_id=observation_slot_id,
+        site="stack-boundary.py:1:0",
+    )
+
+
+def _raise(name: str, marker: str, *, message=None, occurrence=None):
+    occ = occurrence or f"body.py:1:0:{marker}"
+    raised_value = None
+    if message is not None:
+        raised_value = CallSiteValue(
+            name,
+            (message,),
+            ("message",),
+            ctor(f"call:{name}", []),
+            None,
+        )
+    return Halted(
+        _Atomic(f"body-{marker}", ()),
+        RaiseEffect(
+            exception_name=name,
+            blame=occ,
+            occurrence=occ,
+            exception_type_coordinate=_identity(name),
+            exception_type_mro=(_identity(name),),
+            raised_value=raised_value,
+            producer_node_owner="StackBody.desugar",
+        ),
+        _state(marker),
+    )
+
+
+def _observed_binding(face):
+    from sugar_lift_py_tests.effect_router import ObservedEffectBinding
+
+    record = face.value if isinstance(face, Completed) else face.state
+    entries = getattr(record, "entries", ()) or ()
+    return next(
+        (entry for entry in entries if isinstance(entry, ObservedEffectBinding)),
+        None,
+    )
+
+
+def _as_exitset(outcome):
+    from sugar_lift_py_tests.outcome import outcome_to_exitset
+
+    if isinstance(outcome, ExitSet):
+        return outcome
+    return outcome_to_exitset(outcome)
+
+
+def _multi_body():
+    matching = _raise(
+        "ValueError",
+        "matching",
+        occurrence="body.py:10:8:matching",
+        message=StringValue("needle"),
+    )
+    mismatch = _raise(
+        "TypeError",
+        "mismatch",
+        occurrence="body.py:12:8:mismatch",
+        message=StringValue("other"),
+    )
+    completed = Completed(_Atomic("body-completed", ()), _state("completed-no-raise"))
+    return ExitSet((matching, mismatch, completed)), matching.effect, mismatch.effect
+
+
+# ---------------------------------------------------------------------------
+# Source order + dual exit
+# ---------------------------------------------------------------------------
+
+
+def test_resource_outer_assertion_inner_enter_exit_source_order():
+    """with resource, expect: enter resource → body/assert → exit resource.
+
+    Assertion has no enter/exit protocol; resource enter once, exit once per
+    construction (fanned across body faces). Source order: resource outer.
+    """
+    body, matching_effect, mismatch_effect = _multi_body()
+    protocol = _RecordingProtocol(name="resource")
+    boundary = _factored_boundary(body)
+    outer = _source_resource(
+        protocol=protocol,
+        summary=_never_summary(),
+        body=(boundary,),
+    )
+    exits = _as_exitset(outer.desugar())
+    assert protocol.enter_calls == 1
+    # Parametric exit: once per enter, not once per body face construction.
+    assert protocol.exit_calls == 1
+    assert protocol.order == ["enter:resource", "exit:resource"]
+
+    # Both message faces survive the outer resource fan-out.
+    text = " ".join(str(face.guard) for face in exits.exits)
+    assert "match-none-face" in text
+    assert "match-pattern-face" in text
+    assert "body-matching" in text
+    assert "body-mismatch" in text
+
+    # Assertion authority: matching consumed with binding; mismatch restored.
+    assert any(
+        isinstance(face, Completed) and _observed_binding(face) is not None
+        and _observed_binding(face).effect is matching_effect
+        for face in exits.exits
+    )
+    assert any(
+        isinstance(face, Halted) and face.effect is mismatch_effect
+        for face in exits.exits
+    )
+    # Unmet still ExpectationNotMet (assertion authority, not resource).
+    assert any(
+        isinstance(face, Halted) and isinstance(face.effect, ExpectationNotMetEffect)
+        for face in exits.exits
+    )
+
+
+def test_assertion_outer_resource_inner_enter_exit_source_order():
+    """with expect, resource: enter resource (inner) once; exit once; assert outer.
+
+    Outer assertion routes the whole resource ExitSet under dual message faces.
+    """
+    body, matching_effect, mismatch_effect = _multi_body()
+    protocol = _RecordingProtocol(name="resource")
+    resource = _source_resource(
+        protocol=protocol,
+        summary=_never_summary(),
+        body=(Fixed(body),),
+    )
+    # Outer factored boundary over the resource sugar as its body suite.
+    # Manager for assertion still factored faces.
+    expected = _Expected("ValueError")
+    pattern = StringValue("needle")
+    parameters = (
+        CallParameterV1(
+            "expected",
+            PrimitiveSort("Value"),
+            PositionalOrKeywordV1(),
+            True,
+            NoDefaultV1(),
+        ),
+        CallParameterV1(
+            "match",
+            PrimitiveSort("Value"),
+            PositionalOrKeywordV1(),
+            False,
+            LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
+        ),
+    )
+    manager_value = CallSiteValue(
+        target_name="expect",
+        arg_values=(expected, pattern),
+        parameters=tuple(p.name for p in parameters),
+        term=ctor("call:expect", []),
+        body=None,
+        keyword_names=(),
+    )
+    outer = WithEffectBoundarySugar(
+        manager=Fixed(Complete(manager_value)),
+        body=(resource,),
+        semantics=None,
+        contract_ref=SimpleNamespace(
+            import_signature=ImportSignatureV2(parameters)
+        ),
+        context_manager_edge=None,
+        boundary_faces=_factored_boundary_faces(),
+        observation_slot_id="excinfo",
+        site="stack-boundary-outer.py:1:0",
+    )
+    exits = _as_exitset(outer.desugar())
+    assert protocol.enter_calls == 1
+    assert protocol.exit_calls == 1
+    assert protocol.order == ["enter:resource", "exit:resource"]
+
+    text = " ".join(str(face.guard) for face in exits.exits)
+    assert "match-none-face" in text
+    assert "match-pattern-face" in text
+
+    assert any(
+        isinstance(face, Completed)
+        and _observed_binding(face) is not None
+        and _observed_binding(face).effect is matching_effect
+        for face in exits.exits
+    )
+    assert any(
+        isinstance(face, Halted) and face.effect is mismatch_effect
+        for face in exits.exits
+    )
+
+
+def test_each_outgoing_face_keeps_both_manager_identities():
+    """Factored message guards + resource face binding facts ride every path."""
+    body, matching_effect, _ = _multi_body()
+    protocol = _RecordingProtocol(name="resource")
+    boundary = _factored_boundary(body)
+    outer = _source_resource(
+        protocol=protocol,
+        summary=_never_summary(),
+        body=(boundary,),
+        face_id="res-exit",
+    )
+    exits = _as_exitset(outer.desugar())
+    assert protocol.exit_calls == 1
+    # Every face still carries a factored message-face guard.
+    for face in exits.exits:
+        text = str(face.guard)
+        assert (
+            "match-none-face" in text or "match-pattern-face" in text
+        ), text
+
+
+def test_suppression_authorities_remain_separate():
+    """Assertion consumes matching raise; resource NeverSuppresses does not steal.
+
+    Twin: truthy resource exit would suppress raises, but assertion still owns
+    the matching face when it is inner (resource sees assertion's result).
+    """
+    body, matching_effect, mismatch_effect = _multi_body()
+
+    # Resource outer + NeverSuppresses: residual mismatch restored as-is.
+    p_never = _RecordingProtocol(name="never")
+    never_stack = _source_resource(
+        protocol=p_never,
+        summary=_never_summary(),
+        body=(_factored_boundary(body),),
+    )
+    never_exits = _as_exitset(never_stack.desugar())
+    assert any(
+        isinstance(face, Halted) and face.effect is mismatch_effect
+        for face in never_exits.exits
+    )
+    # Matching was already consumed by assertion → Completed, not re-halted.
+    assert any(
+        isinstance(face, Completed)
+        and _observed_binding(face) is not None
+        and _observed_binding(face).effect is matching_effect
+        for face in never_exits.exits
+    )
+
+    # Resource outer + truthy exit: only residual raises could be suppressed;
+    # assertion-consumed completions stay completed (no re-raise invention).
+    p_truthy = _RecordingProtocol(name="truthy", exit_value=TermValue(True))
+    truthy_stack = _source_resource(
+        protocol=p_truthy,
+        summary=_truthiness_summary(),
+        body=(_factored_boundary(body),),
+    )
+    truthy_exits = _as_exitset(truthy_stack.desugar())
+    # Mismatch raise is suppressed by truthy resource exit.
+    assert not any(
+        isinstance(face, Halted) and face.effect is mismatch_effect
+        for face in truthy_exits.exits
+    ), truthy_exits.exits
+    # Assertion's consumed matching face still completes with binding.
+    assert any(
+        isinstance(face, Completed)
+        and _observed_binding(face) is not None
+        and _observed_binding(face).effect is matching_effect
+        for face in truthy_exits.exits
+    )
+    # Unmet ExpectationNotMet is not a RaiseEffect — truthiness does not
+    # invent suppression for it; NeverSuppresses path keeps it halted.
+    assert any(
+        isinstance(face, Halted) and isinstance(face.effect, ExpectationNotMetEffect)
+        for face in never_exits.exits
+    )
+
+
+def test_twin_source_order_swaps_outer_type():
+    """Discrimination: resource-first vs assertion-first swap the outer sugar."""
+    body, _, _ = _multi_body()
+    protocol_a = _RecordingProtocol(name="a")
+    protocol_b = _RecordingProtocol(name="b")
+
+    resource_outer = _source_resource(
+        protocol=protocol_a,
+        summary=_never_summary(),
+        body=(_factored_boundary(body),),
+    )
+    assert isinstance(resource_outer, WithSourceResourceSugar)
+    assert isinstance(resource_outer.body[0], WithEffectBoundarySugar)
+
+    # Assertion outer wrapping resource.
+    resource_inner = _source_resource(
+        protocol=protocol_b,
+        summary=_never_summary(),
+        body=(Fixed(body),),
+    )
+    expected = _Expected("ValueError")
+    parameters = (
+        CallParameterV1(
+            "expected",
+            PrimitiveSort("Value"),
+            PositionalOrKeywordV1(),
+            True,
+            NoDefaultV1(),
+        ),
+        CallParameterV1(
+            "match",
+            PrimitiveSort("Value"),
+            PositionalOrKeywordV1(),
+            False,
+            LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
+        ),
+    )
+    manager_value = CallSiteValue(
+        target_name="expect",
+        arg_values=(expected, StringValue("needle")),
+        parameters=tuple(p.name for p in parameters),
+        term=ctor("call:expect", []),
+        body=None,
+        keyword_names=(),
+    )
+    assertion_outer = WithEffectBoundarySugar(
+        manager=Fixed(Complete(manager_value)),
+        body=(resource_inner,),
+        semantics=None,
+        contract_ref=SimpleNamespace(
+            import_signature=ImportSignatureV2(parameters)
+        ),
+        context_manager_edge=None,
+        boundary_faces=_factored_boundary_faces(),
+        observation_slot_id="excinfo",
+        site="order-twin.py:1:0",
+    )
+    assert isinstance(assertion_outer, WithEffectBoundarySugar)
+    assert isinstance(assertion_outer.body[0], WithSourceResourceSugar)
+    assert type(resource_outer) is not type(assertion_outer)
+
+    # Both evaluate their resource enter/exit once.
+    _as_exitset(resource_outer.desugar())
+    _as_exitset(assertion_outer.desugar())
+    assert protocol_a.enter_calls == protocol_a.exit_calls == 1
+    assert protocol_b.enter_calls == protocol_b.exit_calls == 1
+
+
+def test_excinfo_only_on_consumed_occurrence_through_stack():
+    """Stacked resource does not invent or rebind excinfo on residual faces."""
+    body, matching_effect, mismatch_effect = _multi_body()
+    protocol = _RecordingProtocol(name="resource")
+    outer = _source_resource(
+        protocol=protocol,
+        summary=_never_summary(),
+        body=(_factored_boundary(body),),
+    )
+    exits = _as_exitset(outer.desugar())
+    bound = {
+        _observed_binding(face).effect
+        for face in exits.exits
+        if _observed_binding(face) is not None
+    }
+    assert matching_effect in bound
+    assert mismatch_effect not in bound
+    assert all(
+        e.occurrence == "body.py:10:8:matching" for e in bound
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_try_finally.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_try_finally.py
@@ -1,0 +1,498 @@
+"""Join factored assertion boundaries with try/finally.
+
+Factored message-pattern faces (match-none / match-pattern) route a body, then
+try/finally (``ExitSet.and_finally`` — the same algebra ``TrySugar`` fans) runs
+cleanup over every outgoing face without collapsing either message guard:
+
+- matching and mismatching faces retain original guards through try
+- finally runs on consumed, unmet, and retained-halt paths
+- ordinary cleanup restores incoming result/state
+- terminal cleanup overrides
+- excinfo binds only the consumed occurrence
+- None/pattern and restoring/overriding twins discriminate
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sugar_lift_py_tests.context_manager_contract import (
+    CallParameterV1,
+    EffectBoundarySemanticsV1,
+    ExceptionInfoBindingV1,
+    ExpectsModeV1,
+    FormalArgumentProjectionV1,
+    ImportSignatureV2,
+    LiteralDefaultV1,
+    NoDefaultV1,
+    NoMessagePatternV1,
+    OptionalFormalArgumentProjectionV1,
+    PositionalOrKeywordV1,
+    RaiseEffectKindV1,
+)
+from sugar_lift_py_tests.effect.expectation_not_met_effect import (
+    ExpectationNotMetEffect,
+)
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor import StringValue
+from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+from sugar_lift_py_tests.ir import PrimitiveSort, _Atomic, ctor, make_var
+from sugar_lift_py_tests.outcome import Complete, Completed, Halted
+from sugar_lift_py_tests.outcome.exit_set import ExitSet
+from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
+    WithEffectBoundarySugar,
+)
+
+
+def _identity(name: str):
+    from sugar_lift_py_tests.ir import str_const
+
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
+
+
+class _Expected:
+    def __init__(self, name: str):
+        self.identity = _identity(name)
+
+    def exception_type_identity(self):
+        return self.identity
+
+
+def _state(marker: str, *extra):
+    return _ReducedBlock(
+        entries=(marker, *extra),
+        can_fall_through=False,
+        fall_through=(),
+    )
+
+
+class Fixed(Sugar):
+    def __init__(self, outcome):
+        self.outcome = outcome
+
+    def desugar(self, ctx=None):
+        del ctx
+        return self.outcome
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+def _factored_boundary_faces():
+    none_face = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        NoMessagePatternV1(),
+        ExceptionInfoBindingV1(),
+    )
+    pattern_face = EffectBoundarySemanticsV1(
+        ExpectsModeV1(),
+        RaiseEffectKindV1(),
+        FormalArgumentProjectionV1(0),
+        OptionalFormalArgumentProjectionV1(1),
+        ExceptionInfoBindingV1(),
+    )
+    return ExitSet(
+        (
+            Completed(_Atomic("match-none-face", ()), none_face),
+            Completed(_Atomic("match-pattern-face", ()), pattern_face),
+        )
+    )
+
+
+def _raise(
+    name: str,
+    marker: str,
+    *,
+    occurrence: str | None = None,
+    message: object | None = None,
+):
+    occ = occurrence or f"body.py:1:0:{marker}"
+    raised_value = None
+    if message is not None:
+        raised_value = CallSiteValue(
+            name,
+            (message,),
+            ("message",),
+            ctor(f"call:{name}", []),
+            None,
+        )
+    return Halted(
+        _Atomic(f"body-{marker}", ()),
+        RaiseEffect(
+            exception_name=name,
+            blame=occ,
+            occurrence=occ,
+            exception_type_coordinate=_identity(name),
+            exception_type_mro=(_identity(name),),
+            raised_value=raised_value,
+            producer_node_owner="TryFinallyBody.desugar",
+        ),
+        _state(marker),
+    )
+
+
+def _multi_path_body():
+    matching = _raise(
+        "ValueError",
+        "matching",
+        occurrence="body.py:10:8:matching",
+        message=StringValue("needle"),
+    )
+    mismatch = _raise(
+        "TypeError",
+        "mismatch",
+        occurrence="body.py:12:8:mismatch",
+        message=StringValue("other"),
+    )
+    completed = Completed(
+        _Atomic("body-completed", ()),
+        _state("completed-no-raise"),
+    )
+    return (
+        ExitSet((matching, mismatch, completed)),
+        matching.effect,
+        mismatch.effect,
+    )
+
+
+def _observed_binding(face):
+    from sugar_lift_py_tests.effect_router import ObservedEffectBinding
+
+    record = face.value if isinstance(face, Completed) else face.state
+    entries = getattr(record, "entries", ()) or ()
+    return next(
+        (entry for entry in entries if isinstance(entry, ObservedEffectBinding)),
+        None,
+    )
+
+
+def _marker(face):
+    record = face.value if isinstance(face, Completed) else face.state
+    entries = getattr(record, "entries", ()) or ()
+    for entry in entries:
+        if isinstance(entry, str):
+            return entry
+    return None
+
+
+def _factored_boundary(body: ExitSet, *, pattern=None, observation_slot_id="excinfo"):
+    expected = _Expected("ValueError")
+    if pattern is None:
+        pattern = StringValue("needle")
+    parameters = (
+        CallParameterV1(
+            "expected",
+            PrimitiveSort("Value"),
+            PositionalOrKeywordV1(),
+            True,
+            NoDefaultV1(),
+        ),
+        CallParameterV1(
+            "match",
+            PrimitiveSort("Value"),
+            PositionalOrKeywordV1(),
+            False,
+            LiteralDefaultV1({"kind": "ctor", "name": "None", "args": []}),
+        ),
+    )
+    manager_value = CallSiteValue(
+        target_name="expect",
+        arg_values=(expected, pattern),
+        parameters=tuple(p.name for p in parameters),
+        term=ctor("call:expect", []),
+        body=None,
+        keyword_names=(),
+    )
+    return WithEffectBoundarySugar(
+        manager=Fixed(Complete(manager_value)),
+        body=(Fixed(body),),
+        semantics=None,
+        contract_ref=SimpleNamespace(
+            import_signature=ImportSignatureV2(parameters)
+        ),
+        context_manager_edge=None,
+        boundary_faces=_factored_boundary_faces(),
+        observation_slot_id=observation_slot_id,
+        site="factored-try-finally.py:1:0",
+    )
+
+
+def _boundary_exitset(body: ExitSet, **kwargs) -> ExitSet:
+    outcome = _factored_boundary(body, **kwargs).desugar()
+    assert isinstance(outcome, ExitSet), type(outcome)
+    return outcome
+
+
+def _join_try_finally(incoming: ExitSet, cleanup_es: ExitSet, *, restores: bool = True):
+    """try/finally algebra: cleanup fans over every face (``TrySugar`` shell)."""
+    calls = {"n": 0}
+
+    def cleanup():
+        calls["n"] += 1
+        return cleanup_es
+
+    if restores:
+        after = incoming.and_finally(cleanup)
+    else:
+        after = incoming.and_finally(cleanup, cleanup_restores=lambda _v: False)
+    return after, calls
+
+
+# ---------------------------------------------------------------------------
+# Core laws
+# ---------------------------------------------------------------------------
+
+
+def test_message_faces_retain_original_guards_through_try():
+    """Matching and mismatching faces keep match-none / match-pattern guards."""
+    body, _, _ = _multi_path_body()
+    pattern = SymbolicValue(make_var("open_pattern"))
+    incoming = _boundary_exitset(body, pattern=pattern)
+    cleanup = ExitSet.completed("cleanup-done")
+    routed, calls = _join_try_finally(incoming, cleanup)
+    assert calls["n"] == 1
+
+    guard_text = " ".join(str(face.guard) for face in routed.exits)
+    assert "match-none-face" in guard_text
+    assert "match-pattern-face" in guard_text
+    assert "body-matching" in guard_text
+    assert "body-mismatch" in guard_text
+    assert "body-completed" in guard_text
+    for face in routed.exits:
+        if "py.re_search" in str(face.guard):
+            assert "match-pattern-face" in str(face.guard)
+
+
+def test_finally_runs_on_consumed_unmet_and_retained_halt_paths():
+    """Ordinary finally fans across consumed, ExpectationNotMet, and residual halt."""
+    body, matching_effect, mismatch_effect = _multi_path_body()
+    incoming = _boundary_exitset(body)
+    routed, calls = _join_try_finally(incoming, ExitSet.completed("cleanup-done"))
+    assert calls["n"] == 1
+
+    consumed = [
+        face
+        for face in routed.exits
+        if isinstance(face, Completed)
+        and "match-none-face" in str(face.guard)
+        and "body-matching" in str(face.guard)
+        and _observed_binding(face) is not None
+    ]
+    assert consumed, routed.exits
+    assert all(
+        _observed_binding(face).effect is matching_effect for face in consumed
+    )
+
+    unmet = [
+        face
+        for face in routed.exits
+        if isinstance(face, Halted)
+        and isinstance(face.effect, ExpectationNotMetEffect)
+        and "body-completed" in str(face.guard)
+    ]
+    assert unmet
+    unmet_guards = " ".join(str(face.guard) for face in unmet)
+    assert "match-none-face" in unmet_guards
+    assert "match-pattern-face" in unmet_guards
+
+    retained = [
+        face
+        for face in routed.exits
+        if isinstance(face, Halted) and face.effect is mismatch_effect
+    ]
+    assert retained
+    retained_guards = " ".join(str(face.guard) for face in retained)
+    assert "match-none-face" in retained_guards
+    assert "match-pattern-face" in retained_guards
+    assert all(_observed_binding(face) is None for face in retained)
+    assert all(_marker(face) == "mismatch" for face in retained)
+
+
+def test_ordinary_cleanup_restores_incoming_result_and_state():
+    """Restoring finally keeps consumed binding, unmet effect, and halt state."""
+    body, matching_effect, mismatch_effect = _multi_path_body()
+    incoming = _boundary_exitset(body)
+    routed, _ = _join_try_finally(incoming, ExitSet.completed("cleanup-done"))
+
+    for face in routed.exits:
+        binding = _observed_binding(face)
+        if binding is not None:
+            assert binding.effect is matching_effect
+            assert binding.effect.occurrence == "body.py:10:8:matching"
+
+    for face in routed.exits:
+        if isinstance(face, Halted) and isinstance(
+            face.effect, ExpectationNotMetEffect
+        ):
+            assert _marker(face) == "completed-no-raise"
+
+    for face in routed.exits:
+        if isinstance(face, Halted) and face.effect is mismatch_effect:
+            assert _marker(face) == "mismatch"
+            assert face.state is not None
+            assert "mismatch" in face.state.entries
+
+    # Cleanup completion does not replace incoming faces with its own value.
+    assert not any(
+        isinstance(face, Completed) and face.value == "cleanup-done"
+        for face in routed.exits
+    )
+
+
+def test_terminal_cleanup_overrides_incoming_faces():
+    """Return-in-finally (cleanup_restores=False) supersedes every incoming face."""
+    body, matching_effect, mismatch_effect = _multi_path_body()
+    incoming = _boundary_exitset(body)
+    terminal = ExitSet.completed("return-from-finally")
+    routed, calls = _join_try_finally(incoming, terminal, restores=False)
+    assert calls["n"] == 1
+    assert routed.exits
+
+    assert not any(
+        isinstance(face, Halted) and face.effect is matching_effect
+        for face in routed.exits
+    )
+    assert not any(
+        isinstance(face, Halted) and face.effect is mismatch_effect
+        for face in routed.exits
+    )
+    assert not any(
+        isinstance(face, Halted) and isinstance(face.effect, ExpectationNotMetEffect)
+        for face in routed.exits
+    )
+    assert all(isinstance(face, Completed) for face in routed.exits)
+    assert all(face.value == "return-from-finally" for face in routed.exits)
+
+    # Incoming face guards still ride the superseding completions.
+    guard_text = " ".join(str(face.guard) for face in routed.exits)
+    assert "match-none-face" in guard_text
+    assert "match-pattern-face" in guard_text
+    assert "body-matching" in guard_text
+    assert "body-mismatch" in guard_text
+    assert "body-completed" in guard_text
+
+
+def test_excinfo_binds_only_consumed_occurrence_after_finally():
+    """After restoring finally, only the matching raise binds excinfo."""
+    body, matching_effect, mismatch_effect = _multi_path_body()
+    incoming = _boundary_exitset(body)
+    routed, _ = _join_try_finally(incoming, ExitSet.completed("cleanup-done"))
+
+    bound = {
+        _observed_binding(face).effect
+        for face in routed.exits
+        if _observed_binding(face) is not None
+    }
+    assert matching_effect in bound
+    assert mismatch_effect not in bound
+    assert all(
+        effect is matching_effect and effect.occurrence == "body.py:10:8:matching"
+        for effect in bound
+    )
+    for face in routed.exits:
+        if isinstance(face, Halted):
+            assert _observed_binding(face) is None
+
+
+# ---------------------------------------------------------------------------
+# Discrimination twins
+# ---------------------------------------------------------------------------
+
+
+def test_twin_none_vs_pattern_faces_survive_try_finally():
+    """None/pattern twin: both face identities and distinct operands through try."""
+    body, _, _ = _multi_path_body()
+    pattern = SymbolicValue(make_var("twin_pattern"))
+    boundary = _factored_boundary(body, pattern=pattern)
+    guarded = boundary._guarded_semantics()
+    assert {g.name for g, _ in guarded} == {
+        "match-none-face",
+        "match-pattern-face",
+    }
+    by_name = {g.name: s for g, s in guarded}
+    assert isinstance(by_name["match-none-face"].message_pattern_operand, NoMessagePatternV1)
+    assert isinstance(
+        by_name["match-pattern-face"].message_pattern_operand,
+        OptionalFormalArgumentProjectionV1,
+    )
+
+    routed, _ = _join_try_finally(
+        boundary.desugar(), ExitSet.completed("cleanup-done")
+    )
+    text = " ".join(str(face.guard) for face in routed.exits)
+    assert "match-none-face" in text and "match-pattern-face" in text
+    for face in routed.exits:
+        if "py.re_search" in str(face.guard):
+            assert "match-pattern-face" in str(face.guard)
+
+
+def test_twin_restoring_vs_overriding_cleanup():
+    """Restoring finally keeps incoming; terminal finally overrides — twins."""
+    body, matching_effect, mismatch_effect = _multi_path_body()
+    incoming = _boundary_exitset(body)
+
+    restored, _ = _join_try_finally(incoming, ExitSet.completed("cleanup-done"))
+    assert any(
+        isinstance(face, Halted) and face.effect is mismatch_effect
+        for face in restored.exits
+    )
+    assert any(
+        isinstance(face, Halted) and isinstance(face.effect, ExpectationNotMetEffect)
+        for face in restored.exits
+    )
+    assert any(
+        isinstance(face, Completed) and _observed_binding(face) is not None
+        for face in restored.exits
+    )
+
+    overridden, _ = _join_try_finally(
+        incoming, ExitSet.completed("return-from-finally"), restores=False
+    )
+    assert all(isinstance(face, Completed) for face in overridden.exits)
+    assert all(face.value == "return-from-finally" for face in overridden.exits)
+    assert not any(_observed_binding(face) for face in overridden.exits)
+    assert any(
+        isinstance(face, Halted) and face.effect is mismatch_effect
+        for face in restored.exits
+    )
+    assert not any(
+        isinstance(face, Halted) and face.effect is mismatch_effect
+        for face in overridden.exits
+    )
+
+
+def test_pattern_complement_retained_halt_still_gets_finally():
+    """Open pattern: held binds, complement halt unbound; both go through finally."""
+    body, matching_effect, _ = _multi_path_body()
+    pattern = SymbolicValue(make_var("open_msg"))
+    incoming = _boundary_exitset(body, pattern=pattern)
+    routed, calls = _join_try_finally(incoming, ExitSet.completed("cleanup-done"))
+    assert calls["n"] == 1
+
+    pattern_matching = [
+        face
+        for face in routed.exits
+        if "match-pattern-face" in str(face.guard)
+        and "body-matching" in str(face.guard)
+        and "py.re_search" in str(face.guard)
+    ]
+    assert {type(face).__name__ for face in pattern_matching} == {
+        "Completed",
+        "Halted",
+    }, pattern_matching
+    held = next(f for f in pattern_matching if isinstance(f, Completed))
+    failed = next(f for f in pattern_matching if isinstance(f, Halted))
+    assert _observed_binding(held) is not None
+    assert _observed_binding(held).effect is matching_effect
+    assert failed.effect is matching_effect
+    assert _observed_binding(failed) is None
+    assert _marker(failed) == "matching"

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_resource_stack.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_resource_stack.py
@@ -1,0 +1,290 @@
+"""Returned/assigned stack: factored assertion manager + source-resource manager.
+
+Return projection must preserve both manager identities, their contracts, and
+source-order nesting (enter first manager first; exit last manager first) when
+the consumer writes multi-item ``with`` over returned or assigned factories.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import (
+    EffectBoundarySemanticsV1,
+    NoMessagePatternV1,
+    OptionalFormalArgumentProjectionV1,
+    ProtocolResourceSemanticsV1,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerResolutionGapV1,
+    FactoredSourceDerivedContextManagerRefV1,
+    SourceDerivedContextManagerRefV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBoundarySugar
+from sugar_lift_py_tests.sugar.with_source_resource_sugar import WithSourceResourceSugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.manager_summary_derivation import (
+    populate_source_derived_resource_refs,
+)
+from sugar_source_tree.nodes import With
+from sugar_source_tree.tree import SourceFile
+
+_STACK_PKG = (
+    "class Guard:\n"
+    "    def __init__(self, marker):\n"
+    "        self.marker = marker\n"
+    "    def __enter__(self):\n"
+    "        return self.marker\n"
+    "    def __exit__(self, effect_type, effect, traceback):\n"
+    "        return False\n"
+    "\n"
+    "class Boundary:\n"
+    "    def __init__(self, expected, match=None):\n"
+    "        self.expected = expected\n"
+    "        self.match = match\n"
+    "    def __enter__(self):\n"
+    "        return self\n"
+    "    def __exit__(self, effect_type, effect, traceback):\n"
+    "        if effect_type is None:\n"
+    "            raise RuntimeError('unmet')\n"
+    "        return effect_type is self.expected\n"
+    "\n"
+    "def make_guard(marker):\n"
+    "    return Guard(marker)\n"
+    "\n"
+    "def make_boundary(expected, match=None):\n"
+    "    return Boundary(expected, match)\n"
+)
+
+
+def _distribution(root: Path, source: str):
+    package = root / "arbitrary"
+    package.mkdir(parents=True, exist_ok=True)
+    (package / "__init__.py").write_text(
+        "from arbitrary.manager import make_guard, make_boundary\n",
+        encoding="utf-8",
+    )
+    (package / "manager.py").write_text(source, encoding="utf-8")
+    metadata = root / "arbitrary_dist-1.0.dist-info"
+    metadata.mkdir(exist_ok=True)
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: arbitrary-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "arbitrary/__init__.py",
+        "arbitrary/manager.py",
+        "arbitrary_dist-1.0.dist-info/METADATA",
+        "arbitrary_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _populate(root: Path, consumer: str, *, dist):
+    path = root / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=root,
+        path=path,
+        distribution_index={"arbitrary": dist},
+    )
+    return tree, context, path
+
+
+def _with_nodes(tree):
+    return [node for node in tree.nodes() if isinstance(node, With)]
+
+
+def _with_chain(sugar):
+    """Outermost-first chain of resource/boundary routers."""
+    chain = []
+
+    def walk(node):
+        if isinstance(node, (WithSourceResourceSugar, WithEffectBoundarySugar)):
+            chain.append(node)
+            for child in getattr(node, "body", ()) or ():
+                walk(child)
+            return
+        for field in ("body", "statements", "entries"):
+            for child in getattr(node, field, ()) or ():
+                walk(child)
+
+    walk(sugar)
+    return chain
+
+
+def _item_refs(tree, context):
+    """Per-item prebound manager resolution for the multi-item With site."""
+    site = next(n for n in _with_nodes(tree) if len(n.items) >= 1)
+    # Multi-item sites nest; resolve each item coordinate through populate table.
+    refs = []
+    for item in site.items:
+        try:
+            ref = item.context_expr and site._prebound_manager_resolution(item)
+        except Exception:
+            ref = None
+        if ref is None:
+            # Fall back to all source-derived refs ordered by use-site appearance.
+            break
+        refs.append(ref)
+    if len(refs) == len(site.items):
+        return site, refs
+    # Assigned Name managers seat refs by projected call, not always on the item.
+    all_refs = list(context.source_derived_contract_refs.values())
+    return site, all_refs
+
+
+def test_returned_stack_resource_then_assertion_preserves_both_identities(
+    tmp_path: Path,
+):
+    """``with make_guard(...), make_boundary(...):`` keeps both contracts + order."""
+    dist = _distribution(tmp_path, _STACK_PKG)
+    consumer = (
+        "import arbitrary\n"
+        "def use():\n"
+        "    with arbitrary.make_guard('r'), arbitrary.make_boundary(ValueError) as info:\n"
+        "        raise ValueError('boom')\n"
+    )
+    tree, context, _ = _populate(tmp_path, consumer, dist=dist)
+    site = next(n for n in _with_nodes(tree) if len(n.items) == 2)
+
+    # Nested construction: outer resource, inner assertion.
+    nested = site._nest_items()
+    outer_sugar = nested.sugar()
+    chain = _with_chain(outer_sugar)
+    assert len(chain) == 2, [type(n).__name__ for n in chain]
+    assert isinstance(chain[0], WithSourceResourceSugar), type(chain[0])
+    assert isinstance(chain[1], WithEffectBoundarySugar), type(chain[1])
+    assert chain[1] in chain[0].body
+
+    # Both managers authenticated — not gaps.
+    site2, refs = _item_refs(tree, context)
+    assert len(refs) >= 2 or context.source_derived_contract_refs, (
+        "stack left no source-derived refs"
+    )
+    # At least one ProtocolResource and one EffectBoundary among seated refs.
+    kinds = []
+    for ref in context.source_derived_contract_refs.values():
+        if isinstance(ref, ContextManagerResolutionGapV1):
+            continue
+        if isinstance(ref, FactoredSourceDerivedContextManagerRefV1):
+            kinds.append("factored-boundary")
+        elif isinstance(ref, SourceDerivedContextManagerRefV1):
+            if isinstance(ref.semantics, EffectBoundarySemanticsV1):
+                kinds.append("boundary")
+            elif isinstance(ref.semantics, ProtocolResourceSemanticsV1):
+                kinds.append("resource")
+            else:
+                kinds.append(type(ref.semantics).__name__)
+    assert "resource" in kinds, kinds
+    assert "boundary" in kinds or "factored-boundary" in kinds, kinds
+
+
+def test_returned_stack_assertion_then_resource_swaps_outer(
+    tmp_path: Path,
+):
+    """Source order twin: assertion first → assertion outer, resource inner."""
+    dist = _distribution(tmp_path, _STACK_PKG)
+    consumer = (
+        "import arbitrary\n"
+        "def use():\n"
+        "    with arbitrary.make_boundary(ValueError), arbitrary.make_guard('r'):\n"
+        "        raise ValueError('boom')\n"
+    )
+    tree, context, _ = _populate(tmp_path, consumer, dist=dist)
+    site = next(n for n in _with_nodes(tree) if len(n.items) == 2)
+    nested = site._nest_items()
+    chain = _with_chain(nested.sugar())
+    assert len(chain) == 2, [type(n).__name__ for n in chain]
+    assert isinstance(chain[0], WithEffectBoundarySugar), type(chain[0])
+    assert isinstance(chain[1], WithSourceResourceSugar), type(chain[1])
+    assert chain[1] in chain[0].body
+
+
+def test_returned_call_stack_is_stable_across_populate_runs(tmp_path: Path):
+    """Two independent populate runs of the same returned stack agree on types."""
+    returned = (
+        "import arbitrary\n"
+        "def use():\n"
+        "    with arbitrary.make_guard('r'), arbitrary.make_boundary(ValueError):\n"
+        "        raise ValueError('boom')\n"
+    )
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    root_a.mkdir()
+    root_b.mkdir()
+    tree_a, _, _ = _populate(root_a, returned, dist=_distribution(root_a, _STACK_PKG))
+    tree_b, _, _ = _populate(root_b, returned, dist=_distribution(root_b, _STACK_PKG))
+
+    site_a = next(n for n in _with_nodes(tree_a) if len(n.items) == 2)
+    site_b = next(n for n in _with_nodes(tree_b) if len(n.items) == 2)
+    chain_a = _with_chain(site_a._nest_items().sugar())
+    chain_b = _with_chain(site_b._nest_items().sugar())
+    assert [type(n) for n in chain_a] == [type(n) for n in chain_b]
+    assert len(chain_a) == 2
+    assert isinstance(chain_a[0], WithSourceResourceSugar)
+    assert isinstance(chain_a[1], WithEffectBoundarySugar)
+
+
+def test_discrimination_lying_resource_cannot_borrow_assertion_in_stack(
+    tmp_path: Path,
+):
+    """Lying twin: ordinary resource spelling as second manager is not EffectBoundary."""
+    lying = (
+        "class Guard:\n"
+        "    def __init__(self, marker):\n"
+        "        self.marker = marker\n"
+        "    def __enter__(self):\n"
+        "        return self.marker\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n"
+        "\n"
+        "class Ordinary:\n"
+        "    def __init__(self, expected, match=None):\n"
+        "        self.expected = expected\n"
+        "    def __enter__(self):\n"
+        "        return self\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n"
+        "\n"
+        "def make_guard(marker):\n"
+        "    return Guard(marker)\n"
+        "\n"
+        "def make_boundary(expected, match=None):\n"
+        "    return Ordinary(expected, match)\n"
+    )
+    dist = _distribution(tmp_path, lying)
+    consumer = (
+        "import arbitrary\n"
+        "def use():\n"
+        "    with arbitrary.make_guard('r'), arbitrary.make_boundary(ValueError):\n"
+        "        raise ValueError('boom')\n"
+    )
+    tree, context, _ = _populate(tmp_path, consumer, dist=dist)
+    site = next(n for n in _with_nodes(tree) if len(n.items) == 2)
+    chain = _with_chain(site._nest_items().sugar())
+    # No WithEffectBoundarySugar may be invented for the lie.
+    assert not any(isinstance(n, WithEffectBoundarySugar) for n in chain), [
+        type(n).__name__ for n in chain
+    ]
+    # Resource identity for the first manager may still seat.
+    assert any(isinstance(n, WithSourceResourceSugar) for n in chain) or any(
+        isinstance(ref, SourceDerivedContextManagerRefV1)
+        and isinstance(ref.semantics, ProtocolResourceSemanticsV1)
+        for ref in context.source_derived_contract_refs.values()
+    )


### PR DESCRIPTION
## Summary

Three queued capability shots on factored assertion-manager faces:

1. **try/finally** — dual message faces retain guards through `ExitSet.and_finally`
2. **source-resource stack** — enter/exit once under factored faces; suppression authorities separate (consumer body reduced once per manager face)
3. **returned factory stack** — multi-item `with make_guard(), make_boundary()` preserves both identities and source-order nesting

### 1. try/finally

| Law | Proof |
|-----|--------|
| Matching/mismatching faces retain original guards | both message faces survive |
| Finally on consumed / unmet / retained-halt | cleanup once; all three shapes |
| Ordinary restore vs terminal override | twins |
| excinfo only on consumed occurrence | matching only |

`bin/bpytest tests/test_factored_boundary_try_finally.py` → **8 passed**

### 2. Stack factored assertion + source-resource

| Law | Proof |
|-----|--------|
| Source-order enter/exit | resource outer: enter→exit once |
| Assertion outer body once | consumer hoists body reduce so nested resource not double-entered |
| Separate suppression | NeverSuppresses vs truthiness vs assertion consume |
| excinfo only consumed occurrence | through stack |

Consumer fix: `WithEffectBoundarySugar` reduces body **once** per manager face, then guards under each message face (was re-reducing per face → double enter).

`bin/bpytest tests/test_factored_boundary_source_resource_stack.py` → **6 passed**

### 3. Returned factory stack

| Law | Proof |
|-----|--------|
| `make_guard(), make_boundary()` | outer `WithSourceResourceSugar`, inner `WithEffectBoundarySugar` |
| Swapped source order | outer types swap |
| Lying resource as second manager | no invented EffectBoundary |
| Stable across populate runs | identical chain types |

`bin/bpytest tests/test_returned_factored_assertion_resource_stack.py` → **4 passed** (sugar-lift-python-source)

**MUST NOT TOUCH (honored):** summary producer, contract-ref authority, carrier/ExitSet; no partition reconstruction; message faces never collapsed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix body suite reduction in `WithEffectBoundarySugar.desugar` and add factored assertion tests
> - Fixes a bug in [`WithEffectBoundarySugar.desugar`](https://github.com/TSavo/sugar/pull/6665/files#diff-0d372d766673042627a4eeab5612c75aa23cb49a85e1aa6866cfb0721be30780) where the body suite was reduced once per boundary face instead of once per call, which caused re-entry of nested resources for each factored message face.
> - Adds tests in [`test_factored_boundary_try_finally.py`](https://github.com/TSavo/sugar/pull/6665/files#diff-09e9f24192507e97b597238a5875013758f8b9a614a690a9be415f172bc98025) covering guard retention, finally fan-out over consumed/unmet/residual paths, and excinfo binding through try/finally algebra.
> - Adds tests in [`test_factored_boundary_source_resource_stack.py`](https://github.com/TSavo/sugar/pull/6665/files#diff-add36f4c734cb553f6ecd11608f7e531444f1e7da2793887202796208b8d0525) verifying ordering, guard propagation, suppression, and excinfo binding for stacked source resource context managers.
> - Adds tests in [`test_returned_factored_assertion_resource_stack.py`](https://github.com/TSavo/sugar/pull/6665/files#diff-e5f6a42f1eb3b87bb086b1c58102049d64719b92fe590700e644098034b60e17) verifying that `populate` returns a consistent nesting of `WithSourceResourceSugar` and `WithEffectBoundarySugar` and is stable across runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66913d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->