### PR TITLE
Implement generator protocol enter_resource_outcome / exit_outcome_for

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -413,6 +413,34 @@ class ManagerProtocolConstructionGapV1:
 
 
 @dataclass(frozen=True)
+class EnteredGeneratorManagerStateV1:
+    """Exact generator suspension after authenticated enter (first yield).
+
+    Carries the yielded resource value and the suspended machine. Exit must
+    resume/throw this machine — never a re-allocated twin. Bound to the
+    protocol construction CID so a wrong-face resume refuses.
+    """
+
+    enter_value: object
+    machine: object = field(compare=False, repr=False)
+    protocol_construction_cid: str
+    entry_cid: str
+
+    def __post_init__(self) -> None:
+        if not self.protocol_construction_cid.startswith("blake3-512:"):
+            raise ValueError(
+                "entered generator state requires protocol construction CID"
+            )
+        if not self.entry_cid.startswith("blake3-512:"):
+            raise ValueError("entered generator state requires entry CID")
+        suspended = getattr(self.machine, "suspended_resume_coordinate", None)
+        if suspended is None:
+            raise ValueError(
+                "entered generator state requires a machine suspended at yield"
+            )
+
+
+@dataclass(frozen=True)
 class GeneratorBackedManagerProtocolV1:
     """Closed protocol testimony for authenticated generator managers.
 
@@ -421,6 +449,11 @@ class GeneratorBackedManagerProtocolV1:
     authenticated method spans of the decorator helper's returned class.
     This is not an ObjectValue receiver and cannot be minted from coordinates
     alone or from a non-generator frame.
+
+    Lifecycle performance: :meth:`enter_resource_outcome` runs the generator
+    to its first yield and returns the resource with exact machine state;
+    :meth:`exit_outcome_for` resumes/throws that state once and exposes
+    authenticated suppression testimony.
     """
 
     protocol_construction_cid: str
@@ -461,6 +494,247 @@ class GeneratorBackedManagerProtocolV1:
             raise ValueError(
                 "generator-backed protocol CID does not match its preimage"
             )
+        # One-shot exit log + enter ordinal for this protocol instance.
+        object.__setattr__(self, "_exited_entry_cids", set())
+        object.__setattr__(self, "_enter_ordinal", 0)
+
+    def enter_resource_outcome(self, ctx: object = None):
+        """Enter the authenticated generator lifecycle; return yield + machine."""
+        return enter_generator_resource_outcome(self, ctx=ctx)
+
+    def exit_outcome_for(self, entered, ctx: object = None):
+        """Resume/throw the exact entered machine once; expose suppression."""
+        return exit_generator_resource_outcome_for(self, entered, ctx=ctx)
+
+
+def enter_generator_resource_outcome(protocol, *, ctx: object = None):
+    """Allocate and resume the generator frame to its first yield.
+
+    Shared by :class:`GeneratorBackedManagerProtocolV1` and lifecycle wrappers
+    that duck-type the same fields. Returns ``Complete(EnteredGeneratorManagerStateV1)``
+    on yield; typed-loud refusal when the machine cannot enter.
+    """
+    del ctx
+    from sugar_lift_py_tests.generator_construction import (
+        GeneratorConstructionV1,
+        GeneratorTerminationV1,
+        GeneratorTransitionGapV1,
+        YieldEffect,
+    )
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_source_tree.panic import SugarNotWritten
+
+    frame = protocol.generator_frame
+    steps = getattr(frame, "generator_steps", None)
+    if steps is None:
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.enter_resource_outcome",
+            observed="non-generator frame",
+            requested="authenticated generator_steps on the protocol frame",
+            fix="publish a generator-backed protocol or keep enter loud",
+        )
+    bindings = tuple(getattr(frame, "runtime_entries", ()) or ())
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate=protocol.protocol_construction_cid,
+        frame_coordinate=protocol.generator_frame_cid,
+        binding_state=bindings,
+        steps=steps,
+    )
+    result = machine.resume()
+    if isinstance(result, YieldEffect):
+        enter_value = _floor_enter_value(result.value)
+        # Per-protocol enter ordinal distinguishes successive enters that
+        # content-address to the same machine suspension (double-exit is
+        # per entry, not per content twin).
+        ordinal = int(getattr(protocol, "_enter_ordinal", 0))
+        object.__setattr__(protocol, "_enter_ordinal", ordinal + 1)
+        entry_cid = cid_of_json(
+            {
+                "kind": "generator-resource-entry",
+                "schemaVersion": "1",
+                "protocolConstructionCid": protocol.protocol_construction_cid,
+                "instanceCoordinate": result.machine.instance_coordinate,
+                "resumeCoordinate": result.resume_coordinate,
+                "cursor": result.machine.cursor,
+                "enterOrdinal": ordinal,
+            }
+        )
+        entered = EnteredGeneratorManagerStateV1(
+            enter_value=enter_value,
+            machine=result.machine,
+            protocol_construction_cid=protocol.protocol_construction_cid,
+            entry_cid=entry_cid,
+        )
+        return Complete(entered)
+    if isinstance(result, GeneratorTerminationV1):
+        # Never-yield enter: Python's manager protocol raises at entry.
+        from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+        from sugar_lift_py_tests.generator_entry_refusal import observed_entry_refusal
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        refusal = observed_entry_refusal()
+        blame = str(machine.instance_coordinate)
+        return Incomplete(
+            RaiseEffect(
+                exception_name=refusal.exception_name,
+                blame=blame,
+                occurrence=f"generator-entry-refusal:{blame}",
+                raised_value=refusal.message,
+            )
+        )
+    if isinstance(result, GeneratorTransitionGapV1):
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.enter_resource_outcome",
+            observed=result.observed,
+            requested="first yield of the authenticated generator lifecycle",
+            fix="construct the transition or retain this typed loud boundary",
+        )
+    raise SugarNotWritten(
+        blame=protocol.exit_face_id,
+        owner="GeneratorBackedManagerProtocolV1.enter_resource_outcome",
+        observed=type(result).__name__,
+        requested="YieldEffect from GeneratorConstructionV1.resume",
+        fix="construct the enter transition or keep enter loud",
+    )
+
+
+def exit_generator_resource_outcome_for(protocol, entered, *, ctx: object = None):
+    """Resume/throw the exact entered machine once; return suppression testimony.
+
+    - Wrong protocol / wrong face → refuse.
+    - Double exit of the same entry → refuse.
+    - Suppression is only the authenticated exit outcome (BlockValue return),
+      never a fabricated constant.
+    """
+    del ctx
+    from sugar_lift_py_tests.generator_construction import (
+        GeneratorTerminationV1,
+        GeneratorTransitionGapV1,
+        YieldEffect,
+    )
+    from sugar_lift_py_tests.outcome import Complete, ExitSet
+    from sugar_source_tree.panic import SugarNotWritten
+
+    if not isinstance(entered, EnteredGeneratorManagerStateV1):
+        raise TypeError(
+            "GeneratorBackedManagerProtocolV1.exit_outcome_for requires "
+            f"EnteredGeneratorManagerStateV1, not {type(entered).__name__}"
+        )
+    if entered.protocol_construction_cid != protocol.protocol_construction_cid:
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.exit_outcome_for",
+            observed="entered state protocol construction CID mismatch",
+            requested="exit of the same protocol that performed enter",
+            fix="do not resume a foreign entered generator face",
+        )
+    exited = getattr(protocol, "_exited_entry_cids", None)
+    if exited is None:
+        object.__setattr__(protocol, "_exited_entry_cids", set())
+        exited = protocol._exited_entry_cids
+    if entered.entry_cid in exited:
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.exit_outcome_for",
+            observed="double exit of the same entered generator state",
+            requested="at most one exit_outcome_for per enter_resource_outcome",
+            fix="consume the entered state once; do not re-exit the same entry",
+        )
+    machine = entered.machine
+    if getattr(machine, "suspended_resume_coordinate", None) is None:
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.exit_outcome_for",
+            observed="entered machine is not suspended at yield",
+            requested="exact post-enter suspension from enter_resource_outcome",
+            fix="pass the EnteredGeneratorManagerStateV1 from enter without reallocation",
+        )
+    exited.add(entered.entry_cid)
+    # Normal body completion path: resume the suspended machine (send None).
+    # Body-raise paths are combined by the consumer via and_exit / throw on
+    # the machine; this method exposes the authenticated exit outcome for the
+    # resume/close face. Suppression is the returned FloorValue only.
+    after = machine.resume()
+    if isinstance(after, ExitSet):
+        return after
+    if isinstance(after, YieldEffect):
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.exit_outcome_for",
+            observed="generator yielded during exit",
+            requested="GeneratorTerminationV1 after the resource body",
+            fix="construct single-yield generator managers or keep exit loud",
+        )
+    if isinstance(after, GeneratorTransitionGapV1):
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.exit_outcome_for",
+            observed=after.observed,
+            requested="authenticated generator exit transition",
+            fix="construct the exit transition or retain this typed loud boundary",
+        )
+    if not isinstance(after, GeneratorTerminationV1):
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.exit_outcome_for",
+            observed=type(after).__name__,
+            requested="GeneratorTerminationV1 from post-yield resume",
+            fix="construct the exit transition or keep exit loud",
+        )
+    # Authenticated suppression: generator CM exit is falsy unless the
+    # machine returns an explicit truthy residual (none for ordinary GCM).
+    # Never invent True — only the termination's return_value may speak.
+    return Complete(_suppression_block(after.return_value))
+
+
+def _floor_enter_value(value: object):
+    """Project a yield payload into FloorValue currency when needed."""
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+    from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+    if isinstance(value, FloorValue):
+        return value
+    if isinstance(value, Sugar):
+        outcome = value.desugar()
+        if isinstance(outcome, Complete):
+            return _floor_enter_value(outcome.value)
+        from sugar_source_tree.panic import SugarNotWritten
+
+        raise SugarNotWritten(
+            blame="generator-enter-yield",
+            owner="GeneratorBackedManagerProtocolV1.enter_resource_outcome",
+            observed=type(outcome).__name__,
+            requested="Complete FloorValue from yielded sugar",
+            fix="construct the yield value or keep enter loud",
+        )
+    if value is None:
+        from sugar_lift_py_tests.floor import NoneValue
+
+        return NoneValue()
+    if isinstance(value, (int, float, str, bool)):
+        return TermValue(value)
+    return TermValue(value)
+
+
+def _suppression_block(return_value: object):
+    """BlockValue carrying the authenticated exit return for suppression truth."""
+    from sugar_lift_py_tests.floor import BlockValue, ReturnValue, TermValue
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+    if return_value is None:
+        # contextlib generator __exit__ returns False on normal StopIteration.
+        value: object = TermValue(False)
+    elif isinstance(return_value, FloorValue):
+        value = return_value
+    elif isinstance(return_value, bool):
+        value = TermValue(return_value)
+    else:
+        value = _floor_enter_value(return_value)
+    return BlockValue((ReturnValue(value),), can_fall_through=False)
 
 
 def construct_generator_backed_protocol(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -280,6 +280,21 @@ class GeneratorBackedLifecycleProtocolV1:
         if self.lifecycle_cid and self.lifecycle_cid != expected:
             raise ValueError("generator lifecycle CID does not match its preimage")
         object.__setattr__(self, "lifecycle_cid", expected)
+        # One-shot exit log + enter ordinal (shared lifecycle performance law).
+        object.__setattr__(self, "_exited_entry_cids", set())
+        object.__setattr__(self, "_enter_ordinal", 0)
+
+    def enter_resource_outcome(self, ctx: object = None):
+        """Enter via the shared generator lifecycle producer (no name arms)."""
+        from .manager_protocol_construction import enter_generator_resource_outcome
+
+        return enter_generator_resource_outcome(self, ctx=ctx)
+
+    def exit_outcome_for(self, entered, ctx: object = None):
+        """Exit via the shared generator lifecycle producer (one-shot)."""
+        from .manager_protocol_construction import exit_generator_resource_outcome_for
+
+        return exit_generator_resource_outcome_for(self, entered, ctx=ctx)
 
     @property
     def lifecycle_preimage(self) -> dict:

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
@@ -1,0 +1,133 @@
+"""GeneratorBackedManagerProtocolV1 lifecycle performance.
+
+enter_resource_outcome: first yield + exact machine state.
+exit_outcome_for: resume that state once; suppression from authenticated exit.
+
+Twins: double-exit refuses; wrong-face resume refuses; suppression only from
+exit outcome. No nodes.py / consumer edits.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.floor import BlockValue, ReturnValue, TermValue
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    ReturnStepV1,
+    YieldStepV1,
+)
+from sugar_lift_py_tests.outcome import Complete, outcome_to_exitset
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.manager_protocol_construction import (
+    EnteredGeneratorManagerStateV1,
+    GeneratorBackedManagerProtocolV1,
+    construct_generator_backed_protocol,
+)
+from sugar_source_tree.panic import SugarNotWritten
+
+
+def _coords():
+    enter = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 1, 0, 2, 0)
+    exit_ = SourceFragmentCoordinateV1("blake3-512:" + "b" * 128, 3, 0, 4, 0)
+    return enter, exit_
+
+
+def _frame(*, steps=None, frame_cid=None, bindings=()):
+    if steps is None:
+        steps = (YieldStepV1(TermValue(17)), ReturnStepV1(None))
+    cid = frame_cid or cid_of_json({"frame": "generator-lifecycle-test"})
+    return SimpleNamespace(
+        frame_cid=cid,
+        generator_steps=steps,
+        runtime_entries=bindings,
+    )
+
+
+def _protocol(*, frame=None, construction="blake3-512:" + "c" * 128):
+    enter, exit_ = _coords()
+    frame = frame or _frame()
+    result = construct_generator_backed_protocol(
+        frame=frame,
+        enter_definition=enter,
+        exit_definition=exit_,
+        exit_face_id="face-lifecycle",
+        construction_cid=construction,
+    )
+    assert isinstance(result, GeneratorBackedManagerProtocolV1)
+    return result
+
+
+def test_enter_resource_outcome_yields_value_with_exact_machine_state():
+    protocol = _protocol()
+    outcome = protocol.enter_resource_outcome()
+    assert isinstance(outcome, Complete)
+    entered = outcome.value
+    assert isinstance(entered, EnteredGeneratorManagerStateV1)
+    assert entered.enter_value == TermValue(17)
+    assert isinstance(entered.machine, GeneratorConstructionV1)
+    assert entered.machine.suspended_resume_coordinate is not None
+    assert entered.protocol_construction_cid == protocol.protocol_construction_cid
+    assert entered.entry_cid.startswith("blake3-512:")
+
+
+def test_exit_outcome_for_resumes_exact_entered_machine_once():
+    protocol = _protocol()
+    entered = protocol.enter_resource_outcome().value
+    exit_outcome = protocol.exit_outcome_for(entered)
+    exits = outcome_to_exitset(exit_outcome)
+    assert len(exits.exits) == 1
+    face = exits.exits[0]
+    assert isinstance(face.value, BlockValue)
+    assert face.value.statements[-1] == ReturnValue(TermValue(False))
+
+
+def test_double_exit_of_same_entered_state_refuses():
+    protocol = _protocol()
+    entered = protocol.enter_resource_outcome().value
+    protocol.exit_outcome_for(entered)
+    with pytest.raises(SugarNotWritten, match="double exit"):
+        protocol.exit_outcome_for(entered)
+
+
+def test_wrong_protocol_face_resume_refuses():
+    left = _protocol(construction="blake3-512:" + "1" * 128)
+    right_frame = _frame(frame_cid=cid_of_json({"frame": "other"}))
+    right = _protocol(frame=right_frame, construction="blake3-512:" + "2" * 128)
+    entered_left = left.enter_resource_outcome().value
+    with pytest.raises(SugarNotWritten, match="protocol construction CID mismatch"):
+        right.exit_outcome_for(entered_left)
+
+
+def test_wrong_entered_type_refuses():
+    protocol = _protocol()
+    with pytest.raises(TypeError, match="EnteredGeneratorManagerStateV1"):
+        protocol.exit_outcome_for(TermValue(0))
+
+
+def test_suppression_truth_only_from_authenticated_exit_outcome():
+    """Exit return is the sole suppression testimony — not a fabricated True."""
+    protocol = _protocol()
+    entered = protocol.enter_resource_outcome().value
+    exit_outcome = protocol.exit_outcome_for(entered)
+    block = outcome_to_exitset(exit_outcome).exits[0].value
+    assert isinstance(block, BlockValue)
+    returned = block.statements[-1]
+    assert isinstance(returned, ReturnValue)
+    # Ordinary GCM StopIteration path → False; never invented True.
+    assert returned.value == TermValue(False)
+    assert returned.value != TermValue(True)
+
+
+def test_identical_enters_mint_distinct_entry_cids_and_each_exits_once():
+    protocol = _protocol()
+    first = protocol.enter_resource_outcome().value
+    second = protocol.enter_resource_outcome().value
+    assert first.entry_cid != second.entry_cid
+    protocol.exit_outcome_for(first)
+    protocol.exit_outcome_for(second)
+    with pytest.raises(SugarNotWritten, match="double exit"):
+        protocol.exit_outcome_for(first)


### PR DESCRIPTION
## Summary

Seam-2 lifecycle performance producer for `GeneratorBackedManagerProtocolV1`:

| Method | Behavior |
| --- | --- |
| `enter_resource_outcome(ctx=None)` | Allocate frame steps → resume to first `YieldEffect` → `Complete(EnteredGeneratorManagerStateV1)` with exact machine |
| `exit_outcome_for(entered, ctx=None)` | One-shot resume of that machine → `BlockValue(ReturnValue(suppression))` from authenticated termination |

Also on `GeneratorBackedLifecycleProtocolV1` via shared helpers.

### Twins

- **double-exit** → `SugarNotWritten` (per `entry_cid`)
- **wrong-face** (foreign `protocol_construction_cid`) → refuse
- **wrong type** → `TypeError`
- **suppression** only from exit return (`TermValue(False)` for ordinary GCM), never fabricated `True`

### Held

No `nodes.py`, no consumer edits, no carrier/ExitSet.

### Acceptance / residual

Focused producer suite green. codex-2 join (`test_real_option_context_coordinates_drive_every_resource_lifecycle_face`) still red for two independent reasons outside this PR:

1. option_context `With` still constructs as `GeneratorWithSugar` (generator frame path), not `WithSourceResourceSugar` — consumer routing, not protocol methods.
2. option_context `generator_steps` still include `OpaqueStepV1(If/Assign/...)` before yield — first resume is loud at Opaque, even once `enter_resource_outcome` exists.

Producer boundary for simple Yield/Return generators is complete.

## Tests

```
bin/bpytest tests/test_generator_lifecycle_performance.py -q
# 7 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `enter_resource_outcome` and `exit_outcome_for` on generator-backed manager protocols
> - Adds `enter_generator_resource_outcome` to start a generator-backed manager lifecycle: resumes the generator, floors the yielded value to `FloorValue`, mints a unique `entry_cid`, and returns a `Complete(EnteredGeneratorManagerStateV1)`; generators that never yield return an `Incomplete` with a standardized entry-refusal.
> - Adds `exit_generator_resource_outcome_for` to finish the lifecycle: validates the entered state, enforces one-shot exit semantics per `entry_cid`, resumes the machine once, and returns either an `ExitSet` or a suppression `BlockValue`.
> - Adds `EnteredGeneratorManagerStateV1`, a frozen dataclass carrying the yielded value, opaque machine, `protocol_construction_cid`, and minted `entry_cid`, with CID prefix and suspension validation in `__post_init__`.
> - Wires both functions as `enter_resource_outcome` / `exit_outcome_for` methods on `GeneratorBackedManagerProtocolV1` ([manager_protocol_construction.py](https://github.com/TSavo/sugar/pull/6687/files#diff-bdbfb97c4a5209dd6ce8e2b561f5dde22cdb35bce955d8d781c7c1e72ff11700)) and `GeneratorBackedLifecycleProtocolV1` ([manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6687/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c)).
> - Adds tests covering enter/exit semantics, double-exit and cross-protocol rejection, and distinct `entry_cid` minting ([test_generator_lifecycle_performance.py](https://github.com/TSavo/sugar/pull/6687/files#diff-893aafebd870ec221253d25e22ad86488cc3df7a9457bf846877c36baa1d9cce)).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e7dde9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->