### PR TITLE
Reject mismatched import-use source CID; mint fixtures via path_source

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -839,24 +839,17 @@ def _lexical_revalidation_snapshot(
     return snapshot
 
 
-def _paired_source_cid(source: str, claimed_source_cid: str) -> str:
-    """Content-address of the retained source string (path_source law).
+def _require_source_cid_matches_text(source: str, source_cid: str) -> None:
+    """Refuse dual-door identity at the import-use mint boundary.
 
-    Import-use receipts pin ``source`` + ``source_cid`` together. A dual-door
-    mint — ``read_text()`` for the string and ``blake3(read_bytes())`` for the
-    CID — goes stale under CRLF/universal-newlines translation: the retained
-    source no longer recomputes to the claimed CID, and
-    ``AuthenticatedImportUseV1`` refuses before any nested producer can run.
-
-    The oracle door is one line: CID = blake3(source.encode("utf-8")). When the
-    claim disagrees, repair the pair from the retained source text. This is not
-    a consumer recompute and not a disk re-read — it restores the only identity
-    the lexical pass can honestly authenticate (the text it was given).
+    Claimed ``(source, source_cid)`` must satisfy the path_source law:
+    ``source_cid == blake3(source.encode("utf-8"))``. A mismatched tuple is
+    not repaired — that would rewrite authenticated testimony after minting.
+    Fix the identity at the source door (``path_source`` / oracle triple).
     """
     expected = blake3_512_of(source.encode("utf-8"))
-    if claimed_source_cid != expected:
-        return expected
-    return claimed_source_cid
+    if source_cid != expected:
+        raise ValueError("authenticated import-use source CID is stale")
 
 
 def authenticated_import_uses(
@@ -866,7 +859,7 @@ def authenticated_import_uses(
     source_cid: str,
     module_identities: dict[str, dict[str, Any]] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]]:
-    source_cid = _paired_source_cid(source, source_cid)
+    _require_source_cid_matches_text(source, source_cid)
     module = SourceFile((source, str(path), source_cid)).root
     module_name = module_name_for_path(root, path)
     identities = module_identities or {}
@@ -924,9 +917,8 @@ def authenticated_import_use_receipts(
     module_identities: dict[str, dict[str, Any]] | None = None,
 ) -> tuple[list[AuthenticatedImportUseV1], dict[tuple[int, int, int, int], str]]:
     """Return typed, final-checked receipts from the sole lexical pass."""
-    # Pair before the pass so use-site / demand preimages embed the same CID
-    # AuthenticatedImportUseV1 will require of the retained source.
-    source_cid = _paired_source_cid(source, source_cid)
+    # Refuse mismatched claims here (same boundary as AuthenticatedImportUseV1);
+    # never rewrite source_cid after minting.
     rows, outcomes = authenticated_import_uses(
         root, path, source, source_cid, module_identities=module_identities
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_use_source_cid_pairing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_use_source_cid_pairing.py
@@ -1,131 +1,71 @@
-"""Import-use source CID must pair with retained source text (path_source law).
+"""Import-use source CID must match retained source text — refuse, never repair.
 
-Dual-door identity — ``read_text()`` for the string and ``blake3(read_bytes())``
-for the CID — goes stale under CRLF/universal-newlines translation and aborts
-nested-manager publication before lifecycle. The producer mint repairs the pair
-from the retained source without re-reading disk or weakening authentication.
+Dual-door identity (``read_text`` + ``blake3(read_bytes)``) is a fixture defect.
+``authenticated_import_uses`` rejects a mismatched claimed tuple; it must not
+rewrite the CID downstream of minting.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from sugar_lift_py_tests.import_binding import (
-    _paired_source_cid,
     authenticated_import_use_receipts,
+    authenticated_import_uses,
 )
 from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.source_oracle import path_source
 
 
-def test_paired_source_cid_repairs_dual_door_crlf(tmp_path: Path) -> None:
-    """read_text + blake3(read_bytes) under CRLF must not refuse mint."""
+def test_lying_mismatched_source_cid_is_refused_at_import_use_mint(
+    tmp_path: Path,
+) -> None:
+    """Lying twin: mismatched source text/CID must stay loud at the boundary."""
+    path = tmp_path / "consumer.py"
+    path.write_text("from pkg import f\nx = f()\n", encoding="utf-8")
+    source, _, honest_cid = path_source(str(path))
+    lying_cid = "blake3-512:" + "0" * 128
+    assert lying_cid != honest_cid
+
+    with pytest.raises(ValueError, match="authenticated import-use source CID is stale"):
+        authenticated_import_uses(
+            tmp_path, path, source, lying_cid, module_identities={}
+        )
+
+    with pytest.raises(ValueError, match="authenticated import-use source CID is stale"):
+        authenticated_import_use_receipts(
+            tmp_path, path, source, lying_cid, module_identities={}
+        )
+
+
+def test_dual_door_crlf_claim_is_refused_not_repaired(tmp_path: Path) -> None:
+    """CRLF dual-door claim is refused; production must not normalize the CID."""
     path = tmp_path / "consumer.py"
     path.write_bytes(b"from pkg import f\r\nx = f()\r\n")
-    # Dual-door (the historical nested-manager fixture pattern):
-    source = path.read_text(encoding="utf-8")  # LF after universal newlines
-    claimed = blake3_512_of(path.read_bytes())  # still CRLF bytes
+    # Dual-door anti-pattern (normalized text + byte-derived CID).
+    source = path.read_text(encoding="utf-8")
+    claimed = blake3_512_of(path.read_bytes())
     assert blake3_512_of(source.encode("utf-8")) != claimed
 
-    paired = _paired_source_cid(source, claimed)
-    assert paired == blake3_512_of(source.encode("utf-8"))
-    assert paired != claimed
+    with pytest.raises(ValueError, match="authenticated import-use source CID is stale"):
+        authenticated_import_use_receipts(
+            tmp_path, path, source, claimed, module_identities={}
+        )
 
+
+def test_honest_path_source_triple_mints_receipts(tmp_path: Path) -> None:
+    """Authoritative door: path_source triple is accepted unchanged."""
+    path = tmp_path / "consumer.py"
+    path.write_text("from pkg import f\nx = f()\n", encoding="utf-8")
+    source, locus, source_cid = path_source(str(path))
     receipts, outcomes = authenticated_import_use_receipts(
-        tmp_path, path, source, claimed, module_identities={}
+        tmp_path, path, source, source_cid, module_identities={}
     )
     assert outcomes
     assert receipts
     for receipt in receipts:
-        # Receipt post_init requires source recomputes to source_cid.
+        assert receipt.source_cid == source_cid
         assert blake3_512_of(receipt.source.encode("utf-8")) == receipt.source_cid
-
-
-def test_paired_source_cid_preserves_honest_match() -> None:
-    source = "from pkg import f\nx = f()\n"
-    cid = blake3_512_of(source.encode("utf-8"))
-    assert _paired_source_cid(source, cid) == cid
-
-
-def test_nested_manager_publication_survives_dual_door_consumer_identity(
-    tmp_path: Path,
-) -> None:
-    """Vertical pin: nested publication with dual-door consumer triple.
-
-    Same construction as test_generator_nested_managers._publish identity mint
-    (read_text + blake3(read_bytes)). On CRLF bytes this used to raise
-    ``authenticated import-use source CID is stale`` before nested layers ran.
-    """
-    import csv
-    import importlib.metadata
-
-    from sugar_lift_py_tests.context_manager_resolution import (
-        SourceDerivedGeneratorResourceRefV1,
-        TreeConstructionContextV1,
-    )
-    from sugar_lift_python_source.manager_summary_derivation import (
-        GeneratorBackedLifecycleProtocolV1,
-        populate_source_derived_resource_refs,
-    )
-    from sugar_source_tree.tree import SourceFile
-
-    package = tmp_path / "unprivileged"
-    package.mkdir()
-    helpers = (
-        "from contextlib import contextmanager\r\n"
-        "\r\n"
-        "@contextmanager\r\n"
-        "def inner():\r\n"
-        "    prior = None\r\n"
-        "    yield 'inner'\r\n"
-        "\r\n"
-        "@contextmanager\r\n"
-        "def outer():\r\n"
-        "    with inner():\r\n"
-        "        yield 'outer'\r\n"
-    )
-    (package / "__init__.py").write_bytes(
-        b"from unprivileged.helpers import outer, inner\r\n"
-    )
-    (package / "helpers.py").write_bytes(helpers.encode("utf-8"))
-    metadata = tmp_path / "unprivileged_dist-1.0.dist-info"
-    metadata.mkdir()
-    (metadata / "METADATA").write_bytes(
-        b"Metadata-Version: 2.1\r\nName: unprivileged-dist\r\nVersion: 1.0\r\n"
-    )
-    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
-        writer = csv.writer(stream)
-        for file in (
-            "unprivileged/__init__.py",
-            "unprivileged/helpers.py",
-            "unprivileged_dist-1.0.dist-info/METADATA",
-            "unprivileged_dist-1.0.dist-info/RECORD",
-        ):
-            writer.writerow((file, "", ""))
-    distribution = importlib.metadata.Distribution.at(metadata)
-
-    path = tmp_path / "consumer.py"
-    path.write_bytes(b"from unprivileged import outer\r\nwith outer():\r\n    pass\r\n")
-    # Dual-door identity (do not "fix" by switching to path_source here).
-    text = path.read_text(encoding="utf-8")
-    claimed = blake3_512_of(path.read_bytes())
-    assert blake3_512_of(text.encode("utf-8")) != claimed
-
-    context = TreeConstructionContextV1.for_source_call_construction(
-        workspace_root=str(tmp_path)
-    )
-    tree = SourceFile((text, str(path), claimed), construction_context=context)
-    populate_source_derived_resource_refs(
-        tree,
-        root=tmp_path,
-        path=path,
-        distribution_index={"unprivileged": distribution},
-    )
-    refs = [
-        v
-        for v in context.source_derived_contract_refs.values()
-        if isinstance(v, SourceDerivedGeneratorResourceRefV1)
-    ]
-    assert refs, "nested outer must publish despite dual-door consumer identity"
-    protocol = refs[0].generator_protocol
-    assert isinstance(protocol, GeneratorBackedLifecycleProtocolV1)
-    assert len(protocol.nested_manager_layers) == 1
+    del locus

--- a/implementations/python/sugar-lift-python-source/tests/test_exception_class_testimony_catch.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_exception_class_testimony_catch.py
@@ -16,7 +16,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
-from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
@@ -180,11 +180,7 @@ def test_builtin_valueerror_formal_still_seals_with_class_value(tmp_path: Path):
     )
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
-        (
-            consumer.read_text(encoding="utf-8"),
-            str(consumer),
-            blake3_512_of(consumer.read_bytes()),
-        ),
+        path_source(str(consumer)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_backed_resource_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_backed_resource_publication.py
@@ -20,7 +20,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
-from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.source_oracle import path_source
 from sugar_lift_python_source.manager_protocol_construction import (
     GeneratorBackedManagerProtocolV1,
     ManagerProtocolConstructionGapV1,
@@ -199,7 +199,7 @@ def test_open_still_publishes_neither_generator_ref_nor_native_defs(tmp_path: Pa
     )
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
-        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        path_source(str(path)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(tree, root=tmp_path, path=path)

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_conditional_exit_faces.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_conditional_exit_faces.py
@@ -18,7 +18,8 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceDerivedGeneratorResourceRefV1,
     TreeConstructionContextV1,
 )
-from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.source_oracle import path_source
 from sugar_lift_python_source.manager_summary_derivation import (
     GeneratorBackedLifecycleProtocolV1,
     GeneratorExitHaltFaceV1,
@@ -63,7 +64,7 @@ def _publish(tmp_path: Path, implementation: str):
         workspace_root=str(tmp_path)
     )
     tree = SourceFile(
-        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        path_source(str(path)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_face_general_source_cm_law.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_face_general_source_cm_law.py
@@ -25,7 +25,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceDerivedGeneratorResourceRefV1,
     TreeConstructionContextV1,
 )
-from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.source_oracle import path_source
 from sugar_lift_python_source.manager_summary_derivation import (
     GeneratorBackedLifecycleProtocolV1,
     _project_generator_lifecycle_faces,
@@ -87,7 +87,7 @@ def _publish(tmp_path: Path, consumer: str) -> list:
         workspace_root=str(tmp_path)
     )
     tree = SourceFile(
-        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        path_source(str(path)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_manager_renamed_lifecycle.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_manager_renamed_lifecycle.py
@@ -41,7 +41,7 @@ from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
 from sugar_lift_py_tests.sugar.generator_with_sugar import GeneratorWithSugar
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.with_source_resource_sugar import WithSourceResourceSugar
-from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.source_oracle import path_source
 from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
@@ -173,11 +173,7 @@ def _populate(root: Path, *, shape: _ManagerShape, consumer_source: str, files=N
     consumer.write_text(consumer_source, encoding="utf-8")
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
-        (
-            consumer.read_text(encoding="utf-8"),
-            str(consumer),
-            blake3_512_of(consumer.read_bytes()),
-        ),
+        path_source(str(consumer)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(
@@ -668,11 +664,7 @@ def _populate_multi(root: Path, *, dists: dict, consumer_source: str):
     consumer.write_text(consumer_source, encoding="utf-8")
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
-        (
-            consumer.read_text(encoding="utf-8"),
-            str(consumer),
-            blake3_512_of(consumer.read_bytes()),
-        ),
+        path_source(str(consumer)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_nested_managers.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_nested_managers.py
@@ -46,7 +46,7 @@ from sugar_lift_py_tests.generator_construction import (
     ReturnStepV1,
 )
 from sugar_lift_py_tests.outcome import Complete, Incomplete, outcome_to_exitset
-from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
+from sugar_lift_python_source.canonical import cid_of_json
 from sugar_lift_python_source.manager_protocol_construction import (
     EnteredGeneratorManagerStateV1,
     construct_generator_backed_protocol,
@@ -56,6 +56,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
     GeneratorNestedManagerLayerV1,
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
 
 
@@ -97,7 +98,7 @@ def _publish(tmp_path: Path, implementation: str, consumer: str | None = None):
         workspace_root=str(tmp_path)
     )
     tree = SourceFile(
-        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        path_source(str(path)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_post_yield_exit_halt.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_post_yield_exit_halt.py
@@ -18,13 +18,14 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceDerivedGeneratorResourceRefV1,
     TreeConstructionContextV1,
 )
-from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
+from sugar_lift_python_source.canonical import cid_of_json
 from sugar_lift_python_source.manager_summary_derivation import (
     GeneratorBackedLifecycleProtocolV1,
     GeneratorEnterHaltFaceV1,
     GeneratorExitHaltFaceV1,
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
 
 
@@ -64,7 +65,7 @@ def _publish(tmp_path: Path, implementation: str):
         workspace_root=str(tmp_path)
     )
     tree = SourceFile(
-        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        path_source(str(path)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_enter_halt.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_enter_halt.py
@@ -27,13 +27,14 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceDerivedGeneratorResourceRefV1,
     TreeConstructionContextV1,
 )
-from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
+from sugar_lift_python_source.canonical import cid_of_json
 from sugar_lift_python_source.manager_summary_derivation import (
     GeneratorBackedLifecycleProtocolV1,
     GeneratorEnterHaltFaceV1,
     GeneratorYieldFaceV1,
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
 
 
@@ -74,7 +75,7 @@ def _publish(tmp_path: Path, implementation: str, consumer: str | None = None):
         workspace_root=str(tmp_path)
     )
     tree = SourceFile(
-        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        path_source(str(path)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(

--- a/implementations/python/sugar-lift-python-source/tests/test_option_context_native_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_option_context_native_publication.py
@@ -21,7 +21,6 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
-from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.manager_summary_derivation import (
     _classes_constructed_by_returns,
     _enter_exit_sites_from_class_def,
@@ -29,6 +28,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
     _sole_returned_manager_class,
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
 
 
@@ -68,11 +68,7 @@ def _populate(tmp_path: Path, dist, package: str, consumer_source: str):
     consumer.write_text(consumer_source, encoding="utf-8")
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
-        (
-            consumer.read_text(encoding="utf-8"),
-            str(consumer),
-            blake3_512_of(consumer.read_bytes()),
-        ),
+        path_source(str(consumer)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(
@@ -165,7 +161,7 @@ def test_open_produces_no_source_definition(tmp_path: Path):
     )
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
-        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        path_source(str(path)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
@@ -336,7 +332,6 @@ def test_content_tampered_enter_source_changes_coordinate(tmp_path: Path):
 def test_two_plausible_returned_classes_refuse_first_candidate(tmp_path: Path):
     """Discrimination: two return classes cannot select the first."""
     from sugar_source_tree.nodes import FunctionDef
-    from sugar_lift_python_source.source_oracle import path_source
 
     path = tmp_path / "ambiguous.py"
     path.write_text(
@@ -511,7 +506,7 @@ def test_lying_twin_spelling_without_binding_publishes_nothing(tmp_path: Path):
     )
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
-        (path.read_text(encoding="utf-8"), str(path), blake3_512_of(path.read_bytes())),
+        path_source(str(path)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(tree, root=tmp_path, path=path)

--- a/implementations/python/sugar-lift-python-source/tests/test_renamed_generator_manager_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_renamed_generator_manager_publication.py
@@ -31,7 +31,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
-from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.source_oracle import path_source
 from sugar_lift_python_source.manager_protocol_construction import (
     GeneratorBackedManagerProtocolV1,
 )
@@ -177,11 +177,7 @@ def _populate(root: Path, *, shape: _ManagerShape, consumer_source: str, files=N
     consumer.write_text(consumer_source, encoding="utf-8")
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
-        (
-            consumer.read_text(encoding="utf-8"),
-            str(consumer),
-            blake3_512_of(consumer.read_bytes()),
-        ),
+        path_source(str(consumer)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(
@@ -419,11 +415,7 @@ def test_builtin_open_still_enrolls_nothing(tmp_path: Path):
     )
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile(
-        (
-            path.read_text(encoding="utf-8"),
-            str(path),
-            blake3_512_of(path.read_bytes()),
-        ),
+        path_source(str(path)),
         construction_context=context,
     )
     populate_source_derived_resource_refs(tree, root=tmp_path, path=path)


### PR DESCRIPTION
## Summary

Fix-forward for #6710 advisor post-merge verdict: downstream CID replacement was a doctrine breach. Authenticated import-use must **reject** a mismatched claimed `(source, source_cid)` tuple — never repair testimony after minting.

1. **Production:** removed `_paired_source_cid` repair; `_require_source_cid_matches_text` raises `ValueError("authenticated import-use source CID is stale")` when the claim disagrees with `blake3(source.encode("utf-8"))`.
2. **Fixtures:** manager-test `SourceFile` constructions use `path_source(str(path))` — the authoritative source door (no dual-door `read_text` + `blake3(read_bytes)`).
3. **Lying twin:** mismatched text/CID is refused loud at the mint boundary; dual-door CRLF claim is refused, not repaired.
4. **Nested managers:** publication suite unchanged except for the source door — green through `path_source` is the real semantic movement.

No consumer-side newline normalization. No scan-based reconciliation. Shell deleted: post-mint CID rewrite path.

## Predicted Epsilon R (construction / wall lanes)

n/a — not a construction PR (authentication boundary + fixture door only).

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | no factory/floor change |
| `mandatory_panics` | 0 | refuse stays refuse; fixtures stop feeding dual-door |
| `suppressed_descendants` | 0 | — |
| `typed_effects` | 0 | — |
| `silent` | 0 | floor: must stay 0 |

## Validation

- `test_import_use_source_cid_pairing.py` — lying twin + dual-door refuse + honest path_source mint (3 green)
- `test_generator_nested_managers.py` — nested publication via path_source (7 green)
- Focused manager fixture conversions (pre/post yield halt, conditional exit faces, face CM law, backed resource, renamed publication, option_context, exception class) exercised in the same batch; remaining reds are ambient runtime-authority (cpython-3.12.13 required) or pre-existing codex-2 lifecycle face residuals, not import-use regression.

## Floors preserved

- data_loss=0
- no secret commit
- no test deleted for green (repair tests replaced with refuse twins that name the law)
- silent=0
- authentication boundary stays refuse-only; identity fixed only at the oracle triple

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject mismatched import-use source CID and mint fixtures via `path_source`
> - `_require_source_cid_matches_text` in [`import_binding.py`](https://github.com/TSavo/sugar/pull/6714/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) replaces the old `_paired_source_cid` helper, raising `ValueError('authenticated import-use source CID is stale')` on mismatch instead of silently repairing the CID.
> - `authenticated_import_uses` and `authenticated_import_use_receipts` now propagate this error rather than coercing the caller-supplied `source_cid` to match.
> - Tests in [`test_import_use_source_cid_pairing.py`](https://github.com/TSavo/sugar/pull/6714/files#diff-ba775ee5e830cdec45b8800b8056be70d27a157dd5b33e7cacd770ee5dacffae) are rewritten to assert refusal on stale or CRLF-derived CIDs; prior repair/pairing tests are removed.
> - Across 10 test files in `sugar-lift-python-source`, `SourceFile` construction is simplified by replacing manual `(read_text, path, blake3_512_of(read_bytes))` tuples with `path_source(str(path))`.
> - Risk: callers that previously relied on auto-repair of mismatched `(source, source_cid)` tuples will now receive a `ValueError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1bcda1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->