### PR TITLE
Construct only reachable local definitions for source frames

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
@@ -14,11 +14,15 @@ import pytest
 from pandas import Series, Timedelta
 
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
-from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
 from sugar_lift_py_tests.floor import CallSiteValue, StringValue
 from sugar_lift_py_tests.ir import ctor, str_const
 from sugar_lift_py_tests.outcome import ExitSet
 from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+from sugar_lift_py_tests.source_call_resolution import SourceCallPreconstructionRefV1
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.source_call_preconstruction import (
     populate_source_visible_call_frames,
@@ -454,6 +458,53 @@ def test_authenticated_box_expected_actual_names_type_error_edge(
         ),
     )
     assert routed.exits == (original,)
+
+
+def test_installed_box_expected_source_call_has_an_authenticated_frame(
+    tmp_path: Path,
+) -> None:
+    """Seam-1 specimen: installed ``tm.box_expected`` keeps its authenticated frame.
+
+    Unrelated class/method body panics (Compare leg site in numpy_ arrays)
+    must not erase the box_expected frame. Reachable-only source-frame
+    construction parks incomplete callees; the leg-site panic itself is not
+    weakened when that definition is the authenticated target.
+    """
+    source = (
+        "import pandas as pd\n"
+        "import pandas._testing as tm\n"
+        "actual = tm.box_expected((1,), pd.array)\n"
+    )
+    path = tmp_path / "installed-box-actual.py"
+    path.write_text(source, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction(
+        workspace_root=str(tmp_path)
+    )
+    tree = SourceFile(
+        workspace_path_source(str(path), root=str(tmp_path)),
+        construction_context=context,
+    )
+    call = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, SourceCall)
+        and getattr(node.func, "attr", None) == "box_expected"
+    )
+
+    populate_source_visible_call_frames(tree, root=tmp_path, path=path)
+
+    span = call.line_col_span()
+    coordinate = SourceFragmentCoordinateV1(
+        tree.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    assert isinstance(
+        context.source_call_resolutions[coordinate],
+        SourceCallPreconstructionRefV1,
+    )
 
 
 def test_runtime_wrong_expected_type_does_not_consume_candidate_exception() -> None:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1046,31 +1046,13 @@ def _resolve_source_visible_frame_uncached(
             return base.value.id
         return None
 
-    reachable_names = {target.name}
-    pending_names = [target.name]
-    while pending_names:
-        current = definitions_by_name[pending_names.pop()]
-        dependencies = []
-        if isinstance(current, ClassDef):
-            dependencies.extend(
-                name
-                for base in current.bases
-                if (name := _local_class_base_name(base)) is not None
-            )
-            functions = tuple(
-                item for item in current.body if isinstance(item, FunctionDef)
-            )
-        else:
-            functions = (current,)
-        dependencies.extend(
-            call.func.id
-            for function in functions
-            for call in _local_named_calls(function)
-        )
-        for name in dependencies:
-            if name in definitions_by_name and name not in reachable_names:
-                reachable_names.add(name)
-                pending_names.append(name)
+    # REACHABLE-ONLY definition graph. Frame projection constructs only the
+    # authenticated target and definitions it references by authenticated
+    # local edges (bases + named calls in the target's own frame surface).
+    # Unrelated module-level classes are never constructor-sugared just because
+    # they share a source file — their panics stay loud only if this target
+    # actually reaches them.
+    reachable_names = _reachable_local_definition_names(target, definitions_by_name)
     definitions = tuple(item for item in definitions if item.name in reachable_names)
 
     # Imported calls inside the authenticated factory body are ordinary source
@@ -1158,9 +1140,27 @@ def _resolve_source_visible_frame_uncached(
                 ),
             )
             continue
-        projected = resolve_source_visible_frame(
-            imported, graph=dependency_graph, session=session
-        )
+        from sugar_source_tree.panic import SugarNotWritten
+
+        try:
+            projected = resolve_source_visible_frame(
+                imported, graph=dependency_graph, session=session
+            )
+        except SugarNotWritten as exc:
+            # Imported callee body is incomplete: park the obligation, do not
+            # erase the outer authenticated target frame.
+            _install_opaque_call_obligation(
+                context,
+                call,
+                OpaqueSourceCallObligationV1(
+                    _call_coordinate(call),
+                    receipt.target_symbol,
+                    resolved.cid,
+                    resolution_kind="call-target-export-unresolved",
+                ),
+            )
+            del exc
+            continue
         if isinstance(projected, ManagerConstructionGapV1):
             kind = (
                 "call-graph-cycle"
@@ -1282,6 +1282,8 @@ def _resolve_source_visible_frame_uncached(
     reaching_classes: dict[str, ClassDef] = {}
     from sugar_source_tree.panic import SugarNotWritten
 
+    # Only reachable ClassDefs (see filter above). Never constructor-sugar an
+    # unrelated module-level class just because it shares this source file.
     for item in definitions:
         if not isinstance(item, ClassDef):
             continue
@@ -1303,8 +1305,11 @@ def _resolve_source_visible_frame_uncached(
             context.source_class_bases[item.fragment.seal().cid] = tuple(local_bases)
         reaching_classes[item.name] = item
     for item in definitions:
-        if isinstance(item, ClassDef):
-            frames[item.name] = item.source_visible_constructor_frame()
+        if not isinstance(item, ClassDef):
+            continue
+        # Target class (or a local class the target actually reaches): panics
+        # stay loud. There is no soft-green for a reached broken definition.
+        frames[item.name] = item.source_visible_constructor_frame()
 
     pending = [item for item in definitions if isinstance(item, FunctionDef)]
     while pending:
@@ -1404,7 +1409,17 @@ def _resolve_external_call_frame(
     )
     if not isinstance(callee, _Resolved):
         return _ExternalCallTargetGap("call-target-source-absent")
-    projected = resolve_source_visible_frame(callee, graph=graph, session=session)
+    from sugar_source_tree.panic import SugarNotWritten
+
+    try:
+        projected = resolve_source_visible_frame(callee, graph=graph, session=session)
+    except SugarNotWritten:
+        # Callee body is incomplete (e.g. Compare leg gap inside a method of a
+        # class this target only *names*).  Park the free-name obligation; do
+        # not erase the outer authenticated target frame.  When that broken
+        # definition IS the outer target, resolve_source_visible_frame is the
+        # entry door and the panic stays loud there.
+        return _ExternalCallTargetGap("call-target-export-unresolved")
     if isinstance(projected, ManagerConstructionGapV1):
         # A cycle reached through a re-export hop is still a cycle.  Read the
         # callee's OWN authenticated gap kind rather than restating the hop as a
@@ -1421,6 +1436,95 @@ def _resolve_export(*args, **kwargs):
     from .dependency_artifact import _resolve_export as _door
 
     return _door(*args, **kwargs)
+
+
+def _reachable_local_definition_names(
+    target: Node, definitions_by_name: dict[str, Node]
+) -> set[str]:
+    """Local definitions the authenticated target reaches by reference.
+
+    Edges are authenticated structure only:
+
+    * Class bases named as local ``Name`` / ``Name[T]`` (not attributed/computed)
+    * Named local calls inside the target function, or — for a ClassDef target —
+      inside ``__init__`` and class-level field RHS only (not every method body)
+
+    Method bodies of a class are NOT scanned when expanding the graph for a
+    sibling or for a function target that never names the class.  That keeps
+    unrelated module classes (and panics inside their methods) from aborting a
+    target that does not reach them.  When the target *is* that class, its
+    constructor frame still sugars the full definition and method panics stay
+    loud at the target door.
+    """
+    if not isinstance(target, (FunctionDef, ClassDef)):
+        return set()
+    # Method targets are not module-level definitions_by_name keys; their
+    # enclosing class is not automatically enrolled.  Only __call__ early-exit
+    # handles method frames.  Module-level targets start at their own name.
+    if target.name not in definitions_by_name:
+        return {target.name} if isinstance(target, FunctionDef) else set()
+
+    reachable: set[str] = {target.name}
+    pending = [target.name]
+
+    def _local_class_base_name(base: Node) -> str | None:
+        if isinstance(base, Name):
+            return base.id
+        if isinstance(base, Subscript) and isinstance(base.value, Name):
+            return base.value.id
+        return None
+
+    while pending:
+        current = definitions_by_name[pending.pop()]
+        dependencies: list[str] = []
+        if isinstance(current, ClassDef):
+            dependencies.extend(
+                name
+                for base in current.bases
+                if (name := _local_class_base_name(base)) is not None
+            )
+            # Constructor surface only: __init__ + class-body field values.
+            # Do not name-scan every method — that is the "every class in the
+            # module" residual when one class's method mentions another.
+            functions = tuple(
+                item
+                for item in current.body
+                if isinstance(item, FunctionDef) and item.name == "__init__"
+            )
+            for item in current.body:
+                if isinstance(item, Assign):
+                    # field = LocalClass(...) edges are real construction refs.
+                    for call in _named_calls_under(item.value):
+                        dependencies.append(call.func.id)
+                elif (
+                    isinstance(item, AnnAssign)
+                    and item.value is not None
+                ):
+                    for call in _named_calls_under(item.value):
+                        dependencies.append(call.func.id)
+        else:
+            functions = (current,)
+        dependencies.extend(
+            call.func.id
+            for function in functions
+            for call in _local_named_calls(function)
+        )
+        for name in dependencies:
+            if name in definitions_by_name and name not in reachable:
+                reachable.add(name)
+                pending.append(name)
+    return reachable
+
+
+def _named_calls_under(node: Node):
+    """Named ``Call`` nodes under one expression (authenticated AST walk)."""
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Call) and isinstance(current.func, Name):
+            yield current
+        children = [child for _, _, child in current.children()]
+        stack.extend(children)
 
 
 def _matches_definition(node: Node, resolved: ResolvedPythonObjectV1) -> bool:

--- a/implementations/python/sugar-lift-python-source/tests/test_reachable_source_frame_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reachable_source_frame_construction.py
@@ -1,0 +1,200 @@
+"""Reachable-only source-frame construction.
+
+``_resolve_source_visible_frame_uncached`` constructs only the authenticated
+target's local definition graph. Unrelated module classes must not abort the
+target frame. Unrelated-class panics stay loud when that definition *is* the
+target (or is actually reached). Compare leg-site panics are never weakened.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.source_call_resolution import (
+    SourceCallPreconstructionGapV1,
+    SourceCallPreconstructionRefV1,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.source_call_preconstruction import (
+    populate_source_visible_call_frames,
+)
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.nodes import Call as SourceCall
+from sugar_source_tree.tree import SourceFile
+
+
+def _distribution(root: Path, package: str, module_source: str, export: str):
+    pkg = root / package
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text(
+        f"from {package}.mod import {export}\n", encoding="utf-8"
+    )
+    (pkg / "mod.py").write_text(module_source, encoding="utf-8")
+    meta = root / f"{package}_dist-1.0.dist-info"
+    meta.mkdir()
+    (meta / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {package}-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        f"{package}/__init__.py",
+        f"{package}/mod.py",
+        f"{package}_dist-1.0.dist-info/METADATA",
+        f"{package}_dist-1.0.dist-info/RECORD",
+    )
+    with (meta / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(meta)
+
+
+def _populate(tmp_path: Path, package: str, module_source: str, export: str, consumer: str):
+    dist = _distribution(tmp_path, package, module_source, export)
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction(
+        workspace_root=str(tmp_path)
+    )
+    tree = SourceFile(
+        workspace_path_source(str(path), root=str(tmp_path)),
+        construction_context=context,
+    )
+    # Inject distribution index via authenticate path: populate uses
+    # authenticate_dependency_top_level which reads installed packages.
+    # For unit tests we rely on the package layout under tmp_path being
+    # discoverable — same pattern as other source-call instruments.
+    populate_source_visible_call_frames(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={package: dist},
+    )
+    return context, tree
+
+
+_BROKEN_SIBLING_MODULE = (
+    "def target_fn(x):\n"
+    "    return x + 1\n"
+    "\n"
+    "class BrokenSibling:\n"
+    "    def method(self, a, b):\n"
+    "        # multi-op Compare — same family as numpy_ leg-site residual\n"
+    "        return a < b < 3\n"
+)
+
+
+def test_target_with_broken_sibling_constructs_authenticated_frame(tmp_path: Path):
+    """Broken sibling class in the same module must not erase target_fn frame."""
+    context, tree = _populate(
+        tmp_path,
+        package="reach_pkg",
+        module_source=_BROKEN_SIBLING_MODULE,
+        export="target_fn",
+        consumer=(
+            "from reach_pkg import target_fn\n" "result = target_fn(1)\n"
+        ),
+    )
+    call = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, SourceCall)
+        and getattr(node.func, "id", None) == "target_fn"
+    )
+    span = call.line_col_span()
+    coordinate = SourceFragmentCoordinateV1(
+        tree.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    ref = context.source_call_resolutions.get(coordinate)
+    assert isinstance(ref, SourceCallPreconstructionRefV1), (
+        f"expected authenticated frame for target_fn; got {type(ref).__name__}: {ref}"
+    )
+
+
+def test_target_that_is_broken_class_stays_loud(tmp_path: Path):
+    """When the authenticated target *is* the broken class, panic stays loud."""
+    context, tree = _populate(
+        tmp_path,
+        package="reach_pkg2",
+        module_source=_BROKEN_SIBLING_MODULE,
+        export="BrokenSibling",
+        consumer=(
+            "from reach_pkg2 import BrokenSibling\n" "obj = BrokenSibling()\n"
+        ),
+    )
+    call = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, SourceCall)
+        and getattr(node.func, "id", None) == "BrokenSibling"
+    )
+    span = call.line_col_span()
+    coordinate = SourceFragmentCoordinateV1(
+        tree.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    result = context.source_call_resolutions.get(coordinate)
+    assert not isinstance(result, SourceCallPreconstructionRefV1), (
+        "broken class target must not mint an authenticated frame"
+    )
+    assert isinstance(result, SourceCallPreconstructionGapV1), type(result)
+    # Body gap (Compare leg) or construction gap — never silent green.
+    assert result.kind in {
+        "source-body-gap",
+        "force-floor",
+        "call-target-export-unresolved",
+        "artifact-resolution",
+    }
+
+
+def test_target_actually_reaching_broken_local_class_stays_loud(tmp_path: Path):
+    """Local named call to a broken class is a real reach — construction stays loud."""
+    module = (
+        "class BrokenSibling:\n"
+        "    def method(self, a, b):\n"
+        "        return a < b < 3\n"
+        "\n"
+        "def target_fn(x):\n"
+        "    return BrokenSibling()\n"
+    )
+    context, tree = _populate(
+        tmp_path,
+        package="reach_pkg3",
+        module_source=module,
+        export="target_fn",
+        consumer=(
+            "from reach_pkg3 import target_fn\n" "result = target_fn(1)\n"
+        ),
+    )
+    call = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, SourceCall)
+        and getattr(node.func, "id", None) == "target_fn"
+    )
+    span = call.line_col_span()
+    coordinate = SourceFragmentCoordinateV1(
+        tree.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    result = context.source_call_resolutions.get(coordinate)
+    # Target reaches BrokenSibling locally → constructor sugar panics → gap/raise.
+    assert not isinstance(result, SourceCallPreconstructionRefV1), result


### PR DESCRIPTION
## Summary

**Blocks seam-1 real specimen** (`tm.box_expected` authenticated frame).

`_resolve_source_visible_frame_uncached` was losing authenticated frames when an incomplete **external** callee (or an over-broad local class graph) raised mid-construction — notably `Compare._comparison_leg_site` inside `pandas/core/arrays/numpy_.py` while projecting `box_expected`.

### Contract
- Construct only the authenticated target's **reachable local definition graph**
- Reachability by authenticated reference (bases + named calls on the target frame surface), not whole-module method scanning
- Unrelated module classes are not constructor-sugared
- Unrelated-class / callee body panics stay **loud when that definition is the target or is locally reached**
- External incomplete callees **park** as `call-target-export-unresolved` — do not erase the outer frame
- **Does not weaken** `Compare._comparison_leg_site`

### Twins
1. `target_fn` + broken sibling class in same module → **authenticated frame**
2. Target *is* broken class, or target **locally** constructs broken class → **still loud gap**
3. Acceptance: `test_installed_box_expected_source_call_has_an_authenticated_frame`

## Shot accounting (8-field)

| Field | Value |
| --- | --- |
| **R axis** | `source_frame_unrelated_class_abort` |
| **Epsilon R** | −1 box_expected / outer frames erased by unrelated callee body panics |
| **Floors** | Compare leg-site panic unchanged; reached broken definitions still loud |
| **Instrument** | `test_installed_box_expected_source_call_has_an_authenticated_frame` + `test_reachable_source_frame_construction` twins |
| **Local evidence** | 4 focused + 28 source-call preconstruction green |
| **Observed residual** | Class constructor frame still sugars full method set when the **class itself** is the target |
| **Background** | CI after merge |
| **Shell retired** | Whole-module class constructor sugar as default for every frame project |

## Test plan

- [x] `test_installed_box_expected_source_call_has_an_authenticated_frame`
- [x] broken sibling / reached broken / broken target twins
- [x] source-call preconstruction + external call target suite
- [ ] CI

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct only reachable local definitions when resolving source frames
> - Adds `_reachable_local_definition_names` to [manager_construction.py](https://github.com/TSavo/sugar/pull/6707/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to limit frame construction to AST nodes reachable from the call target, avoiding processing broken sibling classes or unreachable definitions.
> - Updates `_resolve_source_visible_frame_uncached` to return specific `ManagerConstructionGapV1` values for call-graph cycles, unresolved call targets, projection exceptions (`force-floor`), and missing frames instead of raising or silently continuing.
> - Adds tests in [test_reachable_source_frame_construction.py](https://github.com/TSavo/sugar/pull/6707/files#diff-08f558e129188de386ac34da8e29088a038e81ef88b36575a4b65f89e54f53f9) covering: targets with broken sibling classes still resolving successfully, broken class targets returning a gap, and functions that reach a broken local class also returning a gap.
> - Behavioral Change: modules with broken sibling definitions no longer cause resolution of unrelated call targets to fail; each gap case now returns a typed gap rather than propagating an exception.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f985342.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-frame construction so valid exported targets retain authenticated frames even when unrelated classes contain unsupported code.
  * Preserved clear failure behavior when a target directly reaches unsupported or incomplete code.
  * Improved handling of incomplete external call information without discarding valid outer frames.

* **Tests**
  * Added coverage for authenticated pandas call frames and reachable-only source-frame construction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->