### PR TITLE
Execute pre-yield Assign/If and close generator protocol surface

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -164,6 +164,10 @@ class SourceDerivedGeneratorResourceRefV1:
     Coordinates alone cannot construct this ref; a non-generator frame cannot
     acquire generator semantics. Protocol is generator-backed testimony, never
     a fabricated ObjectValue receiver.
+
+    ONE typed surface for consumers: :meth:`generator_protocol` (and the
+    definition accessors) expose enter/exit definitions and lifecycle
+    performance without branching on Lifecycle-vs-Manager wrapper classes.
     """
 
     use_site: SourceFragmentCoordinateV1
@@ -189,6 +193,40 @@ class SourceDerivedGeneratorResourceRefV1:
             raise ValueError("generator resource ref requires exit definition")
         if protocol.enter_definition == protocol.exit_definition:
             raise ValueError("generator enter/exit definitions must differ")
+        # Closed performance surface: enter/exit must be methods, not missing.
+        if not callable(getattr(protocol, "enter_resource_outcome", None)):
+            raise ValueError(
+                "generator resource ref requires enter_resource_outcome on protocol"
+            )
+        if not callable(getattr(protocol, "exit_outcome_for", None)):
+            raise ValueError(
+                "generator resource ref requires exit_outcome_for on protocol"
+            )
+
+    @property
+    def generator_protocol(self):
+        """The one closed protocol surface published on this ref.
+
+        Always the generator-backed protocol (base or lifecycle subclass of
+        it). Consumers rebase onto this property — never enumerate wrapper
+        class names for enter/exit definitions or lifecycle performance.
+        """
+        return self.protocol
+
+    @property
+    def enter_definition(self):
+        """Native enter definition coordinate from the closed protocol surface."""
+        return self.protocol.enter_definition
+
+    @property
+    def exit_definition(self):
+        """Native exit definition coordinate from the closed protocol surface."""
+        return self.protocol.exit_definition
+
+    @property
+    def protocol_construction_cid(self) -> str:
+        """Protocol construction CID from the closed protocol surface."""
+        return self.protocol.protocol_construction_cid
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -110,9 +110,11 @@ class IfStepV1:
     its own partition. That is the property the key exists for.
 
     Admitted by the producer only when EVERY step in both branches is one the
-    vocabulary can already execute. A branch holding a shape we cannot resume --
-    `x = yield v`, whose resumed value reaches no name -- keeps the whole `If`
-    an `OpaqueStepV1` and loud. Naming a step we cannot resume is worse than an
+    vocabulary can already execute — including pre-yield guarded setup
+    (``if cond: x = …`` before yield) and suspension-owning branches
+    (``if c: yield 1``). A branch holding a shape we cannot resume or perform
+    -- ``x = yield v``, ``raise``, ``for``, etc. -- keeps the whole `If` an
+    `OpaqueStepV1` and loud. Naming a step we cannot perform is worse than an
     honest opaque one.
     """
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
@@ -47,6 +47,7 @@ from sugar_lift_py_tests.generator_construction import (
     GeneratorConstructionV1,
     GeneratorTerminationV1,
     IfStepV1,
+    InertStepV1,
     OpaqueStepV1,
     ReturnStepV1,
     YieldEffect,
@@ -113,12 +114,40 @@ def test_a_branch_step_carries_both_sides_and_its_own_fragment(tmp_path) -> None
     assert not hasattr(step, "partition")
 
 
-def test_an_if_without_a_suspension_is_untouched() -> None:
-    """The discriminating face: this arm must not claim every branch."""
+def test_an_if_without_a_suspension_is_pre_yield_guarded_setup() -> None:
+    """Pre-yield guarded setup (pass / assign) is IfStep when wholly nameable.
+
+    Real managers use ``if cond: x = …`` before yield. Pass-only and assign
+    branches are nameable peers; unhandled kinds (raise, for, x=yield) keep
+    the whole If opaque and loud.
+    """
     steps = _steps("def g(c):\n    if c:\n        pass\n    yield 2\n")
 
-    assert isinstance(steps[0], OpaqueStepV1)
+    assert isinstance(steps[0], IfStepV1)
+    assert isinstance(steps[0].then_steps[0], InertStepV1)
+    assert steps[0].else_steps == ()
     assert isinstance(steps[1], YieldStepV1)
+
+
+def test_pre_yield_if_assign_is_nameable_guarded_setup() -> None:
+    steps = _steps(
+        "def g(c):\n    if c:\n        prior = None\n    yield 1\n"
+    )
+    assert isinstance(steps[0], IfStepV1)
+    from sugar_lift_py_tests.generator_construction import AssignStepV1
+
+    assert isinstance(steps[0].then_steps[0], AssignStepV1)
+    assert steps[0].then_steps[0].name == "prior"
+
+
+def test_pre_yield_if_with_raise_stays_opaque_and_loud() -> None:
+    """Unhandled Raise inside a branch keeps the whole If Opaque (never skip)."""
+    steps = _steps(
+        "def g(c):\n    if c:\n        raise ValueError('boom')\n    yield 1\n"
+    )
+    assert isinstance(steps[0], OpaqueStepV1)
+    assert steps[0].observed == "If"
+    assert steps[0].carries_suspension is False
 
 
 # -- the three transition arms -----------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_step_names_its_suspension.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_step_names_its_suspension.py
@@ -1,24 +1,15 @@
 """An opaque generator step says whether it holds a suspension.
 
-``OpaqueStepV1(statement.kind)`` gave ``x = 1`` and ``x = yield 1`` the SAME
-row -- ``Assign`` -- and they are not the same obligation:
+``OpaqueStepV1(statement.kind)`` used to give ``x = 1`` and ``x = yield 1`` the
+SAME row -- ``Assign`` -- and they are not the same obligation. Ordinary
+Assign and nameable pre-yield If are now AssignStepV1 / IfStepV1; residual
+opaque shapes still carry the suspension flag so the board can dispatch:
 
 * an opaque statement owning NO suspension owes ordinary statement execution
-  inside a generator frame;
+  the vocabulary has not yet constructed (e.g. multi-target store);
 * one that OWNS a suspension owes a generator-protocol law -- the resumed
-  value's binding for an assignment, a partition for a branch.
-
-That is the misnamed-bucket shape twice over. ``add x TermValue`` said "a
-number does not stand on the addition floor" for 34 rows that were all complex
-literals, and the binary-operation gaps said nothing about their right operand
-until the pair became the dispatch unit. A gap that cannot name what it could
-not consume cannot be dispatched, and this one names the CONTAINER's kind
-rather than the construct inside it.
-
-WHAT THIS IS NOT. It does not name a single new step. Nothing here executes a
-suspension that did not execute before, and every previously-opaque shape is
-still opaque and still refuses by name. The vocabulary is unchanged; only its
-testimony about itself is sharper.
+  value's binding for an assignment, a partition for a branch that holds an
+  unnameable yield form.
 """
 
 from __future__ import annotations
@@ -26,9 +17,13 @@ from __future__ import annotations
 import pytest
 
 from sugar_lift_py_tests.generator_construction import (
+    AssignStepV1,
     GeneratorConstructionV1,
     GeneratorTransitionGapV1,
+    IfStepV1,
     OpaqueStepV1,
+    YieldEffect,
+    YieldStepV1,
 )
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
@@ -51,11 +46,11 @@ def _first_opaque(steps):
 @pytest.mark.parametrize(
     ("source", "kind", "carries"),
     (
-        # Same statement kind, opposite obligations.
+        # Residual opaque shapes still discriminate suspension ownership.
         ("def g():\n    x = yield 1\n    return x\n", "Assign", True),
-        ("def g():\n    x = 1\n    yield 2\n", "Assign", False),
         ("def g(c):\n    if c:\n        x = yield 1\n", "If", True),
-        ("def g(c):\n    if c:\n        pass\n    yield 2\n", "If", False),
+        # Multi-target assign stays opaque without suspension.
+        ("def g():\n    a, b = 1, 2\n    yield 3\n", "Assign", False),
         # Every bare `yield from` -- where the delegation debt actually lives.
         ("def g(xs):\n    yield from xs\n", "Expr", True),
     ),
@@ -69,6 +64,17 @@ def test_an_opaque_step_states_whether_it_holds_a_suspension(
     assert step.carries_suspension is carries
 
 
+def test_ordinary_assign_and_nameable_if_are_no_longer_opaque(tmp_path) -> None:
+    """Producer item-1: simple Assign and nameable If are named steps."""
+    assign_steps = _steps(tmp_path, "def g():\n    x = 1\n    yield 2\n")
+    assert isinstance(assign_steps[0], AssignStepV1)
+    assert not any(isinstance(s, OpaqueStepV1) for s in assign_steps)
+
+    if_steps = _steps(tmp_path, "def g(c):\n    if c:\n        pass\n    yield 2\n")
+    assert isinstance(if_steps[0], IfStepV1)
+    assert not isinstance(if_steps[0], OpaqueStepV1)
+
+
 @pytest.mark.parametrize(
     ("source", "observed"),
     (
@@ -80,9 +86,7 @@ def test_an_opaque_step_states_whether_it_holds_a_suspension(
 def test_the_transition_gap_names_the_construct_it_could_not_consume(
     tmp_path, source, observed
 ) -> None:
-    """The row has to be dispatchable. `Assign` names the container; a board
-    keyed on it cannot tell generator-protocol work from an ordinary
-    unsupported statement."""
+    """The row has to be dispatchable. Residual opaques name suspension when owned."""
     machine = GeneratorConstructionV1.allocate(
         allocation_coordinate="probe",
         frame_coordinate="frame",
@@ -98,17 +102,12 @@ def test_the_transition_gap_names_the_construct_it_could_not_consume(
 
 
 def test_an_opaque_step_without_a_suspension_is_named_unchanged(tmp_path) -> None:
-    """The discriminating face: the flag must not decorate every opaque row.
-
-    If it did, the distinction would be worthless -- every statement would
-    claim to hold a suspension and the board would be exactly as
-    undifferentiated as before, one word longer.
-    """
+    """The discriminating face: residual opaque without suspension stays plain."""
     machine = GeneratorConstructionV1.allocate(
         allocation_coordinate="probe",
         frame_coordinate="frame",
         binding_state=(),
-        steps=_steps(tmp_path, "def g():\n    x = 1\n    yield 2\n"),
+        steps=_steps(tmp_path, "def g():\n    a, b = 1, 2\n    yield 3\n"),
     )
 
     gap = machine.resume()
@@ -117,7 +116,7 @@ def test_an_opaque_step_without_a_suspension_is_named_unchanged(tmp_path) -> Non
     assert gap.observed == "Assign"
 
 
-# -- nothing was named, nothing was drained ----------------------------------
+# -- residual opaques stay loud ----------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -129,11 +128,7 @@ def test_an_opaque_step_without_a_suspension_is_named_unchanged(tmp_path) -> Non
     ),
 )
 def test_every_previously_opaque_shape_is_still_opaque(tmp_path, source) -> None:
-    """`panic = gap`. Sharper testimony must not become a drain: these still
-    refuse, and nothing constructs a suspension the vocabulary cannot execute.
-    """
-    from sugar_lift_py_tests.generator_construction import YieldStepV1
-
+    """Sharper admission of Assign/If must not drain residual opaque shapes."""
     steps = _steps(tmp_path, source)
 
     assert any(isinstance(step, OpaqueStepV1) for step in steps)
@@ -142,8 +137,6 @@ def test_every_previously_opaque_shape_is_still_opaque(tmp_path, source) -> None
 
 def test_a_named_step_is_untouched_and_still_suspends(tmp_path) -> None:
     """The shapes the vocabulary DOES name keep working, unchanged."""
-    from sugar_lift_py_tests.generator_construction import YieldEffect, YieldStepV1
-
     steps = _steps(tmp_path, "def g():\n    yield 1\n")
 
     assert isinstance(steps[0], YieldStepV1)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -236,10 +236,11 @@ class GeneratorExitHaltFaceV1:
 class GeneratorBackedLifecycleProtocolV1(GeneratorBackedManagerProtocolV1):
     """Generator-backed protocol plus enter-halt / yield / exit-halt faces.
 
-    **Is-a** :class:`GeneratorBackedManagerProtocolV1` (closed protocol surface):
-    publication and consumers admit the lifecycle wrapper through the base
-    protocol type without an isinstance asker over wrapper spelling. Face
-    fields are producer testimony; enter/exit performance inherit from the base.
+    **Is-a** :class:`GeneratorBackedManagerProtocolV1` — the closed protocol
+    surface published on ``SourceDerivedGeneratorResourceRefV1``. Consumers
+    read enter/exit definitions and lifecycle performance through that base
+    type; they never branch on Lifecycle-vs-Manager wrapper spelling. Face
+    fields are producer testimony; enter/exit performance inherit from base.
     """
 
     enter_halt_faces: tuple[GeneratorEnterHaltFaceV1, ...] = ()

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
@@ -189,42 +189,29 @@ def test_pre_yield_never_yield_is_authenticated_entry_refusal():
 
 
 def test_pre_yield_assign_then_yield_enters_with_resource():
-    """LAW (grok-1 item-1): ordinary pre-yield Assign is performed, then yield enters.
+    """LAW (item-1): ordinary pre-yield Assign is performed, then yield enters.
 
     Live shapes from the renamed consumption suite are exactly this row:
 
         prior = None
         yield (key, value, prior)
 
-    Today ``OpaqueStepV1("Assign")`` gaps at enter. When the pre-yield
-    transition producer lands, ``enter_resource_outcome`` completes with the
-    yield value and an exact machine state that can exit once.
+    AssignStepV1 executes on the live machine; enter completes with the yield
+    value and an exact machine state that can exit once.
     """
+    from sugar_lift_py_tests.generator_construction import AssignStepV1
+
     protocol = _protocol(
         frame=_frame(
             steps=(
-                OpaqueStepV1("Assign", carries_suspension=False),
+                AssignStepV1("prior", TermValue(None), "frag:prior"),
                 YieldStepV1(TermValue(42)),
                 ReturnStepV1(None),
             ),
             frame_cid=cid_of_json({"frame": "pre-yield-assign"}),
         )
     )
-    try:
-        outcome = protocol.enter_resource_outcome()
-    except SugarNotWritten as gap:
-        pytest.fail(
-            "MISSING PRODUCER (pre-yield Assign transition → grok-1 item-1):\n"
-            f"  owner: GeneratorBackedManagerProtocolV1.enter_resource_outcome\n"
-            f"  observed: {gap.observed!r}\n"
-            f"  requested: {gap.requested!r}\n"
-            "  expected: step ordinary Assign (binding, no suspension), then "
-            "Complete(EnteredGeneratorManagerStateV1) on the following YieldStepV1\n"
-            "  shapes blocked: config-setter / warnings-filter / temp-state live "
-            "generators in test_generator_manager_renamed_lifecycle.py\n"
-            "  fix: construct Assign (and peer pre-yield statement) transitions "
-            "in GeneratorConstructionV1; do not leave them OpaqueStep gaps"
-        )
+    outcome = protocol.enter_resource_outcome()
     assert isinstance(outcome, Complete), type(outcome)
     entered = outcome.value
     assert isinstance(entered, EnteredGeneratorManagerStateV1)
@@ -283,30 +270,20 @@ def test_pre_yield_suspension_assign_twin_does_not_impersonate_ordinary_assign()
 
 
 def test_pre_yield_assign_and_inert_prefix_compose_then_yield():
-    """Composed pre-yield: inert + Assign + yield — Assign is the blocker today."""
+    """Composed pre-yield: inert + Assign + yield."""
+    from sugar_lift_py_tests.generator_construction import AssignStepV1
+
     protocol = _protocol(
         frame=_frame(
             steps=(
                 InertStepV1("Expr"),
-                OpaqueStepV1("Assign", carries_suspension=False),
+                AssignStepV1("prior", TermValue(None), "frag:prior2"),
                 YieldStepV1(TermValue(7)),
                 ReturnStepV1(None),
             ),
             frame_cid=cid_of_json({"frame": "inert-then-assign-then-yield"}),
         )
     )
-    try:
-        outcome = protocol.enter_resource_outcome()
-    except SugarNotWritten as gap:
-        # Inert must not be reported as the blocker once Assign is the residual.
-        assert gap.observed == "Assign" or "Assign" in str(gap.observed), (
-            f"expected Assign as first real blocker after inert prefix; "
-            f"observed={gap.observed!r}"
-        )
-        pytest.fail(
-            "MISSING PRODUCER (pre-yield Assign after inert → grok-1 item-1):\n"
-            f"  observed: {gap.observed!r}\n"
-            "  expected: step past InertStepV1, perform Assign, yield TermValue(7)"
-        )
+    outcome = protocol.enter_resource_outcome()
     assert isinstance(outcome, Complete)
     assert outcome.value.enter_value == TermValue(7)

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_if_execution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_if_execution.py
@@ -1,0 +1,168 @@
+"""Pre-yield If (guarded setup) execution on the live generator machine.
+
+Real managers use ``if cond: x = …`` before yield. When both branches are
+wholly nameable, IfStepV1 runs (ground true/false splice; undecided partition).
+Unhandled kinds inside a branch keep the whole If Opaque and loud.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+from sugar_lift_py_tests.floor import NoneValue, TermValue
+from sugar_lift_py_tests.generator_construction import (
+    AssignStepV1,
+    GeneratorAssignBindingV1,
+    GeneratorConstructionV1,
+    IfStepV1,
+    OpaqueStepV1,
+    YieldEffect,
+)
+from sugar_lift_py_tests.outcome.exit_set import ExitSet
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _steps(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    function = next(SourceFile(path_source(path)).functions())
+    return function._source_visible_generator_steps_from(function.body)
+
+
+def test_pre_yield_if_assign_emits_if_step_then_yield():
+    steps = _steps(
+        "def g(flag):\n"
+        "    if flag:\n"
+        "        prior = None\n"
+        "    yield 1\n"
+    )
+    assert isinstance(steps[0], IfStepV1)
+    assert isinstance(steps[0].then_steps[0], AssignStepV1)
+    assert steps[0].then_steps[0].name == "prior"
+
+
+def test_ground_true_pre_yield_if_assigns_then_yields():
+    steps = _steps(
+        "def g():\n"
+        "    if True:\n"
+        "        prior = None\n"
+        "    yield 1\n"
+    )
+    assert isinstance(steps[0], IfStepV1)
+    yielded = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:if-true",
+        frame_coordinate="frame:if-true",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert isinstance(yielded, YieldEffect)
+    assert any(
+        isinstance(b, GeneratorAssignBindingV1) and b.name == "prior"
+        for b in yielded.machine.binding_state
+    )
+    prior = next(
+        b
+        for b in yielded.machine.binding_state
+        if isinstance(b, GeneratorAssignBindingV1)
+    )
+    assert isinstance(prior.value, NoneValue)
+
+
+def test_ground_false_pre_yield_if_skips_then_yields():
+    steps = _steps(
+        "def g():\n"
+        "    if False:\n"
+        "        prior = None\n"
+        "    yield 7\n"
+    )
+    yielded = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:if-false",
+        frame_coordinate="frame:if-false",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert isinstance(yielded, YieldEffect)
+    assert not any(
+        isinstance(b, GeneratorAssignBindingV1) and b.name == "prior"
+        for b in yielded.machine.binding_state
+    )
+    assert yielded.value == TermValue(7)
+
+
+def test_undecided_pre_yield_if_partitions():
+    steps = _steps(
+        "def g(flag):\n"
+        "    if flag:\n"
+        "        prior = None\n"
+        "    yield 1\n"
+    )
+    outcome = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:if-undecided",
+        frame_coordinate="frame:if-undecided",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert isinstance(outcome, ExitSet)
+
+
+def test_if_with_raise_stays_opaque_at_enter():
+    steps = _steps(
+        "def g(flag):\n"
+        "    if flag:\n"
+        "        raise ValueError('boom')\n"
+        "    yield 1\n"
+    )
+    assert isinstance(steps[0], OpaqueStepV1)
+    assert steps[0].observed == "If"
+    from sugar_lift_py_tests.generator_construction import GeneratorTransitionGapV1
+
+    gap = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:if-raise",
+        frame_coordinate="frame:if-raise",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert isinstance(gap, GeneratorTransitionGapV1)
+    assert "If" in gap.observed
+
+
+def test_enter_resource_outcome_runs_pre_yield_if_assign():
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_python_source.manager_protocol_construction import (
+        EnteredGeneratorManagerStateV1,
+        construct_generator_backed_protocol,
+    )
+
+    steps = _steps(
+        "def g():\n"
+        "    if True:\n"
+        "        prior = None\n"
+        "    yield 1\n"
+    )
+    frame = SimpleNamespace(
+        frame_cid=cid_of_json({"f": "pre-yield-if-enter"}),
+        generator_steps=steps,
+        runtime_entries=(),
+    )
+    enter = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 1, 0, 2, 0)
+    exit_ = SourceFragmentCoordinateV1("blake3-512:" + "b" * 128, 3, 0, 4, 0)
+    protocol = construct_generator_backed_protocol(
+        frame=frame,
+        enter_definition=enter,
+        exit_definition=exit_,
+        exit_face_id="face",
+        construction_cid="blake3-512:" + "c" * 128,
+    )
+    outcome = protocol.enter_resource_outcome()
+    assert isinstance(outcome, Complete)
+    entered = outcome.value
+    assert isinstance(entered, EnteredGeneratorManagerStateV1)
+    assert entered.enter_value == TermValue(1)

--- a/implementations/python/sugar-lift-python-source/tests/test_renamed_generator_manager_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_renamed_generator_manager_publication.py
@@ -246,7 +246,9 @@ def _publications(context: TreeConstructionContextV1) -> list[_Publication]:
             continue
         if not isinstance(exit_, SourceFragmentCoordinateV1):
             continue
-        protocol = ref.protocol
+        # ONE typed surface on the published ref — never enumerate Lifecycle
+        # vs Manager wrapper spelling; generator_protocol is the closed door.
+        protocol = ref.generator_protocol
         if not isinstance(protocol, GeneratorBackedManagerProtocolV1):
             continue
         frame = protocol.generator_frame
@@ -257,10 +259,10 @@ def _publications(context: TreeConstructionContextV1) -> list[_Publication]:
                 exit=exit_,
                 ref=ref,
                 frame_cid=frame.frame_cid,
-                protocol_construction_cid=protocol.protocol_construction_cid,
+                protocol_construction_cid=ref.protocol_construction_cid,
                 has_generator_steps=frame.generator_steps is not None,
-                enter_definition=protocol.enter_definition,
-                exit_definition=protocol.exit_definition,
+                enter_definition=ref.enter_definition,
+                exit_definition=ref.exit_definition,
             )
         )
     return out

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2425,54 +2425,21 @@ class FunctionDef(Statement):
 
         steps = []
 
-        def branch_steps(body):
-            """Steps for one branch, or None if any shape is unnameable.
+        def name_statement(statement):
+            """One nameable step, or None when the vocabulary cannot perform it.
 
-            None keeps the whole `If` opaque. A partially-nameable branch is
-            not provable: `x = yield v` resumes to a value that reaches no
-            name, so naming the branch holding it would claim an execution we
-            cannot perform. An honest `OpaqueStepV1` is the better answer.
+            None is not a skip: the caller either keeps a containing `If`
+            opaque or appends an honest `OpaqueStepV1`. Unhandled kinds stay
+            loud SUGAR NOT WRITTEN at transition — never silently advanced.
             """
-            collected = []
-            for nested in body:
-                if isinstance(nested, Expr) and isinstance(nested.value, Yield):
-                    value = nested.value.value
-                    collected.append(
-                        YieldStepV1(None if value is None else value.sugar())
-                    )
-                elif isinstance(nested, Return):
-                    collected.append(
-                        ReturnStepV1(
-                            None if nested.value is None else nested.value.sugar()
-                        )
-                    )
-                else:
-                    return None
-            return tuple(collected)
-
-        def append_statement(statement):
             if isinstance(statement, Expr) and isinstance(statement.value, Yield):
                 value = statement.value.value
-                steps.append(YieldStepV1(None if value is None else value.sugar()))
-            elif isinstance(statement, Return):
-                steps.append(
-                    ReturnStepV1(
-                        None if statement.value is None else statement.value.sugar()
-                    )
+                return YieldStepV1(None if value is None else value.sugar())
+            if isinstance(statement, Return):
+                return ReturnStepV1(
+                    None if statement.value is None else statement.value.sugar()
                 )
-            elif (
-                isinstance(statement, Try)
-                and not statement.handlers
-                and not statement.orelse
-                and statement.finalbody
-                and self._owns_yield(statement.body)
-            ):
-                for nested in statement.body:
-                    append_statement(nested)
-                steps.append(
-                    FinallyStepV1(tuple(item.sugar() for item in statement.finalbody))
-                )
-            elif (
+            if (
                 isinstance(statement, Expr)
                 and isinstance(statement.value, Constant)
                 and not self._owns_yield((statement,))
@@ -2487,8 +2454,11 @@ class FunctionDef(Statement):
                 # the suspension check is `_owns_yield`, the same authenticated
                 # predicate the rest of this producer reads -- never a judgement
                 # that a statement "looks harmless".
-                steps.append(InertStepV1(statement.kind))
-            elif (
+                return InertStepV1(statement.kind)
+            if isinstance(statement, Pass) and not self._owns_yield((statement,)):
+                # Peer of inert Constant: `pass` owes nothing.
+                return InertStepV1(statement.kind)
+            if (
                 isinstance(statement, Assign)
                 and not self._owns_yield((statement,))
                 and len(statement.targets) == 1
@@ -2496,81 +2466,106 @@ class FunctionDef(Statement):
             ):
                 # Pre-yield simple name assignment on the live generator machine
                 # (config-set / filter-push / temp-state save). Multi-target and
-                # non-Name stores stay Opaque until named.
-                steps.append(
-                    AssignStepV1(
-                        statement.targets[0].id,
-                        statement.value.sugar(),
-                        statement.fragment.seal().cid,
-                    )
+                # non-Name stores stay unnameable until constructed.
+                return AssignStepV1(
+                    statement.targets[0].id,
+                    statement.value.sugar(),
+                    statement.fragment.seal().cid,
                 )
-            elif (
+            if (
                 isinstance(statement, AnnAssign)
                 and not self._owns_yield((statement,))
                 and isinstance(statement.target, Name)
                 and statement.value is not None
             ):
                 # Peer of simple Assign: annotated name bind without suspension.
-                steps.append(
-                    AssignStepV1(
-                        statement.target.id,
-                        statement.value.sugar(),
-                        statement.fragment.seal().cid,
-                    )
+                return AssignStepV1(
+                    statement.target.id,
+                    statement.value.sugar(),
+                    statement.fragment.seal().cid,
                 )
-            elif isinstance(statement, If) and self._owns_yield((statement,)):
+            if isinstance(statement, If):
                 # A BRANCH IS A TWO-FACE PARTITION and this producer owns it.
-                # Admitted only when BOTH branches are wholly nameable: a
-                # branch holding a shape the machine cannot resume keeps the
-                # whole `If` opaque and loud rather than half-named.
+                # Admitted for suspension-owning branches AND pre-yield guarded
+                # setup (`if cond: x = …` before yield) when BOTH sides are
+                # wholly nameable. Raise / For / x=yield / other unhandled
+                # kinds keep the whole `If` unnameable and loud.
                 #
                 # The partition is NOT minted here. Its key needs the machine's
                 # `instance_coordinate`, which `allocate` mints AFTER these
                 # steps exist, so the mint happens at transition time and this
-                # step stays instance-agnostic -- which is what lets one
-                # generator's steps be shared by every instance over it while
-                # each mints its own partition.
+                # step stays instance-agnostic.
                 then_body = branch_steps(statement.body)
                 else_body = branch_steps(statement.orelse)
                 if then_body is None or else_body is None:
-                    # A branch holds a step the vocabulary cannot name, so the
-                    # whole `If` stays opaque -- but it is still an `If` that
-                    # may CARRY a suspension, and that is the discrimination
-                    # #6439 landed. Dropping the flag here would report
-                    # `if c: x = yield 1` as a plain `If`, which is the exact
-                    # row-merge #6439 exists to prevent. #6439 and #6445 were
-                    # each green and merged with NO textual conflict; this
-                    # line is what the clean merge silently lost.
-                    steps.append(
-                        OpaqueStepV1(
-                            statement.kind,
-                            carries_suspension=self._owns_yield((statement,)),
-                        )
-                    )
-                else:
-                    steps.append(
-                        IfStepV1(
-                            statement.test.sugar(),
-                            then_body,
-                            else_body,
-                            statement.fragment.seal().cid,
-                        )
-                    )
-            else:
-                # The step vocabulary cannot name this shape. Say WHETHER it
-                # holds a suspension, because the two obligations differ:
-                # `x = 1` owes ordinary statement execution, `x = yield 1`
-                # owes the resumed value's binding. Bucketing them as one
-                # `Assign` row is why the suspension owners read as an
-                # undifferentiated mass. Read from `_owns_yield`, the same
-                # authenticated predicate that decided this body is a
-                # generator -- never from the statement's spelling.
+                    return None
+                return IfStepV1(
+                    statement.test.sugar(),
+                    then_body,
+                    else_body,
+                    statement.fragment.seal().cid,
+                )
+            return None
+
+        def branch_steps(body):
+            """Steps for one branch, or None if any shape is unnameable.
+
+            None keeps the whole `If` opaque. A partially-nameable branch is
+            not provable: `x = yield v` resumes to a value that reaches no
+            name, so naming the branch holding it would claim an execution we
+            cannot perform. An honest `OpaqueStepV1` is the better answer.
+            """
+            collected = []
+            for nested in body:
+                step = name_statement(nested)
+                if step is None:
+                    return None
+                collected.append(step)
+            return tuple(collected)
+
+        def append_statement(statement):
+            named = name_statement(statement)
+            if named is not None:
+                steps.append(named)
+                return
+            if (
+                isinstance(statement, Try)
+                and not statement.handlers
+                and not statement.orelse
+                and statement.finalbody
+                and self._owns_yield(statement.body)
+            ):
+                for nested in statement.body:
+                    append_statement(nested)
+                steps.append(
+                    FinallyStepV1(tuple(item.sugar() for item in statement.finalbody))
+                )
+                return
+            if isinstance(statement, If):
+                # Branch held an unnameable shape. Keep the whole If opaque,
+                # but preserve suspension discrimination (#6439):
+                # `if c: x = yield 1` is not a plain `If` row.
                 steps.append(
                     OpaqueStepV1(
                         statement.kind,
                         carries_suspension=self._owns_yield((statement,)),
                     )
                 )
+                return
+            # The step vocabulary cannot name this shape. Say WHETHER it
+            # holds a suspension, because the two obligations differ:
+            # `x = 1` owes ordinary statement execution, `x = yield 1`
+            # owes the resumed value's binding. Bucketing them as one
+            # `Assign` row is why the suspension owners read as an
+            # undifferentiated mass. Read from `_owns_yield`, the same
+            # authenticated predicate that decided this body is a
+            # generator -- never from the statement's spelling.
+            steps.append(
+                OpaqueStepV1(
+                    statement.kind,
+                    carries_suspension=self._owns_yield((statement,)),
+                )
+            )
 
         for statement in body:
             append_statement(statement)


### PR DESCRIPTION
## Summary

Producer item-1 for seam-2 / codex-2 consumption:

1. **Pre-yield statement execution** covers the kinds real managers use:
   - `AssignStepV1` for simple Name / AnnAssign binds (`prior = None`, `filters = […]`, `saved = state`)
   - `IfStepV1` for nameable guarded setup (`if cond: x = …` / `pass` before yield) and suspension-owning nameable branches
   - peers: Pass → Inert, nested nameable If
   - **unhandled kinds stay loud** `OpaqueStepV1` / `SUGAR NOT WRITTEN` (raise-in-branch, multi-target assign, `x = yield`, `for`, `yield from`) — never skip

2. **ONE typed protocol surface** on the published ref:
   - `GeneratorBackedLifecycleProtocolV1` **is-a** `GeneratorBackedManagerProtocolV1`
   - `SourceDerivedGeneratorResourceRefV1.generator_protocol` + `enter_definition` / `exit_definition` / `protocol_construction_cid`
   - publication gap check is closed (`type is ManagerProtocolConstructionGapV1` only) — no isinstance asker over wrapper spelling
   - codex-2 rebases onto `ref.generator_protocol` instead of enumerating Lifecycle vs Manager classes

### Shell deleted / retirement path
- Deletes the Opaque-gap shell for ordinary pre-yield Assign and nameable If (rung: step type + machine transition).
- Deletes the duck-typed Lifecycle wrapper as a second protocol kind (rung: subclass of closed protocol surface).
- Residual opaques (`x = yield`, raise-in-If, For, multi-target) keep the loud Opaque shell until those steps are constructed.

## Shot accounting (8-field)

| Field | Value |
| --- | --- |
| **R axis** | `opaque_pre_yield_assign_if` + `protocol_wrapper_enumeration` |
| **Epsilon R** | −1 opaque Assign/If enter gap for config-setter / warnings-filter / temp-state; −1 Lifecycle-vs-Manager isinstance filter residual |
| **Floors** | no silent skip of unhandled steps; no fabricated enter; suspension-carrying Assign still discriminates |
| **Instrument** | `test_generator_pre_yield_assign_execution`, `test_generator_pre_yield_if_execution`, lifecycle performance twins, renamed publication via `ref.generator_protocol` |
| **Local evidence** | 99 focused pytest green (construction, if-step, assign/if execution, lifecycle, publication, faces) |
| **Observed residual** | renamed lifecycle suite advances past Assign to **MISSING CONSUMER (codex-2)** body-face exit preservation; assigned-Name seating is a separate producer residual |
| **Background** | full `bpytest` / CI after merge |
| **Shell retired** | Opaque pre-yield Assign + nameable If; duck Lifecycle filter |

## Test plan

- [x] `test_generator_pre_yield_assign_execution.py` — config/filter/temp Assign executes
- [x] `test_generator_pre_yield_if_execution.py` — guarded setup If; raise-in-If stays Opaque
- [x] `test_generator_if_step.py` / `test_generator_step_names_its_suspension.py` updated for named steps
- [x] lifecycle performance, renamed publication, enter/exit halt faces
- [ ] CI / bpytest broad sweep after merge
- [ ] codex-2 rebases onto `ref.generator_protocol` for exit face law

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Execute pre-yield `Assign` and `If` steps and expose typed generator protocol surface on resource refs
> - Pre-yield `AssignStepV1` and `IfStepV1` (with nameable branches) are now executed before the first yield in the generator manager protocol, replacing prior `OpaqueStepV1` placeholders that raised `SugarNotWritten`.
> - `SourceDerivedGeneratorResourceRefV1` gains validation that the protocol has callable `enter_resource_outcome` and `exit_outcome_for`, plus new properties (`generator_protocol`, `enter_definition`, `exit_definition`, `protocol_construction_cid`) exposing the protocol surface directly.
> - The `name_statement` helper in [`nodes.py`](https://github.com/TSavo/sugar/pull/6698/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) replaces the old `branch_steps` helper, emitting a single nameable step where possible and keeping the containing `If` opaque otherwise.
> - `If` nodes containing a `raise` remain `OpaqueStepV1`; multi-target assignments remain opaque as residual non-suspending opaques.
> - Behavioral Change: `enter_resource_outcome()` now runs pre-yield assigns/ifs rather than raising a gap error; callers previously catching `SugarNotWritten` will no longer receive it for these cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8d237a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->