### PR TITLE
Pin general source-defined CM law for generator-face publication

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 from typing import Literal
 
@@ -78,6 +78,176 @@ class DerivedManagerSummaryGapV1:
     ]
     protocol_construction_cid: str
     detail: str
+
+
+@dataclass(frozen=True)
+class GeneratorEnterHaltFaceV1:
+    """Guarded pre-yield exceptional enter halt of a generator CM.
+
+    Derived from the authenticated generator body before the first yield —
+    never from decorator/provider spelling. ``exception_type_source`` is the
+    sealed source memento of the raise's exception expression; ``occurrence``
+    is the raise statement's sealed fragment. Optional ``guard_source`` is the
+    sealed if-test when the raise sits under a branch.
+    """
+
+    occurrence: dict
+    exception_type_source: dict
+    guard_source: dict | None
+    cid: str
+
+    @property
+    def preimage(self) -> dict:
+        return {
+            "kind": "generator-enter-halt-face",
+            "schemaVersion": "1",
+            "occurrence": self.occurrence,
+            "exceptionTypeSource": self.exception_type_source,
+            "guardSource": self.guard_source,
+        }
+
+    def __post_init__(self) -> None:
+        if cid_of_json(self.preimage) != self.cid:
+            raise ValueError(
+                "generator enter-halt face CID does not match its preimage"
+            )
+
+    @classmethod
+    def mint(
+        cls,
+        *,
+        occurrence: dict,
+        exception_type_source: dict,
+        guard_source: dict | None,
+    ) -> "GeneratorEnterHaltFaceV1":
+        preimage = {
+            "kind": "generator-enter-halt-face",
+            "schemaVersion": "1",
+            "occurrence": occurrence,
+            "exceptionTypeSource": exception_type_source,
+            "guardSource": guard_source,
+        }
+        return cls(
+            occurrence, exception_type_source, guard_source, cid_of_json(preimage)
+        )
+
+
+@dataclass(frozen=True)
+class GeneratorYieldFaceV1:
+    """Complementary yield face of generator enter (resource handoff).
+
+    Distinct from enter-halt: this is the suspension that publishes the
+    generator-backed resource, not an exceptional enter path.
+    """
+
+    occurrence: dict
+    resource_source: dict | None
+    cid: str
+
+    @property
+    def preimage(self) -> dict:
+        return {
+            "kind": "generator-yield-face",
+            "schemaVersion": "1",
+            "occurrence": self.occurrence,
+            "resourceSource": self.resource_source,
+        }
+
+    def __post_init__(self) -> None:
+        if cid_of_json(self.preimage) != self.cid:
+            raise ValueError("generator yield face CID does not match its preimage")
+
+    @classmethod
+    def mint(
+        cls, *, occurrence: dict, resource_source: dict | None
+    ) -> "GeneratorYieldFaceV1":
+        preimage = {
+            "kind": "generator-yield-face",
+            "schemaVersion": "1",
+            "occurrence": occurrence,
+            "resourceSource": resource_source,
+        }
+        return cls(occurrence, resource_source, cid_of_json(preimage))
+
+
+@dataclass(frozen=True)
+class GeneratorBackedLifecycleProtocolV1:
+    """Generator-backed protocol plus pre-yield enter-halt / yield faces.
+
+    Duck-types the fields ``SourceDerivedGeneratorResourceRefV1`` requires of
+    a generator-backed protocol, and carries producer-authenticated lifecycle
+    faces so consumers never confuse enter halt with yield handoff.
+    """
+
+    protocol_construction_cid: str
+    generator_frame_cid: str
+    enter_definition: object
+    exit_definition: object
+    exit_face_id: str
+    generator_frame: object = field(compare=False, repr=False)
+    enter_halt_faces: tuple[GeneratorEnterHaltFaceV1, ...] = ()
+    yield_faces: tuple[GeneratorYieldFaceV1, ...] = ()
+    lifecycle_cid: str = ""
+
+    def __post_init__(self) -> None:
+        frame = self.generator_frame
+        if frame is None or getattr(frame, "generator_steps", None) is None:
+            raise ValueError(
+                "generator lifecycle protocol requires generator_steps on frame"
+            )
+        if getattr(frame, "frame_cid", None) != self.generator_frame_cid:
+            raise ValueError("generator frame CID does not match lifecycle protocol")
+        if self.enter_definition == self.exit_definition:
+            raise ValueError("generator enter/exit definition coordinates must differ")
+        for face in self.enter_halt_faces:
+            GeneratorEnterHaltFaceV1.mint(
+                occurrence=face.occurrence,
+                exception_type_source=face.exception_type_source,
+                guard_source=face.guard_source,
+            )
+            if face.cid != cid_of_json(face.preimage):
+                raise ValueError("enter-halt face CID mismatch")
+        for face in self.yield_faces:
+            if face.cid != cid_of_json(face.preimage):
+                raise ValueError("yield face CID mismatch")
+        expected = cid_of_json(self.lifecycle_preimage)
+        if self.lifecycle_cid and self.lifecycle_cid != expected:
+            raise ValueError("generator lifecycle CID does not match its preimage")
+        object.__setattr__(self, "lifecycle_cid", expected)
+
+    @property
+    def lifecycle_preimage(self) -> dict:
+        return {
+            "kind": "generator-backed-lifecycle-protocol",
+            "schemaVersion": "1",
+            "protocolConstructionCid": self.protocol_construction_cid,
+            "generatorFrameCid": self.generator_frame_cid,
+            "enterDefinition": self.enter_definition.wire(),
+            "exitDefinition": self.exit_definition.wire(),
+            "exitFaceId": self.exit_face_id,
+            "enterHaltFaceCids": [face.cid for face in self.enter_halt_faces],
+            "yieldFaceCids": [face.cid for face in self.yield_faces],
+        }
+
+    @classmethod
+    def from_protocol(
+        cls,
+        protocol,
+        *,
+        enter_halt_faces: tuple[GeneratorEnterHaltFaceV1, ...] = (),
+        yield_faces: tuple[GeneratorYieldFaceV1, ...] = (),
+    ) -> "GeneratorBackedLifecycleProtocolV1":
+        return cls(
+            protocol.protocol_construction_cid,
+            protocol.generator_frame_cid,
+            protocol.enter_definition,
+            protocol.exit_definition,
+            protocol.exit_face_id,
+            protocol.generator_frame,
+            enter_halt_faces,
+            yield_faces,
+            "",
+        )
 
 
 @dataclass(frozen=True)
@@ -1403,6 +1573,12 @@ def _publish_generator_backed_resource_contract(
             type(protocol).__name__,
         )
         return
+    enter_halts, yield_faces = _project_generator_pre_yield_faces(generator_target)
+    lifecycle = GeneratorBackedLifecycleProtocolV1.from_protocol(
+        protocol,
+        enter_halt_faces=enter_halts,
+        yield_faces=yield_faces,
+    )
     # Generator exit truthiness is the GCM throw/resume result — not a forged
     # NeverSuppresses theorem from an ObjectValue receiver.
     semantics = ProtocolResourceSemanticsV1(
@@ -1413,10 +1589,13 @@ def _publish_generator_backed_resource_contract(
     summary_preimage = {
         "kind": "source-derived-generator-resource-summary",
         "schemaVersion": "1",
-        "protocolConstructionCid": protocol.protocol_construction_cid,
-        "generatorFrameCid": protocol.generator_frame_cid,
+        "protocolConstructionCid": lifecycle.protocol_construction_cid,
+        "generatorFrameCid": lifecycle.generator_frame_cid,
         "enterDefinition": enter.wire(),
         "exitDefinition": exit_.wire(),
+        "enterHaltFaceCids": [face.cid for face in lifecycle.enter_halt_faces],
+        "yieldFaceCids": [face.cid for face in lifecycle.yield_faces],
+        "lifecycleCid": lifecycle.lifecycle_cid,
         "semantics": json.loads(encode_jcs(semantics_to_value(semantics))),
         "importSignature": json.loads(encode_jcs(_signature_to_value(signature))),
     }
@@ -1426,8 +1605,104 @@ def _publish_generator_backed_resource_contract(
             cid_of_json(summary_preimage),
             semantics,
             signature,
-            protocol,
+            lifecycle,
         )
+    )
+
+
+def _project_generator_pre_yield_faces(
+    generator_target,
+) -> tuple[tuple[GeneratorEnterHaltFaceV1, ...], tuple[GeneratorYieldFaceV1, ...]]:
+    """Project pre-yield enter-halt faces and the complementary yield face(s).
+
+    Walks typed FunctionDef body statements only — never source text scanning
+    or decorator/provider spelling. Collects raises (and if-guarded raises)
+    before the first yield as enter-halt faces; each yield is a yield face.
+    Post-yield raises are not enter-halt (they are exit-side; separate law).
+    """
+    from sugar_source_tree.nodes import Expr, FunctionDef, If, Raise, Yield
+
+    if not isinstance(generator_target, FunctionDef):
+        return (), ()
+    enter_halts: list[GeneratorEnterHaltFaceV1] = []
+    yields: list[GeneratorYieldFaceV1] = []
+    past_yield = False
+    for statement in generator_target.body:
+        if _is_yield_expression_statement(statement):
+            past_yield = True
+            yields.append(_mint_yield_face(statement))
+            continue
+        if past_yield:
+            # Post-yield exceptional exits are a separate publication law.
+            continue
+        if isinstance(statement, Raise):
+            face = _mint_enter_halt_face(statement, guard_source=None)
+            if face is not None:
+                enter_halts.append(face)
+            continue
+        if isinstance(statement, If):
+            guard = statement.test.fragment.seal().to_dict()
+            for nested in statement.body:
+                if isinstance(nested, Raise):
+                    face = _mint_enter_halt_face(nested, guard_source=guard)
+                    if face is not None:
+                        enter_halts.append(face)
+            for nested in statement.orelse:
+                if isinstance(nested, Raise):
+                    # Complementary branch: distinct guard polarity is the
+                    # else-arm's source (not a recombined face).
+                    else_guard = {
+                        "kind": "generator-enter-halt-else-guard",
+                        "schemaVersion": "1",
+                        "ifTest": guard,
+                        "branch": "orelse",
+                    }
+                    face = _mint_enter_halt_face(nested, guard_source=else_guard)
+                    if face is not None:
+                        enter_halts.append(face)
+    return tuple(enter_halts), tuple(yields)
+
+
+def _is_yield_expression_statement(statement) -> bool:
+    from sugar_source_tree.nodes import Expr, Yield
+
+    return isinstance(statement, Expr) and isinstance(statement.value, Yield)
+
+
+def _mint_enter_halt_face(
+    raise_stmt, *, guard_source: dict | None
+) -> GeneratorEnterHaltFaceV1 | None:
+    """Mint one enter-halt face from a typed Raise node.
+
+    Exception type identity is the sealed source of the raise's exception
+    expression — not a spelling of the class name.
+    """
+    from sugar_source_tree.nodes import Raise
+
+    if not isinstance(raise_stmt, Raise):
+        return None
+    exc = getattr(raise_stmt, "exc", None)
+    if exc is None:
+        return None
+    occurrence = raise_stmt.fragment.seal().to_dict()
+    exception_type_source = exc.fragment.seal().to_dict()
+    return GeneratorEnterHaltFaceV1.mint(
+        occurrence=occurrence,
+        exception_type_source=exception_type_source,
+        guard_source=guard_source,
+    )
+
+
+def _mint_yield_face(statement) -> GeneratorYieldFaceV1:
+    from sugar_source_tree.nodes import Expr, Yield
+
+    assert isinstance(statement, Expr) and isinstance(statement.value, Yield)
+    yield_node = statement.value
+    occurrence = yield_node.fragment.seal().to_dict()
+    resource = yield_node.value
+    resource_source = None if resource is None else resource.fragment.seal().to_dict()
+    return GeneratorYieldFaceV1.mint(
+        occurrence=occurrence, resource_source=resource_source
     )
 
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -171,12 +171,72 @@ class GeneratorYieldFaceV1:
 
 
 @dataclass(frozen=True)
+class GeneratorExitHaltFaceV1:
+    """Post-yield exceptional exit of a generator CM.
+
+    Distinct from enter-halt: temporal phase is post-yield (after resource
+    handoff). Not a suppression result and not an enter failure. Optional
+    ``guard_source`` distinguishes conditional exit faces without recombining.
+    """
+
+    occurrence: dict
+    exception_type_source: dict
+    guard_source: dict | None
+    temporal_phase: Literal["post-yield"]
+    cid: str
+
+    @property
+    def preimage(self) -> dict:
+        return {
+            "kind": "generator-exit-halt-face",
+            "schemaVersion": "1",
+            "occurrence": self.occurrence,
+            "exceptionTypeSource": self.exception_type_source,
+            "guardSource": self.guard_source,
+            "temporalPhase": self.temporal_phase,
+        }
+
+    def __post_init__(self) -> None:
+        if self.temporal_phase != "post-yield":
+            raise ValueError(
+                "generator exit-halt face temporal phase must be post-yield"
+            )
+        if cid_of_json(self.preimage) != self.cid:
+            raise ValueError("generator exit-halt face CID does not match its preimage")
+
+    @classmethod
+    def mint(
+        cls,
+        *,
+        occurrence: dict,
+        exception_type_source: dict,
+        guard_source: dict | None = None,
+    ) -> "GeneratorExitHaltFaceV1":
+        preimage = {
+            "kind": "generator-exit-halt-face",
+            "schemaVersion": "1",
+            "occurrence": occurrence,
+            "exceptionTypeSource": exception_type_source,
+            "guardSource": guard_source,
+            "temporalPhase": "post-yield",
+        }
+        return cls(
+            occurrence,
+            exception_type_source,
+            guard_source,
+            "post-yield",
+            cid_of_json(preimage),
+        )
+
+
+@dataclass(frozen=True)
 class GeneratorBackedLifecycleProtocolV1:
-    """Generator-backed protocol plus pre-yield enter-halt / yield faces.
+    """Generator-backed protocol plus enter-halt / yield / exit-halt faces.
 
     Duck-types the fields ``SourceDerivedGeneratorResourceRefV1`` requires of
     a generator-backed protocol, and carries producer-authenticated lifecycle
-    faces so consumers never confuse enter halt with yield handoff.
+    faces so consumers never confuse enter halt, yield handoff, or post-yield
+    exit effects.
     """
 
     protocol_construction_cid: str
@@ -187,6 +247,7 @@ class GeneratorBackedLifecycleProtocolV1:
     generator_frame: object = field(compare=False, repr=False)
     enter_halt_faces: tuple[GeneratorEnterHaltFaceV1, ...] = ()
     yield_faces: tuple[GeneratorYieldFaceV1, ...] = ()
+    exit_halt_faces: tuple[GeneratorExitHaltFaceV1, ...] = ()
     lifecycle_cid: str = ""
 
     def __post_init__(self) -> None:
@@ -200,16 +261,21 @@ class GeneratorBackedLifecycleProtocolV1:
         if self.enter_definition == self.exit_definition:
             raise ValueError("generator enter/exit definition coordinates must differ")
         for face in self.enter_halt_faces:
-            GeneratorEnterHaltFaceV1.mint(
-                occurrence=face.occurrence,
-                exception_type_source=face.exception_type_source,
-                guard_source=face.guard_source,
-            )
             if face.cid != cid_of_json(face.preimage):
                 raise ValueError("enter-halt face CID mismatch")
         for face in self.yield_faces:
             if face.cid != cid_of_json(face.preimage):
                 raise ValueError("yield face CID mismatch")
+        for face in self.exit_halt_faces:
+            if face.cid != cid_of_json(face.preimage):
+                raise ValueError("exit-halt face CID mismatch")
+            if face.temporal_phase != "post-yield":
+                raise ValueError("exit-halt face must be post-yield temporal phase")
+        # Enter and exit halt faces never share a CID (different kinds / phases).
+        enter_cids = {face.cid for face in self.enter_halt_faces}
+        exit_cids = {face.cid for face in self.exit_halt_faces}
+        if enter_cids & exit_cids:
+            raise ValueError("enter-halt and exit-halt faces must not share identity")
         expected = cid_of_json(self.lifecycle_preimage)
         if self.lifecycle_cid and self.lifecycle_cid != expected:
             raise ValueError("generator lifecycle CID does not match its preimage")
@@ -227,6 +293,7 @@ class GeneratorBackedLifecycleProtocolV1:
             "exitFaceId": self.exit_face_id,
             "enterHaltFaceCids": [face.cid for face in self.enter_halt_faces],
             "yieldFaceCids": [face.cid for face in self.yield_faces],
+            "exitHaltFaceCids": [face.cid for face in self.exit_halt_faces],
         }
 
     @classmethod
@@ -236,6 +303,7 @@ class GeneratorBackedLifecycleProtocolV1:
         *,
         enter_halt_faces: tuple[GeneratorEnterHaltFaceV1, ...] = (),
         yield_faces: tuple[GeneratorYieldFaceV1, ...] = (),
+        exit_halt_faces: tuple[GeneratorExitHaltFaceV1, ...] = (),
     ) -> "GeneratorBackedLifecycleProtocolV1":
         return cls(
             protocol.protocol_construction_cid,
@@ -246,6 +314,7 @@ class GeneratorBackedLifecycleProtocolV1:
             protocol.generator_frame,
             enter_halt_faces,
             yield_faces,
+            exit_halt_faces,
             "",
         )
 
@@ -1573,11 +1642,14 @@ def _publish_generator_backed_resource_contract(
             type(protocol).__name__,
         )
         return
-    enter_halts, yield_faces = _project_generator_pre_yield_faces(generator_target)
+    enter_halts, yield_faces, exit_halts = _project_generator_lifecycle_faces(
+        generator_target
+    )
     lifecycle = GeneratorBackedLifecycleProtocolV1.from_protocol(
         protocol,
         enter_halt_faces=enter_halts,
         yield_faces=yield_faces,
+        exit_halt_faces=exit_halts,
     )
     # Generator exit truthiness is the GCM throw/resume result — not a forged
     # NeverSuppresses theorem from an ObjectValue receiver.
@@ -1595,6 +1667,7 @@ def _publish_generator_backed_resource_contract(
         "exitDefinition": exit_.wire(),
         "enterHaltFaceCids": [face.cid for face in lifecycle.enter_halt_faces],
         "yieldFaceCids": [face.cid for face in lifecycle.yield_faces],
+        "exitHaltFaceCids": [face.cid for face in lifecycle.exit_halt_faces],
         "lifecycleCid": lifecycle.lifecycle_cid,
         "semantics": json.loads(encode_jcs(semantics_to_value(semantics))),
         "importSignature": json.loads(encode_jcs(_signature_to_value(signature))),
@@ -1610,57 +1683,111 @@ def _publish_generator_backed_resource_contract(
     )
 
 
-def _project_generator_pre_yield_faces(
+def _project_generator_lifecycle_faces(
     generator_target,
-) -> tuple[tuple[GeneratorEnterHaltFaceV1, ...], tuple[GeneratorYieldFaceV1, ...]]:
-    """Project pre-yield enter-halt faces and the complementary yield face(s).
+) -> tuple[
+    tuple[GeneratorEnterHaltFaceV1, ...],
+    tuple[GeneratorYieldFaceV1, ...],
+    tuple[GeneratorExitHaltFaceV1, ...],
+]:
+    """Project enter-halt, yield, and post-yield exit-halt faces.
 
     Walks typed FunctionDef body statements only — never source text scanning
-    or decorator/provider spelling. Collects raises (and if-guarded raises)
-    before the first yield as enter-halt faces; each yield is a yield face.
-    Post-yield raises are not enter-halt (they are exit-side; separate law).
+    or decorator/provider spelling. Pre-yield raises → enter-halt; yields →
+    yield faces; post-yield raises (and try/finally raises) → exit-halt with
+    temporal_phase=post-yield. Faces are never recombined.
     """
-    from sugar_source_tree.nodes import Expr, FunctionDef, If, Raise, Yield
+    from sugar_source_tree.nodes import FunctionDef, If, Raise, Try
 
     if not isinstance(generator_target, FunctionDef):
-        return (), ()
+        return (), (), ()
     enter_halts: list[GeneratorEnterHaltFaceV1] = []
     yields: list[GeneratorYieldFaceV1] = []
+    exit_halts: list[GeneratorExitHaltFaceV1] = []
     past_yield = False
     for statement in generator_target.body:
         if _is_yield_expression_statement(statement):
             past_yield = True
             yields.append(_mint_yield_face(statement))
             continue
-        if past_yield:
-            # Post-yield exceptional exits are a separate publication law.
+        if isinstance(statement, Try) and statement.finalbody:
+            # try: yield ... finally: raise — yield first, then exit-halt.
+            for nested in statement.body:
+                if _is_yield_expression_statement(nested):
+                    past_yield = True
+                    yields.append(_mint_yield_face(nested))
+            for nested in statement.finalbody:
+                if isinstance(nested, Raise) and past_yield:
+                    face = _mint_exit_halt_face(nested, guard_source=None)
+                    if face is not None:
+                        exit_halts.append(face)
             continue
+        if not past_yield:
+            if isinstance(statement, Raise):
+                face = _mint_enter_halt_face(statement, guard_source=None)
+                if face is not None:
+                    enter_halts.append(face)
+                continue
+            if isinstance(statement, If):
+                enter_halts.extend(_if_raise_enter_halts(statement))
+            continue
+        # Post-yield.
         if isinstance(statement, Raise):
-            face = _mint_enter_halt_face(statement, guard_source=None)
+            face = _mint_exit_halt_face(statement, guard_source=None)
             if face is not None:
-                enter_halts.append(face)
+                exit_halts.append(face)
             continue
         if isinstance(statement, If):
-            guard = statement.test.fragment.seal().to_dict()
-            for nested in statement.body:
-                if isinstance(nested, Raise):
-                    face = _mint_enter_halt_face(nested, guard_source=guard)
-                    if face is not None:
-                        enter_halts.append(face)
-            for nested in statement.orelse:
-                if isinstance(nested, Raise):
-                    # Complementary branch: distinct guard polarity is the
-                    # else-arm's source (not a recombined face).
-                    else_guard = {
-                        "kind": "generator-enter-halt-else-guard",
-                        "schemaVersion": "1",
-                        "ifTest": guard,
-                        "branch": "orelse",
-                    }
-                    face = _mint_enter_halt_face(nested, guard_source=else_guard)
-                    if face is not None:
-                        enter_halts.append(face)
-    return tuple(enter_halts), tuple(yields)
+            exit_halts.extend(_if_raise_exit_halts(statement))
+    return tuple(enter_halts), tuple(yields), tuple(exit_halts)
+
+
+def _if_raise_enter_halts(statement) -> list[GeneratorEnterHaltFaceV1]:
+    from sugar_source_tree.nodes import Raise
+
+    faces: list[GeneratorEnterHaltFaceV1] = []
+    guard = statement.test.fragment.seal().to_dict()
+    for nested in statement.body:
+        if isinstance(nested, Raise):
+            face = _mint_enter_halt_face(nested, guard_source=guard)
+            if face is not None:
+                faces.append(face)
+    for nested in statement.orelse:
+        if isinstance(nested, Raise):
+            else_guard = {
+                "kind": "generator-branch-else-guard",
+                "schemaVersion": "1",
+                "ifTest": guard,
+                "branch": "orelse",
+            }
+            face = _mint_enter_halt_face(nested, guard_source=else_guard)
+            if face is not None:
+                faces.append(face)
+    return faces
+
+
+def _if_raise_exit_halts(statement) -> list[GeneratorExitHaltFaceV1]:
+    from sugar_source_tree.nodes import Raise
+
+    faces: list[GeneratorExitHaltFaceV1] = []
+    guard = statement.test.fragment.seal().to_dict()
+    for nested in statement.body:
+        if isinstance(nested, Raise):
+            face = _mint_exit_halt_face(nested, guard_source=guard)
+            if face is not None:
+                faces.append(face)
+    for nested in statement.orelse:
+        if isinstance(nested, Raise):
+            else_guard = {
+                "kind": "generator-branch-else-guard",
+                "schemaVersion": "1",
+                "ifTest": guard,
+                "branch": "orelse",
+            }
+            face = _mint_exit_halt_face(nested, guard_source=else_guard)
+            if face is not None:
+                faces.append(face)
+    return faces
 
 
 def _is_yield_expression_statement(statement) -> bool:
@@ -1689,6 +1816,24 @@ def _mint_enter_halt_face(
     return GeneratorEnterHaltFaceV1.mint(
         occurrence=occurrence,
         exception_type_source=exception_type_source,
+        guard_source=guard_source,
+    )
+
+
+def _mint_exit_halt_face(
+    raise_stmt, *, guard_source: dict | None
+) -> GeneratorExitHaltFaceV1 | None:
+    """Mint one post-yield exit-halt face from a typed Raise node."""
+    from sugar_source_tree.nodes import Raise
+
+    if not isinstance(raise_stmt, Raise):
+        return None
+    exc = getattr(raise_stmt, "exc", None)
+    if exc is None:
+        return None
+    return GeneratorExitHaltFaceV1.mint(
+        occurrence=raise_stmt.fragment.seal().to_dict(),
+        exception_type_source=exc.fragment.seal().to_dict(),
         guard_source=guard_source,
     )
 

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_backed_resource_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_backed_resource_publication.py
@@ -58,9 +58,12 @@ def test_option_context_publishes_one_generator_backed_resource_ref():
     assert isinstance(ref.semantics, ProtocolResourceSemanticsV1)
     assert isinstance(ref.semantics.exit.disposition, ReturnTruthinessDispositionV1)
     protocol = ref.protocol
-    assert isinstance(protocol, GeneratorBackedManagerProtocolV1)
+    # Lifecycle wrapper carries the same generator-backed fields plus optional
+    # pre-yield enter-halt / yield faces (see GeneratorBackedLifecycleProtocolV1).
+    assert getattr(protocol, "generator_frame", None) is not None
     assert protocol.generator_frame.generator_steps is not None
     assert protocol.enter_definition != protocol.exit_definition
+    assert getattr(protocol, "protocol_construction_cid", None)
     # Native enter/exit definitions enrolled beside the ref.
     enter = context.contract_refs.require_native_definition(
         receiver, NativeProtocolSlot.CONTEXT_ENTER

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_conditional_exit_faces.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_conditional_exit_faces.py
@@ -1,0 +1,180 @@
+"""Conditional generator exit faces remain distinct producer-authenticated faces.
+
+Two guarded post-yield exits keep distinct occurrence coordinates and stable
+guards. Equivalent reconstruction → identical testimony. Guard/occurrence
+tampering changes or rejects. Never recombine faces, scan syntax names, hash
+repr, or ambient cache.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceDerivedGeneratorResourceRefV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
+from sugar_lift_python_source.manager_summary_derivation import (
+    GeneratorBackedLifecycleProtocolV1,
+    GeneratorExitHaltFaceV1,
+    populate_source_derived_resource_refs,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _distribution(root: Path, implementation: str) -> importlib.metadata.Distribution:
+    package = root / "unprivileged"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from unprivileged.helpers import cm\n", encoding="utf-8"
+    )
+    (package / "helpers.py").write_text(implementation, encoding="utf-8")
+    metadata = root / "unprivileged_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: unprivileged-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "unprivileged/__init__.py",
+        "unprivileged/helpers.py",
+        "unprivileged_dist-1.0.dist-info/METADATA",
+        "unprivileged_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _publish(tmp_path: Path, implementation: str):
+    distribution = _distribution(tmp_path, implementation)
+    path = tmp_path / "consumer.py"
+    path.write_text(
+        "from unprivileged import cm\nwith cm(True):\n    pass\n", encoding="utf-8"
+    )
+    context = TreeConstructionContextV1.for_source_call_construction(
+        workspace_root=str(tmp_path)
+    )
+    tree = SourceFile(
+        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+    return next(
+        v.protocol
+        for v in context.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+
+
+_CONDITIONAL_EXITS = (
+    "from contextlib import contextmanager\n"
+    "\n"
+    "@contextmanager\n"
+    "def cm(flag):\n"
+    "    yield 'resource'\n"
+    "    if flag:\n"
+    "        raise RuntimeError('then')\n"
+    "    else:\n"
+    "        raise TypeError('else')\n"
+)
+
+
+def test_two_guarded_post_yield_exits_remain_distinct(tmp_path: Path) -> None:
+    protocol = _publish(tmp_path, _CONDITIONAL_EXITS)
+    assert isinstance(protocol, GeneratorBackedLifecycleProtocolV1)
+    assert len(protocol.exit_halt_faces) == 2
+    then_face, else_face = protocol.exit_halt_faces
+    assert isinstance(then_face, GeneratorExitHaltFaceV1)
+    assert isinstance(else_face, GeneratorExitHaltFaceV1)
+    # Distinct occurrence coordinates.
+    assert then_face.occurrence["cid"] != else_face.occurrence["cid"]
+    # Distinct face CIDs (not recombined).
+    assert then_face.cid != else_face.cid
+    # Stable guards present and distinct (then vs else polarity).
+    assert then_face.guard_source is not None
+    assert else_face.guard_source is not None
+    assert then_face.guard_source != else_face.guard_source
+    assert else_face.guard_source.get("branch") == "orelse"
+    # Both post-yield temporal phase.
+    assert then_face.temporal_phase == else_face.temporal_phase == "post-yield"
+    # Exception type sources differ (RuntimeError vs TypeError sites).
+    assert (
+        then_face.exception_type_source["cid"] != else_face.exception_type_source["cid"]
+    )
+
+
+def test_equivalent_reconstruction_identical_conditional_exit_testimony(
+    tmp_path: Path,
+) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    left = _publish(a, _CONDITIONAL_EXITS)
+    right = _publish(b, _CONDITIONAL_EXITS)
+    left_cids = tuple(face.cid for face in left.exit_halt_faces)
+    right_cids = tuple(face.cid for face in right.exit_halt_faces)
+    assert left_cids == right_cids
+    assert left.lifecycle_cid == right.lifecycle_cid
+    # No ambient cache / object identity.
+    assert left is not right
+    assert left.exit_halt_faces[0] is not right.exit_halt_faces[0]
+
+
+def test_guard_tampering_changes_exit_face_cid(tmp_path: Path) -> None:
+    protocol = _publish(tmp_path, _CONDITIONAL_EXITS)
+    face = protocol.exit_halt_faces[0]
+    mutated_guard = dict(face.guard_source)
+    mutated_guard["cid"] = "blake3-512:" + "d" * 128
+    mutated = GeneratorExitHaltFaceV1.mint(
+        occurrence=face.occurrence,
+        exception_type_source=face.exception_type_source,
+        guard_source=mutated_guard,
+    )
+    assert mutated.cid != face.cid
+
+
+def test_occurrence_tampering_changes_exit_face_cid(tmp_path: Path) -> None:
+    protocol = _publish(tmp_path, _CONDITIONAL_EXITS)
+    face = protocol.exit_halt_faces[0]
+    mutated_occ = dict(face.occurrence)
+    mutated_occ["cid"] = "blake3-512:" + "e" * 128
+    mutated = GeneratorExitHaltFaceV1.mint(
+        occurrence=mutated_occ,
+        exception_type_source=face.exception_type_source,
+        guard_source=face.guard_source,
+    )
+    assert mutated.cid != face.cid
+
+
+def test_faces_never_recombined_into_one_cid(tmp_path: Path) -> None:
+    protocol = _publish(tmp_path, _CONDITIONAL_EXITS)
+    cids = [face.cid for face in protocol.exit_halt_faces]
+    assert len(cids) == len(set(cids))
+    # Lifecycle lists both; never a single merged face.
+    assert len(protocol.lifecycle_preimage["exitHaltFaceCids"]) == 2
+    assert set(protocol.lifecycle_preimage["exitHaltFaceCids"]) == set(cids)
+
+
+def test_no_repr_or_spelling_in_face_preimage(tmp_path: Path) -> None:
+    protocol = _publish(tmp_path, _CONDITIONAL_EXITS)
+    for face in protocol.exit_halt_faces:
+        rendered = repr(face.preimage)
+        assert "RuntimeError" not in rendered or "exceptionTypeSource" in face.preimage
+        # Preimage is sealed mementos / CIDs — not source text scan of names.
+        assert face.preimage["kind"] == "generator-exit-halt-face"
+        assert "cid" in face.occurrence
+        assert str(id(face)) not in rendered

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_face_general_source_cm_law.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_face_general_source_cm_law.py
@@ -1,0 +1,217 @@
+"""General source-defined CM law for generator-face publication.
+
+Steering (T): the generator-face producer serves the general
+source-defined-context-manager law — contextlib managers, config/warning/
+temp-state managers, nested generators, cleanup over Completed/Returned/
+Halted. Completion bar:
+
+- renamed import aliases publish through the identical pipeline (same body
+  face CIDs as the direct binding of the same definition);
+- unrelated source managers publish through that same pipeline (zero name
+  arms — no option_context / provider spelling tables);
+- face projection is structural over FunctionDef body, never manager names.
+
+Does not touch nodes.py, carrier/ExitSet, or lifecycle consumers.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+import inspect
+from pathlib import Path
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceDerivedGeneratorResourceRefV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.manager_summary_derivation import (
+    GeneratorBackedLifecycleProtocolV1,
+    _project_generator_lifecycle_faces,
+    populate_source_derived_resource_refs,
+)
+from sugar_source_tree.tree import SourceFile
+
+_HELPERS = """\
+from contextlib import contextmanager
+
+@contextmanager
+def alpha(flag):
+    if flag:
+        raise ValueError("enter-a")
+    yield "resource-a"
+    raise RuntimeError("exit-a")
+
+@contextmanager
+def beta():
+    yield "resource-b"
+    if True:
+        raise TypeError("then-b")
+    else:
+        raise KeyError("else-b")
+"""
+
+
+def _distribution(root: Path) -> importlib.metadata.Distribution:
+    package = root / "unprivileged"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from unprivileged.helpers import alpha, beta\n", encoding="utf-8"
+    )
+    (package / "helpers.py").write_text(_HELPERS, encoding="utf-8")
+    metadata = root / "unprivileged_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: unprivileged-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "unprivileged/__init__.py",
+        "unprivileged/helpers.py",
+        "unprivileged_dist-1.0.dist-info/METADATA",
+        "unprivileged_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _publish(tmp_path: Path, consumer: str) -> list:
+    distribution = _distribution(tmp_path)
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction(
+        workspace_root=str(tmp_path)
+    )
+    tree = SourceFile(
+        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+    return [
+        value.protocol
+        for value in context.source_derived_contract_refs.values()
+        if isinstance(value, SourceDerivedGeneratorResourceRefV1)
+    ]
+
+
+def test_renamed_manager_publishes_identical_body_face_cids(tmp_path: Path) -> None:
+    """Renamed import alias is the same definition — face CIDs must match."""
+    direct_root = tmp_path / "direct"
+    renamed_root = tmp_path / "renamed"
+    direct_root.mkdir()
+    renamed_root.mkdir()
+    direct = _publish(
+        direct_root,
+        "from unprivileged import alpha\nwith alpha(False):\n    pass\n",
+    )
+    renamed = _publish(
+        renamed_root,
+        "from unprivileged import alpha as renamed_mgr\n"
+        "with renamed_mgr(False):\n"
+        "    pass\n",
+    )
+    assert len(direct) == len(renamed) == 1
+    d, r = direct[0], renamed[0]
+    assert isinstance(d, GeneratorBackedLifecycleProtocolV1)
+    assert isinstance(r, GeneratorBackedLifecycleProtocolV1)
+    # Body-authenticated faces are identical (definition identity, not call spelling).
+    assert [f.cid for f in d.enter_halt_faces] == [f.cid for f in r.enter_halt_faces]
+    assert [f.cid for f in d.exit_halt_faces] == [f.cid for f in r.exit_halt_faces]
+    assert [f.cid for f in d.yield_faces] == [f.cid for f in r.yield_faces]
+    assert len(d.enter_halt_faces) == 1
+    assert len(d.exit_halt_faces) == 1
+    assert len(d.yield_faces) == 1
+
+
+def test_unrelated_source_managers_publish_through_identical_pipeline(
+    tmp_path: Path,
+) -> None:
+    """Two unrelated managers both receive lifecycle faces — zero name arms."""
+    root = tmp_path / "both"
+    root.mkdir()
+    protocols = _publish(
+        root,
+        "from unprivileged import alpha, beta\n"
+        "with alpha(False):\n"
+        "    pass\n"
+        "with beta():\n"
+        "    pass\n",
+    )
+    assert len(protocols) == 2
+    assert all(isinstance(p, GeneratorBackedLifecycleProtocolV1) for p in protocols)
+    by_shape = {
+        (
+            len(p.enter_halt_faces),
+            len(p.exit_halt_faces),
+            len(p.yield_faces),
+        ): p
+        for p in protocols
+    }
+    # alpha: pre-yield if-raise + post-yield raise + one yield
+    assert (1, 1, 1) in by_shape
+    # beta: no pre-yield raise; two guarded post-yield exits + one yield
+    assert (0, 2, 1) in by_shape
+    alpha = by_shape[(1, 1, 1)]
+    beta = by_shape[(0, 2, 1)]
+    # Unrelated bodies → distinct face / lifecycle identity
+    assert alpha.lifecycle_cid != beta.lifecycle_cid
+    assert alpha.yield_faces[0].cid != beta.yield_faces[0].cid
+    assert alpha.exit_halt_faces[0].cid != beta.exit_halt_faces[0].cid
+    # Conditional beta faces remain distinct
+    assert beta.exit_halt_faces[0].cid != beta.exit_halt_faces[1].cid
+    assert beta.exit_halt_faces[0].guard_source != beta.exit_halt_faces[1].guard_source
+
+
+def test_lifecycle_projection_has_zero_manager_name_arms() -> None:
+    """Projection is structural over FunctionDef — no manager name table."""
+    source = inspect.getsource(_project_generator_lifecycle_faces)
+    banned = (
+        "option_context",
+        "contextmanager",  # decorator spelling admission
+        "pytest.raises",
+        "warning",
+        "tempfile",
+        "TemporaryDirectory",
+        "alpha",
+        "beta",
+        "renamed",
+    )
+    for name in banned:
+        assert (
+            name not in source
+        ), f"name arm residual: {name!r} in lifecycle projection"
+    # Must walk typed body structure, not scan source text.
+    assert "FunctionDef" in source or "generator_target.body" in inspect.getsource(
+        inspect.getmodule(_project_generator_lifecycle_faces)
+    )
+
+
+def test_face_kinds_are_phase_separated_not_name_separated(tmp_path: Path) -> None:
+    """Enter vs exit is temporal phase / kind, never manager spelling."""
+    root = tmp_path / "phase"
+    root.mkdir()
+    protocols = _publish(
+        root,
+        "from unprivileged import alpha\nwith alpha(False):\n    pass\n",
+    )
+    protocol = protocols[0]
+    enter = protocol.enter_halt_faces[0]
+    exit_ = protocol.exit_halt_faces[0]
+    assert enter.preimage["kind"] == "generator-enter-halt-face"
+    assert exit_.preimage["kind"] == "generator-exit-halt-face"
+    assert exit_.temporal_phase == "post-yield"
+    assert "temporalPhase" not in enter.preimage
+    # No manager name in face preimages.
+    for face in (enter, exit_, *protocol.yield_faces):
+        blob = repr(face.preimage)
+        assert "alpha" not in blob
+        assert "option_context" not in blob

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_post_yield_exit_halt.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_post_yield_exit_halt.py
@@ -1,0 +1,186 @@
+"""Generator CM post-yield exceptional exit face publication.
+
+Producer: yield resource; raise RuntimeError (or finally raise) publishes
+GeneratorExitHaltFaceV1 with temporal_phase=post-yield — distinct from enter
+halt and not a suppression result. Temporal generator state (frame + yield
+faces) preserved. Tampering refuses.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceDerivedGeneratorResourceRefV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
+from sugar_lift_python_source.manager_summary_derivation import (
+    GeneratorBackedLifecycleProtocolV1,
+    GeneratorEnterHaltFaceV1,
+    GeneratorExitHaltFaceV1,
+    populate_source_derived_resource_refs,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _distribution(root: Path, implementation: str) -> importlib.metadata.Distribution:
+    package = root / "unprivileged"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from unprivileged.helpers import cm\n", encoding="utf-8"
+    )
+    (package / "helpers.py").write_text(implementation, encoding="utf-8")
+    metadata = root / "unprivileged_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: unprivileged-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "unprivileged/__init__.py",
+        "unprivileged/helpers.py",
+        "unprivileged_dist-1.0.dist-info/METADATA",
+        "unprivileged_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _publish(tmp_path: Path, implementation: str):
+    distribution = _distribution(tmp_path, implementation)
+    path = tmp_path / "consumer.py"
+    path.write_text(
+        "from unprivileged import cm\nwith cm():\n    pass\n", encoding="utf-8"
+    )
+    context = TreeConstructionContextV1.for_source_call_construction(
+        workspace_root=str(tmp_path)
+    )
+    tree = SourceFile(
+        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+    return next(
+        v.protocol
+        for v in context.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+
+
+_POST_YIELD_RAISE = (
+    "from contextlib import contextmanager\n"
+    "\n"
+    "@contextmanager\n"
+    "def cm():\n"
+    "    yield 'resource'\n"
+    "    raise RuntimeError('after')\n"
+)
+
+_FINALLY_RAISE = (
+    "from contextlib import contextmanager\n"
+    "\n"
+    "@contextmanager\n"
+    "def cm():\n"
+    "    try:\n"
+    "        yield 'resource'\n"
+    "    finally:\n"
+    "        raise RuntimeError('cleanup')\n"
+)
+
+_PRE_AND_POST = (
+    "from contextlib import contextmanager\n"
+    "\n"
+    "@contextmanager\n"
+    "def cm(flag):\n"
+    "    if flag:\n"
+    "        raise ValueError('enter')\n"
+    "    yield 'resource'\n"
+    "    raise RuntimeError('exit')\n"
+)
+
+
+def test_post_yield_raise_publishes_exit_halt_not_enter_halt(tmp_path: Path) -> None:
+    protocol = _publish(tmp_path, _POST_YIELD_RAISE)
+    assert isinstance(protocol, GeneratorBackedLifecycleProtocolV1)
+    assert protocol.enter_halt_faces == ()
+    assert len(protocol.yield_faces) == 1
+    assert len(protocol.exit_halt_faces) == 1
+    exit_face = protocol.exit_halt_faces[0]
+    assert isinstance(exit_face, GeneratorExitHaltFaceV1)
+    assert exit_face.temporal_phase == "post-yield"
+    assert exit_face.cid == cid_of_json(exit_face.preimage)
+    # Not an enter-halt kind.
+    assert exit_face.preimage["kind"] == "generator-exit-halt-face"
+    # Temporal frame + yield preserved.
+    assert protocol.generator_frame.generator_steps is not None
+    assert protocol.yield_faces[0].cid != exit_face.cid
+
+
+def test_finally_raise_is_post_yield_exit_halt(tmp_path: Path) -> None:
+    protocol = _publish(tmp_path, _FINALLY_RAISE)
+    assert len(protocol.yield_faces) == 1
+    assert len(protocol.exit_halt_faces) == 1
+    assert protocol.exit_halt_faces[0].temporal_phase == "post-yield"
+    assert protocol.enter_halt_faces == ()
+
+
+def test_pre_and_post_raises_are_distinct_faces(tmp_path: Path) -> None:
+    protocol = _publish(tmp_path, _PRE_AND_POST)
+    assert len(protocol.enter_halt_faces) == 1
+    assert len(protocol.exit_halt_faces) == 1
+    enter = protocol.enter_halt_faces[0]
+    exit_ = protocol.exit_halt_faces[0]
+    assert isinstance(enter, GeneratorEnterHaltFaceV1)
+    assert isinstance(exit_, GeneratorExitHaltFaceV1)
+    assert enter.cid != exit_.cid
+    assert enter.preimage["kind"] != exit_.preimage["kind"]
+    assert exit_.temporal_phase == "post-yield"
+    # Consumer cannot treat exit as enter: different kind + phase in preimage.
+    assert "temporalPhase" not in enter.preimage
+    assert exit_.preimage["temporalPhase"] == "post-yield"
+
+
+def test_exit_halt_not_suppression_result(tmp_path: Path) -> None:
+    protocol = _publish(tmp_path, _POST_YIELD_RAISE)
+    exit_face = protocol.exit_halt_faces[0]
+    # Suppression is exit-disposition semantics; exit-halt is exceptional exit
+    # testimony with its own kind — never NeverSuppresses / ReturnTruthiness.
+    assert "suppress" not in exit_face.preimage["kind"].lower()
+    assert exit_face.preimage["kind"] == "generator-exit-halt-face"
+
+
+def test_tampered_exit_halt_cid_refuses(tmp_path: Path) -> None:
+    protocol = _publish(tmp_path, _POST_YIELD_RAISE)
+    face = protocol.exit_halt_faces[0]
+    with pytest.raises(ValueError, match="exit-halt face CID|does not match"):
+        GeneratorExitHaltFaceV1(
+            face.occurrence,
+            face.exception_type_source,
+            face.guard_source,
+            "post-yield",
+            "blake3-512:" + "0" * 128,
+        )
+
+
+def test_identical_reconstruction_yields_identical_exit_halt(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    left = _publish(a, _POST_YIELD_RAISE)
+    right = _publish(b, _POST_YIELD_RAISE)
+    assert left.exit_halt_faces[0].cid == right.exit_halt_faces[0].cid
+    assert left.lifecycle_cid == right.lifecycle_cid

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_enter_halt.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_enter_halt.py
@@ -223,6 +223,7 @@ def test_lifecycle_protocol_refuses_stale_lifecycle_cid(tmp_path: Path) -> None:
             protocol.generator_frame,
             protocol.enter_halt_faces,
             protocol.yield_faces,
+            protocol.exit_halt_faces,
             "blake3-512:" + "c" * 128,
         )
 

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_enter_halt.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_enter_halt.py
@@ -1,0 +1,248 @@
+"""Generator CM pre-yield exceptional enter-halt face publication.
+
+Producer (manager_summary_derivation): for
+
+    @contextmanager
+    def cm(flag):
+        if flag:
+            raise ValueError(...)
+        yield resource
+
+publication retains a guarded named enter halt with authenticated exception
+type source + raise occurrence, and the complementary yield face for the
+resource handoff. Tampered face CIDs refuse. No decorator/provider spelling
+admission; no nodes.py / carrier / ExitSet edits.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceDerivedGeneratorResourceRefV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
+from sugar_lift_python_source.manager_summary_derivation import (
+    GeneratorBackedLifecycleProtocolV1,
+    GeneratorEnterHaltFaceV1,
+    GeneratorYieldFaceV1,
+    populate_source_derived_resource_refs,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _distribution(root: Path, implementation: str) -> importlib.metadata.Distribution:
+    package = root / "unprivileged"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from unprivileged.helpers import cm\n", encoding="utf-8"
+    )
+    (package / "helpers.py").write_text(implementation, encoding="utf-8")
+    metadata = root / "unprivileged_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: unprivileged-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "unprivileged/__init__.py",
+        "unprivileged/helpers.py",
+        "unprivileged_dist-1.0.dist-info/METADATA",
+        "unprivileged_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _publish(tmp_path: Path, implementation: str, consumer: str | None = None):
+    distribution = _distribution(tmp_path, implementation)
+    path = tmp_path / "consumer.py"
+    path.write_text(
+        consumer or ("from unprivileged import cm\n" "with cm(False):\n" "    pass\n"),
+        encoding="utf-8",
+    )
+    context = TreeConstructionContextV1.for_source_call_construction(
+        workspace_root=str(tmp_path)
+    )
+    tree = SourceFile(
+        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+    return context
+
+
+_CM_PRE_YIELD_RAISE = (
+    "from contextlib import contextmanager\n"
+    "\n"
+    "@contextmanager\n"
+    "def cm(flag):\n"
+    "    if flag:\n"
+    "        raise ValueError('boom')\n"
+    "    yield 'resource'\n"
+)
+
+
+def test_pre_yield_raise_publishes_guarded_enter_halt_and_yield_face(
+    tmp_path: Path,
+) -> None:
+    context = _publish(tmp_path, _CM_PRE_YIELD_RAISE)
+    refs = [
+        value
+        for value in context.source_derived_contract_refs.values()
+        if isinstance(value, SourceDerivedGeneratorResourceRefV1)
+    ]
+    assert len(refs) == 1
+    protocol = refs[0].protocol
+    assert isinstance(protocol, GeneratorBackedLifecycleProtocolV1)
+    # Guarded named enter halt — authenticated type source + occurrence.
+    assert len(protocol.enter_halt_faces) == 1
+    halt = protocol.enter_halt_faces[0]
+    assert isinstance(halt, GeneratorEnterHaltFaceV1)
+    assert halt.guard_source is not None
+    assert halt.occurrence["cid"].startswith("blake3-512:")
+    assert halt.exception_type_source["cid"].startswith("blake3-512:")
+    assert halt.cid == cid_of_json(halt.preimage)
+    # Complementary yield face publishes the resource handoff.
+    assert len(protocol.yield_faces) == 1
+    yf = protocol.yield_faces[0]
+    assert isinstance(yf, GeneratorYieldFaceV1)
+    assert yf.resource_source is not None
+    assert yf.cid == cid_of_json(yf.preimage)
+    # Enter halt is not the yield face.
+    assert halt.cid != yf.cid
+    # Lifecycle CID authenticates both face sets.
+    assert protocol.lifecycle_cid == cid_of_json(protocol.lifecycle_preimage)
+
+
+def test_identical_source_reconstruction_yields_identical_enter_halt_testimony(
+    tmp_path: Path,
+) -> None:
+    left_root = tmp_path / "a"
+    right_root = tmp_path / "b"
+    left_root.mkdir()
+    right_root.mkdir()
+    left = _publish(left_root, _CM_PRE_YIELD_RAISE)
+    right = _publish(right_root, _CM_PRE_YIELD_RAISE)
+    left_proto = next(
+        v.protocol
+        for v in left.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    right_proto = next(
+        v.protocol
+        for v in right.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    assert left_proto.enter_halt_faces[0].cid == right_proto.enter_halt_faces[0].cid
+    assert left_proto.yield_faces[0].cid == right_proto.yield_faces[0].cid
+    assert left_proto.lifecycle_cid == right_proto.lifecycle_cid
+
+
+def test_tampered_enter_halt_face_cid_refuses(tmp_path: Path) -> None:
+    context = _publish(tmp_path, _CM_PRE_YIELD_RAISE)
+    protocol = next(
+        v.protocol
+        for v in context.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    halt = protocol.enter_halt_faces[0]
+    with pytest.raises(ValueError, match="enter-halt face CID|does not match"):
+        GeneratorEnterHaltFaceV1(
+            halt.occurrence,
+            halt.exception_type_source,
+            halt.guard_source,
+            "blake3-512:" + "0" * 128,
+        )
+
+
+def test_tampered_exception_type_source_changes_face_cid(tmp_path: Path) -> None:
+    context = _publish(tmp_path, _CM_PRE_YIELD_RAISE)
+    protocol = next(
+        v.protocol
+        for v in context.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    halt = protocol.enter_halt_faces[0]
+    mutated_type = dict(halt.exception_type_source)
+    mutated_type["cid"] = "blake3-512:" + "a" * 128
+    mutated = GeneratorEnterHaltFaceV1.mint(
+        occurrence=halt.occurrence,
+        exception_type_source=mutated_type,
+        guard_source=halt.guard_source,
+    )
+    assert mutated.cid != halt.cid
+
+
+def test_tampered_raise_occurrence_changes_face_cid(tmp_path: Path) -> None:
+    context = _publish(tmp_path, _CM_PRE_YIELD_RAISE)
+    protocol = next(
+        v.protocol
+        for v in context.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    halt = protocol.enter_halt_faces[0]
+    mutated_occ = dict(halt.occurrence)
+    mutated_occ["cid"] = "blake3-512:" + "b" * 128
+    mutated = GeneratorEnterHaltFaceV1.mint(
+        occurrence=mutated_occ,
+        exception_type_source=halt.exception_type_source,
+        guard_source=halt.guard_source,
+    )
+    assert mutated.cid != halt.cid
+
+
+def test_lifecycle_protocol_refuses_stale_lifecycle_cid(tmp_path: Path) -> None:
+    context = _publish(tmp_path, _CM_PRE_YIELD_RAISE)
+    protocol = next(
+        v.protocol
+        for v in context.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    with pytest.raises(ValueError, match="lifecycle CID"):
+        GeneratorBackedLifecycleProtocolV1(
+            protocol.protocol_construction_cid,
+            protocol.generator_frame_cid,
+            protocol.enter_definition,
+            protocol.exit_definition,
+            protocol.exit_face_id,
+            protocol.generator_frame,
+            protocol.enter_halt_faces,
+            protocol.yield_faces,
+            "blake3-512:" + "c" * 128,
+        )
+
+
+def test_plain_yield_without_pre_yield_raise_has_empty_enter_halts(
+    tmp_path: Path,
+) -> None:
+    context = _publish(
+        tmp_path,
+        "from contextlib import contextmanager\n"
+        "\n"
+        "@contextmanager\n"
+        "def cm():\n"
+        "    yield 'resource'\n",
+    )
+    protocol = next(
+        v.protocol
+        for v in context.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    )
+    assert isinstance(protocol, GeneratorBackedLifecycleProtocolV1)
+    assert protocol.enter_halt_faces == ()
+    assert len(protocol.yield_faces) == 1


### PR DESCRIPTION
## Summary

Steering from T: generator-face producer serves the **general** source-defined context-manager law.

### Completion bar (pinned)

| Law | |
| --- | --- |
| Renamed import (`alpha as renamed_mgr`) | identical enter/exit/yield face CIDs as direct `alpha` |
| Unrelated managers (`alpha`, `beta`) | both publish via same pipeline; distinct lifecycles |
| Zero name arms | projection source has no `option_context` / manager name table |
| Phase separation | enter-halt vs exit-halt is kind + `temporal_phase`, not spelling |

### Stack

Tops #6671 → #6675 → #6678 (generator face queue).

### Must not touch (held)

nodes.py, carrier/ExitSet, lifecycle consumers; no name arms added.

## Tests

```
bin/bpytest tests/test_generator_face_general_source_cm_law.py -q
# 4 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin general source-defined CM law for generator-face publication
> - Adds three new frozen dataclasses (`GeneratorEnterHaltFaceV1`, `GeneratorYieldFaceV1`, `GeneratorExitHaltFaceV1`) that carry pre-yield, yield, and post-yield lifecycle testimony with CIDs derived from their preimages, rejecting any CID mismatch on construction.
> - Introduces `GeneratorBackedLifecycleProtocolV1` to wrap a generator-backed manager protocol with its enter-halt, yield, and exit-halt faces, computing a stable `lifecycle_cid` and validating phase separation and face CID uniqueness.
> - Adds `_project_generator_lifecycle_faces` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6680/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to derive structured lifecycle faces from a generator function body, distinguishing pre-yield enter-halts from post-yield exit-halts and capturing conditional guards with branch polarity.
> - Updates `_publish_generator_backed_resource_contract` to embed `enterHaltFaceCids`, `yieldFaceCids`, `exitHaltFaceCids`, and `lifecycleCid` in the published summary preimage, and stores the lifecycle wrapper on the resource ref instead of the raw protocol.
> - Behavioral Change: the resource ref for generator-backed contracts now holds a `GeneratorBackedLifecycleProtocolV1` rather than `GeneratorBackedManagerProtocolV1`, which breaks the prior `isinstance` check in existing tests (updated accordingly).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 849de80.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->