### PR TITLE
Canonicalize loop recurrence testimony and bank generator resource join

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
@@ -49,6 +49,50 @@ class LoopRecurrenceSugar(Sugar):
     def witnesses(cls):
         return ()
 
+    def to_term(self, *, owner: str):
+        """Project the authenticated loop construction as one canonical term."""
+        del owner
+        from sugar_lift_py_tests.loop_construction import (
+            LoopWireError,
+            decode_loop_construction_v1,
+        )
+
+        construction = decode_loop_construction_v1(self.construction.wire_graph())
+        if construction.loop_construction_cid != self.loop_construction_cid:
+            raise LoopWireError("loop recurrence construction CID mismatch")
+        if construction.target.target_cid != self.target_cid:
+            raise LoopWireError("loop recurrence target CID mismatch")
+
+        root = construction.wire_graph()["root"]
+        outward_face_cids = tuple(root["outwardHaltedFaceCids"])
+        if len(outward_face_cids) != len(self.outward_faces):
+            raise LoopWireError("loop recurrence outward-face testimony mismatch")
+        coordinates = (*self.binding_coordinate_cids, *outward_face_cids)
+        if any(
+            not isinstance(cid, str) or not cid.startswith("blake3-512:")
+            for cid in coordinates
+        ):
+            raise LoopWireError("loop recurrence testimony must be content-addressed")
+
+        return ctor(
+            "python:loop-recurrence-construction",
+            (
+                str_const(self.target_cid),
+                str_const(self.loop_construction_cid),
+                ctor(
+                    "python:loop-binding-coordinates",
+                    tuple(str_const(cid) for cid in self.binding_coordinate_cids),
+                    symbol_kind="coordinate",
+                ),
+                ctor(
+                    "python:loop-outward-face-testimony",
+                    tuple(str_const(cid) for cid in outward_face_cids),
+                    symbol_kind="coordinate",
+                ),
+            ),
+            symbol_kind="coordinate",
+        )
+
     def desugar(self, ctx=None):
         from sugar_lift_py_tests.floor import InvValue
         from sugar_lift_py_tests.floor.block_value import BlockValue

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import csv
 import importlib.metadata
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -34,6 +35,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     TreeConstructionContextV1,
 )
 from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor import BlockValue, ReturnValue, TermValue
 from sugar_lift_py_tests.fixture_resource_obligation import (
     FixtureSuppliedResourceObligationV1,
 )
@@ -145,19 +147,6 @@ def _tree(root: Path, consumer: str, *, dist):
         path=path,
         distribution_index={"arbitrary": dist},
     )
-    # Inject task-2's publication boundary. These coordinates are deliberately
-    # fixture-owned; rebasing the real producer later swaps only this setup.
-    for receiver in context.source_derived_contract_refs:
-        context.contract_refs.native_definitions[
-            (receiver, NativeProtocolSlot.CONTEXT_ENTER)
-        ] = SourceFragmentCoordinateV1(
-            "blake3-512:" + "e" * 128, 1, 0, 1, 1
-        )
-        context.contract_refs.native_definitions[
-            (receiver, NativeProtocolSlot.CONTEXT_EXIT)
-        ] = SourceFragmentCoordinateV1(
-            "blake3-512:" + "x" * 128, 2, 0, 2, 1
-        )
     return tree, context, path
 
 
@@ -320,6 +309,98 @@ def test_authenticated_pandas_303_get_handle_is_real_resource_reproducer():
     )
     assert "def __exit__(\n        self," in manager_source
     assert "    ) -> None:\n        self.close()" in manager_source
+
+
+def test_real_option_context_coordinates_drive_every_resource_lifecycle_face():
+    """The producer's two real coordinates are the sole lifecycle authority."""
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+
+    corpus = authenticated_pandas_corpus()
+    root = corpus.root.parent
+    path = root / "pandas/tests/io/formats/test_ipython_compat.py"
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = open_source_file_for_construction(
+        path, root=root, construction_context=context, populate_derived=False
+    )
+    populate_source_derived_resource_refs(tree, root=root, path=path)
+    with_node = next(
+        node
+        for node in tree.nodes()
+        if node.kind == "With" and node.line_col_span().start_line == 25
+    )
+    receiver = next(
+        coordinate
+        for coordinate in context.source_manager_provider_calls
+        if coordinate.start_line == 25
+    )
+    refs = context.contract_refs
+    enter_definition = refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_ENTER
+    )
+    exit_definition = refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_EXIT
+    )
+    assert isinstance(enter_definition, SourceFragmentCoordinateV1)
+    assert isinstance(exit_definition, SourceFragmentCoordinateV1)
+    assert enter_definition != exit_definition
+
+    class RecordingDefinitionDoor:
+        def __init__(self, delegate):
+            self.delegate = delegate
+            self.calls = []
+
+        def __getattr__(self, name):
+            return getattr(self.delegate, name)
+
+        def require_native_definition(self, use_site, slot):
+            self.calls.append((use_site, slot))
+            return self.delegate.require_native_definition(use_site, slot)
+
+    recording = RecordingDefinitionDoor(refs)
+    object.__setattr__(context, "contract_refs", recording)
+    resource = with_node.sugar()
+
+    assert isinstance(resource, WithSourceResourceSugar)
+    assert recording.calls == [
+        (receiver, NativeProtocolSlot.CONTEXT_ENTER),
+        (receiver, NativeProtocolSlot.CONTEXT_EXIT),
+    ]
+    assert resource.enter.native_definition_coordinate == enter_definition
+    assert resource.exit.native_definition_coordinate == exit_definition
+
+    completed = replace(
+        resource,
+        body=(_FixedSugar(Complete(BlockValue((), can_fall_through=True))),),
+    ).desugar()
+    returned = replace(
+        resource,
+        body=(
+            _FixedSugar(
+                Complete(
+                    BlockValue(
+                        (ReturnValue(TermValue(7)),), can_fall_through=False
+                    )
+                )
+            ),
+        ),
+    ).desugar()
+    effect = RaiseEffect(exception_name="ValueError", occurrence="consumer.py:26:8")
+    halted = replace(
+        resource,
+        body=(_FixedSugar(Incomplete(effect)),),
+    ).desugar()
+
+    assert any(isinstance(face, Completed) for face in completed.exits)
+    assert any(
+        isinstance(entry, ReturnValue)
+        for face in returned.exits
+        if isinstance(face, Completed)
+        for entry in face.value.contribution()
+    )
+    assert any(
+        isinstance(face, Halted) and face.effect is effect for face in halted.exits
+    )
 
 
 def test_source_true_exit_publishes_truthiness_and_consumes_raise(tmp_path: Path):

--- a/implementations/python/sugar-source-tree/tests/test_loop_recurrence_term.py
+++ b/implementations/python/sugar-source-tree/tests/test_loop_recurrence_term.py
@@ -1,0 +1,67 @@
+"""Canonical construction testimony for ``LoopRecurrenceSugar``."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.loop_construction import LoopWireError
+from sugar_source_tree.tree import SourceFile
+
+
+def _loop(tmp_path: Path, source: str, name: str):
+    path = tmp_path / name
+    path.write_text(source, encoding="utf-8")
+    function = next(SourceFile(path_source(path)).functions()).sugar()
+    return next(
+        statement
+        for statement in function.statements
+        if type(statement).__name__ == "LoopRecurrenceSugar"
+    )
+
+
+_BASE = (
+    "def exercise(xs):\n"
+    "    for item in xs:\n"
+    "        pass\n"
+    "    return xs\n"
+)
+
+
+def test_identical_loop_construction_preimages_yield_identical_terms(tmp_path: Path):
+    first = _loop(tmp_path, _BASE, "first.py")
+    second = _loop(tmp_path, _BASE, "second.py")
+
+    assert first.to_term(owner="test") == second.to_term(owner="test")
+
+
+@pytest.mark.parametrize(
+    "changed",
+    (
+        _BASE.replace("item", "member"),
+        "\n" + _BASE,
+        _BASE.replace("        pass\n", "        raise ValueError\n"),
+    ),
+    ids=("target", "coordinate", "outward-testimony"),
+)
+def test_changed_authenticated_loop_construction_changes_term(
+    tmp_path: Path, changed: str
+):
+    baseline = _loop(tmp_path, _BASE, "baseline.py")
+    variant = _loop(tmp_path, changed, "variant.py")
+
+    assert baseline.to_term(owner="test") != variant.to_term(owner="test")
+
+
+def test_tampered_loop_construction_refuses_term_projection(tmp_path: Path):
+    loop = _loop(tmp_path, _BASE, "tampered.py")
+    graph = deepcopy(loop.construction.wire_graph())
+    graph["root"]["outwardHaltedFaceCids"].append("blake3-512:" + "f" * 128)
+    tampered_construction = replace(loop.construction, _graph=graph)
+
+    with pytest.raises(LoopWireError, match="loopConstructionCid mismatch"):
+        replace(loop, construction=tampered_construction).to_term(owner="test")


### PR DESCRIPTION
## Capability

- Give `LoopRecurrenceSugar` a canonical content-addressable IR term derived only from authenticated target, construction coordinate, binding coordinates, and outward-face testimony.
- Prove identical preimages produce identical terms; changed target, coordinate, or testimony changes the term; sealed-graph tampering refuses.

## Banked instrument

- Replace fixture injection with the real source-published `option_context` coordinates.
- Pin construction-time definition-door use, exact enter/exit coordinates, and Completed/Returned/Halted lifecycle conservation.
- This join is intentionally red at the producer boundary pending grok-1: `GeneratorBackedManagerProtocolV1` does not yet provide `enter_resource_outcome` / `exit_outcome_for`. No consumer fallback, name arm, or lifecycle derivation is included.

## Validation

- `cd implementations/python/sugar-source-tree && ../../../bin/bpytest tests/test_loop_recurrence_term.py` — 5 passed.
- Focused lifecycle join — 1 passed, 1 failed at the named missing producer method.
- `sugar-lift-py-tests` package — 2318 passed, 264 failed, 9 skipped, 5 errors (existing broad telemetry retained).
- `sugar-source-tree` package — 584 passed, 227 failed, 5 skipped (existing broad telemetry retained).

R: generator lifecycle producer operations remain 1 typed boundary gap. Predicted epsilon: loop recurrence term capability is complete; lifecycle R remains unchanged until the protocol producer lands. Floors preserved: no carrier/ExitSet changes, no name matching, no suppressed red or panic.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Canonicalize loop recurrence construction into a verified term and fix resource context coordinate injection
> - Adds `LoopRecurrenceSugar.to_term()` in [loop_recurrence_sugar.py](https://github.com/TSavo/sugar/pull/6681/files#diff-f2f1e95b345c3c7e0569fbbe5a17e9608d1617fd8decf5507ba13f0d25c59547) that decodes the wire graph, validates CID integrity and outward-face testimony length, and returns a canonical `ctor('python:loop-recurrence-construction', ...)` term, raising `LoopWireError` on mismatches.
> - Adds tests in [test_loop_recurrence_term.py](https://github.com/TSavo/sugar/pull/6681/files#diff-ce1949e0324b38fb6d8fc801e1042beb0e57613ec8a3a3aebaed107f864c20b4) covering identical preimage stability, sensitivity to source changes, and tampered wire graph rejection.
> - Removes synthetic `CONTEXT_ENTER`/`CONTEXT_EXIT` injection from the `_tree` helper in [test_returned_resource_with_construction.py](https://github.com/TSavo/sugar/pull/6681/files#diff-516e8891dc248d2149005b9dfa3dfc5e559fe9652a9f705bca9ebd9c97741685); tests now rely on real coordinates from `populate_source_derived_resource_refs`.
> - Behavioral Change: helpers using `_tree` no longer override context contract refs, so tests that depended on the synthetic definitions will now use real source-derived coordinates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d6eb75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->