### PR TITLE
Red doctrine laws: pin BaseException and Exception soft-seals

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_doctrine_lane_broad_catch_laws.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_doctrine_lane_broad_catch_laws.py
@@ -1,0 +1,221 @@
+"""Doctrine laws for fleet-agy-1 lane: broad catches must not swallow panics.
+
+Audit (manager_summary_derivation / manager_protocol_construction /
+binding_state / generator_construction) found two live offenders:
+
+1. ``GeneratorConstructionV1._guard_truth`` / ``_guard_formula`` catch
+   ``BaseException`` and return ``None``, reclassifying ``ConstructionPanic``
+   as ``GeneratorTransitionGapV1(observed='If carrying a suspension')``.
+   ``ConstructionPanic`` is deliberately a BaseException so ordinary
+   ``except Exception`` cannot silence it — catching BaseException undoes that.
+
+2. ``binding_state._semantic_value_cid_for_bound_node`` catches ``Exception``
+   (including ``SugarNotWritten``) and soft-succeeds with the node shape CID,
+   so ``seal_bound_binding_entry_v1`` can mint sealed testimony after sugar
+   refused. Seal must stay loud when value construction refused.
+
+These tests are the red instruments. Production edits only after the red names
+the fix. No carrier/ExitSet, no silent None soft-greens.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.gap.info import ConstructionGap
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    GeneratorTransitionGapV1,
+    IfStepV1,
+    ReturnStepV1,
+    YieldStepV1,
+)
+from sugar_lift_py_tests.ir import num
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.binding_state import (
+    BindingStateWireGap,
+    RuntimeBindingEntryFactoryV1,
+    seal_bound_binding_entry_v1,
+)
+from sugar_source_tree.nodes import Node
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _constant_entry():
+    source = "def gen():\n    bound = 1\n    yield bound\n"
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    function = next(SourceFile(path_source(path)).functions())
+    value = next(node for node in function.walk() if node.kind == "Constant")
+    factory = RuntimeBindingEntryFactoryV1(cid_of_json({"scope": "doctrine-audit"}))
+    entry = factory.mint_entry(
+        binding_site=value.fragment,
+        projection_path=("value", 0),
+        state=value,
+    )
+    return value, entry
+
+
+def test_generator_guard_construction_panic_must_not_become_suspension_gap():
+    """Law: ConstructionPanic from guard.truth propagates; never BaseException→None.
+
+    Illegal shape (live offender):
+        try: truth(...); except BaseException: return None
+        → GeneratorTransitionGapV1(observed='If carrying a suspension')
+
+    Replacement: let ConstructionPanic propagate (it is BaseException by design),
+    or map only non-panic undecided outcomes to the suspension gap. Never catch
+    BaseException around floor truth.
+    """
+    info = ConstructionGap(
+        owner="doctrine.guard-truth",
+        blame="guard-site",
+        observed="incomplete guard floor",
+        requested="guard truth value",
+        fix="implement the guard floor; do not catch BaseException",
+    )
+
+    class PanicGuard:
+        def truth(self, site):
+            del site
+            raise ConstructionPanic(info)
+
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="audit:guard:1",
+        frame_coordinate="frame:audit",
+        binding_state=(),
+        steps=(
+            IfStepV1(
+                PanicGuard(),
+                (YieldStepV1(num(1)),),
+                (ReturnStepV1(num(2)),),
+                "frag:audit-if",
+            ),
+        ),
+    )
+
+    with pytest.raises(ConstructionPanic) as raised:
+        machine.resume()
+    assert raised.value.info.owner == "doctrine.guard-truth"
+    # Twin: must not reclassify as the weaker suspension gap.
+    try:
+        machine.resume()
+    except ConstructionPanic:
+        return
+    except Exception as other:  # pragma: no cover - failure mode documentation
+        pytest.fail(
+            f"reclassified ConstructionPanic as {type(other).__name__}: {other}"
+        )
+    else:  # pragma: no cover
+        pytest.fail(
+            "ConstructionPanic was swallowed; expected raise, got a non-raising result"
+        )
+
+
+def test_generator_guard_construction_panic_is_not_if_carrying_suspension():
+    """Lying twin of the BaseException swallow: suspension gap must not impersonate panic."""
+    info = ConstructionGap(
+        owner="doctrine.guard-truth",
+        blame="guard-site",
+        observed="incomplete guard floor",
+        requested="guard truth value",
+        fix="implement the guard floor; do not catch BaseException",
+    )
+
+    class PanicGuard:
+        def truth(self, site):
+            del site
+            raise ConstructionPanic(info)
+
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="audit:guard:2",
+        frame_coordinate="frame:audit",
+        binding_state=(),
+        steps=(
+            IfStepV1(
+                PanicGuard(),
+                (YieldStepV1(num(1)),),
+                (ReturnStepV1(num(2)),),
+                "frag:audit-if-2",
+            ),
+        ),
+    )
+    # Document the live offender class for the fix-forward PR: today this returns
+    # GeneratorTransitionGapV1 instead of raising. The law forbids that outcome.
+    result = None
+    try:
+        result = machine.resume()
+    except ConstructionPanic:
+        return  # green when production is fixed
+    assert not isinstance(result, GeneratorTransitionGapV1), (
+        "ConstructionPanic was reclassified as GeneratorTransitionGapV1 "
+        f"(observed={getattr(result, 'observed', None)!r}); "
+        "fix=stop catching BaseException in _guard_truth/_guard_formula"
+    )
+
+
+def test_seal_refuses_when_node_sugar_raises_sugar_not_written():
+    """Law: SugarNotWritten from node.sugar() must prevent sealing.
+
+    Illegal shape (live offender):
+        try: node.sugar(); except Exception: return node_construction_shape_cid(node)
+        → seal_bound_binding_entry_v1 succeeds with shape-derived testimony
+
+    Replacement: re-raise SugarNotWritten / map only non-refusal misses, or
+    refuse seal with BindingStateWireGap. Never mint sealed testimony from a
+    value whose sugar refused.
+    """
+    value, entry = _constant_entry()
+    real_sugar = Node.sugar
+
+    def refusing_sugar(self):
+        raise SugarNotWritten(
+            blame=self.fragment,
+            owner="doctrine.seal-sugar",
+            observed="sugar refused for bound value",
+            requested="written constructed sugar",
+            fix="write sugar or refuse seal; do not fall back to shape CID",
+        )
+
+    Node.sugar = refusing_sugar  # type: ignore[method-assign]
+    try:
+        with pytest.raises((SugarNotWritten, BindingStateWireGap)):
+            seal_bound_binding_entry_v1(entry)
+    finally:
+        Node.sugar = real_sugar  # type: ignore[method-assign]
+
+
+def test_seal_must_not_succeed_after_sugar_not_written():
+    """Lying twin: successful seal after SugarNotWritten is the doctrine crime."""
+    _value, entry = _constant_entry()
+    real_sugar = Node.sugar
+
+    def refusing_sugar(self):
+        raise SugarNotWritten(
+            blame=self.fragment,
+            owner="doctrine.seal-sugar",
+            observed="sugar refused for bound value",
+            requested="written constructed sugar",
+            fix="write sugar or refuse seal; do not fall back to shape CID",
+        )
+
+    Node.sugar = refusing_sugar  # type: ignore[method-assign]
+    try:
+        try:
+            sealed = seal_bound_binding_entry_v1(entry)
+        except (SugarNotWritten, BindingStateWireGap):
+            return  # green when production is fixed
+        pytest.fail(
+            "seal_bound_binding_entry_v1 succeeded after SugarNotWritten "
+            f"(testimony={sealed.require_constructed_value_testimony().cid!r}); "
+            "fix=stop except Exception → shape CID fallback in "
+            "_semantic_value_cid_for_bound_node"
+        )
+    finally:
+        Node.sugar = real_sugar  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary

Doctrine-grep audit of fleet-agy-1 lane post-merge. **Tests-only** PR pinning two live offenders with red law twins. No production edits.

## Greps checked (exact)

| Pattern | summary_derivation | protocol_construction | binding_state | generator_construction |
| --- | --- | --- | --- | --- |
| `except Exception` / `except BaseException` / bare | 0 | 0 | **2** | **2** (`BaseException`) |
| `candidates[0]` / first-candidate selection | sole-candidate only (`len==1`); comments forbid first-candidate | faces consensus after equality check; method by reversed MRO name | none | none |
| `ast.walk` / `re.search` / source scan | none | none | none | none |
| `option_context` / `contextmanager` spelling arms | none | none | none | none |
| process-global unkeyed caches | none | none | none (shape memos are WeakKey/ref/content-keyed via construction_cache) | none |

## Live offenders (pinned red)

### 1. `generator_construction._guard_truth` / `_guard_formula`
```python
except BaseException:
    return None
```
→ `ConstructionPanic` reclassified as `GeneratorTransitionGapV1(observed='If carrying a suspension')`.

**Law:** ConstructionPanic must propagate. Do not catch BaseException around floor truth.

### 2. `binding_state._semantic_value_cid_for_bound_node`
```python
except Exception as cause:
    return node_construction_shape_cid(node)  # soft success
```
→ `SugarNotWritten` from `node.sugar()` still seals via shape CID.

**Law:** SugarNotWritten must refuse seal (`BindingStateWireGap` or re-raise). No shape fallback after sugar refusal.

## Cleared (not offenders)

- manager_summary soft-seal: typed `(ConstructionPanic, OpaqueSourceCallResolutionGap, SugarNotWritten)` only; sole-candidate (`len==1`) not first-candidate
- manager_protocol: no broad catches; post-enter fields require face agreement before using `[0]`
- binding `_validated_native_cid` Exception→None: probe fails closed (miss ≠ claim)
- ConstructionPanic is BaseException so `except Exception` cannot catch it — generator undoes that by catching BaseException

## Tests (intentionally red)

```
bin/bpytest tests/test_doctrine_lane_broad_catch_laws.py -q
# 4 failed — red instruments naming the illegal shape + fix
```

## Shell to delete (next production PR)

1. `except BaseException` in `_guard_truth` / `_guard_formula`
2. `except Exception → shape CID` soft path after sugar refusal

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin broad-catch doctrine for `BaseException`/`Exception` soft-seals with tests
> - Adds [test_doctrine_lane_broad_catch_laws.py](https://github.com/TSavo/sugar/pull/6667/files#diff-b2d7212dd4efb6151d97743205ad8bb4cc393927760852b831ffba9d3a457974) to codify rules around broad exception catches in generator guard and seal logic.
> - Asserts that `GeneratorConstructionV1.resume()` must propagate `ConstructionPanic` from a guard's `truth` method rather than reclassifying it as a `GeneratorTransitionGapV1` or swallowing it.
> - Asserts that `seal_bound_binding_entry_v1` must raise `SugarNotWritten` or `BindingStateWireGap` when `Node.sugar` raises `SugarNotWritten`, and must never return a successful sealed result in that case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c166d1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->