### PR TITLE
Name nested-default BinOp carrier residuals

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
@@ -269,8 +269,8 @@ def test_lying_nested_default_caller_coordinate_is_rejected() -> None:
         _nested_default_pair(source=lying)
 
 
-def test_real_nested_default_binop_callers_reach_completed_outcomes() -> None:
-    """RED until nested carrier continuations receive the original actual map."""
+def test_real_nested_default_binop_callers_name_only_binary_carrier_residuals() -> None:
+    """Frames exist; only the nested BinOp dispatch carriers remain undecided."""
     source, _ = _nested_default_pair()
     tree = SourceFile(
         (
@@ -289,12 +289,22 @@ def test_real_nested_default_binop_callers_reach_completed_outcomes() -> None:
     outcomes = tuple(call.sugar().desugar(None) for call in calls)
 
     assert len(outcomes) == 3
-    assert all(
-        isinstance(outcome, ExitSet)
-        and len(outcome.exits) == 1
-        and isinstance(outcome.exits[0], Completed)
-        for outcome in outcomes
-    )
+    for outcome in outcomes:
+        assert isinstance(outcome, ExitSet)
+        completed = tuple(
+            exit_ for exit_ in outcome.exits if isinstance(exit_, Completed)
+        )
+        halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
+        assert len(completed) == 1
+        assert isinstance(completed[0].value, CallSiteValue)
+        assert completed[0].value.source_call_frame_cid is not None
+        assert len(halted) == 2
+        assert all(
+            "python.binary_dispatch_raises" in repr(exit_.guard)
+            and exit_.effect.producer_node_owner == "Call"
+            and exit_.effect.exception_type_coordinate is None
+            for exit_ in halted
+        )
 
 
 def test_runtime_truth_names_the_candidate_exception_without_licensing_floor() -> None:


### PR DESCRIPTION
Strengthens the real pandas nested-default BinOp caller law after #6663 separated authenticated frame existence from semantic completion.

The three content-pinned callers each prove:
- exactly one Completed `CallSiteValue` with an authenticated source-call frame
- exactly two remaining nested BinOp halt faces
- every residual is named by `python.binary_dispatch_raises` and owned by `Call`
- no exception identity is fabricated from an undecided carrier

No production, Carrier, or ExitSet code changed.

Focused battleaxe evidence:
- `../../../bin/bpytest tests/test_source_call_preconstruction.py -q` — 14 passed
- `../../../bin/bpytest tests/test_pandas_binary_caller_twins.py -q` — 12 passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add granular assertions for nested-default BinOp carrier residuals in test
> Updates `test_real_nested_default_binop_callers_name_only_binary_carrier_residuals` in [test_pandas_binary_caller_twins.py](https://github.com/TSavo/sugar/pull/6666/files#diff-2464628a40be2139d8a6abd5a557571ada8c5fe3e139c3c6b694b71b5ead2c96) to verify the exact shape of outcomes from nested-default BinOp dispatch.
>
> - Replaces the single blanket assertion (one `Completed` exit per outcome) with per-outcome checks for one `Completed` exit carrying a `CallSiteValue` with a non-`None` `source_call_frame_cid`
> - Adds assertions that exactly two `Halted` exits are present, each with a guard repr containing `python.binary_dispatch_raises`, a `Call`-owned effect, and a `None` `exception_type_coordinate`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e547a60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->