### PR TITLE
Populate finally raise context_effect from body halt

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -65,14 +65,9 @@ class TrySugar(Sugar):
 
     def _route_discharged_body(self, body_es, ctx):
         """Route one concrete body ExitSet; carriers enter only after discharge."""
-        from sugar_lift_py_tests.floor.return_value import ReturnValue
         from sugar_lift_py_tests.sugar.exit_set_routing import (
             exitset_to_outcome,
             promote_raise_halts,
-        )
-        from sugar_lift_py_tests.sugar.function_universe_sugar import (
-            _ReducedBlock,
-            reduce_block_to_exitset,
         )
 
         pre_finally = _route_handlers_over_exits(
@@ -86,22 +81,116 @@ class TrySugar(Sugar):
         if not self.finalbody:
             return exitset_to_outcome(pre_finally)
 
-        cleanup_es = reduce_block_to_exitset(self.finalbody, ctx)
-
-        def _cleanup():
-            return cleanup_es
-
-        def _restores(value: object) -> bool:
-            if isinstance(value, _ReducedBlock):
-                if not value.can_fall_through:
-                    return False
-                if any(isinstance(e, ReturnValue) for e in value.entries):
-                    return False
-                return True
-            return True
-
-        after = pre_finally.and_finally(_cleanup, cleanup_restores=_restores)
+        after = _and_finally_with_raise_context(
+            pre_finally,
+            self.finalbody,
+            ctx=ctx,
+            site=self.site,
+        )
         return exitset_to_outcome(after)
+
+
+def _finally_restores(value: object) -> bool:
+    """Ordinary finally fall-through restores; return-in-finally does not."""
+    from sugar_lift_py_tests.floor.return_value import ReturnValue
+    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+
+    if isinstance(value, _ReducedBlock):
+        if not value.can_fall_through:
+            return False
+        if any(isinstance(e, ReturnValue) for e in value.entries):
+            return False
+        return True
+    return True
+
+
+def _and_finally_with_raise_context(pre_finally, finalbody, *, ctx, site):
+    """try/finally over ExitSet, retaining body raise as implicit context.
+
+    Mirrors ``ExitSet.and_finally`` laws (restore / cleanup-halt supersede /
+    terminal cleanup supersede) without editing ExitSet. When a finally raise
+    supersedes an incoming RaiseEffect halt, attach that halt as
+    ``context_effect`` on the cleanup raise if it has none — Python's
+    implicit ``__context__`` for a raise in finally after a body exception.
+
+    For halted incoming faces, finally is reduced under
+    ``bind_in_flight_effect`` so bare re-raise / context-sensitive raises in
+    finally can resolve the authentic body effect when they carry a slot.
+    """
+    from dataclasses import replace
+
+    from sugar_lift_py_tests.caller_parameter_contract import merge_pending
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.in_flight_effect import bind_in_flight_effect
+    from sugar_lift_py_tests.outcome.exit_set import (
+        Completed,
+        ExitSet,
+        Halted,
+        _and_guards,
+    )
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        reduce_block_to_exitset,
+    )
+
+    # Shared fall-through cleanup (no body exception active).
+    neutral_cleanup = reduce_block_to_exitset(finalbody, ctx)
+    # Slot for bind/resolve when reducing finally over a body halt.
+    site_key = getattr(site, "filename", None) or repr(site)
+    site_line = getattr(site, "line", "")
+    finally_slot = f"try-finally-in-flight:{site_key}:{site_line}"
+
+    exits: list = []
+    for incoming in pre_finally.exits:
+        if (
+            isinstance(incoming, Halted)
+            and isinstance(incoming.effect, RaiseEffect)
+        ):
+            finally_ctx = bind_in_flight_effect(
+                ctx, finally_slot, incoming.effect, blame=site
+            )
+            cleanup_es = reduce_block_to_exitset(finalbody, finally_ctx)
+        else:
+            cleanup_es = neutral_cleanup
+
+        for clean in cleanup_es.exits:
+            guard = _and_guards(incoming.guard, clean.guard)
+            faces = incoming.faces | clean.faces
+            owed = merge_pending(
+                incoming.pending_contracts, clean.pending_contracts
+            )
+            if isinstance(clean, Halted):
+                effect = clean.effect
+                # Supersede: cleanup halt wins; retain body raise as context.
+                if (
+                    isinstance(effect, RaiseEffect)
+                    and effect.context_effect is None
+                    and isinstance(incoming, Halted)
+                    and isinstance(incoming.effect, RaiseEffect)
+                    and effect is not incoming.effect
+                ):
+                    effect = replace(effect, context_effect=incoming.effect)
+                exits.append(
+                    Halted(guard, effect, clean.state, faces, owed)
+                )
+                continue
+            if _finally_restores(clean.value):
+                if isinstance(incoming, Completed):
+                    exits.append(
+                        Completed(guard, incoming.value, faces, owed)
+                    )
+                else:
+                    exits.append(
+                        Halted(
+                            guard,
+                            incoming.effect,
+                            incoming.state,
+                            faces,
+                            owed,
+                        )
+                    )
+            else:
+                exits.append(Completed(guard, clean.value, faces, owed))
+    return ExitSet(tuple(exits)).normalize()
 
 
 def _effect_match_verdict(effect, matcher, ctx=None):

--- a/implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py
@@ -292,10 +292,10 @@ def test_terminal_finally_raise_supersedes_incoming_body_exit():
 
 
 def test_terminal_finally_raise_retains_truthful_body_context():
-    """Finally raise should retain body First as authenticated context.
+    """Finally raise supersedes body while retaining First as context_effect.
 
-    Banks red if TrySugar finally reduces without binding the pre-finally halt
-    as in-flight context (shared finally algebra, not ExitSet).
+    TrySugar finally composition attaches the pre-finally RaiseEffect as
+    authenticated implicit context on the cleanup raise (not ExitSet).
     """
     source = (
         "def f():\n"
@@ -306,19 +306,6 @@ def test_terminal_finally_raise_retains_truthful_body_context():
     )
     effect = _halt_effect(_desugar(source, name="fin_ctx.py"))
     assert effect.exception_name == "RuntimeError"
-    if effect.context_effect is None:
-        pytest.fail(
-            "MISSING PRODUCER (TrySugar finally / in-flight context):\n"
-            "  observed: terminal finally raise has context_effect=None\n"
-            "  expected: RuntimeError primary with authenticated ValueError "
-            "context_effect (body occurrence), distinct from explicit from-cause\n"
-            "  owned: TrySugar finalbody reduction must bind the pre-finally "
-            "halt effect as in-flight when reducing finally statements — not "
-            "ExitSet.and_finally (frozen); not RaiseSugar alone\n"
-            "  fix: reduce finalbody under bind_in_flight_effect(ctx, slot, "
-            "incoming.effect) per halted face, or attach truthful context when "
-            "cleanup halt supersedes"
-        )
     assert isinstance(effect.context_effect, RaiseEffect)
     assert effect.context_effect.exception_name == "ValueError"
     assert effect.context_effect.occurrence != effect.occurrence


### PR DESCRIPTION
## Summary

- **TrySugar finalbody** now reduces under `bind_in_flight_effect` when the pre-finally face is a `RaiseEffect` halt, and when a cleanup `RaiseEffect` supersedes the body halt with `context_effect is None`, attaches the body effect as authenticated implicit context (Python `__context__` for `raise` in `finally`).
- Mirrors `ExitSet.and_finally` restore/supersede laws locally — **ExitSet and carrier untouched**.
- Unbanks the #6708 honest red: `test_terminal_finally_raise_retains_truthful_body_context` is now a hard assert (RuntimeError primary, ValueError `context_effect`, distinct occurrences).

## Shell deleted

Honest banked red on finally-context (`context_effect is None` fail path). Replaced by production producer in TrySugar only.

## Validation

```
bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py -q
# 11 passed
```

## Floors

- ExitSet/carrier frozen (no edits)
- Supersede law retained (finally raise still wins primary exit)
- No census; acceptance is the red law in the suite

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Populate `context_effect` on finally-block raises from body halt in `TrySugar`
> - Replaces `ExitSet.and_finally` with a new `_and_finally_with_raise_context` helper in [`try_sugar.py`](https://github.com/TSavo/sugar/pull/6711/files#diff-f5d956a5de18664d828d314bf5537a359cc1f2f40c5a42b52f03bbe5ecaac0ff) to preserve exception chaining through finally blocks.
> - When the finally cleanup raises without a `context_effect` and the incoming body halt is a `RaiseEffect`, the incoming raise is attached as `context_effect` on the cleanup raise.
> - For halted `RaiseEffect` faces, the finally block is reduced under `bind_in_flight_effect` so bare re-raises resolve to the correct body exception.
> - Behavioral Change: finally composition now produces a `context_effect` on cleanup raises where none existed before; semantics for try blocks without a finally are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edcad41.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->