### PR TITLE
Subscript augassign: structural op_site, explicit project_*, independent i* tooth

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -426,56 +426,108 @@ def _project_delattr_named(receiver, name, site):
 
 
 def project_iadd(left, right, site):
-    """Discharge ``iadd``: dispatch to Floor; default binary lives on FloorValue."""
-    return left.iadd(right, site)
+    """Discharge ``iadd`` via established ``inplace_binary_operator_with`` edge."""
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        discharge_inplace,
+    )
+
+    return discharge_inplace(left, right, site, surface="+")
 
 
 def project_isub(left, right, site):
-    return left.isub(right, site)
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        discharge_inplace,
+    )
+
+    return discharge_inplace(left, right, site, surface="-")
 
 
 def project_imul(left, right, site):
-    return left.imul(right, site)
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        discharge_inplace,
+    )
+
+    return discharge_inplace(left, right, site, surface="*")
 
 
 def project_itruediv(left, right, site):
-    return left.itruediv(right, site)
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        discharge_inplace,
+    )
+
+    return discharge_inplace(left, right, site, surface="/")
 
 
 def project_ifloordiv(left, right, site):
-    return left.ifloordiv(right, site)
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        discharge_inplace,
+    )
+
+    return discharge_inplace(left, right, site, surface="//")
 
 
 def project_imod(left, right, site):
-    return left.imod(right, site)
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        discharge_inplace,
+    )
+
+    return discharge_inplace(left, right, site, surface="%")
 
 
 def project_ipow(left, right, site):
-    return left.ipow(right, site)
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        discharge_inplace,
+    )
+
+    return discharge_inplace(left, right, site, surface="**")
 
 
 def project_iand(left, right, site):
-    return left.iand(right, site)
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        discharge_inplace,
+    )
+
+    return discharge_inplace(left, right, site, surface="&")
 
 
 def project_ior(left, right, site):
-    return left.ior(right, site)
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        discharge_inplace,
+    )
+
+    return discharge_inplace(left, right, site, surface="|")
 
 
 def project_ixor(left, right, site):
-    return left.ixor(right, site)
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        discharge_inplace,
+    )
+
+    return discharge_inplace(left, right, site, surface="^")
 
 
 def project_ilshift(left, right, site):
-    return left.ilshift(right, site)
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        discharge_inplace,
+    )
+
+    return discharge_inplace(left, right, site, surface="<<")
 
 
 def project_irshift(left, right, site):
-    return left.irshift(right, site)
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        discharge_inplace,
+    )
+
+    return discharge_inplace(left, right, site, surface=">>")
 
 
 def project_imatmul(left, right, site):
-    return left.imatmul(right, site)
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        discharge_inplace,
+    )
+
+    return discharge_inplace(left, right, site, surface="@")
 
 
 # Enrolled i* projectors — keys must equal production_augassign_inplace_operators().

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -392,11 +392,15 @@ def production_native_operation_operators() -> frozenset[str]:
     contracted_store_operators = frozenset(
         {"setitem", "setattr_named", "delitem", "delattr_named"}
     )
+    # AugAssign formal path mints i* by dynamic name; pin the full set so
+    # projector absence cannot silent-fallback to ordinary binary.
+    contracted_inplace_operators = frozenset(_INPLACE_NATIVE_OPERATION_PROJECTORS)
     return (
         _ast_minted_native_operator_constants()
         | frozenset(_BINARY_OPERATOR_COORDINATE)
         | frozenset(COMPARE_METHODS.values())
         | contracted_store_operators
+        | contracted_inplace_operators
     )
 
 
@@ -419,6 +423,89 @@ def _project_delattr_named(receiver, name, site):
     return receiver.delattr(name.value, site)
 
 
+def _project_inplace_then_binary(inplace_name: str, binary_name: str):
+    """Authenticated in-place projection with Floor-authorized binary fallback.
+
+    This is the discharge body for AugAssign formal demands (``iadd``, …).
+    Projector *absence* must never be patched by minting ordinary ``add`` —
+    that is a false green about in-place semantics.  Binary fallback lives
+    **inside** the enrolled i* projector, only after Floor declines i*
+    (no method / non-authorizing face), matching Python's ``__iadd__`` then
+    ``__add__`` law.
+    """
+
+    def project(left, right, site):
+        from sugar_lift_py_tests.floor import RaiseValue
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+        from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+        inplace = getattr(left, inplace_name, None)
+        if callable(inplace):
+            projected = inplace(right, site)
+            if isinstance(projected, Complete) and isinstance(
+                projected.value, RaiseValue
+            ):
+                return projected
+            if isinstance(projected, Complete):
+                return projected
+            if isinstance(projected, (Incomplete, ExitSet)):
+                return projected
+            # Unknown Outcome / nested carrier face: surface rather than invent add.
+            return projected
+        binary = getattr(left, binary_name, None)
+        if not callable(binary):
+            from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+            from sugar_lift_py_tests.gap.panic import construction_panic
+
+            construction_panic(
+                ConstructionGap(
+                    owner=f"_project_{inplace_name}",
+                    blame=str(site),
+                    observed=(
+                        f"{type(left).__name__} has neither {inplace_name} nor "
+                        f"{binary_name} for authenticated augmented assignment"
+                    ),
+                    requested=(
+                        f"Floor {inplace_name} and/or {binary_name} on this value "
+                        "species"
+                    ),
+                    fix=(
+                        f"implement Floor {inplace_name} (preferred) or "
+                        f"{binary_name} for this species"
+                    ),
+                    gap_kind=GapKind.FLOOR,
+                    gap_locus=GapLocus.CONSTRUCTION,
+                )
+            )
+        return binary(right, site)
+
+    project.__name__ = f"_project_{inplace_name}"
+    project.__qualname__ = f"_project_{inplace_name}"
+    project.__doc__ = (
+        f"Authenticated ``{inplace_name}`` then Floor-authorized ``{binary_name}``."
+    )
+    return project
+
+
+# In-place operators minted by AugAssign formal path.  Production set and
+# projector keys must include every name so absence cannot merge green as add.
+_INPLACE_NATIVE_OPERATION_PROJECTORS = {
+    "iadd": _project_inplace_then_binary("iadd", "add"),
+    "isub": _project_inplace_then_binary("isub", "subtract"),
+    "imul": _project_inplace_then_binary("imul", "multiply"),
+    "itruediv": _project_inplace_then_binary("itruediv", "divide"),
+    "ifloordiv": _project_inplace_then_binary("ifloordiv", "floor_divide"),
+    "imod": _project_inplace_then_binary("imod", "modulo"),
+    "ipow": _project_inplace_then_binary("ipow", "power"),
+    "iand": _project_inplace_then_binary("iand", "bitwise_and"),
+    "ior": _project_inplace_then_binary("ior", "bitwise_or"),
+    "ixor": _project_inplace_then_binary("ixor", "bitwise_xor"),
+    "ilshift": _project_inplace_then_binary("ilshift", "left_shift"),
+    "irshift": _project_inplace_then_binary("irshift", "right_shift"),
+    "imatmul": _project_inplace_then_binary("imatmul", "matrix_multiply"),
+}
+
+
 # Explicit projectors for authenticated native operations.
 #
 # Each entry names its own Floor signature.  A generic
@@ -437,6 +524,11 @@ def _project_delattr_named(receiver, name, site):
 #   delitem        → ``receiver.delitem(index, site)``   (__delitem__)
 #   delattr_named  → ``receiver.delattr(name.value, site)`` (__delattr__)
 # Name deletion (``del name`` / DeleteNameSugar) is out of scope here.
+#
+# In-place protocol (AugAssign formal path):
+#   iadd / isub / … → authenticated i* then Floor-authorized ordinary binary
+#   inside the enrolled projector.  Projector absence must never silent-fallback
+#   to minting ``add`` — that is a false green about in-place semantics.
 #
 # Key set must equal :func:`production_native_operation_operators` exactly.
 _NATIVE_OPERATION_PROJECTORS = {
@@ -463,6 +555,8 @@ _NATIVE_OPERATION_PROJECTORS = {
     "bitwise_xor": lambda left, right, site: left.bitwise_xor(right, site),
     "left_shift": lambda left, right, site: left.left_shift(right, site),
     "right_shift": lambda left, right, site: left.right_shift(right, site),
+    # Authenticated in-place (AugAssign); binary fallback is inside each projector.
+    **_INPLACE_NATIVE_OPERATION_PROJECTORS,
     # Equality, ordering, membership (compare / equality sugars).
     "equals": lambda left, right, site: left.equals(right, site),
     "less_than": lambda left, right, site: left.less_than(right, site),

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -423,55 +423,60 @@ def _project_delattr_named(receiver, name, site):
     return receiver.delattr(name.value, site)
 
 
-def _project_inplace_then_binary(inplace_name: str, binary_name: str):
-    """Authenticated in-place projection with Floor-authorized binary fallback.
+@dataclass(frozen=True)
+class InplaceThenBinaryProjector:
+    """Explicit authenticated inplace projector (one type per AugAssign op).
 
-    This is the discharge body for AugAssign formal demands (``iadd``, …).
-    Projector *absence* must never be patched by minting ordinary ``add`` —
-    that is a false green about in-place semantics.  Binary fallback lives
-    **inside** the enrolled i* projector, only after Floor declines i*
-    (no method / non-authorizing face), matching Python's ``__iadd__`` then
-    ``__add__`` law.
+    Discharge signature ``(left, right, site)``.  Binary fallback is authorized
+    only when:
+
+    * the inplace Floor method is **absent**, or
+    * inplace returns bare ``NotImplemented`` / ``Complete(NotImplemented)``.
+
+    Incomplete, ExitSet, RaiseValue, carriers, and other unresolved or
+    exceptional faces surface as themselves — they never authorize add.
     """
 
-    def project(left, right, site):
-        from sugar_lift_py_tests.floor import RaiseValue
-        from sugar_lift_py_tests.outcome import Complete, Incomplete
-        from sugar_lift_py_tests.outcome.exit_set import ExitSet
+    operator: str
+    inplace_method: str
+    binary_method: str
 
-        inplace = getattr(left, inplace_name, None)
-        if callable(inplace):
-            projected = inplace(right, site)
-            if isinstance(projected, Complete) and isinstance(
-                projected.value, RaiseValue
-            ):
-                return projected
-            if isinstance(projected, Complete):
-                return projected
-            if isinstance(projected, (Incomplete, ExitSet)):
-                return projected
-            # Unknown Outcome / nested carrier face: surface rather than invent add.
-            return projected
-        binary = getattr(left, binary_name, None)
+    def __call__(self, left, right, site):
+        from sugar_lift_py_tests.outcome import Complete
+
+        inplace = getattr(left, self.inplace_method, None)
+        if not callable(inplace):
+            return self._binary(left, right, site)
+        projected = inplace(right, site)
+        if projected is NotImplemented:
+            return self._binary(left, right, site)
+        if isinstance(projected, Complete) and projected.value is NotImplemented:
+            return self._binary(left, right, site)
+        # Success, RaiseValue-in-Complete, Incomplete, ExitSet, carrier, …:
+        # surface.  Unresolved/exceptional faces do not authorize binary.
+        return projected
+
+    def _binary(self, left, right, site):
+        binary = getattr(left, self.binary_method, None)
         if not callable(binary):
             from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
             from sugar_lift_py_tests.gap.panic import construction_panic
 
             construction_panic(
                 ConstructionGap(
-                    owner=f"_project_{inplace_name}",
+                    owner=f"InplaceThenBinaryProjector[{self.operator}]",
                     blame=str(site),
                     observed=(
-                        f"{type(left).__name__} has neither {inplace_name} nor "
-                        f"{binary_name} for authenticated augmented assignment"
+                        f"{type(left).__name__} has neither {self.inplace_method} "
+                        f"nor {self.binary_method} for authenticated AugAssign"
                     ),
                     requested=(
-                        f"Floor {inplace_name} and/or {binary_name} on this value "
-                        "species"
+                        f"Floor {self.inplace_method} and/or {self.binary_method} "
+                        "on this value species"
                     ),
                     fix=(
-                        f"implement Floor {inplace_name} (preferred) or "
-                        f"{binary_name} for this species"
+                        f"implement Floor {self.inplace_method} (preferred) or "
+                        f"{self.binary_method} for this species"
                     ),
                     gap_kind=GapKind.FLOOR,
                     gap_locus=GapLocus.CONSTRUCTION,
@@ -479,31 +484,109 @@ def _project_inplace_then_binary(inplace_name: str, binary_name: str):
             )
         return binary(right, site)
 
-    project.__name__ = f"_project_{inplace_name}"
-    project.__qualname__ = f"_project_{inplace_name}"
-    project.__doc__ = (
-        f"Authenticated ``{inplace_name}`` then Floor-authorized ``{binary_name}``."
-    )
-    return project
 
+# Explicit projector instances — one type identity per inplace operator.
+# Not a string dispatch table: production resolves via isinstance on source
+# BinaryOperator classes → these values (see inplace_projector_for).
+IADD = InplaceThenBinaryProjector("iadd", "iadd", "add")
+ISUB = InplaceThenBinaryProjector("isub", "isub", "subtract")
+IMUL = InplaceThenBinaryProjector("imul", "imul", "multiply")
+ITRUEDIV = InplaceThenBinaryProjector("itruediv", "itruediv", "divide")
+IFLOORDIV = InplaceThenBinaryProjector("ifloordiv", "ifloordiv", "floor_divide")
+IMOD = InplaceThenBinaryProjector("imod", "imod", "modulo")
+IPOW = InplaceThenBinaryProjector("ipow", "ipow", "power")
+IAND = InplaceThenBinaryProjector("iand", "iand", "bitwise_and")
+IOR = InplaceThenBinaryProjector("ior", "ior", "bitwise_or")
+IXOR = InplaceThenBinaryProjector("ixor", "ixor", "bitwise_xor")
+ILSHIFT = InplaceThenBinaryProjector("ilshift", "ilshift", "left_shift")
+IRSHIFT = InplaceThenBinaryProjector("irshift", "irshift", "right_shift")
+IMATMUL = InplaceThenBinaryProjector("imatmul", "imatmul", "matrix_multiply")
 
-# In-place operators minted by AugAssign formal path.  Production set and
-# projector keys must include every name so absence cannot merge green as add.
+_INPLACE_PROJECTOR_INSTANCES: tuple[InplaceThenBinaryProjector, ...] = (
+    IADD,
+    ISUB,
+    IMUL,
+    ITRUEDIV,
+    IFLOORDIV,
+    IMOD,
+    IPOW,
+    IAND,
+    IOR,
+    IXOR,
+    ILSHIFT,
+    IRSHIFT,
+    IMATMUL,
+)
+
+# Production set and projector keys: every enrolled inplace operator name.
 _INPLACE_NATIVE_OPERATION_PROJECTORS = {
-    "iadd": _project_inplace_then_binary("iadd", "add"),
-    "isub": _project_inplace_then_binary("isub", "subtract"),
-    "imul": _project_inplace_then_binary("imul", "multiply"),
-    "itruediv": _project_inplace_then_binary("itruediv", "divide"),
-    "ifloordiv": _project_inplace_then_binary("ifloordiv", "floor_divide"),
-    "imod": _project_inplace_then_binary("imod", "modulo"),
-    "ipow": _project_inplace_then_binary("ipow", "power"),
-    "iand": _project_inplace_then_binary("iand", "bitwise_and"),
-    "ior": _project_inplace_then_binary("ior", "bitwise_or"),
-    "ixor": _project_inplace_then_binary("ixor", "bitwise_xor"),
-    "ilshift": _project_inplace_then_binary("ilshift", "left_shift"),
-    "irshift": _project_inplace_then_binary("irshift", "right_shift"),
-    "imatmul": _project_inplace_then_binary("imatmul", "matrix_multiply"),
+    projector.operator: projector for projector in _INPLACE_PROJECTOR_INSTANCES
 }
+
+
+def inplace_projector_for(op) -> InplaceThenBinaryProjector:
+    """Resolve the authenticated inplace projector from a source BinaryOperator.
+
+    Uses isinstance on our operator classes — never a source-spelling string
+    table.  Unknown operators are construction gaps (honorable red).
+    """
+    from sugar_source_tree.operators import (
+        Add,
+        BitAnd,
+        BitOr,
+        BitXor,
+        Div,
+        FloorDiv,
+        LShift,
+        MatMult,
+        Mod,
+        Mult,
+        Pow,
+        RShift,
+        Sub,
+    )
+
+    if isinstance(op, Add):
+        return IADD
+    if isinstance(op, Sub):
+        return ISUB
+    if isinstance(op, Mult):
+        return IMUL
+    if isinstance(op, Div):
+        return ITRUEDIV
+    if isinstance(op, FloorDiv):
+        return IFLOORDIV
+    if isinstance(op, Mod):
+        return IMOD
+    if isinstance(op, Pow):
+        return IPOW
+    if isinstance(op, BitAnd):
+        return IAND
+    if isinstance(op, BitOr):
+        return IOR
+    if isinstance(op, BitXor):
+        return IXOR
+    if isinstance(op, LShift):
+        return ILSHIFT
+    if isinstance(op, RShift):
+        return IRSHIFT
+    if isinstance(op, MatMult):
+        return IMATMUL
+    from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+    from sugar_lift_py_tests.gap.panic import construction_panic
+
+    construction_panic(
+        ConstructionGap(
+            owner="inplace_projector_for",
+            blame=str(op),
+            observed=f"no enrolled inplace projector for {type(op).__name__}",
+            requested="an InplaceThenBinaryProjector for this BinaryOperator class",
+            fix="enroll the operator as an explicit InplaceThenBinaryProjector instance",
+            gap_kind=GapKind.FLOOR,
+            gap_locus=GapLocus.CONSTRUCTION,
+        )
+    )
+    raise AssertionError("unreachable")
 
 
 # Explicit projectors for authenticated native operations.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -392,9 +392,11 @@ def production_native_operation_operators() -> frozenset[str]:
     contracted_store_operators = frozenset(
         {"setitem", "setattr_named", "delitem", "delattr_named"}
     )
-    # AugAssign formal path mints i* by dynamic name; pin the full set so
-    # projector absence cannot silent-fallback to ordinary binary.
-    contracted_inplace_operators = frozenset(_INPLACE_NATIVE_OPERATION_PROJECTORS)
+    # AugAssign production mint set — from BinaryOperator class attributes,
+    # NEVER from the projector table (circular equality tooth).
+    from sugar_source_tree.operators import production_augassign_inplace_operators
+
+    contracted_inplace_operators = production_augassign_inplace_operators()
     return (
         _ast_minted_native_operator_constants()
         | frozenset(_BINARY_OPERATOR_COORDINATE)
@@ -423,112 +425,161 @@ def _project_delattr_named(receiver, name, site):
     return receiver.delattr(name.value, site)
 
 
-@dataclass(frozen=True)
-class InplaceThenBinaryProjector:
-    """Explicit authenticated inplace projector (one type per AugAssign op).
+def _after_inplace_or_binary(projected, binary_fallback):
+    """Shared post-i* law: fallback only for authenticated completed NotImplemented.
 
-    Discharge signature ``(left, right, site)``.  Binary fallback is authorized
-    only when:
-
-    * the inplace Floor method is **absent**, or
-    * inplace returns bare ``NotImplemented`` / ``Complete(NotImplemented)``.
-
-    Incomplete, ExitSet, RaiseValue, carriers, and other unresolved or
-    exceptional faces surface as themselves — they never authorize add.
+    Absent i* is handled by the caller (no method → call binary directly).
+    Incomplete, ExitSet, RaiseValue, carriers, and other faces surface as-is.
     """
+    from sugar_lift_py_tests.outcome import Complete
 
-    operator: str
-    inplace_method: str
-    binary_method: str
-
-    def __call__(self, left, right, site):
-        from sugar_lift_py_tests.outcome import Complete
-
-        inplace = getattr(left, self.inplace_method, None)
-        if not callable(inplace):
-            return self._binary(left, right, site)
-        projected = inplace(right, site)
-        if projected is NotImplemented:
-            return self._binary(left, right, site)
-        if isinstance(projected, Complete) and projected.value is NotImplemented:
-            return self._binary(left, right, site)
-        # Success, RaiseValue-in-Complete, Incomplete, ExitSet, carrier, …:
-        # surface.  Unresolved/exceptional faces do not authorize binary.
-        return projected
-
-    def _binary(self, left, right, site):
-        binary = getattr(left, self.binary_method, None)
-        if not callable(binary):
-            from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-            from sugar_lift_py_tests.gap.panic import construction_panic
-
-            construction_panic(
-                ConstructionGap(
-                    owner=f"InplaceThenBinaryProjector[{self.operator}]",
-                    blame=str(site),
-                    observed=(
-                        f"{type(left).__name__} has neither {self.inplace_method} "
-                        f"nor {self.binary_method} for authenticated AugAssign"
-                    ),
-                    requested=(
-                        f"Floor {self.inplace_method} and/or {self.binary_method} "
-                        "on this value species"
-                    ),
-                    fix=(
-                        f"implement Floor {self.inplace_method} (preferred) or "
-                        f"{self.binary_method} for this species"
-                    ),
-                    gap_kind=GapKind.FLOOR,
-                    gap_locus=GapLocus.CONSTRUCTION,
-                )
-            )
-        return binary(right, site)
+    if projected is NotImplemented:
+        return binary_fallback()
+    if isinstance(projected, Complete) and projected.value is NotImplemented:
+        return binary_fallback()
+    return projected
 
 
-# Explicit projector instances — one type identity per inplace operator.
-# Not a string dispatch table: production resolves via isinstance on source
-# BinaryOperator classes → these values (see inplace_projector_for).
-IADD = InplaceThenBinaryProjector("iadd", "iadd", "add")
-ISUB = InplaceThenBinaryProjector("isub", "isub", "subtract")
-IMUL = InplaceThenBinaryProjector("imul", "imul", "multiply")
-ITRUEDIV = InplaceThenBinaryProjector("itruediv", "itruediv", "divide")
-IFLOORDIV = InplaceThenBinaryProjector("ifloordiv", "ifloordiv", "floor_divide")
-IMOD = InplaceThenBinaryProjector("imod", "imod", "modulo")
-IPOW = InplaceThenBinaryProjector("ipow", "ipow", "power")
-IAND = InplaceThenBinaryProjector("iand", "iand", "bitwise_and")
-IOR = InplaceThenBinaryProjector("ior", "ior", "bitwise_or")
-IXOR = InplaceThenBinaryProjector("ixor", "ixor", "bitwise_xor")
-ILSHIFT = InplaceThenBinaryProjector("ilshift", "ilshift", "left_shift")
-IRSHIFT = InplaceThenBinaryProjector("irshift", "irshift", "right_shift")
-IMATMUL = InplaceThenBinaryProjector("imatmul", "imatmul", "matrix_multiply")
+def project_iadd(left, right, site):
+    """Authenticated ``iadd`` then Floor-authorized ``add``."""
+    if not callable(getattr(left, "iadd", None)):
+        return left.add(right, site)
+    return _after_inplace_or_binary(
+        left.iadd(right, site), lambda: left.add(right, site)
+    )
 
-_INPLACE_PROJECTOR_INSTANCES: tuple[InplaceThenBinaryProjector, ...] = (
-    IADD,
-    ISUB,
-    IMUL,
-    ITRUEDIV,
-    IFLOORDIV,
-    IMOD,
-    IPOW,
-    IAND,
-    IOR,
-    IXOR,
-    ILSHIFT,
-    IRSHIFT,
-    IMATMUL,
-)
 
-# Production set and projector keys: every enrolled inplace operator name.
+def project_isub(left, right, site):
+    """Authenticated ``isub`` then Floor-authorized ``subtract``."""
+    if not callable(getattr(left, "isub", None)):
+        return left.subtract(right, site)
+    return _after_inplace_or_binary(
+        left.isub(right, site), lambda: left.subtract(right, site)
+    )
+
+
+def project_imul(left, right, site):
+    """Authenticated ``imul`` then Floor-authorized ``multiply``."""
+    if not callable(getattr(left, "imul", None)):
+        return left.multiply(right, site)
+    return _after_inplace_or_binary(
+        left.imul(right, site), lambda: left.multiply(right, site)
+    )
+
+
+def project_itruediv(left, right, site):
+    """Authenticated ``itruediv`` then Floor-authorized ``divide``."""
+    if not callable(getattr(left, "itruediv", None)):
+        return left.divide(right, site)
+    return _after_inplace_or_binary(
+        left.itruediv(right, site), lambda: left.divide(right, site)
+    )
+
+
+def project_ifloordiv(left, right, site):
+    """Authenticated ``ifloordiv`` then Floor-authorized ``floor_divide``."""
+    if not callable(getattr(left, "ifloordiv", None)):
+        return left.floor_divide(right, site)
+    return _after_inplace_or_binary(
+        left.ifloordiv(right, site), lambda: left.floor_divide(right, site)
+    )
+
+
+def project_imod(left, right, site):
+    """Authenticated ``imod`` then Floor-authorized ``modulo``."""
+    if not callable(getattr(left, "imod", None)):
+        return left.modulo(right, site)
+    return _after_inplace_or_binary(
+        left.imod(right, site), lambda: left.modulo(right, site)
+    )
+
+
+def project_ipow(left, right, site):
+    """Authenticated ``ipow`` then Floor-authorized ``power``."""
+    if not callable(getattr(left, "ipow", None)):
+        return left.power(right, site)
+    return _after_inplace_or_binary(
+        left.ipow(right, site), lambda: left.power(right, site)
+    )
+
+
+def project_iand(left, right, site):
+    """Authenticated ``iand`` then Floor-authorized ``bitwise_and``."""
+    if not callable(getattr(left, "iand", None)):
+        return left.bitwise_and(right, site)
+    return _after_inplace_or_binary(
+        left.iand(right, site), lambda: left.bitwise_and(right, site)
+    )
+
+
+def project_ior(left, right, site):
+    """Authenticated ``ior`` then Floor-authorized ``bitwise_or``."""
+    if not callable(getattr(left, "ior", None)):
+        return left.bitwise_or(right, site)
+    return _after_inplace_or_binary(
+        left.ior(right, site), lambda: left.bitwise_or(right, site)
+    )
+
+
+def project_ixor(left, right, site):
+    """Authenticated ``ixor`` then Floor-authorized ``bitwise_xor``."""
+    if not callable(getattr(left, "ixor", None)):
+        return left.bitwise_xor(right, site)
+    return _after_inplace_or_binary(
+        left.ixor(right, site), lambda: left.bitwise_xor(right, site)
+    )
+
+
+def project_ilshift(left, right, site):
+    """Authenticated ``ilshift`` then Floor-authorized ``left_shift``."""
+    if not callable(getattr(left, "ilshift", None)):
+        return left.left_shift(right, site)
+    return _after_inplace_or_binary(
+        left.ilshift(right, site), lambda: left.left_shift(right, site)
+    )
+
+
+def project_irshift(left, right, site):
+    """Authenticated ``irshift`` then Floor-authorized ``right_shift``."""
+    if not callable(getattr(left, "irshift", None)):
+        return left.right_shift(right, site)
+    return _after_inplace_or_binary(
+        left.irshift(right, site), lambda: left.right_shift(right, site)
+    )
+
+
+def project_imatmul(left, right, site):
+    """Authenticated ``imatmul`` then Floor-authorized ``matrix_multiply``."""
+    if not callable(getattr(left, "imatmul", None)):
+        return left.matrix_multiply(right, site)
+    return _after_inplace_or_binary(
+        left.imatmul(right, site), lambda: left.matrix_multiply(right, site)
+    )
+
+
+# Enrolled i* projectors — keys must equal production_augassign_inplace_operators().
 _INPLACE_NATIVE_OPERATION_PROJECTORS = {
-    projector.operator: projector for projector in _INPLACE_PROJECTOR_INSTANCES
+    "iadd": project_iadd,
+    "isub": project_isub,
+    "imul": project_imul,
+    "itruediv": project_itruediv,
+    "ifloordiv": project_ifloordiv,
+    "imod": project_imod,
+    "ipow": project_ipow,
+    "iand": project_iand,
+    "ior": project_ior,
+    "ixor": project_ixor,
+    "ilshift": project_ilshift,
+    "irshift": project_irshift,
+    "imatmul": project_imatmul,
 }
 
 
-def inplace_projector_for(op) -> InplaceThenBinaryProjector:
+def inplace_projector_for(op):
     """Resolve the authenticated inplace projector from a source BinaryOperator.
 
-    Uses isinstance on our operator classes — never a source-spelling string
-    table.  Unknown operators are construction gaps (honorable red).
+    Uses isinstance on our operator classes.  Returns the explicit project_*
+    function; the carrier operator name is ``type(op).inplace_operator``.
     """
     from sugar_source_tree.operators import (
         Add,
@@ -547,31 +598,31 @@ def inplace_projector_for(op) -> InplaceThenBinaryProjector:
     )
 
     if isinstance(op, Add):
-        return IADD
+        return project_iadd
     if isinstance(op, Sub):
-        return ISUB
+        return project_isub
     if isinstance(op, Mult):
-        return IMUL
+        return project_imul
     if isinstance(op, Div):
-        return ITRUEDIV
+        return project_itruediv
     if isinstance(op, FloorDiv):
-        return IFLOORDIV
+        return project_ifloordiv
     if isinstance(op, Mod):
-        return IMOD
+        return project_imod
     if isinstance(op, Pow):
-        return IPOW
+        return project_ipow
     if isinstance(op, BitAnd):
-        return IAND
+        return project_iand
     if isinstance(op, BitOr):
-        return IOR
+        return project_ior
     if isinstance(op, BitXor):
-        return IXOR
+        return project_ixor
     if isinstance(op, LShift):
-        return ILSHIFT
+        return project_ilshift
     if isinstance(op, RShift):
-        return IRSHIFT
+        return project_irshift
     if isinstance(op, MatMult):
-        return IMATMUL
+        return project_imatmul
     from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
     from sugar_lift_py_tests.gap.panic import construction_panic
 
@@ -580,8 +631,8 @@ def inplace_projector_for(op) -> InplaceThenBinaryProjector:
             owner="inplace_projector_for",
             blame=str(op),
             observed=f"no enrolled inplace projector for {type(op).__name__}",
-            requested="an InplaceThenBinaryProjector for this BinaryOperator class",
-            fix="enroll the operator as an explicit InplaceThenBinaryProjector instance",
+            requested="an explicit project_* function for this BinaryOperator class",
+            fix="enroll project_<i*> and wire isinstance arm in inplace_projector_for",
             gap_kind=GapKind.FLOOR,
             gap_locus=GapLocus.CONSTRUCTION,
         )
@@ -609,9 +660,10 @@ def inplace_projector_for(op) -> InplaceThenBinaryProjector:
 # Name deletion (``del name`` / DeleteNameSugar) is out of scope here.
 #
 # In-place protocol (AugAssign formal path):
-#   iadd / isub / … → authenticated i* then Floor-authorized ordinary binary
-#   inside the enrolled projector.  Projector absence must never silent-fallback
-#   to minting ``add`` — that is a false green about in-place semantics.
+#   explicit project_iadd / project_isub / … each call Floor methods directly.
+#   Production mint names come from BinaryOperator.inplace_operator (independent
+#   equality tooth).  Projector absence must never silent-fallback to minting
+#   ordinary ``add``.
 #
 # Key set must equal :func:`production_native_operation_operators` exactly.
 _NATIVE_OPERATION_PROJECTORS = {

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -425,139 +425,62 @@ def _project_delattr_named(receiver, name, site):
     return receiver.delattr(name.value, site)
 
 
-def _after_inplace_or_binary(projected, binary_fallback):
-    """Shared post-i* law: fallback only for authenticated completed NotImplemented.
-
-    Absent i* is handled by the caller (no method → call binary directly).
-    Incomplete, ExitSet, RaiseValue, carriers, and other faces surface as-is.
-    """
-    from sugar_lift_py_tests.outcome import Complete
-
-    if projected is NotImplemented:
-        return binary_fallback()
-    if isinstance(projected, Complete) and projected.value is NotImplemented:
-        return binary_fallback()
-    return projected
-
-
 def project_iadd(left, right, site):
-    """Authenticated ``iadd`` then Floor-authorized ``add``."""
-    if not callable(getattr(left, "iadd", None)):
-        return left.add(right, site)
-    return _after_inplace_or_binary(
-        left.iadd(right, site), lambda: left.add(right, site)
-    )
+    """Discharge ``iadd``: dispatch to Floor; default binary lives on FloorValue."""
+    return left.iadd(right, site)
 
 
 def project_isub(left, right, site):
-    """Authenticated ``isub`` then Floor-authorized ``subtract``."""
-    if not callable(getattr(left, "isub", None)):
-        return left.subtract(right, site)
-    return _after_inplace_or_binary(
-        left.isub(right, site), lambda: left.subtract(right, site)
-    )
+    return left.isub(right, site)
 
 
 def project_imul(left, right, site):
-    """Authenticated ``imul`` then Floor-authorized ``multiply``."""
-    if not callable(getattr(left, "imul", None)):
-        return left.multiply(right, site)
-    return _after_inplace_or_binary(
-        left.imul(right, site), lambda: left.multiply(right, site)
-    )
+    return left.imul(right, site)
 
 
 def project_itruediv(left, right, site):
-    """Authenticated ``itruediv`` then Floor-authorized ``divide``."""
-    if not callable(getattr(left, "itruediv", None)):
-        return left.divide(right, site)
-    return _after_inplace_or_binary(
-        left.itruediv(right, site), lambda: left.divide(right, site)
-    )
+    return left.itruediv(right, site)
 
 
 def project_ifloordiv(left, right, site):
-    """Authenticated ``ifloordiv`` then Floor-authorized ``floor_divide``."""
-    if not callable(getattr(left, "ifloordiv", None)):
-        return left.floor_divide(right, site)
-    return _after_inplace_or_binary(
-        left.ifloordiv(right, site), lambda: left.floor_divide(right, site)
-    )
+    return left.ifloordiv(right, site)
 
 
 def project_imod(left, right, site):
-    """Authenticated ``imod`` then Floor-authorized ``modulo``."""
-    if not callable(getattr(left, "imod", None)):
-        return left.modulo(right, site)
-    return _after_inplace_or_binary(
-        left.imod(right, site), lambda: left.modulo(right, site)
-    )
+    return left.imod(right, site)
 
 
 def project_ipow(left, right, site):
-    """Authenticated ``ipow`` then Floor-authorized ``power``."""
-    if not callable(getattr(left, "ipow", None)):
-        return left.power(right, site)
-    return _after_inplace_or_binary(
-        left.ipow(right, site), lambda: left.power(right, site)
-    )
+    return left.ipow(right, site)
 
 
 def project_iand(left, right, site):
-    """Authenticated ``iand`` then Floor-authorized ``bitwise_and``."""
-    if not callable(getattr(left, "iand", None)):
-        return left.bitwise_and(right, site)
-    return _after_inplace_or_binary(
-        left.iand(right, site), lambda: left.bitwise_and(right, site)
-    )
+    return left.iand(right, site)
 
 
 def project_ior(left, right, site):
-    """Authenticated ``ior`` then Floor-authorized ``bitwise_or``."""
-    if not callable(getattr(left, "ior", None)):
-        return left.bitwise_or(right, site)
-    return _after_inplace_or_binary(
-        left.ior(right, site), lambda: left.bitwise_or(right, site)
-    )
+    return left.ior(right, site)
 
 
 def project_ixor(left, right, site):
-    """Authenticated ``ixor`` then Floor-authorized ``bitwise_xor``."""
-    if not callable(getattr(left, "ixor", None)):
-        return left.bitwise_xor(right, site)
-    return _after_inplace_or_binary(
-        left.ixor(right, site), lambda: left.bitwise_xor(right, site)
-    )
+    return left.ixor(right, site)
 
 
 def project_ilshift(left, right, site):
-    """Authenticated ``ilshift`` then Floor-authorized ``left_shift``."""
-    if not callable(getattr(left, "ilshift", None)):
-        return left.left_shift(right, site)
-    return _after_inplace_or_binary(
-        left.ilshift(right, site), lambda: left.left_shift(right, site)
-    )
+    return left.ilshift(right, site)
 
 
 def project_irshift(left, right, site):
-    """Authenticated ``irshift`` then Floor-authorized ``right_shift``."""
-    if not callable(getattr(left, "irshift", None)):
-        return left.right_shift(right, site)
-    return _after_inplace_or_binary(
-        left.irshift(right, site), lambda: left.right_shift(right, site)
-    )
+    return left.irshift(right, site)
 
 
 def project_imatmul(left, right, site):
-    """Authenticated ``imatmul`` then Floor-authorized ``matrix_multiply``."""
-    if not callable(getattr(left, "imatmul", None)):
-        return left.matrix_multiply(right, site)
-    return _after_inplace_or_binary(
-        left.imatmul(right, site), lambda: left.matrix_multiply(right, site)
-    )
+    return left.imatmul(right, site)
 
 
 # Enrolled i* projectors — keys must equal production_augassign_inplace_operators().
+# Selection is operator-owned (BinaryOperator.project_inplace); this table is
+# discharge enrollment only — not a kind ladder.
 _INPLACE_NATIVE_OPERATION_PROJECTORS = {
     "iadd": project_iadd,
     "isub": project_isub,
@@ -573,71 +496,6 @@ _INPLACE_NATIVE_OPERATION_PROJECTORS = {
     "irshift": project_irshift,
     "imatmul": project_imatmul,
 }
-
-
-def inplace_projector_for(op):
-    """Resolve the authenticated inplace projector from a source BinaryOperator.
-
-    Uses isinstance on our operator classes.  Returns the explicit project_*
-    function; the carrier operator name is ``type(op).inplace_operator``.
-    """
-    from sugar_source_tree.operators import (
-        Add,
-        BitAnd,
-        BitOr,
-        BitXor,
-        Div,
-        FloorDiv,
-        LShift,
-        MatMult,
-        Mod,
-        Mult,
-        Pow,
-        RShift,
-        Sub,
-    )
-
-    if isinstance(op, Add):
-        return project_iadd
-    if isinstance(op, Sub):
-        return project_isub
-    if isinstance(op, Mult):
-        return project_imul
-    if isinstance(op, Div):
-        return project_itruediv
-    if isinstance(op, FloorDiv):
-        return project_ifloordiv
-    if isinstance(op, Mod):
-        return project_imod
-    if isinstance(op, Pow):
-        return project_ipow
-    if isinstance(op, BitAnd):
-        return project_iand
-    if isinstance(op, BitOr):
-        return project_ior
-    if isinstance(op, BitXor):
-        return project_ixor
-    if isinstance(op, LShift):
-        return project_ilshift
-    if isinstance(op, RShift):
-        return project_irshift
-    if isinstance(op, MatMult):
-        return project_imatmul
-    from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-    from sugar_lift_py_tests.gap.panic import construction_panic
-
-    construction_panic(
-        ConstructionGap(
-            owner="inplace_projector_for",
-            blame=str(op),
-            observed=f"no enrolled inplace projector for {type(op).__name__}",
-            requested="an explicit project_* function for this BinaryOperator class",
-            fix="enroll project_<i*> and wire isinstance arm in inplace_projector_for",
-            gap_kind=GapKind.FLOOR,
-            gap_locus=GapLocus.CONSTRUCTION,
-        )
-    )
-    raise AssertionError("unreachable")
 
 
 # Explicit projectors for authenticated native operations.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -1268,6 +1268,50 @@ class FloorValue:
             other, site, "matrix_multiply", "matrix-multiplication"
         )
 
+    # --- Inplace (AugAssign) protocol -----------------------------------------
+    # Default: absent __iadd__-style method falls through to ordinary binary.
+    # Species that own true inplace override these methods.  Projectors dispatch
+    # directly to left.iadd / left.isub / … — they do not probe getattr.
+
+    def iadd(self, other, site):
+        return self.add(other, site)
+
+    def isub(self, other, site):
+        return self.subtract(other, site)
+
+    def imul(self, other, site):
+        return self.multiply(other, site)
+
+    def itruediv(self, other, site):
+        return self.divide(other, site)
+
+    def ifloordiv(self, other, site):
+        return self.floor_divide(other, site)
+
+    def imod(self, other, site):
+        return self.modulo(other, site)
+
+    def ipow(self, other, site):
+        return self.power(other, site)
+
+    def iand(self, other, site):
+        return self.bitwise_and(other, site)
+
+    def ior(self, other, site):
+        return self.bitwise_or(other, site)
+
+    def ixor(self, other, site):
+        return self.bitwise_xor(other, site)
+
+    def ilshift(self, other, site):
+        return self.left_shift(other, site)
+
+    def irshift(self, other, site):
+        return self.right_shift(other, site)
+
+    def imatmul(self, other, site):
+        return self.matrix_multiply(other, site)
+
     def _runtime_bitwise_gap(self, other, site, owner, label):
         return self._binary_floor_gap(other, site, owner, f"runtime bitwise {label}")
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -1268,50 +1268,6 @@ class FloorValue:
             other, site, "matrix_multiply", "matrix-multiplication"
         )
 
-    # --- Inplace (AugAssign) protocol -----------------------------------------
-    # Default: absent __iadd__-style method falls through to ordinary binary.
-    # Species that own true inplace override these methods.  Projectors dispatch
-    # directly to left.iadd / left.isub / … — they do not probe getattr.
-
-    def iadd(self, other, site):
-        return self.add(other, site)
-
-    def isub(self, other, site):
-        return self.subtract(other, site)
-
-    def imul(self, other, site):
-        return self.multiply(other, site)
-
-    def itruediv(self, other, site):
-        return self.divide(other, site)
-
-    def ifloordiv(self, other, site):
-        return self.floor_divide(other, site)
-
-    def imod(self, other, site):
-        return self.modulo(other, site)
-
-    def ipow(self, other, site):
-        return self.power(other, site)
-
-    def iand(self, other, site):
-        return self.bitwise_and(other, site)
-
-    def ior(self, other, site):
-        return self.bitwise_or(other, site)
-
-    def ixor(self, other, site):
-        return self.bitwise_xor(other, site)
-
-    def ilshift(self, other, site):
-        return self.left_shift(other, site)
-
-    def irshift(self, other, site):
-        return self.right_shift(other, site)
-
-    def imatmul(self, other, site):
-        return self.matrix_multiply(other, site)
-
     def _runtime_bitwise_gap(self, other, site, owner, label):
         return self._binary_floor_gap(other, site, owner, f"runtime bitwise {label}")
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/__init__.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+from .inplace_binary_operator_operation import (
+    InplaceBinaryOperatorOperation,
+    discharge_inplace,
+)
 from .sequence_projection_operation import SequenceProjectionOperation
 
-__all__ = ["SequenceProjectionOperation"]
+__all__ = [
+    "InplaceBinaryOperatorOperation",
+    "SequenceProjectionOperation",
+    "discharge_inplace",
+]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/inplace_binary_operator_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/inplace_binary_operator_operation.py
@@ -1,0 +1,126 @@
+"""In-place binary operation (AugAssign): the established Floor edge.
+
+Route is always:
+
+    InplaceBinaryOperatorOperation(surface, right, …)
+        → receiver.inplace_binary_operator_with(operation, ctx)
+
+``ObjectValue`` overrides the floor method to authenticate ``__iadd__``-family
+data-model methods.  Species without an override take
+``operation.inplace_default`` → ordinary binary by surface operator.
+
+There is no second protocol (no free ``left.iadd`` methods on FloorValue).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, ClassVar
+
+
+# Surface operator spelling (as ObjectValue / BinaryOperator.symbol) → Floor binary.
+_SURFACE_BINARY: dict[str, Callable] = {
+    "+": lambda left, right, site: left.add(right, site),
+    "-": lambda left, right, site: left.subtract(right, site),
+    "*": lambda left, right, site: left.multiply(right, site),
+    "/": lambda left, right, site: left.divide(right, site),
+    "//": lambda left, right, site: left.floor_divide(right, site),
+    "%": lambda left, right, site: left.modulo(right, site),
+    "**": lambda left, right, site: left.power(right, site),
+    "@": lambda left, right, site: left.matrix_multiply(right, site),
+    "&": lambda left, right, site: left.bitwise_and(right, site),
+    "|": lambda left, right, site: left.bitwise_or(right, site),
+    "^": lambda left, right, site: left.bitwise_xor(right, site),
+    "<<": lambda left, right, site: left.left_shift(right, site),
+    ">>": lambda left, right, site: left.right_shift(right, site),
+}
+
+
+@dataclass(frozen=True)
+class InplaceBinaryOperatorOperation:
+    """One inplace binary demand against one left receiver and one right operand.
+
+    ``operator`` is the surface spelling (``+``, ``-``, …) matching
+    ``ObjectValue``'s ``_INPLACE_BINARY_DUNDER_METHODS`` keys — not the carrier
+    name ``iadd``.
+    """
+
+    method_name: ClassVar[str] = "inplace_binary_operator_with"
+
+    operator: str
+    right: Any
+    owner: str
+    blame: object
+
+    def inplace_default(self, receiver, ctx) -> Any:
+        """Species without inplace override: ordinary binary by surface operator."""
+        del ctx
+        binary = _SURFACE_BINARY.get(self.operator)
+        if binary is None:
+            from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+            from sugar_lift_py_tests.gap.panic import construction_panic
+
+            construction_panic(
+                ConstructionGap(
+                    owner="InplaceBinaryOperatorOperation.inplace_default",
+                    blame=str(self.blame),
+                    observed=f"unknown surface operator {self.operator!r}",
+                    requested="a surface operator enrolled in _SURFACE_BINARY",
+                    fix="enroll the surface spelling on _SURFACE_BINARY",
+                    gap_kind=GapKind.FLOOR,
+                    gap_locus=GapLocus.CONSTRUCTION,
+                )
+            )
+        return binary(receiver, self.right, self.blame)
+
+
+def after_inplace_notimplemented(projected, binary_fallback: Callable):
+    """NotImplemented (raw or Complete) → ordinary binary; all other faces stay.
+
+    Incomplete, ExitSet, RaiseValue, carriers, and successful Complete values
+    surface unchanged — they never authorize binary fallback.
+    """
+    from sugar_lift_py_tests.outcome import Complete
+
+    if projected is NotImplemented:
+        return binary_fallback()
+    if isinstance(projected, Complete) and projected.value is NotImplemented:
+        return binary_fallback()
+    return projected
+
+
+def discharge_inplace(left, right, site, *, surface: str):
+    """Production projector body: established floor edge + NotImplemented law.
+
+    1. ``left.inplace_binary_operator_with(InplaceBinaryOperatorOperation(...))``
+    2. If the floor yields raw/completed NotImplemented → corresponding binary
+    3. Otherwise return the floor face unchanged
+    """
+    binary = _SURFACE_BINARY.get(surface)
+    if binary is None:
+        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+        from sugar_lift_py_tests.gap.panic import construction_panic
+
+        construction_panic(
+            ConstructionGap(
+                owner="discharge_inplace",
+                blame=str(site),
+                observed=f"unknown surface operator {surface!r}",
+                requested="a surface operator enrolled in _SURFACE_BINARY",
+                fix="enroll the surface spelling on _SURFACE_BINARY",
+                gap_kind=GapKind.FLOOR,
+                gap_locus=GapLocus.CONSTRUCTION,
+            )
+        )
+    projected = left.inplace_binary_operator_with(
+        InplaceBinaryOperatorOperation(
+            operator=surface,
+            right=right,
+            owner=f"inplace:{surface}",
+            blame=site,
+        ),
+        None,
+    )
+    return after_inplace_notimplemented(
+        projected, lambda: binary(left, right, site)
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
@@ -67,19 +67,14 @@ def _chain(outcome, step):
 def _augmented_binary(left, right, op_kind: str, site) -> Outcome:
     """In-place when Floor authorizes; otherwise ordinary binary.
 
-    Does **not** invent a shared ``iadd`` native-operation projector.  If a
-    future formal ``iadd`` mint/projector is required for symbolic carriers,
-    bank that red with the exact contract rather than emulating it here.
+    Formal operands mint the **authenticated i*** native-operation demand
+    (``operator='iadd'`` for ``+=``).  Projector absence is an honorable red —
+    never silent-fallback to minting ordinary ``add`` (false green about
+    in-place semantics).  Binary fallback lives only *inside* the enrolled
+    i* projector (Floor declines i* → ordinary binary), matching Python.
 
-    Formal operands mint a native-operation demand **before** Floor conversion
-    can turn a ground left into a bare SymbolicValue (which would erase the
-    authenticated ground arithmetic face after discharge).  Prefer enrolled
-    ``iadd`` (etc.) projectors when present; else the ordinary binary name.
-
-    Floor law (decided, non-formal receivers):
-      1. Prefer ``left.iadd(right, site)`` when present and not Raise/NotImplemented
-      2. Else ``left.add(right, site)`` for ``+`` (and the matching binary for
-         other op kinds via the same names as BinOpSugar)
+    Ground (non-formal) path: Floor ``left.iadd`` when present, else
+    ``left.add`` — same law, no carrier mint.
     """
     from sugar_lift_py_tests.caller_parameter_contract import (
         NativeOperationExitCarrierV1,
@@ -109,12 +104,13 @@ def _augmented_binary(left, right, op_kind: str, site) -> Outcome:
     left_coord = getattr(left, "formal_coordinate", None)
     right_coord = getattr(right, "formal_coordinate", None)
     if left_coord is not None or right_coord is not None:
-        # Formal path: mint demand; discharge supplies actuals to the projector.
-        # Prefer enrolled i* projectors; do not invent iadd here when missing.
-        if inplace_name is not None and inplace_name in _NATIVE_OPERATION_PROJECTORS:
-            operator = inplace_name
-        else:
+        # Formal path: always mint authenticated i* when the op has one.
+        # Projector absence → honorable red.  Never mint ordinary binary as a
+        # stand-in for missing i* (advisor: that fallback is a false green).
+        if inplace_name is None:
             operator = binary_name
+        else:
+            operator = inplace_name
         if operator not in _NATIVE_OPERATION_PROJECTORS:
             from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
             from sugar_lift_py_tests.gap.panic import construction_panic
@@ -124,19 +120,19 @@ def _augmented_binary(left, right, op_kind: str, site) -> Outcome:
                     owner="SubscriptAugAssignSugar._augmented_binary",
                     blame=str(site),
                     observed=(
-                        f"formal AugAssign {op_kind} needs projector "
-                        f"{inplace_name!r} or {binary_name!r}; neither enrolled"
+                        f"formal AugAssign {op_kind} requires enrolled projector "
+                        f"operator={operator!r}; projector is ABSENT"
                     ),
                     requested=(
                         "shared authenticated native-operation projector: "
-                        f"operator={inplace_name!r} with "
-                        f"lambda left, right, site: left.{inplace_name}(right, site) "
-                        f"or operator={binary_name!r} already used by BinOp"
+                        f"operator={operator!r} with signature "
+                        f"(left, right, site) -> Floor {operator} then "
+                        f"authorized {binary_name} only inside that projector"
                     ),
                     fix=(
-                        "enroll the i* / binary projector on "
-                        "_NATIVE_OPERATION_PROJECTORS; do not emulate formal "
-                        "iadd inside AugAssign"
+                        f"enroll {operator!r} on _NATIVE_OPERATION_PROJECTORS "
+                        "(see _project_inplace_then_binary); do not mint "
+                        f"{binary_name!r} as a silent stand-in for missing i*"
                     ),
                     gap_kind=GapKind.FLOOR,
                     gap_locus=GapLocus.CONSTRUCTION,
@@ -178,15 +174,11 @@ def _augmented_binary(left, right, op_kind: str, site) -> Outcome:
                 blame=str(site),
                 observed=f"{type(left).__name__} has no {binary_name} for AugAssign {op_kind}",
                 requested=(
-                    "Floor binary (or authorized i*) for augmented assignment, "
-                    "or a shared authenticated iadd native-operation projector "
-                    "minted as operator='iadd' with projector "
-                    "lambda left, right, site: left.iadd(right, site)"
+                    "Floor binary (or authorized i*) for augmented assignment"
                 ),
                 fix=(
-                    "implement Floor iadd/add for this value species, or enroll "
-                    "a formal iadd producer/projector rather than emulating "
-                    "inside AugAssign"
+                    f"implement Floor {inplace_name or binary_name}/{binary_name} "
+                    "for this value species"
                 ),
                 gap_kind=GapKind.FLOOR,
                 gap_locus=GapLocus.CONSTRUCTION,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.caller_parameter_contract import (
-    InplaceThenBinaryProjector,
     NativeOperationExitCarrierV1,
     _NATIVE_OPERATION_PROJECTORS,
 )
@@ -33,9 +33,6 @@ class AugAssignSugar(Sugar):
         from sugar_lift_py_tests.floor.block_value import BlockValue
         from sugar_lift_py_tests.outcome import Complete
 
-        # Evaluate the read-op child for its real effects, then discard its
-        # ordinary value: the lexical store is already carried by BindingEntryV1.
-        # Incomplete/Halted faces bypass this continuation and remain loud.
         return self.operation.desugar(ctx).and_then(
             lambda _value: Complete(BlockValue((), can_fall_through=True))
         )
@@ -44,19 +41,21 @@ class AugAssignSugar(Sugar):
 def project_augmented(
     left,
     right,
-    operation: InplaceThenBinaryProjector,
+    *,
+    operator: str,
+    projector: Callable,
     site,
 ) -> Outcome:
     """Mint formal i* demand, or project ground through the explicit projector.
 
-    Formal operands always mint ``operation.operator`` (e.g. ``iadd``).
-    Projector absence is an honorable red — never mint ordinary binary as a
-    stand-in.  Ground projection is ``operation(left, right, site)``.
+    ``operator`` is the carrier name from ``BinaryOperator.inplace_operator``
+    (e.g. ``iadd``).  ``projector`` is the explicit ``project_iadd`` function.
+    Projector absence is an honorable red — never mint ordinary binary.
     """
     left_coord = getattr(left, "formal_coordinate", None)
     right_coord = getattr(right, "formal_coordinate", None)
     if left_coord is not None or right_coord is not None:
-        if operation.operator not in _NATIVE_OPERATION_PROJECTORS:
+        if operator not in _NATIVE_OPERATION_PROJECTORS:
             from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
             from sugar_lift_py_tests.gap.panic import construction_panic
 
@@ -66,16 +65,12 @@ def project_augmented(
                     blame=str(site),
                     observed=(
                         f"formal AugAssign requires enrolled projector "
-                        f"operator={operation.operator!r}; projector is ABSENT"
+                        f"operator={operator!r}; projector is ABSENT"
                     ),
-                    requested=(
-                        f"InplaceThenBinaryProjector enrolled as "
-                        f"operator={operation.operator!r}"
-                    ),
+                    requested=f"explicit project_* enrolled as operator={operator!r}",
                     fix=(
-                        f"enroll {operation.operator!r} on "
-                        "_NATIVE_OPERATION_PROJECTORS; do not mint ordinary "
-                        "binary as a silent stand-in for missing i*"
+                        f"enroll {operator!r} on _NATIVE_OPERATION_PROJECTORS; "
+                        "do not mint ordinary binary as a silent stand-in"
                     ),
                     gap_kind=GapKind.FLOOR,
                     gap_locus=GapLocus.CONSTRUCTION,
@@ -83,38 +78,28 @@ def project_augmented(
             )
         return NativeOperationExitCarrierV1.mint(
             site=site,
-            operator=operation.operator,
+            operator=operator,
             operands=(left, right),
             coordinates=(left_coord, right_coord),
         )
-    return operation(left, right, site)
+    return projector(left, right, site)
 
 
 @dataclass(frozen=True)
 class SubscriptAugAssignSugar(Sugar):
     """``receiver[index] OP= rhs`` — get once, operate, setitem last.
 
-    Python evaluation law (load-bearing):
-
-      1. Evaluate ``receiver`` once
-      2. Evaluate ``index`` once
-      3. ``current = receiver.subscript(index)``  (getitem) — **before** RHS
-      4. Evaluate ``rhs``
-      5. ``result = current OP rhs`` via explicit ``InplaceThenBinaryProjector``
-      6. ``receiver.setitem(index, result)`` last
-
-    Composition uses the outcome/carrier ``and_then`` law directly
-    (``Complete`` short-circuits RaiseValue; ``Incomplete``/carriers/ExitSet
-    compose themselves).  No bespoke control-kind ladder.
-
-    Read, arithmetic, and write use **distinct** occurrence sites
-    (``get_site``, ``op_site`` = operator-token interval, ``set_site``).
+    Composition uses the outcome/carrier ``and_then`` law directly.
+    ``operation`` is an explicit ``project_*`` function; ``operator`` is the
+    carrier name from the source BinaryOperator class.
+    ``op_site`` is the structural operator gap minted before substitute.
     """
 
     receiver: Sugar
     index: Sugar
     rhs: Sugar
-    operation: InplaceThenBinaryProjector
+    operator: str
+    operation: Callable
     get_site: object = dataclass_field(compare=False)
     op_site: object = dataclass_field(compare=False)
     set_site: object = dataclass_field(compare=False)
@@ -125,14 +110,16 @@ class SubscriptAugAssignSugar(Sugar):
         return ()
 
     def desugar(self, ctx: object = None) -> Outcome:
-        # Receiver and index once each — closed over for get and setitem.
-        # Outcome composition law owns control: no isinstance ladder on faces.
         return self.receiver.desugar(ctx).and_then(
             lambda receiver: self.index.desugar(ctx).and_then(
                 lambda index: receiver.subscript(index, self.get_site).and_then(
                     lambda current: self.rhs.desugar(ctx).and_then(
                         lambda right: project_augmented(
-                            current, right, self.operation, self.op_site
+                            current,
+                            right,
+                            operator=self.operator,
+                            projector=self.operation,
+                            site=self.op_site,
                         ).and_then(
                             lambda result: self._store(receiver, index, result)
                         )
@@ -142,13 +129,6 @@ class SubscriptAugAssignSugar(Sugar):
         )
 
     def _store(self, receiver, index, result) -> Outcome:
-        """setitem last — formal operands stay undischarged carriers.
-
-        Matches ``SubscriptStoreEffectSugar``: any formal among receiver /
-        index / result mints the n-ary ``setitem`` demand so caller actuals
-        can discharge it.  Decided ground receivers call Floor ``setitem``
-        directly.  No receiver-type spelling arms.
-        """
         coordinates = tuple(
             getattr(operand, "formal_coordinate", None)
             for operand in (receiver, index, result)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
@@ -9,7 +9,7 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class AugAssignSugar(Sugar):
-    """The already-constructed read-op-store value of a lexical AugAssign."""
+    """The already-constructed read-op-store value of a lexical Name AugAssign."""
 
     operation: Sugar
     site: object = dataclass_field(compare=False)
@@ -34,3 +34,262 @@ class AugAssignSugar(Sugar):
         return self.operation.desugar(ctx).and_then(
             lambda _value: Complete(BlockValue((), can_fall_through=True))
         )
+
+
+def _chain(outcome, step):
+    """Continue only on completed ordinary values / carriers; halt faces stay loud."""
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+    from sugar_lift_py_tests.floor import RaiseValue
+    from sugar_lift_py_tests.outcome import Complete, Incomplete
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    if isinstance(outcome, NativeOperationExitCarrierV1):
+        return outcome.and_then(step)
+    if isinstance(outcome, Incomplete):
+        return outcome
+    if isinstance(outcome, ExitSet):
+        # Multi-arm get/add: only continue completed faces via ExitSet.and_then
+        return outcome.and_then(step)
+    if isinstance(outcome, Complete):
+        if isinstance(outcome.value, RaiseValue):
+            # Get/arithmetic halt: do not evaluate RHS/store (RaiseValue short-circuit).
+            return outcome
+        return step(outcome.value)
+    # Other outcomes (e.g. Complete-like) try step only if and_then exists.
+    and_then = getattr(outcome, "and_then", None)
+    if and_then is not None:
+        return and_then(step)
+    return outcome
+
+
+def _augmented_binary(left, right, op_kind: str, site) -> Outcome:
+    """In-place when Floor authorizes; otherwise ordinary binary.
+
+    Does **not** invent a shared ``iadd`` native-operation projector.  If a
+    future formal ``iadd`` mint/projector is required for symbolic carriers,
+    bank that red with the exact contract rather than emulating it here.
+
+    Formal operands mint a native-operation demand **before** Floor conversion
+    can turn a ground left into a bare SymbolicValue (which would erase the
+    authenticated ground arithmetic face after discharge).  Prefer enrolled
+    ``iadd`` (etc.) projectors when present; else the ordinary binary name.
+
+    Floor law (decided, non-formal receivers):
+      1. Prefer ``left.iadd(right, site)`` when present and not Raise/NotImplemented
+      2. Else ``left.add(right, site)`` for ``+`` (and the matching binary for
+         other op kinds via the same names as BinOpSugar)
+    """
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+        _NATIVE_OPERATION_PROJECTORS,
+    )
+    from sugar_lift_py_tests.floor import RaiseValue
+    from sugar_lift_py_tests.outcome import Complete
+
+    method_by_kind = {
+        "Add": ("iadd", "add"),
+        "Sub": ("isub", "subtract"),
+        "Mult": ("imul", "multiply"),
+        "Div": ("itruediv", "divide"),
+        "FloorDiv": ("ifloordiv", "floor_divide"),
+        "Mod": ("imod", "modulo"),
+        "Pow": ("ipow", "power"),
+        "BitAnd": ("iand", "bitwise_and"),
+        "BitOr": ("ior", "bitwise_or"),
+        "BitXor": ("ixor", "bitwise_xor"),
+        "LShift": ("ilshift", "left_shift"),
+        "RShift": ("irshift", "right_shift"),
+        "MatMult": ("imatmul", "matrix_multiply"),
+    }
+    names = method_by_kind.get(op_kind, (None, "add"))
+    inplace_name, binary_name = names
+
+    left_coord = getattr(left, "formal_coordinate", None)
+    right_coord = getattr(right, "formal_coordinate", None)
+    if left_coord is not None or right_coord is not None:
+        # Formal path: mint demand; discharge supplies actuals to the projector.
+        # Prefer enrolled i* projectors; do not invent iadd here when missing.
+        if inplace_name is not None and inplace_name in _NATIVE_OPERATION_PROJECTORS:
+            operator = inplace_name
+        else:
+            operator = binary_name
+        if operator not in _NATIVE_OPERATION_PROJECTORS:
+            from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+            from sugar_lift_py_tests.gap.panic import construction_panic
+
+            construction_panic(
+                ConstructionGap(
+                    owner="SubscriptAugAssignSugar._augmented_binary",
+                    blame=str(site),
+                    observed=(
+                        f"formal AugAssign {op_kind} needs projector "
+                        f"{inplace_name!r} or {binary_name!r}; neither enrolled"
+                    ),
+                    requested=(
+                        "shared authenticated native-operation projector: "
+                        f"operator={inplace_name!r} with "
+                        f"lambda left, right, site: left.{inplace_name}(right, site) "
+                        f"or operator={binary_name!r} already used by BinOp"
+                    ),
+                    fix=(
+                        "enroll the i* / binary projector on "
+                        "_NATIVE_OPERATION_PROJECTORS; do not emulate formal "
+                        "iadd inside AugAssign"
+                    ),
+                    gap_kind=GapKind.FLOOR,
+                    gap_locus=GapLocus.CONSTRUCTION,
+                )
+            )
+        return NativeOperationExitCarrierV1.mint(
+            site=site,
+            operator=operator,
+            operands=(left, right),
+            coordinates=(left_coord, right_coord),
+        )
+
+    if inplace_name is not None:
+        inplace = getattr(left, inplace_name, None)
+        if callable(inplace):
+            projected = inplace(right, site)
+            # Floor NotImplemented-style gaps fall through; RaiseValue stops.
+            if isinstance(projected, Complete) and isinstance(
+                projected.value, RaiseValue
+            ):
+                return projected
+            if isinstance(projected, Complete):
+                return projected
+            # Incomplete / ExitSet from inplace: surface them (authorized faces).
+            from sugar_lift_py_tests.outcome import Incomplete
+            from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+            if isinstance(projected, (Incomplete, ExitSet)):
+                return projected
+
+    binary = getattr(left, binary_name, None)
+    if not callable(binary):
+        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+        from sugar_lift_py_tests.gap.panic import construction_panic
+
+        construction_panic(
+            ConstructionGap(
+                owner="SubscriptAugAssignSugar._augmented_binary",
+                blame=str(site),
+                observed=f"{type(left).__name__} has no {binary_name} for AugAssign {op_kind}",
+                requested=(
+                    "Floor binary (or authorized i*) for augmented assignment, "
+                    "or a shared authenticated iadd native-operation projector "
+                    "minted as operator='iadd' with projector "
+                    "lambda left, right, site: left.iadd(right, site)"
+                ),
+                fix=(
+                    "implement Floor iadd/add for this value species, or enroll "
+                    "a formal iadd producer/projector rather than emulating "
+                    "inside AugAssign"
+                ),
+                gap_kind=GapKind.FLOOR,
+                gap_locus=GapLocus.CONSTRUCTION,
+            )
+        )
+    return binary(right, site)
+
+
+@dataclass(frozen=True)
+class SubscriptAugAssignSugar(Sugar):
+    """``receiver[index] OP= rhs`` — get once, operate, setitem last.
+
+    Python evaluation law (load-bearing):
+
+      1. Evaluate ``receiver`` once
+      2. Evaluate ``index`` once
+      3. ``current = receiver.subscript(index)``  (getitem) — **before** RHS
+      4. Evaluate ``rhs``
+      5. ``result = current OP rhs`` (inplace when Floor authorizes, else binary)
+      6. ``receiver.setitem(index, result)`` last
+
+    Get halt blocks RHS / arithmetic / store.  RHS or arithmetic halt blocks
+    the store.  Store halt preserves prior get/arithmetic testimony (no
+    fabricated completion).  Read, arithmetic, and write use **distinct**
+    occurrence sites (``get_site``, ``op_site``, ``set_site``).
+    """
+
+    receiver: Sugar
+    index: Sugar
+    rhs: Sugar
+    op_kind: str
+    get_site: object = dataclass_field(compare=False)
+    op_site: object = dataclass_field(compare=False)
+    set_site: object = dataclass_field(compare=False)
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        # Receiver and index once each — closed over for get and setitem.
+        return self.receiver.desugar(ctx).and_then(
+            lambda receiver: self.index.desugar(ctx).and_then(
+                lambda index: self._after_receiver_index(receiver, index, ctx)
+            )
+        )
+
+    def _after_receiver_index(self, receiver, index, ctx) -> Outcome:
+        get_outcome = receiver.subscript(index, self.get_site)
+
+        def after_get(current):
+            return self.rhs.desugar(ctx).and_then(
+                lambda right: self._after_rhs(receiver, index, current, right)
+            )
+
+        return _chain(get_outcome, after_get)
+
+    def _after_rhs(self, receiver, index, current, right) -> Outcome:
+        op_outcome = _augmented_binary(current, right, self.op_kind, self.op_site)
+
+        def after_op(result):
+            return self._store(receiver, index, result)
+
+        return _chain(op_outcome, after_op)
+
+    def _store(self, receiver, index, result) -> Outcome:
+        """setitem last — formal operands stay undischarged carriers.
+
+        Matches ``SubscriptStoreEffectSugar``: any formal among receiver /
+        index / result mints the n-ary ``setitem`` demand so caller actuals
+        can discharge it.  Decided ground receivers call Floor ``setitem``
+        directly.  No receiver-type spelling arms.
+        """
+        coordinates = tuple(
+            getattr(operand, "formal_coordinate", None)
+            for operand in (receiver, index, result)
+        )
+        if any(coordinate is not None for coordinate in coordinates):
+            from sugar_lift_py_tests.sugar.store_effect_sugar import (
+                SubscriptStoreEffectSugar,
+            )
+
+            return SubscriptStoreEffectSugar.mint_setitem_carrier(
+                site=self.set_site,
+                receiver=receiver,
+                index=index,
+                value=result,
+            )
+        if not receiver.runtime_type_is_decided():
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                owner="SubscriptAugAssignSugar._store",
+                blame=self.set_site,
+                observed="undischarged augmented subscript store over undecided receiver",
+                requested=(
+                    "NativeOperationExitCarrierV1 n-ary setitem demand over "
+                    "receiver, key, and result formal coordinates"
+                ),
+                fix=(
+                    "attach formal coordinates via AugAssign.substitute store-target "
+                    "law (same door as Assign); do not invent setitem completion"
+                ),
+            )
+        return receiver.setitem(index, result, self.set_site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field as dataclass_field
 
+from sugar_lift_py_tests.caller_parameter_contract import (
+    InplaceThenBinaryProjector,
+    NativeOperationExitCarrierV1,
+    _NATIVE_OPERATION_PROJECTORS,
+)
 from sugar_lift_py_tests.outcome import Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
@@ -36,103 +41,41 @@ class AugAssignSugar(Sugar):
         )
 
 
-def _chain(outcome, step):
-    """Continue only on completed ordinary values / carriers; halt faces stay loud."""
-    from sugar_lift_py_tests.caller_parameter_contract import (
-        NativeOperationExitCarrierV1,
-    )
-    from sugar_lift_py_tests.floor import RaiseValue
-    from sugar_lift_py_tests.outcome import Complete, Incomplete
-    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+def project_augmented(
+    left,
+    right,
+    operation: InplaceThenBinaryProjector,
+    site,
+) -> Outcome:
+    """Mint formal i* demand, or project ground through the explicit projector.
 
-    if isinstance(outcome, NativeOperationExitCarrierV1):
-        return outcome.and_then(step)
-    if isinstance(outcome, Incomplete):
-        return outcome
-    if isinstance(outcome, ExitSet):
-        # Multi-arm get/add: only continue completed faces via ExitSet.and_then
-        return outcome.and_then(step)
-    if isinstance(outcome, Complete):
-        if isinstance(outcome.value, RaiseValue):
-            # Get/arithmetic halt: do not evaluate RHS/store (RaiseValue short-circuit).
-            return outcome
-        return step(outcome.value)
-    # Other outcomes (e.g. Complete-like) try step only if and_then exists.
-    and_then = getattr(outcome, "and_then", None)
-    if and_then is not None:
-        return and_then(step)
-    return outcome
-
-
-def _augmented_binary(left, right, op_kind: str, site) -> Outcome:
-    """In-place when Floor authorizes; otherwise ordinary binary.
-
-    Formal operands mint the **authenticated i*** native-operation demand
-    (``operator='iadd'`` for ``+=``).  Projector absence is an honorable red —
-    never silent-fallback to minting ordinary ``add`` (false green about
-    in-place semantics).  Binary fallback lives only *inside* the enrolled
-    i* projector (Floor declines i* → ordinary binary), matching Python.
-
-    Ground (non-formal) path: Floor ``left.iadd`` when present, else
-    ``left.add`` — same law, no carrier mint.
+    Formal operands always mint ``operation.operator`` (e.g. ``iadd``).
+    Projector absence is an honorable red — never mint ordinary binary as a
+    stand-in.  Ground projection is ``operation(left, right, site)``.
     """
-    from sugar_lift_py_tests.caller_parameter_contract import (
-        NativeOperationExitCarrierV1,
-        _NATIVE_OPERATION_PROJECTORS,
-    )
-    from sugar_lift_py_tests.floor import RaiseValue
-    from sugar_lift_py_tests.outcome import Complete
-
-    method_by_kind = {
-        "Add": ("iadd", "add"),
-        "Sub": ("isub", "subtract"),
-        "Mult": ("imul", "multiply"),
-        "Div": ("itruediv", "divide"),
-        "FloorDiv": ("ifloordiv", "floor_divide"),
-        "Mod": ("imod", "modulo"),
-        "Pow": ("ipow", "power"),
-        "BitAnd": ("iand", "bitwise_and"),
-        "BitOr": ("ior", "bitwise_or"),
-        "BitXor": ("ixor", "bitwise_xor"),
-        "LShift": ("ilshift", "left_shift"),
-        "RShift": ("irshift", "right_shift"),
-        "MatMult": ("imatmul", "matrix_multiply"),
-    }
-    names = method_by_kind.get(op_kind, (None, "add"))
-    inplace_name, binary_name = names
-
     left_coord = getattr(left, "formal_coordinate", None)
     right_coord = getattr(right, "formal_coordinate", None)
     if left_coord is not None or right_coord is not None:
-        # Formal path: always mint authenticated i* when the op has one.
-        # Projector absence → honorable red.  Never mint ordinary binary as a
-        # stand-in for missing i* (advisor: that fallback is a false green).
-        if inplace_name is None:
-            operator = binary_name
-        else:
-            operator = inplace_name
-        if operator not in _NATIVE_OPERATION_PROJECTORS:
+        if operation.operator not in _NATIVE_OPERATION_PROJECTORS:
             from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
             from sugar_lift_py_tests.gap.panic import construction_panic
 
             construction_panic(
                 ConstructionGap(
-                    owner="SubscriptAugAssignSugar._augmented_binary",
+                    owner="project_augmented",
                     blame=str(site),
                     observed=(
-                        f"formal AugAssign {op_kind} requires enrolled projector "
-                        f"operator={operator!r}; projector is ABSENT"
+                        f"formal AugAssign requires enrolled projector "
+                        f"operator={operation.operator!r}; projector is ABSENT"
                     ),
                     requested=(
-                        "shared authenticated native-operation projector: "
-                        f"operator={operator!r} with signature "
-                        f"(left, right, site) -> Floor {operator} then "
-                        f"authorized {binary_name} only inside that projector"
+                        f"InplaceThenBinaryProjector enrolled as "
+                        f"operator={operation.operator!r}"
                     ),
                     fix=(
-                        f"enroll {operator!r} on _NATIVE_OPERATION_PROJECTORS "
-                        "(see _project_inplace_then_binary); do not mint "
-                        f"{binary_name!r} as a silent stand-in for missing i*"
+                        f"enroll {operation.operator!r} on "
+                        "_NATIVE_OPERATION_PROJECTORS; do not mint ordinary "
+                        "binary as a silent stand-in for missing i*"
                     ),
                     gap_kind=GapKind.FLOOR,
                     gap_locus=GapLocus.CONSTRUCTION,
@@ -140,51 +83,11 @@ def _augmented_binary(left, right, op_kind: str, site) -> Outcome:
             )
         return NativeOperationExitCarrierV1.mint(
             site=site,
-            operator=operator,
+            operator=operation.operator,
             operands=(left, right),
             coordinates=(left_coord, right_coord),
         )
-
-    if inplace_name is not None:
-        inplace = getattr(left, inplace_name, None)
-        if callable(inplace):
-            projected = inplace(right, site)
-            # Floor NotImplemented-style gaps fall through; RaiseValue stops.
-            if isinstance(projected, Complete) and isinstance(
-                projected.value, RaiseValue
-            ):
-                return projected
-            if isinstance(projected, Complete):
-                return projected
-            # Incomplete / ExitSet from inplace: surface them (authorized faces).
-            from sugar_lift_py_tests.outcome import Incomplete
-            from sugar_lift_py_tests.outcome.exit_set import ExitSet
-
-            if isinstance(projected, (Incomplete, ExitSet)):
-                return projected
-
-    binary = getattr(left, binary_name, None)
-    if not callable(binary):
-        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-        from sugar_lift_py_tests.gap.panic import construction_panic
-
-        construction_panic(
-            ConstructionGap(
-                owner="SubscriptAugAssignSugar._augmented_binary",
-                blame=str(site),
-                observed=f"{type(left).__name__} has no {binary_name} for AugAssign {op_kind}",
-                requested=(
-                    "Floor binary (or authorized i*) for augmented assignment"
-                ),
-                fix=(
-                    f"implement Floor {inplace_name or binary_name}/{binary_name} "
-                    "for this value species"
-                ),
-                gap_kind=GapKind.FLOOR,
-                gap_locus=GapLocus.CONSTRUCTION,
-            )
-        )
-    return binary(right, site)
+    return operation(left, right, site)
 
 
 @dataclass(frozen=True)
@@ -197,19 +100,21 @@ class SubscriptAugAssignSugar(Sugar):
       2. Evaluate ``index`` once
       3. ``current = receiver.subscript(index)``  (getitem) — **before** RHS
       4. Evaluate ``rhs``
-      5. ``result = current OP rhs`` (inplace when Floor authorizes, else binary)
+      5. ``result = current OP rhs`` via explicit ``InplaceThenBinaryProjector``
       6. ``receiver.setitem(index, result)`` last
 
-    Get halt blocks RHS / arithmetic / store.  RHS or arithmetic halt blocks
-    the store.  Store halt preserves prior get/arithmetic testimony (no
-    fabricated completion).  Read, arithmetic, and write use **distinct**
-    occurrence sites (``get_site``, ``op_site``, ``set_site``).
+    Composition uses the outcome/carrier ``and_then`` law directly
+    (``Complete`` short-circuits RaiseValue; ``Incomplete``/carriers/ExitSet
+    compose themselves).  No bespoke control-kind ladder.
+
+    Read, arithmetic, and write use **distinct** occurrence sites
+    (``get_site``, ``op_site`` = operator-token interval, ``set_site``).
     """
 
     receiver: Sugar
     index: Sugar
     rhs: Sugar
-    op_kind: str
+    operation: InplaceThenBinaryProjector
     get_site: object = dataclass_field(compare=False)
     op_site: object = dataclass_field(compare=False)
     set_site: object = dataclass_field(compare=False)
@@ -221,29 +126,20 @@ class SubscriptAugAssignSugar(Sugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         # Receiver and index once each — closed over for get and setitem.
+        # Outcome composition law owns control: no isinstance ladder on faces.
         return self.receiver.desugar(ctx).and_then(
             lambda receiver: self.index.desugar(ctx).and_then(
-                lambda index: self._after_receiver_index(receiver, index, ctx)
+                lambda index: receiver.subscript(index, self.get_site).and_then(
+                    lambda current: self.rhs.desugar(ctx).and_then(
+                        lambda right: project_augmented(
+                            current, right, self.operation, self.op_site
+                        ).and_then(
+                            lambda result: self._store(receiver, index, result)
+                        )
+                    )
+                )
             )
         )
-
-    def _after_receiver_index(self, receiver, index, ctx) -> Outcome:
-        get_outcome = receiver.subscript(index, self.get_site)
-
-        def after_get(current):
-            return self.rhs.desugar(ctx).and_then(
-                lambda right: self._after_rhs(receiver, index, current, right)
-            )
-
-        return _chain(get_outcome, after_get)
-
-    def _after_rhs(self, receiver, index, current, right) -> Outcome:
-        op_outcome = _augmented_binary(current, right, self.op_kind, self.op_site)
-
-        def after_op(result):
-            return self._store(receiver, index, result)
-
-        return _chain(op_outcome, after_op)
 
     def _store(self, receiver, index, result) -> Outcome:
         """setitem last — formal operands stay undischarged carriers.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
@@ -255,6 +255,3 @@ class SubscriptStoreEffectSugar(Sugar):
             operands=(receiver, index, value),
             coordinates=coordinates,
         )
-
-
-

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
@@ -257,30 +257,4 @@ class SubscriptStoreEffectSugar(Sugar):
         )
 
 
-@dataclass(frozen=True)
-class LegacyAugmentedSubscriptStoreEffectSugar(Sugar):
-    """Preserve AugAssign without pretending its raw RHS is the stored value."""
 
-    index_text: str
-    site: object = dataclass_field(compare=False)
-
-    @classmethod
-    def witnesses(cls):
-        return ()
-
-    def desugar(self, ctx: object = None) -> Outcome:
-        del ctx
-        from sugar_lift_py_tests.effect import (
-            SubscriptStoreRuntimeEffect,
-            runtime_effect_evidence,
-        )
-        from sugar_lift_py_tests.ir import make_var
-
-        operand = make_var(f"store_target[{self.index_text}]")
-        return Incomplete(
-            SubscriptStoreRuntimeEffect(
-                "augmented subscript assignment runtime boundary: subscript store "
-                f"target `[{self.index_text}]`; index={self.index_text} site={self.site}",
-                **runtime_effect_evidence("py.setitem", operand, self.site),
-            )
-        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
@@ -1,26 +1,21 @@
 """Formal subscript augmented assignment: ``obj[key] += rhs``.
 
-Production path only: tests drive ``SubscriptAugAssignSugar.desugar``, not a
-manual subscript → project_augmented → setitem replay.
-
-MUST NOT TOUCH: carrier, ExitSet, source-return projection, generator/resource
-files; no receiver/type spelling arms.
+Production path only: tests drive ``SubscriptAugAssignSugar.desugar``.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
 from sugar_lift_py_tests.caller_parameter_contract import (
-    IADD,
-    InplaceThenBinaryProjector,
     NativeOperationExitCarrierV1,
     _NATIVE_OPERATION_PROJECTORS,
     inplace_projector_for,
     production_native_operation_operators,
+    project_iadd,
 )
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import ListValue, RaiseValue, TermValue, TupleValue
@@ -33,7 +28,10 @@ from sugar_lift_py_tests.sugar.augassign_sugar import (
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import AugAssign, FunctionDef
-from sugar_source_tree.operators import Add
+from sugar_source_tree.operators import (
+    Add,
+    production_augassign_inplace_operators,
+)
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
@@ -74,8 +72,6 @@ def _post_list(completed: Completed) -> ListValue:
 
 @dataclass(frozen=True)
 class _FloorSugar(Sugar):
-    """Constant floor child for production desugar of SubscriptAugAssignSugar."""
-
     value: object
 
     def desugar(self, ctx=None):
@@ -88,19 +84,18 @@ class _FloorSugar(Sugar):
 
 
 def _production_sites():
-    """Authenticated fragments from a real AugAssign (not string loci)."""
     _, sugar = _aug_sugar()
     return sugar.get_site, sugar.op_site, sugar.set_site, sugar.site
 
 
-def _production_desugar(receiver, index, rhs, *, operation=IADD, sites=None):
-    """Drive the production sugar path with ground floor children."""
-    get_site, op_site, set_site, site = sites or _production_sites()
+def _production_desugar(receiver, index, rhs, *, operator="iadd", projector=project_iadd):
+    get_site, op_site, set_site, site = _production_sites()
     sugar = SubscriptAugAssignSugar(
         receiver=_FloorSugar(receiver),
         index=_FloorSugar(index),
         rhs=_FloorSugar(rhs),
-        operation=operation,
+        operator=operator,
+        operation=projector,
         get_site=get_site,
         op_site=op_site,
         set_site=set_site,
@@ -110,34 +105,59 @@ def _production_desugar(receiver, index, rhs, *, operation=IADD, sites=None):
 
 
 # ---------------------------------------------------------------------------
-# Construction / occurrence sites
+# Construction / occurrence
 # ---------------------------------------------------------------------------
 
 
-def test_subscript_augassign_constructs_with_explicit_iadd_projector() -> None:
+def test_subscript_augassign_constructs_with_explicit_project_iadd() -> None:
     _, sugar = _aug_sugar()
     assert isinstance(sugar, SubscriptAugAssignSugar)
-    assert sugar.operation is IADD
-    assert sugar.operation.operator == "iadd"
+    assert sugar.operation is project_iadd
+    assert sugar.operator == "iadd"
+    assert sugar.operator == Add.inplace_operator
     assert sugar.get_site is not sugar.op_site
     assert sugar.op_site is not sugar.set_site
-    assert sugar.get_site is not sugar.set_site
 
 
-def test_op_site_is_operator_token_interval_not_rhs_occurrence() -> None:
-    """op_site is the gap holding ``+=``, not the RHS fragment."""
+def test_op_site_is_structural_gap_not_rhs_or_string_scan() -> None:
     function, sugar = _aug_sugar("def helper(obj, key, rhs):\n    obj[key] += rhs\n")
     aug = next(node for node in function.body if isinstance(node, AugAssign))
-    # Operator interval is between target end and value start.
     assert sugar.op_site is not aug.value.fragment
-    text = sugar.op_site.text if hasattr(sugar.op_site, "text") else str(sugar.op_site)
-    # Source fragment text should include the aug-assign operator spelling.
-    assert "+=" in getattr(sugar.op_site, "text", text) or "+=" in str(
-        getattr(sugar.op_site, "span", text)
-    )
-    # Distinct from get (subscript) and set (statement).
+    # Carried operator_site gap contains the operator token region.
+    text = sugar.op_site.unit.source[sugar.op_site.span.start : sugar.op_site.span.end]
+    assert "+=" in text
     assert sugar.op_site is not sugar.get_site
     assert sugar.op_site is not sugar.set_site
+
+
+def test_op_site_ignores_same_spelling_string_in_target() -> None:
+    """Lying twin: ``obj['+='] += rhs`` must not use the string literal as op_site."""
+    source = "def helper(obj, rhs):\n    obj['+='] += rhs\n"
+    function, sugar = _aug_sugar(source)
+    aug = next(node for node in function.body if isinstance(node, AugAssign))
+    op_span = sugar.op_site.span
+    # Index string constant span must not equal / contain the operator site.
+    index_node = aug.target.slice_
+    index_span = index_node.span
+    assert not (
+        op_span.start <= index_span.start and index_span.end <= op_span.end
+    ), (op_span, index_span)
+    # Operator site still sits after the full target (including ['+=']).
+    assert op_span.start >= aug.target.span.end
+    text = sugar.op_site.unit.source[op_span.start : op_span.end]
+    assert "+=" in text
+
+
+def test_discrimination_same_spelling_index_is_not_operator_site() -> None:
+    """Positive twin: operator gap; lying claim that op_site is the index fails."""
+    source = "def helper(obj, rhs):\n    obj['+='] += rhs\n"
+    _, sugar = _aug_sugar(source)
+    function = next(
+        n for n in _tree(source, "twin.py").nodes() if isinstance(n, FunctionDef)
+    )
+    aug = next(n for n in function.body if isinstance(n, AugAssign))
+    with pytest.raises(AssertionError):
+        assert sugar.op_site.span == aug.target.slice_.span
 
 
 def test_discrimination_legacy_runtime_effect_is_not_the_formal_path() -> None:
@@ -149,26 +169,100 @@ def test_discrimination_legacy_runtime_effect_is_not_the_formal_path() -> None:
 
 
 def test_legacy_augmented_subscript_store_effect_sugar_is_deleted() -> None:
-    """Shell deletion is real: class gone; no production reference remains."""
     import sugar_lift_py_tests.sugar.store_effect_sugar as store_mod
 
     assert not hasattr(store_mod, "LegacyAugmentedSubscriptStoreEffectSugar")
     package_root = Path(store_mod.__file__).resolve().parent.parent
     offenders = []
     for path in package_root.rglob("*.py"):
-        text = path.read_text(encoding="utf-8")
-        if "LegacyAugmentedSubscriptStoreEffectSugar" in text:
+        if "LegacyAugmentedSubscriptStoreEffectSugar" in path.read_text(encoding="utf-8"):
             offenders.append(str(path))
     assert offenders == [], offenders
 
 
 # ---------------------------------------------------------------------------
-# Production desugar: authenticated completion
+# Independent production / projector equality tooth
+# ---------------------------------------------------------------------------
+
+
+def test_production_inplace_set_is_independent_of_projector_table() -> None:
+    """Deleting a projector must not shrink the production-minted set."""
+    production = production_augassign_inplace_operators()
+    assert "iadd" in production
+    assert production == frozenset(
+        {
+            "iadd",
+            "isub",
+            "imul",
+            "itruediv",
+            "ifloordiv",
+            "imod",
+            "ipow",
+            "iand",
+            "ior",
+            "ixor",
+            "ilshift",
+            "irshift",
+            "imatmul",
+        }
+    )
+    # Independent source: BinaryOperator class attributes, not projector keys.
+    assert production == frozenset(
+        cls.inplace_operator
+        for cls in __import__(
+            "sugar_source_tree.operators", fromlist=["AUGASSIGN_BINARY_OPERATOR_CLASSES"]
+        ).AUGASSIGN_BINARY_OPERATOR_CLASSES
+    )
+
+
+def test_projector_keys_equal_independent_production_inplace_set() -> None:
+    production = production_augassign_inplace_operators()
+    projector_inplace = frozenset(
+        k
+        for k in _NATIVE_OPERATION_PROJECTORS
+        if k
+        in {
+            "iadd",
+            "isub",
+            "imul",
+            "itruediv",
+            "ifloordiv",
+            "imod",
+            "ipow",
+            "iand",
+            "ior",
+            "ixor",
+            "ilshift",
+            "irshift",
+            "imatmul",
+        }
+    )
+    assert production == projector_inplace
+    assert production_native_operation_operators() == frozenset(
+        _NATIVE_OPERATION_PROJECTORS
+    )
+
+
+def test_discrimination_circular_tooth_would_hide_missing_projector() -> None:
+    """Lying: derive production set from projector table — circular, forbidden."""
+    circular = frozenset(
+        k for k in _NATIVE_OPERATION_PROJECTORS if k.startswith("i")
+    )
+    # Independent production must not be computed as circular (same object).
+    independent = production_augassign_inplace_operators()
+    # They currently equal when healthy — but sources differ: class attrs vs table.
+    assert independent == production_augassign_inplace_operators()
+    # Twin: claiming circular derivation is the independent source fails identity.
+    with pytest.raises(AssertionError):
+        assert circular is independent
+
+
+# ---------------------------------------------------------------------------
+# Production desugar
 # ---------------------------------------------------------------------------
 
 
 def test_production_desugar_list_augassign_completes_with_updated_cell() -> None:
-    """Production path: xs[0] += 10 on [1,2] → [11,2]."""
     out = _production_desugar(
         ListValue((TermValue(1), TermValue(2))),
         TermValue(0),
@@ -182,14 +276,10 @@ def test_formal_helper_desugars_without_legacy_incomplete_only() -> None:
     function, outcome = _helper_definition()
     stmt = function.sugar().statements[0]
     assert isinstance(stmt, SubscriptAugAssignSugar)
-    assert stmt.operation is IADD
+    assert stmt.operation is project_iadd
+    assert stmt.operator == "iadd"
     assert isinstance(outcome, NativeOperationExitCarrierV1)
     assert outcome.demand.operator == "subscript"
-
-
-# ---------------------------------------------------------------------------
-# Production desugar: get halt / arithmetic halt / store halt
-# ---------------------------------------------------------------------------
 
 
 def test_production_get_halt_blocks_rhs_arithmetic_and_store() -> None:
@@ -217,9 +307,10 @@ def test_production_get_halt_blocks_rhs_arithmetic_and_store() -> None:
 
     sugar = SubscriptAugAssignSugar(
         receiver=_FloorSugar(_HaltList((TermValue(0),))),
-        index=_FloorSugar(TermValue(4)),  # OOB → IndexError on get
+        index=_FloorSugar(TermValue(4)),
         rhs=_RhsProbe(),
-        operation=IADD,
+        operator="iadd",
+        operation=project_iadd,
         get_site=get_site,
         op_site=op_site,
         set_site=set_site,
@@ -229,8 +320,8 @@ def test_production_get_halt_blocks_rhs_arithmetic_and_store() -> None:
     assert isinstance(out, Complete)
     assert isinstance(out.value, RaiseValue)
     assert out.value.effect.exception_name == "IndexError"
-    assert box["rhs"] == 0, "get halt must not evaluate RHS"
-    assert box["set"] == 0, "get halt must not store"
+    assert box["rhs"] == 0
+    assert box["set"] == 0
 
 
 def test_production_arithmetic_halt_blocks_store() -> None:
@@ -251,20 +342,17 @@ def test_production_arithmetic_halt_blocks_store() -> None:
         TermValue(0),
         NoneValue(),
     )
-    # TypeError face (Complete Raise or Incomplete) — store must not run.
-    if isinstance(out, Complete) and isinstance(out.value, RaiseValue):
-        assert box["set"] == 0
-    elif isinstance(out, Incomplete):
-        assert box["set"] == 0
-    else:
-        # Dual ExitSet may include halt — still no completed store of None.
-        assert box["set"] == 0
+    assert box["set"] == 0
+    assert not (
+        isinstance(out, Complete)
+        and not isinstance(out.value, RaiseValue)
+        and box["set"]
+    )
 
 
 def test_production_store_halt_preserves_prior_state_without_fabricated_completion() -> (
     None
 ):
-    """Tuple is readable; setitem must not complete a fabricated write."""
     out = _production_desugar(
         TupleValue((TermValue(1), TermValue(2))),
         TermValue(0),
@@ -272,14 +360,6 @@ def test_production_store_halt_preserves_prior_state_without_fabricated_completi
     )
     if isinstance(out, Complete) and not isinstance(out.value, RaiseValue):
         pytest.fail("readable tuple must not authorize completed setitem")
-    assert isinstance(out, (Incomplete, ExitSet)) or (
-        isinstance(out, Complete) and isinstance(out.value, RaiseValue)
-    )
-
-
-# ---------------------------------------------------------------------------
-# Production desugar: once-eval / order
-# ---------------------------------------------------------------------------
 
 
 class _CountingList(ListValueCls):
@@ -306,7 +386,7 @@ def test_production_receiver_index_evaluated_once_for_get_and_set() -> None:
         TermValue(5),
     )
     assert isinstance(out, Complete)
-    assert box["get"] == 1, "duplicated getitem evaluation"
+    assert box["get"] == 1
     assert box["set"] == 1
     assert out.value.elements[0] == TermValue(6)
 
@@ -348,17 +428,16 @@ def test_production_getitem_before_rhs_order() -> None:
         def witnesses(cls):
             return ()
 
-    class _IAddOrder(InplaceThenBinaryProjector):
-        def __call__(self, left, right, site_):
-            order.append("op")
-            return super().__call__(left, right, site_)
+    def _project_order(left, right, site_):
+        order.append("op")
+        return project_iadd(left, right, site_)
 
-    op = _IAddOrder("iadd", "iadd", "add")
     sugar = SubscriptAugAssignSugar(
         receiver=_FloorSugar(_OrderList((TermValue(3),))),
         index=_FloorSugar(TermValue(0)),
         rhs=_RhsOrder(),
-        operation=op,
+        operator="iadd",
+        operation=_project_order,
         get_site=get_site,
         op_site=op_site,
         set_site=set_site,
@@ -376,11 +455,6 @@ def test_discrimination_wrong_order_rhs_before_get() -> None:
         assert order == ["get", "rhs", "op", "set"]
 
 
-# ---------------------------------------------------------------------------
-# Readability ≠ writability
-# ---------------------------------------------------------------------------
-
-
 def test_production_readability_does_not_authorize_writability() -> None:
     out = _production_desugar(
         TupleValue((TermValue(1),)),
@@ -392,13 +466,13 @@ def test_production_readability_does_not_authorize_writability() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Explicit iadd projector law
+# Explicit project_iadd
 # ---------------------------------------------------------------------------
 
 
-def test_inplace_projector_for_add_is_iadd_instance() -> None:
-    assert inplace_projector_for(Add.instance()) is IADD
-    assert IADD.operator == "iadd"
+def test_inplace_projector_for_add_is_project_iadd() -> None:
+    assert inplace_projector_for(Add.instance()) is project_iadd
+    assert Add.inplace_operator == "iadd"
 
 
 def test_formal_operands_mint_iadd_not_ordinary_add() -> None:
@@ -429,14 +503,16 @@ def test_formal_operands_mint_iadd_not_ordinary_add() -> None:
 
     left = SymbolicValue(make_var("cell"), _coord("cell", 0))
     right = SymbolicValue(make_var("rhs"), _coord("rhs", 1))
-    out = project_augmented(left, right, IADD, site)
+    out = project_augmented(
+        left, right, operator="iadd", projector=project_iadd, site=site
+    )
     assert isinstance(out, NativeOperationExitCarrierV1)
     assert out.demand.operator == "iadd"
     with pytest.raises(AssertionError):
         assert out.demand.operator == "add"
 
 
-def test_iadd_projector_falls_back_only_on_absent_method_or_notimplemented() -> None:
+def test_project_iadd_falls_back_only_on_absent_method_or_notimplemented() -> None:
     calls: list[str] = []
 
     @dataclass(frozen=True)
@@ -447,9 +523,8 @@ def test_iadd_projector_falls_back_only_on_absent_method_or_notimplemented() -> 
             calls.append("add")
             return Complete(TermValue(self.value + other.value))
 
-    assert IADD(_AddOnly(1), TermValue(2), "op").value == TermValue(3)
+    assert project_iadd(_AddOnly(1), TermValue(2), "op").value == TermValue(3)
     assert calls == ["add"]
-
     calls.clear()
 
     @dataclass(frozen=True)
@@ -464,12 +539,11 @@ def test_iadd_projector_falls_back_only_on_absent_method_or_notimplemented() -> 
             calls.append("add")
             return Complete(TermValue(self.value + other.value))
 
-    assert IADD(_NotImpl(1), TermValue(2), "op").value == TermValue(3)
+    assert project_iadd(_NotImpl(1), TermValue(2), "op").value == TermValue(3)
     assert calls == ["iadd", "add"]
 
 
-def test_iadd_projector_does_not_fallback_on_incomplete_face() -> None:
-    """Unresolved Incomplete must not authorize ordinary add."""
+def test_project_iadd_does_not_fallback_on_incomplete_face() -> None:
     from sugar_lift_py_tests.effect import CoverageGapEffect
 
     incomplete_face = Incomplete(
@@ -489,14 +563,11 @@ def test_iadd_projector_does_not_fallback_on_incomplete_face() -> None:
             del other, site
             return Complete(TermValue(0))
 
-    out = IADD(_IncompleteIadd(), TermValue(1), "op")
+    out = project_iadd(_IncompleteIadd(), TermValue(1), "op")
     assert out is incomplete_face
-    assert isinstance(out, Incomplete)
-    with pytest.raises(AssertionError):
-        assert isinstance(out, Complete)
 
 
-def test_iadd_projector_prefers_floor_iadd_when_present() -> None:
+def test_project_iadd_prefers_floor_iadd_when_present() -> None:
     calls: list[str] = []
 
     @dataclass(frozen=True)
@@ -511,7 +582,7 @@ def test_iadd_projector_prefers_floor_iadd_when_present() -> None:
             calls.append("add")
             return Complete(TermValue(self.value + other.value))
 
-    out = IADD(_Both(1), TermValue(2), "op")
+    out = project_iadd(_Both(1), TermValue(2), "op")
     assert isinstance(out, Complete)
     assert calls == ["iadd"]
     with pytest.raises(AssertionError):
@@ -520,25 +591,17 @@ def test_iadd_projector_prefers_floor_iadd_when_present() -> None:
 
 def test_formal_iadd_projector_is_enrolled_with_authenticated_signature() -> None:
     assert "iadd" in _NATIVE_OPERATION_PROJECTORS
-    assert _NATIVE_OPERATION_PROJECTORS["iadd"] is IADD
+    assert _NATIVE_OPERATION_PROJECTORS["iadd"] is project_iadd
     parameters = tuple(
-        __import__("inspect").signature(
-            _NATIVE_OPERATION_PROJECTORS["iadd"]
-        ).parameters
+        __import__("inspect").signature(project_iadd).parameters
     )
-    # Instance __call__ binds self → discharge sees (left, right, site).
     assert parameters == ("left", "right", "site")
-    assert production_native_operation_operators() == frozenset(
-        _NATIVE_OPERATION_PROJECTORS
-    )
 
 
 def test_discrimination_projector_absence_must_not_mint_add() -> None:
-    truthful = IADD.operator
-    assert truthful == "iadd"
-    lying = "add"
+    assert Add.inplace_operator == "iadd"
     with pytest.raises(AssertionError):
-        assert lying == "iadd"
+        assert Add.inplace_operator == "add"
 
 
 # ---------------------------------------------------------------------------
@@ -556,7 +619,6 @@ def test_formal_subscript_get_carrier_missing_actuals_undischarged() -> None:
 
 def test_authenticated_caller_discharges_get_iadd_setitem_to_updated_list() -> None:
     function, pending = _helper_definition()
-    assert isinstance(pending, NativeOperationExitCarrierV1)
     coords = {
         c.declared_name: c.coordinate_cid
         for c in function.sugar().formal_coordinates
@@ -593,13 +655,7 @@ def test_authenticated_get_halt_blocks_store_on_formal_discharge() -> None:
     assert exits.exits[0].effect.exception_name == "IndexError"
 
 
-# ---------------------------------------------------------------------------
-# Attribute substitute is NOT claimed by this PR
-# ---------------------------------------------------------------------------
-
-
 def test_attribute_augassign_still_attribute_store_effect_not_subscript_path() -> None:
-    """Attribute targets stay on AttributeStoreEffectSugar until their production."""
     from sugar_lift_py_tests.sugar.store_effect_sugar import AttributeStoreEffectSugar
 
     tree = _tree("def helper(obj, rhs):\n    obj.field += rhs\n", "attr_aug.py")

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
@@ -13,7 +13,6 @@ import pytest
 from sugar_lift_py_tests.caller_parameter_contract import (
     NativeOperationExitCarrierV1,
     _NATIVE_OPERATION_PROJECTORS,
-    inplace_projector_for,
     production_native_operation_operators,
     project_iadd,
 )
@@ -109,10 +108,11 @@ def _production_desugar(receiver, index, rhs, *, operator="iadd", projector=proj
 # ---------------------------------------------------------------------------
 
 
-def test_subscript_augassign_constructs_with_explicit_project_iadd() -> None:
+def test_subscript_augassign_constructs_with_operator_owned_project_inplace() -> None:
     _, sugar = _aug_sugar()
     assert isinstance(sugar, SubscriptAugAssignSugar)
-    assert sugar.operation is project_iadd
+    # Operator-owned double dispatch — bound project_inplace, not a kind ladder.
+    assert sugar.operation.__func__ is Add.project_inplace
     assert sugar.operator == "iadd"
     assert sugar.operator == Add.inplace_operator
     assert sugar.get_site is not sugar.op_site
@@ -276,7 +276,7 @@ def test_formal_helper_desugars_without_legacy_incomplete_only() -> None:
     function, outcome = _helper_definition()
     stmt = function.sugar().statements[0]
     assert isinstance(stmt, SubscriptAugAssignSugar)
-    assert stmt.operation is project_iadd
+    assert stmt.operation.__func__ is Add.project_inplace
     assert stmt.operator == "iadd"
     assert isinstance(outcome, NativeOperationExitCarrierV1)
     assert outcome.demand.operator == "subscript"
@@ -466,13 +466,74 @@ def test_production_readability_does_not_authorize_writability() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Explicit project_iadd
+# Floor protocol iadd + operator-owned project_inplace
 # ---------------------------------------------------------------------------
 
 
-def test_inplace_projector_for_add_is_project_iadd() -> None:
-    assert inplace_projector_for(Add.instance()) is project_iadd
+def test_operator_owned_project_inplace_dispatches_to_floor_iadd() -> None:
+    """Add.project_inplace → left.iadd; no caller isinstance ladder."""
+    assert Add.instance().project_inplace is not None
+    # Bound method on the singleton operator.
+    bound = Add.instance().project_inplace
+    assert bound.__func__ is Add.project_inplace
     assert Add.inplace_operator == "iadd"
+
+
+def test_floor_iadd_default_falls_through_to_ordinary_add() -> None:
+    """Absent species override: FloorValue.iadd is ordinary add (protocol)."""
+    # TermValue inherits FloorValue.iadd → add; project_iadd only dispatches.
+    out = project_iadd(TermValue(1), TermValue(2), _production_sites()[1])
+    assert isinstance(out, Complete)
+    assert out.value == TermValue(3)
+
+
+def test_floor_species_iadd_override_wins_over_add() -> None:
+    """True inplace override on Floor species is preferred — projector does not probe."""
+    calls: list[str] = []
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+    class _IAddSpecies(FloorValue):
+        def __init__(self, n: int):
+            self.n = n
+
+        def iadd(self, other, site):
+            calls.append("iadd")
+            return Complete(TermValue(self.n + other.value))
+
+        def add(self, other, site):
+            calls.append("add")
+            return Complete(TermValue(self.n + other.value))
+
+    out = project_iadd(_IAddSpecies(1), TermValue(2), "op")
+    assert isinstance(out, Complete)
+    assert calls == ["iadd"]
+    with pytest.raises(AssertionError):
+        assert calls == ["add"]
+
+
+def test_floor_iadd_incomplete_surfaces_without_projector_probe() -> None:
+    """Unresolved Incomplete from Floor iadd surfaces; projector does not rewrite."""
+    from sugar_lift_py_tests.effect import CoverageGapEffect
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+    incomplete_face = Incomplete(
+        CoverageGapEffect(
+            boundary="iadd",
+            reason="inplace unresolved face",
+        )
+    )
+
+    class _IncompleteSpecies(FloorValue):
+        def iadd(self, other, site):
+            del other, site
+            return incomplete_face
+
+        def add(self, other, site):
+            del other, site
+            return Complete(TermValue(0))
+
+    out = project_iadd(_IncompleteSpecies(), TermValue(1), "op")
+    assert out is incomplete_face
 
 
 def test_formal_operands_mint_iadd_not_ordinary_add() -> None:
@@ -510,83 +571,6 @@ def test_formal_operands_mint_iadd_not_ordinary_add() -> None:
     assert out.demand.operator == "iadd"
     with pytest.raises(AssertionError):
         assert out.demand.operator == "add"
-
-
-def test_project_iadd_falls_back_only_on_absent_method_or_notimplemented() -> None:
-    calls: list[str] = []
-
-    @dataclass(frozen=True)
-    class _AddOnly:
-        value: int
-
-        def add(self, other, site):
-            calls.append("add")
-            return Complete(TermValue(self.value + other.value))
-
-    assert project_iadd(_AddOnly(1), TermValue(2), "op").value == TermValue(3)
-    assert calls == ["add"]
-    calls.clear()
-
-    @dataclass(frozen=True)
-    class _NotImpl:
-        value: int
-
-        def iadd(self, other, site):
-            calls.append("iadd")
-            return NotImplemented
-
-        def add(self, other, site):
-            calls.append("add")
-            return Complete(TermValue(self.value + other.value))
-
-    assert project_iadd(_NotImpl(1), TermValue(2), "op").value == TermValue(3)
-    assert calls == ["iadd", "add"]
-
-
-def test_project_iadd_does_not_fallback_on_incomplete_face() -> None:
-    from sugar_lift_py_tests.effect import CoverageGapEffect
-
-    incomplete_face = Incomplete(
-        CoverageGapEffect(
-            boundary="iadd",
-            reason="inplace unresolved face — must not fall back to add",
-        )
-    )
-
-    @dataclass(frozen=True)
-    class _IncompleteIadd:
-        def iadd(self, other, site):
-            del other, site
-            return incomplete_face
-
-        def add(self, other, site):
-            del other, site
-            return Complete(TermValue(0))
-
-    out = project_iadd(_IncompleteIadd(), TermValue(1), "op")
-    assert out is incomplete_face
-
-
-def test_project_iadd_prefers_floor_iadd_when_present() -> None:
-    calls: list[str] = []
-
-    @dataclass(frozen=True)
-    class _Both:
-        value: int
-
-        def iadd(self, other, site):
-            calls.append("iadd")
-            return Complete(TermValue(self.value + other.value))
-
-        def add(self, other, site):
-            calls.append("add")
-            return Complete(TermValue(self.value + other.value))
-
-    out = project_iadd(_Both(1), TermValue(2), "op")
-    assert isinstance(out, Complete)
-    assert calls == ["iadd"]
-    with pytest.raises(AssertionError):
-        assert calls == ["add"]
 
 
 def test_formal_iadd_projector_is_enrolled_with_authenticated_signature() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
@@ -29,6 +29,7 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import AugAssign, FunctionDef
 from sugar_source_tree.operators import (
     Add,
+    BinaryOperator,
     production_augassign_inplace_operators,
 )
 from sugar_source_tree.panic import SugarNotWritten
@@ -466,73 +467,95 @@ def test_production_readability_does_not_authorize_writability() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Floor protocol iadd + operator-owned project_inplace
+# Established inplace_binary_operator_with edge + NotImplemented fallback
 # ---------------------------------------------------------------------------
 
 
-def test_operator_owned_project_inplace_dispatches_to_floor_iadd() -> None:
-    """Add.project_inplace → left.iadd; no caller isinstance ladder."""
-    assert Add.instance().project_inplace is not None
-    # Bound method on the singleton operator.
+def test_operator_owned_project_inplace_uses_inplace_binary_edge() -> None:
+    """Add.project_inplace → discharge_inplace → inplace_binary_operator_with."""
     bound = Add.instance().project_inplace
-    assert bound.__func__ is Add.project_inplace
+    assert bound.__func__ is BinaryOperator.project_inplace
     assert Add.inplace_operator == "iadd"
+    out = bound(TermValue(1), TermValue(2), _production_sites()[1])
+    assert isinstance(out, Complete)
+    assert out.value == TermValue(3)
 
 
-def test_floor_iadd_default_falls_through_to_ordinary_add() -> None:
-    """Absent species override: FloorValue.iadd is ordinary add (protocol)."""
-    # TermValue inherits FloorValue.iadd → add; project_iadd only dispatches.
+def test_production_projector_default_floor_is_ordinary_binary() -> None:
+    """FloorValue.inplace_default → add when species has no inplace override."""
     out = project_iadd(TermValue(1), TermValue(2), _production_sites()[1])
     assert isinstance(out, Complete)
     assert out.value == TermValue(3)
 
 
-def test_floor_species_iadd_override_wins_over_add() -> None:
-    """True inplace override on Floor species is preferred — projector does not probe."""
-    calls: list[str] = []
+def test_production_projector_raw_notimplemented_falls_through_to_binary() -> None:
+    """Twin: raw NotImplemented from floor edge → ordinary add."""
     from sugar_lift_py_tests.floor.floor_value import FloorValue
+    from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+        InplaceBinaryOperatorOperation,
+    )
 
-    class _IAddSpecies(FloorValue):
-        def __init__(self, n: int):
-            self.n = n
+    calls: list[str] = []
 
-        def iadd(self, other, site):
-            calls.append("iadd")
-            return Complete(TermValue(self.n + other.value))
+    class _RawNotImpl(FloorValue):
+        def inplace_binary_operator_with(self, operation, ctx):
+            del operation, ctx
+            calls.append("inplace")
+            return NotImplemented
 
         def add(self, other, site):
             calls.append("add")
-            return Complete(TermValue(self.n + other.value))
+            return Complete(TermValue(7))
 
-    out = project_iadd(_IAddSpecies(1), TermValue(2), "op")
+    out = project_iadd(_RawNotImpl(), TermValue(1), "op")
     assert isinstance(out, Complete)
-    assert calls == ["iadd"]
-    with pytest.raises(AssertionError):
-        assert calls == ["add"]
+    assert out.value == TermValue(7)
+    assert calls == ["inplace", "add"]
 
 
-def test_floor_iadd_incomplete_surfaces_without_projector_probe() -> None:
-    """Unresolved Incomplete from Floor iadd surfaces; projector does not rewrite."""
+def test_production_projector_completed_notimplemented_falls_through_to_binary() -> (
+    None
+):
+    """Twin: Complete(NotImplemented) from floor edge → ordinary add."""
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+    calls: list[str] = []
+
+    class _CompleteNotImpl(FloorValue):
+        def inplace_binary_operator_with(self, operation, ctx):
+            del operation, ctx
+            calls.append("inplace")
+            return Complete(NotImplemented)  # type: ignore[arg-type]
+
+        def add(self, other, site):
+            calls.append("add")
+            return Complete(TermValue(9))
+
+    out = project_iadd(_CompleteNotImpl(), TermValue(1), "op")
+    assert isinstance(out, Complete)
+    assert out.value == TermValue(9)
+    assert calls == ["inplace", "add"]
+
+
+def test_production_projector_incomplete_does_not_fall_through_to_binary() -> None:
+    """Incomplete surfaces unchanged — never authorizes binary fallback."""
     from sugar_lift_py_tests.effect import CoverageGapEffect
     from sugar_lift_py_tests.floor.floor_value import FloorValue
 
     incomplete_face = Incomplete(
-        CoverageGapEffect(
-            boundary="iadd",
-            reason="inplace unresolved face",
-        )
+        CoverageGapEffect(boundary="iadd", reason="inplace unresolved face")
     )
 
-    class _IncompleteSpecies(FloorValue):
-        def iadd(self, other, site):
-            del other, site
+    class _IncompleteInplace(FloorValue):
+        def inplace_binary_operator_with(self, operation, ctx):
+            del operation, ctx
             return incomplete_face
 
         def add(self, other, site):
             del other, site
             return Complete(TermValue(0))
 
-    out = project_iadd(_IncompleteSpecies(), TermValue(1), "op")
+    out = project_iadd(_IncompleteInplace(), TermValue(1), "op")
     assert out is incomplete_face
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
@@ -1,30 +1,7 @@
 """Formal subscript augmented assignment: ``obj[key] += rhs``.
 
-Python law (evaluation order is load-bearing):
-
-  1. Evaluate ``obj`` once, ``key`` once
-  2. ``current = obj[key]`` (getitem) **before** RHS
-  3. Evaluate ``rhs``
-  4. ``result = current + rhs`` (inplace when Floor authorizes; else binary)
-  5. ``obj[key] = result`` (setitem) last
-
-Acceptance:
-
-  - receiver/index evaluated once
-  - getitem before RHS
-  - authenticated in-place with ordinary binary fallback only when Floor
-    authorizes (no unconditional ``__add__`` pretending to be ``__iadd__``)
-  - setitem last
-  - get halt blocks RHS/arithmetic/store
-  - RHS or arithmetic halt blocks the store
-  - store halt preserves prior state without fabricated completion
-  - authenticated caller completes; missing actuals Undischarged
-  - read / arithmetic / write retain DISTINCT occurrence coordinates
-  - twins: duplicated eval, wrong order, readability-as-writability,
-    ``__iadd__`` replaced by unconditional ``__add__``
-
-If a shared formal ``iadd`` native-operation producer/projector is required
-and missing, reds name the exact contract rather than emulating it.
+Production path only: tests drive ``SubscriptAugAssignSugar.desugar``, not a
+manual subscript → project_augmented → setitem replay.
 
 MUST NOT TOUCH: carrier, ExitSet, source-return projection, generator/resource
 files; no receiver/type spelling arms.
@@ -33,12 +10,17 @@ files; no receiver/type spelling arms.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import pytest
 
 from sugar_lift_py_tests.caller_parameter_contract import (
+    IADD,
+    InplaceThenBinaryProjector,
     NativeOperationExitCarrierV1,
     _NATIVE_OPERATION_PROJECTORS,
+    inplace_projector_for,
+    production_native_operation_operators,
 )
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import ListValue, RaiseValue, TermValue, TupleValue
@@ -46,30 +28,20 @@ from sugar_lift_py_tests.floor.list_value import ListValue as ListValueCls
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
 from sugar_lift_py_tests.sugar.augassign_sugar import (
     SubscriptAugAssignSugar,
-    _augmented_binary,
+    project_augmented,
 )
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_python_source.canonical import blake3_512_of
-from sugar_source_tree.nodes import AugAssign, FunctionDef, Subscript
+from sugar_source_tree.nodes import AugAssign, FunctionDef
+from sugar_source_tree.operators import Add
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
-
-# Authenticated iadd is enrolled: binary fallback lives *inside* the projector,
-# never by minting ordinary ``add`` when iadd is absent.
 
 
 def _tree(source: str, name: str = "subscript_augassign.py") -> SourceFile:
     return SourceFile(
         (source, name, blake3_512_of(source.encode())),
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
-    )
-
-
-def _identity(name: str):
-    from sugar_lift_py_tests.ir import ctor, str_const
-
-    return ctor(
-        "python:exception_type_identity",
-        [str_const("builtins"), str_const(name)],
     )
 
 
@@ -100,187 +72,222 @@ def _post_list(completed: Completed) -> ListValue:
     raise AssertionError(f"no ListValue post-state: {type(value).__name__}")
 
 
+@dataclass(frozen=True)
+class _FloorSugar(Sugar):
+    """Constant floor child for production desugar of SubscriptAugAssignSugar."""
+
+    value: object
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+def _production_sites():
+    """Authenticated fragments from a real AugAssign (not string loci)."""
+    _, sugar = _aug_sugar()
+    return sugar.get_site, sugar.op_site, sugar.set_site, sugar.site
+
+
+def _production_desugar(receiver, index, rhs, *, operation=IADD, sites=None):
+    """Drive the production sugar path with ground floor children."""
+    get_site, op_site, set_site, site = sites or _production_sites()
+    sugar = SubscriptAugAssignSugar(
+        receiver=_FloorSugar(receiver),
+        index=_FloorSugar(index),
+        rhs=_FloorSugar(rhs),
+        operation=operation,
+        get_site=get_site,
+        op_site=op_site,
+        set_site=set_site,
+        site=site,
+    )
+    return sugar.desugar(None)
+
+
 # ---------------------------------------------------------------------------
-# Sugar construction / occurrence sites
+# Construction / occurrence sites
 # ---------------------------------------------------------------------------
 
 
-def test_subscript_augassign_constructs_subscript_augassign_sugar() -> None:
+def test_subscript_augassign_constructs_with_explicit_iadd_projector() -> None:
     _, sugar = _aug_sugar()
     assert isinstance(sugar, SubscriptAugAssignSugar)
-    assert sugar.op_kind == "Add"
-    # Distinct occurrence coordinates for get / op / store.
+    assert sugar.operation is IADD
+    assert sugar.operation.operator == "iadd"
     assert sugar.get_site is not sugar.op_site
     assert sugar.op_site is not sugar.set_site
     assert sugar.get_site is not sugar.set_site
 
 
+def test_op_site_is_operator_token_interval_not_rhs_occurrence() -> None:
+    """op_site is the gap holding ``+=``, not the RHS fragment."""
+    function, sugar = _aug_sugar("def helper(obj, key, rhs):\n    obj[key] += rhs\n")
+    aug = next(node for node in function.body if isinstance(node, AugAssign))
+    # Operator interval is between target end and value start.
+    assert sugar.op_site is not aug.value.fragment
+    text = sugar.op_site.text if hasattr(sugar.op_site, "text") else str(sugar.op_site)
+    # Source fragment text should include the aug-assign operator spelling.
+    assert "+=" in getattr(sugar.op_site, "text", text) or "+=" in str(
+        getattr(sugar.op_site, "span", text)
+    )
+    # Distinct from get (subscript) and set (statement).
+    assert sugar.op_site is not sugar.get_site
+    assert sugar.op_site is not sugar.set_site
+
+
 def test_discrimination_legacy_runtime_effect_is_not_the_formal_path() -> None:
-    """Helper alone is undischarged get carrier — not legacy Incomplete effect."""
     _, outcome = _helper_definition()
     assert isinstance(outcome, NativeOperationExitCarrierV1), type(outcome)
     assert outcome.demand.operator == "subscript"
-    from sugar_lift_py_tests.effect import SubscriptStoreRuntimeEffect
-
     with pytest.raises(AssertionError):
-        assert isinstance(outcome, Incomplete) and isinstance(
-            outcome.effect, SubscriptStoreRuntimeEffect
-        )
+        assert isinstance(outcome, Incomplete)
+
+
+def test_legacy_augmented_subscript_store_effect_sugar_is_deleted() -> None:
+    """Shell deletion is real: class gone; no production reference remains."""
+    import sugar_lift_py_tests.sugar.store_effect_sugar as store_mod
+
+    assert not hasattr(store_mod, "LegacyAugmentedSubscriptStoreEffectSugar")
+    package_root = Path(store_mod.__file__).resolve().parent.parent
+    offenders = []
+    for path in package_root.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        if "LegacyAugmentedSubscriptStoreEffectSugar" in text:
+            offenders.append(str(path))
+    assert offenders == [], offenders
 
 
 # ---------------------------------------------------------------------------
-# Authenticated completion: get → add → set
+# Production desugar: authenticated completion
 # ---------------------------------------------------------------------------
 
 
-def test_authenticated_list_augassign_completes_with_updated_cell() -> None:
-    """``xs[0] += 10`` on [1, 2] → [11, 2]."""
-    _, sugar = _aug_sugar()
-    # Drive via Floor chain matching sugar desugar contract (once-eval).
-    receiver = ListValue((TermValue(1), TermValue(2)))
-    index = TermValue(0)
-    rhs = TermValue(10)
-    get_out = receiver.subscript(index, sugar.get_site)
-    assert isinstance(get_out, Complete)
-    op_out = _augmented_binary(get_out.value, rhs, "Add", sugar.op_site)
-    assert isinstance(op_out, Complete)
-    set_out = receiver.setitem(index, op_out.value, sugar.set_site)
-    assert isinstance(set_out, Complete)
-    assert set_out.value == ListValue((TermValue(11), TermValue(2)))
+def test_production_desugar_list_augassign_completes_with_updated_cell() -> None:
+    """Production path: xs[0] += 10 on [1,2] → [11,2]."""
+    out = _production_desugar(
+        ListValue((TermValue(1), TermValue(2))),
+        TermValue(0),
+        TermValue(10),
+    )
+    assert isinstance(out, Complete), out
+    assert out.value == ListValue((TermValue(11), TermValue(2)))
 
 
 def test_formal_helper_desugars_without_legacy_incomplete_only() -> None:
-    """Helper body desugars through SubscriptAugAssignSugar (not legacy effect)."""
     function, outcome = _helper_definition()
-    # Body statement sugar is the formal path (after FunctionDef substitute).
     stmt = function.sugar().statements[0]
     assert isinstance(stmt, SubscriptAugAssignSugar)
-    # Helper alone retains undischarged get demand — not legacy Incomplete.
+    assert stmt.operation is IADD
     assert isinstance(outcome, NativeOperationExitCarrierV1)
     assert outcome.demand.operator == "subscript"
-    assert not (
-        isinstance(outcome, Incomplete)
-        and "augmented subscript assignment runtime boundary" in str(outcome.effect)
-    ), "legacy Incomplete RuntimeEffect must not be the sole formal path"
 
 
 # ---------------------------------------------------------------------------
-# Get halt blocks RHS / arithmetic / store
+# Production desugar: get halt / arithmetic halt / store halt
 # ---------------------------------------------------------------------------
 
 
-def test_get_halt_blocks_rhs_arithmetic_and_store() -> None:
-    """IndexError on getitem: no store completion."""
-    function, sugar = _aug_sugar()
-    receiver = ListValue((TermValue(0),))
-    index = TermValue(4)  # OOB
-    get_out = receiver.subscript(index, sugar.get_site)
-    assert isinstance(get_out, Complete)
-    assert isinstance(get_out.value, RaiseValue)
-    assert get_out.value.effect.exception_name == "IndexError"
-    # RaiseValue short-circuits and_then — store must not run.
-    chained = get_out.and_then(
-        lambda _current: receiver.setitem(index, TermValue(99), sugar.set_site)
+def test_production_get_halt_blocks_rhs_arithmetic_and_store() -> None:
+    box = {"rhs": 0, "set": 0}
+    get_site, op_site, set_site, site = _production_sites()
+
+    @dataclass(frozen=True)
+    class _RhsProbe(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            box["rhs"] += 1
+            return Complete(TermValue(99))
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    class _HaltList(ListValueCls):
+        def __init__(self, elements):
+            object.__setattr__(self, "elements", tuple(elements))
+
+        def setitem(self, index, value, site_):
+            box["set"] += 1
+            return super().setitem(index, value, site_)
+
+    sugar = SubscriptAugAssignSugar(
+        receiver=_FloorSugar(_HaltList((TermValue(0),))),
+        index=_FloorSugar(TermValue(4)),  # OOB → IndexError on get
+        rhs=_RhsProbe(),
+        operation=IADD,
+        get_site=get_site,
+        op_site=op_site,
+        set_site=set_site,
+        site=site,
     )
-    assert isinstance(chained, Complete)
-    assert isinstance(chained.value, RaiseValue)
-    assert chained.value.effect.exception_name == "IndexError"
-    # Original list unchanged.
-    assert receiver == ListValue((TermValue(0),))
+    out = sugar.desugar(None)
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, RaiseValue)
+    assert out.value.effect.exception_name == "IndexError"
+    assert box["rhs"] == 0, "get halt must not evaluate RHS"
+    assert box["set"] == 0, "get halt must not store"
 
 
-# ---------------------------------------------------------------------------
-# Arithmetic halt blocks store
-# ---------------------------------------------------------------------------
+def test_production_arithmetic_halt_blocks_store() -> None:
+    box = {"set": 0}
 
+    class _CountingList(ListValueCls):
+        def __init__(self, elements):
+            object.__setattr__(self, "elements", tuple(elements))
 
-def test_arithmetic_halt_blocks_store() -> None:
-    """TypeError from add: setitem must not complete."""
-    function, sugar = _aug_sugar()
-    receiver = ListValue((TermValue(1),))
-    index = TermValue(0)
-    get_out = receiver.subscript(index, sugar.get_site)
-    assert isinstance(get_out, Complete)
-    # TermValue + ListValue is TypeError on many floors; use None-like if available
+        def setitem(self, index, value, site):
+            box["set"] += 1
+            return super().setitem(index, value, site)
+
     from sugar_lift_py_tests.floor import NoneValue
 
-    op_out = _augmented_binary(get_out.value, NoneValue(), "Add", sugar.op_site)
-    if isinstance(op_out, Complete) and isinstance(op_out.value, RaiseValue):
-        chained = op_out.and_then(
-            lambda result: receiver.setitem(index, result, sugar.set_site)
-        )
-        assert isinstance(chained, Complete)
-        assert isinstance(chained.value, RaiseValue)
-        assert receiver == ListValue((TermValue(1),))
-    elif isinstance(op_out, Incomplete):
-        # Incomplete does not continue to store.
-        assert op_out.and_then(
-            lambda result: receiver.setitem(index, result, sugar.set_site)
-        ) is op_out
+    out = _production_desugar(
+        _CountingList((TermValue(1),)),
+        TermValue(0),
+        NoneValue(),
+    )
+    # TypeError face (Complete Raise or Incomplete) — store must not run.
+    if isinstance(out, Complete) and isinstance(out.value, RaiseValue):
+        assert box["set"] == 0
+    elif isinstance(out, Incomplete):
+        assert box["set"] == 0
     else:
-        # If add completed somehow, still require store would need explicit call.
-        assert not isinstance(op_out, Complete) or not (
-            isinstance(op_out.value, TermValue)
-        )
+        # Dual ExitSet may include halt — still no completed store of None.
+        assert box["set"] == 0
+
+
+def test_production_store_halt_preserves_prior_state_without_fabricated_completion() -> (
+    None
+):
+    """Tuple is readable; setitem must not complete a fabricated write."""
+    out = _production_desugar(
+        TupleValue((TermValue(1), TermValue(2))),
+        TermValue(0),
+        TermValue(10),
+    )
+    if isinstance(out, Complete) and not isinstance(out.value, RaiseValue):
+        pytest.fail("readable tuple must not authorize completed setitem")
+    assert isinstance(out, (Incomplete, ExitSet)) or (
+        isinstance(out, Complete) and isinstance(out.value, RaiseValue)
+    )
 
 
 # ---------------------------------------------------------------------------
-# Store halt preserves prior state
-# ---------------------------------------------------------------------------
-
-
-def test_store_halt_preserves_prior_get_result_without_fabricated_completion() -> None:
-    """Immutable receiver: setitem TypeError; get/add results not fabricated store."""
-    function, sugar = _aug_sugar()
-    # Tuple is readable but not settable.
-    receiver = TupleValue((TermValue(1), TermValue(2)))
-    index = TermValue(0)
-    get_out = receiver.subscript(index, sugar.get_site)
-    assert isinstance(get_out, Complete)
-    assert get_out.value == TermValue(1)
-    op_out = _augmented_binary(get_out.value, TermValue(10), "Add", sugar.op_site)
-    assert isinstance(op_out, Complete)
-    assert op_out.value == TermValue(11)
-    set_out = receiver.setitem(index, op_out.value, sugar.set_site)
-    # Store raises / Incomplete — not Completed updated tuple.
-    if isinstance(set_out, Complete) and isinstance(set_out.value, RaiseValue):
-        assert set_out.value.effect.exception_name in {"TypeError", "AttributeError"}
-    else:
-        assert isinstance(set_out, (Incomplete, ExitSet)) or (
-            isinstance(set_out, Complete) and isinstance(set_out.value, RaiseValue)
-        )
-    # Prior get value still TermValue(1) testimony — not a fabricated store.
-    assert get_out.value == TermValue(1)
-
-
-# ---------------------------------------------------------------------------
-# Distinct occurrence coordinates
-# ---------------------------------------------------------------------------
-
-
-def test_read_arithmetic_write_retain_distinct_occurrence_sites() -> None:
-    _, sugar = _aug_sugar()
-    sites = (sugar.get_site, sugar.op_site, sugar.set_site)
-    assert len({id(s) for s in sites}) == 3
-    # Fragments differ in span / role.
-    texts = tuple(getattr(s, "text", str(s)) for s in sites)
-    assert len(set(texts)) >= 2 or len({str(s) for s in sites}) == 3
-
-
-# ---------------------------------------------------------------------------
-# Once-eval of receiver/index
+# Production desugar: once-eval / order
 # ---------------------------------------------------------------------------
 
 
 class _CountingList(ListValueCls):
-    """ListValue that counts get/set — proves once-eval structure."""
-
-    # Mutable counters live outside the frozen dataclass payload via a box.
-    _box: dict = field(default_factory=dict, repr=False, compare=False)
-
     def __init__(self, elements, box=None):
         object.__setattr__(self, "elements", tuple(elements))
-        object.__setattr__(self, "_box", box if box is not None else {"get": 0, "set": 0})
+        object.__setattr__(
+            self, "_box", box if box is not None else {"get": 0, "set": 0}
+        )
 
     def subscript(self, index, site):
         self._box["get"] = self._box.get("get", 0) + 1
@@ -291,163 +298,110 @@ class _CountingList(ListValueCls):
         return super().setitem(index, value, site)
 
 
-def test_receiver_and_index_evaluated_once_for_get_and_set() -> None:
-    """Subscript/setitem each fire once on the same receiver object."""
-    function, sugar = _aug_sugar()
+def test_production_receiver_index_evaluated_once_for_get_and_set() -> None:
     box = {"get": 0, "set": 0}
-    receiver = _CountingList((TermValue(1), TermValue(2)), box=box)
-    index = TermValue(0)
-    rhs = TermValue(5)
-    # Mirror desugar order with shared receiver/index bindings.
-    get_out = receiver.subscript(index, sugar.get_site)
-    assert box["get"] == 1
-    op_out = _augmented_binary(get_out.value, rhs, "Add", sugar.op_site)
-    set_out = receiver.setitem(index, op_out.value, sugar.set_site)
+    out = _production_desugar(
+        _CountingList((TermValue(1), TermValue(2)), box=box),
+        TermValue(0),
+        TermValue(5),
+    )
+    assert isinstance(out, Complete)
     assert box["get"] == 1, "duplicated getitem evaluation"
     assert box["set"] == 1
-    assert isinstance(set_out, Complete)
-    assert set_out.value.elements[0] == TermValue(6)
+    assert out.value.elements[0] == TermValue(6)
 
 
 def test_discrimination_duplicated_get_is_detected() -> None:
     box = {"get": 0, "set": 0}
     receiver = _CountingList((TermValue(1),), box=box)
-    index = TermValue(0)
-    receiver.subscript(index, "g1")
-    receiver.subscript(index, "g2")  # lying second get
+    receiver.subscript(TermValue(0), "g1")
+    receiver.subscript(TermValue(0), "g2")
     assert box["get"] == 2
     with pytest.raises(AssertionError):
         assert box["get"] == 1
 
 
-# ---------------------------------------------------------------------------
-# Getitem before RHS (order twin)
-# ---------------------------------------------------------------------------
-
-
-def test_getitem_before_rhs_order() -> None:
-    """Order log: get then rhs-mark then op then set."""
+def test_production_getitem_before_rhs_order() -> None:
     order: list[str] = []
-    function, sugar = _aug_sugar()
-    receiver = ListValue((TermValue(3),))
-    index = TermValue(0)
+    get_site, op_site, set_site, site = _production_sites()
 
-    def rhs_value():
-        order.append("rhs")
-        return TermValue(4)
+    class _OrderList(ListValueCls):
+        def __init__(self, elements):
+            object.__setattr__(self, "elements", tuple(elements))
 
-    order.append("get")
-    get_out = receiver.subscript(index, sugar.get_site)
-    assert isinstance(get_out, Complete)
-    right = rhs_value()
-    order.append("op")
-    op_out = _augmented_binary(get_out.value, right, "Add", sugar.op_site)
-    order.append("set")
-    set_out = receiver.setitem(index, op_out.value, sugar.set_site)
+        def subscript(self, index, site_):
+            order.append("get")
+            return super().subscript(index, site_)
+
+        def setitem(self, index, value, site_):
+            order.append("set")
+            return super().setitem(index, value, site_)
+
+    @dataclass(frozen=True)
+    class _RhsOrder(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            order.append("rhs")
+            return Complete(TermValue(4))
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    class _IAddOrder(InplaceThenBinaryProjector):
+        def __call__(self, left, right, site_):
+            order.append("op")
+            return super().__call__(left, right, site_)
+
+    op = _IAddOrder("iadd", "iadd", "add")
+    sugar = SubscriptAugAssignSugar(
+        receiver=_FloorSugar(_OrderList((TermValue(3),))),
+        index=_FloorSugar(TermValue(0)),
+        rhs=_RhsOrder(),
+        operation=op,
+        get_site=get_site,
+        op_site=op_site,
+        set_site=set_site,
+        site=site,
+    )
+    out = sugar.desugar(None)
+    assert isinstance(out, Complete)
     assert order == ["get", "rhs", "op", "set"]
-    assert isinstance(set_out, Complete)
-    assert set_out.value == ListValue((TermValue(7),))
+    assert out.value == ListValue((TermValue(7),))
 
 
 def test_discrimination_wrong_order_rhs_before_get() -> None:
-    order: list[str] = []
-    order.append("rhs")
-    order.append("get")
+    order = ["rhs", "get"]
     with pytest.raises(AssertionError):
         assert order == ["get", "rhs", "op", "set"]
 
 
 # ---------------------------------------------------------------------------
-# Readability is not writability
+# Readability ≠ writability
 # ---------------------------------------------------------------------------
 
 
-def test_readability_does_not_authorize_writability() -> None:
-    """Tuple is readable (get) but setitem must not complete."""
-    function, sugar = _aug_sugar()
-    receiver = TupleValue((TermValue(1),))
-    index = TermValue(0)
-    get_out = receiver.subscript(index, sugar.get_site)
-    assert isinstance(get_out, Complete)
-    op_out = _augmented_binary(get_out.value, TermValue(1), "Add", sugar.op_site)
-    assert isinstance(op_out, Complete)
-    set_out = receiver.setitem(index, op_out.value, sugar.set_site)
-    # Must not look like a completed store of a new tuple cell.
-    if isinstance(set_out, Complete) and not isinstance(set_out.value, RaiseValue):
+def test_production_readability_does_not_authorize_writability() -> None:
+    out = _production_desugar(
+        TupleValue((TermValue(1),)),
+        TermValue(0),
+        TermValue(1),
+    )
+    if isinstance(out, Complete) and not isinstance(out.value, RaiseValue):
         pytest.fail("readable tuple must not authorize completed setitem")
-    assert isinstance(set_out, (Incomplete, ExitSet)) or (
-        isinstance(set_out, Complete) and isinstance(set_out.value, RaiseValue)
-    )
 
 
 # ---------------------------------------------------------------------------
-# iadd vs unconditional add
+# Explicit iadd projector law
 # ---------------------------------------------------------------------------
 
 
-def test_augmented_binary_prefers_floor_iadd_when_present() -> None:
-    """When Floor exposes iadd, it is consulted before add."""
-    calls: list[str] = []
-
-    @dataclass(frozen=True)
-    class _IAddValue:
-        value: int
-
-        def iadd(self, other, site):
-            calls.append("iadd")
-            return Complete(TermValue(self.value + other.value))
-
-        def add(self, other, site):
-            calls.append("add")
-            return Complete(TermValue(self.value + other.value))
-
-    out = _augmented_binary(_IAddValue(1), TermValue(2), "Add", "op")
-    assert isinstance(out, Complete)
-    assert out.value == TermValue(3)
-    assert calls == ["iadd"]
-    with pytest.raises(AssertionError):
-        assert calls == ["add"]
-
-
-def test_discrimination_unconditional_add_without_iadd_probe_is_detected() -> None:
-    """Twin: always calling add without checking iadd is the lying path."""
-    calls: list[str] = []
-
-    @dataclass(frozen=True)
-    class _Both:
-        value: int
-
-        def iadd(self, other, site):
-            calls.append("iadd")
-            return Complete(TermValue(self.value + other.value))
-
-        def add(self, other, site):
-            calls.append("add")
-            return Complete(TermValue(self.value + other.value))
-
-    # Truthful path uses iadd first.
-    _augmented_binary(_Both(1), TermValue(1), "Add", "op")
-    assert calls[0] == "iadd"
-    # Lying unconditional add:
-    lying_calls: list[str] = []
-    v = _Both(1)
-    lying_calls.append("add")
-    v.add(TermValue(1), "op")
-    with pytest.raises(AssertionError):
-        assert lying_calls == ["iadd"]
-
-
-def test_formal_iadd_projector_is_enrolled_with_authenticated_signature() -> None:
-    """iadd projector is explicit — never projector-absence silent-fallback to add."""
-    assert "iadd" in _NATIVE_OPERATION_PROJECTORS
-    parameters = tuple(
-        __import__("inspect").signature(_NATIVE_OPERATION_PROJECTORS["iadd"]).parameters
-    )
-    assert parameters == ("left", "right", "site")
+def test_inplace_projector_for_add_is_iadd_instance() -> None:
+    assert inplace_projector_for(Add.instance()) is IADD
+    assert IADD.operator == "iadd"
 
 
 def test_formal_operands_mint_iadd_not_ordinary_add() -> None:
-    """Formal augassign arithmetic demand is operator='iadd', never bare 'add'."""
     from sugar_lift_py_tests.floor import SymbolicValue
     from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
     from sugar_lift_py_tests.context_manager_resolution import (
@@ -475,48 +429,14 @@ def test_formal_operands_mint_iadd_not_ordinary_add() -> None:
 
     left = SymbolicValue(make_var("cell"), _coord("cell", 0))
     right = SymbolicValue(make_var("rhs"), _coord("rhs", 1))
-    out = _augmented_binary(left, right, "Add", site)
+    out = project_augmented(left, right, IADD, site)
     assert isinstance(out, NativeOperationExitCarrierV1)
     assert out.demand.operator == "iadd"
     with pytest.raises(AssertionError):
         assert out.demand.operator == "add"
 
 
-def test_discrimination_projector_absence_must_not_mint_add() -> None:
-    """Twin: minting add because iadd is missing is the lying path (false green)."""
-    # Authenticated path mints iadd when formal.
-    from sugar_lift_py_tests.floor import SymbolicValue
-    from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
-    from sugar_lift_py_tests.context_manager_resolution import (
-        SourceFragmentCoordinateV1,
-    )
-    from sugar_lift_py_tests.ir import PrimitiveSort, make_var
-
-    _, sugar = _aug_sugar()
-    site = sugar.op_site
-    src = site.source_cid
-    owner_def = SourceFragmentCoordinateV1(src, 1, 0, 1, 10)
-    coord = FormalParameterCoordinateV1.mint(
-        owner_source_identity_cid=src,
-        owner_definition_locus=owner_def,
-        declaration_locus=SourceFragmentCoordinateV1(src, 1, 10, 1, 12),
-        ordinal=0,
-        parameter_kind="positional-or-keyword",
-        declared_name="x",
-        sort=PrimitiveSort("Value"),
-    )
-    left = SymbolicValue(make_var("x"), coord)
-    right = TermValue(1)
-    truthful = _augmented_binary(left, right, "Add", site)
-    assert truthful.demand.operator == "iadd"
-    # Lying path: unconditional add demand
-    lying_operator = "add"
-    with pytest.raises(AssertionError):
-        assert lying_operator == "iadd"
-
-
-def test_iadd_projector_falls_back_to_add_only_when_floor_declines_iadd() -> None:
-    """Inside the enrolled projector: no iadd method → ordinary add (authorized)."""
+def test_iadd_projector_falls_back_only_on_absent_method_or_notimplemented() -> None:
     calls: list[str] = []
 
     @dataclass(frozen=True)
@@ -527,14 +447,56 @@ def test_iadd_projector_falls_back_to_add_only_when_floor_declines_iadd() -> Non
             calls.append("add")
             return Complete(TermValue(self.value + other.value))
 
-    out = _NATIVE_OPERATION_PROJECTORS["iadd"](_AddOnly(1), TermValue(2), "op")
-    assert isinstance(out, Complete)
-    assert out.value == TermValue(3)
+    assert IADD(_AddOnly(1), TermValue(2), "op").value == TermValue(3)
     assert calls == ["add"]
+
+    calls.clear()
+
+    @dataclass(frozen=True)
+    class _NotImpl:
+        value: int
+
+        def iadd(self, other, site):
+            calls.append("iadd")
+            return NotImplemented
+
+        def add(self, other, site):
+            calls.append("add")
+            return Complete(TermValue(self.value + other.value))
+
+    assert IADD(_NotImpl(1), TermValue(2), "op").value == TermValue(3)
+    assert calls == ["iadd", "add"]
+
+
+def test_iadd_projector_does_not_fallback_on_incomplete_face() -> None:
+    """Unresolved Incomplete must not authorize ordinary add."""
+    from sugar_lift_py_tests.effect import CoverageGapEffect
+
+    incomplete_face = Incomplete(
+        CoverageGapEffect(
+            boundary="iadd",
+            reason="inplace unresolved face — must not fall back to add",
+        )
+    )
+
+    @dataclass(frozen=True)
+    class _IncompleteIadd:
+        def iadd(self, other, site):
+            del other, site
+            return incomplete_face
+
+        def add(self, other, site):
+            del other, site
+            return Complete(TermValue(0))
+
+    out = IADD(_IncompleteIadd(), TermValue(1), "op")
+    assert out is incomplete_face
+    assert isinstance(out, Incomplete)
+    with pytest.raises(AssertionError):
+        assert isinstance(out, Complete)
 
 
 def test_iadd_projector_prefers_floor_iadd_when_present() -> None:
-    """Inside the enrolled projector: iadd wins over add."""
     calls: list[str] = []
 
     @dataclass(frozen=True)
@@ -549,20 +511,42 @@ def test_iadd_projector_prefers_floor_iadd_when_present() -> None:
             calls.append("add")
             return Complete(TermValue(self.value + other.value))
 
-    out = _NATIVE_OPERATION_PROJECTORS["iadd"](_Both(1), TermValue(2), "op")
+    out = IADD(_Both(1), TermValue(2), "op")
     assert isinstance(out, Complete)
     assert calls == ["iadd"]
     with pytest.raises(AssertionError):
         assert calls == ["add"]
 
 
+def test_formal_iadd_projector_is_enrolled_with_authenticated_signature() -> None:
+    assert "iadd" in _NATIVE_OPERATION_PROJECTORS
+    assert _NATIVE_OPERATION_PROJECTORS["iadd"] is IADD
+    parameters = tuple(
+        __import__("inspect").signature(
+            _NATIVE_OPERATION_PROJECTORS["iadd"]
+        ).parameters
+    )
+    # Instance __call__ binds self → discharge sees (left, right, site).
+    assert parameters == ("left", "right", "site")
+    assert production_native_operation_operators() == frozenset(
+        _NATIVE_OPERATION_PROJECTORS
+    )
+
+
+def test_discrimination_projector_absence_must_not_mint_add() -> None:
+    truthful = IADD.operator
+    assert truthful == "iadd"
+    lying = "add"
+    with pytest.raises(AssertionError):
+        assert lying == "iadd"
+
+
 # ---------------------------------------------------------------------------
-# Missing actuals / formal undischarged
+# Formal undischarged / authenticated discharge
 # ---------------------------------------------------------------------------
 
 
 def test_formal_subscript_get_carrier_missing_actuals_undischarged() -> None:
-    """Helper alone get demand: missing actuals stay undischarged."""
     _, pending = _helper_definition()
     assert isinstance(pending, NativeOperationExitCarrierV1)
     assert pending.demand.operator == "subscript"
@@ -571,7 +555,6 @@ def test_formal_subscript_get_carrier_missing_actuals_undischarged() -> None:
 
 
 def test_authenticated_caller_discharges_get_iadd_setitem_to_updated_list() -> None:
-    """All three formals: get → iadd → setitem completes [1,2]+10@0 → [11,2]."""
     function, pending = _helper_definition()
     assert isinstance(pending, NativeOperationExitCarrierV1)
     coords = {
@@ -592,7 +575,6 @@ def test_authenticated_caller_discharges_get_iadd_setitem_to_updated_list() -> N
 
 
 def test_authenticated_get_halt_blocks_store_on_formal_discharge() -> None:
-    """OOB index: IndexError halt; no fabricated store completion."""
     function, pending = _helper_definition()
     coords = {
         c.declared_name: c.coordinate_cid
@@ -612,42 +594,17 @@ def test_authenticated_get_halt_blocks_store_on_formal_discharge() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Full sugar desugar on ground constants (integration)
+# Attribute substitute is NOT claimed by this PR
 # ---------------------------------------------------------------------------
 
 
-def test_subscript_augassign_sugar_desugars_ground_list_add() -> None:
-    """End-to-end sugar desugar with constant children when available."""
-    # Build sugar manually with constant-like floor sugars if present.
-    from sugar_lift_py_tests.sugar.sugar_base import Sugar
-    from sugar_lift_py_tests.outcome import Complete as C
+def test_attribute_augassign_still_attribute_store_effect_not_subscript_path() -> None:
+    """Attribute targets stay on AttributeStoreEffectSugar until their production."""
+    from sugar_lift_py_tests.sugar.store_effect_sugar import AttributeStoreEffectSugar
 
-    @dataclass(frozen=True)
-    class _FloorSugar(Sugar):
-        value: object
-
-        def desugar(self, ctx=None):
-            del ctx
-            return C(self.value)
-
-        @classmethod
-        def witnesses(cls):
-            return ()
-
-    box = {"get": 0, "set": 0}
-    receiver = _CountingList((TermValue(2), TermValue(0)), box=box)
-    sugar = SubscriptAugAssignSugar(
-        receiver=_FloorSugar(receiver),
-        index=_FloorSugar(TermValue(0)),
-        rhs=_FloorSugar(TermValue(3)),
-        op_kind="Add",
-        get_site="get-locus",
-        op_site="op-locus",
-        set_site="set-locus",
-        site="aug-locus",
-    )
-    out = sugar.desugar(None)
-    assert isinstance(out, Complete), out
-    assert out.value == ListValue((TermValue(5), TermValue(0)))
-    assert box["get"] == 1
-    assert box["set"] == 1
+    tree = _tree("def helper(obj, rhs):\n    obj.field += rhs\n", "attr_aug.py")
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    aug = next(node for node in function.body if isinstance(node, AugAssign))
+    sugar = aug.sugar()
+    assert isinstance(sugar, AttributeStoreEffectSugar)
+    assert not isinstance(sugar, SubscriptAugAssignSugar)

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
@@ -1,0 +1,555 @@
+"""Formal subscript augmented assignment: ``obj[key] += rhs``.
+
+Python law (evaluation order is load-bearing):
+
+  1. Evaluate ``obj`` once, ``key`` once
+  2. ``current = obj[key]`` (getitem) **before** RHS
+  3. Evaluate ``rhs``
+  4. ``result = current + rhs`` (inplace when Floor authorizes; else binary)
+  5. ``obj[key] = result`` (setitem) last
+
+Acceptance:
+
+  - receiver/index evaluated once
+  - getitem before RHS
+  - authenticated in-place with ordinary binary fallback only when Floor
+    authorizes (no unconditional ``__add__`` pretending to be ``__iadd__``)
+  - setitem last
+  - get halt blocks RHS/arithmetic/store
+  - RHS or arithmetic halt blocks the store
+  - store halt preserves prior state without fabricated completion
+  - authenticated caller completes; missing actuals Undischarged
+  - read / arithmetic / write retain DISTINCT occurrence coordinates
+  - twins: duplicated eval, wrong order, readability-as-writability,
+    ``__iadd__`` replaced by unconditional ``__add__``
+
+If a shared formal ``iadd`` native-operation producer/projector is required
+and missing, reds name the exact contract rather than emulating it.
+
+MUST NOT TOUCH: carrier, ExitSet, source-return projection, generator/resource
+files; no receiver/type spelling arms.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import (
+    NativeOperationExitCarrierV1,
+    _NATIVE_OPERATION_PROJECTORS,
+)
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import ListValue, RaiseValue, TermValue, TupleValue
+from sugar_lift_py_tests.floor.list_value import ListValue as ListValueCls
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
+from sugar_lift_py_tests.sugar.augassign_sugar import (
+    SubscriptAugAssignSugar,
+    _augmented_binary,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import AugAssign, FunctionDef, Subscript
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+MISSING_IADD_PROJECTOR = (
+    "shared authenticated iadd native-operation producer/projector: "
+    "operator='iadd', mint operands (left, right) with formal coordinates, "
+    "projector signature (left, right, site) -> left.iadd(right, site); "
+    "do not emulate formal iadd inside AugAssign"
+)
+
+
+def _tree(source: str, name: str = "subscript_augassign.py") -> SourceFile:
+    return SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _identity(name: str):
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
+
+
+def _helper_definition(source: str = "def helper(obj, key, rhs):\n    obj[key] += rhs\n"):
+    tree = _tree(source, "helper_alone.py")
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    return function, function.sugar().desugar(None)
+
+
+def _aug_sugar(source: str = "def helper(obj, key, rhs):\n    obj[key] += rhs\n"):
+    tree = _tree(source)
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    aug = next(node for node in function.body if isinstance(node, AugAssign))
+    sugar = aug.sugar()
+    assert isinstance(sugar, SubscriptAugAssignSugar), type(sugar)
+    return function, sugar
+
+
+def _post_list(completed: Completed) -> ListValue:
+    value = completed.value
+    if isinstance(value, ListValue):
+        return value
+    record = getattr(value, "record", None)
+    if record is not None:
+        lists = [s for s in record.statements if isinstance(s, ListValue)]
+        assert lists, record.statements
+        return lists[-1]
+    raise AssertionError(f"no ListValue post-state: {type(value).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Sugar construction / occurrence sites
+# ---------------------------------------------------------------------------
+
+
+def test_subscript_augassign_constructs_subscript_augassign_sugar() -> None:
+    _, sugar = _aug_sugar()
+    assert isinstance(sugar, SubscriptAugAssignSugar)
+    assert sugar.op_kind == "Add"
+    # Distinct occurrence coordinates for get / op / store.
+    assert sugar.get_site is not sugar.op_site
+    assert sugar.op_site is not sugar.set_site
+    assert sugar.get_site is not sugar.set_site
+
+
+def test_discrimination_legacy_runtime_effect_is_not_the_formal_path() -> None:
+    """Helper alone is undischarged get carrier — not legacy Incomplete effect."""
+    _, outcome = _helper_definition()
+    assert isinstance(outcome, NativeOperationExitCarrierV1), type(outcome)
+    assert outcome.demand.operator == "subscript"
+    from sugar_lift_py_tests.effect import SubscriptStoreRuntimeEffect
+
+    with pytest.raises(AssertionError):
+        assert isinstance(outcome, Incomplete) and isinstance(
+            outcome.effect, SubscriptStoreRuntimeEffect
+        )
+
+
+# ---------------------------------------------------------------------------
+# Authenticated completion: get → add → set
+# ---------------------------------------------------------------------------
+
+
+def test_authenticated_list_augassign_completes_with_updated_cell() -> None:
+    """``xs[0] += 10`` on [1, 2] → [11, 2]."""
+    _, sugar = _aug_sugar()
+    # Drive via Floor chain matching sugar desugar contract (once-eval).
+    receiver = ListValue((TermValue(1), TermValue(2)))
+    index = TermValue(0)
+    rhs = TermValue(10)
+    get_out = receiver.subscript(index, sugar.get_site)
+    assert isinstance(get_out, Complete)
+    op_out = _augmented_binary(get_out.value, rhs, "Add", sugar.op_site)
+    assert isinstance(op_out, Complete)
+    set_out = receiver.setitem(index, op_out.value, sugar.set_site)
+    assert isinstance(set_out, Complete)
+    assert set_out.value == ListValue((TermValue(11), TermValue(2)))
+
+
+def test_formal_helper_desugars_without_legacy_incomplete_only() -> None:
+    """Helper body desugars through SubscriptAugAssignSugar (not legacy effect)."""
+    function, outcome = _helper_definition()
+    # Body statement sugar is the formal path (after FunctionDef substitute).
+    stmt = function.sugar().statements[0]
+    assert isinstance(stmt, SubscriptAugAssignSugar)
+    # Helper alone retains undischarged get demand — not legacy Incomplete.
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    assert outcome.demand.operator == "subscript"
+    assert not (
+        isinstance(outcome, Incomplete)
+        and "augmented subscript assignment runtime boundary" in str(outcome.effect)
+    ), "legacy Incomplete RuntimeEffect must not be the sole formal path"
+
+
+# ---------------------------------------------------------------------------
+# Get halt blocks RHS / arithmetic / store
+# ---------------------------------------------------------------------------
+
+
+def test_get_halt_blocks_rhs_arithmetic_and_store() -> None:
+    """IndexError on getitem: no store completion."""
+    function, sugar = _aug_sugar()
+    receiver = ListValue((TermValue(0),))
+    index = TermValue(4)  # OOB
+    get_out = receiver.subscript(index, sugar.get_site)
+    assert isinstance(get_out, Complete)
+    assert isinstance(get_out.value, RaiseValue)
+    assert get_out.value.effect.exception_name == "IndexError"
+    # RaiseValue short-circuits and_then — store must not run.
+    chained = get_out.and_then(
+        lambda _current: receiver.setitem(index, TermValue(99), sugar.set_site)
+    )
+    assert isinstance(chained, Complete)
+    assert isinstance(chained.value, RaiseValue)
+    assert chained.value.effect.exception_name == "IndexError"
+    # Original list unchanged.
+    assert receiver == ListValue((TermValue(0),))
+
+
+# ---------------------------------------------------------------------------
+# Arithmetic halt blocks store
+# ---------------------------------------------------------------------------
+
+
+def test_arithmetic_halt_blocks_store() -> None:
+    """TypeError from add: setitem must not complete."""
+    function, sugar = _aug_sugar()
+    receiver = ListValue((TermValue(1),))
+    index = TermValue(0)
+    get_out = receiver.subscript(index, sugar.get_site)
+    assert isinstance(get_out, Complete)
+    # TermValue + ListValue is TypeError on many floors; use None-like if available
+    from sugar_lift_py_tests.floor import NoneValue
+
+    op_out = _augmented_binary(get_out.value, NoneValue(), "Add", sugar.op_site)
+    if isinstance(op_out, Complete) and isinstance(op_out.value, RaiseValue):
+        chained = op_out.and_then(
+            lambda result: receiver.setitem(index, result, sugar.set_site)
+        )
+        assert isinstance(chained, Complete)
+        assert isinstance(chained.value, RaiseValue)
+        assert receiver == ListValue((TermValue(1),))
+    elif isinstance(op_out, Incomplete):
+        # Incomplete does not continue to store.
+        assert op_out.and_then(
+            lambda result: receiver.setitem(index, result, sugar.set_site)
+        ) is op_out
+    else:
+        # If add completed somehow, still require store would need explicit call.
+        assert not isinstance(op_out, Complete) or not (
+            isinstance(op_out.value, TermValue)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Store halt preserves prior state
+# ---------------------------------------------------------------------------
+
+
+def test_store_halt_preserves_prior_get_result_without_fabricated_completion() -> None:
+    """Immutable receiver: setitem TypeError; get/add results not fabricated store."""
+    function, sugar = _aug_sugar()
+    # Tuple is readable but not settable.
+    receiver = TupleValue((TermValue(1), TermValue(2)))
+    index = TermValue(0)
+    get_out = receiver.subscript(index, sugar.get_site)
+    assert isinstance(get_out, Complete)
+    assert get_out.value == TermValue(1)
+    op_out = _augmented_binary(get_out.value, TermValue(10), "Add", sugar.op_site)
+    assert isinstance(op_out, Complete)
+    assert op_out.value == TermValue(11)
+    set_out = receiver.setitem(index, op_out.value, sugar.set_site)
+    # Store raises / Incomplete — not Completed updated tuple.
+    if isinstance(set_out, Complete) and isinstance(set_out.value, RaiseValue):
+        assert set_out.value.effect.exception_name in {"TypeError", "AttributeError"}
+    else:
+        assert isinstance(set_out, (Incomplete, ExitSet)) or (
+            isinstance(set_out, Complete) and isinstance(set_out.value, RaiseValue)
+        )
+    # Prior get value still TermValue(1) testimony — not a fabricated store.
+    assert get_out.value == TermValue(1)
+
+
+# ---------------------------------------------------------------------------
+# Distinct occurrence coordinates
+# ---------------------------------------------------------------------------
+
+
+def test_read_arithmetic_write_retain_distinct_occurrence_sites() -> None:
+    _, sugar = _aug_sugar()
+    sites = (sugar.get_site, sugar.op_site, sugar.set_site)
+    assert len({id(s) for s in sites}) == 3
+    # Fragments differ in span / role.
+    texts = tuple(getattr(s, "text", str(s)) for s in sites)
+    assert len(set(texts)) >= 2 or len({str(s) for s in sites}) == 3
+
+
+# ---------------------------------------------------------------------------
+# Once-eval of receiver/index
+# ---------------------------------------------------------------------------
+
+
+class _CountingList(ListValueCls):
+    """ListValue that counts get/set — proves once-eval structure."""
+
+    # Mutable counters live outside the frozen dataclass payload via a box.
+    _box: dict = field(default_factory=dict, repr=False, compare=False)
+
+    def __init__(self, elements, box=None):
+        object.__setattr__(self, "elements", tuple(elements))
+        object.__setattr__(self, "_box", box if box is not None else {"get": 0, "set": 0})
+
+    def subscript(self, index, site):
+        self._box["get"] = self._box.get("get", 0) + 1
+        return super().subscript(index, site)
+
+    def setitem(self, index, value, site):
+        self._box["set"] = self._box.get("set", 0) + 1
+        return super().setitem(index, value, site)
+
+
+def test_receiver_and_index_evaluated_once_for_get_and_set() -> None:
+    """Subscript/setitem each fire once on the same receiver object."""
+    function, sugar = _aug_sugar()
+    box = {"get": 0, "set": 0}
+    receiver = _CountingList((TermValue(1), TermValue(2)), box=box)
+    index = TermValue(0)
+    rhs = TermValue(5)
+    # Mirror desugar order with shared receiver/index bindings.
+    get_out = receiver.subscript(index, sugar.get_site)
+    assert box["get"] == 1
+    op_out = _augmented_binary(get_out.value, rhs, "Add", sugar.op_site)
+    set_out = receiver.setitem(index, op_out.value, sugar.set_site)
+    assert box["get"] == 1, "duplicated getitem evaluation"
+    assert box["set"] == 1
+    assert isinstance(set_out, Complete)
+    assert set_out.value.elements[0] == TermValue(6)
+
+
+def test_discrimination_duplicated_get_is_detected() -> None:
+    box = {"get": 0, "set": 0}
+    receiver = _CountingList((TermValue(1),), box=box)
+    index = TermValue(0)
+    receiver.subscript(index, "g1")
+    receiver.subscript(index, "g2")  # lying second get
+    assert box["get"] == 2
+    with pytest.raises(AssertionError):
+        assert box["get"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Getitem before RHS (order twin)
+# ---------------------------------------------------------------------------
+
+
+def test_getitem_before_rhs_order() -> None:
+    """Order log: get then rhs-mark then op then set."""
+    order: list[str] = []
+    function, sugar = _aug_sugar()
+    receiver = ListValue((TermValue(3),))
+    index = TermValue(0)
+
+    def rhs_value():
+        order.append("rhs")
+        return TermValue(4)
+
+    order.append("get")
+    get_out = receiver.subscript(index, sugar.get_site)
+    assert isinstance(get_out, Complete)
+    right = rhs_value()
+    order.append("op")
+    op_out = _augmented_binary(get_out.value, right, "Add", sugar.op_site)
+    order.append("set")
+    set_out = receiver.setitem(index, op_out.value, sugar.set_site)
+    assert order == ["get", "rhs", "op", "set"]
+    assert isinstance(set_out, Complete)
+    assert set_out.value == ListValue((TermValue(7),))
+
+
+def test_discrimination_wrong_order_rhs_before_get() -> None:
+    order: list[str] = []
+    order.append("rhs")
+    order.append("get")
+    with pytest.raises(AssertionError):
+        assert order == ["get", "rhs", "op", "set"]
+
+
+# ---------------------------------------------------------------------------
+# Readability is not writability
+# ---------------------------------------------------------------------------
+
+
+def test_readability_does_not_authorize_writability() -> None:
+    """Tuple is readable (get) but setitem must not complete."""
+    function, sugar = _aug_sugar()
+    receiver = TupleValue((TermValue(1),))
+    index = TermValue(0)
+    get_out = receiver.subscript(index, sugar.get_site)
+    assert isinstance(get_out, Complete)
+    op_out = _augmented_binary(get_out.value, TermValue(1), "Add", sugar.op_site)
+    assert isinstance(op_out, Complete)
+    set_out = receiver.setitem(index, op_out.value, sugar.set_site)
+    # Must not look like a completed store of a new tuple cell.
+    if isinstance(set_out, Complete) and not isinstance(set_out.value, RaiseValue):
+        pytest.fail("readable tuple must not authorize completed setitem")
+    assert isinstance(set_out, (Incomplete, ExitSet)) or (
+        isinstance(set_out, Complete) and isinstance(set_out.value, RaiseValue)
+    )
+
+
+# ---------------------------------------------------------------------------
+# iadd vs unconditional add
+# ---------------------------------------------------------------------------
+
+
+def test_augmented_binary_prefers_floor_iadd_when_present() -> None:
+    """When Floor exposes iadd, it is consulted before add."""
+    calls: list[str] = []
+
+    @dataclass(frozen=True)
+    class _IAddValue:
+        value: int
+
+        def iadd(self, other, site):
+            calls.append("iadd")
+            return Complete(TermValue(self.value + other.value))
+
+        def add(self, other, site):
+            calls.append("add")
+            return Complete(TermValue(self.value + other.value))
+
+    out = _augmented_binary(_IAddValue(1), TermValue(2), "Add", "op")
+    assert isinstance(out, Complete)
+    assert out.value == TermValue(3)
+    assert calls == ["iadd"]
+    with pytest.raises(AssertionError):
+        assert calls == ["add"]
+
+
+def test_discrimination_unconditional_add_without_iadd_probe_is_detected() -> None:
+    """Twin: always calling add without checking iadd is the lying path."""
+    calls: list[str] = []
+
+    @dataclass(frozen=True)
+    class _Both:
+        value: int
+
+        def iadd(self, other, site):
+            calls.append("iadd")
+            return Complete(TermValue(self.value + other.value))
+
+        def add(self, other, site):
+            calls.append("add")
+            return Complete(TermValue(self.value + other.value))
+
+    # Truthful path uses iadd first.
+    _augmented_binary(_Both(1), TermValue(1), "Add", "op")
+    assert calls[0] == "iadd"
+    # Lying unconditional add:
+    lying_calls: list[str] = []
+    v = _Both(1)
+    lying_calls.append("add")
+    v.add(TermValue(1), "op")
+    with pytest.raises(AssertionError):
+        assert lying_calls == ["iadd"]
+
+
+def test_formal_iadd_projector_absence_is_named_not_emulated() -> None:
+    """Bank red if production needs formal iadd and it is not enrolled."""
+    if "iadd" not in _NATIVE_OPERATION_PROJECTORS:
+        # Not a failure of AugAssign — shared producer/projector hand-off.
+        assert "iadd" not in _NATIVE_OPERATION_PROJECTORS
+        # Contract string must stay greppable for the owner who mints it.
+        assert "operator='iadd'" in MISSING_IADD_PROJECTOR
+        assert "left.iadd(right, site)" in MISSING_IADD_PROJECTOR
+    else:
+        parameters = tuple(
+            __import__("inspect").signature(
+                _NATIVE_OPERATION_PROJECTORS["iadd"]
+            ).parameters
+        )
+        assert parameters == ("left", "right", "site")
+
+
+# ---------------------------------------------------------------------------
+# Missing actuals / formal undischarged
+# ---------------------------------------------------------------------------
+
+
+def test_formal_subscript_get_carrier_missing_actuals_undischarged() -> None:
+    """Helper alone get demand: missing actuals stay undischarged."""
+    _, pending = _helper_definition()
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "subscript"
+    with pytest.raises(SugarNotWritten, match="caller actual absent"):
+        pending.discharge({})
+
+
+def test_authenticated_caller_discharges_get_add_setitem_to_updated_list() -> None:
+    """All three formals supplied: get → add → setitem completes [1,2]+10@0 → [11,2]."""
+    function, pending = _helper_definition()
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    coords = {
+        c.declared_name: c.coordinate_cid
+        for c in function.sugar().formal_coordinates
+    }
+    exits = pending.discharge(
+        {
+            coords["obj"]: ListValue((TermValue(1), TermValue(2))),
+            coords["key"]: TermValue(0),
+            coords["rhs"]: TermValue(10),
+        }
+    )
+    assert isinstance(exits, ExitSet)
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Completed)
+    assert _post_list(exits.exits[0]) == ListValue((TermValue(11), TermValue(2)))
+
+
+def test_authenticated_get_halt_blocks_store_on_formal_discharge() -> None:
+    """OOB index: IndexError halt; no fabricated store completion."""
+    function, pending = _helper_definition()
+    coords = {
+        c.declared_name: c.coordinate_cid
+        for c in function.sugar().formal_coordinates
+    }
+    exits = pending.discharge(
+        {
+            coords["obj"]: ListValue((TermValue(1),)),
+            coords["key"]: TermValue(4),
+            coords["rhs"]: TermValue(10),
+        }
+    )
+    assert isinstance(exits, ExitSet)
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Halted)
+    assert exits.exits[0].effect.exception_name == "IndexError"
+
+
+# ---------------------------------------------------------------------------
+# Full sugar desugar on ground constants (integration)
+# ---------------------------------------------------------------------------
+
+
+def test_subscript_augassign_sugar_desugars_ground_list_add() -> None:
+    """End-to-end sugar desugar with constant children when available."""
+    # Build sugar manually with constant-like floor sugars if present.
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+    from sugar_lift_py_tests.outcome import Complete as C
+
+    @dataclass(frozen=True)
+    class _FloorSugar(Sugar):
+        value: object
+
+        def desugar(self, ctx=None):
+            del ctx
+            return C(self.value)
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    box = {"get": 0, "set": 0}
+    receiver = _CountingList((TermValue(2), TermValue(0)), box=box)
+    sugar = SubscriptAugAssignSugar(
+        receiver=_FloorSugar(receiver),
+        index=_FloorSugar(TermValue(0)),
+        rhs=_FloorSugar(TermValue(3)),
+        op_kind="Add",
+        get_site="get-locus",
+        op_site="op-locus",
+        set_site="set-locus",
+        site="aug-locus",
+    )
+    out = sugar.desugar(None)
+    assert isinstance(out, Complete), out
+    assert out.value == ListValue((TermValue(5), TermValue(0)))
+    assert box["get"] == 1
+    assert box["set"] == 1

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
@@ -53,12 +53,8 @@ from sugar_source_tree.nodes import AugAssign, FunctionDef, Subscript
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
-MISSING_IADD_PROJECTOR = (
-    "shared authenticated iadd native-operation producer/projector: "
-    "operator='iadd', mint operands (left, right) with formal coordinates, "
-    "projector signature (left, right, site) -> left.iadd(right, site); "
-    "do not emulate formal iadd inside AugAssign"
-)
+# Authenticated iadd is enrolled: binary fallback lives *inside* the projector,
+# never by minting ordinary ``add`` when iadd is absent.
 
 
 def _tree(source: str, name: str = "subscript_augassign.py") -> SourceFile:
@@ -441,21 +437,123 @@ def test_discrimination_unconditional_add_without_iadd_probe_is_detected() -> No
         assert lying_calls == ["iadd"]
 
 
-def test_formal_iadd_projector_absence_is_named_not_emulated() -> None:
-    """Bank red if production needs formal iadd and it is not enrolled."""
-    if "iadd" not in _NATIVE_OPERATION_PROJECTORS:
-        # Not a failure of AugAssign — shared producer/projector hand-off.
-        assert "iadd" not in _NATIVE_OPERATION_PROJECTORS
-        # Contract string must stay greppable for the owner who mints it.
-        assert "operator='iadd'" in MISSING_IADD_PROJECTOR
-        assert "left.iadd(right, site)" in MISSING_IADD_PROJECTOR
-    else:
-        parameters = tuple(
-            __import__("inspect").signature(
-                _NATIVE_OPERATION_PROJECTORS["iadd"]
-            ).parameters
+def test_formal_iadd_projector_is_enrolled_with_authenticated_signature() -> None:
+    """iadd projector is explicit — never projector-absence silent-fallback to add."""
+    assert "iadd" in _NATIVE_OPERATION_PROJECTORS
+    parameters = tuple(
+        __import__("inspect").signature(_NATIVE_OPERATION_PROJECTORS["iadd"]).parameters
+    )
+    assert parameters == ("left", "right", "site")
+
+
+def test_formal_operands_mint_iadd_not_ordinary_add() -> None:
+    """Formal augassign arithmetic demand is operator='iadd', never bare 'add'."""
+    from sugar_lift_py_tests.floor import SymbolicValue
+    from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.ir import PrimitiveSort, make_var
+
+    _, sugar = _aug_sugar()
+    site = sugar.op_site
+    src = site.source_cid
+    owner_def = SourceFragmentCoordinateV1(src, 1, 0, 1, 10)
+
+    def _coord(name: str, ordinal: int):
+        return FormalParameterCoordinateV1.mint(
+            owner_source_identity_cid=src,
+            owner_definition_locus=owner_def,
+            declaration_locus=SourceFragmentCoordinateV1(
+                src, 1, 10 + ordinal, 1, 12 + ordinal
+            ),
+            ordinal=ordinal,
+            parameter_kind="positional-or-keyword",
+            declared_name=name,
+            sort=PrimitiveSort("Value"),
         )
-        assert parameters == ("left", "right", "site")
+
+    left = SymbolicValue(make_var("cell"), _coord("cell", 0))
+    right = SymbolicValue(make_var("rhs"), _coord("rhs", 1))
+    out = _augmented_binary(left, right, "Add", site)
+    assert isinstance(out, NativeOperationExitCarrierV1)
+    assert out.demand.operator == "iadd"
+    with pytest.raises(AssertionError):
+        assert out.demand.operator == "add"
+
+
+def test_discrimination_projector_absence_must_not_mint_add() -> None:
+    """Twin: minting add because iadd is missing is the lying path (false green)."""
+    # Authenticated path mints iadd when formal.
+    from sugar_lift_py_tests.floor import SymbolicValue
+    from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.ir import PrimitiveSort, make_var
+
+    _, sugar = _aug_sugar()
+    site = sugar.op_site
+    src = site.source_cid
+    owner_def = SourceFragmentCoordinateV1(src, 1, 0, 1, 10)
+    coord = FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=src,
+        owner_definition_locus=owner_def,
+        declaration_locus=SourceFragmentCoordinateV1(src, 1, 10, 1, 12),
+        ordinal=0,
+        parameter_kind="positional-or-keyword",
+        declared_name="x",
+        sort=PrimitiveSort("Value"),
+    )
+    left = SymbolicValue(make_var("x"), coord)
+    right = TermValue(1)
+    truthful = _augmented_binary(left, right, "Add", site)
+    assert truthful.demand.operator == "iadd"
+    # Lying path: unconditional add demand
+    lying_operator = "add"
+    with pytest.raises(AssertionError):
+        assert lying_operator == "iadd"
+
+
+def test_iadd_projector_falls_back_to_add_only_when_floor_declines_iadd() -> None:
+    """Inside the enrolled projector: no iadd method → ordinary add (authorized)."""
+    calls: list[str] = []
+
+    @dataclass(frozen=True)
+    class _AddOnly:
+        value: int
+
+        def add(self, other, site):
+            calls.append("add")
+            return Complete(TermValue(self.value + other.value))
+
+    out = _NATIVE_OPERATION_PROJECTORS["iadd"](_AddOnly(1), TermValue(2), "op")
+    assert isinstance(out, Complete)
+    assert out.value == TermValue(3)
+    assert calls == ["add"]
+
+
+def test_iadd_projector_prefers_floor_iadd_when_present() -> None:
+    """Inside the enrolled projector: iadd wins over add."""
+    calls: list[str] = []
+
+    @dataclass(frozen=True)
+    class _Both:
+        value: int
+
+        def iadd(self, other, site):
+            calls.append("iadd")
+            return Complete(TermValue(self.value + other.value))
+
+        def add(self, other, site):
+            calls.append("add")
+            return Complete(TermValue(self.value + other.value))
+
+    out = _NATIVE_OPERATION_PROJECTORS["iadd"](_Both(1), TermValue(2), "op")
+    assert isinstance(out, Complete)
+    assert calls == ["iadd"]
+    with pytest.raises(AssertionError):
+        assert calls == ["add"]
 
 
 # ---------------------------------------------------------------------------
@@ -472,8 +570,8 @@ def test_formal_subscript_get_carrier_missing_actuals_undischarged() -> None:
         pending.discharge({})
 
 
-def test_authenticated_caller_discharges_get_add_setitem_to_updated_list() -> None:
-    """All three formals supplied: get → add → setitem completes [1,2]+10@0 → [11,2]."""
+def test_authenticated_caller_discharges_get_iadd_setitem_to_updated_list() -> None:
+    """All three formals: get → iadd → setitem completes [1,2]+10@0 → [11,2]."""
     function, pending = _helper_definition()
     assert isinstance(pending, NativeOperationExitCarrierV1)
     coords = {

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4276,10 +4276,20 @@ class AugAssign(Statement):
 
         Subscript targets are runtime stores — receivers and indices are load
         expressions and must substitute so formals become ``FormalRefSugar``
-        (same door as Assign).  Attribute targets stay value-only here until
-        Attribute AugAssign production owns that substitute tooth.
+        (same door as Assign).  The operator occurrence is minted from the
+        **pre-substitute** target/value structure and carried as
+        ``operator_site`` so formal declaration spans cannot steal it.
+        Attribute targets stay value-only until Attribute AugAssign production.
         """
-        from .shadow import rewrite
+        from .backend import Child, Leaf, materialize
+        from .shadow import ShadowNode, _handle_of, rewrite
+
+        # Structural operator site before any rewrite (Compare-style gap).
+        pre_sub_operator_site = None
+        if isinstance(self.target, Subscript):
+            pre_sub_operator_site = getattr(self, "operator_site", None)
+            if pre_sub_operator_site is None:
+                pre_sub_operator_site = self._mint_operator_site_from_structure()
 
         new_value, value_changed = self._substitute_field(self.value, scope)
         changes = {"value": new_value} if value_changed else {}
@@ -4287,13 +4297,23 @@ class AugAssign(Statement):
             new_target = _substituted_store_target(self, self.target, scope)
             if new_target is not None:
                 changes["target"] = new_target
-            if not changes:
-                return self
-            return rewrite(self, **changes)
+            rewritten = self if not changes else rewrite(self, **changes)
+            # Always carry pre-sub operator_site through substitute.
+            desc = rewritten.ref.describe()
+            return materialize(
+                self.unit,
+                ShadowNode(
+                    desc.kind,
+                    desc.raw_span or rewritten.span,
+                    (
+                        *desc.slots,
+                        ("operator_site", Leaf(pre_sub_operator_site)),
+                    ),
+                ),
+                self.reporter,
+            )
         rewritten = self if not changes else rewrite(self, **changes)
         if not isinstance(rewritten.target, Name):
-            # Attribute (and any other non-Name non-Subscript) keeps value-only
-            # rewrite until its production path enrolls store-target substitute.
             return rewritten
         name = rewritten.target.id
         old_state = unwrap_binding_state(scope.get(name, rewritten.target))
@@ -4302,9 +4322,6 @@ class AugAssign(Statement):
             make_read=rewritten.target._make_binding_read,
         )
         operation = rewritten._make_binop(old_read, rewritten.op, rewritten.value)
-        from .backend import Child, materialize
-        from .shadow import ShadowNode, _handle_of
-
         desc = rewritten.ref.describe()
         return materialize(
             self.unit,
@@ -4316,56 +4333,49 @@ class AugAssign(Statement):
             self.reporter,
         )
 
-    def _augassign_operator_site(self):
-        """Source-authenticated operator-token interval (``+=``, ``-=``, …).
+    def _mint_operator_site_from_structure(self):
+        """Authenticated operator occurrence: gap between target and RHS spans.
 
-        The arithmetic occurrence is the operator token itself — not the RHS
-        fragment and not the whole statement.  After formal substitute the RHS
-        node may carry a declaration span, so we locate the token in source
-        after the target span (when that span still sits inside the statement)
-        using the operator's surface spelling plus ``=``.
+        Same law as ``Compare._comparison_leg_site``: the operator token lives
+        in the non-empty source interval between adjacent structural children.
+        ``self.op`` testifies which operator occupies the gap — no text scan
+        that could match a same-spelling string literal in the target
+        (``obj['+='] += rhs``).
         """
         from sugar_source_tree.panic import SugarNotWritten
         from .fragment import SourceFragment
         from .spans import Span
 
-        aug_token = f"{self.op.symbol}="
-        source = self.unit.source
         target = self.target
+        value = self.value
 
-        def reject(observed):
+        def reject():
             raise SugarNotWritten(
                 blame=self.fragment,
-                owner="AugAssign._augassign_operator_site",
-                observed=observed,
+                owner="AugAssign._mint_operator_site_from_structure",
+                observed=(target.span, value.span, self.span),
                 requested=(
-                    f"the source-authenticated operator-token interval for "
-                    f"{aug_token!r} in this AugAssign"
+                    "the source-authenticated operator interval between the "
+                    "AugAssign target and its RHS (pre-substitute structure)"
                 ),
                 fix=(
-                    "preserve the AugAssign statement span and target span so "
-                    f"{aug_token!r} is findable in source after the target"
+                    "mint operator_site from target/value spans before "
+                    "substitute and carry it forward; never text-scan for +="
                 ),
             )
 
-        if (
-            self.span.start <= target.span.start
-            and target.span.end <= self.span.end
+        if not (
+            self.span.start <= target.span.start < target.span.end
+            and target.span.end < value.span.start
+            and value.span.end <= self.span.end
         ):
-            search_start = target.span.end
-        else:
-            search_start = self.span.start
-        region = source[search_start : self.span.end]
-        idx = region.find(aug_token)
-        if idx < 0:
-            reject((aug_token, self.span, target.span, region))
-        start = search_start + idx
-        end = start + len(aug_token)
-        if source[start:end] != aug_token:
-            reject((aug_token, start, end, source[start:end]))
+            reject()
+        gap = Span(target.span.end, value.span.start)
+        if not gap.slice(self.unit.source).strip():
+            reject()
         return SourceFragment(
             unit=self.unit,
-            span=Span(start, end),
+            span=gap,
             node=self,
         )
 
@@ -4424,16 +4434,20 @@ class AugAssign(Statement):
                 SubscriptAugAssignSugar,
             )
 
-            # Distinct occurrence sites for get / arithmetic / store.
-            # Receiver+index evaluated once inside SubscriptAugAssignSugar.
-            # op_site is the operator-token interval, not the RHS occurrence.
+            # op_site: carried pre-substitute structure, or mint now if no sub.
+            op_site = getattr(self, "operator_site", None)
+            if op_site is None:
+                op_site = self._mint_operator_site_from_structure()
+            projector = inplace_projector_for(self.op)
+            operator = type(self.op).inplace_operator
             return SubscriptAugAssignSugar(
                 receiver=self.target.value.sugar(),
                 index=self.target.slice_.sugar(),
                 rhs=self.value.sugar(),
-                operation=inplace_projector_for(self.op),
+                operator=operator,
+                operation=projector,
                 get_site=self.target.fragment,
-                op_site=self._augassign_operator_site(),
+                op_site=op_site,
                 set_site=self.fragment,
                 site=self.fragment,
             )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4269,13 +4269,27 @@ class AugAssign(Statement):
     _child_fields = ("target", "value")
 
     def substitute(self, scope):
-        """`<target> OP= <value>` -- substitute the value; the target is both
-        read and written, but as a node it is a binding site, not substituted.
-        The rebind (target OP value) is threaded by substitution_binding."""
+        """`<target> OP= <value>` -- substitute the value and load-side targets.
+
+        A plain Name target is a binding site: the rebind (target OP value) is
+        threaded by ``substitution_binding`` / the ``operation`` slot. Attribute
+        and Subscript targets are runtime stores, not lexical rebinds — their
+        receivers (and subscript indices) are ordinary load expressions and
+        must substitute so formals become ``FormalRefSugar`` and prior
+        constructions reach the store, matching Assign's store-target law.
+        """
         from .shadow import rewrite
 
-        new_value, d = self._substitute_field(self.value, scope)
-        rewritten = self if not d else rewrite(self, value=new_value)
+        new_value, value_changed = self._substitute_field(self.value, scope)
+        changes = {"value": new_value} if value_changed else {}
+        if isinstance(self.target, (Attribute, Subscript)):
+            new_target = _substituted_store_target(self, self.target, scope)
+            if new_target is not None:
+                changes["target"] = new_target
+            if not changes:
+                return self
+            return rewrite(self, **changes)
+        rewritten = self if not changes else rewrite(self, **changes)
         if not isinstance(rewritten.target, Name):
             return rewritten
         name = rewritten.target.id
@@ -4347,12 +4361,20 @@ class AugAssign(Statement):
                 site=self.fragment,
             )
         if isinstance(self.target, Subscript):
-            from sugar_lift_py_tests.sugar.store_effect_sugar import (
-                LegacyAugmentedSubscriptStoreEffectSugar,
+            from sugar_lift_py_tests.sugar.augassign_sugar import (
+                SubscriptAugAssignSugar,
             )
 
-            return LegacyAugmentedSubscriptStoreEffectSugar(
-                index_text=self.target.slice_.fragment.text,
+            # Distinct occurrence sites for get / arithmetic / store.
+            # Receiver+index evaluated once inside SubscriptAugAssignSugar.
+            return SubscriptAugAssignSugar(
+                receiver=self.target.value.sugar(),
+                index=self.target.slice_.sugar(),
+                rhs=self.value.sugar(),
+                op_kind=self.op.kind,
+                get_site=self.target.fragment,
+                op_site=self.value.fragment,
+                set_site=self.fragment,
                 site=self.fragment,
             )
         return super()._construct_sugar()

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4427,9 +4427,6 @@ class AugAssign(Statement):
                 site=self.fragment,
             )
         if isinstance(self.target, Subscript):
-            from sugar_lift_py_tests.caller_parameter_contract import (
-                inplace_projector_for,
-            )
             from sugar_lift_py_tests.sugar.augassign_sugar import (
                 SubscriptAugAssignSugar,
             )
@@ -4438,14 +4435,13 @@ class AugAssign(Statement):
             op_site = getattr(self, "operator_site", None)
             if op_site is None:
                 op_site = self._mint_operator_site_from_structure()
-            projector = inplace_projector_for(self.op)
-            operator = type(self.op).inplace_operator
+            # Operator-owned double dispatch — not a caller isinstance ladder.
             return SubscriptAugAssignSugar(
                 receiver=self.target.value.sugar(),
                 index=self.target.slice_.sugar(),
                 rhs=self.value.sugar(),
-                operator=operator,
-                operation=projector,
+                operator=type(self.op).inplace_operator,
+                operation=self.op.project_inplace,
                 get_site=self.target.fragment,
                 op_site=op_site,
                 set_site=self.fragment,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4272,17 +4272,18 @@ class AugAssign(Statement):
         """`<target> OP= <value>` -- substitute the value and load-side targets.
 
         A plain Name target is a binding site: the rebind (target OP value) is
-        threaded by ``substitution_binding`` / the ``operation`` slot. Attribute
-        and Subscript targets are runtime stores, not lexical rebinds — their
-        receivers (and subscript indices) are ordinary load expressions and
-        must substitute so formals become ``FormalRefSugar`` and prior
-        constructions reach the store, matching Assign's store-target law.
+        threaded by ``substitution_binding`` / the ``operation`` slot.
+
+        Subscript targets are runtime stores — receivers and indices are load
+        expressions and must substitute so formals become ``FormalRefSugar``
+        (same door as Assign).  Attribute targets stay value-only here until
+        Attribute AugAssign production owns that substitute tooth.
         """
         from .shadow import rewrite
 
         new_value, value_changed = self._substitute_field(self.value, scope)
         changes = {"value": new_value} if value_changed else {}
-        if isinstance(self.target, (Attribute, Subscript)):
+        if isinstance(self.target, Subscript):
             new_target = _substituted_store_target(self, self.target, scope)
             if new_target is not None:
                 changes["target"] = new_target
@@ -4291,6 +4292,8 @@ class AugAssign(Statement):
             return rewrite(self, **changes)
         rewritten = self if not changes else rewrite(self, **changes)
         if not isinstance(rewritten.target, Name):
+            # Attribute (and any other non-Name non-Subscript) keeps value-only
+            # rewrite until its production path enrolls store-target substitute.
             return rewritten
         name = rewritten.target.id
         old_state = unwrap_binding_state(scope.get(name, rewritten.target))
@@ -4311,6 +4314,59 @@ class AugAssign(Statement):
                 (*desc.slots, ("operation", Child(_handle_of(operation)))),
             ),
             self.reporter,
+        )
+
+    def _augassign_operator_site(self):
+        """Source-authenticated operator-token interval (``+=``, ``-=``, …).
+
+        The arithmetic occurrence is the operator token itself — not the RHS
+        fragment and not the whole statement.  After formal substitute the RHS
+        node may carry a declaration span, so we locate the token in source
+        after the target span (when that span still sits inside the statement)
+        using the operator's surface spelling plus ``=``.
+        """
+        from sugar_source_tree.panic import SugarNotWritten
+        from .fragment import SourceFragment
+        from .spans import Span
+
+        aug_token = f"{self.op.symbol}="
+        source = self.unit.source
+        target = self.target
+
+        def reject(observed):
+            raise SugarNotWritten(
+                blame=self.fragment,
+                owner="AugAssign._augassign_operator_site",
+                observed=observed,
+                requested=(
+                    f"the source-authenticated operator-token interval for "
+                    f"{aug_token!r} in this AugAssign"
+                ),
+                fix=(
+                    "preserve the AugAssign statement span and target span so "
+                    f"{aug_token!r} is findable in source after the target"
+                ),
+            )
+
+        if (
+            self.span.start <= target.span.start
+            and target.span.end <= self.span.end
+        ):
+            search_start = target.span.end
+        else:
+            search_start = self.span.start
+        region = source[search_start : self.span.end]
+        idx = region.find(aug_token)
+        if idx < 0:
+            reject((aug_token, self.span, target.span, region))
+        start = search_start + idx
+        end = start + len(aug_token)
+        if source[start:end] != aug_token:
+            reject((aug_token, start, end, source[start:end]))
+        return SourceFragment(
+            unit=self.unit,
+            span=Span(start, end),
+            node=self,
         )
 
     def substitution_binding(self, scope):
@@ -4361,19 +4417,23 @@ class AugAssign(Statement):
                 site=self.fragment,
             )
         if isinstance(self.target, Subscript):
+            from sugar_lift_py_tests.caller_parameter_contract import (
+                inplace_projector_for,
+            )
             from sugar_lift_py_tests.sugar.augassign_sugar import (
                 SubscriptAugAssignSugar,
             )
 
             # Distinct occurrence sites for get / arithmetic / store.
             # Receiver+index evaluated once inside SubscriptAugAssignSugar.
+            # op_site is the operator-token interval, not the RHS occurrence.
             return SubscriptAugAssignSugar(
                 receiver=self.target.value.sugar(),
                 index=self.target.slice_.sugar(),
                 rhs=self.value.sugar(),
-                op_kind=self.op.kind,
+                operation=inplace_projector_for(self.op),
                 get_site=self.target.fragment,
-                op_site=self.value.fragment,
+                op_site=self._augassign_operator_site(),
                 set_site=self.fragment,
                 site=self.fragment,
             )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/operators.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/operators.py
@@ -76,53 +76,93 @@ class ComparisonOperator(Operator):
 class Add(BinaryOperator):
     kind, symbol, inplace_operator = "Add", "+", "iadd"
 
+    def project_inplace(self, left, right, site):
+        """Double-dispatch: left owns iadd (Floor default → add)."""
+        return left.iadd(right, site)
+
 
 class Sub(BinaryOperator):
     kind, symbol, inplace_operator = "Sub", "-", "isub"
+
+    def project_inplace(self, left, right, site):
+        return left.isub(right, site)
 
 
 class Mult(BinaryOperator):
     kind, symbol, inplace_operator = "Mult", "*", "imul"
 
+    def project_inplace(self, left, right, site):
+        return left.imul(right, site)
+
 
 class MatMult(BinaryOperator):
     kind, symbol, inplace_operator = "MatMult", "@", "imatmul"
+
+    def project_inplace(self, left, right, site):
+        return left.imatmul(right, site)
 
 
 class Div(BinaryOperator):
     kind, symbol, inplace_operator = "Div", "/", "itruediv"
 
+    def project_inplace(self, left, right, site):
+        return left.itruediv(right, site)
+
 
 class Mod(BinaryOperator):
     kind, symbol, inplace_operator = "Mod", "%", "imod"
+
+    def project_inplace(self, left, right, site):
+        return left.imod(right, site)
 
 
 class Pow(BinaryOperator):
     kind, symbol, inplace_operator = "Pow", "**", "ipow"
 
+    def project_inplace(self, left, right, site):
+        return left.ipow(right, site)
+
 
 class LShift(BinaryOperator):
     kind, symbol, inplace_operator = "LShift", "<<", "ilshift"
+
+    def project_inplace(self, left, right, site):
+        return left.ilshift(right, site)
 
 
 class RShift(BinaryOperator):
     kind, symbol, inplace_operator = "RShift", ">>", "irshift"
 
+    def project_inplace(self, left, right, site):
+        return left.irshift(right, site)
+
 
 class BitOr(BinaryOperator):
     kind, symbol, inplace_operator = "BitOr", "|", "ior"
+
+    def project_inplace(self, left, right, site):
+        return left.ior(right, site)
 
 
 class BitXor(BinaryOperator):
     kind, symbol, inplace_operator = "BitXor", "^", "ixor"
 
+    def project_inplace(self, left, right, site):
+        return left.ixor(right, site)
+
 
 class BitAnd(BinaryOperator):
     kind, symbol, inplace_operator = "BitAnd", "&", "iand"
 
+    def project_inplace(self, left, right, site):
+        return left.iand(right, site)
+
 
 class FloorDiv(BinaryOperator):
     kind, symbol, inplace_operator = "FloorDiv", "//", "ifloordiv"
+
+    def project_inplace(self, left, right, site):
+        return left.ifloordiv(right, site)
 
 
 # BinaryOperator classes AugAssign may host — production mint set source.

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/operators.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/operators.py
@@ -56,9 +56,20 @@ class BinaryOperator(Operator):
     for formal ``OP=`` (e.g. ``iadd`` for ``+=``).  Declared on the operator
     class so production's enrolled set is derived from constructors — never
     from the projector table (circular equality tooth).
+
+    ``project_inplace`` is operator-owned double dispatch into the established
+    Floor edge ``inplace_binary_operator_with`` (not a second iadd protocol).
     """
 
     inplace_operator: str = ""
+
+    def project_inplace(self, left, right, site):
+        """Surface operator → Floor ``inplace_binary_operator_with`` + NotImplemented law."""
+        from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
+            discharge_inplace,
+        )
+
+        return discharge_inplace(left, right, site, surface=self.symbol)
 
 
 class UnaryOperator(Operator):
@@ -76,93 +87,53 @@ class ComparisonOperator(Operator):
 class Add(BinaryOperator):
     kind, symbol, inplace_operator = "Add", "+", "iadd"
 
-    def project_inplace(self, left, right, site):
-        """Double-dispatch: left owns iadd (Floor default → add)."""
-        return left.iadd(right, site)
-
 
 class Sub(BinaryOperator):
     kind, symbol, inplace_operator = "Sub", "-", "isub"
-
-    def project_inplace(self, left, right, site):
-        return left.isub(right, site)
 
 
 class Mult(BinaryOperator):
     kind, symbol, inplace_operator = "Mult", "*", "imul"
 
-    def project_inplace(self, left, right, site):
-        return left.imul(right, site)
-
 
 class MatMult(BinaryOperator):
     kind, symbol, inplace_operator = "MatMult", "@", "imatmul"
-
-    def project_inplace(self, left, right, site):
-        return left.imatmul(right, site)
 
 
 class Div(BinaryOperator):
     kind, symbol, inplace_operator = "Div", "/", "itruediv"
 
-    def project_inplace(self, left, right, site):
-        return left.itruediv(right, site)
-
 
 class Mod(BinaryOperator):
     kind, symbol, inplace_operator = "Mod", "%", "imod"
-
-    def project_inplace(self, left, right, site):
-        return left.imod(right, site)
 
 
 class Pow(BinaryOperator):
     kind, symbol, inplace_operator = "Pow", "**", "ipow"
 
-    def project_inplace(self, left, right, site):
-        return left.ipow(right, site)
-
 
 class LShift(BinaryOperator):
     kind, symbol, inplace_operator = "LShift", "<<", "ilshift"
-
-    def project_inplace(self, left, right, site):
-        return left.ilshift(right, site)
 
 
 class RShift(BinaryOperator):
     kind, symbol, inplace_operator = "RShift", ">>", "irshift"
 
-    def project_inplace(self, left, right, site):
-        return left.irshift(right, site)
-
 
 class BitOr(BinaryOperator):
     kind, symbol, inplace_operator = "BitOr", "|", "ior"
-
-    def project_inplace(self, left, right, site):
-        return left.ior(right, site)
 
 
 class BitXor(BinaryOperator):
     kind, symbol, inplace_operator = "BitXor", "^", "ixor"
 
-    def project_inplace(self, left, right, site):
-        return left.ixor(right, site)
-
 
 class BitAnd(BinaryOperator):
     kind, symbol, inplace_operator = "BitAnd", "&", "iand"
 
-    def project_inplace(self, left, right, site):
-        return left.iand(right, site)
-
 
 class FloorDiv(BinaryOperator):
     kind, symbol, inplace_operator = "FloorDiv", "//", "ifloordiv"
-
-    def project_inplace(self, left, right, site):
-        return left.ifloordiv(right, site)
 
 
 # BinaryOperator classes AugAssign may host — production mint set source.

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/operators.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/operators.py
@@ -50,7 +50,15 @@ class Operator:
 
 
 class BinaryOperator(Operator):
-    """Operators of BinOp / AugAssign."""
+    """Operators of BinOp / AugAssign.
+
+    ``inplace_operator`` is the native-operation carrier name AugAssign mints
+    for formal ``OP=`` (e.g. ``iadd`` for ``+=``).  Declared on the operator
+    class so production's enrolled set is derived from constructors — never
+    from the projector table (circular equality tooth).
+    """
+
+    inplace_operator: str = ""
 
 
 class UnaryOperator(Operator):
@@ -66,55 +74,87 @@ class ComparisonOperator(Operator):
 
 
 class Add(BinaryOperator):
-    kind, symbol = "Add", "+"
+    kind, symbol, inplace_operator = "Add", "+", "iadd"
 
 
 class Sub(BinaryOperator):
-    kind, symbol = "Sub", "-"
+    kind, symbol, inplace_operator = "Sub", "-", "isub"
 
 
 class Mult(BinaryOperator):
-    kind, symbol = "Mult", "*"
+    kind, symbol, inplace_operator = "Mult", "*", "imul"
 
 
 class MatMult(BinaryOperator):
-    kind, symbol = "MatMult", "@"
+    kind, symbol, inplace_operator = "MatMult", "@", "imatmul"
 
 
 class Div(BinaryOperator):
-    kind, symbol = "Div", "/"
+    kind, symbol, inplace_operator = "Div", "/", "itruediv"
 
 
 class Mod(BinaryOperator):
-    kind, symbol = "Mod", "%"
+    kind, symbol, inplace_operator = "Mod", "%", "imod"
 
 
 class Pow(BinaryOperator):
-    kind, symbol = "Pow", "**"
+    kind, symbol, inplace_operator = "Pow", "**", "ipow"
 
 
 class LShift(BinaryOperator):
-    kind, symbol = "LShift", "<<"
+    kind, symbol, inplace_operator = "LShift", "<<", "ilshift"
 
 
 class RShift(BinaryOperator):
-    kind, symbol = "RShift", ">>"
+    kind, symbol, inplace_operator = "RShift", ">>", "irshift"
 
 
 class BitOr(BinaryOperator):
-    kind, symbol = "BitOr", "|"
+    kind, symbol, inplace_operator = "BitOr", "|", "ior"
 
 
 class BitXor(BinaryOperator):
-    kind, symbol = "BitXor", "^"
+    kind, symbol, inplace_operator = "BitXor", "^", "ixor"
 
 
 class BitAnd(BinaryOperator):
-    kind, symbol = "BitAnd", "&"
+    kind, symbol, inplace_operator = "BitAnd", "&", "iand"
 
 
 class FloorDiv(BinaryOperator):
-    kind, symbol = "FloorDiv", "//"
+    kind, symbol, inplace_operator = "FloorDiv", "//", "ifloordiv"
+
+
+# BinaryOperator classes AugAssign may host — production mint set source.
+AUGASSIGN_BINARY_OPERATOR_CLASSES: tuple[type[BinaryOperator], ...] = (
+    Add,
+    Sub,
+    Mult,
+    MatMult,
+    Div,
+    Mod,
+    Pow,
+    LShift,
+    RShift,
+    BitOr,
+    BitXor,
+    BitAnd,
+    FloorDiv,
+)
+
+
+def production_augassign_inplace_operators() -> frozenset[str]:
+    """Inplace carrier names AugAssign production may mint.
+
+    Derived **only** from BinaryOperator class attributes — independent of
+    any projector table.  Equality tooth: this set must equal the i* keys
+    enrolled on the projector side.
+    """
+    return frozenset(
+        cls.inplace_operator
+        for cls in AUGASSIGN_BINARY_OPERATOR_CLASSES
+        if cls.inplace_operator
+    )
 
 
 class UAdd(UnaryOperator):


### PR DESCRIPTION
## Summary

Subscript augmented assignment `obj[key] += rhs` on the formal carrier chain — **advisor-revised**.

### Law
1. Receiver/index once → getitem **before** RHS → authenticated **i*** → setitem last
2. Composition: outcome/carrier `and_then` only (no bespoke kind ladder)
3. Explicit `InplaceThenBinaryProjector` types; formal mints `operator='iadd'`
4. Binary fallback only for absent i* or completed `NotImplemented`
5. `op_site` = source-authenticated operator token (`+=`), not RHS fragment
6. Attribute AugAssign **deferred** (same substrate after merge; no second table)

### Shell actually deleted
`LegacyAugmentedSubscriptStoreEffectSugar` removed; no-reference tooth in suite.

### Validation
```
bin/bpytest tests/test_subscript_augassign_formal_caller.py tests/test_delete_formal_caller.py -q
# 52 passed
```

### Shot accounting
- **R axis:** formal subscript augassign production path
- **Epsilon R:** 8 advisor defects closed; vertical green
- **Floors:** no carrier/ExitSet edits
- **Shell deleted:** LegacyAugmentedSubscriptStoreEffectSugar (verified absent)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add formal inplace dispatch for subscript augmented assignment with operator-owned projectors
> - Replaces `LegacyAugmentedSubscriptStoreEffectSugar` with `SubscriptAugAssignSugar`, which follows a formal get/op/set sequence with authenticated caller discharge and correct halting semantics.
> - Adds `inplace_operator` names (e.g. `'iadd'`, `'isub'`) and `project_inplace` to all `BinaryOperator` subclasses in [operators.py](https://github.com/TSavo/sugar/pull/6712/files#diff-2a787c27d5cfb8ace10baeed30342e75e95f7c45e3a7425a3692d87afa8b193d), driving dispatch through `discharge_inplace`.
> - Introduces `InplaceBinaryOperatorOperation` and `discharge_inplace` in [inplace_binary_operator_operation.py](https://github.com/TSavo/sugar/pull/6712/files#diff-6d4870c525b48b3738439c31b922bb88eef795594c4c1cfbcce9591ad4e83d1f), with `NotImplemented` fallback to the corresponding binary operation.
> - Adds explicit `project_i*` projectors and a `_INPLACE_NATIVE_OPERATION_PROJECTORS` table in [caller_parameter_contract.py](https://github.com/TSavo/sugar/pull/6712/files#diff-5136726cb5a60b48beb30152aecb6eca8ad0173bdefc676eb112b1c1b2acbf57); formal operands now mint authenticated carriers instead of silently falling back.
> - `AugAssign.substitute` and `_mint_operator_site_from_structure` in [nodes.py](https://github.com/TSavo/sugar/pull/6712/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now capture the operator site structurally from source spans for subscript targets.
> - Risk: `LegacyAugmentedSubscriptStoreEffectSugar` is deleted; any code importing or instantiating it will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6509eb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for augmented assignments across arithmetic, bitwise, shift, and matrix operators.
  * Added formal handling for subscript assignments such as `items[index] += value`.
  * Ensured receiver and index expressions are evaluated once, with correct get, update, and store ordering.
* **Bug Fixes**
  * Improved error and halt propagation during augmented assignments.
  * Prevented unsupported in-place operations from silently falling back to ordinary operations.
* **Tests**
  * Added comprehensive coverage for subscript augmented assignments, operator dispatch, evaluation order, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->