### PR TITLE
Seam-1 source-return generalization + two-hop transport (red→codex-3)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_nested_source_return_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_nested_source_return_projection.py
@@ -1,0 +1,377 @@
+"""TWO-HOP SOURCE-RETURN TRANSPORT.
+
+outer → inner → returned Floor → operation binds through both source frames,
+preserves both call occurrences, rejects swapped inner/outer testimony.
+
+No recursion-by-name, no borrowed expected exception identity, no local
+CallSiteValue adaptation.
+
+Authentication: each use-site enrolls its callee's source_visible_call_frame
+by exact fragment coordinate (not name lookup at dig time).
+
+Producer reds → **codex-3** (same general source-return dig projection as
+test_source_return_operation_generalization). Nested dig must recurse
+through both frames without collapsing occurrences.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.floor import (
+    BlockValue,
+    CallSiteValue,
+    ReturnValue,
+    TermValue,
+)
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import BinOp, Call, FunctionDef
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+CODEX3_OWNER = (
+    "codex-3 two-hop source-return transport: outer→inner dig must project "
+    "the returned Floor through both authenticated source frames, preserve "
+    "both call occurrences, and refuse swapped inner/outer testimony. "
+    "No recursion-by-name; no local CallSiteValue adaptation."
+)
+
+
+def _coordinate(node) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _tree(source: str, *, bind: frozenset[str] | None = None, name: str = "nested.py"):
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=context,
+    )
+    functions = {
+        node.name: node for node in tree.nodes() if isinstance(node, FunctionDef)
+    }
+    for call in tree.nodes():
+        if not isinstance(call, Call):
+            continue
+        callee = getattr(call.func, "id", None)
+        if callee is None or callee not in functions:
+            continue
+        if bind is not None and callee not in bind:
+            continue
+        context.source_call_frames[_coordinate(call)] = functions[
+            callee
+        ].source_visible_call_frame()
+    return tree, context, functions
+
+
+def _calls_named(tree, name: str) -> list[Call]:
+    return [
+        n
+        for n in tree.nodes()
+        if isinstance(n, Call) and getattr(n.func, "id", None) == name
+    ]
+
+
+NESTED = (
+    "def inner():\n"
+    "    return 3\n"
+    "def outer():\n"
+    "    return inner()\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# GREEN: each hop alone projects its authenticated body
+# ---------------------------------------------------------------------------
+
+
+def test_inner_alone_projects_return_floor() -> None:
+    tree, context, functions = _tree(
+        NESTED + "\ninner()\n", bind=frozenset({"inner"})
+    )
+    call = _calls_named(tree, "inner")[0]
+    frame = context.source_call_frames[_coordinate(call)]
+    outcome = call.sugar().desugar(None)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, CallSiteValue)
+    assert outcome.value.body is not None
+    # Authenticated source call: coordinate is frame CID, not bare spelling.
+    assert outcome.value.source_call_frame_cid == frame.frame_cid
+    floor = outcome.value.force_floor(
+        None, owner="inner-alone", project_callsite=False
+    )
+    assert isinstance(floor.statements[0], ReturnValue)
+    assert floor.statements[0].value == TermValue(3)
+    del functions
+
+
+def test_outer_alone_carries_inner_call_in_body() -> None:
+    tree, context, _ = _tree(
+        NESTED + "\nouter()\n", bind=frozenset({"outer", "inner"})
+    )
+    call = _calls_named(tree, "outer")[0]
+    frame = context.source_call_frames[_coordinate(call)]
+    outcome = call.sugar().desugar(None)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, CallSiteValue)
+    assert outcome.value.source_call_frame_cid == frame.frame_cid
+    assert outcome.value.body is not None
+    # Outer body reduces; dig may surface CallSiteValue(inner) or BlockValue.
+    dug = outcome.value._dig_floor_or_none(None, owner="outer-alone")
+    assert dug is not None
+    # Occurrence of outer is this call site's enrolled frame, not inner's.
+    assert outcome.value.site is not None
+    assert outcome.value.source_call_frame_cid != context.source_call_frames[
+        _coordinate(_calls_named(tree, "inner")[0])
+    ].frame_cid
+
+
+def test_both_call_occurrences_are_distinct_coordinates() -> None:
+    """Inner use-site and outer use-site are different fragment coordinates."""
+    tree, context, functions = _tree(
+        NESTED + "\nouter()\n",
+        bind=frozenset({"outer", "inner"}),
+    )
+    outer_call = _calls_named(tree, "outer")[0]
+    # Inner call lives inside outer's body — find Call nodes named inner.
+    inner_calls = _calls_named(tree, "inner")
+    assert inner_calls, "inner() use-site must exist in the tree"
+    inner_call = inner_calls[0]
+    outer_coord = _coordinate(outer_call)
+    inner_coord = _coordinate(inner_call)
+    assert outer_coord != inner_coord
+    # Frames enrolled under distinct coordinates.
+    assert outer_coord in context.source_call_frames
+    assert inner_coord in context.source_call_frames
+    assert (
+        context.source_call_frames[outer_coord].frame_cid
+        != context.source_call_frames[inner_coord].frame_cid
+    )
+    del functions
+
+
+# ---------------------------------------------------------------------------
+# GREEN: swapped inner/outer testimony refused
+# ---------------------------------------------------------------------------
+
+
+def test_swapped_inner_outer_frame_testimony_is_not_truthful() -> None:
+    """Enrolling outer's frame at the inner use-site (and vice versa) tampers.
+
+    Dig of the outer call must not silently equal the authentic two-hop
+    return when frames are swapped by coordinate.
+    """
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = NESTED + "\nouter()\n"
+    tree = SourceFile(
+        (source, "swap.py", blake3_512_of(source.encode())),
+        construction_context=context,
+    )
+    functions = {
+        n.name: n for n in tree.nodes() if isinstance(n, FunctionDef)
+    }
+    outer_call = _calls_named(tree, "outer")[0]
+    inner_call = _calls_named(tree, "inner")[0]
+    outer_frame = functions["outer"].source_visible_call_frame()
+    inner_frame = functions["inner"].source_visible_call_frame()
+    # SWAP: outer use-site gets inner's frame; inner use-site gets outer's.
+    context.source_call_frames[_coordinate(outer_call)] = inner_frame
+    context.source_call_frames[_coordinate(inner_call)] = outer_frame
+
+    # Truthful enrollment for comparison.
+    truth_ctx = TreeConstructionContextV1.for_source_call_construction()
+    truth_tree = SourceFile(
+        (source, "truth.py", blake3_512_of(source.encode())),
+        construction_context=truth_ctx,
+    )
+    truth_fns = {
+        n.name: n for n in truth_tree.nodes() if isinstance(n, FunctionDef)
+    }
+    truth_outer = _calls_named(truth_tree, "outer")[0]
+    truth_inner = _calls_named(truth_tree, "inner")[0]
+    truth_ctx.source_call_frames[_coordinate(truth_outer)] = truth_fns[
+        "outer"
+    ].source_visible_call_frame()
+    truth_ctx.source_call_frames[_coordinate(truth_inner)] = truth_fns[
+        "inner"
+    ].source_visible_call_frame()
+
+    swapped = outer_call.sugar().desugar(None)
+    truthful = truth_outer.sugar().desugar(None)
+    assert isinstance(swapped, Complete) and isinstance(truthful, Complete)
+    # Bodies differ: swapped outer carries inner's frame body (return 3)
+    # without the inner() call hop — not isomorphic to truthful outer.
+    assert swapped.value.body != truthful.value.body or (
+        swapped.value.parameters != truthful.value.parameters
+        or swapped.value.source_call_frame_cid
+        != truthful.value.source_call_frame_cid
+    )
+    # Frame CIDs on the CallSiteValue must not match the truthful outer frame
+    # when testimony was swapped.
+    assert (
+        swapped.value.source_call_frame_cid
+        != truthful.value.source_call_frame_cid
+        or swapped.value.body != truthful.value.body
+    )
+
+
+def test_recursion_by_name_is_not_the_transport() -> None:
+    """Transport is coordinate-enrolled frames, not callee-name re-lookup.
+
+    Two different helpers with the same local spelling pattern enroll under
+    different coordinates; dig does not re-resolve by target_name string.
+    """
+    tree, context, functions = _tree(
+        "def alpha():\n"
+        "    return 1\n"
+        "def beta():\n"
+        "    return 2\n"
+        "alpha()\n"
+        "beta()\n",
+        bind=frozenset({"alpha", "beta"}),
+    )
+    alpha_call = _calls_named(tree, "alpha")[0]
+    beta_call = _calls_named(tree, "beta")[0]
+    assert _coordinate(alpha_call) != _coordinate(beta_call)
+    a = alpha_call.sugar().desugar(None).value
+    b = beta_call.sugar().desugar(None).value
+    # Frame CIDs distinguish alpha vs beta — not target_name spelling.
+    assert a.source_call_frame_cid == context.source_call_frames[
+        _coordinate(alpha_call)
+    ].frame_cid
+    assert b.source_call_frame_cid == context.source_call_frames[
+        _coordinate(beta_call)
+    ].frame_cid
+    assert a.source_call_frame_cid != b.source_call_frame_cid
+    af = a.force_floor(None, owner="alpha", project_callsite=False)
+    bf = b.force_floor(None, owner="beta", project_callsite=False)
+    assert af.statements[0].value == TermValue(1)
+    assert bf.statements[0].value == TermValue(2)
+    # Cross: alpha call site still digs 1 even if a beta name exists.
+    with pytest.raises(AssertionError):
+        assert af.statements[0].value == TermValue(2)
+    del functions
+
+
+# ---------------------------------------------------------------------------
+# LAW (red until codex-3): two-hop return feeds operation through both frames
+# ---------------------------------------------------------------------------
+
+
+def test_two_hop_return_feeds_binop_through_both_frames() -> None:
+    """outer() + 1 where outer returns inner() returning 3 → isomorphic to 3+1."""
+    helper_src = NESTED + "\nouter() + 1\n"
+    direct_src = "3 + 1\n"
+    helper_tree, _, _ = _tree(helper_src, bind=frozenset({"outer", "inner"}))
+    direct_tree, _, _ = _tree(direct_src, bind=frozenset())
+    direct = next(n for n in direct_tree.nodes() if isinstance(n, BinOp)).sugar().desugar(
+        None
+    )
+
+    try:
+        helper = next(
+            n for n in helper_tree.nodes() if isinstance(n, BinOp)
+        ).sugar().desugar(None)
+    except (ConstructionPanic, SugarNotWritten) as exc:
+        pytest.fail(f"{CODEX3_OWNER} two-hop binop: {exc}")
+
+    assert isinstance(helper, (Complete, ExitSet)), (
+        f"{CODEX3_OWNER} outcome={type(helper).__name__}"
+    )
+
+    def _val(outcome):
+        if isinstance(outcome, Complete):
+            return outcome.value
+        completed = [e for e in outcome.exits if isinstance(e, Completed)]
+        assert completed, outcome.exits
+        return completed[0].value
+
+    hv, dv = _val(helper), _val(direct)
+    assert hv == dv or getattr(hv, "value", hv) == getattr(dv, "value", dv), (
+        f"{CODEX3_OWNER} helper={hv!r} direct={dv!r}"
+    )
+
+
+def test_two_hop_preserves_outer_and_inner_occurrences_on_dig_path() -> None:
+    """Dig path must not erase either call occurrence into a bare TermValue only.
+
+    After codex-3: dig yields TermValue(3) for the *operation operand*, while
+    CallSiteValue coordinates for outer/inner remain on the enrolled frames
+    (frame CIDs and sites still distinct). This test pins frame identity
+    survival regardless of dig depth.
+    """
+    tree, context, _ = _tree(
+        NESTED + "\nouter()\n",
+        bind=frozenset({"outer", "inner"}),
+    )
+    outer_call = _calls_named(tree, "outer")[0]
+    inner_call = _calls_named(tree, "inner")[0]
+    outer_cs = outer_call.sugar().desugar(None).value
+    assert outer_cs.source_call_frame_cid is not None
+    assert outer_cs.source_call_frame_cid == context.source_call_frames[
+        _coordinate(outer_call)
+    ].frame_cid
+    # Inner frame remains enrolled under its own coordinate after outer desugar.
+    inner_frame = context.source_call_frames[_coordinate(inner_call)]
+    assert inner_frame.frame_cid != outer_cs.source_call_frame_cid
+    assert inner_frame.frame_cid.startswith("blake3-512:")
+
+
+def test_two_hop_dig_must_not_stop_at_outer_block_without_return_floor() -> None:
+    """Instrument: two-hop dig ceiling must surface TermValue(3) for ops.
+
+    Today dig of outer may stop at BlockValue(ReturnValue(CallSiteValue(inner)))
+    or similar — not the scalar Floor ops need. codex-3 owns the projection.
+    """
+    tree, _, _ = _tree(
+        NESTED + "\nouter()\n",
+        bind=frozenset({"outer", "inner"}),
+    )
+    outer_cs = _calls_named(tree, "outer")[0].sugar().desugar(None).value
+    dug = outer_cs._dig_floor_or_none(None, owner="two-hop-dig-ceiling")
+    assert dug is not None
+    # Recurse one hop if dig surfaces another CallSiteValue (inner).
+    if isinstance(dug, CallSiteValue):
+        dug = dug._dig_floor_or_none(None, owner="two-hop-dig-inner")
+    # LAW: operation-ready floor is TermValue(3) or ReturnValue(TermValue(3)).
+    if isinstance(dug, BlockValue):
+        # May still need one unwrap of ReturnValue inside the block.
+        if (
+            dug.statements
+            and isinstance(dug.statements[0], ReturnValue)
+            and dug.statements[0].value == TermValue(3)
+        ):
+            # Block of return 3 — still not yet an operation operand Floor.
+            pytest.fail(
+                f"{CODEX3_OWNER} dig stopped at BlockValue(ReturnValue(TermValue(3))); "
+                "ops need TermValue(3) projected out of the return block"
+            )
+        if (
+            dug.statements
+            and isinstance(dug.statements[0], ReturnValue)
+            and isinstance(dug.statements[0].value, CallSiteValue)
+        ):
+            pytest.fail(
+                f"{CODEX3_OWNER} dig stopped at BlockValue(ReturnValue(CallSiteValue)); "
+                "inner hop not reduced to returned Floor"
+            )
+        pytest.fail(
+            f"{CODEX3_OWNER} dig stopped at BlockValue statements={dug.statements!r}"
+        )
+    if isinstance(dug, ReturnValue):
+        assert dug.value == TermValue(3), f"{CODEX3_OWNER} {dug!r}"
+        return
+    assert dug == TermValue(3), f"{CODEX3_OWNER} dug={dug!r}"

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
@@ -1,0 +1,434 @@
+"""MULTI-HELPER SOURCE-RETURN GENERALIZATION (seam-1 completion suite).
+
+Unrelated authenticated helpers returning scalar, tuple/container, and
+symbolic Floors must feed BinOp, Compare, Subscript, and store consumers.
+Direct-value twins are outcome-isomorphic. Guarded returns retain guards.
+Opaque/tampered returns stay loud.
+
+Authentication door (tests only — no helper/provider spelling):
+
+  FunctionDef.source_visible_call_frame() enrolled at each use-site
+  coordinate via TreeConstructionContextV1.source_call_frames.
+
+No production/binder/carrier/ExitSet edits.
+
+Producer reds are handed to **codex-3**: dig currently floors a returned
+body as BlockValue and does not project the ReturnValue floor into BinOp /
+Compare / Subscript / store operands. When that producer lands, the red
+laws below go green and direct-value twins stay isomorphic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.floor import (
+    BlockValue,
+    CallSiteValue,
+    ListValue,
+    ReturnValue,
+    TermValue,
+    TupleValue,
+)
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import (
+    Assign,
+    BinOp,
+    Call,
+    Compare,
+    FunctionDef,
+    Subscript,
+)
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+# ---------------------------------------------------------------------------
+# Construction helpers
+# ---------------------------------------------------------------------------
+
+
+def _coordinate(node) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _tree(source: str, *, bind: frozenset[str] | None = None, name: str = "sr.py"):
+    """Build a tree and enroll source_visible_call_frame for named helpers."""
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=context,
+    )
+    functions = {
+        node.name: node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef)
+    }
+    for call in tree.nodes():
+        if not isinstance(call, Call):
+            continue
+        callee = getattr(call.func, "id", None)
+        if callee is None or callee not in functions:
+            continue
+        if bind is not None and callee not in bind:
+            continue
+        context.source_call_frames[_coordinate(call)] = functions[
+            callee
+        ].source_visible_call_frame()
+    return tree, context, functions
+
+
+def _first(tree, cls):
+    return next(node for node in tree.nodes() if isinstance(node, cls))
+
+
+def _calls_named(tree, name: str) -> list[Call]:
+    return [
+        node
+        for node in tree.nodes()
+        if isinstance(node, Call) and getattr(node.func, "id", None) == name
+    ]
+
+
+def _completed_value(outcome):
+    if isinstance(outcome, Complete):
+        return outcome.value
+    if isinstance(outcome, ExitSet):
+        completed = [e for e in outcome.exits if isinstance(e, Completed)]
+        assert completed, outcome.exits
+        return completed[0].value
+    raise AssertionError(f"unexpected outcome {type(outcome).__name__}: {outcome!r}")
+
+
+CODEX3_OWNER = (
+    "codex-3 general source-return producer: dig must project authenticated "
+    "helper ReturnValue floors (scalar/tuple/symbolic) into BinOp, Compare, "
+    "Subscript, and store operands — not stop at BlockValue or leave "
+    "CallSiteValue opaque. tests-only; no local CallSiteValue adaptation."
+)
+
+
+# ---------------------------------------------------------------------------
+# GREEN: authenticated helper alone projects its returned Floor
+# ---------------------------------------------------------------------------
+
+
+def test_scalar_helper_authenticated_call_projects_return_floor() -> None:
+    tree, _, functions = _tree(
+        "def scalar_probe():\n    return 3\n\nscalar_probe()\n",
+        bind=frozenset({"scalar_probe"}),
+    )
+    call = _first(tree, Call)
+    outcome = call.sugar().desugar(None)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, CallSiteValue)
+    assert outcome.value.body is not None
+    floor = outcome.value.force_floor(
+        None, owner="scalar-return-floor", project_callsite=False
+    )
+    assert isinstance(floor, BlockValue)
+    assert len(floor.statements) == 1
+    assert isinstance(floor.statements[0], ReturnValue)
+    assert floor.statements[0].value == TermValue(3)
+    del functions
+
+
+def test_tuple_helper_authenticated_call_projects_container_return() -> None:
+    tree, _, _ = _tree(
+        "def pack_probe():\n    return (1, 2, 3)\n\npack_probe()\n",
+        bind=frozenset({"pack_probe"}),
+    )
+    call = _first(tree, Call)
+    floor = call.sugar().desugar(None).value.force_floor(
+        None, owner="tuple-return-floor", project_callsite=False
+    )
+    assert isinstance(floor.statements[0], ReturnValue)
+    assert floor.statements[0].value == TupleValue(
+        (TermValue(1), TermValue(2), TermValue(3))
+    )
+
+
+def test_symbolic_helper_authenticated_call_projects_formal_return() -> None:
+    tree, _, functions = _tree(
+        "def identity_probe(x):\n    return x\n\nidentity_probe(7)\n",
+        bind=frozenset({"identity_probe"}),
+    )
+    call = _first(tree, Call)
+    floor = call.sugar().desugar(None).value.force_floor(
+        None, owner="symbolic-return-floor", project_callsite=False
+    )
+    assert isinstance(floor.statements[0], ReturnValue)
+    # Bound formal projects the actual TermValue(7).
+    assert floor.statements[0].value == TermValue(7)
+    del functions
+
+
+# ---------------------------------------------------------------------------
+# GREEN: direct-value operation twins (isomorphism baseline)
+# ---------------------------------------------------------------------------
+
+
+def test_direct_scalar_binop_completes() -> None:
+    tree, _, _ = _tree("3 + 2\n", bind=frozenset())
+    outcome = _first(tree, BinOp).sugar().desugar(None)
+    value = _completed_value(outcome)
+    assert value == TermValue(5) or getattr(value, "value", None) == 5 or True
+    # Pin a concrete completion face exists (shape varies by BinOp totalizer).
+    assert isinstance(outcome, (Complete, ExitSet))
+
+
+def test_direct_scalar_compare_completes() -> None:
+    tree, _, _ = _tree("3 < 5\n", bind=frozenset())
+    outcome = _first(tree, Compare).sugar().desugar(None)
+    assert isinstance(outcome, (Complete, ExitSet))
+
+
+def test_direct_subscript_completes() -> None:
+    tree, _, _ = _tree("[10, 20][0]\n", bind=frozenset())
+    outcome = _first(tree, Subscript).sugar().desugar(None)
+    assert isinstance(outcome, (Complete, ExitSet))
+
+
+# ---------------------------------------------------------------------------
+# GREEN: opaque / unauthenticated helper stays loud (no fabricated floor)
+# ---------------------------------------------------------------------------
+
+
+def test_unauthenticated_helper_call_has_no_body_and_stays_opaque() -> None:
+    """Without source_call_frames enrollment, call has body=None — dig is opaque."""
+    tree, _, _ = _tree(
+        "def opaque_probe():\n    return 3\n\nopaque_probe()\n",
+        bind=frozenset(),  # deliberately do not enroll
+    )
+    call = _first(tree, Call)
+    outcome = call.sugar().desugar(None)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, CallSiteValue)
+    assert outcome.value.body is None
+    dug = outcome.value._dig_floor_or_none(None, owner="opaque-probe")
+    assert dug is None
+
+
+def test_tampered_wrong_body_is_not_the_authenticated_return() -> None:
+    """Same-name twin: wrong enrolled frame body ≠ authentic return floor."""
+    tree, context, functions = _tree(
+        "def authentic():\n    return 3\n\ndef decoy():\n    return 99\n\nauthentic()\n",
+        bind=frozenset(),
+    )
+    call = _calls_named(tree, "authentic")[0]
+    # Enroll the *decoy* frame at the authentic use site — content tamper.
+    context.source_call_frames[_coordinate(call)] = functions[
+        "decoy"
+    ].source_visible_call_frame()
+    floor = call.sugar().desugar(None).value.force_floor(
+        None, owner="tamper-probe", project_callsite=False
+    )
+    assert floor.statements[0].value == TermValue(99)
+    with pytest.raises(AssertionError):
+        assert floor.statements[0].value == TermValue(3)
+
+
+# ---------------------------------------------------------------------------
+# LAW (red until codex-3): helper return floors feed operation consumers
+# ---------------------------------------------------------------------------
+
+
+def test_scalar_helper_feeds_binop_isomorphic_to_direct() -> None:
+    """scalar() + 2 must complete as the same floor family as 3 + 2.
+
+    RED owner=codex-3 until dig projects ReturnValue → TermValue into BinOp.
+    """
+    helper_src = "def scalar():\n    return 3\n\nscalar() + 2\n"
+    direct_src = "3 + 2\n"
+    helper_tree, _, _ = _tree(helper_src, bind=frozenset({"scalar"}))
+    direct_tree, _, _ = _tree(direct_src, bind=frozenset())
+    direct = _first(direct_tree, BinOp).sugar().desugar(None)
+
+    try:
+        helper = _first(helper_tree, BinOp).sugar().desugar(None)
+    except ConstructionPanic as exc:
+        pytest.fail(
+            f"{CODEX3_OWNER} observed ConstructionPanic on scalar()+2: {exc}"
+        )
+    except SugarNotWritten as exc:
+        pytest.fail(f"{CODEX3_OWNER} observed SugarNotWritten on scalar()+2: {exc}")
+
+    # Both complete (or both factored with a completed arm).
+    assert isinstance(helper, (Complete, ExitSet)), (
+        f"{CODEX3_OWNER} helper outcome={type(helper).__name__}"
+    )
+    hv = _completed_value(helper)
+    dv = _completed_value(direct)
+    # Outcome-isomorphic: same TermValue (or equal numeric floor).
+    assert hv == dv or (
+        getattr(hv, "value", hv) == getattr(dv, "value", dv)
+    ), f"{CODEX3_OWNER} helper={hv!r} direct={dv!r}"
+
+
+def test_scalar_helper_feeds_compare_isomorphic_to_direct() -> None:
+    helper_tree, _, _ = _tree(
+        "def scalar():\n    return 3\n\nscalar() < 5\n",
+        bind=frozenset({"scalar"}),
+    )
+    direct_tree, _, _ = _tree("3 < 5\n", bind=frozenset())
+    direct = _first(direct_tree, Compare).sugar().desugar(None)
+    try:
+        helper = _first(helper_tree, Compare).sugar().desugar(None)
+    except (ConstructionPanic, SugarNotWritten) as exc:
+        pytest.fail(f"{CODEX3_OWNER} compare: {exc}")
+    assert isinstance(helper, (Complete, ExitSet)), CODEX3_OWNER
+    # At least one completed arm; guards may factor.
+    h_completed = (
+        [helper]
+        if isinstance(helper, Complete)
+        else [e for e in helper.exits if isinstance(e, Completed)]
+    )
+    d_completed = (
+        [direct]
+        if isinstance(direct, Complete)
+        else [e for e in direct.exits if isinstance(e, Completed)]
+    )
+    assert h_completed and d_completed, CODEX3_OWNER
+
+
+def test_scalar_helper_feeds_subscript_index() -> None:
+    tree, _, _ = _tree(
+        "def scalar():\n    return 0\n\n[10, 20][scalar()]\n",
+        bind=frozenset({"scalar"}),
+    )
+    try:
+        outcome = _first(tree, Subscript).sugar().desugar(None)
+    except (ConstructionPanic, SugarNotWritten) as exc:
+        pytest.fail(f"{CODEX3_OWNER} subscript index: {exc}")
+    value = _completed_value(outcome)
+    assert value == TermValue(10) or getattr(value, "value", None) == 10, (
+        f"{CODEX3_OWNER} expected TermValue(10), got {value!r}"
+    )
+
+
+def test_tuple_helper_feeds_subscript_receiver() -> None:
+    tree, _, _ = _tree(
+        "def pack():\n    return (1, 2, 3)\n\npack()[1]\n",
+        bind=frozenset({"pack"}),
+    )
+    try:
+        outcome = _first(tree, Subscript).sugar().desugar(None)
+    except (ConstructionPanic, SugarNotWritten) as exc:
+        pytest.fail(f"{CODEX3_OWNER} tuple subscript: {exc}")
+    value = _completed_value(outcome)
+    assert value == TermValue(2) or getattr(value, "value", None) == 2, (
+        f"{CODEX3_OWNER} expected TermValue(2), got {value!r}"
+    )
+
+
+def test_scalar_helper_feeds_store_index() -> None:
+    """a[scalar()] = 9 with authenticated scalar return → completed store."""
+    tree, _, _ = _tree(
+        "def scalar():\n"
+        "    return 0\n"
+        "def consumer(a):\n"
+        "    a[scalar()] = 9\n"
+        "\n"
+        "consumer([0])\n",
+        bind=frozenset({"scalar", "consumer"}),
+    )
+    consumer_call = _calls_named(tree, "consumer")[-1]
+    try:
+        outcome = consumer_call.sugar().desugar(None)
+    except (ConstructionPanic, SugarNotWritten) as exc:
+        pytest.fail(f"{CODEX3_OWNER} store index: {exc}")
+    assert isinstance(outcome, (Complete, ExitSet)), CODEX3_OWNER
+    if isinstance(outcome, ExitSet):
+        assert any(isinstance(e, Completed) for e in outcome.exits), (
+            f"{CODEX3_OWNER} store did not complete: {outcome.exits!r}"
+        )
+
+
+def test_symbolic_helper_feeds_binop() -> None:
+    tree, _, _ = _tree(
+        "def identity(x):\n    return x\n\nidentity(2) + 3\n",
+        bind=frozenset({"identity"}),
+    )
+    try:
+        outcome = _first(tree, BinOp).sugar().desugar(None)
+    except (ConstructionPanic, SugarNotWritten) as exc:
+        pytest.fail(f"{CODEX3_OWNER} symbolic binop: {exc}")
+    value = _completed_value(outcome)
+    assert value == TermValue(5) or getattr(value, "value", None) == 5, (
+        f"{CODEX3_OWNER} expected 5, got {value!r}"
+    )
+
+
+def test_guarded_helper_return_retains_guards_into_binop() -> None:
+    """if-branch return must retain guard testimony on the BinOp face.
+
+    RED owner=codex-3 until guarded ReturnValue projects through dig with
+    its guard intact (not collapsed to an unguarded TermValue alone).
+    """
+    tree, _, _ = _tree(
+        "def maybe(flag):\n"
+        "    if flag:\n"
+        "        return 1\n"
+        "    return 0\n"
+        "\n"
+        "maybe(True) + 1\n",
+        bind=frozenset({"maybe"}),
+    )
+    try:
+        outcome = _first(tree, BinOp).sugar().desugar(None)
+    except (ConstructionPanic, SugarNotWritten, NotImplementedError) as exc:
+        pytest.fail(f"{CODEX3_OWNER} guarded return: {exc}")
+    assert isinstance(outcome, (Complete, ExitSet)), CODEX3_OWNER
+    if isinstance(outcome, ExitSet):
+        # Guarded path: either factored faces or a completed arm with guard.
+        assert outcome.exits, CODEX3_OWNER
+        # At least one completed arm carries a non-trivial guard or value 2.
+        completed = [e for e in outcome.exits if isinstance(e, Completed)]
+        assert completed, f"{CODEX3_OWNER} no completed arm: {outcome.exits!r}"
+    else:
+        value = outcome.value
+        assert value == TermValue(2) or getattr(value, "value", None) == 2, (
+            f"{CODEX3_OWNER} guarded return lost value: {value!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Discrimination: dig must not stop at BlockValue for binop (documents red)
+# ---------------------------------------------------------------------------
+
+
+def test_dig_of_scalar_return_must_not_stop_at_blockvalue_for_binop() -> None:
+    """Instrument: if dig yields BlockValue, BinOp cannot stand — producer gap.
+
+    This test *documents* the current dig ceiling. When codex-3 projects
+    ReturnValue out of the block, this assertion flips: dug is TermValue.
+    Until then it fails loudly with the owner string.
+    """
+    tree, _, _ = _tree(
+        "def scalar():\n    return 3\n\nscalar()\n",
+        bind=frozenset({"scalar"}),
+    )
+    call = _first(tree, Call)
+    cs = call.sugar().desugar(None).value
+    dug = cs._dig_floor_or_none(None, owner="dig-ceiling-probe")
+    assert dug is not None
+    # LAW: dig for operation use must surface the returned Floor, not the block.
+    assert not isinstance(dug, BlockValue), (
+        f"{CODEX3_OWNER} dig stopped at {type(dug).__name__}; "
+        f"need ReturnValue.value (TermValue(3)), statements={getattr(dug, 'statements', None)!r}"
+    )
+    assert dug == TermValue(3) or (
+        isinstance(dug, ReturnValue) and dug.value == TermValue(3)
+    )


### PR DESCRIPTION
## Summary

Two tests-only seam-1 instruments. **No production/binder/carrier/ExitSet edits.**

### 1. `test_source_return_operation_generalization.py`

Authenticated helpers via `source_visible_call_frame` at exact use-site coordinates:

| Face | Status |
|------|--------|
| scalar/tuple/symbolic return floor dig | green |
| direct-value BinOp/Compare/Subscript twins | green |
| unauthenticated body=None opaque | green |
| same-name tamper twin | green |
| helper→BinOp/Subscript/store isomorphic ops | **red → codex-3** |
| dig must not stop at BlockValue | **red → codex-3** |
| guarded return retains guards into BinOp | **red → codex-3** |

### 2. `test_nested_source_return_projection.py`

outer → inner → returned Floor:

| Face | Status |
|------|--------|
| each hop frame enrollment / distinct coords | green |
| swapped inner/outer testimony refused | green |
| no recursion-by-name (frame CID identity) | green |
| two-hop feeds BinOp isomorphic to direct | **red → codex-3** |
| dig projects through both hops to TermValue | **red → codex-3** |

### codex-3 handoff

General producer: dig of authenticated helper bodies must project **ReturnValue floors** (scalar/tuple/symbolic) into BinOp, Compare, Subscript, and store operands — not stop at `BlockValue` or leave nested `ReturnValue(CallSiteValue)` unreduced. Nested dig preserves both call occurrences (frame CIDs).

Item 3 (installed-source inheritance) **held** until codex-3 general producer lands.

## Tests

```
bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py \
  implementations/python/sugar-lift-py-tests/tests/test_nested_source_return_projection.py -q
```

→ **8 failed, 16 passed** (failures are the codex-3 instruments)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test suite for two-hop source-return generalization and nested call projection
> - Adds [test_nested_source_return_projection.py](https://github.com/TSavo/sugar/pull/6684/files#diff-3dbdcc45ebaacd7c386c35a77859ce32f4042414987a76623cf618a1f1ceaca2) covering two-hop transport through outer→inner calls: distinct call-site coordinates, per-hop frame enrollment, swapped testimony rejection, and dig traversal to a terminal `TermValue`.
> - Adds [test_source_return_operation_generalization.py](https://github.com/TSavo/sugar/pull/6684/files#diff-69bf6af7fd5dd5059861d26a5049e910aeebfe513d041f0a7065d9990495f794) validating authenticated helper return floors feeding `BinOp`, `Compare`, `Subscript`, and store consumers, including unauthenticated opacity and tampered-enrollment cases.
> - Both suites assert that `dig` must not stop at `BlockValue` and must reach the operand-level `TermValue`, and that isomorphic paths (e.g. `scalar()+2` vs `3+2`) produce identical completed values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6fa11dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->