### PR TITLE
Publish generator CM pre-yield enter-halt faces with yield handoff

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 from typing import Literal
 
@@ -78,6 +78,176 @@ class DerivedManagerSummaryGapV1:
     ]
     protocol_construction_cid: str
     detail: str
+
+
+@dataclass(frozen=True)
+class GeneratorEnterHaltFaceV1:
+    """Guarded pre-yield exceptional enter halt of a generator CM.
+
+    Derived from the authenticated generator body before the first yield —
+    never from decorator/provider spelling. ``exception_type_source`` is the
+    sealed source memento of the raise's exception expression; ``occurrence``
+    is the raise statement's sealed fragment. Optional ``guard_source`` is the
+    sealed if-test when the raise sits under a branch.
+    """
+
+    occurrence: dict
+    exception_type_source: dict
+    guard_source: dict | None
+    cid: str
+
+    @property
+    def preimage(self) -> dict:
+        return {
+            "kind": "generator-enter-halt-face",
+            "schemaVersion": "1",
+            "occurrence": self.occurrence,
+            "exceptionTypeSource": self.exception_type_source,
+            "guardSource": self.guard_source,
+        }
+
+    def __post_init__(self) -> None:
+        if cid_of_json(self.preimage) != self.cid:
+            raise ValueError(
+                "generator enter-halt face CID does not match its preimage"
+            )
+
+    @classmethod
+    def mint(
+        cls,
+        *,
+        occurrence: dict,
+        exception_type_source: dict,
+        guard_source: dict | None,
+    ) -> "GeneratorEnterHaltFaceV1":
+        preimage = {
+            "kind": "generator-enter-halt-face",
+            "schemaVersion": "1",
+            "occurrence": occurrence,
+            "exceptionTypeSource": exception_type_source,
+            "guardSource": guard_source,
+        }
+        return cls(
+            occurrence, exception_type_source, guard_source, cid_of_json(preimage)
+        )
+
+
+@dataclass(frozen=True)
+class GeneratorYieldFaceV1:
+    """Complementary yield face of generator enter (resource handoff).
+
+    Distinct from enter-halt: this is the suspension that publishes the
+    generator-backed resource, not an exceptional enter path.
+    """
+
+    occurrence: dict
+    resource_source: dict | None
+    cid: str
+
+    @property
+    def preimage(self) -> dict:
+        return {
+            "kind": "generator-yield-face",
+            "schemaVersion": "1",
+            "occurrence": self.occurrence,
+            "resourceSource": self.resource_source,
+        }
+
+    def __post_init__(self) -> None:
+        if cid_of_json(self.preimage) != self.cid:
+            raise ValueError("generator yield face CID does not match its preimage")
+
+    @classmethod
+    def mint(
+        cls, *, occurrence: dict, resource_source: dict | None
+    ) -> "GeneratorYieldFaceV1":
+        preimage = {
+            "kind": "generator-yield-face",
+            "schemaVersion": "1",
+            "occurrence": occurrence,
+            "resourceSource": resource_source,
+        }
+        return cls(occurrence, resource_source, cid_of_json(preimage))
+
+
+@dataclass(frozen=True)
+class GeneratorBackedLifecycleProtocolV1:
+    """Generator-backed protocol plus pre-yield enter-halt / yield faces.
+
+    Duck-types the fields ``SourceDerivedGeneratorResourceRefV1`` requires of
+    a generator-backed protocol, and carries producer-authenticated lifecycle
+    faces so consumers never confuse enter halt with yield handoff.
+    """
+
+    protocol_construction_cid: str
+    generator_frame_cid: str
+    enter_definition: object
+    exit_definition: object
+    exit_face_id: str
+    generator_frame: object = field(compare=False, repr=False)
+    enter_halt_faces: tuple[GeneratorEnterHaltFaceV1, ...] = ()
+    yield_faces: tuple[GeneratorYieldFaceV1, ...] = ()
+    lifecycle_cid: str = ""
+
+    def __post_init__(self) -> None:
+        frame = self.generator_frame
+        if frame is None or getattr(frame, "generator_steps", None) is None:
+            raise ValueError(
+                "generator lifecycle protocol requires generator_steps on frame"
+            )
+        if getattr(frame, "frame_cid", None) != self.generator_frame_cid:
+            raise ValueError("generator frame CID does not match lifecycle protocol")
+        if self.enter_definition == self.exit_definition:
+            raise ValueError("generator enter/exit definition coordinates must differ")
+        for face in self.enter_halt_faces:
+            GeneratorEnterHaltFaceV1.mint(
+                occurrence=face.occurrence,
+                exception_type_source=face.exception_type_source,
+                guard_source=face.guard_source,
+            )
+            if face.cid != cid_of_json(face.preimage):
+                raise ValueError("enter-halt face CID mismatch")
+        for face in self.yield_faces:
+            if face.cid != cid_of_json(face.preimage):
+                raise ValueError("yield face CID mismatch")
+        expected = cid_of_json(self.lifecycle_preimage)
+        if self.lifecycle_cid and self.lifecycle_cid != expected:
+            raise ValueError("generator lifecycle CID does not match its preimage")
+        object.__setattr__(self, "lifecycle_cid", expected)
+
+    @property
+    def lifecycle_preimage(self) -> dict:
+        return {
+            "kind": "generator-backed-lifecycle-protocol",
+            "schemaVersion": "1",
+            "protocolConstructionCid": self.protocol_construction_cid,
+            "generatorFrameCid": self.generator_frame_cid,
+            "enterDefinition": self.enter_definition.wire(),
+            "exitDefinition": self.exit_definition.wire(),
+            "exitFaceId": self.exit_face_id,
+            "enterHaltFaceCids": [face.cid for face in self.enter_halt_faces],
+            "yieldFaceCids": [face.cid for face in self.yield_faces],
+        }
+
+    @classmethod
+    def from_protocol(
+        cls,
+        protocol,
+        *,
+        enter_halt_faces: tuple[GeneratorEnterHaltFaceV1, ...] = (),
+        yield_faces: tuple[GeneratorYieldFaceV1, ...] = (),
+    ) -> "GeneratorBackedLifecycleProtocolV1":
+        return cls(
+            protocol.protocol_construction_cid,
+            protocol.generator_frame_cid,
+            protocol.enter_definition,
+            protocol.exit_definition,
+            protocol.exit_face_id,
+            protocol.generator_frame,
+            enter_halt_faces,
+            yield_faces,
+            "",
+        )
 
 
 @dataclass(frozen=True)
@@ -1403,6 +1573,12 @@ def _publish_generator_backed_resource_contract(
             type(protocol).__name__,
         )
         return
+    enter_halts, yield_faces = _project_generator_pre_yield_faces(generator_target)
+    lifecycle = GeneratorBackedLifecycleProtocolV1.from_protocol(
+        protocol,
+        enter_halt_faces=enter_halts,
+        yield_faces=yield_faces,
+    )
     # Generator exit truthiness is the GCM throw/resume result — not a forged
     # NeverSuppresses theorem from an ObjectValue receiver.
     semantics = ProtocolResourceSemanticsV1(
@@ -1413,10 +1589,13 @@ def _publish_generator_backed_resource_contract(
     summary_preimage = {
         "kind": "source-derived-generator-resource-summary",
         "schemaVersion": "1",
-        "protocolConstructionCid": protocol.protocol_construction_cid,
-        "generatorFrameCid": protocol.generator_frame_cid,
+        "protocolConstructionCid": lifecycle.protocol_construction_cid,
+        "generatorFrameCid": lifecycle.generator_frame_cid,
         "enterDefinition": enter.wire(),
         "exitDefinition": exit_.wire(),
+        "enterHaltFaceCids": [face.cid for face in lifecycle.enter_halt_faces],
+        "yieldFaceCids": [face.cid for face in lifecycle.yield_faces],
+        "lifecycleCid": lifecycle.lifecycle_cid,
         "semantics": json.loads(encode_jcs(semantics_to_value(semantics))),
         "importSignature": json.loads(encode_jcs(_signature_to_value(signature))),
     }
@@ -1426,8 +1605,104 @@ def _publish_generator_backed_resource_contract(
             cid_of_json(summary_preimage),
             semantics,
             signature,
-            protocol,
+            lifecycle,
         )
+    )
+
+
+def _project_generator_pre_yield_faces(
+    generator_target,
+) -> tuple[tuple[GeneratorEnterHaltFaceV1, ...], tuple[GeneratorYieldFaceV1, ...]]:
+    """Project pre-yield enter-halt faces and the complementary yield face(s).
+
+    Walks typed FunctionDef body statements only — never source text scanning
+    or decorator/provider spelling. Collects raises (and if-guarded raises)
+    before the first yield as enter-halt faces; each yield is a yield face.
+    Post-yield raises are not enter-halt (they are exit-side; separate law).
+    """
+    from sugar_source_tree.nodes import Expr, FunctionDef, If, Raise, Yield
+
+    if not isinstance(generator_target, FunctionDef):
+        return (), ()
+    enter_halts: list[GeneratorEnterHaltFaceV1] = []
+    yields: list[GeneratorYieldFaceV1] = []
+    past_yield = False
+    for statement in generator_target.body:
+        if _is_yield_expression_statement(statement):
+            past_yield = True
+            yields.append(_mint_yield_face(statement))
+            continue
+        if past_yield:
+            # Post-yield exceptional exits are a separate publication law.
+            continue
+        if isinstance(statement, Raise):
+            face = _mint_enter_halt_face(statement, guard_source=None)
+            if face is not None:
+                enter_halts.append(face)
+            continue
+        if isinstance(statement, If):
+            guard = statement.test.fragment.seal().to_dict()
+            for nested in statement.body:
+                if isinstance(nested, Raise):
+                    face = _mint_enter_halt_face(nested, guard_source=guard)
+                    if face is not None:
+                        enter_halts.append(face)
+            for nested in statement.orelse:
+                if isinstance(nested, Raise):
+                    # Complementary branch: distinct guard polarity is the
+                    # else-arm's source (not a recombined face).
+                    else_guard = {
+                        "kind": "generator-enter-halt-else-guard",
+                        "schemaVersion": "1",
+                        "ifTest": guard,
+                        "branch": "orelse",
+                    }
+                    face = _mint_enter_halt_face(nested, guard_source=else_guard)
+                    if face is not None:
+                        enter_halts.append(face)
+    return tuple(enter_halts), tuple(yields)
+
+
+def _is_yield_expression_statement(statement) -> bool:
+    from sugar_source_tree.nodes import Expr, Yield
+
+    return isinstance(statement, Expr) and isinstance(statement.value, Yield)
+
+
+def _mint_enter_halt_face(
+    raise_stmt, *, guard_source: dict | None
+) -> GeneratorEnterHaltFaceV1 | None:
+    """Mint one enter-halt face from a typed Raise node.
+
+    Exception type identity is the sealed source of the raise's exception
+    expression — not a spelling of the class name.
+    """
+    from sugar_source_tree.nodes import Raise
+
+    if not isinstance(raise_stmt, Raise):
+        return None
+    exc = getattr(raise_stmt, "exc", None)
+    if exc is None:
+        return None
+    occurrence = raise_stmt.fragment.seal().to_dict()
+    exception_type_source = exc.fragment.seal().to_dict()
+    return GeneratorEnterHaltFaceV1.mint(
+        occurrence=occurrence,
+        exception_type_source=exception_type_source,
+        guard_source=guard_source,
+    )
+
+
+def _mint_yield_face(statement) -> GeneratorYieldFaceV1:
+    from sugar_source_tree.nodes import Expr, Yield
+
+    assert isinstance(statement, Expr) and isinstance(statement.value, Yield)
+    yield_node = statement.value
+    occurrence = yield_node.fragment.seal().to_dict()
+    resource = yield_node.value
+    resource_source = None if resource is None else resource.fragment.seal().to_dict()
+    return GeneratorYieldFaceV1.mint(
+        occurrence=occurrence, resource_source=resource_source
     )
 
 

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_backed_resource_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_backed_resource_publication.py
@@ -58,9 +58,12 @@ def test_option_context_publishes_one_generator_backed_resource_ref():
     assert isinstance(ref.semantics, ProtocolResourceSemanticsV1)
     assert isinstance(ref.semantics.exit.disposition, ReturnTruthinessDispositionV1)
     protocol = ref.protocol
-    assert isinstance(protocol, GeneratorBackedManagerProtocolV1)
+    # Lifecycle wrapper carries the same generator-backed fields plus optional
+    # pre-yield enter-halt / yield faces (see GeneratorBackedLifecycleProtocolV1).
+    assert getattr(protocol, "generator_frame", None) is not None
     assert protocol.generator_frame.generator_steps is not None
     assert protocol.enter_definition != protocol.exit_definition
+    assert getattr(protocol, "protocol_construction_cid", None)
     # Native enter/exit definitions enrolled beside the ref.
     enter = context.contract_refs.require_native_definition(
         receiver, NativeProtocolSlot.CONTEXT_ENTER

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_enter_halt.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_enter_halt.py
@@ -1,0 +1,248 @@
+"""Generator CM pre-yield exceptional enter-halt face publication.
+
+Producer (manager_summary_derivation): for
+
+    @contextmanager
+    def cm(flag):
+        if flag:
+            raise ValueError(...)
+        yield resource
+
+publication retains a guarded named enter halt with authenticated exception
+type source + raise occurrence, and the complementary yield face for the
+resource handoff. Tampered face CIDs refuse. No decorator/provider spelling
+admission; no nodes.py / carrier / ExitSet edits.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceDerivedGeneratorResourceRefV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
+from sugar_lift_python_source.manager_summary_derivation import (
+    GeneratorBackedLifecycleProtocolV1,
+    GeneratorEnterHaltFaceV1,
+    GeneratorYieldFaceV1,
+    populate_source_derived_resource_refs,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _distribution(root: Path, implementation: str) -> importlib.metadata.Distribution:
+    package = root / "unprivileged"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from unprivileged.helpers import cm\n", encoding="utf-8"
+    )
+    (package / "helpers.py").write_text(implementation, encoding="utf-8")
+    metadata = root / "unprivileged_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: unprivileged-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "unprivileged/__init__.py",
+        "unprivileged/helpers.py",
+        "unprivileged_dist-1.0.dist-info/METADATA",
+        "unprivileged_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _publish(tmp_path: Path, implementation: str, consumer: str | None = None):
+    distribution = _distribution(tmp_path, implementation)
+    path = tmp_path / "consumer.py"
+    path.write_text(
+        consumer or ("from unprivileged import cm\n" "with cm(False):\n" "    pass\n"),
+        encoding="utf-8",
+    )
+    context = TreeConstructionContextV1.for_source_call_construction(
+        workspace_root=str(tmp_path)
+    )
+    tree = SourceFile(
+        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+    return context
+
+
+_CM_PRE_YIELD_RAISE = (
+    "from contextlib import contextmanager\n"
+    "\n"
+    "@contextmanager\n"
+    "def cm(flag):\n"
+    "    if flag:\n"
+    "        raise ValueError('boom')\n"
+    "    yield 'resource'\n"
+)
+
+
+def test_pre_yield_raise_publishes_guarded_enter_halt_and_yield_face(
+    tmp_path: Path,
+) -> None:
+    context = _publish(tmp_path, _CM_PRE_YIELD_RAISE)
+    refs = [
+        value
+        for value in context.source_derived_contract_refs.values()
+        if isinstance(value, SourceDerivedGeneratorResourceRefV1)
+    ]
+    assert len(refs) == 1
+    protocol = refs[0].protocol
+    assert isinstance(protocol, GeneratorBackedLifecycleProtocolV1)
+    # Guarded named enter halt — authenticated type source + occurrence.
+    assert len(protocol.enter_halt_faces) == 1
+    halt = protocol.enter_halt_faces[0]
+    assert isinstance(halt, GeneratorEnterHaltFaceV1)
+    assert halt.guard_source is not None
+    assert halt.occurrence["cid"].startswith("blake3-512:")
+    assert halt.exception_type_source["cid"].startswith("blake3-512:")
+    assert halt.cid == cid_of_json(halt.preimage)
+    # Complementary yield face publishes the resource handoff.
+    assert len(protocol.yield_faces) == 1
+    yf = protocol.yield_faces[0]
+    assert isinstance(yf, GeneratorYieldFaceV1)
+    assert yf.resource_source is not None
+    assert yf.cid == cid_of_json(yf.preimage)
+    # Enter halt is not the yield face.
+    assert halt.cid != yf.cid
+    # Lifecycle CID authenticates both face sets.
+    assert protocol.lifecycle_cid == cid_of_json(protocol.lifecycle_preimage)
+
+
+def test_identical_source_reconstruction_yields_identical_enter_halt_testimony(
+    tmp_path: Path,
+) -> None:
+    left_root = tmp_path / "a"
+    right_root = tmp_path / "b"
+    left_root.mkdir()
+    right_root.mkdir()
+    left = _publish(left_root, _CM_PRE_YIELD_RAISE)
+    right = _publish(right_root, _CM_PRE_YIELD_RAISE)
+    left_proto = next(
+        v.protocol
+        for v in left.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    right_proto = next(
+        v.protocol
+        for v in right.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    assert left_proto.enter_halt_faces[0].cid == right_proto.enter_halt_faces[0].cid
+    assert left_proto.yield_faces[0].cid == right_proto.yield_faces[0].cid
+    assert left_proto.lifecycle_cid == right_proto.lifecycle_cid
+
+
+def test_tampered_enter_halt_face_cid_refuses(tmp_path: Path) -> None:
+    context = _publish(tmp_path, _CM_PRE_YIELD_RAISE)
+    protocol = next(
+        v.protocol
+        for v in context.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    halt = protocol.enter_halt_faces[0]
+    with pytest.raises(ValueError, match="enter-halt face CID|does not match"):
+        GeneratorEnterHaltFaceV1(
+            halt.occurrence,
+            halt.exception_type_source,
+            halt.guard_source,
+            "blake3-512:" + "0" * 128,
+        )
+
+
+def test_tampered_exception_type_source_changes_face_cid(tmp_path: Path) -> None:
+    context = _publish(tmp_path, _CM_PRE_YIELD_RAISE)
+    protocol = next(
+        v.protocol
+        for v in context.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    halt = protocol.enter_halt_faces[0]
+    mutated_type = dict(halt.exception_type_source)
+    mutated_type["cid"] = "blake3-512:" + "a" * 128
+    mutated = GeneratorEnterHaltFaceV1.mint(
+        occurrence=halt.occurrence,
+        exception_type_source=mutated_type,
+        guard_source=halt.guard_source,
+    )
+    assert mutated.cid != halt.cid
+
+
+def test_tampered_raise_occurrence_changes_face_cid(tmp_path: Path) -> None:
+    context = _publish(tmp_path, _CM_PRE_YIELD_RAISE)
+    protocol = next(
+        v.protocol
+        for v in context.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    halt = protocol.enter_halt_faces[0]
+    mutated_occ = dict(halt.occurrence)
+    mutated_occ["cid"] = "blake3-512:" + "b" * 128
+    mutated = GeneratorEnterHaltFaceV1.mint(
+        occurrence=mutated_occ,
+        exception_type_source=halt.exception_type_source,
+        guard_source=halt.guard_source,
+    )
+    assert mutated.cid != halt.cid
+
+
+def test_lifecycle_protocol_refuses_stale_lifecycle_cid(tmp_path: Path) -> None:
+    context = _publish(tmp_path, _CM_PRE_YIELD_RAISE)
+    protocol = next(
+        v.protocol
+        for v in context.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    with pytest.raises(ValueError, match="lifecycle CID"):
+        GeneratorBackedLifecycleProtocolV1(
+            protocol.protocol_construction_cid,
+            protocol.generator_frame_cid,
+            protocol.enter_definition,
+            protocol.exit_definition,
+            protocol.exit_face_id,
+            protocol.generator_frame,
+            protocol.enter_halt_faces,
+            protocol.yield_faces,
+            "blake3-512:" + "c" * 128,
+        )
+
+
+def test_plain_yield_without_pre_yield_raise_has_empty_enter_halts(
+    tmp_path: Path,
+) -> None:
+    context = _publish(
+        tmp_path,
+        "from contextlib import contextmanager\n"
+        "\n"
+        "@contextmanager\n"
+        "def cm():\n"
+        "    yield 'resource'\n",
+    )
+    protocol = next(
+        v.protocol
+        for v in context.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    assert isinstance(protocol, GeneratorBackedLifecycleProtocolV1)
+    assert protocol.enter_halt_faces == ()
+    assert len(protocol.yield_faces) == 1


### PR DESCRIPTION
## Summary

Item 1 of advisor queue: generator CM pre-yield exceptional enter-halt face.

For:
```python
@contextmanager
def cm(flag):
    if flag:
        raise ValueError(...)
    yield resource
```

- **Enter halt**: `GeneratorEnterHaltFaceV1` with sealed raise occurrence, exception type source, and if-guard source
- **Yield face**: complementary `GeneratorYieldFaceV1` for the resource handoff
- Wrapped as `GeneratorBackedLifecycleProtocolV1` (duck-types generator-backed protocol fields)
- Tampered face / lifecycle CIDs refuse
- Identical reconstruction → identical face CIDs

## Must not touch (held)

nodes.py, lifecycle consumers, carrier/ExitSet; no decorator/provider spelling admission.

## Tests

```
bin/bpytest tests/test_generator_pre_yield_enter_halt.py tests/test_generator_backed_resource_publication.py -q
# 15 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish generator CM pre-yield enter-halt and yield faces with lifecycle CID handoff
> - Adds `GeneratorEnterHaltFaceV1` and `GeneratorYieldFaceV1` dataclasses in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6671/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) that mint CID-authenticated face objects from a generator function's pre-yield AST.
> - Adds `GeneratorBackedLifecycleProtocolV1` as a validated wrapper around generator-backed protocols that binds enter-halt and yield face CIDs into a single `lifecycle_cid`.
> - Extends `_publish_generator_backed_resource_contract` to project pre-yield faces via `_project_generator_pre_yield_faces`, wrap the protocol in the lifecycle object, and include `enterHaltFaceCids`, `yieldFaceCids`, and `lifecycleCid` in the summary preimage.
> - The stored protocol in `source_derived_contract_refs` is now a `GeneratorBackedLifecycleProtocolV1` instead of a bare `GeneratorBackedManagerProtocolV1`.
> - Behavioral Change: existing consumers that do an `isinstance` check against `GeneratorBackedManagerProtocolV1` on the published protocol will need to be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c4bd4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->