### PR TITLE
Give chained Compare legs distinct occurrences

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -841,7 +841,7 @@ def test_chained_comparison_composes_pair_ordering_laws() -> None:
     adjacent ComparisonOpSugar pairs). Residual faces are ordered dual-edge
     composition under short-circuit And — not a monomorphic chain panic.
     """
-    from sugar_lift_py_tests.ir import and_, atomic, make_var, not_, or_
+    from sugar_lift_py_tests.ir import and_, atomic, make_var, not_
     from sugar_lift_py_tests.outcome import ExitSet
     from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
 
@@ -854,21 +854,60 @@ def test_chained_comparison_composes_pair_ordering_laws() -> None:
     assert isinstance(outcome, ExitSet)
     halted = [face for face in outcome.exits if isinstance(face, Halted)]
     completed = [face for face in outcome.exits if isinstance(face, Completed)]
-    assert len(halted) == 1  # normalization merges the same Compare effect
+    assert len(halted) == 2
+    assert halted[0].effect.occurrence_id != halted[1].effect.occurrence_id
 
     a, b, c = make_var("a"), make_var("b"), make_var("c")
     first_raises = atomic("python.lt_dispatch_raises", [a, b])
     first_true = atomic("py.lt", [a, b])
     second_raises = atomic("python.lt_dispatch_raises", [b, c])
-    assert halted[0].guard == or_(
-        [
-            first_raises,
-            and_([not_(first_raises), and_([first_true, second_raises])]),
-        ]
-    )
+    assert {face.guard for face in halted} == {
+        first_raises,
+        and_([not_(first_raises), and_([first_true, second_raises])]),
+    }
     assert any(
         face.guard == and_([not_(first_raises), not_(first_true)]) for face in completed
     )
+
+
+def test_chained_compare_leg_sites_follow_operator_occurrences_not_operands() -> None:
+    """Repeated operand spelling cannot collapse two operator occurrences."""
+    node = _synthetic_compare("left < left < left")
+    sugar = node.sugar()
+
+    first, second = sugar.values
+    assert first.site.text.strip() == second.site.text.strip() == "<"
+    assert first.site.source_cid == second.site.source_cid == node.fragment.source_cid
+    assert first.site.line_col_span != second.site.line_col_span
+
+
+def test_chained_compare_rejects_an_operator_coordinate_from_the_wrong_leg() -> None:
+    """A same-spelling operator from leg one cannot authenticate leg two."""
+    from sugar_source_tree.panic import SugarNotWritten
+
+    node = _synthetic_compare("left < left < left")
+    operands = (node.left, *node.comparators)
+    tampered = (operands[0], operands[1], operands[1])
+
+    with pytest.raises(SugarNotWritten, match="Compare._comparison_leg_site"):
+        node._comparison_leg_site(1, tampered)
+
+
+def test_decided_false_first_leg_emits_no_second_leg_occurrence() -> None:
+    from sugar_lift_py_tests.outcome import ExitSet
+    from sugar_lift_py_tests.outcome.exit_set import Halted
+
+    node = _synthetic_compare("2 < 1 < None")
+    sugar = node.sugar()
+    second_occurrence = str(sugar.values[1].site)
+    outcome = sugar.desugar(None)
+
+    effects = (
+        tuple(exit_.effect for exit_ in outcome.exits if isinstance(exit_, Halted))
+        if isinstance(outcome, ExitSet)
+        else ()
+    )
+    assert all(effect.occurrence_id != second_occurrence for effect in effects)
 
 
 def test_subscript_root_preserves_nested_compare_owned_halt() -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -7961,6 +7961,50 @@ class Compare(Expression):
         are leaves, carried through)."""
         return self._substitute_children(scope)
 
+    def _comparison_leg_site(self, index: int, operands: tuple[Expression, ...]):
+        """Return the enumerated operator occurrence for one chained leg.
+
+        The operator token, not operand content or the enclosing Compare span,
+        distinguishes adjacent operations.  Authenticate that token against
+        the two operands it separates before allowing it to become an effect
+        occurrence coordinate.
+        """
+        left = operands[index]
+        right = operands[index + 1]
+
+        def reject():
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                blame=self.fragment,
+                owner="Compare._comparison_leg_site",
+                observed=(index, left.span, right.span),
+                requested="the source-authenticated operator interval between adjacent operands",
+                fix="preserve each Compare leg's adjacent operand spans in source order",
+            )
+
+        if not (
+            self.span.start <= left.span.start < left.span.end
+            and left.span.end < right.span.start
+            and right.span.end <= self.span.end
+        ):
+            reject()
+        gap = Span(left.span.end, right.span.start)
+        if not gap.slice(self.unit.source).strip():
+            reject()
+        from .fragment import SourceFragment
+
+        # Comparison operators have no backend node of their own.  The exact
+        # source-authenticated occurrence is the non-empty source interval
+        # between the adjacent operand nodes; the Compare grammar testifies
+        # which operator occupies that interval.  Repeated operand content
+        # cannot collapse these positional intervals.
+        return SourceFragment(
+            unit=self.unit,
+            span=gap,
+            node=self,
+        )
+
     def _construct_sugar(self):
         """A comparison constructs its operator's sugar, built WITH its
         children's sugar. `==` is EqualityOpSugar (it also refines); the ordering
@@ -7989,6 +8033,11 @@ class Compare(Expression):
             op = self.ops[index]
             left_s = operands[index].sugar()
             right_s = operands[index + 1].sugar()
+            site = (
+                self._comparison_leg_site(index, operands)
+                if len(self.ops) > 1
+                else self.fragment
+            )
             if isinstance(op, Eq):
                 # The refinement coordinate is the PAIR's left operand, read
                 # here where the tree is in hand. In a chain `a.k == b == c` the
@@ -7998,11 +8047,11 @@ class Compare(Expression):
                 return EqualityOpSugar(
                     left=left_s,
                     right=right_s,
-                    site=self.fragment,
+                    site=site,
                     left_coordinate=operands[index].dotted_expr_name(),
                 )
             return ComparisonOpSugar(
-                op_kind=op.kind, left=left_s, right=right_s, site=self.fragment
+                op_kind=op.kind, left=left_s, right=right_s, site=site
             )
 
         pairs = tuple(pair(i) for i in range(len(self.ops)))


### PR DESCRIPTION
## Capability

Chained Compare now derives each leg occurrence from the authenticated source interval between its adjacent operands. Repeated operand spelling cannot collapse the sites, and an out-of-order coordinate twin stays loudly rejected. A decided-false first leg emits no second-leg occurrence.

No carrier, ExitSet, short_circuit, reducer, or boundary-routing code changed. Chained-ordering follow-ons are parked per advisor ruling.

## Tests

- `../../../bin/bpytest tests/test_compare_exceptional_exit_producer.py -q` — 51 passed
- `../../../bin/bpytest -q` in sugar-source-tree — 570 passed, 226 failed, 5 skipped (preserved broad reds)
- `../../../bin/bpytest -q` in sugar-lift-py-tests — 2202 passed, 279 failed, 12 skipped, 5 errors (preserved broad reds)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Give each leg of a chained `Compare` node a distinct operator-occurrence site
> - Adds `Compare._comparison_leg_site` in [nodes.py](https://github.com/TSavo/sugar/pull/6682/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to compute a `SourceFragment` covering the exact operator token gap between adjacent operands for each leg of a chained comparison.
> - Updates `Compare._construct_sugar` to pass this per-leg site into `EqualityOpSugar` and `ComparisonOpSugar` instead of always using the enclosing `Compare` fragment; single comparisons are unaffected.
> - `_comparison_leg_site` validates that the provided operands fall within `Compare.span` and raises `SugarNotWritten` if mismatched operands are supplied.
> - New tests cover: distinct `occurrence_id`s per leg, site text matching the operator token, rejection of wrong-leg coordinates, and suppression of the second leg occurrence when the first leg short-circuits to false.
> - Behavioral Change: chained comparisons now produce two `Halted` exits with distinct `occurrence_id`s rather than a single merged one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09ff58b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->