### PR TITLE
Prove exceptional source-return transport (raise-path mirror)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -501,6 +501,9 @@ class NativeOperationExitCarrierV1:
     prefix_composition: object | None = dataclass_field(
         default=None, compare=False, repr=False
     )
+    exitset_continuations: tuple = dataclass_field(
+        default=(), compare=False, repr=False
+    )
     pre_effect_state: ReducerPreEffectStateV1 | None = dataclass_field(
         default=None, compare=False, repr=False
     )
@@ -591,6 +594,16 @@ class NativeOperationExitCarrierV1:
         del face
         return replace(self, guards=(*self.guards, guard))
 
+    def after_discharge(self, step) -> "NativeOperationExitCarrierV1":
+        """Defer an ExitSet-wide consumer until authenticated discharge."""
+        return replace(
+            self,
+            exitset_continuations=(
+                *self.exitset_continuations,
+                (len(self.continuations), step),
+            ),
+        )
+
     @classmethod
     def compose_prefix(cls, prefix, step):
         """Sequence a prefix without exposing a deferred carrier to ExitSet.
@@ -660,6 +673,17 @@ class NativeOperationExitCarrierV1:
         from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete
         from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
 
+        def apply_exitset_steps(projected, continuation_count):
+            for enrolled_count, step in self.exitset_continuations:
+                if enrolled_count != continuation_count:
+                    continue
+                projected = step(projected)
+                if isinstance(projected, NativeOperationExitCarrierV1):
+                    projected = projected.discharge(actuals_by_formal_coordinate)
+                if not isinstance(projected, ExitSet):
+                    projected = outcome_to_exitset(projected)
+            return projected
+
         if self.prefix_composition is not None:
             resolved, deferred, continuation_count, guard_count = (
                 self.prefix_composition
@@ -681,6 +705,8 @@ class NativeOperationExitCarrierV1:
             guard = _conjoin_guards(self.guards[guard_count:])
             if guard is not None:
                 projected = projected.guarded(guard)
+            for count in range(len(self.continuations) + 1):
+                projected = apply_exitset_steps(projected, count)
             return projected
 
         def undischarged(reason):
@@ -750,7 +776,8 @@ class NativeOperationExitCarrierV1:
             # a normal completion.
             exits = outcome_to_exitset(projected)
 
-        for continuation in self.continuations:
+        exits = apply_exitset_steps(exits, 0)
+        for index, continuation in enumerate(self.continuations, start=1):
             def resume(value, *, step=continuation):
                 next_outcome = step(value)
                 if isinstance(next_outcome, NativeOperationExitCarrierV1):
@@ -758,6 +785,7 @@ class NativeOperationExitCarrierV1:
                 return next_outcome
 
             exits = exits.and_then(resume)
+            exits = apply_exitset_steps(exits, index)
         guard = _conjoin_guards(self.guards)
         if guard is not None:
             exits = exits.guarded(guard)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -507,10 +507,10 @@ class GeneratorConstructionV1:
         truth = getattr(value, "truth", None)
         if truth is None:
             return None
-        try:
-            outcome = truth(self.instance_coordinate)
-        except BaseException:
-            return None
+        # ConstructionPanic is BaseException by design so ordinary Exception
+        # handlers cannot silence it. Do not catch BaseException here — that
+        # would reclassify incomplete floors as undecided suspension gaps.
+        outcome = truth(self.instance_coordinate)
         if not isinstance(outcome, Complete):
             return None
         return outcome.value
@@ -540,10 +540,8 @@ class GeneratorConstructionV1:
             return truth.formula
         to_formula = getattr(truth, "to_formula", None)
         if to_formula is not None:
-            try:
-                return to_formula()
-            except BaseException:
-                return None
+            # Same law as _guard_truth: never catch BaseException / ConstructionPanic.
+            return to_formula()
         return None
 
     def _reduce_value(self, value: object, requested: str):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -49,6 +49,22 @@ class TrySugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            NativeOperationExitCarrierV1,
+        )
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
+
+        body_es = reduce_block_to_exitset(self.body, ctx)
+        if isinstance(body_es, NativeOperationExitCarrierV1):
+            return body_es.after_discharge(
+                lambda discharged: self._route_discharged_body(discharged, ctx)
+            )
+        return self._route_discharged_body(body_es, ctx)
+
+    def _route_discharged_body(self, body_es, ctx):
+        """Route one concrete body ExitSet; carriers enter only after discharge."""
         from sugar_lift_py_tests.floor.return_value import ReturnValue
         from sugar_lift_py_tests.sugar.exit_set_routing import (
             exitset_to_outcome,
@@ -59,9 +75,8 @@ class TrySugar(Sugar):
             reduce_block_to_exitset,
         )
 
-        body_es = promote_raise_halts(reduce_block_to_exitset(self.body, ctx))
         pre_finally = _route_handlers_over_exits(
-            body_es,
+            promote_raise_halts(body_es),
             self.handlers,
             self.orelse,
             site=self.site,

--- a/implementations/python/sugar-lift-py-tests/tests/test_doctrine_lane_broad_catch_laws.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_doctrine_lane_broad_catch_laws.py
@@ -14,8 +14,9 @@ binding_state / generator_construction) found two live offenders:
    so ``seal_bound_binding_entry_v1`` can mint sealed testimony after sugar
    refused. Seal must stay loud when value construction refused.
 
-These tests are the red instruments. Production edits only after the red names
-the fix. No carrier/ExitSet, no silent None soft-greens.
+These instruments stay green when production refuses soft-seals: ConstructionPanic
+propagates from guard truth; SugarNotWritten refuses seal. No carrier/ExitSet,
+no silent None soft-greens.
 """
 
 from __future__ import annotations
@@ -207,15 +208,35 @@ def test_seal_must_not_succeed_after_sugar_not_written():
 
     Node.sugar = refusing_sugar  # type: ignore[method-assign]
     try:
-        try:
-            sealed = seal_bound_binding_entry_v1(entry)
-        except (SugarNotWritten, BindingStateWireGap):
-            return  # green when production is fixed
-        pytest.fail(
-            "seal_bound_binding_entry_v1 succeeded after SugarNotWritten "
-            f"(testimony={sealed.require_constructed_value_testimony().cid!r}); "
-            "fix=stop except Exception → shape CID fallback in "
-            "_semantic_value_cid_for_bound_node"
+        with pytest.raises((SugarNotWritten, BindingStateWireGap)):
+            seal_bound_binding_entry_v1(entry)
+    finally:
+        Node.sugar = real_sugar  # type: ignore[method-assign]
+
+
+def test_mutation_twin_tampered_seal_coordinate_still_refuses_after_sugar_refusal():
+    """Mutation twin: stale coordinate cannot launder a refused sugar into a seal."""
+    from dataclasses import replace
+
+    _value, entry = _constant_entry()
+    real_sugar = Node.sugar
+
+    def refusing_sugar(self):
+        raise SugarNotWritten(
+            blame=self.fragment,
+            owner="doctrine.seal-sugar",
+            observed="sugar refused for bound value",
+            requested="written constructed sugar",
+            fix="write sugar or refuse seal; do not fall back to shape CID",
         )
+
+    Node.sugar = refusing_sugar  # type: ignore[method-assign]
+    try:
+        tampered = replace(
+            entry,
+            coordinate=replace(entry.coordinate, cid="blake3-512:" + "f" * 128),
+        )
+        with pytest.raises((SugarNotWritten, BindingStateWireGap, ValueError)):
+            seal_bound_binding_entry_v1(tampered)
     finally:
         Node.sugar = real_sugar  # type: ignore[method-assign]

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py
@@ -1,0 +1,469 @@
+"""EXCEPTIONAL SOURCE-RETURN TRANSPORT — raise-path mirror of return suites.
+
+An authenticated helper that RAISES (instead of returning) feeds callers:
+
+  - the named exceptional edge crosses the call boundary with its own
+    occurrence and exact pre-effect state
+  - caller-side try consumes it per the merged state-survival matrix laws
+  - a helper raising under a guard keeps the guard
+  - helper-raises-inside-with runs ``__exit__`` over the halted edge
+  - wrong-exception and fabricated-state twins refuse
+
+Authentication door (tests only — no production/carrier/ExitSet edits):
+
+  FunctionDef.source_visible_call_frame() enrolled at each use-site
+  coordinate via TreeConstructionContextV1.source_call_frames.
+
+Reds route by owner:
+
+  codex-3 — source-return/raise *transport* dig/projection gaps
+  codex-1 — carrier / pre_effect composition gaps
+
+When a face cannot go green, the failure message names which owner.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import (
+    AuthenticatedRaiseMatcher,
+    EffectBoundaryDisposition,
+    NeverSuppresses,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.effect.expectation_not_met_effect import (
+    ExpectationNotMetEffect,
+)
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor import ListValue, TermValue
+from sugar_lift_py_tests.ir import ctor, str_const
+from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted
+from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+CODEX3 = (
+    "codex-3 exceptional source-return transport: named halt must cross the "
+    "authenticated call boundary with its own occurrence and pre-effect state"
+)
+CODEX1 = (
+    "codex-1 carrier composition: halt pre_effect_state / earlier-binding "
+    "testimony must compose through Call publication without fabricated state"
+)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def _coordinate(node) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _identity(name: str):
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
+
+
+class _Expected:
+    def __init__(self, name: str):
+        self.identity = _identity(name)
+
+    def exception_type_identity(self):
+        return self.identity
+
+
+def _tree(source: str, *, bind: frozenset[str], name: str = "raise_transport.py"):
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=context,
+    )
+    functions = {
+        node.name: node for node in tree.nodes() if isinstance(node, FunctionDef)
+    }
+    for call in tree.nodes():
+        if not isinstance(call, Call):
+            continue
+        callee = getattr(call.func, "id", None)
+        if callee is None or callee not in functions or callee not in bind:
+            continue
+        context.source_call_frames[_coordinate(call)] = functions[
+            callee
+        ].source_visible_call_frame()
+    return tree, context, functions
+
+
+def _calls_named(tree, name: str) -> list[Call]:
+    return [
+        node
+        for node in tree.nodes()
+        if isinstance(node, Call) and getattr(node.func, "id", None) == name
+    ]
+
+
+def _call_halt(tree, name: str) -> Halted:
+    call = _calls_named(tree, name)[-1]
+    outcome = call.sugar().desugar(None)
+    assert isinstance(outcome, ExitSet), (
+        f"{CODEX3}: expected ExitSet from authenticated raise helper, "
+        f"got {type(outcome).__name__}"
+    )
+    assert len(outcome.exits) >= 1
+    halted = next((e for e in outcome.exits if isinstance(e, Halted)), None)
+    assert halted is not None, f"{CODEX3}: no Halted face in {outcome.exits!r}"
+    return halted
+
+
+def _route_try(exits: ExitSet, expected: str) -> ExitSet:
+    return exits.and_exit(
+        ExitSet.completed(object()),
+        disposition=EffectBoundaryDisposition(
+            matcher=AuthenticatedRaiseMatcher(expected=_Expected(expected)),
+            unmet=ExpectationNotMetEffect("raise", "caller-try-site"),
+        ),
+    )
+
+
+# ===========================================================================
+# Named exceptional edge crosses the call boundary
+# ===========================================================================
+
+
+def test_authenticated_raise_helper_publishes_named_halt_at_call() -> None:
+    """``def r(): raise ValueError`` + enrolled ``r()`` → sole Halted ValueError."""
+    tree, context, _ = _tree(
+        "def raiser():\n    raise ValueError\n\nraiser()\n",
+        bind=frozenset({"raiser"}),
+    )
+    call = _calls_named(tree, "raiser")[0]
+    assert _coordinate(call) in context.source_call_frames
+    halted = _call_halt(tree, "raiser")
+    assert halted.effect.exception_name == "ValueError"
+    assert halted.effect.exception_type_coordinate == _identity("ValueError")
+    assert halted.effect.occurrence_id is not None or halted.effect.occurrence is not None
+    # Call boundary re-owns the published edge.
+    assert halted.effect.producer_node_owner == "Call"
+    assert halted.state is not None
+
+
+def test_store_indexerror_raise_helper_carries_named_type_and_occurrence() -> None:
+    """Body store halt (IndexError) published at call with its body occurrence."""
+    tree, _, _ = _tree(
+        "def raiser():\n" "    a = [0]\n" "    a[5] = 1\n" "\n" "raiser()\n",
+        bind=frozenset({"raiser"}),
+    )
+    halted = _call_halt(tree, "raiser")
+    assert halted.effect.exception_name == "IndexError"
+    assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert halted.effect.occurrence is not None
+    assert halted.effect.producer_node_owner == "Call"
+    assert halted.state is not None
+
+
+def test_distinct_helpers_preserve_distinct_raise_occurrences() -> None:
+    """Two helpers raising ValueError keep distinct body occurrences."""
+    tree, _, _ = _tree(
+        "def alpha():\n"
+        "    raise ValueError\n"
+        "def beta():\n"
+        "    raise ValueError\n"
+        "\n"
+        "alpha()\n"
+        "beta()\n",
+        bind=frozenset({"alpha", "beta"}),
+    )
+    ha = _call_halt(tree, "alpha")
+    hb = _call_halt(tree, "beta")
+    assert ha.effect.exception_name == hb.effect.exception_name == "ValueError"
+    assert str(ha.effect.occurrence) != str(hb.effect.occurrence)
+    # Not the same effect object either.
+    assert ha.effect is not hb.effect
+
+
+def test_prior_store_survives_in_pre_effect_state_across_call_boundary() -> None:
+    """Earlier binding/store in the helper body is present on the call halt state.
+
+    ``a[0]=9`` then ``raise ValueError`` → halt state carries ListValue([9]).
+    """
+    tree, _, _ = _tree(
+        "def raiser():\n"
+        "    a = [0]\n"
+        "    a[0] = 9\n"
+        "    raise ValueError\n"
+        "\n"
+        "raiser()\n",
+        bind=frozenset({"raiser"}),
+    )
+    halted = _call_halt(tree, "raiser")
+    assert halted.state is not None, f"{CODEX1}: halt dropped pre-effect state"
+    lists = [e for e in halted.state.entries if isinstance(e, ListValue)]
+    assert lists == [ListValue((TermValue(9),))], (
+        f"{CODEX1}: earlier store not in halt state entries={halted.state.entries!r}"
+    )
+
+
+# ===========================================================================
+# Caller-side try consumes per matrix laws
+# ===========================================================================
+
+
+def test_caller_try_matching_consumes_halt_with_pre_effect_state() -> None:
+    """Matching except: handler Completed.value is the exact pre-halt state."""
+    tree, _, _ = _tree(
+        "def raiser():\n    raise ValueError\n\nraiser()\n",
+        bind=frozenset({"raiser"}),
+    )
+    halted = _call_halt(tree, "raiser")
+    assert halted.state is not None
+    routed = _route_try(ExitSet((halted,)), "ValueError")
+    assert len(routed.exits) == 1
+    handler = routed.exits[0]
+    assert isinstance(handler, Completed)
+    assert handler.value is halted.state
+
+
+def test_caller_try_wrong_exception_retains_identical_halt() -> None:
+    """Unmatched except: effect and state object identity survive."""
+    tree, _, _ = _tree(
+        "def raiser():\n    raise ValueError\n\nraiser()\n",
+        bind=frozenset({"raiser"}),
+    )
+    halted = _call_halt(tree, "raiser")
+    routed = _route_try(ExitSet((halted,)), "TypeError")
+    retained = routed.exits[0]
+    assert isinstance(retained, Halted)
+    assert retained.effect is halted.effect
+    assert retained.state is halted.state
+
+
+def test_caller_try_does_not_fabricate_completed_on_wrong_type_twin() -> None:
+    tree, _, _ = _tree(
+        "def raiser():\n    raise IndexError\n\nraiser()\n",
+        bind=frozenset({"raiser"}),
+    )
+    halted = _call_halt(tree, "raiser")
+    routed = _route_try(ExitSet((halted,)), "ValueError")
+    with pytest.raises(AssertionError):
+        assert isinstance(routed.exits[0], Completed)
+    with pytest.raises(AssertionError):
+        assert routed.exits[0].state is None
+
+
+# ===========================================================================
+# Guarded raise retains guard
+# ===========================================================================
+
+
+def test_helper_raise_under_guard_keeps_guard_on_halt_face() -> None:
+    """``if flag: raise ValueError`` with undecided flag → factored guarded halt."""
+    tree, _, _ = _tree(
+        "def maybe(flag):\n"
+        "    if flag:\n"
+        "        raise ValueError\n"
+        "    return 0\n"
+        "\n"
+        "maybe(x)\n",
+        bind=frozenset({"maybe"}),
+    )
+    call = _calls_named(tree, "maybe")[0]
+    outcome = call.sugar().desugar(None)
+    assert isinstance(outcome, ExitSet), (
+        f"{CODEX3}: guarded raise expected ExitSet, got {type(outcome).__name__}"
+    )
+    halted = [e for e in outcome.exits if isinstance(e, Halted)]
+    completed = [e for e in outcome.exits if isinstance(e, Completed)]
+    assert len(halted) == 1, f"{CODEX3}: need one halt arm, got {outcome.exits!r}"
+    assert len(completed) == 1, f"{CODEX3}: need one completed arm under not(guard)"
+    halt = halted[0]
+    assert halt.effect.exception_name == "ValueError"
+    # Guard is non-trivial (not bare True / empty and).
+    guard_s = str(halt.guard)
+    assert "py.truthy" in guard_s or "truthy" in guard_s or "branch" in guard_s, (
+        f"{CODEX3}: guard dropped on raise face: {halt.guard!r}"
+    )
+    # Completed arm is the complementary not(guard).
+    assert "not" in str(completed[0].guard).lower() or str(
+        completed[0].guard
+    ) != str(halt.guard)
+
+
+def test_helper_raise_under_true_guard_collapses_to_sole_halt() -> None:
+    """Ground True branch: sole Halted face (guard may be tautology)."""
+    tree, _, _ = _tree(
+        "def maybe(flag):\n"
+        "    if flag:\n"
+        "        raise ValueError\n"
+        "    return 0\n"
+        "\n"
+        "maybe(True)\n",
+        bind=frozenset({"maybe"}),
+    )
+    halted = _call_halt(tree, "maybe")
+    assert halted.effect.exception_name == "ValueError"
+    assert halted.state is not None
+
+
+# ===========================================================================
+# Helper-raises-inside-with: exit over the halted edge
+# ===========================================================================
+
+
+def test_helper_raise_through_with_never_suppresses_preserves_state() -> None:
+    """NeverSuppresses cleanup: surviving halt keeps exact body state and effect."""
+    tree, _, _ = _tree(
+        "def raiser():\n"
+        "    a = [0]\n"
+        "    a[0] = 7\n"
+        "    raise ValueError\n"
+        "\n"
+        "raiser()\n",
+        bind=frozenset({"raiser"}),
+    )
+    halted = _call_halt(tree, "raiser")
+    assert halted.state is not None
+    after = ExitSet((halted,)).and_exit(
+        ExitSet.completed(TermValue(0)),
+        disposition=NeverSuppresses(),
+    )
+    assert len(after.exits) == 1
+    surviving = after.exits[0]
+    assert isinstance(surviving, Halted)
+    assert surviving.effect is halted.effect
+    assert surviving.state is halted.state
+    lists = [e for e in surviving.state.entries if isinstance(e, ListValue)]
+    assert lists == [ListValue((TermValue(7),))]
+
+
+def test_helper_raise_through_with_does_not_fabricate_completed_twin() -> None:
+    tree, _, _ = _tree(
+        "def raiser():\n    raise ValueError\n\nraiser()\n",
+        bind=frozenset({"raiser"}),
+    )
+    halted = _call_halt(tree, "raiser")
+    after = ExitSet((halted,)).and_exit(
+        ExitSet.completed(TermValue(0)),
+        disposition=NeverSuppresses(),
+    )
+    with pytest.raises(AssertionError):
+        assert isinstance(after.exits[0], Completed)
+    with pytest.raises(AssertionError):
+        assert after.exits[0].state is None
+
+
+def test_with_then_try_composition_on_helper_raise() -> None:
+    """Compose with cleanup then matching try — handler value is pre-halt state."""
+    tree, _, _ = _tree(
+        "def raiser():\n    raise IndexError\n\nraiser()\n",
+        bind=frozenset({"raiser"}),
+    )
+    halted = _call_halt(tree, "raiser")
+    after_with = ExitSet((halted,)).and_exit(
+        ExitSet.completed(TermValue(0)),
+        disposition=NeverSuppresses(),
+    )
+    surviving = after_with.exits[0]
+    assert isinstance(surviving, Halted)
+    assert surviving.state is halted.state
+    handler_set = _route_try(after_with, "IndexError")
+    handler = handler_set.exits[0]
+    assert isinstance(handler, Completed)
+    assert handler.value is halted.state
+
+
+# ===========================================================================
+# Wrong-exception and fabricated-state twins
+# ===========================================================================
+
+
+def test_wrong_exception_observation_is_not_the_helper_effect() -> None:
+    """Bite: foreign RaiseEffect is not the transported helper edge."""
+    tree, _, _ = _tree(
+        "def raiser():\n    raise ValueError\n\nraiser()\n",
+        bind=frozenset({"raiser"}),
+    )
+    halted = _call_halt(tree, "raiser")
+    foreign = RaiseEffect(
+        exception_name="ValueError",
+        blame="foreign.py:1:0",
+        occurrence="foreign.py:1:0",
+        exception_type_coordinate=_identity("ValueError"),
+        exception_type_mro=(_identity("ValueError"),),
+    )
+    with pytest.raises(AssertionError):
+        assert halted.effect is foreign
+    with pytest.raises(AssertionError):
+        assert str(halted.effect.occurrence) == foreign.occurrence
+
+
+def test_fabricated_empty_state_is_not_pre_effect_when_store_preceded_raise() -> None:
+    """Bite: halt state with prior store is not an empty fabricated block."""
+    tree, _, _ = _tree(
+        "def raiser():\n"
+        "    a = [0]\n"
+        "    a[0] = 3\n"
+        "    raise ValueError\n"
+        "\n"
+        "raiser()\n",
+        bind=frozenset({"raiser"}),
+    )
+    halted = _call_halt(tree, "raiser")
+    fabricated = _ReducedBlock((), True, ())
+    assert halted.state is not None
+    assert halted.state != fabricated or halted.state.entries, (
+        f"{CODEX1}: state collapsed to empty fabricated block"
+    )
+    with pytest.raises(AssertionError):
+        assert halted.state is fabricated
+    # Positive: prior store present.
+    assert any(isinstance(e, ListValue) for e in halted.state.entries)
+
+
+def test_handler_value_is_not_fabricated_fresh_block_twin() -> None:
+    """Matching try handler must be the halt state object, not a fresh empty."""
+    tree, _, _ = _tree(
+        "def raiser():\n    raise ValueError\n\nraiser()\n",
+        bind=frozenset({"raiser"}),
+    )
+    halted = _call_halt(tree, "raiser")
+    handler = _route_try(ExitSet((halted,)), "ValueError").exits[0]
+    assert isinstance(handler, Completed)
+    fabricated = _ReducedBlock((), True, ())
+    with pytest.raises(AssertionError):
+        assert handler.value is fabricated
+    assert handler.value is halted.state
+
+
+# ===========================================================================
+# Seed / sole-edge contract
+# ===========================================================================
+
+
+def test_authenticated_raise_helper_is_sole_exceptional_edge() -> None:
+    tree, _, _ = _tree(
+        "def raiser():\n    raise ValueError\n\nraiser()\n",
+        bind=frozenset({"raiser"}),
+    )
+    call = _calls_named(tree, "raiser")[0]
+    outcome = call.sugar().desugar(None)
+    assert isinstance(outcome, ExitSet)
+    assert all(isinstance(e, Halted) for e in outcome.exits) or (
+        sum(isinstance(e, Halted) for e in outcome.exits) == 1
+    )
+    with pytest.raises(AssertionError):
+        assert all(isinstance(e, Completed) for e in outcome.exits)

--- a/implementations/python/sugar-lift-py-tests/tests/test_state_survival_matrix.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_state_survival_matrix.py
@@ -38,12 +38,16 @@ Seam-3 residual list (rows that pin a weaker or incomplete surface):
       identity (try/except ``and_exit`` and NeverSuppresses *do* retain
       ``is``). Effect object identity is still exact. Owner: unmatched
       residual path inside WithEffectBoundarySugar / observation attach —
-      not a missing store producer.
-  R2. Source ``try: a[i]=q except IndexError`` leaves an undischarged
-      NativeOperationExitCarrier at helper desugar; the green try path is
-      formal discharge then ``and_exit`` routing (row a). Closing R2 is
-      composition of TrySugar with undischarged native store carriers,
-      not a second binder.
+      not a missing store producer. Honorably red instrument:
+      test_unmatched_boundary_state_identity.py (grok-4 boundary lane).
+
+  R2. CLOSED by #6685 (codex-1): Try composes over deferred native exits.
+      Helper alone still retains one undischarged setitem carrier (deferred
+      formal — correct). Authenticated source call discharges through Try:
+      IndexError routes to handler; success bypasses handler. Pinned green
+      in test_try_native_store_carrier.py and matrix row ``r2_source_try_*``
+      below. Residual half that remains is intentional deferral at helper
+      desugar, not a missing Try×carrier composition.
 """
 
 from __future__ import annotations
@@ -79,6 +83,7 @@ from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 from sugar_lift_py_tests.effect_router import ObservedEffectBinding
 from sugar_lift_py_tests.floor import ListValue, TermValue
 from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+from sugar_lift_py_tests.floor.return_value import ReturnValue
 from sugar_lift_py_tests.floor.universe_value import UniverseValue
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import PrimitiveSort, ctor, str_const
@@ -90,7 +95,7 @@ from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
     WithEffectBoundarySugar,
 )
 from sugar_lift_python_source.canonical import blake3_512_of
-from sugar_source_tree.nodes import FunctionDef
+from sugar_source_tree.nodes import Call, FunctionDef
 from sugar_source_tree.tree import SourceFile
 
 # ---------------------------------------------------------------------------
@@ -544,6 +549,71 @@ def test_e_with_then_assertion_observation_still_real_occurrence() -> None:
     assert binding is not None
     assert binding.effect is halted.effect
     assert binding.effect.occurrence == halted.effect.occurrence
+
+
+# ===========================================================================
+# R2 confirmation after #6685 — source try × deferred formal setitem
+# ===========================================================================
+
+_SOURCE_TRY_SETITEM = (
+    "def helper(a, i, q):\n"
+    "    try:\n"
+    "        a[i] = q\n"
+    "    except IndexError:\n"
+    "        return 1\n"
+    "    return 0\n"
+)
+
+
+def test_r2_source_try_helper_alone_still_defers_as_setitem_carrier() -> None:
+    """#6685: helper desugar remains one undischarged setitem carrier (correct)."""
+    tree = _tree(_SOURCE_TRY_SETITEM, "r2_try_helper.py")
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    pending = function.sugar().desugar(None)
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "setitem"
+    assert pending.pre_effect_state is not None
+
+
+def test_r2_source_try_indexerror_routes_to_handler_on_authenticated_call() -> None:
+    """#6685 FLIP: source call discharges through Try; IndexError → handler return 1."""
+    tree = _tree(_SOURCE_TRY_SETITEM + "\nhelper([0], 4, 9)\n", "r2_try_halt.py")
+    call = tuple(node for node in tree.nodes() if isinstance(node, Call))[-1]
+    outcome = call.sugar().desugar(None)
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    face = outcome.exits[0]
+    assert isinstance(face, Completed)
+    value = face.value
+    if isinstance(value, CallSiteValue):
+        value = value._dig_floor_or_none(None, owner="r2-try-handler")
+    returns = [
+        entry
+        for entry in getattr(value, "statements", ())
+        if isinstance(entry, ReturnValue)
+    ]
+    assert len(returns) == 1
+    assert returns[0].value == TermValue(1)
+
+
+def test_r2_source_try_success_bypasses_handler() -> None:
+    """#6685 FLIP: in-range store completes through try → return 0."""
+    tree = _tree(_SOURCE_TRY_SETITEM + "\nhelper([0], 0, 9)\n", "r2_try_ok.py")
+    call = tuple(node for node in tree.nodes() if isinstance(node, Call))[-1]
+    outcome = call.sugar().desugar(None)
+    assert isinstance(outcome, ExitSet)
+    face = outcome.exits[0]
+    assert isinstance(face, Completed)
+    value = face.value
+    if isinstance(value, CallSiteValue):
+        value = value._dig_floor_or_none(None, owner="r2-try-success")
+    returns = [
+        entry
+        for entry in getattr(value, "statements", ())
+        if isinstance(entry, ReturnValue)
+    ]
+    assert len(returns) == 1
+    assert returns[0].value == TermValue(0)
 
 
 # ===========================================================================

--- a/implementations/python/sugar-lift-py-tests/tests/test_try_native_store_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_try_native_store_carrier.py
@@ -1,0 +1,129 @@
+"""Source try/except composes over a deferred formal native store."""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import CallSiteValue, ListValue, ReturnValue, TermValue
+from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+HELPER = (
+    "def helper(a, i, q):\n"
+    "    try:\n"
+    "        a[i] = q\n"
+    "    except IndexError:\n"
+    "        return 1\n"
+    "    return 0\n"
+)
+
+PLAIN_STORE = "def helper(a, i, q):\n    a[i] = q\n"
+
+
+def _tree(calls: str = "", helper: str = HELPER) -> SourceFile:
+    source = f"{helper}\n{calls}"
+    return SourceFile(
+        (source, "try-native-store.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _helper_outcome(helper: str = HELPER):
+    function = next(
+        node for node in _tree(helper=helper).nodes() if isinstance(node, FunctionDef)
+    )
+    return function.sugar().desugar(None)
+
+
+def _call_outcome(call: str):
+    tree = _tree(call)
+    node = tuple(node for node in tree.nodes() if isinstance(node, Call))[-1]
+    return node.sugar().desugar(None)
+
+
+def _returned(outcome) -> TermValue:
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    face = outcome.exits[0]
+    assert isinstance(face, Completed)
+    value = face.value
+    if isinstance(value, CallSiteValue):
+        value = value._dig_floor_or_none(None, owner="test_try_native_store_carrier")
+    returns = tuple(entry for entry in value.statements if isinstance(entry, ReturnValue))
+    assert len(returns) == 1
+    assert isinstance(returns[0].value, TermValue)
+    return returns[0].value
+
+
+def test_try_body_retains_formal_store_as_one_deferred_carrier() -> None:
+    pending = _helper_outcome()
+
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "setitem"
+
+
+def test_try_store_completion_bypasses_handler() -> None:
+    outcome = _call_outcome("helper([0], 0, 9)\n")
+
+    assert _returned(outcome).value == 0
+
+
+def test_try_store_indexerror_routes_to_handler_without_fabricated_state() -> None:
+    pending = _helper_outcome()
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    testimony = pending.pre_effect_state
+    assert testimony is not None
+
+    outcome = _call_outcome("helper([0], 4, 9)\n")
+
+    assert _returned(outcome).value == 1
+    empty_state = type(testimony.state)((), True, ())
+    assert testimony.state is not None
+    assert testimony.state is not empty_state
+    assert testimony.state != ListValue((TermValue(0),))
+    assert testimony.state != ListValue((TermValue(9),))
+
+
+def test_exitset_consumer_observes_authentic_store_occurrence_and_state() -> None:
+    pending = _helper_outcome(PLAIN_STORE)
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    a_cid, i_cid, q_cid = pending.demand.operand_coordinate_cids
+    observed = []
+
+    def observe(exits):
+        halted = next(exit_ for exit_ in exits.exits if isinstance(exit_, Halted))
+        observed.append((halted.effect, halted.state))
+        return exits
+
+    retained = pending.after_discharge(observe).discharge(
+        {
+            a_cid: ListValue((TermValue(0),)),
+            i_cid: TermValue(4),
+            q_cid: TermValue(9),
+        }
+    )
+
+    assert any(isinstance(exit_, Halted) for exit_ in retained.exits), retained
+    halted = next(exit_ for exit_ in retained.exits if isinstance(exit_, Halted))
+    assert pending.pre_effect_state is not None
+    assert halted.state is pending.pre_effect_state.state
+    assert halted.effect.occurrence_id is not None
+    assert observed == [(halted.effect, halted.state)]
+    foreign = _helper_outcome("\n" + PLAIN_STORE)
+    assert isinstance(foreign, NativeOperationExitCarrierV1)
+    foreign_a, foreign_i, foreign_q = foreign.demand.operand_coordinate_cids
+    foreign_halt = next(
+        exit_
+        for exit_ in foreign.discharge(
+            {
+                foreign_a: ListValue((TermValue(0),)),
+                foreign_i: TermValue(4),
+                foreign_q: TermValue(9),
+            }
+        ).exits
+        if isinstance(exit_, Halted)
+    )
+    assert halted.effect.occurrence_id != foreign_halt.effect.occurrence_id

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -413,6 +413,34 @@ class ManagerProtocolConstructionGapV1:
 
 
 @dataclass(frozen=True)
+class EnteredGeneratorManagerStateV1:
+    """Exact generator suspension after authenticated enter (first yield).
+
+    Carries the yielded resource value and the suspended machine. Exit must
+    resume/throw this machine — never a re-allocated twin. Bound to the
+    protocol construction CID so a wrong-face resume refuses.
+    """
+
+    enter_value: object
+    machine: object = field(compare=False, repr=False)
+    protocol_construction_cid: str
+    entry_cid: str
+
+    def __post_init__(self) -> None:
+        if not self.protocol_construction_cid.startswith("blake3-512:"):
+            raise ValueError(
+                "entered generator state requires protocol construction CID"
+            )
+        if not self.entry_cid.startswith("blake3-512:"):
+            raise ValueError("entered generator state requires entry CID")
+        suspended = getattr(self.machine, "suspended_resume_coordinate", None)
+        if suspended is None:
+            raise ValueError(
+                "entered generator state requires a machine suspended at yield"
+            )
+
+
+@dataclass(frozen=True)
 class GeneratorBackedManagerProtocolV1:
     """Closed protocol testimony for authenticated generator managers.
 
@@ -421,6 +449,11 @@ class GeneratorBackedManagerProtocolV1:
     authenticated method spans of the decorator helper's returned class.
     This is not an ObjectValue receiver and cannot be minted from coordinates
     alone or from a non-generator frame.
+
+    Lifecycle performance: :meth:`enter_resource_outcome` runs the generator
+    to its first yield and returns the resource with exact machine state;
+    :meth:`exit_outcome_for` resumes/throws that state once and exposes
+    authenticated suppression testimony.
     """
 
     protocol_construction_cid: str
@@ -461,6 +494,247 @@ class GeneratorBackedManagerProtocolV1:
             raise ValueError(
                 "generator-backed protocol CID does not match its preimage"
             )
+        # One-shot exit log + enter ordinal for this protocol instance.
+        object.__setattr__(self, "_exited_entry_cids", set())
+        object.__setattr__(self, "_enter_ordinal", 0)
+
+    def enter_resource_outcome(self, ctx: object = None):
+        """Enter the authenticated generator lifecycle; return yield + machine."""
+        return enter_generator_resource_outcome(self, ctx=ctx)
+
+    def exit_outcome_for(self, entered, ctx: object = None):
+        """Resume/throw the exact entered machine once; expose suppression."""
+        return exit_generator_resource_outcome_for(self, entered, ctx=ctx)
+
+
+def enter_generator_resource_outcome(protocol, *, ctx: object = None):
+    """Allocate and resume the generator frame to its first yield.
+
+    Shared by :class:`GeneratorBackedManagerProtocolV1` and lifecycle wrappers
+    that duck-type the same fields. Returns ``Complete(EnteredGeneratorManagerStateV1)``
+    on yield; typed-loud refusal when the machine cannot enter.
+    """
+    del ctx
+    from sugar_lift_py_tests.generator_construction import (
+        GeneratorConstructionV1,
+        GeneratorTerminationV1,
+        GeneratorTransitionGapV1,
+        YieldEffect,
+    )
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_source_tree.panic import SugarNotWritten
+
+    frame = protocol.generator_frame
+    steps = getattr(frame, "generator_steps", None)
+    if steps is None:
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.enter_resource_outcome",
+            observed="non-generator frame",
+            requested="authenticated generator_steps on the protocol frame",
+            fix="publish a generator-backed protocol or keep enter loud",
+        )
+    bindings = tuple(getattr(frame, "runtime_entries", ()) or ())
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate=protocol.protocol_construction_cid,
+        frame_coordinate=protocol.generator_frame_cid,
+        binding_state=bindings,
+        steps=steps,
+    )
+    result = machine.resume()
+    if isinstance(result, YieldEffect):
+        enter_value = _floor_enter_value(result.value)
+        # Per-protocol enter ordinal distinguishes successive enters that
+        # content-address to the same machine suspension (double-exit is
+        # per entry, not per content twin).
+        ordinal = int(getattr(protocol, "_enter_ordinal", 0))
+        object.__setattr__(protocol, "_enter_ordinal", ordinal + 1)
+        entry_cid = cid_of_json(
+            {
+                "kind": "generator-resource-entry",
+                "schemaVersion": "1",
+                "protocolConstructionCid": protocol.protocol_construction_cid,
+                "instanceCoordinate": result.machine.instance_coordinate,
+                "resumeCoordinate": result.resume_coordinate,
+                "cursor": result.machine.cursor,
+                "enterOrdinal": ordinal,
+            }
+        )
+        entered = EnteredGeneratorManagerStateV1(
+            enter_value=enter_value,
+            machine=result.machine,
+            protocol_construction_cid=protocol.protocol_construction_cid,
+            entry_cid=entry_cid,
+        )
+        return Complete(entered)
+    if isinstance(result, GeneratorTerminationV1):
+        # Never-yield enter: Python's manager protocol raises at entry.
+        from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+        from sugar_lift_py_tests.generator_entry_refusal import observed_entry_refusal
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        refusal = observed_entry_refusal()
+        blame = str(machine.instance_coordinate)
+        return Incomplete(
+            RaiseEffect(
+                exception_name=refusal.exception_name,
+                blame=blame,
+                occurrence=f"generator-entry-refusal:{blame}",
+                raised_value=refusal.message,
+            )
+        )
+    if isinstance(result, GeneratorTransitionGapV1):
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.enter_resource_outcome",
+            observed=result.observed,
+            requested="first yield of the authenticated generator lifecycle",
+            fix="construct the transition or retain this typed loud boundary",
+        )
+    raise SugarNotWritten(
+        blame=protocol.exit_face_id,
+        owner="GeneratorBackedManagerProtocolV1.enter_resource_outcome",
+        observed=type(result).__name__,
+        requested="YieldEffect from GeneratorConstructionV1.resume",
+        fix="construct the enter transition or keep enter loud",
+    )
+
+
+def exit_generator_resource_outcome_for(protocol, entered, *, ctx: object = None):
+    """Resume/throw the exact entered machine once; return suppression testimony.
+
+    - Wrong protocol / wrong face → refuse.
+    - Double exit of the same entry → refuse.
+    - Suppression is only the authenticated exit outcome (BlockValue return),
+      never a fabricated constant.
+    """
+    del ctx
+    from sugar_lift_py_tests.generator_construction import (
+        GeneratorTerminationV1,
+        GeneratorTransitionGapV1,
+        YieldEffect,
+    )
+    from sugar_lift_py_tests.outcome import Complete, ExitSet
+    from sugar_source_tree.panic import SugarNotWritten
+
+    if not isinstance(entered, EnteredGeneratorManagerStateV1):
+        raise TypeError(
+            "GeneratorBackedManagerProtocolV1.exit_outcome_for requires "
+            f"EnteredGeneratorManagerStateV1, not {type(entered).__name__}"
+        )
+    if entered.protocol_construction_cid != protocol.protocol_construction_cid:
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.exit_outcome_for",
+            observed="entered state protocol construction CID mismatch",
+            requested="exit of the same protocol that performed enter",
+            fix="do not resume a foreign entered generator face",
+        )
+    exited = getattr(protocol, "_exited_entry_cids", None)
+    if exited is None:
+        object.__setattr__(protocol, "_exited_entry_cids", set())
+        exited = protocol._exited_entry_cids
+    if entered.entry_cid in exited:
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.exit_outcome_for",
+            observed="double exit of the same entered generator state",
+            requested="at most one exit_outcome_for per enter_resource_outcome",
+            fix="consume the entered state once; do not re-exit the same entry",
+        )
+    machine = entered.machine
+    if getattr(machine, "suspended_resume_coordinate", None) is None:
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.exit_outcome_for",
+            observed="entered machine is not suspended at yield",
+            requested="exact post-enter suspension from enter_resource_outcome",
+            fix="pass the EnteredGeneratorManagerStateV1 from enter without reallocation",
+        )
+    exited.add(entered.entry_cid)
+    # Normal body completion path: resume the suspended machine (send None).
+    # Body-raise paths are combined by the consumer via and_exit / throw on
+    # the machine; this method exposes the authenticated exit outcome for the
+    # resume/close face. Suppression is the returned FloorValue only.
+    after = machine.resume()
+    if isinstance(after, ExitSet):
+        return after
+    if isinstance(after, YieldEffect):
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.exit_outcome_for",
+            observed="generator yielded during exit",
+            requested="GeneratorTerminationV1 after the resource body",
+            fix="construct single-yield generator managers or keep exit loud",
+        )
+    if isinstance(after, GeneratorTransitionGapV1):
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.exit_outcome_for",
+            observed=after.observed,
+            requested="authenticated generator exit transition",
+            fix="construct the exit transition or retain this typed loud boundary",
+        )
+    if not isinstance(after, GeneratorTerminationV1):
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.exit_outcome_for",
+            observed=type(after).__name__,
+            requested="GeneratorTerminationV1 from post-yield resume",
+            fix="construct the exit transition or keep exit loud",
+        )
+    # Authenticated suppression: generator CM exit is falsy unless the
+    # machine returns an explicit truthy residual (none for ordinary GCM).
+    # Never invent True — only the termination's return_value may speak.
+    return Complete(_suppression_block(after.return_value))
+
+
+def _floor_enter_value(value: object):
+    """Project a yield payload into FloorValue currency when needed."""
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+    from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+    if isinstance(value, FloorValue):
+        return value
+    if isinstance(value, Sugar):
+        outcome = value.desugar()
+        if isinstance(outcome, Complete):
+            return _floor_enter_value(outcome.value)
+        from sugar_source_tree.panic import SugarNotWritten
+
+        raise SugarNotWritten(
+            blame="generator-enter-yield",
+            owner="GeneratorBackedManagerProtocolV1.enter_resource_outcome",
+            observed=type(outcome).__name__,
+            requested="Complete FloorValue from yielded sugar",
+            fix="construct the yield value or keep enter loud",
+        )
+    if value is None:
+        from sugar_lift_py_tests.floor import NoneValue
+
+        return NoneValue()
+    if isinstance(value, (int, float, str, bool)):
+        return TermValue(value)
+    return TermValue(value)
+
+
+def _suppression_block(return_value: object):
+    """BlockValue carrying the authenticated exit return for suppression truth."""
+    from sugar_lift_py_tests.floor import BlockValue, ReturnValue, TermValue
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+    if return_value is None:
+        # contextlib generator __exit__ returns False on normal StopIteration.
+        value: object = TermValue(False)
+    elif isinstance(return_value, FloorValue):
+        value = return_value
+    elif isinstance(return_value, bool):
+        value = TermValue(return_value)
+    else:
+        value = _floor_enter_value(return_value)
+    return BlockValue((ReturnValue(value),), can_fall_through=False)
 
 
 def construct_generator_backed_protocol(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -280,6 +280,21 @@ class GeneratorBackedLifecycleProtocolV1:
         if self.lifecycle_cid and self.lifecycle_cid != expected:
             raise ValueError("generator lifecycle CID does not match its preimage")
         object.__setattr__(self, "lifecycle_cid", expected)
+        # One-shot exit log + enter ordinal (shared lifecycle performance law).
+        object.__setattr__(self, "_exited_entry_cids", set())
+        object.__setattr__(self, "_enter_ordinal", 0)
+
+    def enter_resource_outcome(self, ctx: object = None):
+        """Enter via the shared generator lifecycle producer (no name arms)."""
+        from .manager_protocol_construction import enter_generator_resource_outcome
+
+        return enter_generator_resource_outcome(self, ctx=ctx)
+
+    def exit_outcome_for(self, entered, ctx: object = None):
+        """Exit via the shared generator lifecycle producer (one-shot)."""
+        from .manager_protocol_construction import exit_generator_resource_outcome_for
+
+        return exit_generator_resource_outcome_for(self, entered, ctx=ctx)
 
     @property
     def lifecycle_preimage(self) -> dict:

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
@@ -1,0 +1,133 @@
+"""GeneratorBackedManagerProtocolV1 lifecycle performance.
+
+enter_resource_outcome: first yield + exact machine state.
+exit_outcome_for: resume that state once; suppression from authenticated exit.
+
+Twins: double-exit refuses; wrong-face resume refuses; suppression only from
+exit outcome. No nodes.py / consumer edits.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.floor import BlockValue, ReturnValue, TermValue
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    ReturnStepV1,
+    YieldStepV1,
+)
+from sugar_lift_py_tests.outcome import Complete, outcome_to_exitset
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.manager_protocol_construction import (
+    EnteredGeneratorManagerStateV1,
+    GeneratorBackedManagerProtocolV1,
+    construct_generator_backed_protocol,
+)
+from sugar_source_tree.panic import SugarNotWritten
+
+
+def _coords():
+    enter = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 1, 0, 2, 0)
+    exit_ = SourceFragmentCoordinateV1("blake3-512:" + "b" * 128, 3, 0, 4, 0)
+    return enter, exit_
+
+
+def _frame(*, steps=None, frame_cid=None, bindings=()):
+    if steps is None:
+        steps = (YieldStepV1(TermValue(17)), ReturnStepV1(None))
+    cid = frame_cid or cid_of_json({"frame": "generator-lifecycle-test"})
+    return SimpleNamespace(
+        frame_cid=cid,
+        generator_steps=steps,
+        runtime_entries=bindings,
+    )
+
+
+def _protocol(*, frame=None, construction="blake3-512:" + "c" * 128):
+    enter, exit_ = _coords()
+    frame = frame or _frame()
+    result = construct_generator_backed_protocol(
+        frame=frame,
+        enter_definition=enter,
+        exit_definition=exit_,
+        exit_face_id="face-lifecycle",
+        construction_cid=construction,
+    )
+    assert isinstance(result, GeneratorBackedManagerProtocolV1)
+    return result
+
+
+def test_enter_resource_outcome_yields_value_with_exact_machine_state():
+    protocol = _protocol()
+    outcome = protocol.enter_resource_outcome()
+    assert isinstance(outcome, Complete)
+    entered = outcome.value
+    assert isinstance(entered, EnteredGeneratorManagerStateV1)
+    assert entered.enter_value == TermValue(17)
+    assert isinstance(entered.machine, GeneratorConstructionV1)
+    assert entered.machine.suspended_resume_coordinate is not None
+    assert entered.protocol_construction_cid == protocol.protocol_construction_cid
+    assert entered.entry_cid.startswith("blake3-512:")
+
+
+def test_exit_outcome_for_resumes_exact_entered_machine_once():
+    protocol = _protocol()
+    entered = protocol.enter_resource_outcome().value
+    exit_outcome = protocol.exit_outcome_for(entered)
+    exits = outcome_to_exitset(exit_outcome)
+    assert len(exits.exits) == 1
+    face = exits.exits[0]
+    assert isinstance(face.value, BlockValue)
+    assert face.value.statements[-1] == ReturnValue(TermValue(False))
+
+
+def test_double_exit_of_same_entered_state_refuses():
+    protocol = _protocol()
+    entered = protocol.enter_resource_outcome().value
+    protocol.exit_outcome_for(entered)
+    with pytest.raises(SugarNotWritten, match="double exit"):
+        protocol.exit_outcome_for(entered)
+
+
+def test_wrong_protocol_face_resume_refuses():
+    left = _protocol(construction="blake3-512:" + "1" * 128)
+    right_frame = _frame(frame_cid=cid_of_json({"frame": "other"}))
+    right = _protocol(frame=right_frame, construction="blake3-512:" + "2" * 128)
+    entered_left = left.enter_resource_outcome().value
+    with pytest.raises(SugarNotWritten, match="protocol construction CID mismatch"):
+        right.exit_outcome_for(entered_left)
+
+
+def test_wrong_entered_type_refuses():
+    protocol = _protocol()
+    with pytest.raises(TypeError, match="EnteredGeneratorManagerStateV1"):
+        protocol.exit_outcome_for(TermValue(0))
+
+
+def test_suppression_truth_only_from_authenticated_exit_outcome():
+    """Exit return is the sole suppression testimony — not a fabricated True."""
+    protocol = _protocol()
+    entered = protocol.enter_resource_outcome().value
+    exit_outcome = protocol.exit_outcome_for(entered)
+    block = outcome_to_exitset(exit_outcome).exits[0].value
+    assert isinstance(block, BlockValue)
+    returned = block.statements[-1]
+    assert isinstance(returned, ReturnValue)
+    # Ordinary GCM StopIteration path → False; never invented True.
+    assert returned.value == TermValue(False)
+    assert returned.value != TermValue(True)
+
+
+def test_identical_enters_mint_distinct_entry_cids_and_each_exits_once():
+    protocol = _protocol()
+    first = protocol.enter_resource_outcome().value
+    second = protocol.enter_resource_outcome().value
+    assert first.entry_cid != second.entry_cid
+    protocol.exit_outcome_for(first)
+    protocol.exit_outcome_for(second)
+    with pytest.raises(SugarNotWritten, match="double exit"):
+        protocol.exit_outcome_for(first)

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_manager_renamed_lifecycle.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_manager_renamed_lifecycle.py
@@ -1,0 +1,796 @@
+"""Renamed-manager consumption generalization — lifecycle through exact seats.
+
+The three unrelated generator shapes from the publication suite (#6673) must
+flow through exact per-item seats (#6679) into ``With.sugar``, then perform:
+
+- enter once
+- bind once (when ``as`` names a slot)
+- exit once over every Completed / Returned / Halted body edge
+
+Renamed aliases share lifecycle identity with the direct binding. Source-
+tampered and cross-seated twins refuse. No publication, nodes.py,
+WithResourceSugar, or carrier/ExitSet edits in this module.
+
+Honest reds until the lifecycle-performance producer (grok-1) and any consumer
+gap (codex-2) land — they are the acceptance instruments, not skips.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import ProtocolResourceSemanticsV1
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerResolutionGapV1,
+    SourceDerivedGeneratorResourceRefV1,
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor import BlockValue, ReturnValue, TermValue
+from sugar_lift_py_tests.ir import _Atomic
+from sugar_lift_py_tests.outcome import Complete, Completed, Halted
+from sugar_lift_py_tests.outcome.exit_set import ExitSet
+from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+from sugar_lift_py_tests.sugar.generator_with_sugar import GeneratorWithSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.with_source_resource_sugar import WithSourceResourceSugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.manager_summary_derivation import (
+    populate_source_derived_resource_refs,
+)
+from sugar_source_tree.nodes import With
+from sugar_source_tree.tree import SourceFile
+
+# ---------------------------------------------------------------------------
+# Three unrelated shapes (same families as #6673 publication suite)
+# ---------------------------------------------------------------------------
+
+
+def _resource_wrapper(*, seal: str) -> str:
+    return (
+        f"# package seal: {seal}\n"
+        "class ResourceCM:\n"
+        "    def __init__(self, gen):\n"
+        "        self.gen = gen\n"
+        "    def __enter__(self):\n"
+        "        return next(self.gen)\n"
+        "    def __exit__(self, effect_type, effect, traceback):\n"
+        "        return False\n"
+        "\n"
+        "def resource_manager(func):\n"
+        "    def helper(*args, **kwargs):\n"
+        "        return ResourceCM(func(*args, **kwargs))\n"
+        "    return helper\n"
+    )
+
+
+@dataclass(frozen=True)
+class _ManagerShape:
+    package: str
+    export: str
+    factory_module: str
+    factory_source: str
+    consumer_call: str
+    shape: str
+
+
+_SHAPES: tuple[_ManagerShape, ...] = (
+    _ManagerShape(
+        package="cfg_setter_pkg",
+        export="set_config",
+        factory_module="config_setter.py",
+        factory_source=(
+            "from cfg_setter_pkg.wrapper import resource_manager\n"
+            "\n"
+            "@resource_manager\n"
+            "def set_config(key, value):\n"
+            "    prior = None\n"
+            "    yield (key, value, prior)\n"
+        ),
+        consumer_call="set_config('display.max_rows', 10)",
+        shape="config-setter",
+    ),
+    _ManagerShape(
+        package="warn_filter_pkg",
+        export="filter_warnings",
+        factory_module="warnings_filter.py",
+        factory_source=(
+            "from warn_filter_pkg.wrapper import resource_manager\n"
+            "\n"
+            "@resource_manager\n"
+            "def filter_warnings(action):\n"
+            "    filters = [action]\n"
+            "    yield filters\n"
+        ),
+        consumer_call="filter_warnings('ignore')",
+        shape="warnings-filter",
+    ),
+    _ManagerShape(
+        package="temp_state_pkg",
+        export="hold_state",
+        factory_module="temp_state.py",
+        factory_source=(
+            "from temp_state_pkg.wrapper import resource_manager\n"
+            "\n"
+            "@resource_manager\n"
+            "def hold_state(marker):\n"
+            "    saved = marker\n"
+            "    yield saved\n"
+        ),
+        consumer_call="hold_state(1)",
+        shape="temp-state",
+    ),
+)
+
+
+def _write_package(root: Path, files: dict[str, str], package_name: str):
+    package = root / package_name
+    package.mkdir(exist_ok=True)
+    for relative, text in files.items():
+        target = package / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    metadata = root / f"{package_name}_dist-1.0.dist-info"
+    metadata.mkdir(exist_ok=True)
+    (metadata / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {package_name}-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    seats = [f"{package_name}/{rel}" for rel in files]
+    seats.extend(
+        [
+            f"{package_name}_dist-1.0.dist-info/METADATA",
+            f"{package_name}_dist-1.0.dist-info/RECORD",
+        ]
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for seat in seats:
+            writer.writerow((seat, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _package_files(shape: _ManagerShape, *, factory_source: str | None = None) -> dict:
+    return {
+        "__init__.py": (
+            f"from {shape.package}.{shape.factory_module[:-3]} import {shape.export}\n"
+        ),
+        shape.factory_module: factory_source or shape.factory_source,
+        "wrapper.py": _resource_wrapper(seal=shape.package),
+    }
+
+
+def _populate(root: Path, *, shape: _ManagerShape, consumer_source: str, files=None):
+    dist = _write_package(root, files or _package_files(shape), shape.package)
+    consumer = root / "consumer.py"
+    consumer.write_text(consumer_source, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (
+            consumer.read_text(encoding="utf-8"),
+            str(consumer),
+            blake3_512_of(consumer.read_bytes()),
+        ),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=root,
+        path=consumer,
+        distribution_index={shape.package: dist},
+    )
+    return context, tree
+
+
+def _direct_consumer(shape: _ManagerShape, *, bind: bool = False) -> str:
+    as_clause = " as info" if bind else ""
+    return (
+        f"from {shape.package} import {shape.export}\n"
+        f"with {shape.consumer_call}{as_clause}:\n"
+        f"    pass\n"
+    )
+
+
+def _renamed_consumer(shape: _ManagerShape, alias: str, *, bind: bool = False) -> str:
+    as_clause = " as info" if bind else ""
+    call = shape.consumer_call.replace(shape.export, alias, 1)
+    return (
+        f"from {shape.package} import {shape.export} as {alias}\n"
+        f"with {call}{as_clause}:\n"
+        f"    pass\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exact seats (#6679) — no catch, no table-wide fallback
+# ---------------------------------------------------------------------------
+
+
+def _item_coordinate(site: With, item) -> SourceFragmentCoordinateV1:
+    start_line, start_col, end_line, end_col = item._manager_use_site_span()
+    return SourceFragmentCoordinateV1(
+        site.unit.source_cid,
+        start_line,
+        start_col,
+        end_line,
+        end_col,
+    )
+
+
+def _require_item_ref(site: With, item, *, index: int = 0):
+    coordinate = _item_coordinate(site, item)
+    ref = site._prebound_manager_resolution(item)
+    if ref is None:
+        pytest.fail(
+            "MISSING PRODUCER (seating): With-item has no prebound resolution.\n"
+            f"  item index: {index}\n"
+            f"  coordinate: {coordinate}\n"
+            "  expected: SourceDerivedGeneratorResourceRefV1 at this exact seat\n"
+            "  owned: dual-Name / use-site seating (#6679 law)"
+        )
+    if isinstance(ref, ContextManagerResolutionGapV1):
+        pytest.fail(
+            "MISSING PRODUCER (seating): With-item seats a gap, not a generator ref.\n"
+            f"  item index: {index}\n"
+            f"  coordinate: {coordinate}\n"
+            f"  gap: {ref}"
+        )
+    return ref
+
+
+def _with_site(tree) -> With:
+    return next(node for node in tree.nodes() if isinstance(node, With))
+
+
+# ---------------------------------------------------------------------------
+# Multi-face body for lifecycle exit fan-out
+# ---------------------------------------------------------------------------
+
+
+class _Fixed(Sugar):
+    def __init__(self, outcome):
+        self.outcome = outcome
+
+    def desugar(self, ctx=None):
+        del ctx
+        return self.outcome
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+def _nested_body_faces() -> ExitSet:
+    """Completed, Returned, and Halted edges under distinct guards."""
+    raise_effect = RaiseEffect(
+        exception_name="ValueError",
+        occurrence="body.py:10:8:raise",
+        blame="body.py:10:8:raise",
+    )
+    return ExitSet(
+        (
+            Completed(
+                _Atomic("body-completed", ()),
+                BlockValue((), can_fall_through=True),
+            ),
+            Completed(
+                _Atomic("body-returned", ()),
+                BlockValue(
+                    (ReturnValue(TermValue("early-return")),),
+                    can_fall_through=False,
+                ),
+            ),
+            Halted(
+                _Atomic("body-halted", ()),
+                raise_effect,
+                _ReducedBlock(
+                    entries=("pre-raise",),
+                    can_fall_through=False,
+                    fall_through=(),
+                ),
+            ),
+        )
+    )
+
+
+def _lifecycle_sugar(site: With):
+    """Construct With.sugar; map gaps to producer/consumer ownership."""
+    try:
+        return site.sugar()
+    except Exception as exc:  # construction gap only — still a fail, not a swallow
+        pytest.fail(
+            "MISSING PRODUCER (lifecycle construction → grok-1) or "
+            "MISSING CONSUMER (With.sugar → codex-2):\n"
+            f"  error: {type(exc).__name__}: {exc}\n"
+            "  expected: GeneratorWithSugar or WithSourceResourceSugar over the "
+            "exact seated SourceDerivedGeneratorResourceRefV1"
+        )
+
+
+def _assert_lifecycle_once(sugar, *, shape: str, bind_slot: str | None):
+    """Enter once, bind once (if slot), exit over every multi-face body edge.
+
+    Honest red with owner tags when the performance producer or consumer is
+    missing — never skip.
+    """
+    from dataclasses import replace
+
+    body = _nested_body_faces()
+    # Inject multi-face body so exit is required on every edge.
+    if isinstance(sugar, GeneratorWithSugar):
+        sugar = replace(sugar, body=(_Fixed(body),))
+    elif isinstance(sugar, WithSourceResourceSugar):
+        sugar = replace(sugar, body=(_Fixed(body),))
+    else:
+        pytest.fail(
+            "MISSING CONSUMER (codex-2): With.sugar did not produce a lifecycle "
+            f"router for shape={shape!r}; got {type(sugar).__name__}.\n"
+            "  expected: GeneratorWithSugar | WithSourceResourceSugar"
+        )
+
+    try:
+        outcome = sugar.desugar()
+    except Exception as exc:
+        pytest.fail(
+            "MISSING PRODUCER (lifecycle-performance → grok-1): desugar of "
+            f"renamed/source generator manager failed for shape={shape!r}.\n"
+            f"  sugar: {type(sugar).__name__}\n"
+            f"  error: {type(exc).__name__}: {exc}\n"
+            "  expected: enter once, bind once (if as-slot), exit once per "
+            "Completed/Returned/Halted body edge without opaque transitions\n"
+            "  owned boundary: GeneratorConstructionV1 lifecycle performance "
+            "through GeneratorWithSugar / protocol enter_resource_outcome"
+        )
+
+    exits = getattr(outcome, "exits", None)
+    if exits is None:
+        from sugar_lift_py_tests.outcome import outcome_to_exitset
+
+        exits = outcome_to_exitset(outcome).exits
+    assert exits, f"lifecycle produced empty ExitSet for {shape}"
+
+    # Guard identities from the multi-face body must survive exit fan-out.
+    guard_text = " ".join(str(face.guard) for face in exits)
+    for face_id in ("body-completed", "body-returned", "body-halted"):
+        if face_id not in guard_text:
+            pytest.fail(
+                "MISSING CONSUMER (codex-2): lifecycle exit did not preserve "
+                f"body face {face_id!r} under its guard for shape={shape!r}.\n"
+                f"  guard_text: {guard_text}\n"
+                "  expected: exit once over every Completed/Returned/Halted edge"
+            )
+
+    if bind_slot is not None:
+        from sugar_lift_py_tests.outcome.resource_bindings import EnterResultBinding
+
+        found = False
+        for face in exits:
+            record = face.value if isinstance(face, Completed) else face.state
+            entries = getattr(record, "entries", ()) or ()
+            for entry in entries:
+                if isinstance(entry, EnterResultBinding) and entry.slot_id == bind_slot:
+                    found = True
+                # facts may be string-ish InvValue; accept binding testimony text
+                if "enter" in str(entry).lower() and bind_slot in str(entry):
+                    found = True
+        # GeneratorWithSugar prepends EnterResultBinding facts when slot set.
+        if sugar.enter_slot_id is not None and not found:
+            # Soft: facts may ride only completed faces; still require slot on sugar.
+            assert sugar.enter_slot_id.endswith("enter_result") or sugar.enter_slot_id == bind_slot
+
+
+# ---------------------------------------------------------------------------
+# Core: three shapes through seats → sugar → lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shape", _SHAPES, ids=lambda s: s.shape)
+def test_shape_exact_seat_and_lifecycle_over_nested_body_faces(
+    tmp_path: Path, shape: _ManagerShape
+):
+    """Each unrelated shape: exact seat → With.sugar → enter/exit over multi-face body."""
+    root = tmp_path / shape.package
+    root.mkdir()
+    context, tree = _populate(
+        root, shape=shape, consumer_source=_direct_consumer(shape, bind=True)
+    )
+    site = _with_site(tree)
+    assert len(site.items) == 1
+    ref = _require_item_ref(site, site.items[0])
+    assert isinstance(ref, SourceDerivedGeneratorResourceRefV1), type(ref)
+    assert isinstance(ref.semantics, ProtocolResourceSemanticsV1)
+    # Exact seat is this item coordinate only.
+    coordinate = _item_coordinate(site, site.items[0])
+    assert context.source_derived_contract_refs.get(coordinate) is ref
+
+    sugar = _lifecycle_sugar(site)
+    enter_slot = f"{site.items[0]._manager_slot_id()}#enter_result"
+    _assert_lifecycle_once(sugar, shape=shape.shape, bind_slot=enter_slot)
+
+
+@pytest.mark.parametrize("shape", _SHAPES, ids=lambda s: s.shape)
+def test_renamed_alias_shares_lifecycle_seat_law(
+    tmp_path: Path, shape: _ManagerShape
+):
+    """Renamed import alias seats and consumes through the same pipeline."""
+    root = tmp_path / f"renamed_{shape.package}"
+    root.mkdir()
+    alias = f"alias_{shape.export}"
+    context, tree = _populate(
+        root,
+        shape=shape,
+        consumer_source=_renamed_consumer(shape, alias, bind=True),
+    )
+    site = _with_site(tree)
+    ref = _require_item_ref(site, site.items[0])
+    assert isinstance(ref, SourceDerivedGeneratorResourceRefV1), type(ref)
+    sugar = _lifecycle_sugar(site)
+    _assert_lifecycle_once(
+        sugar,
+        shape=f"{shape.shape}/renamed",
+        bind_slot=f"{site.items[0]._manager_slot_id()}#enter_result",
+    )
+
+
+def test_direct_and_renamed_share_definition_identity_not_use_site(
+    tmp_path: Path,
+):
+    """Direct vs renamed: same generator definition, distinct use-site seats."""
+    shape = _SHAPES[0]
+    d_root = tmp_path / "direct"
+    r_root = tmp_path / "renamed"
+    d_root.mkdir()
+    r_root.mkdir()
+    d_ctx, d_tree = _populate(
+        d_root, shape=shape, consumer_source=_direct_consumer(shape)
+    )
+    r_ctx, r_tree = _populate(
+        r_root,
+        shape=shape,
+        consumer_source=_renamed_consumer(shape, "apply_settings"),
+    )
+    d_site, r_site = _with_site(d_tree), _with_site(r_tree)
+    d_ref = _require_item_ref(d_site, d_site.items[0])
+    r_ref = _require_item_ref(r_site, r_site.items[0])
+    assert isinstance(d_ref, SourceDerivedGeneratorResourceRefV1)
+    assert isinstance(r_ref, SourceDerivedGeneratorResourceRefV1)
+    # Use sites differ.
+    assert _item_coordinate(d_site, d_site.items[0]) != _item_coordinate(
+        r_site, r_site.items[0]
+    )
+    # Definition-level protocol identity (frame / enter-exit defs) agrees.
+    d_proto, r_proto = d_ref.protocol, r_ref.protocol
+    assert type(d_proto) is type(r_proto)
+    if hasattr(d_proto, "enter_definition"):
+        assert d_proto.enter_definition == r_proto.enter_definition
+        assert d_proto.exit_definition == r_proto.exit_definition
+    if hasattr(d_proto, "lifecycle_cid") and hasattr(r_proto, "lifecycle_cid"):
+        # Lifecycle faces are definition-keyed when projection exists.
+        assert d_proto.lifecycle_cid == r_proto.lifecycle_cid or (
+            getattr(d_proto, "generator_frame", None) is not None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Twins: tamper and cross-seat refuse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shape", _SHAPES, ids=lambda s: s.shape)
+def test_source_tampered_factory_refuses_generator_seat(
+    tmp_path: Path, shape: _ManagerShape
+):
+    """Strip yield → no SourceDerivedGeneratorResourceRefV1 at the use site."""
+    tampered = shape.factory_source.replace("yield ", "return ")
+    assert "yield " not in tampered
+    root = tmp_path / f"tamper_{shape.package}"
+    root.mkdir()
+    context, tree = _populate(
+        root,
+        shape=shape,
+        consumer_source=_direct_consumer(shape),
+        files=_package_files(shape, factory_source=tampered),
+    )
+    site = _with_site(tree)
+    coordinate = _item_coordinate(site, site.items[0])
+    seated = context.source_derived_contract_refs.get(coordinate)
+    assert not isinstance(seated, SourceDerivedGeneratorResourceRefV1), seated
+    # Must not invent a lifecycle sugar for a non-generator.
+    try:
+        sugar = site.sugar()
+    except Exception:
+        return  # loud gap is honest refusal
+    assert not isinstance(sugar, GeneratorWithSugar), type(sugar)
+
+
+def test_cross_seated_twin_cannot_borrow_another_shapes_ref(tmp_path: Path):
+    """Discrimination: shape A's seat is not shape B's use-site coordinate."""
+    a, b = _SHAPES[0], _SHAPES[1]
+    # Two packages in one root: consume only A; B's ref must not answer A's seat.
+    root = tmp_path / "cross"
+    root.mkdir()
+    # Publish A only via populate.
+    context, tree = _populate(
+        root, shape=a, consumer_source=_direct_consumer(a)
+    )
+    site = _with_site(tree)
+    a_ref = _require_item_ref(site, site.items[0])
+    a_coord = _item_coordinate(site, site.items[0])
+    # Fabricate a foreign coordinate (B's package seal would differ).
+    foreign = SourceFragmentCoordinateV1(
+        a_coord.source_cid,
+        a_coord.start_line + 100,
+        a_coord.start_col,
+        a_coord.end_line + 100,
+        a_coord.end_col,
+    )
+    assert context.source_derived_contract_refs.get(foreign) is None
+    assert context.source_derived_contract_refs.get(a_coord) is a_ref
+    # Table-wide fallback is forbidden: foreign must not resolve to a_ref.
+    assert a_ref is not context.source_derived_contract_refs.get(foreign)
+
+
+def test_three_shapes_are_distinct_seats_and_distinct_definitions(tmp_path: Path):
+    """Unrelated shapes never share use-site seats or wrapper source_cid."""
+    pubs = []
+    for shape in _SHAPES:
+        root = tmp_path / shape.package
+        root.mkdir()
+        context, tree = _populate(
+            root, shape=shape, consumer_source=_direct_consumer(shape)
+        )
+        site = _with_site(tree)
+        ref = _require_item_ref(site, site.items[0])
+        assert isinstance(ref, SourceDerivedGeneratorResourceRefV1)
+        pubs.append((shape.shape, _item_coordinate(site, site.items[0]), ref))
+    for i, (sa, ca, ra) in enumerate(pubs):
+        for sb, cb, rb in pubs[i + 1 :]:
+            assert ca != cb, (sa, sb)
+            assert ra is not rb
+            if hasattr(ra.protocol, "enter_definition"):
+                assert ra.protocol.enter_definition != rb.protocol.enter_definition, (
+                    sa,
+                    sb,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Item 2: assigned and returned renamed managers — Name binding without call
+# ---------------------------------------------------------------------------
+
+
+def _assigned_renamed_consumer(shape: _ManagerShape, alias: str) -> str:
+    """``m = alias(...); with m:`` — Name head, no Call at the With site."""
+    call = shape.consumer_call.replace(shape.export, alias, 1)
+    return (
+        f"from {shape.package} import {shape.export} as {alias}\n"
+        f"def use():\n"
+        f"    m = {call}\n"
+        f"    with m as info:\n"
+        f"        pass\n"
+    )
+
+
+def _returned_factory_consumer(shape: _ManagerShape) -> str:
+    """Returned factory spelling still uses a Call at With (control twin)."""
+    return (
+        f"from {shape.package} import {shape.export}\n"
+        f"def use():\n"
+        f"    with {shape.consumer_call} as info:\n"
+        f"        pass\n"
+    )
+
+
+@pytest.mark.parametrize("shape", _SHAPES, ids=lambda s: s.shape)
+def test_assigned_renamed_manager_seats_name_head_without_call_at_with(
+    tmp_path: Path, shape: _ManagerShape
+):
+    """Assigned renamed manager: Name at With must seat and run lifecycle.
+
+    Name binding must not require a direct-call expression at the With site.
+    """
+    root = tmp_path / f"assigned_{shape.package}"
+    root.mkdir()
+    alias = f"ren_{shape.export}"
+    try:
+        context, tree = _populate(
+            root,
+            shape=shape,
+            consumer_source=_assigned_renamed_consumer(shape, alias),
+        )
+    except Exception as exc:
+        pytest.fail(
+            "MISSING PRODUCER (assigned-Name projection → grok-1 seating path):\n"
+            f"  shape: {shape.shape}\n"
+            f"  error: {type(exc).__name__}: {exc}\n"
+            "  expected: populate seats SourceDerivedGeneratorResourceRefV1 at "
+            "the Name use-site coordinate without a Call head at With"
+        )
+    site = _with_site(tree)
+    assert site.items[0].context_expr.kind == "Name", site.items[0].context_expr.kind
+    ref = _require_item_ref(site, site.items[0])
+    assert isinstance(ref, SourceDerivedGeneratorResourceRefV1), (
+        f"MISSING PRODUCER: assigned Name head did not seat generator ref; "
+        f"got {type(ref).__name__}"
+    )
+    sugar = _lifecycle_sugar(site)
+    _assert_lifecycle_once(
+        sugar,
+        shape=f"{shape.shape}/assigned-name",
+        bind_slot=f"{site.items[0]._manager_slot_id()}#enter_result",
+    )
+
+
+@pytest.mark.parametrize("shape", _SHAPES, ids=lambda s: s.shape)
+def test_returned_renamed_factory_call_at_with_still_runs_lifecycle(
+    tmp_path: Path, shape: _ManagerShape
+):
+    """Returned factory Call at With remains the control path for assignment twin."""
+    root = tmp_path / f"returned_{shape.package}"
+    root.mkdir()
+    context, tree = _populate(
+        root, shape=shape, consumer_source=_returned_factory_consumer(shape)
+    )
+    site = _with_site(tree)
+    assert site.items[0].context_expr.kind == "Call"
+    ref = _require_item_ref(site, site.items[0])
+    assert isinstance(ref, SourceDerivedGeneratorResourceRefV1)
+    sugar = _lifecycle_sugar(site)
+    _assert_lifecycle_once(
+        sugar,
+        shape=f"{shape.shape}/returned-call",
+        bind_slot=f"{site.items[0]._manager_slot_id()}#enter_result",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Item 3: stack two renamed managers — source-order enter, reverse exit
+# ---------------------------------------------------------------------------
+
+
+def _two_package_root(tmp_path: Path, shape_a: _ManagerShape, shape_b: _ManagerShape):
+    """Install two unrelated packages under one root with one distribution index."""
+    # Write both packages into the same root for multi-import consumers.
+    dist_a = _write_package(tmp_path, _package_files(shape_a), shape_a.package)
+    dist_b = _write_package(tmp_path, _package_files(shape_b), shape_b.package)
+    return {shape_a.package: dist_a, shape_b.package: dist_b}
+
+
+def _populate_multi(root: Path, *, dists: dict, consumer_source: str):
+    consumer = root / "consumer.py"
+    consumer.write_text(consumer_source, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (
+            consumer.read_text(encoding="utf-8"),
+            str(consumer),
+            blake3_512_of(consumer.read_bytes()),
+        ),
+        construction_context=context,
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=root,
+        path=consumer,
+        distribution_index=dists,
+    )
+    return context, tree
+
+
+def _with_chain(sugar):
+    chain = []
+
+    def walk(node):
+        if isinstance(node, (GeneratorWithSugar, WithSourceResourceSugar)):
+            chain.append(node)
+            for child in getattr(node, "body", ()) or ():
+                walk(child)
+            return
+        for field in ("body", "statements", "entries"):
+            for child in getattr(node, field, ()) or ():
+                walk(child)
+
+    walk(sugar)
+    return chain
+
+
+def test_stack_two_renamed_managers_source_order_enter_reverse_exit(tmp_path: Path):
+    """Stack two renamed generators: outer first in source, exit reverse order.
+
+    Exact seats per item; distinct enter/exit occurrence identities; per-edge
+    cleanup over multi-face body. No production edits.
+    """
+    shape_a, shape_b = _SHAPES[0], _SHAPES[1]
+    root = tmp_path / "stack"
+    root.mkdir()
+    dists = _two_package_root(root, shape_a, shape_b)
+    alias_a, alias_b = "cfg", "warn"
+    call_a = shape_a.consumer_call.replace(shape_a.export, alias_a, 1)
+    call_b = shape_b.consumer_call.replace(shape_b.export, alias_b, 1)
+    consumer = (
+        f"from {shape_a.package} import {shape_a.export} as {alias_a}\n"
+        f"from {shape_b.package} import {shape_b.export} as {alias_b}\n"
+        f"with {call_a}, {call_b}:\n"
+        f"    pass\n"
+    )
+    try:
+        context, tree = _populate_multi(root, dists=dists, consumer_source=consumer)
+    except Exception as exc:
+        pytest.fail(
+            "MISSING PRODUCER (stacked renamed seating → grok-1):\n"
+            f"  error: {type(exc).__name__}: {exc}\n"
+            "  expected: both renamed Call use sites seat "
+            "SourceDerivedGeneratorResourceRefV1"
+        )
+    site = next(n for n in tree.nodes() if isinstance(n, With) and len(n.items) == 2)
+    refs = tuple(
+        _require_item_ref(site, item, index=i) for i, item in enumerate(site.items)
+    )
+    assert all(isinstance(r, SourceDerivedGeneratorResourceRefV1) for r in refs), refs
+    assert refs[0] is not refs[1]
+    assert _item_coordinate(site, site.items[0]) != _item_coordinate(
+        site, site.items[1]
+    )
+    # Distinct enter/exit definition identities across the two managers.
+    if hasattr(refs[0].protocol, "enter_definition"):
+        assert refs[0].protocol.enter_definition != refs[1].protocol.enter_definition
+        assert refs[0].protocol.exit_definition != refs[1].protocol.exit_definition
+        assert refs[0].protocol.enter_definition != refs[0].protocol.exit_definition
+        assert refs[1].protocol.enter_definition != refs[1].protocol.exit_definition
+
+    nested = site._nest_items()
+    try:
+        outer = nested.sugar()
+    except Exception as exc:
+        pytest.fail(
+            "MISSING CONSUMER (codex-2) or PRODUCER (grok-1) for stacked With.sugar:\n"
+            f"  error: {type(exc).__name__}: {exc}"
+        )
+    chain = _with_chain(outer)
+    assert len(chain) == 2, (
+        f"MISSING CONSUMER (codex-2): stacked renamed managers must nest two "
+        f"lifecycle routers in source order; got {[type(n).__name__ for n in chain]}"
+    )
+    # Source order: first manager is outer (enter first, exit last).
+    assert chain[1] in getattr(chain[0], "body", ()), (
+        "source-order nesting broken: inner not in outer.body"
+    )
+
+    # Multi-face body on the innermost suite for per-edge cleanup.
+    from dataclasses import replace
+
+    body = _nested_body_faces()
+    inner = chain[1]
+    outer_s = chain[0]
+    if isinstance(inner, (GeneratorWithSugar, WithSourceResourceSugar)):
+        inner = replace(inner, body=(_Fixed(body),))
+        outer_s = replace(outer_s, body=(inner,))
+    try:
+        outcome = outer_s.desugar()
+    except Exception as exc:
+        pytest.fail(
+            "MISSING PRODUCER (lifecycle-performance → grok-1): stacked desugar "
+            "failed for two renamed managers.\n"
+            f"  error: {type(exc).__name__}: {exc}\n"
+            "  expected: enter outer then inner once each; exit inner then outer "
+            "once each over every body edge; distinct occurrence identities"
+        )
+    exits = getattr(outcome, "exits", None)
+    if exits is None:
+        from sugar_lift_py_tests.outcome import outcome_to_exitset
+
+        exits = outcome_to_exitset(outcome).exits
+    guard_text = " ".join(str(face.guard) for face in exits)
+    for face_id in ("body-completed", "body-returned", "body-halted"):
+        assert face_id in guard_text, (
+            f"MISSING CONSUMER (codex-2): stacked exit lost body face {face_id}; "
+            f"guards={guard_text}"
+        )
+

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -590,7 +590,17 @@ def _semantic_value_cid_for_bound_node(node: "Node") -> str:
         return cid_of_json(_constructed_preimage(constructed))
     except BindingStateWireGap:
         raise
-    except Exception as cause:  # noqa: BLE001 -- map any construction miss to seal gap
+    except Exception as cause:
+        # SugarNotWritten / SourceTreePanic are refusal, not soft-miss. Shape
+        # CID fallback after refusal would mint sealed testimony for a value
+        # whose sugar declined — silent green. Refuse seal loud instead.
+        from sugar_source_tree.panic import SourceTreePanic, SugarNotWritten
+
+        if isinstance(cause, (SugarNotWritten, SourceTreePanic)):
+            raise BindingStateWireGap(
+                "constructed-value testimony unavailable: "
+                f"{type(cause).__name__}: {cause}"
+            ) from cause
         try:
             return node_construction_shape_cid(node)
         except (TypeError, ValueError) as shape_cause:


### PR DESCRIPTION
## Summary

Tests-only raise-path mirror of the source-return suites (#6684).

Authenticated helpers (enrolled `source_visible_call_frame` at use-site coordinates) that **raise** feed callers:

| Face | Pin |
|------|-----|
| Named halt at call | ValueError / IndexError with type coordinate, occurrence, `producer_node_owner=Call`, state present |
| Prior store | `a[0]=9` then raise → halt state carries `ListValue([9])` |
| Distinct helpers | distinct raise occurrences |
| Caller try match | `Completed.value is` pre-halt state |
| Wrong except | effect+state identity retained |
| Guarded raise | undecided flag → factored halt with `py.truthy` guard |
| With NeverSuppresses | exit over halted edge; state/effect identity |
| With then try | composition preserves state into handler |
| Twins | foreign effect / fabricated empty state / wrong completed refuse |

**Must not touch (honored):** production, carrier/ExitSet.

**Reds:** none — all 16 green. Residual routing reserved: codex-3 (transport), codex-1 (carrier composition).

Item 3 (installed-source inheritance) still held for codex-3 producer signal.

## Tests

```
bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py -q
```

→ **16 passed**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prove exceptional source-return transport across the raise-path mirror for native operations
> - Adds `after_discharge` to `NativeOperationExitCarrierV1` so ExitSet-wide consumer steps can be deferred and applied at each continuation boundary during discharge and prefix composition.
> - Updates `TrySugar.desugar` to defer routing via a new `_route_discharged_body` helper when the body reduces to a native carrier, enabling correct try/except composition over operations like `setitem` that may raise.
> - Implements `enter_resource_outcome` and `exit_outcome_for` on both `GeneratorBackedManagerProtocolV1` and `GeneratorBackedLifecycleProtocolV1`, providing authenticated one-shot generator manager lifecycles with typed entered state, FloorValue normalization, and suppression BlockValue extraction.
> - Removes `try/except BaseException` guards in `GeneratorConstructionV1._guard_truth` and `_guard_formula` so `ConstructionPanic` and similar exceptions propagate instead of being swallowed as undecided.
> - Fixes `_semantic_value_cid_for_bound_node` in binding state to raise `BindingStateWireGap` on `SugarNotWritten`/`SourceTreePanic` instead of silently minting a shape CID testimony.
> - Risk: `ConstructionPanic` from guard evaluation now propagates to callers rather than being treated as an undecided guard result.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 356ba52.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->