### PR TITLE
Project authenticated source returns into operations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -1122,6 +1122,7 @@ class CallSiteValue(FloorValue):
                 incomplete_outcome.append(outcome)
             return None
         value = complete_value(outcome, owner=owner)
+        value = _project_authenticated_source_return(value)
         if isinstance(value, CallSiteValue):
             return value._dig_floor_or_none(
                 reduce_ctx,
@@ -1439,6 +1440,40 @@ def _force_floor_gap(
         gap_locus=GapLocus.PROJECTION,
     )
     construction_panic(info)
+
+
+def _project_authenticated_source_return(value: FloorValue) -> FloorValue:
+    """Project the sole returned Floor from an authenticated source body.
+
+    A source-call dig has already authenticated and reduced its enrolled body
+    before reaching this function.  Only the body's exact, non-fall-through
+    single-return shape owns a scalar projection.  Multi-path bodies remain a
+    ``BlockValue`` so their guards and alternatives cannot be fabricated away.
+    """
+    from sugar_lift_py_tests.floor.block_value import BlockValue
+    from sugar_lift_py_tests.floor.guarded_return import GuardedReturn
+    from sugar_lift_py_tests.floor.return_value import ReturnValue
+    from sugar_lift_py_tests.outcome.exit_set import true_guard
+
+    if (
+        isinstance(value, BlockValue)
+        and not value.fall_through
+        and not value.can_fall_through
+        and len(value.statements) == 1
+        and isinstance(value.statements[0], ReturnValue)
+        and isinstance(value.statements[0].value, FloorValue)
+    ):
+        return value.statements[0].value
+    if isinstance(value, BlockValue):
+        for statement in value.statements:
+            if (
+                isinstance(statement, GuardedReturn)
+                and statement.guards
+                and all(guard == true_guard() for guard in statement.guards)
+                and isinstance(statement.value, FloorValue)
+            ):
+                return statement.value
+    return value
 
 
 def _ctx_with_curried_args(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -131,6 +131,20 @@ class CallSiteValue(FloorValue):
         """A call result denotes a Python runtime value."""
         return True
 
+    def project_operation_receiver(self, ctx: object, *, owner: str):
+        """Project an authenticated sole return before operation dispatch.
+
+        The call remains a CallSiteValue everywhere else. A bodyless or
+        multi-exit call stays itself, preserving the loud operation law; only
+        this producer can expose the Floor authenticated by its source body.
+        """
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+
+        projected = self._dig_floor_or_none(ctx, owner=owner)
+        if projected is None or isinstance(projected, BlockValue):
+            return self
+        return projected
+
     def runtime_type_is_decided(self) -> bool:
         """Undecided: no citation fixes an unexecuted call's result type.
 
@@ -407,12 +421,6 @@ class CallSiteValue(FloorValue):
                 operand_callsites=(*item.callsites(), self),
             )
         )
-
-    def less_than(self, other, site):
-        dug = self._dig_floor_or_none(None, owner="CallSiteValue.less_than")
-        if dug is not None and dug is not self:
-            return dug.less_than(other, site)
-        return super().less_than(other, site)
 
     def subscript(self, index, site):
         return self.undecided_subscript(index, site, owner="CallSiteValue.subscript")
@@ -1457,8 +1465,15 @@ def _project_authenticated_source_return(value: FloorValue) -> FloorValue:
     ``BlockValue`` so their guards and alternatives cannot be fabricated away.
     """
     from sugar_lift_py_tests.floor.block_value import BlockValue
+    from sugar_lift_py_tests.floor.exceptional_exit_value import ExceptionalExitValue
+    from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
+    from sugar_lift_py_tests.floor.guarded_loop_control import GuardedLoopControl
+    from sugar_lift_py_tests.floor.guarded_raise import GuardedRaise
     from sugar_lift_py_tests.floor.guarded_return import GuardedReturn
+    from sugar_lift_py_tests.floor.loop_control_value import LoopControlValue
+    from sugar_lift_py_tests.floor.raise_value import RaiseValue
     from sugar_lift_py_tests.floor.return_value import ReturnValue
+    from sugar_lift_py_tests.outcome import Incomplete
     from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
 
     returns = (
@@ -1470,6 +1485,26 @@ def _project_authenticated_source_return(value: FloorValue) -> FloorValue:
         if isinstance(value, BlockValue)
         else ()
     )
+    control_exits = (
+        tuple(
+            statement
+            for statement in value.statements
+            if isinstance(
+                statement,
+                (
+                    ExceptionalExitValue,
+                    GuardedFaces,
+                    GuardedLoopControl,
+                    GuardedRaise,
+                    Incomplete,
+                    LoopControlValue,
+                    RaiseValue,
+                ),
+            )
+        )
+        if isinstance(value, BlockValue)
+        else ()
+    )
     if (
         isinstance(value, BlockValue)
         and (
@@ -1477,6 +1512,7 @@ def _project_authenticated_source_return(value: FloorValue) -> FloorValue:
             or all(guard == false_guard() for guard in value.fall_through)
         )
         and len(returns) == 1
+        and not control_exits
         and isinstance(returns[0], ReturnValue)
         and isinstance(returns[0].value, FloorValue)
     ):
@@ -1484,6 +1520,7 @@ def _project_authenticated_source_return(value: FloorValue) -> FloorValue:
     if (
         isinstance(value, BlockValue)
         and len(returns) == 1
+        and not control_exits
         and isinstance(returns[0], GuardedReturn)
         and returns[0].guards
         and all(guard == true_guard() for guard in returns[0].guards)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -408,6 +408,27 @@ class CallSiteValue(FloorValue):
             )
         )
 
+    def less_than(self, other, site):
+        return self._ordering_through_source_return(other, site, "less_than")
+
+    def less_equal(self, other, site):
+        return self._ordering_through_source_return(other, site, "less_equal")
+
+    def greater_than(self, other, site):
+        return self._ordering_through_source_return(other, site, "greater_than")
+
+    def greater_equal(self, other, site):
+        return self._ordering_through_source_return(other, site, "greater_equal")
+
+    def _ordering_through_source_return(self, other, site, method_name: str):
+        """Dispatch ordering on an authenticated returned Floor when available."""
+        dug = self._dig_floor_or_none(
+            None, owner=f"CallSiteValue.{method_name} source return"
+        )
+        if dug is not None and dug is not self:
+            return getattr(dug, method_name)(other, site)
+        return getattr(super(), method_name)(other, site)
+
     def subscript(self, index, site):
         return self.undecided_subscript(index, site, owner="CallSiteValue.subscript")
 
@@ -1453,12 +1474,14 @@ def _project_authenticated_source_return(value: FloorValue) -> FloorValue:
     from sugar_lift_py_tests.floor.block_value import BlockValue
     from sugar_lift_py_tests.floor.guarded_return import GuardedReturn
     from sugar_lift_py_tests.floor.return_value import ReturnValue
-    from sugar_lift_py_tests.outcome.exit_set import true_guard
+    from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
 
     if (
         isinstance(value, BlockValue)
-        and not value.fall_through
-        and not value.can_fall_through
+        and (
+            not value.fall_through
+            or all(guard == false_guard() for guard in value.fall_through)
+        )
         and len(value.statements) == 1
         and isinstance(value.statements[0], ReturnValue)
         and isinstance(value.statements[0].value, FloorValue)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -126,6 +126,9 @@ class CallSiteValue(FloorValue):
     )
     source_call_frame_cid: str | None = dataclass_field(default=None, compare=False)
     formal_coordinate_cids: tuple[str, ...] = dataclass_field(default=(), compare=False)
+    bound_native_actuals_by_coordinate: dict[str, FloorValue] | None = dataclass_field(
+        default=None, compare=False
+    )
 
     def denotes_value(self) -> bool:
         """A call result denotes a Python runtime value."""
@@ -1295,6 +1298,12 @@ class CallSiteValue(FloorValue):
 
         if isinstance(outcome, Complete):
             return Complete(self)
+        from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+        if isinstance(outcome, NativeOperationExitCarrierV1):
+            actuals = self.bound_native_actuals_by_coordinate
+            if actuals is None:
+                return outcome
+            outcome = outcome.discharge(actuals)
         exits = outcome_to_exitset(outcome)
         return ExitSet(
             tuple(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -409,25 +409,10 @@ class CallSiteValue(FloorValue):
         )
 
     def less_than(self, other, site):
-        return self._ordering_through_source_return(other, site, "less_than")
-
-    def less_equal(self, other, site):
-        return self._ordering_through_source_return(other, site, "less_equal")
-
-    def greater_than(self, other, site):
-        return self._ordering_through_source_return(other, site, "greater_than")
-
-    def greater_equal(self, other, site):
-        return self._ordering_through_source_return(other, site, "greater_equal")
-
-    def _ordering_through_source_return(self, other, site, method_name: str):
-        """Dispatch ordering on an authenticated returned Floor when available."""
-        dug = self._dig_floor_or_none(
-            None, owner=f"CallSiteValue.{method_name} source return"
-        )
+        dug = self._dig_floor_or_none(None, owner="CallSiteValue.less_than")
         if dug is not None and dug is not self:
-            return getattr(dug, method_name)(other, site)
-        return getattr(super(), method_name)(other, site)
+            return dug.less_than(other, site)
+        return super().less_than(other, site)
 
     def subscript(self, index, site):
         return self.undecided_subscript(index, site, owner="CallSiteValue.subscript")
@@ -1476,26 +1461,35 @@ def _project_authenticated_source_return(value: FloorValue) -> FloorValue:
     from sugar_lift_py_tests.floor.return_value import ReturnValue
     from sugar_lift_py_tests.outcome.exit_set import false_guard, true_guard
 
+    returns = (
+        tuple(
+            statement
+            for statement in value.statements
+            if isinstance(statement, (ReturnValue, GuardedReturn))
+        )
+        if isinstance(value, BlockValue)
+        else ()
+    )
     if (
         isinstance(value, BlockValue)
         and (
             not value.fall_through
             or all(guard == false_guard() for guard in value.fall_through)
         )
-        and len(value.statements) == 1
-        and isinstance(value.statements[0], ReturnValue)
-        and isinstance(value.statements[0].value, FloorValue)
+        and len(returns) == 1
+        and isinstance(returns[0], ReturnValue)
+        and isinstance(returns[0].value, FloorValue)
     ):
-        return value.statements[0].value
-    if isinstance(value, BlockValue):
-        for statement in value.statements:
-            if (
-                isinstance(statement, GuardedReturn)
-                and statement.guards
-                and all(guard == true_guard() for guard in statement.guards)
-                and isinstance(statement.value, FloorValue)
-            ):
-                return statement.value
+        return returns[0].value
+    if (
+        isinstance(value, BlockValue)
+        and len(returns) == 1
+        and isinstance(returns[0], GuardedReturn)
+        and returns[0].guards
+        and all(guard == true_guard() for guard in returns[0].guards)
+        and isinstance(returns[0].value, FloorValue)
+    ):
+        return returns[0].value
     return value
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -122,6 +122,16 @@ _BINARY_OPERATOR_COORDINATE = {
 
 
 class FloorValue:
+    def project_operation_receiver(self, ctx: object, *, owner: str):
+        """Return the value that owns the next operation dispatch.
+
+        Ordinary Floors already are their operation receiver. Producers whose
+        authenticated result is deferred may override this one protocol before
+        any operation family selects its concrete floor method.
+        """
+        del ctx, owner
+        return self
+
     def _floor_gap(
         self,
         *,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete.py
@@ -32,8 +32,15 @@ class Complete:
         # A completed ordinary value keeps going. A constructed raise is also
         # complete testimony, but Python does not evaluate any enclosing
         # expression step after it; preserve the control-flow value unchanged.
-        from sugar_lift_py_tests.floor import RaiseValue
+        from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, RaiseValue
 
         if isinstance(self.value, RaiseValue):
             return self
-        return step(self.value)
+        value = self.value
+        if isinstance(value, CallSiteValue) and value.body is not None:
+            projected = value._dig_floor_or_none(
+                None, owner="Complete.and_then authenticated source return"
+            )
+            if projected is not None and not isinstance(projected, BlockValue):
+                value = projected
+        return step(value)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete.py
@@ -32,15 +32,8 @@ class Complete:
         # A completed ordinary value keeps going. A constructed raise is also
         # complete testimony, but Python does not evaluate any enclosing
         # expression step after it; preserve the control-flow value unchanged.
-        from sugar_lift_py_tests.floor import BlockValue, CallSiteValue, RaiseValue
+        from sugar_lift_py_tests.floor import RaiseValue
 
         if isinstance(self.value, RaiseValue):
             return self
-        value = self.value
-        if isinstance(value, CallSiteValue) and value.body is not None:
-            projected = value._dig_floor_or_none(
-                None, owner="Complete.and_then authenticated source return"
-            )
-            if projected is not None and not isinstance(projected, BlockValue):
-                value = projected
-        return step(value)
+        return step(self.value)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binop_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binop_sugar.py
@@ -86,6 +86,16 @@ class BinOpSugar(ConstructedTermSugar):
         method = BINOP_METHODS[self.op_kind]
         return self.left.desugar(ctx).and_then(
             lambda left: self.right.desugar(ctx).and_then(
-                lambda right: getattr(left, method)(right, self.site)
+                lambda right: getattr(
+                    left.project_operation_receiver(
+                        ctx, owner="BinOpSugar left operation receiver"
+                    ),
+                    method,
+                )(
+                    right.project_operation_receiver(
+                        ctx, owner="BinOpSugar right operation receiver"
+                    ),
+                    self.site,
+                )
             )
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -237,9 +237,10 @@ class CallSiteSugar(ConstructedTermSugar):
 
             try:
                 if self.source_call_frame.pending_native_operation is None:
-                    positional = self.source_call_frame.bind_actuals(
+                    bound_source_actuals = self.source_call_frame.bind_actuals(
                         positional, kw_values, ctx
                     )
+                    positional = bound_source_actuals.actuals
                 else:
                     native_operation_actuals = (
                         self.source_call_frame.bind_native_operation_actuals(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -153,7 +153,16 @@ class CallSiteSugar(ConstructedTermSugar):
         if remaining:
             head, *rest = remaining
             return head.desugar(ctx).and_then(
-                lambda value: self._collect(tuple(rest), accumulated + (value,), ctx)
+                lambda value: self._collect(
+                    tuple(rest),
+                    accumulated
+                    + (
+                        value.project_operation_receiver(
+                            ctx, owner="CallSiteSugar positional actual"
+                        ),
+                    ),
+                    ctx,
+                )
             )
         return self._collect_kwargs(self.keywords, (), accumulated, ctx)
 
@@ -164,7 +173,18 @@ class CallSiteSugar(ConstructedTermSugar):
             (name, sugar), *rest = remaining
             return sugar.desugar(ctx).and_then(
                 lambda value: self._collect_kwargs(
-                    tuple(rest), kw_values + ((name, value),), positional, ctx
+                    tuple(rest),
+                    kw_values
+                    + (
+                        (
+                            name,
+                            value.project_operation_receiver(
+                                ctx, owner="CallSiteSugar keyword actual"
+                            ),
+                        ),
+                    ),
+                    positional,
+                    ctx,
                 )
             )
         if ctx is not None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -338,6 +338,11 @@ class CallSiteSugar(ConstructedTermSugar):
                 if self.source_call_frame is not None
                 else ()
             ),
+            bound_native_actuals_by_coordinate=(
+                None
+                if native_operation_actuals is None
+                else native_operation_actuals.by_formal_coordinate
+            ),
         )
         if native_operation_actuals is not None:
             pending = self.source_call_frame.pending_native_operation.discharge(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -305,7 +305,14 @@ class ComparisonOpSugar(ConstructedTermSugar):
     def desugar(self, ctx: object = None) -> Outcome:
         left = self.left.desugar(ctx)
         right = lambda l: self.right.desugar(ctx).and_then(  # noqa: E731
-            lambda r: self._apply(l, r)
+            lambda r: self._apply(
+                l.project_operation_receiver(
+                    ctx, owner="ComparisonOpSugar left operation receiver"
+                ),
+                r.project_operation_receiver(
+                    ctx, owner="ComparisonOpSugar right operation receiver"
+                ),
+            )
         )
         return left.and_then(right)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
@@ -103,7 +103,14 @@ class MethodCallSugar(ConstructedTermSugar):
         # The RECEIVER is the prefix of the whole argument fold, so its arm
         # count is the base of the exponent every argument raises (#6324).
         return factored_operand(self.receiver.desugar(ctx)).and_then(
-            lambda receiver: self._collect(receiver, self.args, (), ctx)
+            lambda receiver: self._collect(
+                receiver.project_operation_receiver(
+                    ctx, owner="MethodCallSugar receiver"
+                ),
+                self.args,
+                (),
+                ctx,
+            )
         )
 
     def _collect(self, receiver, remaining: tuple, accumulated: tuple, ctx) -> Outcome:
@@ -117,7 +124,15 @@ class MethodCallSugar(ConstructedTermSugar):
             # arguments distribute into m ** k arms.
             return factored_operand(head.desugar(ctx)).and_then(
                 lambda value: self._collect(
-                    receiver, tuple(rest), accumulated + (value,), ctx
+                    receiver,
+                    tuple(rest),
+                    accumulated
+                    + (
+                        value.project_operation_receiver(
+                            ctx, owner="MethodCallSugar positional actual"
+                        ),
+                    ),
+                    ctx,
                 )
             )
         return self._collect_kwargs(receiver, self.keywords, (), accumulated, ctx)
@@ -132,21 +147,22 @@ class MethodCallSugar(ConstructedTermSugar):
             # Same law as the positional fold (#6324).
             return factored_operand(sugar.desugar(ctx)).and_then(
                 lambda value: self._collect_kwargs(
-                    receiver, tuple(rest), kw_values + ((name, value),), positional, ctx
+                    receiver,
+                    tuple(rest),
+                    kw_values
+                    + (
+                        (
+                            name,
+                            value.project_operation_receiver(
+                                ctx, owner="MethodCallSugar keyword actual"
+                            ),
+                        ),
+                    ),
+                    positional,
+                    ctx,
                 )
             )
-        from sugar_lift_py_tests.floor import CallSiteValue, ObjectValue
-
-        if (
-            isinstance(receiver, CallSiteValue)
-            and receiver.body is not None
-            and receiver.source_call_frame_cid is not None
-        ):
-            receiver = receiver.force_floor(
-                ctx,
-                owner="authenticated method receiver",
-                project_callsite=False,
-            )
+        from sugar_lift_py_tests.floor import ObjectValue
 
         if isinstance(receiver, ObjectValue):
             return receiver.call_method_value(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
@@ -194,7 +194,7 @@ class SubscriptStoreEffectSugar(Sugar):
         return self.value.desugar(ctx).and_then(
             lambda value: self.receiver.desugar(ctx).and_then(
                 lambda receiver: self.index.desugar(ctx).and_then(
-                    lambda index: self._store(receiver, index, value)
+                    lambda index: self._store(receiver, index, value, ctx)
                 )
             )
         )
@@ -202,31 +202,28 @@ class SubscriptStoreEffectSugar(Sugar):
     def desugar_store(self, ctx: object, value) -> Outcome:
         return self.receiver.desugar(ctx).and_then(
             lambda receiver: self.index.desugar(ctx).and_then(
-                lambda index: self.project_setitem(
-                    receiver, index, value, self.site
-                )
+                lambda index: self._store(receiver, index, value, ctx)
             )
         )
 
-    def _store(self, receiver, index, value) -> Outcome:
-        return self.project_setitem(receiver, index, value, self.site)
-
-    @staticmethod
-    def project_setitem(receiver, index, value, site) -> Outcome:
-        """Producer-owned subscript **store** projection (one door).
-
-        Shared by ordinary ``SubscriptStoreEffectSugar`` and unpack store
-        targets that already hold a pre-reduced member Floor value — the
-        member never re-enters as a desugared child.
-        """
+    def _store(self, receiver, index, value, ctx=None) -> Outcome:
+        receiver = receiver.project_operation_receiver(
+            ctx, owner="SubscriptStoreEffectSugar receiver"
+        )
+        index = index.project_operation_receiver(
+            ctx, owner="SubscriptStoreEffectSugar index"
+        )
+        value = value.project_operation_receiver(
+            ctx, owner="SubscriptStoreEffectSugar value"
+        )
         coordinates = tuple(
             getattr(operand, "formal_coordinate", None)
             for operand in (receiver, index, value)
         )
         if any(coordinate is not None for coordinate in coordinates):
             # Undischarged demand awaiting caller actuals — not a refusal.
-            return SubscriptStoreEffectSugar.mint_setitem_carrier(
-                site=site,
+            return self.mint_setitem_carrier(
+                site=self.site,
                 receiver=receiver,
                 index=index,
                 value=value,
@@ -235,8 +232,8 @@ class SubscriptStoreEffectSugar(Sugar):
             from sugar_source_tree.panic import SugarNotWritten
 
             raise SugarNotWritten(
-                owner="SubscriptStoreEffectSugar.project_setitem",
-                blame=site,
+                owner="SubscriptStoreEffectSugar._store",
+                blame=self.site,
                 observed="undischarged subscript store over runtime-selected receiver",
                 requested=(
                     "NativeOperationExitCarrierV1 n-ary setitem demand over "
@@ -244,7 +241,7 @@ class SubscriptStoreEffectSugar(Sugar):
                 ),
                 fix="attach the three-operand carrier seam owned by 9883",
             )
-        projected = receiver.setitem(index, value, site)
+        projected = receiver.setitem(index, value, self.site)
         from sugar_lift_py_tests.floor import RaiseValue
         from sugar_lift_py_tests.outcome import Complete, Incomplete
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
@@ -158,6 +158,11 @@ class SubscriptSugar(ConstructedTermSugar):
     def _subscript(self, receiver, index, ctx):
         from sugar_lift_py_tests.floor import ObjectValue
 
+        receiver = receiver.project_operation_receiver(
+            ctx, owner="SubscriptSugar receiver"
+        )
+        index = index.project_operation_receiver(ctx, owner="SubscriptSugar index")
+
         if isinstance(receiver, ObjectValue):
             return receiver.call_method_value(
                 "__getitem__",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
@@ -156,18 +156,7 @@ class SubscriptSugar(ConstructedTermSugar):
         )
 
     def _subscript(self, receiver, index, ctx):
-        from sugar_lift_py_tests.floor import CallSiteValue, ObjectValue
-
-        if isinstance(receiver, CallSiteValue):
-            projected = receiver._dig_floor_or_none(
-                ctx, owner="SubscriptSugar.receiver"
-            )
-            if projected is not None:
-                receiver = projected
-        if isinstance(index, CallSiteValue):
-            projected = index._dig_floor_or_none(ctx, owner="SubscriptSugar.index")
-            if projected is not None:
-                index = projected
+        from sugar_lift_py_tests.floor import ObjectValue
 
         if isinstance(receiver, ObjectValue):
             return receiver.call_method_value(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
@@ -156,7 +156,18 @@ class SubscriptSugar(ConstructedTermSugar):
         )
 
     def _subscript(self, receiver, index, ctx):
-        from sugar_lift_py_tests.floor import ObjectValue
+        from sugar_lift_py_tests.floor import CallSiteValue, ObjectValue
+
+        if isinstance(receiver, CallSiteValue):
+            projected = receiver._dig_floor_or_none(
+                ctx, owner="SubscriptSugar.receiver"
+            )
+            if projected is not None:
+                receiver = projected
+        if isinstance(index, CallSiteValue):
+            projected = index._dig_floor_or_none(ctx, owner="SubscriptSugar.index")
+            if projected is not None:
+                index = projected
 
         if isinstance(receiver, ObjectValue):
             return receiver.call_method_value(

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_if_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_if_method_caller.py
@@ -170,11 +170,12 @@ def _returned_term(completed: Completed) -> TermValue:
         assert value is not None
         returns = tuple(
             entry
-            for entry in value.statements
+            for entry in getattr(value, "statements", ())
             if isinstance(entry, (ReturnValue, GuardedReturn))
         )
-        assert len(returns) == 1
-        value = returns[0]
+        if returns:
+            assert len(returns) == 1
+            value = returns[0]
     if isinstance(value, GuardedReturn):
         value = value.value
     if isinstance(value, ReturnValue):

--- a/implementations/python/sugar-lift-py-tests/tests/test_method_return_as_actual.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_method_return_as_actual.py
@@ -363,9 +363,7 @@ def test_self_binding_does_not_leak_into_returned_testimony() -> None:
     assert site.arg_values[0].class_name == "Factory"
 
     dug = _returned_floor_from_make()
-    returns = _collect_return_values(dug)
-    assert returns, f"no ReturnValue under dig: {type(dug).__name__} {dug!r:.200}"
-    returned = returns[0].value
+    returned = dug
     assert returned == TermValue(41), returned
     # Self is not the returned testimony.
     assert not isinstance(returned, ObjectValue)
@@ -375,10 +373,8 @@ def test_self_binding_does_not_leak_into_returned_testimony() -> None:
 def test_discrimination_returned_term_is_not_the_receiver_object() -> None:
     site = _attr_callsite(FACTORY_MAKE_41 + "\nFactory().make()\n", "make")
     dug = site._dig_floor_or_none(None, owner="method-return-as-actual")
-    returns = _collect_return_values(dug)
-    assert returns
-    assert returns[0].value == TermValue(41)
-    assert returns[0].value != site.arg_values[0]
+    assert dug == TermValue(41)
+    assert dug != site.arg_values[0]
 
 
 # ---------------------------------------------------------------------------
@@ -414,8 +410,7 @@ def test_discrimination_completed_return_is_not_valueerror_halt() -> None:
     else:
         assert isinstance(outcome, Complete)
         dug = outcome.value._dig_floor_or_none(None, owner="method-return-as-actual")
-        returns = _collect_return_values(dug)
-        assert returns and returns[0].value == TermValue(41)
+        assert dug == TermValue(41)
 
 
 # ---------------------------------------------------------------------------
@@ -447,6 +442,8 @@ def test_chained_method_return_stays_honestly_typed() -> None:
     # Green path: dig / complete to TermValue(7).
     if isinstance(outcome, Complete) and isinstance(outcome.value, CallSiteValue):
         dug = outcome.value._dig_floor_or_none(None, owner="method-return-as-actual")
+        if dug == TermValue(7):
+            return
         returns = _collect_return_values(dug) if dug is not None else []
         if returns and returns[0].value == TermValue(7):
             return
@@ -484,14 +481,12 @@ def test_swapped_receiver_is_not_the_returned_value() -> None:
     receiver = site.arg_values[0]
     assert isinstance(receiver, ObjectValue)
     dug = site._dig_floor_or_none(None, owner="method-return-as-actual")
-    returns = _collect_return_values(dug)
-    assert returns
-    assert returns[0].value == TermValue(41)
-    assert returns[0].value != receiver
+    assert dug == TermValue(41)
+    assert dug != receiver
     # A swapped lying map that treats self as the returned actual fails.
     assert not (
-        isinstance(returns[0].value, ObjectValue)
-        and returns[0].value.class_name == "Factory"
+        isinstance(dug, ObjectValue)
+        and dug.class_name == "Factory"
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
@@ -505,6 +505,18 @@ def test_installed_box_expected_source_call_has_an_authenticated_frame(
         context.source_call_resolutions[coordinate],
         SourceCallPreconstructionRefV1,
     )
+    result = call.sugar().desugar(None).value._dig_floor_or_none(
+        None, owner="installed box_expected return"
+    )
+    assert result is not None
+    assert not isinstance(result, CallSiteValue)
+    produced = result.add(StringValue("a"), call.fragment)
+    halted = tuple(exit_ for exit_ in produced.exits if isinstance(exit_, Halted))
+    assert len(halted) == 1
+    assert halted[0].effect.exception_type_coordinate == ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("TypeError")],
+    )
 
 
 def test_runtime_wrong_expected_type_does_not_consume_candidate_exception() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_compare_caller_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_compare_caller_twins.py
@@ -153,21 +153,24 @@ def test_real_caller_runtime_actuals_raise_but_do_not_supply_floor_testimony() -
     assert assert_invalid_comparison(left, right, box) is None
 
 
-def test_existing_floor_cannot_authenticate_this_pandas_ordering_exception() -> None:
-    """Finding (b): this pair needs return-type testimony the Floor lacks.
+def test_opaque_floor_cannot_authenticate_this_pandas_ordering_exception() -> None:
+    """An opaque call remains undecided after source-return projection exists.
 
     The caller's left actual is the result of ``tm.box_expected``.  Until that
     call result authenticates a pandas datetime-array Floor value, substitution
-    yields ``CallSiteValue``.  Its inherited generic ordering law can state a
-    ``py.lt`` atom but cannot mint an exception identity.  Consequently this
-    operation must remain undischarged; neither the helper's ``pytest.raises``
-    expectation nor pandas-specific spelling may fill the missing coordinate.
+    yields ``CallSiteValue``.  Authenticated bodies now project their returned
+    Floor before ordering, but a body-less call cannot mint an exception
+    identity.  Neither the helper boundary nor pandas spelling may fill it.
     """
     pair = _pair()
 
     assert ast.unparse(pair.operation) == "left < right"
-    assert "less_than" not in CallSiteValue.__dict__
-    assert CallSiteValue.less_than is FloorValue.less_than
+    assert CallSiteValue.less_than is not FloorValue.less_than
+    assert CallSiteValue(
+        "opaque", (), (), __import__("sugar_lift_py_tests.ir", fromlist=["ctor"]).ctor(
+            "call:opaque", []
+        ), None
+    )._dig_floor_or_none(None, owner="opaque compare twin") is None
 
 
 def test_lying_caller_coordinate_is_rejected_before_it_can_be_evidence() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_compare_caller_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_compare_caller_twins.py
@@ -11,7 +11,8 @@ import pytest
 from pandas import date_range
 
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
-from sugar_lift_py_tests.floor import CallSiteValue, FloorValue
+from sugar_lift_py_tests.floor import CallSiteValue
+from sugar_lift_py_tests.ir import ctor
 
 MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
@@ -153,24 +154,12 @@ def test_real_caller_runtime_actuals_raise_but_do_not_supply_floor_testimony() -
     assert assert_invalid_comparison(left, right, box) is None
 
 
-def test_opaque_floor_cannot_authenticate_this_pandas_ordering_exception() -> None:
-    """An opaque call remains undecided after source-return projection exists.
+def test_bodyless_call_remains_opaque_without_borrowing_ordering_testimony() -> None:
+    """A bodyless call is the negative twin, not a label for the real caller."""
+    opaque = CallSiteValue("opaque", (), (), ctor("call:opaque", []), None)
 
-    The caller's left actual is the result of ``tm.box_expected``.  Until that
-    call result authenticates a pandas datetime-array Floor value, substitution
-    yields ``CallSiteValue``.  Authenticated bodies now project their returned
-    Floor before ordering, but a body-less call cannot mint an exception
-    identity.  Neither the helper boundary nor pandas spelling may fill it.
-    """
-    pair = _pair()
-
-    assert ast.unparse(pair.operation) == "left < right"
-    assert CallSiteValue.less_than is not FloorValue.less_than
-    assert CallSiteValue(
-        "opaque", (), (), __import__("sugar_lift_py_tests.ir", fromlist=["ctor"]).ctor(
-            "call:opaque", []
-        ), None
-    )._dig_floor_or_none(None, owner="opaque compare twin") is None
+    assert "less_than" not in CallSiteValue.__dict__
+    assert opaque._dig_floor_or_none(None, owner="opaque compare twin") is None
 
 
 def test_lying_caller_coordinate_is_rejected_before_it_can_be_evidence() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_compare_control.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_compare_control.py
@@ -100,11 +100,12 @@ def _return_value(outcome) -> TermValue:
         assert value is not None
         entries = tuple(
             entry
-            for entry in value.statements
+            for entry in getattr(value, "statements", ())
             if isinstance(entry, (ReturnValue, GuardedReturn))
         )
-        assert len(entries) == 1
-        value = entries[0]
+        if entries:
+            assert len(entries) == 1
+            value = entries[0]
     if isinstance(value, GuardedReturn):
         value = value.value
     if isinstance(value, ReturnValue):

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_compare_control.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_compare_control.py
@@ -106,10 +106,21 @@ def _return_value(outcome) -> TermValue:
         if entries:
             assert len(entries) == 1
             value = entries[0]
-    if isinstance(value, GuardedReturn):
-        value = value.value
-    if isinstance(value, ReturnValue):
-        value = value.value
+    while True:
+        if isinstance(value, GuardedReturn):
+            value = value.value
+            continue
+        if isinstance(value, ReturnValue):
+            value = value.value
+            continue
+        if isinstance(value, CallSiteValue):
+            projected = value._dig_floor_or_none(
+                None, owner="source-return-compare-control nested return"
+            )
+            assert projected is not None
+            value = projected
+            continue
+        break
     assert isinstance(value, TermValue)
     return value
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
@@ -41,6 +41,7 @@ from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.outcome import Incomplete
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
+from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import (
     Assign,
@@ -466,3 +467,55 @@ def test_dig_of_scalar_return_must_not_stop_at_blockvalue_for_binop() -> None:
     assert dug == TermValue(3) or (
         isinstance(dug, ReturnValue) and dug.value == TermValue(3)
     )
+
+
+def test_keyword_bound_source_return_flows_into_binop() -> None:
+    tree, _, _ = _tree(
+        "def combine(left, right):\n"
+        "    return left + right\n\n"
+        "result = combine(2, right=3) + 1\n",
+        bind=frozenset({"combine"}),
+    )
+    outer = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, BinOp) and isinstance(node.left, Call)
+    )
+
+    assert _completed_value(outer.sugar().desugar(None)) == TermValue(6)
+
+
+def test_keyword_binding_does_not_accept_an_unknown_formal() -> None:
+    tree, _, _ = _tree(
+        "def combine(left, right):\n"
+        "    return left + right\n\n"
+        "result = combine(2, stranger=3) + 1\n",
+        bind=frozenset({"combine"}),
+    )
+    outer = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, BinOp) and isinstance(node.left, Call)
+    )
+
+    with pytest.raises(SourceCallBindingGap, match="missing required formal|unconsumed"):
+        outer.sugar().desugar(None)
+
+
+@pytest.mark.parametrize(("call", "expected"), (("choose(2)", 7), ("choose(2, 8)", 10)))
+def test_default_and_explicit_source_return_values_stay_distinct_actuals(
+    call: str, expected: int
+) -> None:
+    tree, _, _ = _tree(
+        "def choose(left, right=5):\n"
+        "    return left + right\n\n"
+        f"result = {call} + 0\n",
+        bind=frozenset({"choose"}),
+    )
+    outer = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, BinOp) and isinstance(node.left, Call)
+    )
+
+    assert _completed_value(outer.sugar().desugar(None)) == TermValue(expected)

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
@@ -519,3 +519,30 @@ def test_default_and_explicit_source_return_values_stay_distinct_actuals(
     )
 
     assert _completed_value(outer.sugar().desugar(None)) == TermValue(expected)
+
+
+def test_authenticated_lambda_return_flows_into_binop() -> None:
+    tree, _, _ = _tree(
+        "def consume():\n"
+        "    return (lambda value: value + 1)(2) + 3\n\n"
+        "consume()\n",
+        bind=frozenset({"consume"}),
+    )
+    call = _calls_named(tree, "consume")[0]
+    value = call.sugar().desugar(None).value._dig_floor_or_none(
+        None, owner="authenticated-lambda-return"
+    )
+
+    assert value == TermValue(6)
+
+
+def test_unauthenticated_lambda_callee_stays_loud() -> None:
+    tree, _, _ = _tree("result = (lambda value: value + 1)(2) + 3\n")
+    outer = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, BinOp) and isinstance(node.left, Call)
+    )
+
+    with pytest.raises(SugarNotWritten, match=r"SUGAR NOT WRITTEN \[Lambda\.sugar\]"):
+        outer.sugar().desugar(None)

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
@@ -546,3 +546,83 @@ def test_unauthenticated_lambda_callee_stays_loud() -> None:
 
     with pytest.raises(SugarNotWritten, match=r"SUGAR NOT WRITTEN \[Lambda\.sugar\]"):
         outer.sugar().desugar(None)
+
+
+def test_nested_function_source_return_projects_into_outer_caller() -> None:
+    tree, _, _ = _tree(
+        "def outer():\n"
+        "    def inner(value):\n"
+        "        return value + 1\n"
+        "    return inner(3) + 2\n\n"
+        "outer()\n",
+        bind=frozenset({"outer", "inner"}),
+    )
+    call = _calls_named(tree, "outer")[0]
+    value = call.sugar().desugar(None).value._dig_floor_or_none(
+        None, owner="nested-function-return"
+    )
+
+    assert value == TermValue(6)
+
+
+def test_nested_function_closure_capture_stays_loud_without_binding_testimony() -> None:
+    tree, _, _ = _tree(
+        "def outer():\n"
+        "    offset = 2\n"
+        "    def inner(value):\n"
+        "        return value + offset\n"
+        "    return inner(3)\n\n"
+        "outer()\n",
+        bind=frozenset({"outer", "inner"}),
+    )
+    call = _calls_named(tree, "outer")[0]
+
+    with pytest.raises((SugarNotWritten, ConstructionPanic)):
+        call.sugar().desugar(None).value._dig_floor_or_none(
+            None, owner="nested-closure-refusal"
+        )
+
+
+def test_nested_shadowed_function_does_not_cross_wire_outer_same_name() -> None:
+    tree, context, functions = _tree(
+        "def inner(value):\n"
+        "    return value + 10\n\n"
+        "def outer():\n"
+        "    def inner(value):\n"
+        "        return value + 1\n"
+        "    return inner(3)\n\n"
+        "outer()\n",
+        bind=frozenset({"outer", "inner"}),
+    )
+    call = _calls_named(tree, "outer")[0]
+    nested = [node for node in tree.nodes() if isinstance(node, FunctionDef) and node.name == "inner"]
+    assert len(nested) == 2
+    # Deliberately seat the outer same-name frame at the nested call: the
+    # authenticated coordinate must reject this cross-wired testimony.
+    nested_call = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, Call) and getattr(node.func, "id", None) == "inner"
+    )
+    context.source_call_frames[_coordinate(nested_call)] = nested[0].source_visible_call_frame()
+
+    with pytest.raises((AssertionError, ConstructionPanic, SugarNotWritten)):
+        call.sugar().desugar(None).value._dig_floor_or_none(
+            None, owner="nested-shadow-cross-wire"
+        )
+
+
+def test_lambda_inside_nested_function_composes_with_source_return_projection() -> None:
+    tree, _, _ = _tree(
+        "def outer():\n"
+        "    def inner(value):\n"
+        "        return (lambda item: item + 1)(value)\n"
+        "    return inner(3) + 2\n\n"
+        "outer()\n",
+        bind=frozenset({"outer", "inner"}),
+    )
+    call = _calls_named(tree, "outer")[0]
+
+    assert call.sugar().desugar(None).value._dig_floor_or_none(
+        None, owner="nested-lambda-return"
+    ) == TermValue(6)

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
@@ -29,11 +29,16 @@ from sugar_lift_py_tests.context_manager_resolution import (
 from sugar_lift_py_tests.floor import (
     BlockValue,
     CallSiteValue,
+    GuardedRaise,
     ListValue,
+    LoopControlValue,
+    RaiseValue,
     ReturnValue,
     TermValue,
     TupleValue,
 )
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.outcome import Incomplete
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
 from sugar_lift_python_source.canonical import blake3_512_of
@@ -118,6 +123,35 @@ CODEX3_OWNER = (
     "Subscript, and store operands — not stop at BlockValue or leave "
     "CallSiteValue opaque. tests-only; no local CallSiteValue adaptation."
 )
+
+
+@pytest.mark.parametrize(
+    "competing_exit",
+    (
+        RaiseValue(RaiseEffect(exception_name="TypeError")),
+        GuardedRaise(
+            (TermValue(True).to_term(owner="guard"),),
+            RaiseEffect(exception_name="TypeError"),
+        ),
+        Incomplete(RaiseEffect(exception_name="TypeError")),
+        LoopControlValue("break", "helper.py:3"),
+    ),
+)
+def test_source_return_projection_refuses_any_competing_control_exit(
+    competing_exit,
+) -> None:
+    """One return is ineligible when any other authenticated exit survives."""
+    from sugar_lift_py_tests.floor.call_site_value import (
+        _project_authenticated_source_return,
+    )
+
+    body = BlockValue(
+        (ReturnValue(TermValue(3)), competing_exit),
+        fall_through=(),
+        can_fall_through=False,
+    )
+
+    assert _project_authenticated_source_return(body) is body
 
 
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
@@ -122,6 +122,15 @@ def populate_source_visible_call_frames(
             )
             continue
         frame, target = frame_result
+        if isinstance(target, FunctionDef) and target.decorators:
+            context.source_call_resolutions[coordinate] = (
+                SourceCallPreconstructionGapV1(
+                    "decorator-application",
+                    coordinate,
+                    "authenticated definition has unapplied decorators",
+                )
+            )
+            continue
         _preconstruct_authenticated_attribute_calls(target, graph=graph, session=session)
         from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
@@ -240,6 +249,8 @@ def _preconstruct_authenticated_attribute_calls(
         if isinstance(projected, ManagerConstructionGapV1):
             continue
         frame, nested_target = projected
+        if isinstance(nested_target, FunctionDef) and nested_target.decorators:
+            continue
         _preconstruct_authenticated_attribute_calls(
             nested_target, graph=graph, session=session, visited=visited
         )

--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -176,6 +176,71 @@ def test_authenticated_nested_attribute_call_installs_recursive_source_frame(
     assert nested_result.statements == (ReturnValue(TermValue(17)),)
 
 
+def test_decorator_wrapped_source_call_does_not_borrow_undecorated_body(
+    tmp_path: Path,
+) -> None:
+    distribution = _distribution(
+        tmp_path,
+        "from functools import wraps as preserve_metadata\n\n"
+        "def decorate(original):\n"
+        "    @preserve_metadata(original)\n"
+        "    def wrapper(value):\n"
+        "        return original(value)\n"
+        "    return wrapper\n\n"
+        "@decorate\n"
+        "def arbitrary_helper(value):\n"
+        "    return value + 1\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as renamed\n"
+        "renamed(2) + 3\n",
+    )
+    call = next(node for node in source_file.nodes() if isinstance(node, Call))
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+
+    coordinate = _coordinate(call)
+    row = context.source_call_resolutions[coordinate]
+    assert isinstance(row, SourceCallPreconstructionGapV1)
+    assert row.kind == "decorator-application"
+    assert coordinate not in context.source_call_frames
+
+
+def test_undecorated_twin_still_installs_its_authenticated_return_frame(
+    tmp_path: Path,
+) -> None:
+    distribution = _distribution(
+        tmp_path,
+        "def arbitrary_helper(value):\n"
+        "    return value + 1\n",
+    )
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import arbitrary_helper as renamed\n"
+        "renamed(2) + 3\n",
+    )
+    call = next(node for node in source_file.nodes() if isinstance(node, Call))
+
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+
+    coordinate = _coordinate(call)
+    assert isinstance(
+        context.source_call_resolutions[coordinate], SourceCallPreconstructionRefV1
+    )
+    assert coordinate in context.source_call_frames
+
+
 def test_runtime_receiver_attribute_call_remains_dynamic_and_loud(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Projects authenticated source-body returns at the shared completed-result composition seam. A standalone source call retains its CallSiteValue coordinate; when its completed result becomes a downstream operand, receiver, index, or outer-call actual, the producer projects exactly one authenticated ReturnValue/ground-true GuardedReturn Floor and recursively follows returned source calls. Multi-return and unresolved conditional bodies remain explicit BlockValue testimony.

This removes the Subscript-specific consumer membrane. Bound-method returns, chained method receivers, setitem actuals, BinOp, Compare, subscript, and exceptional raise transport all inherit the same result projection. Opaque calls stay loud. Production contains no pandas/provider spelling and does not touch Carrier or ExitSet.

Focused validation:
- bin/bpytest tests/test_method_raise_transport.py tests/test_method_return_as_actual.py tests/test_source_return_compare_control.py tests/test_source_return_operation_generalization.py tests/test_nested_source_return_projection.py tests/test_binop_method_caller.py tests/test_compare_if_method_caller.py tests/test_pandas_binary_caller_twins.py tests/test_pandas_compare_caller_twins.py -q
- 107 passed

Full touched-package telemetry:
- bin/bpytest tests -q
- 2512 passed, 284 failed, 9 skipped, 5 errors in 431.58s
- Existing broad red population preserved; no failures suppressed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Project authenticated source returns into operations on call site values
> - Adds `_project_authenticated_source_return` to unwrap a `BlockValue` with a single authenticated `ReturnValue` (and no competing exits) into the inner `FloorValue`, so downstream operations act on the concrete returned value rather than the call site wrapper.
> - Adds `project_operation_receiver` to `FloorValue` (default no-op) and overrides it on `CallSiteValue` to return the projected floor value when it is not a `BlockValue`.
> - Applies `project_operation_receiver` uniformly across binary ops, comparisons, method calls, subscript reads/writes, and call site argument collection so all operation sites benefit from the projection.
> - Adds `bound_native_actuals_by_coordinate` to `CallSiteValue` and wires it through `CallSiteSugar.desugar` so native operation carriers are discharged with the correct actuals when available.
> - Decorated authenticated functions are now excluded from source-visible call frame preconstruction; calls to them record a `decorator-application` gap instead of borrowing the undecorated body.
> - Behavioral Change: dug values from authenticated single-return helpers now resolve to the inner `FloorValue` rather than a `BlockValue`, which changes existing test assertions around `ReturnValue` navigation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2827919.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->