### PR TITLE
Stop BaseException and SugarNotWritten soft-seals in lane producers

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -507,10 +507,10 @@ class GeneratorConstructionV1:
         truth = getattr(value, "truth", None)
         if truth is None:
             return None
-        try:
-            outcome = truth(self.instance_coordinate)
-        except BaseException:
-            return None
+        # ConstructionPanic is BaseException by design so ordinary Exception
+        # handlers cannot silence it. Do not catch BaseException here — that
+        # would reclassify incomplete floors as undecided suspension gaps.
+        outcome = truth(self.instance_coordinate)
         if not isinstance(outcome, Complete):
             return None
         return outcome.value
@@ -540,10 +540,8 @@ class GeneratorConstructionV1:
             return truth.formula
         to_formula = getattr(truth, "to_formula", None)
         if to_formula is not None:
-            try:
-                return to_formula()
-            except BaseException:
-                return None
+            # Same law as _guard_truth: never catch BaseException / ConstructionPanic.
+            return to_formula()
         return None
 
     def _reduce_value(self, value: object, requested: str):

--- a/implementations/python/sugar-lift-py-tests/tests/test_doctrine_lane_broad_catch_laws.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_doctrine_lane_broad_catch_laws.py
@@ -14,8 +14,9 @@ binding_state / generator_construction) found two live offenders:
    so ``seal_bound_binding_entry_v1`` can mint sealed testimony after sugar
    refused. Seal must stay loud when value construction refused.
 
-These tests are the red instruments. Production edits only after the red names
-the fix. No carrier/ExitSet, no silent None soft-greens.
+These instruments stay green when production refuses soft-seals: ConstructionPanic
+propagates from guard truth; SugarNotWritten refuses seal. No carrier/ExitSet,
+no silent None soft-greens.
 """
 
 from __future__ import annotations
@@ -207,15 +208,35 @@ def test_seal_must_not_succeed_after_sugar_not_written():
 
     Node.sugar = refusing_sugar  # type: ignore[method-assign]
     try:
-        try:
-            sealed = seal_bound_binding_entry_v1(entry)
-        except (SugarNotWritten, BindingStateWireGap):
-            return  # green when production is fixed
-        pytest.fail(
-            "seal_bound_binding_entry_v1 succeeded after SugarNotWritten "
-            f"(testimony={sealed.require_constructed_value_testimony().cid!r}); "
-            "fix=stop except Exception → shape CID fallback in "
-            "_semantic_value_cid_for_bound_node"
+        with pytest.raises((SugarNotWritten, BindingStateWireGap)):
+            seal_bound_binding_entry_v1(entry)
+    finally:
+        Node.sugar = real_sugar  # type: ignore[method-assign]
+
+
+def test_mutation_twin_tampered_seal_coordinate_still_refuses_after_sugar_refusal():
+    """Mutation twin: stale coordinate cannot launder a refused sugar into a seal."""
+    from dataclasses import replace
+
+    _value, entry = _constant_entry()
+    real_sugar = Node.sugar
+
+    def refusing_sugar(self):
+        raise SugarNotWritten(
+            blame=self.fragment,
+            owner="doctrine.seal-sugar",
+            observed="sugar refused for bound value",
+            requested="written constructed sugar",
+            fix="write sugar or refuse seal; do not fall back to shape CID",
         )
+
+    Node.sugar = refusing_sugar  # type: ignore[method-assign]
+    try:
+        tampered = replace(
+            entry,
+            coordinate=replace(entry.coordinate, cid="blake3-512:" + "f" * 128),
+        )
+        with pytest.raises((SugarNotWritten, BindingStateWireGap, ValueError)):
+            seal_bound_binding_entry_v1(tampered)
     finally:
         Node.sugar = real_sugar  # type: ignore[method-assign]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -590,7 +590,17 @@ def _semantic_value_cid_for_bound_node(node: "Node") -> str:
         return cid_of_json(_constructed_preimage(constructed))
     except BindingStateWireGap:
         raise
-    except Exception as cause:  # noqa: BLE001 -- map any construction miss to seal gap
+    except Exception as cause:
+        # SugarNotWritten / SourceTreePanic are refusal, not soft-miss. Shape
+        # CID fallback after refusal would mint sealed testimony for a value
+        # whose sugar declined — silent green. Refuse seal loud instead.
+        from sugar_source_tree.panic import SourceTreePanic, SugarNotWritten
+
+        if isinstance(cause, (SugarNotWritten, SourceTreePanic)):
+            raise BindingStateWireGap(
+                "constructed-value testimony unavailable: "
+                f"{type(cause).__name__}: {cause}"
+            ) from cause
         try:
             return node_construction_shape_cid(node)
         except (TypeError, ValueError) as shape_cause:


### PR DESCRIPTION
## Summary

Doctrine-audit preempt: green the red instruments from #6667.

1. **generator_construction**: remove `except BaseException` around guard `truth` / `to_formula` so `ConstructionPanic` propagates.
2. **binding_state**: `_semantic_value_cid_for_bound_node` re-raises `SugarNotWritten` / `SourceTreePanic` as `BindingStateWireGap` — no shape-CID seal after sugar refusal.
3. **Tests**: doctrine law twins + mutation twin (tampered coordinate still refuses).

## Shell deleted

- `except BaseException: return None` in `_guard_truth` / `_guard_formula`
- soft-success path: sugar refusal → shape CID → sealed testimony

## Tests

```
pytest tests/test_doctrine_lane_broad_catch_laws.py tests/test_generator_if_step.py tests/test_generator_construction_v1.py -q
# green (doctrine suite + generator)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop `BaseException` and `SugarNotWritten` from being swallowed as soft-seals in lane producers
> - `GeneratorConstructionV1._guard_truth` and `_guard_formula` no longer catch `BaseException`; exceptions (including `ConstructionPanic`) now propagate instead of being coerced into a `None`/undecided result.
> - `_semantic_value_cid_for_bound_node` in [binding_state.py](https://github.com/TSavo/sugar/pull/6670/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40) now raises `BindingStateWireGap` immediately when `SugarNotWritten` or `SourceTreePanic` occur, preventing fallback to a shape CID and blocking a successful seal.
> - Tests in [test_doctrine_lane_broad_catch_laws.py](https://github.com/TSavo/sugar/pull/6670/files#diff-b2d7212dd4efb6151d97743205ad8bb4cc393927760852b831ffba9d3a457974) are updated to use `pytest.raises` and a new test asserts that tampering with the entry coordinate CID still fails to seal after sugar refuses.
> - Behavioral Change: code that previously succeeded with a fallback shape CID after a sugar refusal will now raise `BindingStateWireGap` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf23179.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->