### PR TITLE
Implement formal delitem/delattr_named mint carriers and projectors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -385,9 +385,11 @@ def production_native_operation_operators() -> frozenset[str]:
     from sugar_lift_py_tests.floor.floor_value import _BINARY_OPERATOR_COORDINATE
     from sugar_lift_py_tests.sugar.comparison_op_sugar import COMPARE_METHODS
 
-    # Store producers pin these operator strings for n-ary discharge.  Keep
-    # them in the production set so a missing projector cannot merge green.
-    contracted_store_operators = frozenset({"setitem", "setattr_named"})
+    # Store/delete producers pin these operator strings for n-ary discharge.
+    # Keep them in the production set so a missing projector cannot merge green.
+    contracted_store_operators = frozenset(
+        {"setitem", "setattr_named", "delitem", "delattr_named"}
+    )
     return (
         _ast_minted_native_operator_constants()
         | frozenset(_BINARY_OPERATOR_COORDINATE)
@@ -453,6 +455,11 @@ _NATIVE_OPERATION_PROJECTORS = {
     "setattr_named": lambda receiver, name, value, site: receiver.setattr(
         name.value, value, site
     ),
+    # Binary delete protocol (receiver, index|name + site) — store-family twin.
+    # Discharge order: receiver, index — never source-eval order confusion.
+    "delitem": lambda receiver, index, site: receiver.delitem(index, site),
+    # Attribute delete: name arrives as StringValue; unwrap with .value.
+    "delattr_named": lambda receiver, name, site: receiver.delattr(name.value, site),
 }
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -387,6 +387,8 @@ def production_native_operation_operators() -> frozenset[str]:
 
     # Store/delete producers pin these operator strings for n-ary discharge.
     # Keep them in the production set so a missing projector cannot merge green.
+    # Equality tooth: this frozenset union MUST equal
+    # frozenset(_NATIVE_OPERATION_PROJECTORS) both directions.
     contracted_store_operators = frozenset(
         {"setitem", "setattr_named", "delitem", "delattr_named"}
     )
@@ -396,6 +398,25 @@ def production_native_operation_operators() -> frozenset[str]:
         | frozenset(COMPARE_METHODS.values())
         | contracted_store_operators
     )
+
+
+def _project_delitem(receiver, index, site):
+    """Python protocol ``__delitem__(self, key)`` — discharge order (receiver, index).
+
+    Ordered operands and formal coordinates match this signature exactly.
+    Name deletion (``del name``) is out of scope for this projector.
+    """
+    return receiver.delitem(index, site)
+
+
+def _project_delattr_named(receiver, name, site):
+    """Python protocol ``__delattr__(self, name)`` — (receiver, StringValue name).
+
+    ``name`` arrives as StringValue from the mint; unwrap with ``.value``.
+    Readability never authorizes deletion: Floor ``delattr`` refuses
+    getter-only properties without consulting the read path.
+    """
+    return receiver.delattr(name.value, site)
 
 
 # Explicit projectors for authenticated native operations.
@@ -411,6 +432,11 @@ def production_native_operation_operators() -> frozenset[str]:
 # resolved operation is called as ``receiver.setitem(index, value)``.  Those
 # two orders are distinct; producers (windows 10876 / 17534) own the source
 # chain, and these projectors own the call signature.
+#
+# Delete protocol (store-family twin):
+#   delitem        → ``receiver.delitem(index, site)``   (__delitem__)
+#   delattr_named  → ``receiver.delattr(name.value, site)`` (__delattr__)
+# Name deletion (``del name`` / DeleteNameSugar) is out of scope here.
 #
 # Key set must equal :func:`production_native_operation_operators` exactly.
 _NATIVE_OPERATION_PROJECTORS = {
@@ -455,11 +481,9 @@ _NATIVE_OPERATION_PROJECTORS = {
     "setattr_named": lambda receiver, name, value, site: receiver.setattr(
         name.value, value, site
     ),
-    # Binary delete protocol (receiver, index|name + site) — store-family twin.
-    # Discharge order: receiver, index — never source-eval order confusion.
-    "delitem": lambda receiver, index, site: receiver.delitem(index, site),
-    # Attribute delete: name arrives as StringValue; unwrap with .value.
-    "delattr_named": lambda receiver, name, site: receiver.delattr(name.value, site),
+    # Binary delete protocol — explicit projectors (Python protocol signatures).
+    "delitem": _project_delitem,
+    "delattr_named": _project_delattr_named,
 }
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
@@ -213,17 +213,13 @@ class DictValue(FloorValue):
                             )
                         )
                     )
-            from sugar_lift_py_tests.effect import (
-                KeyErrorRuntimeEffect,
-                runtime_effect_evidence,
-            )
+            # Ground missing key: decidable KeyError — not a RuntimeEffect mint.
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
 
-            return Incomplete(
-                KeyErrorRuntimeEffect(
-                    "dict deletion key missing runtime boundary: "
-                    f"key={index!r}; owner=DictValue.delitem site={site}",
-                    **runtime_effect_evidence("py.delitem", index, site),
-                )
+            return ground_exceptional_exit(
+                exception_name="KeyError",
+                site=site,
+                owner="DictValue.delitem",
             )
 
         from sugar_lift_py_tests.effect import (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -795,6 +795,23 @@ class FloorValue:
         )
         construction_panic(info)
 
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.gap.panic import construction_panic
+        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+
+        observed = type(self).__name__
+        info = ConstructionGap(
+            owner="delattr",
+            blame=str(site),
+            observed=observed,
+            requested="stand on the attribute-delete floor",
+            fix=f"write more Floor: implement {observed}.delattr",
+            gap_kind=GapKind.FLOOR,
+            gap_locus=GapLocus.CONSTRUCTION,
+        )
+        construction_panic(info)
+
     def absolute(self, site):
         from sugar_lift_py_tests.gap.panic import construction_panic
         from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -264,6 +264,47 @@ class ObjectValue(FloorValue):
             )
         return Complete(self.with_field_store(name, value))
 
+    def delattr(self, name, site):
+        """``del self.name`` via instance-field delete or property refusal.
+
+        Properties are data descriptors: a getter without an authenticated
+        deleter raises ``AttributeError`` on the **delete** path — never by
+        consulting :meth:`attribute` / the read path.  Missing ordinary
+        fields also raise ``AttributeError``.
+        """
+        from sugar_lift_py_tests.outcome import Complete
+
+        if any(
+            method.name == name and method.descriptor_kind == "property"
+            for method in self.methods
+        ):
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+            return ground_exceptional_exit(
+                exception_name="AttributeError",
+                site=site,
+                owner="ObjectValue.delattr",
+            )
+        remaining = tuple(field for field in self.fields if field.name != name)
+        if len(remaining) == len(self.fields):
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+            return ground_exceptional_exit(
+                exception_name="AttributeError",
+                site=site,
+                owner="ObjectValue.delattr",
+            )
+        return Complete(
+            ObjectValue(
+                self.class_name,
+                remaining,
+                self.methods,
+                self.class_fields,
+                self.identity,
+                self.deferred_helper_fields,
+            )
+        )
+
     def with_deferred_helper_fields(self) -> "ObjectValue":
         names = self.helper_receiver_field_names()
         return ObjectValue(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py
@@ -8,6 +8,23 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 
 @dataclass(frozen=True)
 class AttributeDeleteEffectSugar(Sugar):
+    """`del receiver.attr` — evaluate once, then project the delete face.
+
+    Projection arms (mirrors :class:`AttributeStoreEffectSugar`):
+
+    1. **Formal receiver** → ``NativeOperationExitCarrierV1`` demand
+       ``delattr_named`` with operands
+       ``(receiver, StringValue(name))`` and coordinates
+       ``(receiver.formal_coordinate, None)``.  The n-ary projector unwraps
+       the name and calls ``receiver.delattr(name.value, site)``.  Helper
+       alone stays undischarged; an ordinary source caller supplies actuals.
+    2. **Decided runtime type** → ``receiver.delattr(attr, site)`` projecting
+       ``Completed`` or ``RaiseValue`` exceptional faces through the delete
+       path (never the read path).
+    3. **Undecided non-formal** → ``AttributeDeleteRuntimeEffect`` dual faces
+       under complementary store-outcome guards.
+    """
+
     receiver: Sugar
     attr: str
     site: object = dataclass_field(compare=False)
@@ -17,30 +34,94 @@ class AttributeDeleteEffectSugar(Sugar):
         return ()
 
     def desugar(self, ctx: object = None) -> Outcome:
+        return self.receiver.desugar(ctx).and_then(
+            lambda receiver: self._delete(receiver)
+        )
+
+    def _delete(self, receiver) -> Outcome:
+        from sugar_lift_py_tests.floor import RaiseValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        formal_coordinate = getattr(receiver, "formal_coordinate", None)
+        if formal_coordinate is not None:
+            # Undischarged demand awaiting caller actuals — not a refusal.
+            return self.mint_delattr_named_carrier(
+                site=self.site,
+                receiver=receiver,
+                attr=self.attr,
+            )
+
+        if receiver.runtime_type_is_decided():
+            projected = receiver.delattr(self.attr, self.site)
+            if isinstance(projected, Complete) and isinstance(
+                projected.value, RaiseValue
+            ):
+                return Incomplete(projected.value.effect)
+            return projected
+
         from sugar_lift_py_tests.effect import (
             AttributeDeleteRuntimeEffect,
             runtime_effect_evidence,
         )
         from sugar_lift_py_tests.ir import ctor, str_const
 
-        def delete(receiver):
-            operand = ctor(
-                "python:attribute_delete_target",
-                [receiver.to_term(owner="attribute delete"), str_const(self.attr)],
+        operand = ctor(
+            "python:attribute_delete_target",
+            [receiver.to_term(owner="attribute delete"), str_const(self.attr)],
+        )
+        return Incomplete(
+            AttributeDeleteRuntimeEffect(
+                "attribute deletion runtime boundary: Python dispatches "
+                f"__delattr__/descriptor deletion for .{self.attr}",
+                **runtime_effect_evidence("py.delattr", operand, self.site),
             )
-            return Incomplete(
-                AttributeDeleteRuntimeEffect(
-                    "attribute deletion runtime boundary: Python dispatches "
-                    f"__delattr__/descriptor deletion for .{self.attr}",
-                    **runtime_effect_evidence("py.delattr", operand, self.site),
-                )
-            )
+        )
 
-        return self.receiver.desugar(ctx).and_then(delete)
+    @staticmethod
+    def mint_delattr_named_carrier(*, site, receiver, attr: str):
+        """Producer-side contract for n-ary ``delattr_named`` discharge.
+
+        Operand order matches the projector table:
+        ``receiver.delattr(name.value, site)`` after unwrap.
+        Coordinates: ``(receiver.formal, None)`` — lengths and order are
+        load-bearing (#6613 ``__post_init__``).
+        """
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            NativeOperationExitCarrierV1,
+        )
+        from sugar_lift_py_tests.floor import StringValue
+
+        formal_coordinate = getattr(receiver, "formal_coordinate", None)
+        if formal_coordinate is None:
+            raise ValueError(
+                "delattr_named carrier requires a receiver formal_coordinate"
+            )
+        return NativeOperationExitCarrierV1.mint(
+            site=site,
+            operator="delattr_named",
+            operands=(receiver, StringValue(attr)),
+            coordinates=(formal_coordinate, None),
+        )
 
 
 @dataclass(frozen=True)
 class SubscriptDeleteEffectSugar(Sugar):
+    """`del receiver[index]` — evaluate once, then project the delete face.
+
+    Projection arms (mirrors :class:`SubscriptStoreEffectSugar`):
+
+    1. **Any formal operand** → ``NativeOperationExitCarrierV1`` demand
+       ``delitem`` with operands and coordinates in *discharge* order
+       ``(receiver, index)``.  The n-ary projector calls
+       ``receiver.delitem(index, site)``.  Helper alone stays undischarged;
+       an ordinary source caller supplies actuals.
+    2. **Decided runtime type** → ``receiver.delitem(index, site)`` projecting
+       ``Completed`` or ``RaiseValue`` exceptional faces through the delete
+       path (never the load path).
+    3. **Undecided non-formal** → loud ``SugarNotWritten`` until the
+       two-operand formal carrier is attachable.
+    """
+
     receiver: Sugar
     index: Sugar
     site: object = dataclass_field(compare=False)
@@ -50,33 +131,73 @@ class SubscriptDeleteEffectSugar(Sugar):
         return ()
 
     def desugar(self, ctx: object = None) -> Outcome:
-        from sugar_lift_py_tests.effect import (
-            SubscriptDeleteRuntimeEffect,
-            runtime_effect_evidence,
-        )
-        from sugar_lift_py_tests.ir import ctor
-
         return self.receiver.desugar(ctx).and_then(
             lambda receiver: self.index.desugar(ctx).and_then(
-                lambda index: self._delete(
-                    receiver, index, runtime_effect_evidence, ctor
-                )
+                lambda index: self._delete(receiver, index)
             )
         )
 
-    def _delete(self, receiver, index, evidence, make_ctor):
-        operand = make_ctor(
-            "python:subscript_delete_target",
-            [
-                receiver.to_term(owner="subscript delete receiver"),
-                index.to_term(owner="subscript delete index"),
-            ],
+    def _delete(self, receiver, index) -> Outcome:
+        coordinates = tuple(
+            getattr(operand, "formal_coordinate", None)
+            for operand in (receiver, index)
         )
-        from sugar_lift_py_tests.effect import SubscriptDeleteRuntimeEffect
-
-        return Incomplete(
-            SubscriptDeleteRuntimeEffect(
-                "subscript deletion runtime boundary: Python dispatches __delitem__",
-                **evidence("py.delitem", operand, self.site),
+        if any(coordinate is not None for coordinate in coordinates):
+            # Undischarged demand awaiting caller actuals — not a refusal.
+            return self.mint_delitem_carrier(
+                site=self.site,
+                receiver=receiver,
+                index=index,
             )
+        if not receiver.runtime_type_is_decided():
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                owner="SubscriptDeleteEffectSugar._delete",
+                blame=self.site,
+                observed="undischarged subscript delete over runtime-selected receiver",
+                requested=(
+                    "NativeOperationExitCarrierV1 n-ary delitem demand over "
+                    "receiver and key formal coordinates"
+                ),
+                fix=(
+                    "attach the two-operand carrier via "
+                    "SubscriptDeleteEffectSugar.mint_delitem_carrier"
+                ),
+            )
+        projected = receiver.delitem(index, self.site)
+        from sugar_lift_py_tests.floor import RaiseValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        if isinstance(projected, Complete) and isinstance(projected.value, RaiseValue):
+            return Incomplete(projected.value.effect)
+        return projected
+
+    @staticmethod
+    def mint_delitem_carrier(*, site, receiver, index):
+        """Producer-side contract for n-ary ``delitem`` discharge.
+
+        Operand order matches the projector table:
+        ``receiver.delitem(index, site)``.  Discharge order is
+        ``(receiver, index)``.  Coordinates are exactly one slot per ordered
+        operand; lengths and order are load-bearing (#6613 ``__post_init__``).
+        """
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            NativeOperationExitCarrierV1,
+        )
+
+        coordinates = tuple(
+            getattr(operand, "formal_coordinate", None)
+            for operand in (receiver, index)
+        )
+        if not any(coordinate is not None for coordinate in coordinates):
+            raise ValueError(
+                "delitem carrier requires at least one formal_coordinate among "
+                "receiver and index"
+            )
+        return NativeOperationExitCarrierV1.mint(
+            site=site,
+            operator="delitem",
+            operands=(receiver, index),
+            coordinates=coordinates,
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py
@@ -15,14 +15,17 @@ class AttributeDeleteEffectSugar(Sugar):
     1. **Formal receiver** → ``NativeOperationExitCarrierV1`` demand
        ``delattr_named`` with operands
        ``(receiver, StringValue(name))`` and coordinates
-       ``(receiver.formal_coordinate, None)``.  The n-ary projector unwraps
-       the name and calls ``receiver.delattr(name.value, site)``.  Helper
-       alone stays undischarged; an ordinary source caller supplies actuals.
+       ``(receiver.formal_coordinate, None)``.  Explicit projector
+       ``_project_delattr_named(receiver, name, site)`` unwraps the name
+       and calls ``receiver.delattr(name.value, site)`` (Python
+       ``__delattr__``).  Helper alone stays undischarged.
     2. **Decided runtime type** → ``receiver.delattr(attr, site)`` projecting
        ``Completed`` or ``RaiseValue`` exceptional faces through the delete
-       path (never the read path).
+       path (never the read path — readability never authorizes deletion).
     3. **Undecided non-formal** → ``AttributeDeleteRuntimeEffect`` dual faces
        under complementary store-outcome guards.
+
+    Out of scope: Name deletion (``del name`` / DeleteNameSugar).
     """
 
     receiver: Sugar
@@ -112,14 +115,18 @@ class SubscriptDeleteEffectSugar(Sugar):
 
     1. **Any formal operand** → ``NativeOperationExitCarrierV1`` demand
        ``delitem`` with operands and coordinates in *discharge* order
-       ``(receiver, index)``.  The n-ary projector calls
-       ``receiver.delitem(index, site)``.  Helper alone stays undischarged;
-       an ordinary source caller supplies actuals.
+       ``(receiver, index)``.  Explicit projector
+       ``_project_delitem(receiver, index, site)`` calls
+       ``receiver.delitem(index, site)`` (Python ``__delitem__``).  Helper
+       alone stays undischarged; an ordinary source caller supplies actuals.
     2. **Decided runtime type** → ``receiver.delitem(index, site)`` projecting
        ``Completed`` or ``RaiseValue`` exceptional faces through the delete
-       path (never the load path).
+       path (never the load path).  Earlier bindings survive later delete
+       halts via reducer pre-effect state on the carrier.
     3. **Undecided non-formal** → loud ``SugarNotWritten`` until the
        two-operand formal carrier is attachable.
+
+    Out of scope: Name deletion (``del name`` / DeleteNameSugar).
     """
 
     receiver: Sugar

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py
@@ -12,26 +12,27 @@ Helper alone retains the respective delete demand as an undischarged
 ``NativeOperationExitCarrierV1``. Authenticated callers discharge; mutable
 receivers complete with the element/attribute gone; missing key → named
 KeyError; missing/read-only attribute → named AttributeError — each with
-exact pre-effect state. Missing caller actual stays Undischarged. Deletion
-does not roll back earlier bindings. Swapped-coordinate and
-read-authorizes-delete twins fail.
+exact pre-effect state. Missing caller actual stays Undischarged. Earlier
+bindings survive later delete halts. Swapped-coordinate and
+read-authorizes-delete twins fail (readability never authorizes deletion).
 
-Mint contracts (to match setitem/setattr projectors once producers land):
+Mint contracts (Python protocol signatures; ordered operands + formals):
 
-  operator ``delitem``
+  operator ``delitem``  (~ ``__delitem__(self, key)``)
   operands ``(receiver, index)``  — discharge order
-  projector: ``receiver.delitem(index, site)``
+  projector: ``_project_delitem(receiver, index, site)``
   producer: ``SubscriptDeleteEffectSugar.mint_delitem_carrier``
 
-  operator ``delattr_named``
+  operator ``delattr_named``  (~ ``__delattr__(self, name)``)
   operands ``(receiver, StringValue(name))``
   coordinates ``(receiver.formal, None)``
-  projector: ``receiver.delattr(name.value, site)``
+  projector: ``_project_delattr_named(receiver, name, site)``
   producer: ``AttributeDeleteEffectSugar.mint_delattr_named_carrier``
 
-If the delete producers do not exist, reds name the exact missing methods —
-that is a valid deliverable. Tests only: no carrier/ExitSet, store
-producers/projectors, or parameter-map edits.
+Equality tooth: production-minted operator set == projector-table keys.
+
+Out of scope: Name deletion (``del name`` / DeleteNameSugar) — not delitem,
+not delattr_named.
 """
 
 from __future__ import annotations
@@ -44,6 +45,9 @@ import pytest
 from sugar_lift_py_tests.caller_parameter_contract import (
     NativeOperationExitCarrierV1,
     _NATIVE_OPERATION_PROJECTORS,
+    _project_delattr_named,
+    _project_delitem,
+    production_native_operation_operators,
 )
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import (
@@ -217,23 +221,81 @@ def test_delattr_producer_method_is_enrolled_or_named_missing() -> None:
 
 
 def test_delitem_projector_is_enrolled_or_named_missing() -> None:
+    """Explicit projector matches Python ``__delitem__(self, key)`` arity."""
     assert "setitem" in _NATIVE_OPERATION_PROJECTORS
     if "delitem" not in _NATIVE_OPERATION_PROJECTORS:
         raise AssertionError(f"missing projector {MISSING_DELITEM_PROJECTOR}")
-    parameters = tuple(
-        inspect.signature(_NATIVE_OPERATION_PROJECTORS["delitem"]).parameters
-    )
+    projector = _NATIVE_OPERATION_PROJECTORS["delitem"]
+    assert projector is _project_delitem
+    parameters = tuple(inspect.signature(projector).parameters)
     assert parameters == ("receiver", "index", "site")
 
 
 def test_delattr_projector_is_enrolled_or_named_missing() -> None:
+    """Explicit ``delattr_named(receiver, name, site)`` projector enrolled."""
     assert "setattr_named" in _NATIVE_OPERATION_PROJECTORS
     if "delattr_named" not in _NATIVE_OPERATION_PROJECTORS:
         raise AssertionError(f"missing projector {MISSING_DELATTR_PROJECTOR}")
-    parameters = tuple(
-        inspect.signature(_NATIVE_OPERATION_PROJECTORS["delattr_named"]).parameters
-    )
+    projector = _NATIVE_OPERATION_PROJECTORS["delattr_named"]
+    assert projector is _project_delattr_named
+    parameters = tuple(inspect.signature(projector).parameters)
     assert parameters == ("receiver", "name", "site")
+
+
+def test_production_minted_operators_equal_projector_keys_including_delete() -> None:
+    """Equality tooth: production set == projector keys (delete twins included)."""
+    production = production_native_operation_operators()
+    projectors = frozenset(_NATIVE_OPERATION_PROJECTORS)
+    assert production == projectors, (
+        f"missing_projectors={sorted(production - projectors)} "
+        f"orphan_projectors={sorted(projectors - production)}"
+    )
+    assert {"delitem", "delattr_named"} <= production
+    assert {"delitem", "delattr_named"} <= projectors
+
+
+def test_ordered_operands_and_formals_match_protocol_signatures() -> None:
+    """Mint coordinate order is protocol discharge order, not source-eval order."""
+    _, delitem = _delitem_helper()
+    delitem = _require_delitem_carrier(delitem)
+    assert delitem.demand.operator == "delitem"
+    assert tuple(v.term.name for v in delitem.operands) == ("obj", "key")
+    assert list(inspect.signature(_project_delitem).parameters) == [
+        "receiver",
+        "index",
+        "site",
+    ]
+
+    _, delattr_c = _delattr_helper()
+    delattr_c = _require_delattr_carrier(delattr_c)
+    assert delattr_c.demand.operator == "delattr_named"
+    assert delattr_c.demand.operand_coordinate_cids == (
+        delattr_c.demand.operand_coordinate_cids[0],
+        None,
+    )
+    assert isinstance(delattr_c.operands[1], StringValue)
+    assert list(inspect.signature(_project_delattr_named).parameters) == [
+        "receiver",
+        "name",
+        "site",
+    ]
+
+
+def test_name_deletion_is_out_of_scope_for_delitem_and_delattr_named() -> None:
+    """``del name`` is DeleteNameSugar territory — not delitem/delattr_named."""
+    source = "def helper(x):\n    del x\n"
+    tree = _tree(source, "name_delete_out_of_scope.py")
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    pending = function.sugar().desugar(None)
+    if isinstance(pending, NativeOperationExitCarrierV1):
+        assert pending.demand.operator not in {"delitem", "delattr_named"}, (
+            "Name deletion must not mint delitem/delattr_named"
+        )
+    # Positive: attribute/subscript delete still own those operators.
+    _, item = _delitem_helper()
+    assert _require_delitem_carrier(item).demand.operator == "delitem"
+    _, attr = _delattr_helper()
+    assert _require_delattr_carrier(attr).demand.operator == "delattr_named"
 
 
 # ===========================================================================

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py
@@ -479,7 +479,14 @@ def test_deletion_does_not_roll_back_earlier_bindings_on_keyerror() -> None:
 
 
 def test_swapped_receiver_index_coordinates_rejected_against_truthful_delete() -> None:
-    """Lying mint (receiver/index swapped) must not equal truthful post-state."""
+    """Lying mint (receiver/index swapped) must not equal truthful post-state.
+
+    Swapped discharge puts the index formal in the receiver slot; Floor
+    ``TermValue.delitem`` refuses loudly (ConstructionPanic).  That is a valid
+    discrimination face — the lying mint must not complete the truthful list.
+    """
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
     function, truthful = _delitem_helper()
     truthful = _require_delitem_carrier(truthful)
     site = function.body[0].fragment
@@ -496,10 +503,14 @@ def test_swapped_receiver_index_coordinates_rejected_against_truthful_delete() -
         key_c.coordinate_cid: TermValue(0),
     }
     truthful_exits = truthful.discharge(actuals)
-    lying_exits = lying.discharge(actuals)
     assert isinstance(truthful_exits.exits[0], Completed)
     truthful_list = _deleted_list(truthful_exits.exits[0])
     assert truthful_list == ListValue((TermValue(1),))
+    try:
+        lying_exits = lying.discharge(actuals)
+    except ConstructionPanic:
+        # Receiver slot received TermValue — Floor refuses delitem. Discrimination holds.
+        return
     lying_face = lying_exits.exits[0]
     if isinstance(lying_face, Completed):
         lying_value = lying_face.value

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -791,6 +791,11 @@ def test_production_minted_operators_equal_projector_table_exactly():
     assert "subscript" in projectors
     assert "setitem" in projectors
     assert "setattr_named" in projectors
+    # Store-family delete twins: production set == projector keys (both ways).
+    assert "delitem" in projectors
+    assert "delattr_named" in projectors
+    assert "delitem" in production
+    assert "delattr_named" in production
 
 
 def test_symbolic_formal_subscript_discharges_completed_through_projector():


### PR DESCRIPTION
## Summary

Ownership extension on the store-family delete vertical (#6697 instruments): implement the **named producers** and projectors so formal delete chases green.

### Producers (mirrors setitem/setattr_named)

| Method | Operator | Operands / coordinates | Projector |
|--------|----------|------------------------|-----------|
| `SubscriptDeleteEffectSugar.mint_delitem_carrier` | `delitem` | `(receiver, index)` / formal slots | `receiver.delitem(index, site)` |
| `AttributeDeleteEffectSugar.mint_delattr_named_carrier` | `delattr_named` | `(receiver, StringValue(name))` / `(receiver.formal, None)` | `receiver.delattr(name.value, site)` |

Formal receivers mint **undischarged carriers**, not dual-faced RuntimeEffect. Decided receivers project through Floor delete; undecided non-formals retain RuntimeEffect dual faces.

### Shared enrollment

- `_NATIVE_OPERATION_PROJECTORS['delitem' | 'delattr_named']`
- `production_native_operation_operators` contracted store/delete set includes both

### Floor faces for exceptional discharge

- `ObjectValue.delattr` — field gone, missing/property → ground `AttributeError`
- `DictValue.delitem` missing ground key → ground `KeyError` (was illegal RuntimeEffect mint)
- `FloorValue.delattr` base construction panic (arm ladder)

### Must not touch (honored)

Carrier/ExitSet core; setitem/setattr producers untouched beyond shared projector enrollment table.

### Validation

```
cd implementations/python/sugar-lift-py-tests && ../../../bin/bpytest \
  tests/test_delete_formal_caller.py \
  tests/test_setitem_formal_caller.py \
  tests/test_setattr_named_formal_caller.py -q
# 60 passed

../../../bin/bpytest tests/test_native_operation_exit_carrier.py tests/test_attribute_native_operation_demand.py -q
# 55 passed
```

### Shot accounting

- **R axis:** formal delete verticals (delitem + delattr_named)
- **Epsilon R:** −21 red instruments → 0 (24/24 green on delete suite)
- **Floors:** no carrier/ExitSet edits; store producers unchanged
- **Shell deleted:** dual-face RuntimeEffect path for formal delete receivers — replaced by undischarged mint carriers

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `delitem` and `delattr_named` mint carriers and projectors for delete operations
> - Adds `_project_delitem` and `_project_delattr_named` projector functions to the `_NATIVE_OPERATION_PROJECTORS` table in [caller_parameter_contract.py](https://github.com/TSavo/sugar/pull/6699/files#diff-5136726cb5a60b48beb30152aecb6eca8ad0173bdefc676eb112b1c1b2acbf57), and includes both operators in `production_native_operation_operators`.
> - Rewrites `AttributeDeleteEffectSugar` and `SubscriptDeleteEffectSugar` in [delete_effect_sugar.py](https://github.com/TSavo/sugar/pull/6699/files#diff-d5a3db73a2e419b12a61ff4b4c0616c177ae77361c5f7de3a02053c360131345) to mint `NativeOperationExitCarrierV1` carriers when a formal coordinate is present, or dispatch directly to Floor when the receiver runtime type is decided.
> - Adds `ObjectValue.delattr` in [object_value.py](https://github.com/TSavo/sugar/pull/6699/files#diff-915d55e3a0e35db85dc48bceffe52001584a598ab89e134e598a042edea35a7b) to support attribute deletion, grounding `AttributeError` for missing or property-backed fields.
> - Adds a default `FloorValue.delattr` in [floor_value.py](https://github.com/TSavo/sugar/pull/6699/files#diff-e465d9d796b4d8a065950433dc35b2a788306abfe91dab378d35f42a38a2cdd7) that raises a construction panic for unimplemented subtypes.
> - Updates `DictValue.delitem` in [dict_value.py](https://github.com/TSavo/sugar/pull/6699/files#diff-76c3d825471eeab5a86de09645ff49d3e80a9f865138d6646ad5b6ef3e2e1002) to ground a `KeyError` via `ground_exceptional_exit` instead of minting a `KeyErrorRuntimeEffect`-based incomplete.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f67c73b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->