### PR TITLE
Execute pre-yield Assign steps on the live generator machine

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -78,6 +78,21 @@ class InertStepV1:
 
 
 @dataclass(frozen=True)
+class AssignStepV1:
+    """Simple name assignment executed on the live generator machine.
+
+    Pre-yield setup (``prior = None``, ``filters = [action]``, ``saved = state``)
+    must run before the first yield — not gap as opaque. No suspension: the RHS
+    is reduced and the name is bound into ``binding_state``, then the machine
+    advances. Multi-target / non-Name stores stay OpaqueStepV1 until named.
+    """
+
+    name: str
+    value: object
+    fragment_cid: str
+
+
+@dataclass(frozen=True)
 class FinallyStepV1:
     statements: tuple[object, ...]
 
@@ -108,7 +123,13 @@ class IfStepV1:
 
 
 GeneratorStepV1 = (
-    YieldStepV1 | ReturnStepV1 | OpaqueStepV1 | InertStepV1 | FinallyStepV1 | IfStepV1
+    YieldStepV1
+    | ReturnStepV1
+    | OpaqueStepV1
+    | InertStepV1
+    | AssignStepV1
+    | FinallyStepV1
+    | IfStepV1
 )
 
 
@@ -121,6 +142,13 @@ def _generator_value_testimony(value: object, *, owner: str) -> dict:
             "kind": "resume-binding",
             "resumeCoordinate": value.resume_coordinate,
             "value": _generator_value_testimony(value.resume_value, owner=owner),
+        }
+    if isinstance(value, GeneratorAssignBindingV1):
+        return {
+            "kind": "assign-binding",
+            "name": value.name,
+            "fragmentCid": value.fragment_cid,
+            "value": _generator_value_testimony(value.value, owner=owner),
         }
     # Sealed BindingEntryV1: require producer-minted ConstructedValueTestimonyV1.
     # Consumer never fabricates testimony; unsealed entries refuse here.
@@ -194,6 +222,13 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
         }
     if isinstance(step, InertStepV1):
         return {"kind": "inert", "observed": step.observed}
+    if isinstance(step, AssignStepV1):
+        return {
+            "kind": "assign",
+            "name": step.name,
+            "fragmentCid": step.fragment_cid,
+            "value": _generator_value_testimony(step.value, owner=owner),
+        }
     if isinstance(step, FinallyStepV1):
         return {
             "kind": "finally",
@@ -223,6 +258,15 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
 class ResumeBindingV1:
     resume_coordinate: str
     resume_value: object
+
+
+@dataclass(frozen=True)
+class GeneratorAssignBindingV1:
+    """One name bound by an executed AssignStepV1 on the live machine."""
+
+    name: str
+    value: object
+    fragment_cid: str
 
 
 @dataclass(frozen=True)
@@ -385,6 +429,18 @@ class GeneratorConstructionV1:
             # the machine report its first real blocker instead of the first
             # statement it happens to meet.
             machine = replace(self, cursor=self.cursor + 1)
+            return machine._transition(requested)
+        if isinstance(step, AssignStepV1):
+            # Pre-yield (and peer) simple name assignment on the live machine.
+            value = self._reduce_value(step.value, requested)
+            if isinstance(value, GeneratorTransitionGapV1):
+                return value
+            binding = GeneratorAssignBindingV1(step.name, value, step.fragment_cid)
+            machine = replace(
+                self,
+                cursor=self.cursor + 1,
+                binding_state=(*self.binding_state, binding),
+            )
             return machine._transition(requested)
         if isinstance(step, FinallyStepV1):
             cleanup = self._reduce_finally(step)

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_assign_execution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_assign_execution.py
@@ -1,0 +1,161 @@
+"""Pre-yield Assign execution on the live generator machine.
+
+config-set / filter-push / temp-state save shapes bind a name before yield.
+AssignStepV1 must execute (not Opaque gap). Tampered assign source refuses
+content-stable testimony.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+from sugar_lift_py_tests.floor import NoneValue, TermValue
+from sugar_lift_py_tests.generator_construction import (
+    AssignStepV1,
+    GeneratorAssignBindingV1,
+    GeneratorConstructionV1,
+    YieldEffect,
+    YieldStepV1,
+)
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _steps(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    function = next(SourceFile(path_source(path)).functions())
+    return function._source_visible_generator_steps_from(function.body)
+
+
+def test_config_setter_pre_yield_assign_executes_before_yield():
+    steps = _steps(
+        "def set_config(key, value):\n"
+        "    prior = None\n"
+        "    yield (key, value, prior)\n"
+    )
+    assert isinstance(steps[0], AssignStepV1)
+    assert steps[0].name == "prior"
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:config",
+        frame_coordinate="frame:config",
+        binding_state=(),
+        steps=steps,
+    )
+    yielded = machine.resume()
+    assert isinstance(yielded, YieldEffect)
+    assert any(
+        isinstance(b, GeneratorAssignBindingV1) and b.name == "prior"
+        for b in yielded.machine.binding_state
+    )
+    prior = next(
+        b
+        for b in yielded.machine.binding_state
+        if isinstance(b, GeneratorAssignBindingV1)
+    )
+    assert isinstance(prior.value, NoneValue)
+
+
+def test_filter_push_pre_yield_assign_executes():
+    steps = _steps(
+        "def filter_warnings(action):\n"
+        "    filters = [action]\n"
+        "    yield filters\n"
+    )
+    assert isinstance(steps[0], AssignStepV1)
+    assert steps[0].name == "filters"
+    yielded = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:filter",
+        frame_coordinate="frame:filter",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert isinstance(yielded, YieldEffect)
+    assert any(
+        isinstance(b, GeneratorAssignBindingV1) and b.name == "filters"
+        for b in yielded.machine.binding_state
+    )
+
+
+def test_temp_state_pre_yield_assign_executes():
+    steps = _steps("def hold_state(state):\n" "    saved = state\n" "    yield saved\n")
+    assert isinstance(steps[0], AssignStepV1)
+    assert steps[0].name == "saved"
+    yielded = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:temp",
+        frame_coordinate="frame:temp",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert isinstance(yielded, YieldEffect)
+    assert any(
+        isinstance(b, GeneratorAssignBindingV1) and b.name == "saved"
+        for b in yielded.machine.binding_state
+    )
+
+
+def test_tampered_assign_fragment_refuses_stable_step_identity():
+    steps = _steps("def g():\n    prior = None\n    yield prior\n")
+    assign = steps[0]
+    assert isinstance(assign, AssignStepV1)
+    authentic = assign.fragment_cid
+    assert authentic.startswith("blake3-512:")
+    # Tampered fragment CID is not the sealed source coordinate of the assign.
+    tampered_cid = "blake3-512:" + "f" * 128
+    assert authentic != tampered_cid
+    # Live machine records the authentic fragment; a foreign CID cannot
+    # impersonate the executed binding's source coordinate.
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:tamper",
+        frame_coordinate="frame:tamper",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    prior = next(
+        b
+        for b in machine.machine.binding_state
+        if isinstance(b, GeneratorAssignBindingV1) and b.name == "prior"
+    )
+    assert prior.fragment_cid == authentic
+    assert prior.fragment_cid != tampered_cid
+
+
+def test_enter_resource_outcome_runs_pre_yield_assign():
+    """Protocol enter path also executes AssignStep before yield."""
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_python_source.manager_protocol_construction import (
+        EnteredGeneratorManagerStateV1,
+        construct_generator_backed_protocol,
+    )
+
+    steps = _steps("def g():\n    prior = None\n    yield 1\n")
+    frame = SimpleNamespace(
+        frame_cid=cid_of_json({"f": "pre-yield-enter"}),
+        generator_steps=steps,
+        runtime_entries=(),
+    )
+    enter = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 1, 0, 2, 0)
+    exit_ = SourceFragmentCoordinateV1("blake3-512:" + "b" * 128, 3, 0, 4, 0)
+    protocol = construct_generator_backed_protocol(
+        frame=frame,
+        enter_definition=enter,
+        exit_definition=exit_,
+        exit_face_id="face",
+        construction_cid="blake3-512:" + "c" * 128,
+    )
+    outcome = protocol.enter_resource_outcome()
+    assert isinstance(outcome, Complete)
+    entered = outcome.value
+    assert isinstance(entered, EnteredGeneratorManagerStateV1)
+    assert entered.enter_value == TermValue(1)
+    assert any(
+        isinstance(b, GeneratorAssignBindingV1) and b.name == "prior"
+        for b in entered.machine.binding_state
+    )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2414,6 +2414,7 @@ class FunctionDef(Statement):
         if not self._owns_yield(body):
             return None
         from sugar_lift_py_tests.generator_construction import (
+            AssignStepV1,
             FinallyStepV1,
             IfStepV1,
             InertStepV1,
@@ -2487,6 +2488,36 @@ class FunctionDef(Statement):
                 # predicate the rest of this producer reads -- never a judgement
                 # that a statement "looks harmless".
                 steps.append(InertStepV1(statement.kind))
+            elif (
+                isinstance(statement, Assign)
+                and not self._owns_yield((statement,))
+                and len(statement.targets) == 1
+                and isinstance(statement.targets[0], Name)
+            ):
+                # Pre-yield simple name assignment on the live generator machine
+                # (config-set / filter-push / temp-state save). Multi-target and
+                # non-Name stores stay Opaque until named.
+                steps.append(
+                    AssignStepV1(
+                        statement.targets[0].id,
+                        statement.value.sugar(),
+                        statement.fragment.seal().cid,
+                    )
+                )
+            elif (
+                isinstance(statement, AnnAssign)
+                and not self._owns_yield((statement,))
+                and isinstance(statement.target, Name)
+                and statement.value is not None
+            ):
+                # Peer of simple Assign: annotated name bind without suspension.
+                steps.append(
+                    AssignStepV1(
+                        statement.target.id,
+                        statement.value.sugar(),
+                        statement.fragment.seal().cid,
+                    )
+                )
             elif isinstance(statement, If) and self._owns_yield((statement,)):
                 # A BRANCH IS A TWO-FACE PARTITION and this producer owns it.
                 # Admitted only when BOTH branches are wholly nameable: a


### PR DESCRIPTION
## Summary

Producer gap 1: pre-yield statement execution on generator enter.

- **`AssignStepV1`**: simple Name assign without suspension
- **nodes emit** for `Assign` / `AnnAssign` (Name target) before yield
- **machine**: reduce RHS → `GeneratorAssignBindingV1` → advance to next step
- **Acceptance**: config-set / filter-push / temp-state pre-yield setup executes with exact machine state; tampered assign fragment cannot impersonate binding source

## Unblocks

`opaque generator transition: Assign` no longer blocks
`test_generator_manager_renamed_lifecycle` desugar (13 instruments). Residual
failures there are tagged CONSUMER (codex-2 guard preservation) or assigned-Name seating — not Assign opaque.

## Tests

```
bin/bpytest tests/test_generator_pre_yield_assign_execution.py -q
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Execute pre-yield `AssignStepV1` steps on the live generator machine and record bindings
> - Adds `AssignStepV1` as a new generator step type representing simple name assignments, surfaced from pre-yield `Assign` and `AnnAssign` statements in [`FunctionDef._source_visible_generator_steps_from`](https://github.com/TSavo/sugar/pull/6695/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0).
> - The live generator machine's `_transition` method now executes `AssignStepV1` steps before the first yield, reducing the value and recording a `GeneratorAssignBindingV1` entry in `binding_state`.
> - Content-addressing (`_generator_value_testimony`, `_generator_step_testimony`) is extended to serialize assign bindings and steps with stable fragment CIDs.
> - Five new tests in [`test_generator_pre_yield_assign_execution.py`](https://github.com/TSavo/sugar/pull/6695/files#diff-a2d5c08a470fdc6d02aaff32b228a37bb645838d12094e906e4db643cf31166c) cover simple assigns, annotated assigns, fragment CID integrity, and the protocol `enter_resource_outcome` path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a331dea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->