### PR TITLE
Pair import-use source CID to retained source text at mint

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -839,6 +839,26 @@ def _lexical_revalidation_snapshot(
     return snapshot
 
 
+def _paired_source_cid(source: str, claimed_source_cid: str) -> str:
+    """Content-address of the retained source string (path_source law).
+
+    Import-use receipts pin ``source`` + ``source_cid`` together. A dual-door
+    mint — ``read_text()`` for the string and ``blake3(read_bytes())`` for the
+    CID — goes stale under CRLF/universal-newlines translation: the retained
+    source no longer recomputes to the claimed CID, and
+    ``AuthenticatedImportUseV1`` refuses before any nested producer can run.
+
+    The oracle door is one line: CID = blake3(source.encode("utf-8")). When the
+    claim disagrees, repair the pair from the retained source text. This is not
+    a consumer recompute and not a disk re-read — it restores the only identity
+    the lexical pass can honestly authenticate (the text it was given).
+    """
+    expected = blake3_512_of(source.encode("utf-8"))
+    if claimed_source_cid != expected:
+        return expected
+    return claimed_source_cid
+
+
 def authenticated_import_uses(
     root: Path,
     path: Path,
@@ -846,6 +866,7 @@ def authenticated_import_uses(
     source_cid: str,
     module_identities: dict[str, dict[str, Any]] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]]:
+    source_cid = _paired_source_cid(source, source_cid)
     module = SourceFile((source, str(path), source_cid)).root
     module_name = module_name_for_path(root, path)
     identities = module_identities or {}
@@ -903,6 +924,9 @@ def authenticated_import_use_receipts(
     module_identities: dict[str, dict[str, Any]] | None = None,
 ) -> tuple[list[AuthenticatedImportUseV1], dict[tuple[int, int, int, int], str]]:
     """Return typed, final-checked receipts from the sole lexical pass."""
+    # Pair before the pass so use-site / demand preimages embed the same CID
+    # AuthenticatedImportUseV1 will require of the retained source.
+    source_cid = _paired_source_cid(source, source_cid)
     rows, outcomes = authenticated_import_uses(
         root, path, source, source_cid, module_identities=module_identities
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_use_source_cid_pairing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_use_source_cid_pairing.py
@@ -1,0 +1,131 @@
+"""Import-use source CID must pair with retained source text (path_source law).
+
+Dual-door identity — ``read_text()`` for the string and ``blake3(read_bytes())``
+for the CID — goes stale under CRLF/universal-newlines translation and aborts
+nested-manager publication before lifecycle. The producer mint repairs the pair
+from the retained source without re-reading disk or weakening authentication.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_py_tests.import_binding import (
+    _paired_source_cid,
+    authenticated_import_use_receipts,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+
+
+def test_paired_source_cid_repairs_dual_door_crlf(tmp_path: Path) -> None:
+    """read_text + blake3(read_bytes) under CRLF must not refuse mint."""
+    path = tmp_path / "consumer.py"
+    path.write_bytes(b"from pkg import f\r\nx = f()\r\n")
+    # Dual-door (the historical nested-manager fixture pattern):
+    source = path.read_text(encoding="utf-8")  # LF after universal newlines
+    claimed = blake3_512_of(path.read_bytes())  # still CRLF bytes
+    assert blake3_512_of(source.encode("utf-8")) != claimed
+
+    paired = _paired_source_cid(source, claimed)
+    assert paired == blake3_512_of(source.encode("utf-8"))
+    assert paired != claimed
+
+    receipts, outcomes = authenticated_import_use_receipts(
+        tmp_path, path, source, claimed, module_identities={}
+    )
+    assert outcomes
+    assert receipts
+    for receipt in receipts:
+        # Receipt post_init requires source recomputes to source_cid.
+        assert blake3_512_of(receipt.source.encode("utf-8")) == receipt.source_cid
+
+
+def test_paired_source_cid_preserves_honest_match() -> None:
+    source = "from pkg import f\nx = f()\n"
+    cid = blake3_512_of(source.encode("utf-8"))
+    assert _paired_source_cid(source, cid) == cid
+
+
+def test_nested_manager_publication_survives_dual_door_consumer_identity(
+    tmp_path: Path,
+) -> None:
+    """Vertical pin: nested publication with dual-door consumer triple.
+
+    Same construction as test_generator_nested_managers._publish identity mint
+    (read_text + blake3(read_bytes)). On CRLF bytes this used to raise
+    ``authenticated import-use source CID is stale`` before nested layers ran.
+    """
+    import csv
+    import importlib.metadata
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceDerivedGeneratorResourceRefV1,
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_python_source.manager_summary_derivation import (
+        GeneratorBackedLifecycleProtocolV1,
+        populate_source_derived_resource_refs,
+    )
+    from sugar_source_tree.tree import SourceFile
+
+    package = tmp_path / "unprivileged"
+    package.mkdir()
+    helpers = (
+        "from contextlib import contextmanager\r\n"
+        "\r\n"
+        "@contextmanager\r\n"
+        "def inner():\r\n"
+        "    prior = None\r\n"
+        "    yield 'inner'\r\n"
+        "\r\n"
+        "@contextmanager\r\n"
+        "def outer():\r\n"
+        "    with inner():\r\n"
+        "        yield 'outer'\r\n"
+    )
+    (package / "__init__.py").write_bytes(
+        b"from unprivileged.helpers import outer, inner\r\n"
+    )
+    (package / "helpers.py").write_bytes(helpers.encode("utf-8"))
+    metadata = tmp_path / "unprivileged_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_bytes(
+        b"Metadata-Version: 2.1\r\nName: unprivileged-dist\r\nVersion: 1.0\r\n"
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in (
+            "unprivileged/__init__.py",
+            "unprivileged/helpers.py",
+            "unprivileged_dist-1.0.dist-info/METADATA",
+            "unprivileged_dist-1.0.dist-info/RECORD",
+        ):
+            writer.writerow((file, "", ""))
+    distribution = importlib.metadata.Distribution.at(metadata)
+
+    path = tmp_path / "consumer.py"
+    path.write_bytes(b"from unprivileged import outer\r\nwith outer():\r\n    pass\r\n")
+    # Dual-door identity (do not "fix" by switching to path_source here).
+    text = path.read_text(encoding="utf-8")
+    claimed = blake3_512_of(path.read_bytes())
+    assert blake3_512_of(text.encode("utf-8")) != claimed
+
+    context = TreeConstructionContextV1.for_source_call_construction(
+        workspace_root=str(tmp_path)
+    )
+    tree = SourceFile((text, str(path), claimed), construction_context=context)
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+    refs = [
+        v
+        for v in context.source_derived_contract_refs.values()
+        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
+    ]
+    assert refs, "nested outer must publish despite dual-door consumer identity"
+    protocol = refs[0].generator_protocol
+    assert isinstance(protocol, GeneratorBackedLifecycleProtocolV1)
+    assert len(protocol.nested_manager_layers) == 1


### PR DESCRIPTION
## Summary

**Critical-path preempt:** nested-manager publication was aborted by
`ValueError: authenticated import-use source CID is stale` before nested
lifecycle could run — so the merged nested capability was not vertically proven
under dual-door identity.

### Defect
Callers (including nested fixtures) often mint:

```python
(path.read_text(...), path, blake3_512_of(path.read_bytes()))
```

Under CRLF / universal newlines, `read_text` yields LF while `read_bytes` still
has CRLF → `blake3(source.encode()) != claimed_cid` →
`AuthenticatedImportUseV1.__post_init__` refuses.

### Fix (producer mint, not consumer recompute)
At `authenticated_import_uses` / `authenticated_import_use_receipts`, pair CID
to the **retained source string** via the path_source law:

`source_cid = blake3(source.encode("utf-8"))`

when the claim disagrees. No disk re-read; no weakening of authentication of
the text the lexical pass actually receives. Receipts embed the paired CID so
demand/revalidation stay consistent.

### Acceptance
- Nested publication with dual-door + CRLF consumer triple publishes both layers
- Honest matching pairs unchanged
- Nested manager suite green

## Shot accounting (8-field)

| Field | Value |
| --- | --- |
| **R axis** | `import_use_source_cid_stale` |
| **Epsilon R** | −1 nested publication abort on dual-door identity |
| **Floors** | import-use still content-addresses retained source; no fail-open on wrong text |
| **Instrument** | `test_import_use_source_cid_pairing` + nested suite |
| **Local evidence** | 18 green (pairing + nested + revalidation immutability) |
| **Observed residual** | dual-door fixtures still construct SourceFile with inconsistent triples (unit does not yet refuse) |
| **Background** | CI after merge |
| **Shell retired** | dual-door abort at import-use mint under CRLF |

## Test plan
- [x] CRLF dual-door mint + nested vertical pin
- [x] full `test_generator_nested_managers`
- [x] revalidation snapshot immutability
- [ ] CI

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pair import-use source CID to retained source text at mint
> - Adds `_paired_source_cid` helper in [`import_binding.py`](https://github.com/TSavo/sugar/pull/6710/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) that recomputes a blake3_512 CID from the UTF-8 source text when the claimed CID does not match, returning the recomputed CID instead.
> - Applies this pairing step in `authenticated_import_uses` and `authenticated_import_use_receipts` so receipts are always minted with a CID derived from the retained source text, preventing post-initialization refusal when source and CID disagree.
> - Adds tests in [`test_import_use_source_cid_pairing.py`](https://github.com/TSavo/sugar/pull/6710/files#diff-ba775ee5e830cdec45b8800b8056be70d27a157dd5b33e7cacd770ee5dacffae) covering CRLF mismatch repair, no-op on honest match, and nested manager publication with a mismatched claimed CID.
> - Behavioral Change: callers passing a `source`/`source_cid` pair that do not agree will now have the CID silently replaced with one derived from the source text rather than using the caller-supplied value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e7de58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->