### PR TITLE
Compose Try over deferred native exits

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -501,6 +501,9 @@ class NativeOperationExitCarrierV1:
     prefix_composition: object | None = dataclass_field(
         default=None, compare=False, repr=False
     )
+    exitset_continuations: tuple = dataclass_field(
+        default=(), compare=False, repr=False
+    )
     pre_effect_state: ReducerPreEffectStateV1 | None = dataclass_field(
         default=None, compare=False, repr=False
     )
@@ -591,6 +594,16 @@ class NativeOperationExitCarrierV1:
         del face
         return replace(self, guards=(*self.guards, guard))
 
+    def after_discharge(self, step) -> "NativeOperationExitCarrierV1":
+        """Defer an ExitSet-wide consumer until authenticated discharge."""
+        return replace(
+            self,
+            exitset_continuations=(
+                *self.exitset_continuations,
+                (len(self.continuations), step),
+            ),
+        )
+
     @classmethod
     def compose_prefix(cls, prefix, step):
         """Sequence a prefix without exposing a deferred carrier to ExitSet.
@@ -660,6 +673,17 @@ class NativeOperationExitCarrierV1:
         from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete
         from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
 
+        def apply_exitset_steps(projected, continuation_count):
+            for enrolled_count, step in self.exitset_continuations:
+                if enrolled_count != continuation_count:
+                    continue
+                projected = step(projected)
+                if isinstance(projected, NativeOperationExitCarrierV1):
+                    projected = projected.discharge(actuals_by_formal_coordinate)
+                if not isinstance(projected, ExitSet):
+                    projected = outcome_to_exitset(projected)
+            return projected
+
         if self.prefix_composition is not None:
             resolved, deferred, continuation_count, guard_count = (
                 self.prefix_composition
@@ -681,6 +705,8 @@ class NativeOperationExitCarrierV1:
             guard = _conjoin_guards(self.guards[guard_count:])
             if guard is not None:
                 projected = projected.guarded(guard)
+            for count in range(len(self.continuations) + 1):
+                projected = apply_exitset_steps(projected, count)
             return projected
 
         def undischarged(reason):
@@ -750,7 +776,8 @@ class NativeOperationExitCarrierV1:
             # a normal completion.
             exits = outcome_to_exitset(projected)
 
-        for continuation in self.continuations:
+        exits = apply_exitset_steps(exits, 0)
+        for index, continuation in enumerate(self.continuations, start=1):
             def resume(value, *, step=continuation):
                 next_outcome = step(value)
                 if isinstance(next_outcome, NativeOperationExitCarrierV1):
@@ -758,6 +785,7 @@ class NativeOperationExitCarrierV1:
                 return next_outcome
 
             exits = exits.and_then(resume)
+            exits = apply_exitset_steps(exits, index)
         guard = _conjoin_guards(self.guards)
         if guard is not None:
             exits = exits.guarded(guard)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -49,6 +49,22 @@ class TrySugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            NativeOperationExitCarrierV1,
+        )
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
+
+        body_es = reduce_block_to_exitset(self.body, ctx)
+        if isinstance(body_es, NativeOperationExitCarrierV1):
+            return body_es.after_discharge(
+                lambda discharged: self._route_discharged_body(discharged, ctx)
+            )
+        return self._route_discharged_body(body_es, ctx)
+
+    def _route_discharged_body(self, body_es, ctx):
+        """Route one concrete body ExitSet; carriers enter only after discharge."""
         from sugar_lift_py_tests.floor.return_value import ReturnValue
         from sugar_lift_py_tests.sugar.exit_set_routing import (
             exitset_to_outcome,
@@ -59,9 +75,8 @@ class TrySugar(Sugar):
             reduce_block_to_exitset,
         )
 
-        body_es = promote_raise_halts(reduce_block_to_exitset(self.body, ctx))
         pre_finally = _route_handlers_over_exits(
-            body_es,
+            promote_raise_halts(body_es),
             self.handlers,
             self.orelse,
             site=self.site,

--- a/implementations/python/sugar-lift-py-tests/tests/test_try_native_store_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_try_native_store_carrier.py
@@ -1,0 +1,129 @@
+"""Source try/except composes over a deferred formal native store."""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import CallSiteValue, ListValue, ReturnValue, TermValue
+from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+HELPER = (
+    "def helper(a, i, q):\n"
+    "    try:\n"
+    "        a[i] = q\n"
+    "    except IndexError:\n"
+    "        return 1\n"
+    "    return 0\n"
+)
+
+PLAIN_STORE = "def helper(a, i, q):\n    a[i] = q\n"
+
+
+def _tree(calls: str = "", helper: str = HELPER) -> SourceFile:
+    source = f"{helper}\n{calls}"
+    return SourceFile(
+        (source, "try-native-store.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _helper_outcome(helper: str = HELPER):
+    function = next(
+        node for node in _tree(helper=helper).nodes() if isinstance(node, FunctionDef)
+    )
+    return function.sugar().desugar(None)
+
+
+def _call_outcome(call: str):
+    tree = _tree(call)
+    node = tuple(node for node in tree.nodes() if isinstance(node, Call))[-1]
+    return node.sugar().desugar(None)
+
+
+def _returned(outcome) -> TermValue:
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    face = outcome.exits[0]
+    assert isinstance(face, Completed)
+    value = face.value
+    if isinstance(value, CallSiteValue):
+        value = value._dig_floor_or_none(None, owner="test_try_native_store_carrier")
+    returns = tuple(entry for entry in value.statements if isinstance(entry, ReturnValue))
+    assert len(returns) == 1
+    assert isinstance(returns[0].value, TermValue)
+    return returns[0].value
+
+
+def test_try_body_retains_formal_store_as_one_deferred_carrier() -> None:
+    pending = _helper_outcome()
+
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "setitem"
+
+
+def test_try_store_completion_bypasses_handler() -> None:
+    outcome = _call_outcome("helper([0], 0, 9)\n")
+
+    assert _returned(outcome).value == 0
+
+
+def test_try_store_indexerror_routes_to_handler_without_fabricated_state() -> None:
+    pending = _helper_outcome()
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    testimony = pending.pre_effect_state
+    assert testimony is not None
+
+    outcome = _call_outcome("helper([0], 4, 9)\n")
+
+    assert _returned(outcome).value == 1
+    empty_state = type(testimony.state)((), True, ())
+    assert testimony.state is not None
+    assert testimony.state is not empty_state
+    assert testimony.state != ListValue((TermValue(0),))
+    assert testimony.state != ListValue((TermValue(9),))
+
+
+def test_exitset_consumer_observes_authentic_store_occurrence_and_state() -> None:
+    pending = _helper_outcome(PLAIN_STORE)
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    a_cid, i_cid, q_cid = pending.demand.operand_coordinate_cids
+    observed = []
+
+    def observe(exits):
+        halted = next(exit_ for exit_ in exits.exits if isinstance(exit_, Halted))
+        observed.append((halted.effect, halted.state))
+        return exits
+
+    retained = pending.after_discharge(observe).discharge(
+        {
+            a_cid: ListValue((TermValue(0),)),
+            i_cid: TermValue(4),
+            q_cid: TermValue(9),
+        }
+    )
+
+    assert any(isinstance(exit_, Halted) for exit_ in retained.exits), retained
+    halted = next(exit_ for exit_ in retained.exits if isinstance(exit_, Halted))
+    assert pending.pre_effect_state is not None
+    assert halted.state is pending.pre_effect_state.state
+    assert halted.effect.occurrence_id is not None
+    assert observed == [(halted.effect, halted.state)]
+    foreign = _helper_outcome("\n" + PLAIN_STORE)
+    assert isinstance(foreign, NativeOperationExitCarrierV1)
+    foreign_a, foreign_i, foreign_q = foreign.demand.operand_coordinate_cids
+    foreign_halt = next(
+        exit_
+        for exit_ in foreign.discharge(
+            {
+                foreign_a: ListValue((TermValue(0),)),
+                foreign_i: TermValue(4),
+                foreign_q: TermValue(9),
+            }
+        ).exits
+        if isinstance(exit_, Halted)
+    )
+    assert halted.effect.occurrence_id != foreign_halt.effect.occurrence_id


### PR DESCRIPTION
## Capability
- add a carrier-owned post-discharge ExitSet consumer seam, ordered relative to value continuations
- let TrySugar defer handler routing until a native store carrier authenticates its exit
- preserve the authentic store occurrence and pre-effect temporal-state object; matching handler consumes the raise and normal completion bypasses it

## Instruments
- source `try: a[i] = q except IndexError` retains one formal carrier
- valid and exceptional caller arms both execute
- truthful state/occurrence checks plus fabricated-equal-empty, receiver, post-store, and wrong-occurrence twins
- merged state-survival matrix and carrier regression families remain green

## R1 adjudication
R1 is not carrier-side: the carrier has already discharged to a concrete ExitSet before `WithEffectBoundarySugar._route_raise_boundary`; the equal-but-not-identical `_ReducedBlock` re-seat belongs to the With effect-boundary routing/state splice owner, not NativeOperationExitCarrierV1.

## Test
`../../../bin/bpytest tests/test_try_native_store_carrier.py tests/test_state_survival_matrix.py tests/test_native_operation_exit_carrier.py tests/test_native_operation_prefix_carrier.py tests/test_native_operation_pre_effect_state.py tests/test_compare_through_if_sugar.py tests/test_setitem_formal_caller.py`

109 passed in 4.43s after rebase onto origin/main.

Predicted epsilon: R2 1 -> 0. Floors preserved: ExitSet untouched; no construct-specific state adapter; no fabricated completion/state/occurrence; sacred halt bypass retained.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Compose Try desugaring over deferred native operation exit carriers
> - `NativeOperationExitCarrierV1` gains an `after_discharge` method that enrolls an ExitSet-wide consumer step to execute at a specific continuation-count position during discharge.
> - `TrySugar.desugar` now detects when a try body reduces to a carrier and defers handler routing (raise promotion, except/orelse/finally) until after the carrier is authenticated and discharged, via the new `_route_discharged_body` helper.
> - The `discharge` method interleaves enrolled consumers before any continuation, after each continuation, and within the `compose_prefix` path.
> - New tests in [test_try_native_store_carrier.py](https://github.com/TSavo/sugar/pull/6685/files#diff-3180f9c0726c4d012f1dfeaec64c73f99259cac18fe641f06c7068d64feb76cb) cover completion bypassing handlers, exception routing, and halted-effect observation post-discharge.
> - Behavioral Change: try bodies that previously resolved immediately to an ExitSet now return a carrier when the body involves a native operation, deferring all handler logic until discharge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ec690d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->