### PR TITLE
Compose deferred native-operation short circuits

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -501,6 +501,7 @@ class NativeOperationExitCarrierV1:
     prefix_composition: object | None = dataclass_field(
         default=None, compare=False, repr=False
     )
+    short_circuits: tuple = dataclass_field(default=(), compare=False, repr=False)
     pre_effect_state: ReducerPreEffectStateV1 | None = dataclass_field(
         default=None, compare=False, repr=False
     )
@@ -648,6 +649,32 @@ class NativeOperationExitCarrierV1:
             ),
         )
 
+    def short_circuit(
+        self,
+        *,
+        continuing_guard: Formula,
+        stopped: "ExitSet",
+        continuing_face,
+        stopped_face,
+    ) -> "NativeOperationExitCarrierV1":
+        """Retain this deferred leg beside an already-decided stopping face.
+
+        Compare owns the carrier's operation site and therefore its eventual
+        occurrence.  This composition records only control-flow testimony; it
+        never rebuilds the operation or manufactures an occurrence.
+        """
+        from sugar_lift_py_tests.outcome import ExitSet
+
+        if not isinstance(stopped, ExitSet):
+            raise TypeError("short-circuit stopping face must be an ExitSet")
+        return replace(
+            self,
+            short_circuits=(
+                *self.short_circuits,
+                (continuing_guard, stopped, continuing_face, stopped_face),
+            ),
+        )
+
     def discharge(self, actuals_by_formal_coordinate):
         """Evaluate against authenticated actual operands and project exits.
 
@@ -657,7 +684,13 @@ class NativeOperationExitCarrierV1:
         remain undischarged — never a construction panic.
         """
         from sugar_lift_py_tests.floor import RaiseValue
-        from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete
+        from sugar_lift_py_tests.outcome import (
+            Complete,
+            ExitSet,
+            Halted,
+            Incomplete,
+            true_guard,
+        )
         from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
 
         if self.prefix_composition is not None:
@@ -761,6 +794,20 @@ class NativeOperationExitCarrierV1:
         guard = _conjoin_guards(self.guards)
         if guard is not None:
             exits = exits.guarded(guard)
+        for continuing_guard, stopped, continuing_face, stopped_face in self.short_circuits:
+            stopping_exits = []
+            for exit_ in stopped.exits:
+                if isinstance(exit_, Halted):
+                    # A first-leg exception predates the truth-value split and
+                    # bypasses both faces unchanged.
+                    stopping_exits.append(exit_)
+                    continue
+                stopping_exits.extend(
+                    ExitSet((exit_,)).guarded(true_guard(), stopped_face).exits
+                )
+            exits = exits.guarded(continuing_guard, continuing_face).union(
+                ExitSet(tuple(stopping_exits))
+            )
         return exits
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -43,6 +43,7 @@ from sugar_lift_py_tests.outcome import (
     outcome_to_exitset,
     true_guard,
 )
+from sugar_lift_py_tests.outcome.exit_set import complement_guard, partition
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.panic import SugarNotWritten
@@ -87,6 +88,131 @@ def _carrier(operator: str = "add"):
         coordinates=(left_coordinate, right_coordinate),
     )
     return carrier, left_coordinate, right_coordinate
+
+
+def test_short_circuit_truthful_second_leg_joins_untouched_stopping_face():
+    """A completed second leg runs only under the continuing partition face."""
+    carrier, left, right = _carrier(operator="less_than")
+    continuing_guard = atomic("test:first-leg-truth", [])
+    continuing_face, stopped_face = partition("test:carrier-short-circuit")
+    stopped_value = TermValue(41)
+    stopped = ExitSet.completed(
+        stopped_value, complement_guard(continuing_guard)
+    )
+
+    exits = carrier.short_circuit(
+        continuing_guard=continuing_guard,
+        stopped=stopped,
+        continuing_face=continuing_face,
+        stopped_face=stopped_face,
+    ).discharge(
+        {
+            left.coordinate_cid: TermValue(1),
+            right.coordinate_cid: TermValue(2),
+        }
+    )
+
+    assert len(exits.exits) == 2
+    continuing = next(
+        exit_
+        for exit_ in exits.exits
+        if isinstance(exit_, Completed) and exit_.value != stopped_value
+    )
+    stopping = next(
+        exit_
+        for exit_ in exits.exits
+        if isinstance(exit_, Completed) and exit_.value == stopped_value
+    )
+    assert continuing.guard == continuing_guard
+    assert continuing.faces == frozenset({continuing_face})
+    assert stopping.guard == complement_guard(continuing_guard)
+    assert stopping.faces == frozenset({stopped_face})
+
+
+def test_short_circuit_lying_second_leg_retains_its_authentic_halt_occurrence():
+    """A halting second leg is guarded, never rebuilt as a made-up occurrence."""
+    carrier, left, right = _carrier(operator="less_than")
+    continuing_guard = atomic("test:first-leg-truth", [])
+    continuing_face, stopped_face = partition("test:carrier-short-circuit-halt")
+    stopped = ExitSet.completed(
+        TermValue(42), complement_guard(continuing_guard)
+    )
+
+    raw = carrier.discharge(
+        {
+            left.coordinate_cid: NoneValue(),
+            right.coordinate_cid: TermValue(2),
+        }
+    )
+    authentic = next(exit_ for exit_ in raw.exits if isinstance(exit_, Halted))
+    exits = carrier.short_circuit(
+        continuing_guard=continuing_guard,
+        stopped=stopped,
+        continuing_face=continuing_face,
+        stopped_face=stopped_face,
+    ).discharge(
+        {
+            left.coordinate_cid: NoneValue(),
+            right.coordinate_cid: TermValue(2),
+        }
+    )
+
+    halted = next(exit_ for exit_ in exits.exits if isinstance(exit_, Halted))
+    assert halted.guard == continuing_guard
+    assert halted.effect == authentic.effect
+    assert halted.effect.occurrence_id == authentic.effect.occurrence_id
+    assert halted.faces == frozenset({continuing_face})
+    assert any(
+        isinstance(exit_, Completed) and exit_.value == TermValue(42)
+        for exit_ in exits.exits
+    )
+
+
+def test_short_circuit_preserves_first_leg_halt_without_stopping_face():
+    """The first comparison's halt bypasses both truth-value partition arms."""
+    first, first_left, first_right = _carrier(operator="less_than")
+    first_result = first.discharge(
+        {
+            first_left.coordinate_cid: NoneValue(),
+            first_right.coordinate_cid: TermValue(2),
+        }
+    )
+    first_halt = next(exit_ for exit_ in first_result.exits if isinstance(exit_, Halted))
+
+    second, second_left, second_right = _carrier(operator="less_than")
+    continuing_guard = atomic("test:first-leg-completed-truthy", [])
+    continuing_face, stopped_face = partition("test:first-leg-halt-bypass")
+    stopped_value = TermValue(43)
+    stopped = ExitSet(
+        (
+            first_halt,
+            ExitSet.completed(
+                stopped_value, complement_guard(continuing_guard)
+            ).exits[0],
+        )
+    )
+
+    exits = second.short_circuit(
+        continuing_guard=continuing_guard,
+        stopped=stopped,
+        continuing_face=continuing_face,
+        stopped_face=stopped_face,
+    ).discharge(
+        {
+            second_left.coordinate_cid: TermValue(1),
+            second_right.coordinate_cid: TermValue(2),
+        }
+    )
+
+    retained = next(exit_ for exit_ in exits.exits if isinstance(exit_, Halted))
+    assert retained == first_halt
+    assert retained.faces == first_halt.faces
+    stopping = next(
+        exit_
+        for exit_ in exits.exits
+        if isinstance(exit_, Completed) and exit_.value == stopped_value
+    )
+    assert stopping.faces == frozenset({stopped_face})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Capability

Adds `NativeOperationExitCarrierV1.short_circuit(self, *, continuing_guard: Formula, stopped: ExitSet, continuing_face, stopped_face)`. The carrier retains the deferred second comparison leg under only the first leg's continuing guard, then unions its authenticated exits with the stopping completion.

- first-leg halt bypasses both truth-value faces unchanged
- second-leg completion or authentic halt appears only under the continuing guard/face
- stopping completion retains its complementary guard and stopping face
- Compare remains the sole occurrence minter; the carrier reuses the projector-produced occurrence

`exit_set.py` and `exit_disposition.py` are untouched.

## Tests

- post-matrix rebase focused carrier/Compare/state plus grok-3 matrix: 224 passed in 14.36s
- grok-3 state-survival matrix alone: 37 passed in 2.55s, no carrier-side red

## Shot accounting

- R: missing deferred chained-ordering short-circuit carrier producer becomes 0.
- Floors: first carrier halt, authenticated occurrence, prefix/state joins, and frozen ExitSet remain intact.

Supersedes parked/closed #6669 after the advisor matrix interlude. Full package telemetry remains in flight and its exact loud result will be appended.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Compose deferred native-operation short circuits in `NativeOperationExitCarrierV1`
> - Adds a `short_circuits` field to `NativeOperationExitCarrierV1` (default empty tuple) storing `(continuing_guard, stopped ExitSet, continuing_face, stopped_face)` tuples.
> - Adds a `short_circuit` method to record a short-circuit composition on the carrier for later application.
> - Extends `discharge` to apply short circuits: the continuing leg is guarded by `continuing_guard` and `continuing_face`; stopped exits are placed on `stopped_face`; `Halted` exits from the first leg bypass both faces and are preserved verbatim.
> - Adds three tests in [`test_native_operation_exit_carrier.py`](https://github.com/TSavo/sugar/pull/6674/files#diff-1f11ed61160a89cc13f7f8660fd6936e828ac1510feeedc6c90119db53970fe0) covering truthful second-leg partitioning, halted second-leg preservation, and first-leg halt passthrough.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21900b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->