### PR TITLE
Select published generator resource contracts at construction

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -338,11 +338,18 @@ def test_real_option_context_coordinates_drive_every_resource_lifecycle_face():
         for node in tree.nodes()
         if node.kind == "With" and node.line_col_span().start_line == 25
     )
-    receiver = next(
+    receivers = tuple(
         coordinate
         for coordinate in context.source_manager_provider_calls
         if coordinate.start_line == 25
     )
+    assert len(receivers) == 1, (
+        "authenticated pandas option_context use at line 25 must publish exactly "
+        "one provider receiver before With construction; publication stopped "
+        "upstream, derived refs="
+        f"{tuple(type(ref).__name__ for ref in context.source_derived_contract_refs.values())}"
+    )
+    receiver = receivers[0]
     refs = context.contract_refs
     enter_definition = refs.require_native_definition(
         receiver, NativeProtocolSlot.CONTEXT_ENTER

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -403,6 +403,114 @@ def test_real_option_context_coordinates_drive_every_resource_lifecycle_face():
     )
 
 
+def test_real_option_context_published_ref_selects_source_resource_at_construction():
+    """The closed generator-resource ref outranks the legacy generator path."""
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+
+    corpus = authenticated_pandas_corpus()
+    root = corpus.root.parent
+    path = root / "pandas/tests/io/formats/test_ipython_compat.py"
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = open_source_file_for_construction(
+        path, root=root, construction_context=context, populate_derived=False
+    )
+    populate_source_derived_resource_refs(tree, root=root, path=path)
+    with_node = next(
+        node
+        for node in tree.nodes()
+        if node.kind == "With" and node.line_col_span().start_line == 25
+    )
+    receiver = next(
+        coordinate
+        for coordinate in context.source_manager_provider_calls
+        if coordinate.start_line == 25
+    )
+    refs = context.contract_refs
+    enter_definition = refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_ENTER
+    )
+    exit_definition = refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_EXIT
+    )
+
+    class RecordingDefinitionDoor:
+        def __init__(self, delegate):
+            self.delegate = delegate
+            self.calls = []
+
+        def __getattr__(self, name):
+            return getattr(self.delegate, name)
+
+        def require_native_definition(self, use_site, slot):
+            self.calls.append((use_site, slot))
+            return self.delegate.require_native_definition(use_site, slot)
+
+    recording = RecordingDefinitionDoor(refs)
+    object.__setattr__(context, "contract_refs", recording)
+
+    resource = with_node.sugar()
+
+    assert isinstance(resource, WithSourceResourceSugar)
+    assert recording.calls == [
+        (receiver, NativeProtocolSlot.CONTEXT_ENTER),
+        (receiver, NativeProtocolSlot.CONTEXT_EXIT),
+    ]
+    assert resource.enter.native_definition_coordinate == enter_definition
+    assert resource.exit.native_definition_coordinate == exit_definition
+
+
+@pytest.mark.parametrize("manager_name", ("borrowed_state", "temporary_setting"))
+def test_renamed_source_generator_resources_use_the_same_closed_factory_arm(
+    tmp_path: Path, manager_name: str
+):
+    """Selection follows the published ref type, never a manager spelling."""
+    implementation = (
+        "from contextlib import contextmanager\n\n"
+        "@contextmanager\n"
+        f"def {manager_name}(value):\n"
+        "    try:\n"
+        "        yield value\n"
+        "    finally:\n"
+        "        release(value)\n"
+    )
+    dist = _distribution(tmp_path, implementation, exported=manager_name)
+    tree, context, _ = _tree(
+        tmp_path,
+        f"from arbitrary import {manager_name}\n"
+        f"with {manager_name}(7) as entered:\n"
+        "    observed = entered\n",
+        dist=dist,
+    )
+    with_node = next(node for node in tree.nodes() if node.kind == "With")
+    receiver = next(iter(context.source_manager_provider_calls))
+
+    class RecordingDefinitionDoor:
+        def __init__(self, delegate):
+            self.delegate = delegate
+            self.calls = []
+
+        def __getattr__(self, name):
+            return getattr(self.delegate, name)
+
+        def require_native_definition(self, use_site, slot):
+            self.calls.append((use_site, slot))
+            return self.delegate.require_native_definition(use_site, slot)
+
+    recording = RecordingDefinitionDoor(context.contract_refs)
+    object.__setattr__(context, "contract_refs", recording)
+
+    resource = with_node.substitute({}).sugar()
+
+    assert isinstance(resource, WithSourceResourceSugar)
+    assert recording.calls == [
+        (receiver, NativeProtocolSlot.CONTEXT_ENTER),
+        (receiver, NativeProtocolSlot.CONTEXT_EXIT),
+    ]
+    assert resource.enter.native_definition_coordinate == resource.enter_definition
+    assert resource.exit.native_definition_coordinate == resource.exit_definition
+
+
 def test_source_true_exit_publishes_truthiness_and_consumes_raise(tmp_path: Path):
     """Source-derived ``return True`` is suppression testimony, not a name arm."""
     implementation = _GUARD_SOURCE.replace("return False", "return True")

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -313,8 +313,17 @@ def test_authenticated_pandas_303_get_handle_is_real_resource_reproducer():
 
 def test_real_option_context_coordinates_drive_every_resource_lifecycle_face():
     """The producer's two real coordinates are the sole lifecycle authority."""
+    import platform
+    import sys
+
+    import pandas
+
     from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
     from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+
+    assert sys.executable == "/usr/local/bin/python"
+    assert platform.python_version() == "3.12.13"
+    assert pandas.__file__ == "/usr/local/lib/python3.12/site-packages/pandas/__init__.py"
 
     corpus = authenticated_pandas_corpus()
     root = corpus.root.parent
@@ -368,6 +377,10 @@ def test_real_option_context_coordinates_drive_every_resource_lifecycle_face():
     ]
     assert resource.enter.native_definition_coordinate == enter_definition
     assert resource.exit.native_definition_coordinate == exit_definition
+    assert resource.enter_definition == enter_definition
+    assert resource.exit_definition == exit_definition
+    assert resource.protocol.enter_definition == enter_definition
+    assert resource.protocol.exit_definition == exit_definition
 
     completed = replace(
         resource,
@@ -509,6 +522,100 @@ def test_renamed_source_generator_resources_use_the_same_closed_factory_arm(
     ]
     assert resource.enter.native_definition_coordinate == resource.enter_definition
     assert resource.exit.native_definition_coordinate == resource.exit_definition
+
+
+@pytest.mark.parametrize(
+    ("manager_name", "guard_name", "cleanup_name"),
+    (
+        ("borrowed_branch", "should_borrow", "release_borrowed"),
+        ("temporary_branch", "should_install", "restore_temporary"),
+    ),
+)
+def test_renamed_pre_yield_branch_and_cleanup_spellings_share_one_resource_path(
+    tmp_path: Path, manager_name: str, guard_name: str, cleanup_name: str
+):
+    """Only the published structure selects; every local spelling may change."""
+    implementation = (
+        "from contextlib import contextmanager\n\n"
+        f"def {cleanup_name}(value):\n"
+        "    return value\n\n"
+        "@contextmanager\n"
+        f"def {manager_name}(value):\n"
+        f"    {guard_name} = value is not None\n"
+        f"    if {guard_name}:\n"
+        "        entered = value\n"
+        "    else:\n"
+        "        entered = value\n"
+        "    try:\n"
+        "        yield entered\n"
+        "    finally:\n"
+        f"        {cleanup_name}(entered)\n"
+    )
+    dist = _distribution(tmp_path, implementation, exported=manager_name)
+    tree, context, _ = _tree(
+        tmp_path,
+        f"from arbitrary import {manager_name}\n"
+        f"with {manager_name}(7) as entered:\n"
+        "    observed = entered\n",
+        dist=dist,
+    )
+    with_node = next(node for node in tree.nodes() if node.kind == "With")
+    receiver = next(iter(context.source_manager_provider_calls))
+
+    class RecordingDefinitionDoor:
+        def __init__(self, delegate):
+            self.delegate = delegate
+            self.calls = []
+
+        def __getattr__(self, name):
+            return getattr(self.delegate, name)
+
+        def require_native_definition(self, use_site, slot):
+            self.calls.append((use_site, slot))
+            return self.delegate.require_native_definition(use_site, slot)
+
+    recording = RecordingDefinitionDoor(context.contract_refs)
+    object.__setattr__(context, "contract_refs", recording)
+    resource = with_node.substitute({}).sugar()
+
+    assert isinstance(resource, WithSourceResourceSugar)
+    assert recording.calls == [
+        (receiver, NativeProtocolSlot.CONTEXT_ENTER),
+        (receiver, NativeProtocolSlot.CONTEXT_EXIT),
+    ]
+    assert resource.enter.native_definition_coordinate == resource.enter_definition
+    assert resource.exit.native_definition_coordinate == resource.exit_definition
+
+
+def test_unauthenticated_generator_manager_stays_on_generator_path(tmp_path: Path):
+    """A source generator without resource coordinates never enters this arm."""
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+    )
+    from sugar_lift_py_tests.sugar.generator_with_sugar import GeneratorWithSugar
+
+    manager_name = "unsealed_stream"
+    dist = _distribution(
+        tmp_path,
+        f"def {manager_name}(value):\n"
+        "    yield value\n",
+        exported=manager_name,
+    )
+    tree, context, _ = _tree(
+        tmp_path,
+        f"from arbitrary import {manager_name}\n"
+        f"with {manager_name}(7) as entered:\n"
+        "    observed = entered\n",
+        dist=dist,
+    )
+    resource = next(node for node in tree.nodes() if node.kind == "With").sugar()
+
+    assert len(context.source_derived_contract_refs) == 1
+    assert all(
+        isinstance(reference, ContextManagerResolutionGapV1)
+        for reference in context.source_derived_contract_refs.values()
+    )
+    assert isinstance(resource, GeneratorWithSugar)
 
 
 def test_source_true_exit_publishes_truthiness_and_consumes_raise(tmp_path: Path):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5651,6 +5651,32 @@ class With(Statement):
             self.reporter.report_gap(self, panic)
             raise panic
 
+    def _published_generator_resource_testimony(self, item: WithItem):
+        """Return the producer's one closed generator-resource surface."""
+        context = self.unit.construction_context
+        if context is None:
+            return None
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceDerivedGeneratorResourceRefV1,
+            SourceFragmentCoordinateV1,
+            TreeConstructionContextV1,
+        )
+
+        if not isinstance(context, TreeConstructionContextV1):
+            return None
+        start_line, start_col, end_line, end_col = item._manager_use_site_span()
+        coordinate = SourceFragmentCoordinateV1(
+            self.unit.source_cid,
+            start_line,
+            start_col,
+            end_line,
+            end_col,
+        )
+        published = context.source_derived_contract_refs.get(coordinate)
+        if isinstance(published, SourceDerivedGeneratorResourceRefV1):
+            return published
+        return None
+
     def _raise_resolution_gap(self, resolution) -> None:
         from .panic import ContextManagerResolutionConstructionGap
 
@@ -5803,8 +5829,17 @@ class With(Statement):
             _ = resolution.shared_expected_type_operand
             _ = resolution.shared_binding
             return resolution
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceDerivedGeneratorResourceRefV1,
+        )
+
         if not isinstance(
-            resolution, (ContextManagerContractRefV1, SourceDerivedContextManagerRefV1)
+            resolution,
+            (
+                ContextManagerContractRefV1,
+                SourceDerivedContextManagerRefV1,
+                SourceDerivedGeneratorResourceRefV1,
+            ),
         ):
             backend_defect(
                 blame=self.fragment,
@@ -5972,8 +6007,9 @@ class With(Statement):
         if binds_enter_result and item.optional_vars.kind == "Name":
             as_name = item.optional_vars.id
 
+        published_generator_resource = self._published_generator_resource_testimony(item)
         generator_manager = self._generator_manager_sugar(item)
-        if generator_manager is not None:
+        if generator_manager is not None and published_generator_resource is None:
             from sugar_lift_py_tests.sugar.generator_with_sugar import (
                 GeneratorWithSugar,
             )
@@ -6018,8 +6054,18 @@ class With(Statement):
                 SourceDerivedContextManagerRefV1,
             )
 
-            if isinstance(
-                resolved_ref, SourceDerivedContextManagerRefV1
+            from sugar_lift_py_tests.context_manager_resolution import (
+                SourceDerivedGeneratorResourceRefV1,
+            )
+
+            generator_protocol = (
+                resolved_ref.generator_protocol
+                if isinstance(resolved_ref, SourceDerivedGeneratorResourceRefV1)
+                else None
+            )
+            if (
+                isinstance(resolved_ref, SourceDerivedContextManagerRefV1)
+                or generator_protocol is not None
             ) and isinstance(resolved_ref.semantics, ProtocolResourceSemanticsV1):
                 from sugar_lift_py_tests.sugar.with_source_resource_sugar import (
                     WithSourceResourceSugar,
@@ -6032,21 +6078,59 @@ class With(Statement):
                 enter_definition, exit_definition = (
                     self._require_native_resource_definitions(resolved_ref)
                 )
-                from dataclasses import replace
+                if generator_protocol is not None:
+                    from sugar_lift_py_tests.sugar.method_call_sugar import (
+                        MethodCallSugar,
+                    )
+                    from sugar_lift_py_tests.sugar.resource_coord_sugar import (
+                        ManagerRefSugar,
+                    )
 
-                enter_sugar = replace(
-                    item._make_enter_call().sugar(),
-                    native_definition_coordinate=enter_definition,
-                )
-                exit_sugar = replace(
-                    item._make_parametric_exit_call().sugar(),
-                    native_definition_coordinate=exit_definition,
-                )
+                    receiver = ManagerRefSugar(
+                        slot_id=manager_slot, site=self.fragment
+                    )
+                    enter_sugar = MethodCallSugar(
+                        receiver=receiver,
+                        name="__enter__",
+                        args=(),
+                        native_definition_coordinate=enter_definition,
+                        site=self.fragment,
+                    )
+                    exit_sugar = MethodCallSugar(
+                        receiver=receiver,
+                        name="__exit__",
+                        args=(
+                            item._make_exit_type_ref().sugar(),
+                            item._make_exit_value_ref().sugar(),
+                            item._make_exit_traceback_ref().sugar(),
+                        ),
+                        native_definition_coordinate=exit_definition,
+                        site=self.fragment,
+                    )
+                else:
+                    from dataclasses import replace
+
+                    enter_sugar = replace(
+                        item._make_enter_call().sugar(),
+                        native_definition_coordinate=enter_definition,
+                    )
+                    exit_sugar = replace(
+                        item._make_parametric_exit_call().sugar(),
+                        native_definition_coordinate=exit_definition,
+                    )
                 return WithSourceResourceSugar(
-                    manager=item.context_expr.sugar(),
+                    manager=(
+                        generator_manager
+                        if generator_protocol is not None
+                        else item.context_expr.sugar()
+                    ),
                     enter=enter_sugar,
                     exit=exit_sugar,
-                    protocol=resolved_ref.protocol,
+                    protocol=(
+                        generator_protocol
+                        if generator_protocol is not None
+                        else resolved_ref.protocol
+                    ),
                     summary=resolved_ref,
                     body=tuple(stmt.sugar() for stmt in self.body),
                     manager_slot_id=manager_slot,


### PR DESCRIPTION
## Capability

- Select `WithSourceResourceSugar` at tree construction from the published `SourceDerivedGeneratorResourceRefV1` closed surface.
- Require authenticated enter and exit definitions through the definition door exactly twice and carry those coordinates on the constructed calls.
- Keep generators without authenticated resource testimony on their honest `GeneratorWithSugar` / gap path.
- Consume `generator_protocol` directly from the closed published ref; no lifecycle-wrapper enumeration, provider derivation, desugar-time authority lookup, fallback coordinate, or manager-name arm.

## General discrimination

The construction arm passes for the real pandas specimen and two independently renamed source-defined generator managers. The unauthenticated renamed generator remains on `GeneratorWithSugar`.

## Fresh authenticated evidence

Battleaxe reports CPython 3.12.13, pandas 3.0.3.

- Selection + renamed-manager laws: 3 passed.
- Real `option_context` lifecycle vertical: construction succeeds, the definition door is consulted exactly twice, and the exact published enter/exit coordinates reach the source-resource sugar. Lifecycle then remains loudly red while content-addressing the producer construction guard:

`TypeError: GeneratorConstructionV1 cannot content-address value of type BoolOpSugar; project authenticated construction testimony, never object identity`

This replaces the obsolete pre-yield `If` blocker. The remaining producer obligation is the separately owned ConstructedTermSugar promotion; this consumer does not probe, derive, skip, or fabricate its testimony.

Floors preserved: Carrier/ExitSet untouched; lifecycle red retained; no vendor spelling branches; no semantic derivation in the factory.