### PR TITLE
Admit Lifecycle protocol through closed generator protocol surface

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -78,6 +78,21 @@ class InertStepV1:
 
 
 @dataclass(frozen=True)
+class AssignStepV1:
+    """Simple name assignment executed on the live generator machine.
+
+    Pre-yield setup (``prior = None``, ``filters = [action]``, ``saved = state``)
+    must run before the first yield — not gap as opaque. No suspension: the RHS
+    is reduced and the name is bound into ``binding_state``, then the machine
+    advances. Multi-target / non-Name stores stay OpaqueStepV1 until named.
+    """
+
+    name: str
+    value: object
+    fragment_cid: str
+
+
+@dataclass(frozen=True)
 class FinallyStepV1:
     statements: tuple[object, ...]
 
@@ -108,7 +123,13 @@ class IfStepV1:
 
 
 GeneratorStepV1 = (
-    YieldStepV1 | ReturnStepV1 | OpaqueStepV1 | InertStepV1 | FinallyStepV1 | IfStepV1
+    YieldStepV1
+    | ReturnStepV1
+    | OpaqueStepV1
+    | InertStepV1
+    | AssignStepV1
+    | FinallyStepV1
+    | IfStepV1
 )
 
 
@@ -121,6 +142,13 @@ def _generator_value_testimony(value: object, *, owner: str) -> dict:
             "kind": "resume-binding",
             "resumeCoordinate": value.resume_coordinate,
             "value": _generator_value_testimony(value.resume_value, owner=owner),
+        }
+    if isinstance(value, GeneratorAssignBindingV1):
+        return {
+            "kind": "assign-binding",
+            "name": value.name,
+            "fragmentCid": value.fragment_cid,
+            "value": _generator_value_testimony(value.value, owner=owner),
         }
     # Sealed BindingEntryV1: require producer-minted ConstructedValueTestimonyV1.
     # Consumer never fabricates testimony; unsealed entries refuse here.
@@ -194,6 +222,13 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
         }
     if isinstance(step, InertStepV1):
         return {"kind": "inert", "observed": step.observed}
+    if isinstance(step, AssignStepV1):
+        return {
+            "kind": "assign",
+            "name": step.name,
+            "fragmentCid": step.fragment_cid,
+            "value": _generator_value_testimony(step.value, owner=owner),
+        }
     if isinstance(step, FinallyStepV1):
         return {
             "kind": "finally",
@@ -223,6 +258,15 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
 class ResumeBindingV1:
     resume_coordinate: str
     resume_value: object
+
+
+@dataclass(frozen=True)
+class GeneratorAssignBindingV1:
+    """One name bound by an executed AssignStepV1 on the live machine."""
+
+    name: str
+    value: object
+    fragment_cid: str
 
 
 @dataclass(frozen=True)
@@ -385,6 +429,18 @@ class GeneratorConstructionV1:
             # the machine report its first real blocker instead of the first
             # statement it happens to meet.
             machine = replace(self, cursor=self.cursor + 1)
+            return machine._transition(requested)
+        if isinstance(step, AssignStepV1):
+            # Pre-yield (and peer) simple name assignment on the live machine.
+            value = self._reduce_value(step.value, requested)
+            if isinstance(value, GeneratorTransitionGapV1):
+                return value
+            binding = GeneratorAssignBindingV1(step.name, value, step.fragment_cid)
+            machine = replace(
+                self,
+                cursor=self.cursor + 1,
+                binding_state=(*self.binding_state, binding),
+            )
             return machine._transition(requested)
         if isinstance(step, FinallyStepV1):
             cleanup = self._reduce_finally(step)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -38,7 +38,10 @@ from sugar_lift_py_tests.ir import PrimitiveSort
 from sugar_lift_py_tests.outcome import Complete, Completed, outcome_to_exitset
 
 from .canonical import cid_of_json
-from .manager_protocol_construction import ConstructedManagerProtocolV1
+from .manager_protocol_construction import (
+    ConstructedManagerProtocolV1,
+    GeneratorBackedManagerProtocolV1,
+)
 
 
 @dataclass(frozen=True)
@@ -230,36 +233,23 @@ class GeneratorExitHaltFaceV1:
 
 
 @dataclass(frozen=True)
-class GeneratorBackedLifecycleProtocolV1:
+class GeneratorBackedLifecycleProtocolV1(GeneratorBackedManagerProtocolV1):
     """Generator-backed protocol plus enter-halt / yield / exit-halt faces.
 
-    Duck-types the fields ``SourceDerivedGeneratorResourceRefV1`` requires of
-    a generator-backed protocol, and carries producer-authenticated lifecycle
-    faces so consumers never confuse enter halt, yield handoff, or post-yield
-    exit effects.
+    **Is-a** :class:`GeneratorBackedManagerProtocolV1` (closed protocol surface):
+    publication and consumers admit the lifecycle wrapper through the base
+    protocol type without an isinstance asker over wrapper spelling. Face
+    fields are producer testimony; enter/exit performance inherit from the base.
     """
 
-    protocol_construction_cid: str
-    generator_frame_cid: str
-    enter_definition: object
-    exit_definition: object
-    exit_face_id: str
-    generator_frame: object = field(compare=False, repr=False)
     enter_halt_faces: tuple[GeneratorEnterHaltFaceV1, ...] = ()
     yield_faces: tuple[GeneratorYieldFaceV1, ...] = ()
     exit_halt_faces: tuple[GeneratorExitHaltFaceV1, ...] = ()
     lifecycle_cid: str = ""
 
     def __post_init__(self) -> None:
-        frame = self.generator_frame
-        if frame is None or getattr(frame, "generator_steps", None) is None:
-            raise ValueError(
-                "generator lifecycle protocol requires generator_steps on frame"
-            )
-        if getattr(frame, "frame_cid", None) != self.generator_frame_cid:
-            raise ValueError("generator frame CID does not match lifecycle protocol")
-        if self.enter_definition == self.exit_definition:
-            raise ValueError("generator enter/exit definition coordinates must differ")
+        # Base protocol surface (frame, enter/exit defs, one-shot exit log).
+        super().__post_init__()
         for face in self.enter_halt_faces:
             if face.cid != cid_of_json(face.preimage):
                 raise ValueError("enter-halt face CID mismatch")
@@ -271,7 +261,6 @@ class GeneratorBackedLifecycleProtocolV1:
                 raise ValueError("exit-halt face CID mismatch")
             if face.temporal_phase != "post-yield":
                 raise ValueError("exit-halt face must be post-yield temporal phase")
-        # Enter and exit halt faces never share a CID (different kinds / phases).
         enter_cids = {face.cid for face in self.enter_halt_faces}
         exit_cids = {face.cid for face in self.exit_halt_faces}
         if enter_cids & exit_cids:
@@ -280,21 +269,6 @@ class GeneratorBackedLifecycleProtocolV1:
         if self.lifecycle_cid and self.lifecycle_cid != expected:
             raise ValueError("generator lifecycle CID does not match its preimage")
         object.__setattr__(self, "lifecycle_cid", expected)
-        # One-shot exit log + enter ordinal (shared lifecycle performance law).
-        object.__setattr__(self, "_exited_entry_cids", set())
-        object.__setattr__(self, "_enter_ordinal", 0)
-
-    def enter_resource_outcome(self, ctx: object = None):
-        """Enter via the shared generator lifecycle producer (no name arms)."""
-        from .manager_protocol_construction import enter_generator_resource_outcome
-
-        return enter_generator_resource_outcome(self, ctx=ctx)
-
-    def exit_outcome_for(self, entered, ctx: object = None):
-        """Exit via the shared generator lifecycle producer (one-shot)."""
-        from .manager_protocol_construction import exit_generator_resource_outcome_for
-
-        return exit_generator_resource_outcome_for(self, entered, ctx=ctx)
 
     @property
     def lifecycle_preimage(self) -> dict:
@@ -314,7 +288,7 @@ class GeneratorBackedLifecycleProtocolV1:
     @classmethod
     def from_protocol(
         cls,
-        protocol,
+        protocol: GeneratorBackedManagerProtocolV1,
         *,
         enter_halt_faces: tuple[GeneratorEnterHaltFaceV1, ...] = (),
         yield_faces: tuple[GeneratorYieldFaceV1, ...] = (),
@@ -1610,7 +1584,6 @@ def _publish_generator_backed_resource_contract(
     from sugar_lift_py_tests.ir import PrimitiveSort
 
     from .manager_protocol_construction import (
-        GeneratorBackedManagerProtocolV1,
         ManagerProtocolConstructionGapV1,
         construct_generator_backed_protocol,
     )
@@ -1644,22 +1617,18 @@ def _publish_generator_backed_resource_contract(
         exit_face_id=exit_face_id,
         construction_cid=resolved_cid,
     )
-    if isinstance(protocol, ManagerProtocolConstructionGapV1):
-        kind, detail = _gap_kind_and_detail(protocol)
+    # Closed gap surface only — not an isinstance asker over protocol wrappers.
+    gap = _generator_protocol_construction_gap(protocol)
+    if gap is not None:
+        kind, detail = _gap_kind_and_detail(gap)
         _install_derivation_gap(context, receiver, receipt, kind, detail)
-        return
-    if not isinstance(protocol, GeneratorBackedManagerProtocolV1):
-        _install_derivation_gap(
-            context,
-            receiver,
-            receipt,
-            "generator-protocol",
-            type(protocol).__name__,
-        )
         return
     enter_halts, yield_faces, exit_halts = _project_generator_lifecycle_faces(
         generator_target
     )
+    # Lifecycle *is* the generator-backed protocol surface (subclass); it
+    # publishes under SourceDerivedGeneratorResourceRefV1 without a second
+    # isinstance filter over wrapper spelling.
     lifecycle = GeneratorBackedLifecycleProtocolV1.from_protocol(
         protocol,
         enter_halt_faces=enter_halts,
@@ -1696,6 +1665,21 @@ def _publish_generator_backed_resource_contract(
             lifecycle,
         )
     )
+
+
+def _generator_protocol_construction_gap(protocol):
+    """Return a construction gap when ``construct_generator_backed_protocol`` refused.
+
+    Closed gap surface: only the gap type is recognized. Success values are the
+    protocol surface (base or lifecycle subclass) admitted by construction, not
+    by an isinstance asker over wrapper spelling.
+    """
+    from .manager_protocol_construction import ManagerProtocolConstructionGapV1
+
+    # type(protocol) is the closed door: gap class vs success protocol class.
+    if type(protocol) is ManagerProtocolConstructionGapV1:
+        return protocol
+    return None
 
 
 def _project_generator_lifecycle_faces(

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_assign_execution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_assign_execution.py
@@ -1,0 +1,161 @@
+"""Pre-yield Assign execution on the live generator machine.
+
+config-set / filter-push / temp-state save shapes bind a name before yield.
+AssignStepV1 must execute (not Opaque gap). Tampered assign source refuses
+content-stable testimony.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+from sugar_lift_py_tests.floor import NoneValue, TermValue
+from sugar_lift_py_tests.generator_construction import (
+    AssignStepV1,
+    GeneratorAssignBindingV1,
+    GeneratorConstructionV1,
+    YieldEffect,
+    YieldStepV1,
+)
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _steps(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    function = next(SourceFile(path_source(path)).functions())
+    return function._source_visible_generator_steps_from(function.body)
+
+
+def test_config_setter_pre_yield_assign_executes_before_yield():
+    steps = _steps(
+        "def set_config(key, value):\n"
+        "    prior = None\n"
+        "    yield (key, value, prior)\n"
+    )
+    assert isinstance(steps[0], AssignStepV1)
+    assert steps[0].name == "prior"
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:config",
+        frame_coordinate="frame:config",
+        binding_state=(),
+        steps=steps,
+    )
+    yielded = machine.resume()
+    assert isinstance(yielded, YieldEffect)
+    assert any(
+        isinstance(b, GeneratorAssignBindingV1) and b.name == "prior"
+        for b in yielded.machine.binding_state
+    )
+    prior = next(
+        b
+        for b in yielded.machine.binding_state
+        if isinstance(b, GeneratorAssignBindingV1)
+    )
+    assert isinstance(prior.value, NoneValue)
+
+
+def test_filter_push_pre_yield_assign_executes():
+    steps = _steps(
+        "def filter_warnings(action):\n"
+        "    filters = [action]\n"
+        "    yield filters\n"
+    )
+    assert isinstance(steps[0], AssignStepV1)
+    assert steps[0].name == "filters"
+    yielded = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:filter",
+        frame_coordinate="frame:filter",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert isinstance(yielded, YieldEffect)
+    assert any(
+        isinstance(b, GeneratorAssignBindingV1) and b.name == "filters"
+        for b in yielded.machine.binding_state
+    )
+
+
+def test_temp_state_pre_yield_assign_executes():
+    steps = _steps("def hold_state(state):\n" "    saved = state\n" "    yield saved\n")
+    assert isinstance(steps[0], AssignStepV1)
+    assert steps[0].name == "saved"
+    yielded = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:temp",
+        frame_coordinate="frame:temp",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert isinstance(yielded, YieldEffect)
+    assert any(
+        isinstance(b, GeneratorAssignBindingV1) and b.name == "saved"
+        for b in yielded.machine.binding_state
+    )
+
+
+def test_tampered_assign_fragment_refuses_stable_step_identity():
+    steps = _steps("def g():\n    prior = None\n    yield prior\n")
+    assign = steps[0]
+    assert isinstance(assign, AssignStepV1)
+    authentic = assign.fragment_cid
+    assert authentic.startswith("blake3-512:")
+    # Tampered fragment CID is not the sealed source coordinate of the assign.
+    tampered_cid = "blake3-512:" + "f" * 128
+    assert authentic != tampered_cid
+    # Live machine records the authentic fragment; a foreign CID cannot
+    # impersonate the executed binding's source coordinate.
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:tamper",
+        frame_coordinate="frame:tamper",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    prior = next(
+        b
+        for b in machine.machine.binding_state
+        if isinstance(b, GeneratorAssignBindingV1) and b.name == "prior"
+    )
+    assert prior.fragment_cid == authentic
+    assert prior.fragment_cid != tampered_cid
+
+
+def test_enter_resource_outcome_runs_pre_yield_assign():
+    """Protocol enter path also executes AssignStep before yield."""
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_python_source.manager_protocol_construction import (
+        EnteredGeneratorManagerStateV1,
+        construct_generator_backed_protocol,
+    )
+
+    steps = _steps("def g():\n    prior = None\n    yield 1\n")
+    frame = SimpleNamespace(
+        frame_cid=cid_of_json({"f": "pre-yield-enter"}),
+        generator_steps=steps,
+        runtime_entries=(),
+    )
+    enter = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 1, 0, 2, 0)
+    exit_ = SourceFragmentCoordinateV1("blake3-512:" + "b" * 128, 3, 0, 4, 0)
+    protocol = construct_generator_backed_protocol(
+        frame=frame,
+        enter_definition=enter,
+        exit_definition=exit_,
+        exit_face_id="face",
+        construction_cid="blake3-512:" + "c" * 128,
+    )
+    outcome = protocol.enter_resource_outcome()
+    assert isinstance(outcome, Complete)
+    entered = outcome.value
+    assert isinstance(entered, EnteredGeneratorManagerStateV1)
+    assert entered.enter_value == TermValue(1)
+    assert any(
+        isinstance(b, GeneratorAssignBindingV1) and b.name == "prior"
+        for b in entered.machine.binding_state
+    )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2414,6 +2414,7 @@ class FunctionDef(Statement):
         if not self._owns_yield(body):
             return None
         from sugar_lift_py_tests.generator_construction import (
+            AssignStepV1,
             FinallyStepV1,
             IfStepV1,
             InertStepV1,
@@ -2487,6 +2488,36 @@ class FunctionDef(Statement):
                 # predicate the rest of this producer reads -- never a judgement
                 # that a statement "looks harmless".
                 steps.append(InertStepV1(statement.kind))
+            elif (
+                isinstance(statement, Assign)
+                and not self._owns_yield((statement,))
+                and len(statement.targets) == 1
+                and isinstance(statement.targets[0], Name)
+            ):
+                # Pre-yield simple name assignment on the live generator machine
+                # (config-set / filter-push / temp-state save). Multi-target and
+                # non-Name stores stay Opaque until named.
+                steps.append(
+                    AssignStepV1(
+                        statement.targets[0].id,
+                        statement.value.sugar(),
+                        statement.fragment.seal().cid,
+                    )
+                )
+            elif (
+                isinstance(statement, AnnAssign)
+                and not self._owns_yield((statement,))
+                and isinstance(statement.target, Name)
+                and statement.value is not None
+            ):
+                # Peer of simple Assign: annotated name bind without suspension.
+                steps.append(
+                    AssignStepV1(
+                        statement.target.id,
+                        statement.value.sugar(),
+                        statement.fragment.seal().cid,
+                    )
+                )
             elif isinstance(statement, If) and self._owns_yield((statement,)):
                 # A BRANCH IS A TWO-FACE PARTITION and this producer owns it.
                 # Admitted only when BOTH branches are wholly nameable: a


### PR DESCRIPTION
## Summary

Producer gap 2: publication filter rejected \`GeneratorBackedLifecycleProtocolV1\`.

- **Lifecycle is-a** \`GeneratorBackedManagerProtocolV1\` (closed protocol surface)
- Publication admits success via construction gap type only — **no isinstance asker** over wrapper spelling
- \`from_protocol\` still attaches enter-halt / yield / exit-halt faces

## Acceptance

\`test_renamed_generator_manager_publication.py\` (10 instruments that waited on publication) green.

## Stack note

Independent of #6695 (pre-yield Assign); stacks cleanly after it or on main.

## Tests

\`\`\`
bin/bpytest tests/test_renamed_generator_manager_publication.py -q
# 13 passed
\`\`\`

----
## Summary by Gitar

- **Generator execution:**
    - Added `AssignStepV1` and execution support for pre-yield simple name assignments on the live machine
- **Protocol construction:**
    - Subclassed `GeneratorBackedLifecycleProtocolV1` from `GeneratorBackedManagerProtocolV1` for a closed protocol surface

<sub>This will update automatically on new commits.</sub>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Admit Lifecycle protocol through closed generator protocol surface by supporting pre-yield Assign steps
> - Adds `AssignStepV1` as a new generator step type in [generator_construction.py](https://github.com/TSavo/sugar/pull/6696/files#diff-35db5b3e2bf70dbb9aa1b5a6d30899e84d402ab203905605799dbd5855b1f072), allowing simple name assignments before the first yield to be recorded as `GeneratorAssignBindingV1` entries in `binding_state`.
> - Extends `FunctionDef._source_visible_generator_steps_from` in [nodes.py](https://github.com/TSavo/sugar/pull/6696/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to emit `AssignStepV1` for single-name `Assign` and `AnnAssign` statements that precede any yield; multi-target or non-Name targets remain opaque.
> - Refactors `GeneratorBackedLifecycleProtocolV1` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6696/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to subclass `GeneratorBackedManagerProtocolV1`, and replaces `isinstance` gap detection with an exact-type check via a new `_generator_protocol_construction_gap` helper so wrapped/subclassed protocols are no longer rejected.
> - Adds content-addressed testimony serialization for `assign-binding` values and `assign` steps, making pre-yield assignments attestable.
> - Behavioral Change: `_publish_generator_backed_resource_contract` no longer rejects protocol wrappers that are subclasses of `GeneratorBackedManagerProtocolV1`; only an exact `ManagerProtocolConstructionGapV1` type triggers a derivation gap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51e0277.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->