### PR TITLE
ObjectValue.attribute: AttributeError after authenticated delattr

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -100,6 +100,13 @@ class ObjectValue(FloorValue):
     class_fields: tuple[ObjectField, ...] = ()
     identity: str = ""
     deferred_helper_fields: tuple[str, ...] = dataclass_field(default=(), compare=False)
+    # Instance field names removed by an authenticated delattr.  Reading one
+    # of these is AttributeError (delete readback), without inventing
+    # AttributeError for unenrolled members of a partial construction
+    # (those stay undecided via deferred_helper_fields / undecided_attribute).
+    deleted_instance_fields: tuple[str, ...] = dataclass_field(
+        default=(), compare=False
+    )
 
     def format_data_model(self, spec, site, ctx):
         return self.call_method_value(
@@ -194,6 +201,16 @@ class ObjectValue(FloorValue):
                 owner="ObjectValue.attribute.property",
                 blame=site,
             ).and_then(invoke)
+        if name in self.deleted_instance_fields:
+            # Authenticated delattr removed this instance field — read is
+            # AttributeError with delete→read lineage, not an undecided gap.
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+            return ground_exceptional_exit(
+                exception_name="AttributeError",
+                site=site,
+                owner="ObjectValue.attribute",
+            )
         if name in self.deferred_helper_fields:
             from sugar_lift_py_tests.floor.getattr_coordinate import (
                 getattr_coordinate,
@@ -205,6 +222,8 @@ class ObjectValue(FloorValue):
         # with an honest owner name — do not fall through to the generic
         # FloorValue.attribute owner="attribute" panic, and do not invent
         # AttributeError for a member table that is not source-complete.
+        # (Contrast: names in deleted_instance_fields above — those absences
+        # are delete-authenticated, not construction incompleteness.)
         return self.undecided_attribute(name, site, owner="ObjectValue.attribute")
 
     def with_field_store(self, name: str, value: FloorValue) -> "ObjectValue":
@@ -226,6 +245,8 @@ class ObjectValue(FloorValue):
                 ),
             )
         remaining = tuple(field for field in self.fields if field.name != name)
+        # Restore retires the deleted-field mark for this name.
+        still_deleted = tuple(d for d in self.deleted_instance_fields if d != name)
         return ObjectValue(
             self.class_name,
             (*remaining, ObjectField(name, value)),
@@ -233,6 +254,7 @@ class ObjectValue(FloorValue):
             self.class_fields,
             self.identity,
             self.deferred_helper_fields,
+            still_deleted,
         )
 
     def authenticates_plain_attribute_store(self, name: str) -> bool:
@@ -294,6 +316,11 @@ class ObjectValue(FloorValue):
                 site=site,
                 owner="ObjectValue.delattr",
             )
+        deleted = (
+            self.deleted_instance_fields
+            if name in self.deleted_instance_fields
+            else (*self.deleted_instance_fields, name)
+        )
         return Complete(
             ObjectValue(
                 self.class_name,
@@ -302,6 +329,7 @@ class ObjectValue(FloorValue):
                 self.class_fields,
                 self.identity,
                 self.deferred_helper_fields,
+                deleted,
             )
         )
 
@@ -314,6 +342,7 @@ class ObjectValue(FloorValue):
             self.class_fields,
             self.identity,
             names,
+            self.deleted_instance_fields,
         )
 
     def helper_receiver_field_names(self) -> tuple[str, ...]:


### PR DESCRIPTION
## Summary

Fixes the honest Floor residual from #6702: after a completed `delattr`, `ObjectValue.attribute` of that name must yield **named AttributeError**, not `SugarNotWritten` undecided.

### Design

`ObjectValue` gains `deleted_instance_fields` — names removed by authenticated `delattr`. 

| Path | Behavior |
|------|----------|
| `attribute(name)` and `name in deleted_instance_fields` | `ground_exceptional_exit(AttributeError)` |
| Missing name not deleted, no deferred helper | still `undecided_attribute` (partial construction) |
| `setattr` restore of a deleted name | retires the deleted mark |
| `delattr` of present field | records the name in `deleted_instance_fields` |

This does **not** invent AttributeError for unenrolled members of incomplete constructions — only absences authenticated by delete.

### Must not touch (honored)

Carrier/ExitSet; other Floor families.

### Validation

```
cd implementations/python/sugar-lift-py-tests && ../../../bin/bpytest \
  tests/test_delete_readback_laws.py \
  tests/test_delete_formal_caller.py \
  tests/test_delete_state_joins.py \
  tests/test_setattr_named_formal_caller.py -q
# 69 passed
```

### Shot accounting

- **R axis:** Floor delete readback AttributeError residual from #6702
- **Epsilon R:** −1 red instrument (readback suite fully green)
- **Floors:** ObjectValue only
- **Shell deleted:** SugarNotWritten undecided path for post-delattr instance field reads

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ObjectValue.attribute` to raise AttributeError after authenticated `delattr`
> Adds a `deleted_instance_fields` tuple to the `ObjectValue` dataclass to track instance fields removed via authenticated `delattr`. Reading a deleted field now returns a ground exceptional exit for `AttributeError` instead of falling through to deferred helper logic or returning undecided.
>
> - `ObjectValue.delattr` records the deleted field name in `deleted_instance_fields` on success.
> - `ObjectValue.attribute` checks `deleted_instance_fields` first and short-circuits with an `AttributeError` exit if the field was deleted.
> - `ObjectValue.with_field_store` clears the deletion mark for a field when it is written back, so subsequent reads resolve normally.
> - `ObjectValue.with_deferred_helper_fields` propagates `deleted_instance_fields` so deletion state is preserved across deferred helper transitions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8522838.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->