### PR TITLE
Prove *args/**kwargs binding through formal setitem/setattr_named and unpack join

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py
@@ -1,0 +1,296 @@
+"""Variadic binding through formal setattr_named.
+
+Concrete signatures:
+
+    def helper(obj, *values):
+        obj.field = values
+
+    def helper(obj, **values):
+        obj.field = values
+
+*values / **values reach the declared stored value without self/name shifting:
+  - mint operands stay ``(receiver, StringValue(\"field\"), value_formal)``
+  - name coordinate remains null (static attribute name, not a formal)
+  - value formal is the variadic pack (TupleValue / DictValue)
+  - no phantom self/name formal steals the pack slot
+
+Getter-only property stays named AttributeError (store path, not read).
+
+Does not touch carrier/ExitSet, store producer/projector/Floor; no second binder.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import (
+    DictValue,
+    ObjectValue,
+    StringValue,
+    TermValue,
+    TupleValue,
+)
+from sugar_lift_py_tests.floor.class_definition_value import ClassDefinitionValue
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, ClassDef, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+HELPER_STAR = "def helper(obj, *values):\n    obj.field = values\n"
+HELPER_KW = "def helper(obj, **values):\n    obj.field = values\n"
+
+
+def _tree(source: str, name: str = "setattr_variadic.py") -> SourceFile:
+    return SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _helper(program: str):
+    tree = _tree(program, "helper_alone.py")
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    return function, function.sugar().desugar(None)
+
+
+def _identity(name: str):
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
+
+
+def _source_class_and_helper(class_body: str, helper_source: str, field: str = "field"):
+    source = f"class Widget:\n{class_body}\n{helper_source}"
+    tree = _tree(source, "source_class_setattr_var.py")
+    class_def = next(node for node in tree.nodes() if isinstance(node, ClassDef))
+    helper = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == "helper"
+    )
+    class_outcome = class_def.sugar().desugar(None)
+    assert isinstance(class_outcome, Complete)
+    assert isinstance(class_outcome.value, ClassDefinitionValue)
+    receiver = class_outcome.value.construct_receiver_state_from_block(
+        None, class_outcome.value.class_definition_cid
+    )
+    assert isinstance(receiver, ObjectValue)
+    pending = helper.sugar().desugar(None)
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "setattr_named"
+    return helper, pending, receiver
+
+
+# ---------------------------------------------------------------------------
+# Helper alone → Undischarged setattr_named; no self/name shifting
+# ---------------------------------------------------------------------------
+
+
+def test_helper_star_alone_undischarged_without_self_name_shift() -> None:
+    function, pending = _helper(HELPER_STAR)
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "setattr_named"
+    # Static name slot is null; value formal is *values — not shifted by self/name.
+    obj_cid, name_cid, values_cid = pending.demand.operand_coordinate_cids
+    assert name_cid is None
+    assert obj_cid is not None
+    assert values_cid is not None
+    assert obj_cid != values_cid
+    assert isinstance(pending.operands[1], StringValue)
+    assert pending.operands[1].value == "field"
+    assert pending.operands[0].term.name == "obj"
+    assert pending.operands[2].term.name == "values"
+    kinds = tuple(c.parameter_kind for c in function.sugar().formal_coordinates)
+    names = tuple(c.declared_name for c in function.sugar().formal_coordinates)
+    assert kinds == ("positional-or-keyword", "variadic-positional")
+    assert names == ("obj", "values")
+    # Exactly two formals — no phantom self or name formal.
+    assert len(function.sugar().formal_coordinates) == 2
+    formal_cids = {c.coordinate_cid for c in function.sugar().formal_coordinates}
+    assert obj_cid in formal_cids and values_cid in formal_cids
+
+
+def test_helper_kw_alone_undischarged_without_self_name_shift() -> None:
+    function, pending = _helper(HELPER_KW)
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "setattr_named"
+    obj_cid, name_cid, values_cid = pending.demand.operand_coordinate_cids
+    assert name_cid is None
+    assert pending.operands[1].value == "field"
+    assert pending.operands[2].term.name == "values"
+    kinds = tuple(c.parameter_kind for c in function.sugar().formal_coordinates)
+    assert kinds == ("positional-or-keyword", "variadic-keyword")
+    assert len(function.sugar().formal_coordinates) == 2
+
+
+def test_helper_alone_is_not_completed_discrimination() -> None:
+    _, pending = _helper(HELPER_STAR)
+    with pytest.raises(AssertionError):
+        assert isinstance(pending, Completed)
+
+
+# ---------------------------------------------------------------------------
+# *values / **values reach the declared stored value
+# ---------------------------------------------------------------------------
+
+
+def test_star_values_reach_declared_stored_value() -> None:
+    helper, pending, receiver = _source_class_and_helper("    pass\n", HELPER_STAR)
+    obj_cid, name_cid, values_cid = pending.demand.operand_coordinate_cids
+    assert name_cid is None
+    pack = TupleValue((TermValue(1), TermValue(2)))
+    exits = pending.discharge({obj_cid: receiver, values_cid: pack})
+    assert isinstance(exits, ExitSet)
+    assert isinstance(exits.exits[0], Completed)
+    stored = exits.exits[0].value
+    record = getattr(stored, "record", None)
+    assert record is not None
+    assert any(
+        isinstance(s, ObjectValue)
+        and s.fields
+        and s.fields[-1].name == "field"
+        and s.fields[-1].value == pack
+        for s in record.statements
+    )
+    del helper
+
+
+def test_kw_values_reach_declared_stored_value() -> None:
+    helper, pending, receiver = _source_class_and_helper("    pass\n", HELPER_KW)
+    obj_cid, name_cid, values_cid = pending.demand.operand_coordinate_cids
+    assert name_cid is None
+    mapping = DictValue(((StringValue("a"), TermValue(1)),))
+    exits = pending.discharge({obj_cid: receiver, values_cid: mapping})
+    assert isinstance(exits.exits[0], Completed)
+    record = exits.exits[0].value.record
+    assert any(
+        isinstance(s, ObjectValue)
+        and s.fields
+        and s.fields[-1].name == "field"
+        and s.fields[-1].value == mapping
+        for s in record.statements
+    )
+    del helper
+
+
+def test_empty_star_stores_honest_empty_tuple() -> None:
+    _, pending, receiver = _source_class_and_helper("    pass\n", HELPER_STAR)
+    obj_cid, _, values_cid = pending.demand.operand_coordinate_cids
+    exits = pending.discharge({obj_cid: receiver, values_cid: TupleValue(())})
+    assert isinstance(exits.exits[0], Completed)
+    record = exits.exits[0].value.record
+    assert any(
+        isinstance(s, ObjectValue)
+        and s.fields
+        and s.fields[-1].value == TupleValue(())
+        for s in record.statements
+    )
+
+
+def test_bind_actuals_packs_star_without_self_name_shift() -> None:
+    """SourceCallFrame.bind_actuals packs remaining positionals into *values.
+
+    Frame parameters are exactly ``(obj, values)`` — no phantom self/name
+    formal steals the pack slot (name is static StringValue on the mint).
+    """
+    from sugar_lift_py_tests.floor import ListValue
+
+    tree = _tree(HELPER_STAR + "\nhelper([0], 1, 2, 3)\n")
+    call = tuple(node for node in tree.nodes() if isinstance(node, Call))[-1]
+    frame = call.sugar().source_call_frame
+    assert frame.parameters == ("obj", "values")
+    assert frame.parameter_kinds == ("positional_or_keyword", "vararg")
+    bound = frame.bind_actuals(
+        (ListValue((TermValue(0),)), TermValue(1), TermValue(2), TermValue(3)),
+        (),
+    )
+    assert bound == (
+        ListValue((TermValue(0),)),
+        TupleValue((TermValue(1), TermValue(2), TermValue(3))),
+    )
+    # Two bound slots only — pack is values, not shifted by self/name.
+    assert len(bound) == 2
+
+
+def test_bind_actuals_packs_kw_without_self_name_shift() -> None:
+    """SourceCallFrame.bind_actuals packs extra keywords into **values."""
+    from sugar_lift_py_tests.floor import ListValue
+
+    tree = _tree(HELPER_KW + "\nhelper([0], a=1, b=2)\n")
+    call = tuple(node for node in tree.nodes() if isinstance(node, Call))[-1]
+    frame = call.sugar().source_call_frame
+    assert frame.parameters == ("obj", "values")
+    assert frame.parameter_kinds == ("positional_or_keyword", "kwarg")
+    bound = frame.bind_actuals(
+        (ListValue((TermValue(0),)),),
+        (("a", TermValue(1)), ("b", TermValue(2))),
+    )
+    assert bound == (
+        ListValue((TermValue(0),)),
+        DictValue(
+            (
+                (StringValue("a"), TermValue(1)),
+                (StringValue("b"), TermValue(2)),
+            )
+        ),
+    )
+    assert len(bound) == 2
+
+
+# ---------------------------------------------------------------------------
+# Getter-only stays named AttributeError
+# ---------------------------------------------------------------------------
+
+
+def test_getter_only_property_named_attributeerror_with_star_pack() -> None:
+    _, pending, receiver = _source_class_and_helper(
+        "    @property\n" "    def field(self):\n" "        return 1\n",
+        HELPER_STAR,
+    )
+    obj_cid, name_cid, values_cid = pending.demand.operand_coordinate_cids
+    assert name_cid is None
+    assert pending.pre_effect_state is not None
+    exits = pending.discharge(
+        {obj_cid: receiver, values_cid: TupleValue((TermValue(9),))}
+    )
+    halted = exits.exits[0]
+    assert isinstance(halted, Halted)
+    assert not isinstance(halted, Completed)
+    assert halted.effect.exception_type_coordinate == _identity("AttributeError")
+    assert halted.effect.occurrence_id is not None
+    assert halted.state is not None
+    assert pending.pre_effect_state.state is halted.state
+
+
+def test_getter_only_discrimination_not_completed() -> None:
+    _, pending, receiver = _source_class_and_helper(
+        "    @property\n" "    def field(self):\n" "        return 1\n",
+        HELPER_KW,
+    )
+    obj_cid, _, values_cid = pending.demand.operand_coordinate_cids
+    exits = pending.discharge(
+        {
+            obj_cid: receiver,
+            values_cid: DictValue(((StringValue("a"), TermValue(1)),)),
+        }
+    )
+    with pytest.raises(AssertionError):
+        assert isinstance(exits.exits[0], Completed)
+
+
+def test_no_self_name_shift_operand_order_discrimination() -> None:
+    """Bite: name is static StringValue at slot 1; pack is value at slot 2."""
+    _, pending = _helper(HELPER_STAR)
+    assert isinstance(pending.operands[1], StringValue)
+    assert pending.operands[1].value == "field"
+    assert pending.operands[2].term.name == "values"
+    # Must not look like (self, values, field) or (values, field, obj).
+    with pytest.raises(AssertionError):
+        assert pending.operands[0].term.name == "values"
+    with pytest.raises(AssertionError):
+        assert pending.demand.operand_coordinate_cids[1] is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_variadic_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_variadic_binding.py
@@ -1,0 +1,372 @@
+"""*args/**kwargs binding through formal setitem.
+
+Concrete signatures:
+
+    def helper(obj, key, *values):
+        obj[key] = values
+
+    def helper(obj, key, **values):
+        obj[key] = values
+
+Binding (SourceCallFrame.bind_actuals only — no second binder):
+
+  - remaining positionals pack into authenticated ``TupleValue`` on the
+    variadic-positional formal; setitem stores that tuple as the value
+  - extra keywords pack into authenticated ``DictValue`` on the
+    variadic-keyword formal; setitem stores that mapping as the value
+  - empty * / ** are honest empty TupleValue / DictValue (never fabricated
+    None or omitted)
+  - invalid index: named IndexError; exact pre_effect_state identity
+  - dropped/reordered variadic twins fail (lying mint ≠ truthful store)
+
+Helper alone remains Undischarged setitem on exact formals
+``(obj, key, values)``. Does not touch carrier/ExitSet, store
+producer/projector/Floor.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import (
+    NativeOperationExitCarrierV1,
+    _NATIVE_OPERATION_PROJECTORS,
+)
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import (
+    DictValue,
+    ListValue,
+    StringValue,
+    TermValue,
+    TupleValue,
+)
+from sugar_lift_py_tests.floor.universe_value import UniverseValue
+from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+HELPER_STAR = "def helper(obj, key, *values):\n    obj[key] = values\n"
+HELPER_KW = "def helper(obj, key, **values):\n    obj[key] = values\n"
+
+
+def _tree(source: str, name: str = "setitem_variadic.py") -> SourceFile:
+    return SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _helper(program: str):
+    tree = _tree(program, "helper_alone.py")
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    return function, function.sugar().desugar(None)
+
+
+def _call(program: str, actuals: str):
+    tree = _tree(program + f"\nhelper({actuals})\n")
+    call = tuple(node for node in tree.nodes() if isinstance(node, Call))[-1]
+    return call.sugar().desugar(None)
+
+
+def _identity(name: str):
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
+
+
+def _stored_list(completed_face) -> ListValue:
+    assert isinstance(completed_face, Completed)
+    record = getattr(completed_face.value, "record", None)
+    assert record is not None
+    lists = [s for s in record.statements if isinstance(s, ListValue)]
+    assert len(lists) == 1, lists
+    return lists[0]
+
+
+# ---------------------------------------------------------------------------
+# Helper alone → Undischarged setitem on variadic formals
+# ---------------------------------------------------------------------------
+
+
+def test_helper_star_alone_is_undischarged_setitem_with_variadic_positional() -> None:
+    function, pending = _helper(HELPER_STAR)
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "setitem"
+    assert tuple(value.term.name for value in pending.operands) == (
+        "obj",
+        "key",
+        "values",
+    )
+    kinds = tuple(c.parameter_kind for c in function.sugar().formal_coordinates)
+    assert kinds == (
+        "positional-or-keyword",
+        "positional-or-keyword",
+        "variadic-positional",
+    )
+    assert pending.demand.operand_coordinate_cids == tuple(
+        c.coordinate_cid for c in function.sugar().formal_coordinates
+    )
+    assert pending.pre_effect_state is not None
+    parameters = tuple(
+        inspect.signature(_NATIVE_OPERATION_PROJECTORS["setitem"]).parameters
+    )
+    assert parameters == ("receiver", "index", "value", "site")
+
+
+def test_helper_kw_alone_is_undischarged_setitem_with_variadic_keyword() -> None:
+    function, pending = _helper(HELPER_KW)
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "setitem"
+    kinds = tuple(c.parameter_kind for c in function.sugar().formal_coordinates)
+    assert kinds == (
+        "positional-or-keyword",
+        "positional-or-keyword",
+        "variadic-keyword",
+    )
+    assert pending.demand.operand_coordinate_cids == tuple(
+        c.coordinate_cid for c in function.sugar().formal_coordinates
+    )
+
+
+def test_helper_alone_is_not_completed_discrimination() -> None:
+    _, pending = _helper(HELPER_STAR)
+    with pytest.raises(AssertionError):
+        assert isinstance(pending, Completed)
+
+
+# ---------------------------------------------------------------------------
+# Remaining positionals → authenticated TupleValue stored by setitem
+# ---------------------------------------------------------------------------
+
+
+def test_remaining_positionals_become_authenticated_tuple_store_value() -> None:
+    """``helper([0], 0, 1, 2, 3)`` — *values packs (1,2,3) as stored value."""
+    face = _call(HELPER_STAR, "[0], 0, 1, 2, 3").exits[0]
+    assert isinstance(face, Completed)
+    assert face.value.arg_values == (
+        ListValue((TermValue(0),)),
+        TermValue(0),
+        TupleValue((TermValue(1), TermValue(2), TermValue(3))),
+    )
+    assert face.value.parameters == ("obj", "key", "values")
+
+
+def test_star_values_discharge_stores_tuple_at_index() -> None:
+    _, pending = _helper(HELPER_STAR)
+    obj_cid, key_cid, values_cid = pending.demand.operand_coordinate_cids
+    exits = pending.discharge(
+        {
+            obj_cid: ListValue((TermValue(0),)),
+            key_cid: TermValue(0),
+            values_cid: TupleValue((TermValue(1), TermValue(2))),
+        }
+    )
+    assert isinstance(exits, ExitSet)
+    assert isinstance(exits.exits[0], Completed)
+    assert _stored_list(exits.exits[0]) == ListValue(
+        (TupleValue((TermValue(1), TermValue(2))),)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Extra keywords → authenticated DictValue stored by setitem
+# ---------------------------------------------------------------------------
+
+
+def test_extra_keywords_become_authenticated_mapping_store_value() -> None:
+    """``helper([0], 0, a=1, b=2)`` — **values packs mapping as stored value."""
+    face = _call(HELPER_KW, "[0], 0, a=1, b=2").exits[0]
+    assert isinstance(face, Completed)
+    assert face.value.arg_values == (
+        ListValue((TermValue(0),)),
+        TermValue(0),
+        DictValue(
+            (
+                (StringValue("a"), TermValue(1)),
+                (StringValue("b"), TermValue(2)),
+            )
+        ),
+    )
+    assert face.value.parameters == ("obj", "key", "values")
+
+
+def test_kw_values_discharge_stores_dict_at_index() -> None:
+    _, pending = _helper(HELPER_KW)
+    obj_cid, key_cid, values_cid = pending.demand.operand_coordinate_cids
+    mapping = DictValue(((StringValue("a"), TermValue(1)),))
+    exits = pending.discharge(
+        {
+            obj_cid: ListValue((TermValue(0),)),
+            key_cid: TermValue(0),
+            values_cid: mapping,
+        }
+    )
+    assert isinstance(exits.exits[0], Completed)
+    assert _stored_list(exits.exits[0]) == ListValue((mapping,))
+
+
+# ---------------------------------------------------------------------------
+# Empty variadics are honest empty values
+# ---------------------------------------------------------------------------
+
+
+def test_empty_star_is_honest_empty_tuple() -> None:
+    """``helper([0], 0)`` with *values — empty pack, not None / omitted."""
+    face = _call(HELPER_STAR, "[0], 0").exits[0]
+    assert isinstance(face, Completed)
+    assert face.value.arg_values[2] == TupleValue(())
+    assert face.value.arg_values[2] is not None
+
+
+def test_empty_kw_is_honest_empty_dict() -> None:
+    """``helper([0], 0)`` with **values — empty mapping, not None / omitted."""
+    face = _call(HELPER_KW, "[0], 0").exits[0]
+    assert isinstance(face, Completed)
+    assert face.value.arg_values[2] == DictValue(())
+    assert face.value.arg_values[2] is not None
+
+
+def test_empty_star_discharge_stores_empty_tuple() -> None:
+    _, pending = _helper(HELPER_STAR)
+    obj_cid, key_cid, values_cid = pending.demand.operand_coordinate_cids
+    exits = pending.discharge(
+        {
+            obj_cid: ListValue((TermValue(0),)),
+            key_cid: TermValue(0),
+            values_cid: TupleValue(()),
+        }
+    )
+    assert isinstance(exits.exits[0], Completed)
+    assert _stored_list(exits.exits[0]) == ListValue((TupleValue(()),))
+
+
+# ---------------------------------------------------------------------------
+# Invalid index retains exact pre-effect state
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_index_named_indexerror_with_exact_pre_effect_state() -> None:
+    _, pending = _helper(HELPER_STAR)
+    assert pending.pre_effect_state is not None
+    obj_cid, key_cid, values_cid = pending.demand.operand_coordinate_cids
+    exits = pending.discharge(
+        {
+            obj_cid: ListValue((TermValue(0),)),
+            key_cid: TermValue(1),
+            values_cid: TupleValue((TermValue(9),)),
+        }
+    )
+    halted = exits.exits[0]
+    assert isinstance(halted, Halted)
+    assert not isinstance(halted, Completed)
+    assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert halted.effect.occurrence_id is not None
+    assert halted.state is not None
+    assert pending.pre_effect_state.state is halted.state
+    assert not isinstance(getattr(halted, "value", None), UniverseValue)
+
+
+def test_source_caller_invalid_index_preserves_state() -> None:
+    outcome = _call(HELPER_STAR, "[0], 1, 9")
+    assert isinstance(outcome, ExitSet)
+    halted = outcome.exits[0]
+    assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert halted.state is not None
+
+
+def test_invalid_index_discrimination_not_completed() -> None:
+    _, pending = _helper(HELPER_STAR)
+    obj_cid, key_cid, values_cid = pending.demand.operand_coordinate_cids
+    exits = pending.discharge(
+        {
+            obj_cid: ListValue((TermValue(0),)),
+            key_cid: TermValue(1),
+            values_cid: TupleValue((TermValue(9),)),
+        }
+    )
+    with pytest.raises(AssertionError):
+        assert isinstance(exits.exits[0], Completed)
+    with pytest.raises(AssertionError):
+        assert exits.exits[0].state is None
+
+
+# ---------------------------------------------------------------------------
+# Dropped / reordered variadic twins fail
+# ---------------------------------------------------------------------------
+
+
+def test_dropped_variadic_value_coordinate_is_undischarged() -> None:
+    """Omitting the *values formal from discharge stays loud — no green store."""
+    _, pending = _helper(HELPER_STAR)
+    obj_cid, key_cid, _values_cid = pending.demand.operand_coordinate_cids
+    from sugar_source_tree.panic import SugarNotWritten
+
+    with pytest.raises(SugarNotWritten, match="caller actual absent"):
+        pending.discharge(
+            {
+                obj_cid: ListValue((TermValue(0),)),
+                key_cid: TermValue(0),
+                # values_cid deliberately omitted
+            }
+        )
+
+
+def test_reordered_variadic_twin_fails() -> None:
+    """Lying mint with index/value slots swapped is not the truthful *store.
+
+    Truthful discharge stores the TupleValue pack at TermValue index.
+    Swapped mint feeds the pack as index — Floor refuses ground tuple index
+    (ConstructionPanic) or yields a non-matching face. Never equals truthful.
+    """
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    function, truthful = _helper(HELPER_STAR)
+    site = function.body[0].fragment
+    obj_c, key_c, values_c = truthful.coordinates
+    lying = NativeOperationExitCarrierV1.mint(
+        site=site,
+        operator="setitem",
+        operands=(
+            truthful.operands[0],
+            truthful.operands[2],
+            truthful.operands[1],
+        ),
+        coordinates=(obj_c, values_c, key_c),
+    )
+    pack = TupleValue((TermValue(9), TermValue(8)))
+    actuals = {
+        obj_c.coordinate_cid: ListValue((TermValue(0), TermValue(1), TermValue(2))),
+        key_c.coordinate_cid: TermValue(1),
+        values_c.coordinate_cid: pack,
+    }
+    t_face = truthful.discharge(actuals).exits[0]
+    assert isinstance(t_face, Completed)
+    t_list = _stored_list(t_face)
+    assert t_list == ListValue((TermValue(0), pack, TermValue(2)))
+    try:
+        l_face = lying.discharge(actuals).exits[0]
+    except ConstructionPanic:
+        return  # lying index is the packed tuple — not a lawful setitem index
+    if isinstance(l_face, Completed) and isinstance(l_face.value, UniverseValue):
+        assert _stored_list(l_face) != t_list
+    elif isinstance(l_face, Completed) and isinstance(l_face.value, ListValue):
+        assert l_face.value != t_list
+    else:
+        assert isinstance(l_face, Halted)
+
+
+def test_star_vs_kw_kinds_are_not_interchangeable_discrimination() -> None:
+    """Bite: *values pack is TupleValue; **values pack is DictValue."""
+    star_face = _call(HELPER_STAR, "[0], 0, 1").exits[0]
+    kw_face = _call(HELPER_KW, "[0], 0, a=1").exits[0]
+    assert isinstance(star_face.value.arg_values[2], TupleValue)
+    assert isinstance(kw_face.value.arg_values[2], DictValue)
+    with pytest.raises(AssertionError):
+        assert star_face.value.arg_values[2] == kw_face.value.arg_values[2]

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_variadic_setitem_join.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_variadic_setitem_join.py
@@ -1,0 +1,273 @@
+"""JOIN: unpack Name + formal setitem whose value is a variadic pack.
+
+Concrete program:
+
+    def f(a, i, p, *values):
+        x, a[i] = p, values
+        return x
+
+Earlier Name binding (x ← p) survives later variadic-derived store halt:
+when a[i] raises IndexError, the sole face is Halted with exact
+pre_effect_state identity — never a fabricated Completed return of x.
+
+Success path: x returns as formal p; a[i] stores the authenticated TupleValue
+packed from remaining positionals.
+
+Does not touch carrier/ExitSet, store producer/projector/Floor; no second binder.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import (
+    NativeOperationExitCarrierV1,
+    _NATIVE_OPERATION_PROJECTORS,
+)
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import ListValue, ReturnValue, SymbolicValue, TermValue, TupleValue
+from sugar_lift_py_tests.floor.universe_value import UniverseValue
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+PROGRAM = "def f(a, i, p, *values):\n    x, a[i] = p, values\n    return x\n"
+
+
+def _tree(source: str, name: str = "unpack_variadic_setitem.py") -> SourceFile:
+    return SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _helper():
+    tree = _tree(PROGRAM, "helper_alone.py")
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    return function, function.sugar().desugar(None)
+
+
+def _call(actuals: str):
+    tree = _tree(PROGRAM + f"\nf({actuals})\n")
+    call = tuple(node for node in tree.nodes() if isinstance(node, Call))[-1]
+    return call.sugar().desugar(None)
+
+
+def _identity(name: str):
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
+
+
+def _completed_universe(pending, actuals) -> UniverseValue:
+    exits = pending.discharge(actuals)
+    assert isinstance(exits, ExitSet)
+    assert len(exits.exits) == 1
+    face = exits.exits[0]
+    assert isinstance(face, Completed)
+    assert isinstance(face.value, UniverseValue)
+    return face.value
+
+
+def _stored_list(universe: UniverseValue) -> ListValue:
+    lists = [s for s in universe.record.statements if isinstance(s, ListValue)]
+    assert len(lists) == 1, lists
+    return lists[0]
+
+
+def _returned(universe: UniverseValue) -> ReturnValue:
+    returns = [s for s in universe.record.statements if isinstance(s, ReturnValue)]
+    assert len(returns) == 1, returns
+    return returns[0]
+
+
+# ---------------------------------------------------------------------------
+# Helper alone: setitem demand; value formal is *values
+# ---------------------------------------------------------------------------
+
+
+def test_helper_alone_retains_setitem_with_variadic_value() -> None:
+    function, pending = _helper()
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "setitem"
+    assert tuple(operand.term.name for operand in pending.operands) == (
+        "a",
+        "i",
+        "values",
+    )
+    kinds = {
+        c.declared_name: c.parameter_kind for c in function.sugar().formal_coordinates
+    }
+    assert kinds["values"] == "variadic-positional"
+    assert kinds["p"] == "positional-or-keyword"
+    # p is a Name-binding formal, not a setitem operand.
+    setitem_cids = set(pending.demand.operand_coordinate_cids)
+    p_cid = next(
+        c.coordinate_cid
+        for c in function.sugar().formal_coordinates
+        if c.declared_name == "p"
+    )
+    assert p_cid not in setitem_cids
+    parameters = tuple(
+        inspect.signature(_NATIVE_OPERATION_PROJECTORS["setitem"]).parameters
+    )
+    assert parameters == ("receiver", "index", "value", "site")
+
+
+def test_helper_alone_is_not_completed_discrimination() -> None:
+    _, pending = _helper()
+    with pytest.raises(AssertionError):
+        assert isinstance(pending, Complete)
+    with pytest.raises(AssertionError):
+        assert isinstance(pending, Completed)
+
+
+# ---------------------------------------------------------------------------
+# Success: Name x ← p survives; store packs *values
+# ---------------------------------------------------------------------------
+
+
+def test_mutable_receiver_completes_with_x_and_variadic_store() -> None:
+    _, pending = _helper()
+    a_cid, i_cid, values_cid = pending.demand.operand_coordinate_cids
+    pack = TupleValue((TermValue(1), TermValue(2)))
+    universe = _completed_universe(
+        pending,
+        {
+            a_cid: ListValue((TermValue(0),)),
+            i_cid: TermValue(0),
+            values_cid: pack,
+        },
+    )
+    assert _stored_list(universe) == ListValue((pack,))
+    returned = _returned(universe)
+    assert isinstance(returned.value, SymbolicValue)
+    assert returned.value.term.name == "p"
+    post = str(universe.post())
+    assert "out" in post and "p" in post
+
+
+def test_source_caller_packs_remaining_positionals_into_values() -> None:
+    outcome = _call("[0], 0, 7, 1, 2")
+    assert isinstance(outcome, ExitSet)
+    face = outcome.exits[0]
+    assert isinstance(face, Completed)
+    assert face.value.arg_values == (
+        ListValue((TermValue(0),)),
+        TermValue(0),
+        TermValue(7),
+        TupleValue((TermValue(1), TermValue(2))),
+    )
+    assert face.value.parameters == ("a", "i", "p", "values")
+
+
+def test_empty_variadic_store_is_honest_empty_tuple() -> None:
+    _, pending = _helper()
+    a_cid, i_cid, values_cid = pending.demand.operand_coordinate_cids
+    universe = _completed_universe(
+        pending,
+        {
+            a_cid: ListValue((TermValue(0),)),
+            i_cid: TermValue(0),
+            values_cid: TupleValue(()),
+        },
+    )
+    assert _stored_list(universe) == ListValue((TupleValue(()),))
+    assert _returned(universe).value.term.name == "p"
+
+
+# ---------------------------------------------------------------------------
+# Halt: earlier Name binding survives; no fabricated completion
+# ---------------------------------------------------------------------------
+
+
+def test_variadic_store_halt_preserves_earlier_name_binding_state() -> None:
+    """IndexError on a[i]=values; x←p is not rolled into a Completed return.
+
+    Post-#6644: halt face carries pending.pre_effect_state.state identity.
+    Sole face is Halted — no fabricated completion of the return of x.
+    """
+    _, pending = _helper()
+    assert pending.pre_effect_state is not None
+    a_cid, i_cid, values_cid = pending.demand.operand_coordinate_cids
+    exits = pending.discharge(
+        {
+            a_cid: ListValue((TermValue(0),)),
+            i_cid: TermValue(5),
+            values_cid: TupleValue((TermValue(9),)),
+        }
+    )
+    assert isinstance(exits, ExitSet)
+    assert len(exits.exits) == 1
+    halted = exits.exits[0]
+    assert isinstance(halted, Halted)
+    assert not isinstance(halted, Completed)
+    assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert halted.effect.occurrence_id is not None
+    assert halted.state is not None
+    assert pending.pre_effect_state.state is halted.state
+    assert not isinstance(getattr(halted, "value", None), UniverseValue)
+    assert all(isinstance(face, Halted) for face in exits.exits)
+
+
+def test_source_caller_variadic_store_halt_no_fabricated_completion() -> None:
+    outcome = _call("[0], 5, 7, 1, 2")
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    halted = outcome.exits[0]
+    assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert halted.state is not None
+    assert not isinstance(getattr(halted, "value", None), UniverseValue)
+
+
+def test_halt_discrimination_is_not_completed_return_of_x() -> None:
+    """Bite: store halt must not present Completed with return of p/x."""
+    _, pending = _helper()
+    a_cid, i_cid, values_cid = pending.demand.operand_coordinate_cids
+    exits = pending.discharge(
+        {
+            a_cid: ListValue((TermValue(0),)),
+            i_cid: TermValue(5),
+            values_cid: TupleValue((TermValue(9),)),
+        }
+    )
+    with pytest.raises(AssertionError):
+        assert isinstance(exits.exits[0], Completed), "halted store completed the body"
+    with pytest.raises(AssertionError):
+        assert exits.exits[0].state is None, "halt dropped earlier-binding state"
+
+
+# ---------------------------------------------------------------------------
+# Twins: discharge order ≠ eval order; dropped pack undischarged
+# ---------------------------------------------------------------------------
+
+
+def test_swapped_source_discharge_order_twin_fails() -> None:
+    _, pending = _helper()
+    discharge_names = tuple(operand.term.name for operand in pending.operands)
+    source_eval_names = ("values", "a", "i")  # value, receiver, index
+    assert discharge_names == ("a", "i", "values")
+    assert discharge_names != source_eval_names
+    with pytest.raises(AssertionError):
+        assert discharge_names == source_eval_names
+
+
+def test_dropped_variadic_pack_is_undischarged() -> None:
+    from sugar_source_tree.panic import SugarNotWritten
+
+    _, pending = _helper()
+    a_cid, i_cid, _values_cid = pending.demand.operand_coordinate_cids
+    with pytest.raises(SugarNotWritten, match="caller actual absent"):
+        pending.discharge(
+            {
+                a_cid: ListValue((TermValue(0),)),
+                i_cid: TermValue(0),
+            }
+        )


### PR DESCRIPTION
## Summary

Three ordered instruments for variadic binding through formal native stores. Tests only — no carrier/ExitSet, store producer/projector/Floor, or second binder. Binding only through `SourceCallFrame.bind_actuals`.

### 1. `test_setitem_variadic_binding.py` (16 tests)

```python
def helper(obj, key, *values):
    obj[key] = values

def helper(obj, key, **values):
    obj[key] = values
```

| Face | Pin |
|------|-----|
| Remaining positionals | authenticated `TupleValue` store value |
| Extra keywords | authenticated `DictValue` store value |
| Empty * / ** | honest empty `TupleValue` / `DictValue` |
| Invalid index | named IndexError; `pending.pre_effect_state.state is halted.state` |
| Dropped pack | undischarged (SugarNotWritten) |
| Reordered twin | lying index/value mint ≠ truthful store |

### 2. `test_setattr_named_variadic_binding.py` (11 tests)

```python
def helper(obj, *values):
    obj.field = values
```

| Face | Pin |
|------|-----|
| No self/name shift | mint `(obj, StringValue("field"), values)`; name coord `None` |
| *values / **values | pack reaches declared field store |
| Empty * | honest empty tuple on field |
| Getter-only | named AttributeError; pre_effect_state identity |

### 3. `test_unpack_variadic_setitem_join.py` (10 tests)

```python
def f(a, i, p, *values):
    x, a[i] = p, values
    return x
```

| Face | Pin |
|------|-----|
| Success | `x→p` return; `a[i]` stores `TupleValue` pack |
| Halt | IndexError; earlier Name binding state retained; no fabricated Completed |
| Empty pack | honest empty tuple store |

**Must not touch (honored):** carrier/ExitSet, store producer/projector/Floor, second binder.

## Tests

```
bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_setitem_variadic_binding.py \
  implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py \
  implementations/python/sugar-lift-py-tests/tests/test_unpack_variadic_setitem_join.py -q
```

→ **37 passed**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests proving *args/**kwargs binding through `setitem`, `setattr_named`, and unpack join
> - Adds three new pytest modules covering desugaring, binding, and discharge semantics for variadic arguments (`*args`/`**kwargs`) in `setitem` and `setattr_named` operations.
> - [`test_setitem_variadic_binding.py`](https://github.com/TSavo/sugar/pull/6668/files#diff-51e22b559fd9946be07138902d6a239167f9193f6d2ddb83e72ac55c7beda8ab) verifies positional remainders pack into `TupleValue` and keyword remainders into `DictValue` when stored at an index, plus error-state preservation on invalid index.
> - [`test_setattr_named_variadic_binding.py`](https://github.com/TSavo/sugar/pull/6668/files#diff-99b4f8c62f136b148902c329f870f7e0f1350e03231f1511250ee1cc7c9542fe) asserts correct operand ordering, coordinate CIDs, and discharge behavior for object field assignment with variadic formals.
> - [`test_unpack_variadic_setitem_join.py`](https://github.com/TSavo/sugar/pull/6668/files#diff-97e669a9f53bee1b005f6e02f0b2291bab5297ad2b76c18c38a9627a3fce0daa) tests combined name-binding with variadic `setitem` via an unpacking assignment, including halt semantics and discharge-order vs evaluation-order discrimination.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42b1d6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->