### PR TITLE
Promote generator payloads to ConstructedTermSugar

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -8,16 +8,32 @@ from sugar_lift_python_source.canonical import cid_of_json
 
 from .effect import Effect, require_effect
 from .outcome import ExitSet
+from .sugar.sugar_base import ConstructedTermSugar
+
+
+def _require_constructed_term(value: object, *, owner: str) -> None:
+    if not isinstance(value, ConstructedTermSugar):
+        raise TypeError(
+            f"{owner} requires ConstructedTermSugar, got {type(value).__name__}"
+        )
 
 
 @dataclass(frozen=True)
 class YieldStepV1:
-    value: object
+    value: ConstructedTermSugar | None
+
+    def __post_init__(self) -> None:
+        if self.value is not None:
+            _require_constructed_term(self.value, owner="YieldStepV1.value")
 
 
 @dataclass(frozen=True)
 class ReturnStepV1:
-    value: object | None = None
+    value: ConstructedTermSugar | None = None
+
+    def __post_init__(self) -> None:
+        if self.value is not None:
+            _require_constructed_term(self.value, owner="ReturnStepV1.value")
 
 
 @dataclass(frozen=True)
@@ -88,13 +104,20 @@ class AssignStepV1:
     """
 
     name: str
-    value: object
+    value: ConstructedTermSugar
     fragment_cid: str
+
+    def __post_init__(self) -> None:
+        _require_constructed_term(self.value, owner="AssignStepV1.value")
 
 
 @dataclass(frozen=True)
 class FinallyStepV1:
-    statements: tuple[object, ...]
+    statements: tuple[ConstructedTermSugar, ...]
+
+    def __post_init__(self) -> None:
+        for statement in self.statements:
+            _require_constructed_term(statement, owner="FinallyStepV1.statements")
 
 
 @dataclass(frozen=True)
@@ -118,10 +141,13 @@ class IfStepV1:
     honest opaque one.
     """
 
-    guard: object
+    guard: ConstructedTermSugar
     then_steps: tuple
     else_steps: tuple
     fragment_cid: str
+
+    def __post_init__(self) -> None:
+        _require_constructed_term(self.guard, owner="IfStepV1.guard")
 
 
 @dataclass(frozen=True)
@@ -201,13 +227,12 @@ def _generator_value_testimony(value: object, *, owner: str) -> dict:
             "constructedValueTestimonyCid": testimony.cid,
             "entry": value.wire(),
         }
-    to_term = getattr(value, "to_term", None)
-    if callable(to_term):
+    if isinstance(value, ConstructedTermSugar):
         from sugar_lift_py_tests.ir import _term_content_cid
 
         return {
             "kind": "term-cid",
-            "contentCid": _term_content_cid(to_term(owner=owner)),
+            "contentCid": _term_content_cid(value.to_term(owner=owner)),
         }
     # IR Terms are already content-addressable without a FloorValue wrapper.
     from sugar_lift_py_tests.ir import (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
@@ -13,15 +13,21 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
 @dataclass(frozen=True)
-class AttributeSugar(Sugar):
-    receiver: Sugar
+class AttributeSugar(ConstructedTermSugar):
+    receiver: ConstructedTermSugar
     name: str
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        require_constructed_term_sugar(self.receiver, owner="AttributeSugar.receiver")
 
     @classmethod
     def witnesses(cls):
@@ -35,6 +41,19 @@ class AttributeSugar(Sugar):
             lying=prefix + "def test_a():\n    assert A(5) == 6\n",
         )
 
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:attribute-construction",
+            (
+                self.occurrence_term(owner=owner),
+                self.receiver.to_term(owner=owner),
+                str_const(self.name),
+            ),
+            symbol_kind="coordinate",
+        )
+
     @staticmethod
     def project_attribute(receiver, name: str, site, ctx: object = None) -> Outcome:
         """Producer-owned attribute **read** projection (one door).
@@ -44,7 +63,6 @@ class AttributeSugar(Sugar):
         1. Formal receiver → undischarged ``attribute_named`` carrier
         2. Authenticated CallSiteValue body → ``force_floor`` then attribute
         3. Else Floor ``receiver.attribute(name, site)``
-
         Callers that already hold a reduced receiver (AugAssign) enter here
         without re-evaluating the receiver expression.
         """

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_coordinate_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_coordinate_ref_sugar.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from sugar_lift_py_tests.outcome import Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
 
 @dataclass(frozen=True)
-class BindingCoordinateRefSugar(Sugar):
+class BindingCoordinateRefSugar(ConstructedTermSugar):
     coordinate: object
     site: object = field(compare=False)
 
@@ -36,4 +36,13 @@ class BindingCoordinateRefSugar(Sugar):
             observed="unspecialized source-call formal",
             requested="runtime BindingEntryV1 substitution before Sugar construction",
             fix="bind the exact typed actual Node through SourceVisibleCallFrameV1",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:binding-coordinate-reference",
+            (self.occurrence_term(owner=owner), str_const(self.coordinate.cid)),
+            symbol_kind="coordinate",
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binop_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binop_sugar.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 # Binary operator kind -> the floor method that owns its meaning. The value
@@ -29,7 +32,7 @@ BINOP_METHODS: dict[str, str] = {
 
 
 @dataclass(frozen=True)
-class BinOpSugar(Sugar):
+class BinOpSugar(ConstructedTermSugar):
     """A binary operation `<left> <op> <right>`. It reduces both sides and asks
     the LEFT value to apply the operation against the right -- the value owns
     the answer (numbers fold, strings concatenate, mixed types hit the honest
@@ -43,9 +46,15 @@ class BinOpSugar(Sugar):
     """
 
     op_kind: str
-    left: Sugar
-    right: Sugar
+    left: ConstructedTermSugar
+    right: ConstructedTermSugar
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        if self.op_kind not in BINOP_METHODS:
+            raise ValueError(f"unknown binary operator {self.op_kind!r}")
+        require_constructed_term_sugar(self.left, owner="BinOpSugar.left")
+        require_constructed_term_sugar(self.right, owner="BinOpSugar.right")
 
     @classmethod
     def witnesses(cls):
@@ -57,6 +66,20 @@ class BinOpSugar(Sugar):
             owner_sugar="BinOpSugar",
             truthful=prefix + "def test_a():\n    assert A(5) == 5\n",
             lying=prefix + "def test_a():\n    assert A(5) == 0\n",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:binary-op-construction",
+            (
+                self.occurrence_term(owner=owner),
+                str_const(self.op_kind),
+                self.left.to_term(owner=owner),
+                self.right.to_term(owner=owner),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field as dataclass_field
 
+from sugar_lift_py_tests.ir import Term
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.witnesses import _boolop_wrapped_pair
 
 _BOOL_OPERATOR_COORDINATE = {
@@ -58,7 +59,7 @@ def refuse_undecided_boolean_truth(value, site, op_kind: str) -> None:
 
 
 @dataclass(frozen=True)
-class BoolOpSugar(Sugar):
+class BoolOpSugar(ConstructedTermSugar):
     op_kind: str  # "And" | "Or"
     values: tuple  # the operand sugars, in source order (>= 2)
     site: object = dataclass_field(compare=False)
@@ -72,6 +73,33 @@ class BoolOpSugar(Sugar):
             owner_sugar="BoolOpSugar",
             truthful="(1 == 1) and (2 == 2)",
             lying="(1 == 1) and (2 == 3)",
+        )
+
+    def to_term(self, *, owner: str) -> Term:
+        """Project the authenticated operator and ordered operands canonically."""
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        if self.op_kind not in _BOOL_OPERATOR_COORDINATE:
+            raise ValueError(
+                f"{owner} requires an authenticated BoolOp operator, got {self.op_kind!r}"
+            )
+        if len(self.values) < 2:
+            raise ValueError(f"{owner} requires at least two BoolOp operands")
+
+        operands = [value.to_term(owner=owner) for value in self.values]
+
+        return ctor(
+            "python:bool-op-construction",
+            (
+                str_const(_BOOL_OPERATOR_COORDINATE[self.op_kind]),
+                self.occurrence_term(owner=owner),
+                ctor(
+                    "python:bool-op-operands",
+                    tuple(operands),
+                    symbol_kind="coordinate",
+                ),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -12,7 +12,10 @@ from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.ir import Term
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _boolop_wrapped_pair
 
 _BOOL_OPERATOR_COORDINATE = {
@@ -61,8 +64,12 @@ def refuse_undecided_boolean_truth(value, site, op_kind: str) -> None:
 @dataclass(frozen=True)
 class BoolOpSugar(ConstructedTermSugar):
     op_kind: str  # "And" | "Or"
-    values: tuple  # the operand sugars, in source order (>= 2)
+    values: tuple[ConstructedTermSugar, ...]
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        for value in self.values:
+            require_constructed_term_sugar(value, owner="BoolOpSugar.values")
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/branch_result_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/branch_result_ref_sugar.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass, field
 
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
 
 @dataclass(frozen=True)
-class BranchResultRefSugar(Sugar):
+class BranchResultRefSugar(ConstructedTermSugar):
     slot: object
     site: object = field(compare=False)
 
@@ -20,3 +20,12 @@ class BranchResultRefSugar(Sugar):
         from sugar_lift_py_tests.outcome import Complete
 
         return Complete(BranchResultCoordinate(self.slot, self.site))
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:branch-result-reference",
+            (self.occurrence_term(owner=owner), str_const(self.slot.slot_id)),
+            symbol_kind="coordinate",
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -6,7 +6,10 @@ from typing import Any
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
 from sugar_lift_py_tests.ir import Term
-from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
@@ -33,9 +36,9 @@ class CallSiteSugar(ConstructedTermSugar):
     """
 
     target_name: str
-    args: tuple  # the argument sugars, in source order
+    args: tuple[ConstructedTermSugar, ...]
     site: object = dataclass_field(compare=False)
-    keywords: tuple = ()  # (name, sugar) pairs, in source order
+    keywords: tuple[tuple[str, ConstructedTermSugar], ...] = ()
     contract_ref: Any = dataclass_field(default=None, compare=False)
     contract_resolution_gap: str | None = dataclass_field(default=None, compare=False)
     exception_type_coordinate: Any = dataclass_field(default=None, compare=False)
@@ -43,6 +46,12 @@ class CallSiteSugar(ConstructedTermSugar):
     source_call_frame: Any = dataclass_field(default=None, compare=False)
     formal_function_sugar: Any = dataclass_field(default=None, compare=False)
     formal_coordinate_cids: tuple[str, ...] = dataclass_field(default=(), compare=False)
+
+    def __post_init__(self) -> None:
+        for argument in self.args:
+            require_constructed_term_sugar(argument, owner="CallSiteSugar.args")
+        for _name, argument in self.keywords:
+            require_constructed_term_sugar(argument, owner="CallSiteSugar.keywords")
 
     @classmethod
     def witnesses(cls):
@@ -82,6 +91,26 @@ class CallSiteSugar(ConstructedTermSugar):
         definition_authority.extend(
             str_const(cid) for cid in self.formal_coordinate_cids
         )
+        if self.contract_ref is None:
+            contract_authority = ctor("python:no-resolved-call-contract", ())
+        else:
+            from sugar_lift_py_tests.call_contract_resolution import (
+                ResolvedCallContractRefV1,
+            )
+
+            if not isinstance(self.contract_ref, ResolvedCallContractRefV1):
+                raise TypeError(
+                    f"{owner} requires authenticated ResolvedCallContractRefV1, "
+                    f"got {type(self.contract_ref).__name__}"
+                )
+            contract_authority = ctor(
+                "python:resolved-call-contract",
+                (
+                    str_const(self.contract_ref.resolution_cid),
+                    str_const(self.contract_ref.contract_cid),
+                ),
+                symbol_kind="coordinate",
+            )
         positional = tuple(argument.to_term(owner=owner) for argument in self.args)
         keywords = tuple(
             ctor(
@@ -102,6 +131,7 @@ class CallSiteSugar(ConstructedTermSugar):
                     tuple(definition_authority),
                     symbol_kind="coordinate",
                 ),
+                contract_authority,
             ),
             symbol_kind="coordinate",
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -5,12 +5,13 @@ from dataclasses import dataclass, field as dataclass_field
 from typing import Any
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.ir import Term
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
 @dataclass(frozen=True)
-class CallSiteSugar(Sugar):
+class CallSiteSugar(ConstructedTermSugar):
     """`<name>(<args>)` -> a call-site coordinate: THE DIG CUE.
 
     Reduce each argument, then stand as a CallSiteValue whose term is the bridge
@@ -54,6 +55,55 @@ class CallSiteSugar(Sugar):
             owner_sugar="CallSiteSugar",
             truthful=prefix + "def test_a():\n    assert A(5) == 5\n",
             lying=prefix + "def test_a():\n    assert A(5) == 6\n",
+        )
+
+    def to_term(self, *, owner: str) -> Term:
+        """Project authenticated callee, arguments, authority, and occurrence."""
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        occurrence = self.occurrence_term(owner=owner)
+        if self.source_call_frame is not None:
+            callee = ctor(
+                "python:source-callee",
+                (str_const(self.source_call_frame.frame_cid),),
+                symbol_kind="coordinate",
+            )
+        else:
+            # The exact call occurrence is the available callee authority for
+            # builtin/opaque calls; never elevate the target spelling.
+            callee = ctor(
+                "python:occurrence-callee", (occurrence,), symbol_kind="coordinate"
+            )
+        definition_authority = []
+        if self.exception_type_coordinate is not None:
+            definition_authority.append(
+                str_const(self.exception_type_coordinate.cid)
+            )
+        definition_authority.extend(
+            str_const(cid) for cid in self.formal_coordinate_cids
+        )
+        positional = tuple(argument.to_term(owner=owner) for argument in self.args)
+        keywords = tuple(
+            ctor(
+                "python:keyword-argument",
+                (str_const(name), argument.to_term(owner=owner)),
+            )
+            for name, argument in self.keywords
+        )
+        return ctor(
+            "python:call-construction",
+            (
+                occurrence,
+                callee,
+                ctor("python:positional-arguments", positional),
+                ctor("python:keyword-arguments", keywords),
+                ctor(
+                    "python:definition-authority",
+                    tuple(definition_authority),
+                    symbol_kind="coordinate",
+                ),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
@@ -118,8 +118,14 @@ class ListSugar(Sugar):
 
 @dataclass(frozen=True)
 class TupleSugar(ConstructedTermSugar):
-    elements: tuple
+    elements: tuple[ConstructedTermSugar, ...]
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        from sugar_lift_py_tests.sugar.sugar_base import require_constructed_term_sugar
+
+        for element in self.elements:
+            require_constructed_term_sugar(element, owner="TupleSugar.elements")
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
@@ -96,9 +99,13 @@ def _reduce_into(element_sugars, ctx, build):
 
 
 @dataclass(frozen=True)
-class ListSugar(Sugar):
-    elements: tuple
+class ListSugar(ConstructedTermSugar):
+    elements: tuple[ConstructedTermSugar, ...]
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        for element in self.elements:
+            require_constructed_term_sugar(element, owner="ListSugar.elements")
 
     @classmethod
     def witnesses(cls):
@@ -115,6 +122,21 @@ class ListSugar(Sugar):
 
         return _reduce_into(self.elements, ctx, ListValue)
 
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:list-construction",
+            (
+                self.occurrence_term(owner=owner),
+                ctor(
+                    "python:list-elements",
+                    tuple(element.to_term(owner=owner) for element in self.elements),
+                ),
+            ),
+            symbol_kind="coordinate",
+        )
+
 
 @dataclass(frozen=True)
 class TupleSugar(ConstructedTermSugar):
@@ -122,8 +144,6 @@ class TupleSugar(ConstructedTermSugar):
     site: object = dataclass_field(compare=False)
 
     def __post_init__(self) -> None:
-        from sugar_lift_py_tests.sugar.sugar_base import require_constructed_term_sugar
-
         for element in self.elements:
             require_constructed_term_sugar(element, owner="TupleSugar.elements")
 
@@ -159,9 +179,13 @@ class TupleSugar(ConstructedTermSugar):
 
 
 @dataclass(frozen=True)
-class SetSugar(Sugar):
-    elements: tuple
+class SetSugar(ConstructedTermSugar):
+    elements: tuple[ConstructedTermSugar, ...]
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        for element in self.elements:
+            require_constructed_term_sugar(element, owner="SetSugar.elements")
 
     @classmethod
     def witnesses(cls):
@@ -178,12 +202,35 @@ class SetSugar(Sugar):
 
         return _reduce_into(self.elements, ctx, SetValue)
 
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:set-construction",
+            (
+                self.occurrence_term(owner=owner),
+                ctor(
+                    "python:set-elements",
+                    tuple(element.to_term(owner=owner) for element in self.elements),
+                ),
+            ),
+            symbol_kind="coordinate",
+        )
+
 
 @dataclass(frozen=True)
-class DictSugar(Sugar):
-    keys: tuple  # key sugars, in source order
-    values: tuple  # value sugars, in source order
+class DictSugar(ConstructedTermSugar):
+    keys: tuple[ConstructedTermSugar, ...]
+    values: tuple[ConstructedTermSugar, ...]
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        if len(self.keys) != len(self.values):
+            raise ValueError("DictSugar requires equal key/value arity")
+        for key in self.keys:
+            require_constructed_term_sugar(key, owner="DictSugar.keys")
+        for value in self.values:
+            require_constructed_term_sugar(value, owner="DictSugar.values")
 
     @classmethod
     def witnesses(cls):
@@ -209,3 +256,22 @@ class DictSugar(Sugar):
             return DictValue(tuple(zip(flat[0::2], flat[1::2])))
 
         return _reduce_into(interleaved, ctx, build)
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        entries = tuple(
+            ctor(
+                "python:dict-entry",
+                (key.to_term(owner=owner), value.to_term(owner=owner)),
+            )
+            for key, value in zip(self.keys, self.values, strict=True)
+        )
+        return ctor(
+            "python:dict-construction",
+            (
+                self.occurrence_term(owner=owner),
+                ctor("python:dict-entries", entries),
+            ),
+            symbol_kind="coordinate",
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
@@ -117,7 +117,7 @@ class ListSugar(Sugar):
 
 
 @dataclass(frozen=True)
-class TupleSugar(Sugar):
+class TupleSugar(ConstructedTermSugar):
     elements: tuple
     site: object = dataclass_field(compare=False)
 
@@ -129,6 +129,21 @@ class TupleSugar(Sugar):
             body="len((z, z))",
             truthful="2",
             lying="3",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:tuple-construction",
+            (
+                self.occurrence_term(owner=owner),
+                ctor(
+                    "python:tuple-elements",
+                    tuple(element.to_term(owner=owner) for element in self.elements),
+                ),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -24,7 +24,10 @@ from dataclasses import dataclass, field as dataclass_field
 from enum import Enum
 
 from sugar_lift_py_tests.outcome import Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _boolop_wrapped_pair
 
 # Comparison operator kind -> the floor method that owns its meaning. `Eq` is
@@ -264,11 +267,17 @@ def _publish_undecided_dispatch_edges(
 
 
 @dataclass(frozen=True)
-class ComparisonOpSugar(Sugar):
+class ComparisonOpSugar(ConstructedTermSugar):
     op_kind: str
-    left: Sugar
-    right: Sugar
+    left: ConstructedTermSugar
+    right: ConstructedTermSugar
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        if self.op_kind not in COMPARISON_KINDS:
+            raise ValueError(f"unknown comparison operator {self.op_kind!r}")
+        require_constructed_term_sugar(self.left, owner="ComparisonOpSugar.left")
+        require_constructed_term_sugar(self.right, owner="ComparisonOpSugar.right")
 
     @classmethod
     def witnesses(cls):
@@ -277,6 +286,20 @@ class ComparisonOpSugar(Sugar):
             owner_sugar="ComparisonOpSugar",
             truthful="1 < 2",
             lying="2 < 1",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:comparison-construction",
+            (
+                self.occurrence_term(owner=owner),
+                str_const(self.op_kind),
+                self.left.to_term(owner=owner),
+                self.right.to_term(owner=owner),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
@@ -31,22 +34,73 @@ class ComprehensionTargetSugar:
                 "comprehension target is exactly one of a name or a destructuring"
             )
 
+    def to_term(self):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        if self.source_name is not None:
+            return ctor("python:comprehension-name-target", (str_const(self.source_name),))
+        assert self.coordinates is not None
+        return ctor(
+            "python:comprehension-destructure-target",
+            tuple(coordinate.to_term() for coordinate in self.coordinates),
+        )
+
 
 @dataclass(frozen=True)
 class ComprehensionGeneratorSugar:
     target: ComprehensionTargetSugar
     binding_coordinate_cid: str
-    iterable: Sugar
-    filters: tuple[Sugar, ...]
+    iterable: ConstructedTermSugar
+    filters: tuple[ConstructedTermSugar, ...]
+
+    def __post_init__(self) -> None:
+        require_constructed_term_sugar(
+            self.iterable, owner="ComprehensionGeneratorSugar.iterable"
+        )
+        for filter_sugar in self.filters:
+            require_constructed_term_sugar(
+                filter_sugar, owner="ComprehensionGeneratorSugar.filters"
+            )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:comprehension-generator-construction",
+            (
+                self.target.to_term(),
+                str_const(self.binding_coordinate_cid),
+                self.iterable.to_term(owner=owner),
+                ctor(
+                    "python:comprehension-filters",
+                    tuple(value.to_term(owner=owner) for value in self.filters),
+                ),
+            ),
+            symbol_kind="coordinate",
+        )
 
 
 @dataclass(frozen=True)
-class ComprehensionSugar(Sugar):
+class ComprehensionSugar(ConstructedTermSugar):
     kind: str
     generators: tuple[ComprehensionGeneratorSugar, ...]
-    element: Sugar
-    key: Sugar | None = None
+    element: ConstructedTermSugar
+    key: ConstructedTermSugar | None = None
     site: object = dataclass_field(compare=False, default=None)
+
+    def __post_init__(self) -> None:
+        if self.kind not in {
+            "py.listcomp",
+            "py.setcomp",
+            "py.dictcomp",
+            "py.generatorexp",
+        }:
+            raise ValueError(f"unknown comprehension kind {self.kind!r}")
+        require_constructed_term_sugar(
+            self.element, owner="ComprehensionSugar.element"
+        )
+        if self.key is not None:
+            require_constructed_term_sugar(self.key, owner="ComprehensionSugar.key")
 
     @classmethod
     def witnesses(cls):
@@ -56,6 +110,29 @@ class ComprehensionSugar(Sugar):
             owner_sugar="ComprehensionSugar",
             truthful=prefix + "def test_a():\n    assert A([1]) == [1]\n",
             lying=prefix + "def test_a():\n    assert A([1]) == [2]\n",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        key = (
+            ctor("python:no-comprehension-key", ())
+            if self.key is None
+            else self.key.to_term(owner=owner)
+        )
+        return ctor(
+            "python:comprehension-construction",
+            (
+                self.occurrence_term(owner=owner),
+                str_const(self.kind),
+                ctor(
+                    "python:comprehension-generators",
+                    tuple(generator.to_term(owner=owner) for generator in self.generators),
+                ),
+                self.element.to_term(owner=owner),
+                key,
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
@@ -20,17 +20,27 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
 @dataclass(frozen=True)
-class ComputedCallSugar(Sugar):
-    callee: Sugar
-    args: tuple  # the argument sugars, in source order
+class ComputedCallSugar(ConstructedTermSugar):
+    callee: ConstructedTermSugar
+    args: tuple[ConstructedTermSugar, ...]
     site: object = dataclass_field(compare=False)
-    keywords: tuple = ()  # (name or explicit "**", sugar), source order
+    keywords: tuple[tuple[str, ConstructedTermSugar], ...] = ()
     source_call_frame: object | None = dataclass_field(default=None, compare=False)
+
+    def __post_init__(self) -> None:
+        require_constructed_term_sugar(self.callee, owner="ComputedCallSugar.callee")
+        for argument in self.args:
+            require_constructed_term_sugar(argument, owner="ComputedCallSugar.args")
+        for _name, argument in self.keywords:
+            require_constructed_term_sugar(argument, owner="ComputedCallSugar.keywords")
 
     @classmethod
     def witnesses(cls):
@@ -42,6 +52,43 @@ class ComputedCallSugar(Sugar):
             owner_sugar="ComputedCallSugar",
             truthful=prefix + "def test_a():\n    assert A([lambda z: z], 5) == 5\n",
             lying=prefix + "def test_a():\n    assert A([lambda z: z], 5) == 6\n",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        frame = self.source_call_frame
+        authority = (
+            ctor("python:no-source-call-frame", ())
+            if frame is None
+            else ctor(
+                "python:source-call-frame",
+                (str_const(frame.frame_cid),),
+                symbol_kind="coordinate",
+            )
+        )
+        return ctor(
+            "python:computed-call-construction",
+            (
+                self.occurrence_term(owner=owner),
+                self.callee.to_term(owner=owner),
+                ctor(
+                    "python:positional-arguments",
+                    tuple(argument.to_term(owner=owner) for argument in self.args),
+                ),
+                ctor(
+                    "python:keyword-arguments",
+                    tuple(
+                        ctor(
+                            "python:keyword-argument",
+                            (str_const(name), argument.to_term(owner=owner)),
+                        )
+                        for name, argument in self.keywords
+                    ),
+                ),
+                authority,
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/effect_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/effect_ref_sugar.py
@@ -10,17 +10,26 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
 
 @dataclass(frozen=True)
-class EffectRefSugar(Sugar):
+class EffectRefSugar(ConstructedTermSugar):
     slot_id: str
     site: object = dataclass_field(compare=False, default=None)
 
     @classmethod
     def witnesses(cls):
         return ()
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:effect-reference-construction",
+            (self.occurrence_term(owner=owner), str_const(self.slot_id)),
+            symbol_kind="coordinate",
+        )
 
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.effect_coordinate import (
@@ -41,7 +50,7 @@ class EffectRefSugar(Sugar):
 
 
 @dataclass(frozen=True)
-class ObservationRefSugar(Sugar):
+class ObservationRefSugar(ConstructedTermSugar):
     slot_id: str
     projection: str
     site: object = dataclass_field(compare=False, default=None)
@@ -49,6 +58,19 @@ class ObservationRefSugar(Sugar):
     @classmethod
     def witnesses(cls):
         return ()
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:observation-reference-construction",
+            (
+                self.occurrence_term(owner=owner),
+                str_const(self.slot_id),
+                str_const(self.projection),
+            ),
+            symbol_kind="coordinate",
+        )
 
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.effect_coordinate import (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field as dataclass_field, replace
 
+from sugar_lift_py_tests.ir import Term
 from sugar_lift_py_tests.outcome import Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
 
 
 @dataclass(frozen=True)
-class EqualityOpSugar(Sugar):
+class EqualityOpSugar(ConstructedTermSugar):
     """The `==` operator. One of the comparison family (`!=`, `<`, ... are their own
     sugars, their own types -- no operator field to switch on). It reduces both sides
     and asks the left whether it equals the right: the left stands on the equals floor
@@ -24,6 +25,40 @@ class EqualityOpSugar(Sugar):
     @classmethod
     def witnesses(cls):
         return ()
+
+    def to_term(self, *, owner: str) -> Term:
+        """Project the fixed equality operator and ordered operands canonically."""
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        operands = [
+            self.left.to_term(owner=owner),
+            self.right.to_term(owner=owner),
+        ]
+        coordinate = self.left_coordinate
+        if coordinate is None:
+            refinement = ctor("python:no-refinement-coordinate", ())
+        else:
+            cid = coordinate.cid
+            refinement = ctor(
+                "python:refinement-coordinate",
+                (str_const(cid),),
+                symbol_kind="coordinate",
+            )
+
+        return ctor(
+            "python:equality-op-construction",
+            (
+                str_const("equals"),
+                self.occurrence_term(owner=owner),
+                refinement,
+                ctor(
+                    "python:equality-op-operands",
+                    tuple(operands),
+                    symbol_kind="coordinate",
+                ),
+            ),
+            symbol_kind="coordinate",
+        )
 
     def desugar(self, ctx: object = None) -> Outcome:
         # Reduce both sides; the left, standing on the equals floor, answers

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
@@ -4,7 +4,10 @@ from dataclasses import dataclass, field as dataclass_field, replace
 
 from sugar_lift_py_tests.ir import Term
 from sugar_lift_py_tests.outcome import Outcome
-from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 
 
 @dataclass(frozen=True)
@@ -14,13 +17,17 @@ class EqualityOpSugar(ConstructedTermSugar):
     and asks the left whether it equals the right: the left stands on the equals floor
     and gives back a True or False literal."""
 
-    left: Sugar
-    right: Sugar
+    left: ConstructedTermSugar
+    right: ConstructedTermSugar
     site: object = dataclass_field(compare=False)
     # The dotted PLACE this pair's left operand names (`x`, `a.b.c`), or None if
     # it names none. Read off the tree by `Compare._construct_sugar`, because
     # only construction knows which operand is this pair's left.
     left_coordinate: object = None
+
+    def __post_init__(self) -> None:
+        require_constructed_term_sugar(self.left, owner="EqualityOpSugar.left")
+        require_constructed_term_sugar(self.right, owner="EqualityOpSugar.right")
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/false_bool_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/false_bool_literal_sugar.py
@@ -5,12 +5,12 @@ from dataclasses import dataclass, field as dataclass_field
 from sugar_lift_py_tests.floor.block_value import BlockValue
 from sugar_lift_py_tests.floor.guard_stable_value import GuardStableValue
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
 @dataclass(frozen=True)
-class FalseBoolLiteralSugar(Sugar, GuardStableValue):
+class FalseBoolLiteralSugar(ConstructedTermSugar, GuardStableValue):
     """The literal `False`. It holds no value -- the boolean IS the type. It is its own
     floor value and it dispatches the emit to the else-face; with no else it emits
     nothing (an empty block adds no constraint). No fork.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/formal_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/formal_ref_sugar.py
@@ -6,11 +6,11 @@ from sugar_lift_py_tests.floor import SymbolicValue
 from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
 from sugar_lift_py_tests.ir import make_var
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
 
 @dataclass(frozen=True)
-class FormalRefSugar(Sugar):
+class FormalRefSugar(ConstructedTermSugar):
     coordinate: FormalParameterCoordinateV1
     site: object = field(compare=False)
 
@@ -23,6 +23,18 @@ class FormalRefSugar(Sugar):
         from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 
         return NameSugar.witnesses()
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:formal-reference-construction",
+            (
+                self.occurrence_term(owner=owner),
+                str_const(self.coordinate.coordinate_cid),
+            ),
+            symbol_kind="coordinate",
+        )
 
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/fstring_sugar.py
@@ -14,22 +14,56 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
 @dataclass(frozen=True)
-class FormattedValueSugar(Sugar):
+class FormattedValueSugar(ConstructedTermSugar):
     """A Python-reference formatted-value coordinate, without execution."""
 
-    value: Sugar
+    value: ConstructedTermSugar
     conversion: str | None
     format_spec: JoinedStrSugar | None
     site: object = dataclass_field(compare=False)
 
+    def __post_init__(self) -> None:
+        require_constructed_term_sugar(self.value, owner="FormattedValueSugar.value")
+        if self.format_spec is not None:
+            require_constructed_term_sugar(
+                self.format_spec, owner="FormattedValueSugar.format_spec"
+            )
+
     @classmethod
     def witnesses(cls):
         return ()
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        conversion = (
+            ctor("python:no-fstring-conversion", ())
+            if self.conversion is None
+            else str_const(self.conversion)
+        )
+        format_spec = (
+            ctor("python:no-format-spec", ())
+            if self.format_spec is None
+            else self.format_spec.to_term(owner=owner)
+        )
+        return ctor(
+            "python:formatted-value-construction",
+            (
+                self.occurrence_term(owner=owner),
+                self.value.to_term(owner=owner),
+                conversion,
+                format_spec,
+            ),
+            symbol_kind="coordinate",
+        )
 
     def desugar(self, ctx: object = None) -> Outcome:
         from sugar_lift_py_tests.floor.string_value import StringValue
@@ -81,11 +115,15 @@ class FormattedValueSugar(Sugar):
 
 
 @dataclass(frozen=True)
-class JoinedStrSugar(Sugar):
+class JoinedStrSugar(ConstructedTermSugar):
     """The whole f-string: concatenate its parts left-to-right via `add`."""
 
-    parts: tuple
+    parts: tuple[ConstructedTermSugar, ...]
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        for part in self.parts:
+            require_constructed_term_sugar(part, owner="JoinedStrSugar.parts")
 
     @classmethod
     def witnesses(cls):
@@ -95,6 +133,21 @@ class JoinedStrSugar(Sugar):
             owner_sugar="JoinedStrSugar",
             truthful=prefix + "def test_a():\n    assert A(5) == '5'\n",
             lying=prefix + "def test_a():\n    assert A(5) == '6'\n",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:joined-string-construction",
+            (
+                self.occurrence_term(owner=owner),
+                ctor(
+                    "python:joined-string-parts",
+                    tuple(part.to_term(owner=owner) for part in self.parts),
+                ),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -21,13 +21,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
 
 @dataclass(frozen=True)
-class IfExpSugar(Sugar):
+class IfExpSugar(ConstructedTermSugar):
     """`<body> if <test> else <orelse>`, constructed by `IfExp.sugar()` with the
     test's and both arms' sugars already built."""
 
@@ -46,6 +46,20 @@ class IfExpSugar(Sugar):
             body="10 if z == 1 else 20",
             truthful="10",
             lying="11",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:if-expression-construction",
+            (
+                self.occurrence_term(owner=owner),
+                self.test.to_term(owner=owner),
+                self.body.to_term(owner=owner),
+                self.orelse.to_term(owner=owner),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -21,7 +21,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
@@ -31,10 +34,15 @@ class IfExpSugar(ConstructedTermSugar):
     """`<body> if <test> else <orelse>`, constructed by `IfExp.sugar()` with the
     test's and both arms' sugars already built."""
 
-    test: Sugar
-    body: Sugar  # the then-value
-    orelse: Sugar  # the else-value
+    test: ConstructedTermSugar
+    body: ConstructedTermSugar  # the then-value
+    orelse: ConstructedTermSugar  # the else-value
     site: object = dataclass_field(compare=False, default=None)
+
+    def __post_init__(self) -> None:
+        require_constructed_term_sugar(self.test, owner="IfExpSugar.test")
+        require_constructed_term_sugar(self.body, owner="IfExpSugar.body")
+        require_constructed_term_sugar(self.orelse, owner="IfExpSugar.orelse")
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/int_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/int_literal_sugar.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.floor import TermValue
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
 @dataclass(frozen=True)
-class IntLiteralSugar(Sugar):
+class IntLiteralSugar(ConstructedTermSugar):
     """An integer literal. A leaf: it holds its value and no child sugars, and
     it desugars to the number as a term. (`bool` is a subclass of `int`, so the
     node that constructs this must have already distinguished `True`/`False` --
@@ -31,3 +31,12 @@ class IntLiteralSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx  # the number stands as a term
         return Complete(TermValue(self.value))
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, num
+
+        return ctor(
+            "python:int-literal-construction",
+            (self.occurrence_term(owner=owner), num(self.value)),
+            symbol_kind="coordinate",
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from sugar_lift_py_tests.floor import SymbolicValue
 from sugar_lift_py_tests.ir import atomic, ctor, not_, or_, str_const
 from sugar_lift_py_tests.outcome import Complete
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
 
 
 @dataclass(frozen=True)
@@ -37,7 +37,7 @@ class LoopBindingRefSugar(Sugar):
 
 
 @dataclass(frozen=True)
-class LoopRecurrenceSugar(Sugar):
+class LoopRecurrenceSugar(ConstructedTermSugar):
     target_cid: str
     loop_construction_cid: str
     binding_coordinate_cids: tuple[str, ...]
@@ -51,7 +51,6 @@ class LoopRecurrenceSugar(Sugar):
 
     def to_term(self, *, owner: str):
         """Project the authenticated loop construction as one canonical term."""
-        del owner
         from sugar_lift_py_tests.loop_construction import (
             LoopWireError,
             decode_loop_construction_v1,
@@ -79,6 +78,7 @@ class LoopRecurrenceSugar(Sugar):
             (
                 str_const(self.target_cid),
                 str_const(self.loop_construction_cid),
+                self.occurrence_term(owner=owner),
                 ctor(
                     "python:loop-binding-coordinates",
                     tuple(str_const(cid) for cid in self.binding_coordinate_cids),

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
@@ -18,23 +18,33 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
 @dataclass(frozen=True)
-class MethodCallSugar(Sugar):
-    receiver: Sugar
+class MethodCallSugar(ConstructedTermSugar):
+    receiver: ConstructedTermSugar
     name: str
-    args: tuple  # the argument sugars, in source order
+    args: tuple[ConstructedTermSugar, ...]
     site: object = dataclass_field(compare=False)
-    keywords: tuple = ()  # (name, sugar) pairs, in source order
+    keywords: tuple[tuple[str, ConstructedTermSugar], ...] = ()
     source_call_frame: object = dataclass_field(default=None, compare=False)
     # Exception construction only: when Raise authenticates an Attribute
     # exception-class path, the resulting CallSiteValue carries that identity.
     exception_type_coordinate: object = dataclass_field(default=None, compare=False)
     exception_type_mro: tuple | None = dataclass_field(default=None, compare=False)
     native_definition_coordinate: object = dataclass_field(default=None, compare=False)
+
+    def __post_init__(self) -> None:
+        require_constructed_term_sugar(self.receiver, owner="MethodCallSugar.receiver")
+        for argument in self.args:
+            require_constructed_term_sugar(argument, owner="MethodCallSugar.args")
+        for _name, argument in self.keywords:
+            require_constructed_term_sugar(argument, owner="MethodCallSugar.keywords")
 
     @classmethod
     def witnesses(cls):
@@ -46,6 +56,45 @@ class MethodCallSugar(Sugar):
             owner_sugar="MethodCallSugar",
             truthful=prefix + "def test_a():\n    assert A(5) == 3\n",
             lying=prefix + "def test_a():\n    assert A(5) == 4\n",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        authority = []
+        if self.source_call_frame is not None:
+            authority.append(str_const(self.source_call_frame.frame_cid))
+        if self.exception_type_coordinate is not None:
+            authority.append(str_const(self.exception_type_coordinate.cid))
+        if self.native_definition_coordinate is not None:
+            authority.append(str_const(self.native_definition_coordinate.cid))
+        return ctor(
+            "python:method-call-construction",
+            (
+                self.occurrence_term(owner=owner),
+                self.receiver.to_term(owner=owner),
+                str_const(self.name),
+                ctor(
+                    "python:positional-arguments",
+                    tuple(argument.to_term(owner=owner) for argument in self.args),
+                ),
+                ctor(
+                    "python:keyword-arguments",
+                    tuple(
+                        ctor(
+                            "python:keyword-argument",
+                            (str_const(name), argument.to_term(owner=owner)),
+                        )
+                        for name, argument in self.keywords
+                    ),
+                ),
+                ctor(
+                    "python:definition-authority",
+                    tuple(authority),
+                    symbol_kind="coordinate",
+                ),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/name_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/name_sugar.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
 @dataclass(frozen=True)
-class NameSugar(Sugar):
+class NameSugar(ConstructedTermSugar):
     """A name that survives to the meaning layer is a free formal or builtin.
 
     substitute runs before sugar (FunctionDef.sugar), so every temporal binding
@@ -37,6 +37,15 @@ class NameSugar(Sugar):
             owner_sugar="NameSugar",
             truthful=prefix + "def test_a():\n    assert A(5) == 5\n",
             lying=prefix + "def test_a():\n    assert A(5) == 6\n",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:name-construction",
+            (self.occurrence_term(owner=owner), str_const(self.name)),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/none_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/none_literal_sugar.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.floor.none_value import NoneValue
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
 @dataclass(frozen=True)
-class NoneLiteralSugar(Sugar):
+class NoneLiteralSugar(ConstructedTermSugar):
     """The `None` literal. A leaf: it stands as the NoneValue floor -- the
     None-ness IS the type, there is no value to carry."""
 
@@ -28,3 +28,12 @@ class NoneLiteralSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx
         return Complete(NoneValue())
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:none-literal-construction",
+            (self.occurrence_term(owner=owner),),
+            symbol_kind="coordinate",
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/resource_coord_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/resource_coord_sugar.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
 
 @dataclass(frozen=True)
-class ManagerRefSugar(Sugar):
+class ManagerRefSugar(ConstructedTermSugar):
     """Tree ``ManagerRef(M)`` — pure manager-slot coordinate."""
 
     slot_id: str
@@ -23,6 +23,15 @@ class ManagerRefSugar(Sugar):
     def witnesses(cls):
         return ()
 
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:manager-reference-construction",
+            (self.occurrence_term(owner=owner), str_const(self.slot_id)),
+            symbol_kind="coordinate",
+        )
+
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx
         from sugar_lift_py_tests.floor.manager_coordinate import ManagerCoordinate
@@ -31,7 +40,7 @@ class ManagerRefSugar(Sugar):
 
 
 @dataclass(frozen=True)
-class ExitTypeRefSugar(Sugar):
+class ExitTypeRefSugar(ConstructedTermSugar):
     """Tree ``ExitTypeRef(X)`` — pure parametric exit-type coordinate."""
 
     face_id: str
@@ -41,6 +50,15 @@ class ExitTypeRefSugar(Sugar):
     def witnesses(cls):
         return ()
 
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:exit-type-reference-construction",
+            (self.occurrence_term(owner=owner), str_const(self.face_id)),
+            symbol_kind="coordinate",
+        )
+
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx
         from sugar_lift_py_tests.floor.manager_coordinate import ExitTypeCoordinate
@@ -49,7 +67,7 @@ class ExitTypeRefSugar(Sugar):
 
 
 @dataclass(frozen=True)
-class ExitValueRefSugar(Sugar):
+class ExitValueRefSugar(ConstructedTermSugar):
     """Tree ``ExitValueRef(X)`` — pure parametric exit-value coordinate."""
 
     face_id: str
@@ -59,6 +77,15 @@ class ExitValueRefSugar(Sugar):
     def witnesses(cls):
         return ()
 
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:exit-value-reference-construction",
+            (self.occurrence_term(owner=owner), str_const(self.face_id)),
+            symbol_kind="coordinate",
+        )
+
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx
         from sugar_lift_py_tests.floor.manager_coordinate import ExitValueCoordinate
@@ -67,7 +94,7 @@ class ExitValueRefSugar(Sugar):
 
 
 @dataclass(frozen=True)
-class ExitTracebackRefSugar(Sugar):
+class ExitTracebackRefSugar(ConstructedTermSugar):
     """Tree ``ExitTracebackRef(X)`` — pure parametric exit-traceback coordinate."""
 
     face_id: str
@@ -76,6 +103,15 @@ class ExitTracebackRefSugar(Sugar):
     @classmethod
     def witnesses(cls):
         return ()
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:exit-traceback-reference-construction",
+            (self.occurrence_term(owner=owner), str_const(self.face_id)),
+            symbol_kind="coordinate",
+        )
 
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/slice_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/slice_sugar.py
@@ -11,19 +11,52 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 
 
 @dataclass(frozen=True)
-class SliceSugar(Sugar):
-    lower: object  # sugar or None (omitted bound)
-    upper: object
-    step: object
+class SliceSugar(ConstructedTermSugar):
+    lower: ConstructedTermSugar | None
+    upper: ConstructedTermSugar | None
+    step: ConstructedTermSugar | None
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        for name, bound in (
+            ("lower", self.lower),
+            ("upper", self.upper),
+            ("step", self.step),
+        ):
+            if bound is not None:
+                require_constructed_term_sugar(bound, owner=f"SliceSugar.{name}")
 
     @classmethod
     def witnesses(cls):
         return ()
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        def bound_term(bound):
+            return (
+                ctor("python:omitted-slice-bound", ())
+                if bound is None
+                else bound.to_term(owner=owner)
+            )
+
+        return ctor(
+            "python:slice-construction",
+            (
+                self.occurrence_term(owner=owner),
+                bound_term(self.lower),
+                bound_term(self.upper),
+                bound_term(self.step),
+            ),
+            symbol_kind="coordinate",
+        )
 
     def desugar(self, ctx: object = None) -> Outcome:
         # A BOUND IS AN ORDINARY OPERAND, and an operand does not answer with

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/string_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/string_literal_sugar.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.floor import StringValue
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
 @dataclass(frozen=True)
-class StringLiteralSugar(Sugar):
+class StringLiteralSugar(ConstructedTermSugar):
     """A string literal. Infinitely many values, so the value is a field. It
     reduces to a StringValue: the string as a term. A leaf -- no child sugars.
 
@@ -33,3 +33,12 @@ class StringLiteralSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx  # the string stands as a term
         return Complete(StringValue(self.value))
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:string-literal-construction",
+            (self.occurrence_term(owner=owner), str_const(self.value)),
+            symbol_kind="coordinate",
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
@@ -4,12 +4,15 @@ from dataclasses import dataclass, field as dataclass_field
 from typing import Any
 
 from sugar_lift_py_tests.outcome import Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
 @dataclass(frozen=True)
-class SubscriptSugar(Sugar):
+class SubscriptSugar(ConstructedTermSugar):
     """`<receiver>[<index>]`. Reduce the receiver and the index, then ask the
     receiver to subscript by the index -- the value owns what indexing means.
     Concrete containers fold (a string indexes to its character); a vendor
@@ -22,9 +25,13 @@ class SubscriptSugar(Sugar):
     never silently handled by this parent.
     """
 
-    receiver: Sugar
-    index: Sugar
+    receiver: ConstructedTermSugar
+    index: ConstructedTermSugar
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        require_constructed_term_sugar(self.receiver, owner="SubscriptSugar.receiver")
+        require_constructed_term_sugar(self.index, owner="SubscriptSugar.index")
 
     @classmethod
     def witnesses(cls):
@@ -37,6 +44,19 @@ class SubscriptSugar(Sugar):
             owner_sugar="SubscriptSugar",
             truthful=prefix + "def test_a():\n    assert A(5) == 5\n",
             lying=prefix + "def test_a():\n    assert A(5) == 6\n",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:subscript-construction",
+            (
+                self.occurrence_term(owner=owner),
+                self.receiver.to_term(owner=owner),
+                self.index.to_term(owner=owner),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: Any = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/sugar_base.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/sugar_base.py
@@ -81,3 +81,14 @@ class ConstructedTermSugar(Sugar):
             ),
             symbol_kind="coordinate",
         )
+
+
+def require_constructed_term_sugar(
+    value: object, *, owner: str
+) -> ConstructedTermSugar:
+    """Close a nested construction payload before canonical projection."""
+    if not isinstance(value, ConstructedTermSugar):
+        raise TypeError(
+            f"{owner} requires ConstructedTermSugar, got {type(value).__name__}"
+        )
+    return value

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/sugar_base.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/sugar_base.py
@@ -6,6 +6,7 @@ import inspect
 from typing import Any, Callable, ClassVar, List, cast
 
 from sugar_lift_py_tests.outcome import Complete, Incomplete, Outcome
+from sugar_lift_py_tests.ir import Term
 from sugar_lift_py_tests.sugar.witnesses import SugarWitnesses
 from sugar_lift_py_tests.sugar_body import SugarBody
 
@@ -50,3 +51,33 @@ class Sugar(ABC):
         # Default: a leaf. Sugars that hold SugarBody children override to
         # return them in source order -- the factory walk projects those.
         return ()
+
+
+class ConstructedTermSugar(Sugar):
+    """Sugar admitted as canonical generator/nested-construction testimony."""
+
+    @abstractmethod
+    def to_term(self, *, owner: str) -> Term:
+        """Project authenticated construction testimony into canonical IR."""
+
+    def occurrence_term(self, *, owner: str) -> Term:
+        """Seal the exact source occurrence; identical spelling elsewhere differs."""
+        from sugar_lift_py_tests.ir import ctor, num, str_const
+
+        try:
+            occurrence = self.site.seal()
+        except (AttributeError, TypeError) as exc:
+            raise TypeError(
+                f"{owner} requires an authenticated source occurrence for "
+                f"{type(self).__name__}"
+            ) from exc
+        return ctor(
+            "python:source-occurrence",
+            (
+                str_const(occurrence.source_cid),
+                num(occurrence.start),
+                num(occurrence.end),
+                str_const(occurrence.cid),
+            ),
+            symbol_kind="coordinate",
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/true_bool_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/true_bool_literal_sugar.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.floor.guard_stable_value import GuardStableValue
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
 @dataclass(frozen=True)
-class TrueBoolLiteralSugar(Sugar, GuardStableValue):
+class TrueBoolLiteralSugar(ConstructedTermSugar, GuardStableValue):
     """The literal `True`. It holds no value -- the boolean IS the type. It is its own
     floor value and it stands on the bool floor as True: it emits the then-face,
     always, with no fork.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
@@ -28,7 +28,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 # Unary operator kind -> the floor method that owns its meaning. Every entry is
@@ -97,10 +100,15 @@ def refuse_undecided_unary_truth(value, site) -> None:
 
 
 @dataclass(frozen=True)
-class UnaryOpSugar(Sugar):
+class UnaryOpSugar(ConstructedTermSugar):
     op_kind: str
-    operand: Sugar
+    operand: ConstructedTermSugar
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        if self.op_kind not in {*UNARYOP_METHODS, "Not"}:
+            raise ValueError(f"unknown unary operator {self.op_kind!r}")
+        require_constructed_term_sugar(self.operand, owner="UnaryOpSugar.operand")
 
     @classmethod
     def witnesses(cls):
@@ -111,6 +119,19 @@ class UnaryOpSugar(Sugar):
             owner_sugar="UnaryOpSugar",
             truthful=prefix + "def test_a():\n    assert A(5) == 5\n",
             lying=prefix + "def test_a():\n    assert A(5) == 0\n",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:unary-op-construction",
+            (
+                self.occurrence_term(owner=owner),
+                str_const(self.op_kind),
+                self.operand.to_term(owner=owner),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/tests/test_bool_op_term.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bool_op_term.py
@@ -1,0 +1,69 @@
+"""Canonical construction testimony for ``BoolOpSugar``."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.ir import str_const
+from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.tree import SourceFile
+
+
+@dataclass(frozen=True)
+class _Operand(ConstructedTermSugar):
+    testimony: str
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):  # pragma: no cover - term-only fixture
+        raise AssertionError("term projection must not execute operands")
+
+    def to_term(self, *, owner: str):
+        del owner
+        return str_const(self.testimony)
+
+
+def _sites(source="left and right\n"):
+    tree = SourceFile((source, "boolop.py", blake3_512_of(source.encode())))
+    return tuple(node.fragment for node in tree.nodes() if node.kind == "BoolOp")
+
+
+def _boolop(kind="And", values=("left", "right"), site=None):
+    if site is None:
+        site = _sites()[0]
+    return BoolOpSugar(kind, tuple(_Operand(value) for value in values), site)
+
+
+def test_identical_boolop_preimages_yield_identical_terms():
+    assert _boolop(site=_sites()[0]).to_term(owner="first") == _boolop(
+        site=_sites()[0]
+    ).to_term(owner="second")
+
+
+def test_changed_boolop_occurrence_changes_term():
+    first, second = _sites("left and right\nleft and right\n")
+    assert _boolop(site=first).to_term(owner="first") != _boolop(
+        site=second
+    ).to_term(owner="second")
+
+
+@pytest.mark.parametrize(
+    "variant",
+    (
+        _boolop(kind="Or"),
+        _boolop(values=("right", "left")),
+        _boolop(values=("left", "changed")),
+    ),
+    ids=("operator", "operand-order", "operand-testimony"),
+)
+def test_changed_boolop_preimage_changes_term(variant):
+    assert _boolop().to_term(owner="baseline") != variant.to_term(owner="variant")
+
+
+def test_tampered_boolop_operator_refuses_term_projection():
+    with pytest.raises(ValueError, match="authenticated BoolOp operator"):
+        _boolop(kind="Xor").to_term(owner="tampered")

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
@@ -1,0 +1,110 @@
+"""Closed constructed-Sugar canonical term admission."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.ir import str_const
+from sugar_lift_py_tests.generator_construction import YieldStepV1
+from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.tree import SourceFile
+
+
+class _MissingTerm(ConstructedTermSugar):
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        raise AssertionError
+
+
+class _ArbitrarySugar(Sugar):
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        raise AssertionError
+
+
+@dataclass(frozen=True)
+class _Operand(ConstructedTermSugar):
+    testimony: str
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        raise AssertionError
+
+    def to_term(self, *, owner: str):
+        del owner
+        return str_const(self.testimony)
+
+
+@dataclass(frozen=True)
+class _Coordinate:
+    cid: str
+
+
+def _call_sites():
+    source = "callee(a, b)\ncallee(a, b)\n"
+    tree = SourceFile((source, "calls.py", blake3_512_of(source.encode())))
+    return tuple(node.fragment for node in tree.nodes() if node.kind == "Call")
+
+
+def _call(*, site=None, args=("a", "b"), keywords=(), definition="d"):
+    if site is None:
+        site = _call_sites()[0]
+    coordinate = _Coordinate("blake3-512:" + definition * 128)
+    return CallSiteSugar(
+        target_name="ignored-spelling",
+        args=tuple(_Operand(value) for value in args),
+        keywords=tuple((name, _Operand(value)) for name, value in keywords),
+        exception_type_coordinate=coordinate,
+        site=site,
+    )
+
+
+def test_missing_constructed_term_obligation_refuses_at_instantiation():
+    with pytest.raises(TypeError, match="abstract method 'to_term'"):
+        _MissingTerm()
+
+
+def test_generator_payload_admission_refuses_arbitrary_sugar():
+    with pytest.raises(TypeError, match="YieldStepV1.value requires ConstructedTermSugar"):
+        YieldStepV1(_ArbitrarySugar())
+
+
+def test_equivalent_call_reconstruction_has_the_same_term():
+    site = _call_sites()[0]
+    assert _call(site=site).to_term(owner="first") == _call(site=site).to_term(
+        owner="second"
+    )
+
+
+@pytest.mark.parametrize(
+    "variant",
+    (
+        _call(site=_call_sites()[1]),
+        _call(args=("b", "a")),
+        _call(args=("a", "changed")),
+        _call(keywords=(("left", "a"), ("right", "b"))),
+        _call(keywords=(("right", "b"), ("left", "a"))),
+        _call(definition="e"),
+    ),
+    ids=(
+        "occurrence",
+        "argument-order",
+        "argument-testimony",
+        "keyword-arguments",
+        "keyword-order",
+        "definition-coordinate",
+    ),
+)
+def test_changed_call_preimage_changes_term(variant):
+    assert _call().to_term(owner="baseline") != variant.to_term(owner="variant")

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
@@ -12,7 +12,12 @@ from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
 from sugar_lift_py_tests.sugar.binop_sugar import BinOpSugar
 from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
 from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
-from sugar_lift_py_tests.sugar.collection_sugar import TupleSugar
+from sugar_lift_py_tests.sugar.collection_sugar import (
+    DictSugar,
+    ListSugar,
+    SetSugar,
+    TupleSugar,
+)
 from sugar_lift_py_tests.sugar.computed_call_sugar import ComputedCallSugar
 from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
 from sugar_lift_py_tests.sugar.comprehension_sugar import (
@@ -135,6 +140,10 @@ def test_generator_payload_admission_refuses_arbitrary_sugar():
         lambda child, site: EqualityOpSugar(child, _Operand("right"), site),
         lambda child, site: BoolOpSugar("And", (child, _Operand("right")), site),
         lambda child, site: TupleSugar((child,), site),
+        lambda child, site: ListSugar((child,), site),
+        lambda child, site: SetSugar((child,), site),
+        lambda child, site: DictSugar((child,), (_Operand("value"),), site),
+        lambda child, site: DictSugar((_Operand("key"),), (child,), site),
         lambda child, site: IfExpSugar(child, _Operand("body"), _Operand("else"), site),
         lambda child, site: CallSiteSugar("ignored", (child,), site),
         lambda child, site: CallSiteSugar("ignored", (), site, (("key", child),)),
@@ -188,6 +197,10 @@ def test_generator_payload_admission_refuses_arbitrary_sugar():
         "equality",
         "bool-op",
         "tuple",
+        "list",
+        "set",
+        "dict-key",
+        "dict-value",
         "if-expression",
         "call-arg",
         "call-keyword",
@@ -256,3 +269,73 @@ def test_changed_resolved_contract_authority_changes_call_term():
 )
 def test_changed_call_preimage_changes_term(variant):
     assert _call().to_term(owner="baseline") != variant.to_term(owner="variant")
+
+
+@pytest.mark.parametrize(
+    "build",
+    (
+        lambda site: ListSugar((_Operand("a"), _Operand("b")), site),
+        lambda site: SetSugar((_Operand("a"), _Operand("b")), site),
+        lambda site: DictSugar(
+            (_Operand("a"), _Operand("b")),
+            (_Operand("1"), _Operand("2")),
+            site,
+        ),
+    ),
+    ids=("list", "set", "dict"),
+)
+def test_collection_reconstruction_and_occurrence_discriminate(build):
+    first, second = _call_sites()
+    assert build(first).to_term(owner="first") == build(first).to_term(
+        owner="reconstructed"
+    )
+    assert build(first).to_term(owner="first") != build(second).to_term(
+        owner="second"
+    )
+
+
+@pytest.mark.parametrize(
+    "build",
+    (
+        lambda site, values: ListSugar(tuple(_Operand(v) for v in values), site),
+        lambda site, values: SetSugar(tuple(_Operand(v) for v in values), site),
+    ),
+    ids=("list", "set"),
+)
+def test_ordered_collection_child_testimony_discriminates(build):
+    site = _call_sites()[0]
+    assert build(site, ("a", "b")).to_term(owner="forward") != build(
+        site, ("b", "a")
+    ).to_term(owner="reverse")
+
+
+def test_dict_term_preserves_exact_ordered_key_value_pairing():
+    site = _call_sites()[0]
+    baseline = DictSugar(
+        (_Operand("k1"), _Operand("k2")),
+        (_Operand("v1"), _Operand("v2")),
+        site,
+    )
+    crossed = DictSugar(
+        (_Operand("k1"), _Operand("k2")),
+        (_Operand("v2"), _Operand("v1")),
+        site,
+    )
+    reordered_pairs = DictSugar(
+        (_Operand("k2"), _Operand("k1")),
+        (_Operand("v2"), _Operand("v1")),
+        site,
+    )
+
+    term = baseline.to_term(owner="baseline")
+    assert term != crossed.to_term(owner="crossed")
+    assert term != reordered_pairs.to_term(owner="reordered")
+    assert term.name == "python:dict-construction"
+    pairs = term.args[1]
+    assert pairs.name == "python:dict-entries"
+    assert [pair.name for pair in pairs.args] == ["python:dict-entry"] * 2
+
+
+def test_dict_key_value_arity_mismatch_refuses_at_construction():
+    with pytest.raises(ValueError, match="equal key/value arity"):
+        DictSugar((_Operand("key"),), (), _call_sites()[0])

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
@@ -1,12 +1,18 @@
 """Closed constructed-Sugar canonical term admission."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from types import MappingProxyType
 
 import pytest
 
-from sugar_lift_py_tests.ir import str_const
+from sugar_lift_py_tests.call_contract_resolution import ResolvedCallContractRefV1
+from sugar_lift_py_tests.ir import PrimitiveSort, str_const
 from sugar_lift_py_tests.generator_construction import YieldStepV1
+from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
 from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+from sugar_lift_py_tests.sugar.collection_sugar import TupleSugar
+from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
+from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
 from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.tree import SourceFile
@@ -57,7 +63,26 @@ def _call_sites():
     return tuple(node.fragment for node in tree.nodes() if node.kind == "Call")
 
 
-def _call(*, site=None, args=("a", "b"), keywords=(), definition="d"):
+def _contract(letter: str) -> ResolvedCallContractRefV1:
+    cid = "blake3-512:" + letter * 128
+    return ResolvedCallContractRefV1(
+        resolution_cid=cid,
+        demand_cid="blake3-512:" + "d" * 128,
+        use_site=None,
+        import_binding_cid="blake3-512:" + "i" * 128,
+        catalog_cid="blake3-512:" + "c" * 128,
+        member_cid="blake3-512:" + "m" * 128,
+        contract_cid=cid,
+        bridge_source_symbol="ignored-spelling",
+        formals=("value",),
+        sorts=(PrimitiveSort("Value"),),
+        return_term=None,
+        source_warrant_cids=(),
+        contract_decl=MappingProxyType({"kind": "contract"}),
+    )
+
+
+def _call(*, site=None, args=("a", "b"), keywords=(), definition="d", contract=None):
     if site is None:
         site = _call_sites()[0]
     coordinate = _Coordinate("blake3-512:" + definition * 128)
@@ -66,6 +91,7 @@ def _call(*, site=None, args=("a", "b"), keywords=(), definition="d"):
         args=tuple(_Operand(value) for value in args),
         keywords=tuple((name, _Operand(value)) for name, value in keywords),
         exception_type_coordinate=coordinate,
+        contract_ref=contract,
         site=site,
     )
 
@@ -80,11 +106,36 @@ def test_generator_payload_admission_refuses_arbitrary_sugar():
         YieldStepV1(_ArbitrarySugar())
 
 
+@pytest.mark.parametrize(
+    "build",
+    (
+        lambda child, site: EqualityOpSugar(child, _Operand("right"), site),
+        lambda child, site: BoolOpSugar("And", (child, _Operand("right")), site),
+        lambda child, site: TupleSugar((child,), site),
+        lambda child, site: IfExpSugar(child, _Operand("body"), _Operand("else"), site),
+        lambda child, site: CallSiteSugar("ignored", (child,), site),
+        lambda child, site: CallSiteSugar("ignored", (), site, (("key", child),)),
+    ),
+    ids=("equality", "bool-op", "tuple", "if-expression", "call-arg", "call-keyword"),
+)
+def test_constructed_term_nested_children_are_closed_at_construction(build):
+    site = _call_sites()[0]
+    assert isinstance(build(_Operand("good"), site), ConstructedTermSugar)
+    with pytest.raises(TypeError, match="requires ConstructedTermSugar"):
+        build(_ArbitrarySugar(), site)
+
+
 def test_equivalent_call_reconstruction_has_the_same_term():
     site = _call_sites()[0]
     assert _call(site=site).to_term(owner="first") == _call(site=site).to_term(
         owner="second"
     )
+
+
+def test_changed_resolved_contract_authority_changes_call_term():
+    assert _call(contract=_contract("a")).to_term(
+        owner="first-contract"
+    ) != _call(contract=_contract("b")).to_term(owner="second-contract")
 
 
 @pytest.mark.parametrize(
@@ -96,6 +147,8 @@ def test_equivalent_call_reconstruction_has_the_same_term():
         _call(keywords=(("left", "a"), ("right", "b"))),
         _call(keywords=(("right", "b"), ("left", "a"))),
         _call(definition="e"),
+        _call(contract=_contract("a")),
+        _call(contract=_contract("b")),
     ),
     ids=(
         "occurrence",
@@ -104,6 +157,8 @@ def test_equivalent_call_reconstruction_has_the_same_term():
         "keyword-arguments",
         "keyword-order",
         "definition-coordinate",
+        "first-contract-authority",
+        "changed-contract-authority",
     ),
 )
 def test_changed_call_preimage_changes_term(variant):

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
@@ -8,11 +8,25 @@ import pytest
 from sugar_lift_py_tests.call_contract_resolution import ResolvedCallContractRefV1
 from sugar_lift_py_tests.ir import PrimitiveSort, str_const
 from sugar_lift_py_tests.generator_construction import YieldStepV1
+from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
+from sugar_lift_py_tests.sugar.binop_sugar import BinOpSugar
 from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
 from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 from sugar_lift_py_tests.sugar.collection_sugar import TupleSugar
+from sugar_lift_py_tests.sugar.computed_call_sugar import ComputedCallSugar
+from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
+from sugar_lift_py_tests.sugar.comprehension_sugar import (
+    ComprehensionGeneratorSugar,
+    ComprehensionSugar,
+    ComprehensionTargetSugar,
+)
 from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
 from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
+from sugar_lift_py_tests.sugar.fstring_sugar import FormattedValueSugar, JoinedStrSugar
+from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+from sugar_lift_py_tests.sugar.subscript_sugar import SubscriptSugar
+from sugar_lift_py_tests.sugar.slice_sugar import SliceSugar
+from sugar_lift_py_tests.sugar.unary_op_sugar import UnaryOpSugar
 from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.tree import SourceFile
@@ -61,6 +75,15 @@ def _call_sites():
     source = "callee(a, b)\ncallee(a, b)\n"
     tree = SourceFile((source, "calls.py", blake3_512_of(source.encode())))
     return tuple(node.fragment for node in tree.nodes() if node.kind == "Call")
+
+
+def _comprehension_generator(iterable, *, filters=()):
+    return ComprehensionGeneratorSugar(
+        target=ComprehensionTargetSugar(source_name="item"),
+        binding_coordinate_cid="blake3-512:" + "g" * 128,
+        iterable=iterable,
+        filters=filters,
+    )
 
 
 def _contract(letter: str) -> ResolvedCallContractRefV1:
@@ -115,8 +138,78 @@ def test_generator_payload_admission_refuses_arbitrary_sugar():
         lambda child, site: IfExpSugar(child, _Operand("body"), _Operand("else"), site),
         lambda child, site: CallSiteSugar("ignored", (child,), site),
         lambda child, site: CallSiteSugar("ignored", (), site, (("key", child),)),
+        lambda child, site: AttributeSugar(child, "field", site),
+        lambda child, site: ComputedCallSugar(child, (_Operand("arg"),), site),
+        lambda child, site: ComputedCallSugar(_Operand("callee"), (child,), site),
+        lambda child, site: ComputedCallSugar(
+            _Operand("callee"), (), site, (("key", child),)
+        ),
+        lambda child, site: ComparisonOpSugar("Is", child, _Operand("right"), site),
+        lambda child, site: MethodCallSugar(child, "method", (), site),
+        lambda child, site: MethodCallSugar(
+            _Operand("receiver"), "method", (child,), site
+        ),
+        lambda child, site: MethodCallSugar(
+            _Operand("receiver"), "method", (), site, (("key", child),)
+        ),
+        lambda child, site: SubscriptSugar(child, _Operand("index"), site),
+        lambda child, site: UnaryOpSugar("Not", child, site),
+        lambda child, site: SliceSugar(child, None, None, site),
+        lambda child, site: BinOpSugar("Add", child, _Operand("right"), site),
+        lambda child, site: FormattedValueSugar(child, None, None, site),
+        lambda child, site: JoinedStrSugar((child,), site),
+        lambda child, site: ComprehensionSugar(
+            "py.generatorexp",
+            (_comprehension_generator(child),),
+            _Operand("element"),
+            site=site,
+        ),
+        lambda child, site: ComprehensionSugar(
+            "py.generatorexp",
+            (_comprehension_generator(_Operand("iterable"), filters=(child,)),),
+            _Operand("element"),
+            site=site,
+        ),
+        lambda child, site: ComprehensionSugar(
+            "py.generatorexp",
+            (_comprehension_generator(_Operand("iterable")),),
+            child,
+            site=site,
+        ),
+        lambda child, site: ComprehensionSugar(
+            "py.dictcomp",
+            (_comprehension_generator(_Operand("iterable")),),
+            _Operand("value"),
+            key=child,
+            site=site,
+        ),
     ),
-    ids=("equality", "bool-op", "tuple", "if-expression", "call-arg", "call-keyword"),
+    ids=(
+        "equality",
+        "bool-op",
+        "tuple",
+        "if-expression",
+        "call-arg",
+        "call-keyword",
+        "attribute",
+        "computed-callee",
+        "computed-arg",
+        "computed-keyword",
+        "comparison",
+        "method-receiver",
+        "method-arg",
+        "method-keyword",
+        "subscript",
+        "unary-op",
+        "slice",
+        "binary-op",
+        "formatted-value",
+        "joined-string",
+        "comprehension-iterable",
+        "comprehension-filter",
+        "comprehension-element",
+        "comprehension-key",
+    ),
 )
 def test_constructed_term_nested_children_are_closed_at_construction(build):
     site = _call_sites()[0]

--- a/implementations/python/sugar-lift-py-tests/tests/test_equality_op_term.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_equality_op_term.py
@@ -1,0 +1,89 @@
+"""Canonical construction testimony for ``EqualityOpSugar``."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.ir import str_const
+from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.tree import SourceFile
+
+
+@dataclass(frozen=True)
+class _Operand(ConstructedTermSugar):
+    testimony: str
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):  # pragma: no cover - term-only fixture
+        raise AssertionError("term projection must not execute operands")
+
+    def to_term(self, *, owner: str):
+        del owner
+        return str_const(self.testimony)
+
+
+@dataclass(frozen=True)
+class _TamperedOperand(ConstructedTermSugar):
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):  # pragma: no cover - term-only fixture
+        raise AssertionError("term projection must not execute operands")
+
+
+@dataclass(frozen=True)
+class _Coordinate:
+    cid: str
+
+
+def _sites(source="left == right\n"):
+    tree = SourceFile((source, "equality.py", blake3_512_of(source.encode())))
+    return tuple(node.fragment for node in tree.nodes() if node.kind == "Compare")
+
+
+def _equality(left="left", right="right", site=None, coordinate="a"):
+    if site is None:
+        site = _sites()[0]
+    return EqualityOpSugar(
+        _Operand(left),
+        _Operand(right),
+        site,
+        left_coordinate=_Coordinate("blake3-512:" + coordinate * 128),
+    )
+
+
+def test_identical_equality_preimages_yield_identical_terms():
+    assert _equality(site=_sites()[0]).to_term(owner="first") == _equality(
+        site=_sites()[0]
+    ).to_term(owner="second")
+
+
+def test_changed_equality_occurrence_changes_term():
+    first, second = _sites("left == right\nleft == right\n")
+    assert _equality(site=first).to_term(owner="first") != _equality(
+        site=second
+    ).to_term(owner="second")
+
+
+@pytest.mark.parametrize(
+    "variant",
+    (
+        _equality("right", "left"),
+        _equality("left", "changed"),
+        _equality(coordinate="b"),
+    ),
+    ids=("operand-order", "operand-testimony", "refinement-coordinate"),
+)
+def test_changed_equality_preimage_changes_term(variant):
+    assert _equality().to_term(owner="baseline") != variant.to_term(owner="variant")
+
+
+def test_tampered_equality_operand_refuses_term_projection():
+    with pytest.raises(TypeError, match="abstract method 'to_term'"):
+        _TamperedOperand()

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -175,14 +175,43 @@ def test_non_display_rhs_constructs_and_retains_its_arity_obligation():
     # assertion is correspondingly stronger.
     from sugar_lift_py_tests.effect import SequenceUnpackRuntimeEffect
 
-    function = _fn("def A(p):\n    a, b = p\n    return a\n")
+    from sugar_lift_py_tests.ir import num
+    from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted, true_guard
+    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+
+    function = _fn(
+        "def A(p, receiver):\n"
+        "    a, b = p\n"
+        "    receiver.after = 1\n"
+        "    later = 2\n"
+        "    return later\n"
+    )
     sugar = function.sugar()
 
     out = sugar.desugar()
-    assert isinstance(out, Incomplete)
-    assert isinstance(out.effect, SequenceUnpackRuntimeEffect)
-    assert "exactly 2 members" in out.effect.reason
-    assert "(a, b)" in out.effect.reason
+    assert isinstance(out, ExitSet)
+    assert len(out.exits) == 1
+    (halted,) = out.exits
+    assert isinstance(halted, Halted)
+    assert not any(isinstance(exit_, Completed) for exit_ in out.exits)
+    assert halted.guard == true_guard()
+    assert halted.state == _ReducedBlock((), True, ())
+
+    effect = halted.effect
+    assert isinstance(effect, SequenceUnpackRuntimeEffect)
+    assert "exactly 2 members" in effect.reason
+    assert "(a, b)" in effect.reason
+    assert effect.witness.operation == effect.runtime_operand.term
+    assert effect.witness.operation.name == "python:unpack.destructure"
+    assert effect.witness.operation.args[1] == num(2)
+    assert effect.witness.site.line == 2
+    assert effect.witness.site.col == 4
+
+    # The exact pre-effect state is still empty: neither unpack target bound,
+    # and the later attribute store / name binding never executed.
+    assert halted.state.entries == ()
+    assert halted.state.fall_through == ()
+    assert halted.state.transforms == ()
 
 
 def test_display_rhs_arity_mismatch_is_still_a_refusal_not_an_effect():

--- a/implementations/python/sugar-source-tree/tests/test_loop_recurrence_term.py
+++ b/implementations/python/sugar-source-tree/tests/test_loop_recurrence_term.py
@@ -9,7 +9,10 @@ from pathlib import Path
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.generator_construction import _generator_value_testimony
+from sugar_lift_py_tests.ir import _term_content_cid, ctor, str_const
 from sugar_lift_py_tests.loop_construction import LoopWireError
+from sugar_lift_py_tests.outcome.resource_bindings import ManagerBinding
 from sugar_source_tree.tree import SourceFile
 
 
@@ -30,6 +33,37 @@ _BASE = (
     "        pass\n"
     "    return xs\n"
 )
+
+
+_OLD_TERM_CONSUMERS = (
+    "GeneratorConstructionV1 payload testimony",
+    "ManagerBinding fact testimony",
+)
+
+
+def _old_loop_term(loop):
+    """The pre-occurrence term shape replaced by ConstructedTermSugar."""
+    root = loop.construction.wire_graph()["root"]
+    return ctor(
+        "python:loop-recurrence-construction",
+        (
+            str_const(loop.target_cid),
+            str_const(loop.loop_construction_cid),
+            ctor(
+                "python:loop-binding-coordinates",
+                tuple(str_const(cid) for cid in loop.binding_coordinate_cids),
+                symbol_kind="coordinate",
+            ),
+            ctor(
+                "python:loop-outward-face-testimony",
+                tuple(
+                    str_const(cid) for cid in root["outwardHaltedFaceCids"]
+                ),
+                symbol_kind="coordinate",
+            ),
+        ),
+        symbol_kind="coordinate",
+    )
 
 
 def test_identical_loop_construction_preimages_yield_identical_terms(tmp_path: Path):
@@ -65,3 +99,38 @@ def test_tampered_loop_construction_refuses_term_projection(tmp_path: Path):
 
     with pytest.raises(LoopWireError, match="loopConstructionCid mismatch"):
         replace(loop, construction=tampered_construction).to_term(owner="test")
+
+
+def test_loop_term_occurrence_migration_reaches_every_existing_consumer(
+    tmp_path: Path,
+):
+    """Old-vs-new identity changes are consumed opaquely at both live seats."""
+    loop = _loop(tmp_path, _BASE, "migration.py")
+    old_term = _old_loop_term(loop)
+    new_term = loop.to_term(owner="migration")
+
+    # Pinned schema migration: the authenticated occurrence is inserted after
+    # target/construction identity; the remaining testimony is conserved.
+    assert old_term != new_term
+    assert new_term.args[:2] == old_term.args[:2]
+    assert new_term.args[2] == loop.occurrence_term(owner="migration")
+    assert new_term.args[3:] == old_term.args[2:]
+
+    observed_consumers = []
+
+    generator_testimony = _generator_value_testimony(
+        loop, owner="LoopRecurrence migration"
+    )
+    assert generator_testimony == {
+        "kind": "term-cid",
+        "contentCid": _term_content_cid(new_term),
+    }
+    assert generator_testimony["contentCid"] != _term_content_cid(old_term)
+    observed_consumers.append("GeneratorConstructionV1 payload testimony")
+
+    (manager_fact,) = ManagerBinding("loop-manager", loop).to_facts()
+    assert manager_fact.formula.args[1] == new_term
+    assert manager_fact.formula.args[1] != old_term
+    observed_consumers.append("ManagerBinding fact testimony")
+
+    assert tuple(observed_consumers) == _OLD_TERM_CONSUMERS


### PR DESCRIPTION
## Capability

Promotes ConstructedTermSugar as the abstract construction-testimony obligation for Sugars admitted into generator payloads and recursively closes nested testimony. CallSite includes authenticated contract authority; BoolOp, EqualityOp, LoopRecurrence, List, Set, Dict, and Tuple carry authenticated source occurrence and ordered semantic children. Dict testimony is an ordered sequence of exact key/value entry pairs. Each collection has its own constructor vocabulary; there is no generic collection fallback.

## Migration and discrimination evidence

- LoopRecurrence old-vs-new schema is executable: authenticated occurrence insertion is pinned, and both existing consumers (GeneratorConstructionV1 payload testimony and ManagerBinding facts) explicitly consume the new term/CID.
- List/Set/Dict reconstruct identically at one occurrence and discriminate different occurrences and child order.
- Dict cross-wired values and reordered pairs discriminate; unequal key/value arity and arbitrary nested Sugar children refuse at construction.
- Missing to_term refuses at instantiation; child terms are called directly without probing, identity/repr, spelling dispatch, eager desugar, or fallback testimony.

## Authenticated evidence

- Constructed-term suite: 47 passed on CPython 3.12.13.
- Expanded collection/term/publication run: 90 passed, 2 warnings.
- The stale dynamic-unpack test now requires the improved sole Halted SequenceUnpackRuntimeEffect face: exact true guard and pre-effect state, authenticated unpack operation/arity/site, no Completed sibling, and proof that later store and binding statements did not execute.

Carrier and ExitSet are untouched.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Promote generator payload Sugar classes to ConstructedTermSugar with `to_term` projection
> - Introduces `ConstructedTermSugar` abstract base class in [`sugar_base.py`](https://github.com/TSavo/sugar/pull/6713/files#diff-3ead5a2eda55fc9b3526fc46a51f2813cd3a19dc7e3984c56bf53ee39227559d) with an abstract `to_term(owner)` and a concrete `occurrence_term(owner)` that seals authenticated source-occurrence coordinates into IR terms.
> - Promotes all Sugar payload classes (literals, operators, collections, calls, comprehensions, f-strings, references, etc.) from `Sugar` to `ConstructedTermSugar`, adding `__post_init__` validation and `to_term()` implementations that emit canonical construction IR terms.
> - Tightens field types across generator step dataclasses (`YieldStepV1`, `ReturnStepV1`, `AssignStepV1`, `IfStepV1`, `FinallyStepV1`) in [`generator_construction.py`](https://github.com/TSavo/sugar/pull/6713/files#diff-35db5b3e2bf70dbb9aa1b5a6d30899e84d402ab203905605799dbd5855b1f072) to require `ConstructedTermSugar`, raising `TypeError` at construction for invalid inputs.
> - Updates `_generator_value_testimony` to use `isinstance(value, ConstructedTermSugar)` instead of duck-typing a `to_term` callable; arbitrary objects with `to_term` no longer produce term-cid testimony.
> - Adds test coverage in [`test_constructed_term_sugar.py`](https://github.com/TSavo/sugar/pull/6713/files#diff-d8497d443998ee5dc10c87fca87617ebc657ed83c207c112d48449abcff5ff0e), [`test_bool_op_term.py`](https://github.com/TSavo/sugar/pull/6713/files#diff-f4b5a2f6524fd458048f5689b3aea1e00bd540e0efedaafcb36af21685c1474d), [`test_equality_op_term.py`](https://github.com/TSavo/sugar/pull/6713/files#diff-be48925bd8c58fec1ee9673de3240859f77d89877d49234751da8fa7d8f8df93), and [`test_loop_recurrence_term.py`](https://github.com/TSavo/sugar/pull/6713/files#diff-ce1949e0324b38fb6d8fc801e1042beb0e57613ec8a3a3aebaed107f864c20b4) for term identity, occurrence discrimination, and input validation.
> - Risk: any code passing a plain `Sugar` subclass (or arbitrary object with `to_term`) where a `ConstructedTermSugar` is now expected will raise `TypeError` at construction time instead of failing later.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3ecebb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->