### PR TITLE
Mint authenticated import value-use receipts for Name/Attribute loads

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -120,6 +120,15 @@ class _ModuleFunctionDef:
 
 _IMPORT_AUTHORITY = object()
 
+# Closed demand-kind admission for AuthenticatedImportUseV1.  Unknown kinds
+# must refuse — there is no fallthrough third surface.
+_ADMITTED_IMPORT_DEMAND_KINDS = frozenset(
+    {
+        "call-contract-demand",
+        "import-value-use-demand",
+    }
+)
+
 
 @dataclass(frozen=True)
 class ImportBindingV1:
@@ -182,18 +191,18 @@ class AuthenticatedImportUseV1:
         ):
             if self.demand.get(key) != value:
                 raise ValueError(f"authenticated demand has stale {key}")
-        # Role-bound surfaces stay disjoint: value-use and call-target cannot
-        # substitute for each other even at a nearby coordinate.
+        # Closed kind admission: exactly two surfaces.  Unknown kinds and
+        # cross-surface relabeling refuse at mint — not by observing output sets.
         demand_kind = self.demand.get("kind")
+        if demand_kind not in _ADMITTED_IMPORT_DEMAND_KINDS:
+            raise ValueError(
+                f"authenticated import demand has unadmitted kind {demand_kind!r}"
+            )
         if demand_kind == "import-value-use-demand":
             _require_value_use_role(self)
-        elif demand_kind == "call-contract-demand":
-            if self.use.get("role") == "value-use" or self.demand.get("role") == (
-                "value-use"
-            ):
-                raise ValueError(
-                    "call-contract-demand cannot carry value-use role"
-                )
+        else:
+            # call-contract-demand — closed call shape only.
+            _require_call_contract_demand(self)
 
     def revalidate(self) -> None:
         """Demand byte identity against one shared #6090 snapshot per module.
@@ -240,19 +249,71 @@ class AuthenticatedImportUseV1:
             )
 
 
+def _authenticated_binding_target_symbol(binding: ImportBindingV1) -> str:
+    """Closed target coordinate of an authenticated import binding.
+
+    Recovered only from the binding preimage (module identity + binding
+    exportedPath) — never from the receipt's targetSymbol string.
+    """
+    value = binding.to_value()
+    if value.get("kind") != "python-import-binding":
+        raise ValueError("authenticated import binding has the wrong kind")
+    target = value.get("target")
+    if not isinstance(target, dict):
+        raise ValueError("authenticated import binding target is missing")
+    identity = target.get("moduleIdentity")
+    if not isinstance(identity, dict):
+        raise ValueError("authenticated import binding module identity is missing")
+    kind = identity.get("kind")
+    if kind == "unavailable-python-module":
+        module_name = identity.get("name")
+    elif kind == "authenticated-python-module":
+        module_name = identity.get("moduleName")
+    else:
+        raise ValueError(
+            "authenticated import binding module identity kind is unsupported"
+        )
+    if not isinstance(module_name, str) or not module_name:
+        raise ValueError("authenticated import binding module name is invalid")
+    path = target.get("exportedPath")
+    if not isinstance(path, list) or any(
+        not isinstance(part, str) or not part for part in path
+    ):
+        raise ValueError("authenticated import binding exportedPath is invalid")
+    return "python:" + module_name + "".join(f".{part}" for part in path)
+
+
+def _require_call_contract_demand(receipt: AuthenticatedImportUseV1) -> None:
+    """Final-check a call-target demand: closed shape, no value-use fields."""
+    use = receipt.use
+    demand = receipt.demand
+    if use.get("role") == "value-use" or demand.get("role") == "value-use":
+        raise ValueError("call-contract-demand cannot carry value-use role")
+    if "role" in use or "role" in demand:
+        raise ValueError("call-contract-demand cannot carry a use role")
+    if "exportedMemberPath" in use or "exportedMemberPath" in demand:
+        raise ValueError("call-contract-demand cannot carry exportedMemberPath")
+    if "sourceCid" in use:
+        raise ValueError("call-contract-demand use cannot carry sourceCid")
+    if demand.get("importSignature") is None:
+        raise ValueError("call-contract-demand requires importSignature")
+
+
 def _require_value_use_role(receipt: AuthenticatedImportUseV1) -> None:
     """Final-check the value-use role and its bound identity fields.
 
     A value-use receipt authenticates together: exact source occurrence,
     import binding CID, exported member path, consumer source CID, and the
-    value-use role.  Missing any field, or borrowing a call-target shape, is
-    refusal — not repair.  No AST-scan fallback, first-candidate, or spelling
-    resolver may reconstruct what the lexical pass did not pin.
+    value-use role.  ``targetSymbol`` must equal the authenticated binding
+    target composed with structural ``exportedMemberPath`` exactly — suffix
+    checks are not enough (a forged head can endswith the same path).
     """
     use = receipt.use
     demand = receipt.demand
     if use.get("role") != "value-use" or demand.get("role") != "value-use":
         raise ValueError("import-value-use-demand requires value-use role")
+    if "importSignature" in demand:
+        raise ValueError("import-value-use-demand cannot carry importSignature")
     if use.get("sourceCid") != receipt.source_cid:
         raise ValueError("authenticated import value-use sourceCid is stale")
     if demand.get("sourceCid") != receipt.source_cid:
@@ -276,21 +337,15 @@ def _require_value_use_role(receipt: AuthenticatedImportUseV1) -> None:
         raise ValueError("authenticated import value-use binding sourceCid is stale")
     if use.get("importBindingCid") != receipt.import_binding.cid:
         raise ValueError("authenticated import value-use cites another binding")
-    # Composition law: targetSymbol is binding head + structural Attribute
-    # segments only (exportedMemberPath), never a spelling-resolved rewrite.
-    target = receipt.target_symbol
-    if exported:
-        suffix = "".join(f".{part}" for part in exported)
-        if not target.endswith(suffix):
-            raise ValueError(
-                "authenticated import value-use targetSymbol disagrees with "
-                "exportedMemberPath"
-            )
-        head = target[: -len(suffix)]
-    else:
-        head = target
-    if not head.startswith("python:") or head == "python:":
-        raise ValueError("authenticated import value-use targetSymbol is incomplete")
+    # Exact composition: binding target (from binding preimage only) + structural
+    # Attribute segments.  endswith(exportedMemberPath) is not authentication.
+    binding_target = _authenticated_binding_target_symbol(receipt.import_binding)
+    expected = binding_target + "".join(f".{part}" for part in exported)
+    if receipt.target_symbol != expected:
+        raise ValueError(
+            "authenticated import value-use targetSymbol disagrees with "
+            "binding target and exportedMemberPath"
+        )
 
 
 _NON_IMPORT = "non-import"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -1,8 +1,15 @@
-"""Non-constructing lexical authentication for imported call uses.
+"""Non-constructing lexical authentication for imported uses.
 
 This pass owns only Python def-use.  It never imports a module, opens a target
 module, or constructs Sugar.  Its output is the source-authenticated half of
 the import-to-contract bridge protocol.
+
+Two receipt faces share one reaching-definition walk:
+
+- **Call targets** — ``authenticated_import_use_receipts`` (existing).
+- **Value occurrences** — ``authenticated_import_value_use_receipts`` for
+  source-visible imported ``Name`` and ``Attribute`` loads (caller actuals,
+  helper identity operands).  Call-target rows stay a separate surface.
 """
 
 from __future__ import annotations
@@ -180,17 +187,13 @@ class AuthenticatedImportUseV1:
         """Demand byte identity against one shared #6090 snapshot per module.
 
         Full-module lexical recompute is amortized: many receipts from one
-        consumer module share one ``authenticated_import_uses`` pass.  Byte
-        identity is unchanged — only recompute frequency (see
+        consumer module share one lexical pass.  Byte identity is unchanged —
+        only recompute frequency (see
         docs/audits/pandas-recensus-latency-bisect.md).
+
+        Call-target and value-use demands revalidate against their own
+        row/outcome surfaces so Call receipts stay unchanged.
         """
-        snapshot = _lexical_revalidation_snapshot(
-            self.root,
-            self.path,
-            self.source,
-            self.source_cid,
-            self.module_identities,
-        )
         site = self.use["useSite"]
         key = (
             site["startLine"],
@@ -198,7 +201,25 @@ class AuthenticatedImportUseV1:
             site["endLine"],
             site["endCol"],
         )
-        if snapshot.outcome_at(key) != "authenticated-import-use" or not (
+        if self.demand.get("kind") == "import-value-use-demand":
+            snapshot = _lexical_value_revalidation_snapshot(
+                self.root,
+                self.path,
+                self.source,
+                self.source_cid,
+                self.module_identities,
+            )
+            expected = "authenticated-import-value-use"
+        else:
+            snapshot = _lexical_revalidation_snapshot(
+                self.root,
+                self.path,
+                self.source,
+                self.source_cid,
+                self.module_identities,
+            )
+            expected = "authenticated-import-use"
+        if snapshot.outcome_at(key) != expected or not (
             snapshot.contains_row(self.demand)
         ):
             raise ValueError(
@@ -299,6 +320,9 @@ class _Pass:
         self.module_identities = module_identities
         self.rows: list[dict[str, Any]] = []
         self.outcomes: dict[tuple[int, int, int, int], str] = {}
+        # Value-occurrence rows (Name / Attribute loads), separate from Call.
+        self.value_rows: list[dict[str, Any]] = []
+        self.value_outcomes: dict[tuple[int, int, int, int], str] = {}
         # Per-occurrence import targets for NAME uses, from this same pass.
         self.name_targets: dict[tuple[int, int, int, int], str] = {}
         self.module_state = module_state or {}
@@ -349,14 +373,26 @@ class _Pass:
             # path; the ImportDef is still the only source-visible binding.
             # Recorded here by the same reaching-definition state the call rows
             # use -- never by a second resolver and never by spelling.
-            reaching = state.get(node.id, frozenset({_UNBOUND}))
-            imports = {value for value in reaching if isinstance(value, _ImportDef)}
-            if len(imports) == 1 and not (reaching - imports - {_UNBOUND}):
-                definition = next(iter(imports))
+            binding = self._unique_import_def(node.id, state, allow_unbound=True)
+            if binding is not None:
                 span = node.line_col_span()
                 self.name_targets[
                     (span.start_line, span.start_col, span.end_line, span.end_col)
-                ] = definition.target_symbol
+                ] = binding.target_symbol
+                self._enroll_value_use(node, binding, ())
+            return
+        if node.kind == "Attribute":
+            # Value occurrence of ``head.attr...`` when head is import-bound.
+            # Recurse first so nested Attribute / Name loads enroll too.
+            self.expression(node.value, state, scope)
+            path = self._attribute_export_path(node)
+            if path is not None:
+                local_name, exported_path = path
+                binding = self._unique_import_def(
+                    local_name, state, allow_unbound=False
+                )
+                if binding is not None:
+                    self._enroll_value_use(node, binding, exported_path)
             return
         if node.kind == "Call":
             self.expression(node.func, state, scope)
@@ -395,6 +431,64 @@ class _Pass:
         for _, _, child in node.children():
             if isinstance(child, Expression):
                 self.expression(child, state, scope)
+
+    def _unique_import_def(
+        self, local_name: str, state: State, *, allow_unbound: bool
+    ) -> _ImportDef | None:
+        reaching = state.get(local_name, frozenset({_UNBOUND}))
+        imports = {value for value in reaching if isinstance(value, _ImportDef)}
+        if len(imports) != 1:
+            return None
+        rest = reaching - imports
+        if allow_unbound:
+            rest = rest - {_UNBOUND}
+        if rest:
+            return None
+        return next(iter(imports))
+
+    @staticmethod
+    def _attribute_export_path(
+        node: Node,
+    ) -> tuple[str, tuple[str, ...]] | None:
+        """``(local_name, exported_path)`` for an Attribute chain to a Name."""
+        attrs: list[str] = []
+        link = node
+        while link.kind == "Attribute":
+            attrs.append(link.attr)
+            link = link.value
+        if link.kind != "Name":
+            return None
+        return link.id, tuple(reversed(attrs))
+
+    def _enroll_value_use(
+        self,
+        node: Node,
+        binding: _ImportDef,
+        exported_path: tuple[str, ...],
+    ) -> None:
+        """Final-checked value-occurrence row at the exact Name/Attribute site."""
+        span = node.line_col_span()
+        key = (span.start_line, span.start_col, span.end_line, span.end_col)
+        self.value_outcomes[key] = "authenticated-import-value-use"
+        use_site = _site(self.source_cid, node)
+        use = {
+            "kind": "authenticated-import-use",
+            "schemaVersion": "1",
+            "useSite": use_site,
+            "importBindingCid": binding.cid,
+        }
+        self.value_rows.append(
+            {
+                "schemaVersion": "1",
+                "kind": "import-value-use-demand",
+                "authenticatedImportUse": {**use, "cid": _hash(use)},
+                "importBinding": json.loads(binding.payload_jcs),
+                "targetSymbol": binding.target_symbol
+                + "".join(f".{part}" for part in exported_path),
+                "importBindingCid": binding.cid,
+                "useSite": use_site,
+            }
+        )
 
     def _call(self, node: Node, state: State, scope: Node) -> None:
         if node.func.kind == "Name":
@@ -800,11 +894,29 @@ class _LexicalRevalidationSnapshotV1:
 _REVALIDATION_SNAPSHOTS: dict[
     tuple[str, str, str, str], _LexicalRevalidationSnapshotV1
 ] = {}
+_VALUE_REVALIDATION_SNAPSHOTS: dict[
+    tuple[str, str, str, str], _LexicalRevalidationSnapshotV1
+] = {}
 
 
 def clear_lexical_revalidation_snapshots() -> None:
     """Drop amortized revalidation snapshots (tests / hermetic process reuse)."""
     _REVALIDATION_SNAPSHOTS.clear()
+    _VALUE_REVALIDATION_SNAPSHOTS.clear()
+
+
+def _revalidation_cache_key(
+    root: Path,
+    path: Path,
+    source_cid: str,
+    module_identities: dict[str, dict[str, Any]],
+) -> tuple[str, str, str, str]:
+    return (
+        str(root.resolve()),
+        str(path.resolve()),
+        source_cid,
+        _hash(module_identities),
+    )
 
 
 def _lexical_revalidation_snapshot(
@@ -814,13 +926,8 @@ def _lexical_revalidation_snapshot(
     source_cid: str,
     module_identities: dict[str, dict[str, Any]],
 ) -> _LexicalRevalidationSnapshotV1:
-    """One full-module #6090 pass per consumer module for revalidation."""
-    cache_key = (
-        str(root.resolve()),
-        str(path.resolve()),
-        source_cid,
-        _hash(module_identities),
-    )
+    """One full-module call-use pass per consumer module for revalidation."""
+    cache_key = _revalidation_cache_key(root, path, source_cid, module_identities)
     hit = _REVALIDATION_SNAPSHOTS.get(cache_key)
     if hit is not None:
         return hit
@@ -839,6 +946,33 @@ def _lexical_revalidation_snapshot(
     return snapshot
 
 
+def _lexical_value_revalidation_snapshot(
+    root: Path,
+    path: Path,
+    source: str,
+    source_cid: str,
+    module_identities: dict[str, dict[str, Any]],
+) -> _LexicalRevalidationSnapshotV1:
+    """One full-module value-use pass per consumer module for revalidation."""
+    cache_key = _revalidation_cache_key(root, path, source_cid, module_identities)
+    hit = _VALUE_REVALIDATION_SNAPSHOTS.get(cache_key)
+    if hit is not None:
+        return hit
+    rows, outcomes = authenticated_import_value_uses(
+        root,
+        path,
+        source,
+        source_cid,
+        module_identities=module_identities,
+    )
+    snapshot = _LexicalRevalidationSnapshotV1(
+        row_cids=frozenset(_hash(row) for row in rows),
+        outcomes=MappingProxyType(dict(outcomes)),
+    )
+    _VALUE_REVALIDATION_SNAPSHOTS[cache_key] = snapshot
+    return snapshot
+
+
 def _require_source_cid_matches_text(source: str, source_cid: str) -> None:
     """Refuse dual-door identity at the import-use mint boundary.
 
@@ -852,13 +986,14 @@ def _require_source_cid_matches_text(source: str, source_cid: str) -> None:
         raise ValueError("authenticated import-use source CID is stale")
 
 
-def authenticated_import_uses(
+def _run_lexical_import_pass(
     root: Path,
     path: Path,
     source: str,
     source_cid: str,
     module_identities: dict[str, dict[str, Any]] | None = None,
-) -> tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]]:
+) -> _Pass:
+    """One reaching-definition walk: call rows, value rows, and name targets."""
     _require_source_cid_matches_text(source, source_cid)
     module = SourceFile((source, str(path), source_cid)).root
     module_name = module_name_for_path(root, path)
@@ -876,7 +1011,38 @@ def authenticated_import_uses(
         module_state=module_state,
     )
     runner.statements(module.body, {}, module)
+    return runner
+
+
+def authenticated_import_uses(
+    root: Path,
+    path: Path,
+    source: str,
+    source_cid: str,
+    module_identities: dict[str, dict[str, Any]] | None = None,
+) -> tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]]:
+    runner = _run_lexical_import_pass(
+        root, path, source, source_cid, module_identities
+    )
     return runner.rows, runner.outcomes
+
+
+def authenticated_import_value_uses(
+    root: Path,
+    path: Path,
+    source: str,
+    source_cid: str,
+    module_identities: dict[str, dict[str, Any]] | None = None,
+) -> tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]]:
+    """Raw value-occurrence rows for imported Name and Attribute loads.
+
+    Same lexical pass as call uses; separate row surface so Call-target
+    receipts stay byte-identical.
+    """
+    runner = _run_lexical_import_pass(
+        root, path, source, source_cid, module_identities
+    )
+    return runner.value_rows, runner.value_outcomes
 
 
 def import_bound_name_targets(
@@ -909,19 +1075,15 @@ def import_bound_name_targets(
     return dict(runner.name_targets)
 
 
-def authenticated_import_use_receipts(
+def _mint_import_use_receipts(
+    rows: list[dict[str, Any]],
+    *,
     root: Path,
     path: Path,
     source: str,
     source_cid: str,
-    module_identities: dict[str, dict[str, Any]] | None = None,
-) -> tuple[list[AuthenticatedImportUseV1], dict[tuple[int, int, int, int], str]]:
-    """Return typed, final-checked receipts from the sole lexical pass."""
-    # Refuse mismatched claims here (same boundary as AuthenticatedImportUseV1);
-    # never rewrite source_cid after minting.
-    rows, outcomes = authenticated_import_uses(
-        root, path, source, source_cid, module_identities=module_identities
-    )
+    module_identities: dict[str, dict[str, Any]] | None,
+) -> list[AuthenticatedImportUseV1]:
     receipts: list[AuthenticatedImportUseV1] = []
     for row in rows:
         binding_value = row["importBinding"]
@@ -942,7 +1104,63 @@ def authenticated_import_use_receipts(
                 _authority=_IMPORT_AUTHORITY,
             )
         )
-    return receipts, outcomes
+    return receipts
+
+
+def authenticated_import_use_receipts(
+    root: Path,
+    path: Path,
+    source: str,
+    source_cid: str,
+    module_identities: dict[str, dict[str, Any]] | None = None,
+) -> tuple[list[AuthenticatedImportUseV1], dict[tuple[int, int, int, int], str]]:
+    """Return typed, final-checked Call-target receipts from the lexical pass."""
+    # Refuse mismatched claims here (same boundary as AuthenticatedImportUseV1);
+    # never rewrite source_cid after minting.
+    rows, outcomes = authenticated_import_uses(
+        root, path, source, source_cid, module_identities=module_identities
+    )
+    return (
+        _mint_import_use_receipts(
+            rows,
+            root=root,
+            path=path,
+            source=source,
+            source_cid=source_cid,
+            module_identities=module_identities,
+        ),
+        outcomes,
+    )
+
+
+def authenticated_import_value_use_receipts(
+    root: Path,
+    path: Path,
+    source: str,
+    source_cid: str,
+    module_identities: dict[str, dict[str, Any]] | None = None,
+) -> tuple[list[AuthenticatedImportUseV1], dict[tuple[int, int, int, int], str]]:
+    """Final-checked receipts for imported Name and Attribute value occurrences.
+
+    Exact-coordinate rows so preconstruction can resolve caller actuals and
+    helper identity operands to authenticated object CIDs without spelling
+    authority.  Call-target receipts remain on
+    ``authenticated_import_use_receipts`` unchanged.
+    """
+    rows, outcomes = authenticated_import_value_uses(
+        root, path, source, source_cid, module_identities=module_identities
+    )
+    return (
+        _mint_import_use_receipts(
+            rows,
+            root=root,
+            path=path,
+            source=source,
+            source_cid=source_cid,
+            module_identities=module_identities,
+        ),
+        outcomes,
+    )
 
 
 def authenticated_module_exports(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -182,6 +182,18 @@ class AuthenticatedImportUseV1:
         ):
             if self.demand.get(key) != value:
                 raise ValueError(f"authenticated demand has stale {key}")
+        # Role-bound surfaces stay disjoint: value-use and call-target cannot
+        # substitute for each other even at a nearby coordinate.
+        demand_kind = self.demand.get("kind")
+        if demand_kind == "import-value-use-demand":
+            _require_value_use_role(self)
+        elif demand_kind == "call-contract-demand":
+            if self.use.get("role") == "value-use" or self.demand.get("role") == (
+                "value-use"
+            ):
+                raise ValueError(
+                    "call-contract-demand cannot carry value-use role"
+                )
 
     def revalidate(self) -> None:
         """Demand byte identity against one shared #6090 snapshot per module.
@@ -192,7 +204,8 @@ class AuthenticatedImportUseV1:
         docs/audits/pandas-recensus-latency-bisect.md).
 
         Call-target and value-use demands revalidate against their own
-        row/outcome surfaces so Call receipts stay unchanged.
+        row/outcome surfaces so Call receipts stay unchanged and neither
+        surface can authorize the other.
         """
         site = self.use["useSite"]
         key = (
@@ -225,6 +238,59 @@ class AuthenticatedImportUseV1:
             raise ValueError(
                 "authenticated import use is not byte-identical to lexical revalidation"
             )
+
+
+def _require_value_use_role(receipt: AuthenticatedImportUseV1) -> None:
+    """Final-check the value-use role and its bound identity fields.
+
+    A value-use receipt authenticates together: exact source occurrence,
+    import binding CID, exported member path, consumer source CID, and the
+    value-use role.  Missing any field, or borrowing a call-target shape, is
+    refusal — not repair.  No AST-scan fallback, first-candidate, or spelling
+    resolver may reconstruct what the lexical pass did not pin.
+    """
+    use = receipt.use
+    demand = receipt.demand
+    if use.get("role") != "value-use" or demand.get("role") != "value-use":
+        raise ValueError("import-value-use-demand requires value-use role")
+    if use.get("sourceCid") != receipt.source_cid:
+        raise ValueError("authenticated import value-use sourceCid is stale")
+    if demand.get("sourceCid") != receipt.source_cid:
+        raise ValueError("authenticated import value-use demand sourceCid is stale")
+    site = use.get("useSite")
+    if not isinstance(site, dict) or site.get("sourceCid") != receipt.source_cid:
+        raise ValueError("authenticated import value-use site sourceCid is stale")
+    if demand.get("useSite") != site:
+        raise ValueError("authenticated import value-use demand has stale useSite")
+    exported = use.get("exportedMemberPath")
+    if not isinstance(exported, list) or any(
+        not isinstance(part, str) or not part for part in exported
+    ):
+        raise ValueError("authenticated import value-use exportedMemberPath is invalid")
+    if demand.get("exportedMemberPath") != exported:
+        raise ValueError(
+            "authenticated import value-use demand has stale exportedMemberPath"
+        )
+    binding = receipt.import_binding.to_value()
+    if binding.get("sourceCid") != receipt.source_cid:
+        raise ValueError("authenticated import value-use binding sourceCid is stale")
+    if use.get("importBindingCid") != receipt.import_binding.cid:
+        raise ValueError("authenticated import value-use cites another binding")
+    # Composition law: targetSymbol is binding head + structural Attribute
+    # segments only (exportedMemberPath), never a spelling-resolved rewrite.
+    target = receipt.target_symbol
+    if exported:
+        suffix = "".join(f".{part}" for part in exported)
+        if not target.endswith(suffix):
+            raise ValueError(
+                "authenticated import value-use targetSymbol disagrees with "
+                "exportedMemberPath"
+            )
+        head = target[: -len(suffix)]
+    else:
+        head = target
+    if not head.startswith("python:") or head == "python:":
+        raise ValueError("authenticated import value-use targetSymbol is incomplete")
 
 
 _NON_IMPORT = "non-import"
@@ -370,20 +436,29 @@ class _Pass:
             # A name USE whose sole concrete reaching definition is an import
             # statement is lexically bound to that import's target coordinate.
             # Optional try/import joins ImportDef with unbound on the except
-            # path; the ImportDef is still the only source-visible binding.
-            # Recorded here by the same reaching-definition state the call rows
-            # use -- never by a second resolver and never by spelling.
-            binding = self._unique_import_def(node.id, state, allow_unbound=True)
-            if binding is not None:
+            # path; the ImportDef is still the only source-visible binding for
+            # name_targets (closed-coordinate projection).  Value-use receipts
+            # are stricter: unique ImportDef only — shadowing, reassignment,
+            # unbound join, and wildcard ambiguity do not authorize a value.
+            name_binding = self._unique_import_def(
+                node.id, state, allow_unbound=True
+            )
+            if name_binding is not None:
                 span = node.line_col_span()
                 self.name_targets[
                     (span.start_line, span.start_col, span.end_line, span.end_col)
-                ] = binding.target_symbol
-                self._enroll_value_use(node, binding, ())
+                ] = name_binding.target_symbol
+            value_binding = self._unique_import_def(
+                node.id, state, allow_unbound=False
+            )
+            if value_binding is not None:
+                self._enroll_value_use(node, value_binding, ())
             return
         if node.kind == "Attribute":
-            # Value occurrence of ``head.attr...`` when head is import-bound.
-            # Recurse first so nested Attribute / Name loads enroll too.
+            # Value occurrence of ``head.attr...`` when head is uniquely
+            # import-bound.  Recurse first so each chained Attribute keeps its
+            # own exact coordinate; exportedMemberPath is structural Attribute
+            # segments only — never spelling resolution or first-candidate.
             self.expression(node.value, state, scope)
             path = self._attribute_export_path(node)
             if path is not None:
@@ -466,25 +541,37 @@ class _Pass:
         binding: _ImportDef,
         exported_path: tuple[str, ...],
     ) -> None:
-        """Final-checked value-occurrence row at the exact Name/Attribute site."""
+        """Final-checked value-occurrence row at the exact Name/Attribute site.
+
+        Authenticates together: exact occurrence (useSite), import binding,
+        structural exported member path, consumer sourceCid, and value-use role.
+        Call-target enrollment is a separate row surface; sets stay disjoint.
+        """
         span = node.line_col_span()
         key = (span.start_line, span.start_col, span.end_line, span.end_col)
         self.value_outcomes[key] = "authenticated-import-value-use"
         use_site = _site(self.source_cid, node)
+        member_path = list(exported_path)
         use = {
             "kind": "authenticated-import-use",
             "schemaVersion": "1",
+            "role": "value-use",
+            "sourceCid": self.source_cid,
             "useSite": use_site,
             "importBindingCid": binding.cid,
+            "exportedMemberPath": member_path,
         }
         self.value_rows.append(
             {
                 "schemaVersion": "1",
                 "kind": "import-value-use-demand",
+                "role": "value-use",
+                "sourceCid": self.source_cid,
                 "authenticatedImportUse": {**use, "cid": _hash(use)},
                 "importBinding": json.loads(binding.payload_jcs),
                 "targetSymbol": binding.target_symbol
                 + "".join(f".{part}" for part in exported_path),
+                "exportedMemberPath": member_path,
                 "importBindingCid": binding.cid,
                 "useSite": use_site,
             }

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
@@ -267,82 +267,156 @@ def test_nearby_call_receipt_does_not_authorize_value_use(tmp_path: Path) -> Non
         assert _site_key(value) != call_key
 
 
-def test_call_receipt_cannot_substitute_for_value_use(tmp_path: Path) -> None:
-    """Lying twin: minting a value-use demand from a call row is refused."""
-    path = tmp_path / "sub_call.py"
-    source, source_cid = _write(path, "from pkg import f\nf(1)\n")
-    call_receipts, _ = authenticated_import_use_receipts(
+def test_value_relabeled_as_call_contract_refused_with_real_authority(
+    tmp_path: Path,
+) -> None:
+    """Lying twin: value receipt → call-contract-demand (roles stripped, CID recomputed).
+
+    Must refuse under real mint authority — observing output-set disjointness
+    is not enough; substitution is attempted at __post_init__.
+    """
+    from sugar_lift_py_tests import import_binding as ib
+
+    path = tmp_path / "sub_value_as_call.py"
+    source, source_cid = _write(path, "from pkg import f\nx = f\n")
+    value_receipts, _ = authenticated_import_value_use_receipts(
         tmp_path, path, source, source_cid, module_identities={}
     )
-    call = call_receipts[0]
-    # Strip call-only fields and claim value-use role — must not mint.
+    value = value_receipts[0]
+    # Strip value-only fields; recompute use CID — the advisor hole shape.
     forged_use = {
-        key: value
-        for key, value in call.use.items()
-        if key != "cid"
+        key: val
+        for key, val in value.use.items()
+        if key not in {"cid", "role", "sourceCid", "exportedMemberPath"}
     }
-    forged_use["role"] = "value-use"
-    forged_use["sourceCid"] = source_cid
-    forged_use["exportedMemberPath"] = []
-    from sugar_lift_py_tests.import_binding import _hash
-
-    forged_use_with_cid = {**forged_use, "cid": _hash(forged_use)}
+    forged_use_cid = {**forged_use, "cid": ib._hash(forged_use)}
     forged_demand = {
-        "schemaVersion": "1",
-        "kind": "import-value-use-demand",
-        "role": "value-use",
-        "sourceCid": source_cid,
-        "authenticatedImportUse": forged_use_with_cid,
-        "importBinding": call.import_binding.to_value(),
-        "targetSymbol": call.target_symbol,
-        "exportedMemberPath": [],
-        "importBindingCid": call.import_binding.cid,
-        "useSite": call.use["useSite"],
+        key: val
+        for key, val in value.demand.items()
+        if key
+        not in {
+            "role",
+            "sourceCid",
+            "exportedMemberPath",
+            "authenticatedImportUse",
+            "kind",
+        }
     }
-    # Authority token is private — public construction without mint authority fails.
-    with pytest.raises(ValueError, match="not minted by the lexical pass"):
+    forged_demand["kind"] = "call-contract-demand"
+    forged_demand["authenticatedImportUse"] = forged_use_cid
+    # No importSignature added — pure relabel of a value receipt.
+    with pytest.raises(ValueError, match="requires importSignature|unadmitted kind"):
         AuthenticatedImportUseV1(
-            import_binding=call.import_binding,
-            target_symbol=call.target_symbol,
-            use=forged_use_with_cid,
+            import_binding=value.import_binding,
+            target_symbol=value.target_symbol,
+            use=forged_use_cid,
             demand=forged_demand,
             root=tmp_path,
             path=path,
             source=source,
             source_cid=source_cid,
             module_identities={},
-            _authority=object(),
+            _authority=ib._IMPORT_AUTHORITY,
         )
-    # Even with the real binding, value revalidation does not contain the call row.
-    call.revalidate()
-    value_receipts, value_outcomes = authenticated_import_value_use_receipts(
+
+
+def test_call_relabeled_as_value_use_refused_with_real_authority(
+    tmp_path: Path,
+) -> None:
+    """Lying twin: call receipt → import-value-use-demand without value role fields."""
+    from sugar_lift_py_tests import import_binding as ib
+
+    path = tmp_path / "sub_call_as_value.py"
+    source, source_cid = _write(path, "from pkg import f\nf(1)\n")
+    call_receipts, _ = authenticated_import_use_receipts(
         tmp_path, path, source, source_cid, module_identities={}
     )
-    assert _site_key(call) not in value_outcomes
-    assert all(r.demand != call.demand for r in value_receipts)
+    call = call_receipts[0]
+    forged_demand = dict(call.demand)
+    forged_demand["kind"] = "import-value-use-demand"
+    # Keep call use shape (no role / exportedMemberPath / sourceCid on use).
+    with pytest.raises(ValueError, match="requires value-use role"):
+        AuthenticatedImportUseV1(
+            import_binding=call.import_binding,
+            target_symbol=call.target_symbol,
+            use=call.use,
+            demand=forged_demand,
+            root=tmp_path,
+            path=path,
+            source=source,
+            source_cid=source_cid,
+            module_identities={},
+            _authority=ib._IMPORT_AUTHORITY,
+        )
 
 
-def test_value_receipt_cannot_substitute_for_call_target(tmp_path: Path) -> None:
-    """Lying twin: a value-use receipt is not a call-contract demand."""
-    path = tmp_path / "sub_value.py"
+def test_forged_binding_head_with_real_authority_refused(tmp_path: Path) -> None:
+    """Lying twin: targetSymbol head forged; real binding CID + path still refuse.
+
+    endswith(exportedMemberPath) would accept python:other.box_expected with a
+    binding for python:pkg — exact composition must not.
+    """
+    from sugar_lift_py_tests import import_binding as ib
+
+    path = tmp_path / "forge_head.py"
+    source, source_cid = _write(
+        path,
+        "import pkg as tm\nactual = tm.box_expected\n",
+    )
+    receipts, _ = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    attr = [r for r in receipts if r.target_symbol == "python:pkg.box_expected"]
+    assert len(attr) == 1
+    honest = attr[0]
+    # Change only the binding head in targetSymbol; keep real binding + path.
+    forged_target = "python:other.box_expected"
+    assert forged_target.endswith(".box_expected")
+    assert forged_target != honest.target_symbol
+    forged_demand = dict(honest.demand)
+    forged_demand["targetSymbol"] = forged_target
+    with pytest.raises(
+        ValueError,
+        match="targetSymbol disagrees with binding target and exportedMemberPath",
+    ):
+        AuthenticatedImportUseV1(
+            import_binding=honest.import_binding,
+            target_symbol=forged_target,
+            use=honest.use,
+            demand=forged_demand,
+            root=tmp_path,
+            path=path,
+            source=source,
+            source_cid=source_cid,
+            module_identities={},
+            _authority=ib._IMPORT_AUTHORITY,
+        )
+
+
+def test_unadmitted_demand_kind_refused_with_real_authority(tmp_path: Path) -> None:
+    """Unknown demand kinds fall through no longer — closed admission only."""
+    from sugar_lift_py_tests import import_binding as ib
+
+    path = tmp_path / "unknown_kind.py"
     source, source_cid = _write(path, "from pkg import f\nx = f\n")
-    value_receipts, value_outcomes = authenticated_import_value_use_receipts(
+    value = authenticated_import_value_use_receipts(
         tmp_path, path, source, source_cid, module_identities={}
-    )
-    call_receipts, call_outcomes = authenticated_import_use_receipts(
-        tmp_path, path, source, source_cid, module_identities={}
-    )
-    assert value_receipts
-    assert call_receipts == []
-    value = value_receipts[0]
-    value_key = _site_key(value)
-    assert value_key in value_outcomes
-    assert value_key not in call_outcomes
-    assert value.demand["kind"] == "import-value-use-demand"
-    assert value.use["role"] == "value-use"
-    # Call surface has no receipt for a pure value load.
-    assert all(r.demand["kind"] != "import-value-use-demand" for r in call_receipts)
-    value.revalidate()
+    )[0][0]
+    forged_demand = dict(value.demand)
+    forged_demand["kind"] = "forged-third-surface-demand"
+    with pytest.raises(ValueError, match="unadmitted kind"):
+        AuthenticatedImportUseV1(
+            import_binding=value.import_binding,
+            target_symbol=value.target_symbol,
+            use=value.use,
+            demand=forged_demand,
+            root=tmp_path,
+            path=path,
+            source=source,
+            source_cid=source_cid,
+            module_identities={},
+            _authority=ib._IMPORT_AUTHORITY,
+        )
 
 
 def test_forged_value_role_on_call_shape_is_refused_at_mint(tmp_path: Path) -> None:
@@ -361,7 +435,7 @@ def test_forged_value_role_on_call_shape_is_refused_at_mint(tmp_path: Path) -> N
     forged_demand = dict(call.demand)
     forged_demand["authenticatedImportUse"] = forged_use_cid
     forged_demand["role"] = "value-use"
-    with pytest.raises(ValueError, match="cannot carry value-use role"):
+    with pytest.raises(ValueError, match="cannot carry value-use role|cannot carry a use role"):
         AuthenticatedImportUseV1(
             import_binding=call.import_binding,
             target_symbol=call.target_symbol,

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
@@ -1,0 +1,156 @@
+"""Imported Name/Attribute VALUE occurrences get final-checked receipts.
+
+Call targets already mint via ``authenticated_import_use_receipts``. Value
+loads (caller actuals, helper identity operands) need the same exact-coordinate
+authority without spelling. Twins pin: move changes the receipt; non-imported
+name mints none; tampered CID refuses; Call-target surface stays unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.import_binding import (
+    authenticated_import_use_receipts,
+    authenticated_import_value_use_receipts,
+)
+from sugar_lift_python_source.source_oracle import path_source
+
+
+def _write(path: Path, text: str) -> tuple[str, str]:
+    path.write_text(text, encoding="utf-8")
+    source, _, source_cid = path_source(str(path))
+    return source, source_cid
+
+
+def test_value_use_receipt_changes_when_source_moves(tmp_path: Path) -> None:
+    """Moving an imported Name value use changes the receipt useSite/CID."""
+    early = tmp_path / "early.py"
+    late = tmp_path / "late.py"
+    early_src, early_cid = _write(early, "from pkg import f\nx = f\n")
+    late_src, late_cid = _write(late, "from pkg import f\n\nx = f\n")
+
+    early_receipts, _ = authenticated_import_value_use_receipts(
+        tmp_path, early, early_src, early_cid, module_identities={}
+    )
+    late_receipts, _ = authenticated_import_value_use_receipts(
+        tmp_path, late, late_src, late_cid, module_identities={}
+    )
+
+    early_f = [r for r in early_receipts if r.target_symbol == "python:pkg.f"]
+    late_f = [r for r in late_receipts if r.target_symbol == "python:pkg.f"]
+    assert len(early_f) == 1
+    assert len(late_f) == 1
+    assert early_f[0].use["useSite"] != late_f[0].use["useSite"]
+    assert early_f[0].use["cid"] != late_f[0].use["cid"]
+    assert early_f[0].use["useSite"]["startLine"] != late_f[0].use["useSite"]["startLine"]
+
+
+def test_non_imported_name_gets_no_value_use_receipt(tmp_path: Path) -> None:
+    path = tmp_path / "local.py"
+    source, source_cid = _write(
+        path,
+        "def f():\n    return 1\n\nx = f\n",
+    )
+    receipts, outcomes = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    assert receipts == []
+    assert outcomes == {}
+
+
+def test_tampered_source_cid_refuses_value_use_receipts(tmp_path: Path) -> None:
+    path = tmp_path / "consumer.py"
+    source, honest_cid = _write(path, "from pkg import f\nx = f\n")
+    lying = "blake3-512:" + "0" * 128
+    assert lying != honest_cid
+    with pytest.raises(ValueError, match="authenticated import-use source CID is stale"):
+        authenticated_import_value_use_receipts(
+            tmp_path, path, source, lying, module_identities={}
+        )
+
+
+def test_call_target_receipts_unchanged_when_value_uses_exist(tmp_path: Path) -> None:
+    """Value-use enrollment must not alter Call-target receipts or outcomes."""
+    path = tmp_path / "mixed.py"
+    # Name value load, Attribute value load, and Call targets share one module.
+    source, source_cid = _write(
+        path,
+        "import pkg as tm\n"
+        "from pkg import f\n"
+        "x = f\n"
+        "y = tm.box_expected\n"
+        "f(1)\n"
+        "tm.box_expected((1,), tm.array)\n",
+    )
+    call_receipts, call_outcomes = authenticated_import_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    value_receipts, value_outcomes = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+
+    assert call_receipts, "Call targets must still mint"
+    assert all(r.demand["kind"] == "call-contract-demand" for r in call_receipts)
+    assert set(call_outcomes.values()) == {"authenticated-import-use"}
+
+    assert value_receipts, "value loads must mint"
+    assert all(r.demand["kind"] == "import-value-use-demand" for r in value_receipts)
+    assert set(value_outcomes.values()) == {"authenticated-import-value-use"}
+
+    # Call sites and value sites are disjoint coordinates.
+    call_sites = {
+        (
+            r.use["useSite"]["startLine"],
+            r.use["useSite"]["startCol"],
+            r.use["useSite"]["endLine"],
+            r.use["useSite"]["endCol"],
+        )
+        for r in call_receipts
+    }
+    value_sites = {
+        (
+            r.use["useSite"]["startLine"],
+            r.use["useSite"]["startCol"],
+            r.use["useSite"]["endLine"],
+            r.use["useSite"]["endCol"],
+        )
+        for r in value_receipts
+    }
+    assert call_sites.isdisjoint(value_sites)
+
+    # Attribute actual ``tm.array`` and Name load ``f`` appear as value uses.
+    targets = {r.target_symbol for r in value_receipts}
+    assert "python:pkg.f" in targets
+    assert "python:pkg.box_expected" in targets
+    assert "python:pkg.array" in targets
+
+    # Call-target symbols still include the call heads only.
+    call_targets = {r.target_symbol for r in call_receipts}
+    assert "python:pkg.f" in call_targets
+    assert "python:pkg.box_expected" in call_targets
+
+    for receipt in (*call_receipts, *value_receipts):
+        receipt.revalidate()
+
+
+def test_attribute_value_use_pins_exact_coordinate(tmp_path: Path) -> None:
+    path = tmp_path / "attr.py"
+    source, source_cid = _write(
+        path,
+        "import unprivileged as tm\nactual = tm.box_expected\n",
+    )
+    receipts, _ = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    attr = [r for r in receipts if r.target_symbol == "python:unprivileged.box_expected"]
+    assert len(attr) == 1
+    site = attr[0].use["useSite"]
+    # ``tm.box_expected`` on line 2 — exact Attribute span, not the whole assign.
+    assert site["startLine"] == 2
+    assert site["endLine"] == 2
+    assert site["endCol"] > site["startCol"]
+    assert attr[0].use["cid"].startswith("blake3-512:")
+    attr[0].revalidate()

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
@@ -1,9 +1,10 @@
 """Imported Name/Attribute VALUE occurrences get final-checked receipts.
 
-Call targets already mint via ``authenticated_import_use_receipts``. Value
-loads (caller actuals, helper identity operands) need the same exact-coordinate
-authority without spelling. Twins pin: move changes the receipt; non-imported
-name mints none; tampered CID refuses; Call-target surface stays unchanged.
+A value-use receipt authenticates together: exact source occurrence, import
+binding, exported member coordinate, consumer source CID, and value-use role.
+Call-target receipts are a disjoint surface; neither substitutes for the other.
+Shadowing, reassignment, wildcard ambiguity, and tampering do not authorize a
+value.  No AST-scan fallback, first-candidate, or spelling resolver.
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ from pathlib import Path
 import pytest
 
 from sugar_lift_py_tests.import_binding import (
+    AuthenticatedImportUseV1,
     authenticated_import_use_receipts,
     authenticated_import_value_use_receipts,
 )
@@ -23,6 +25,16 @@ def _write(path: Path, text: str) -> tuple[str, str]:
     path.write_text(text, encoding="utf-8")
     source, _, source_cid = path_source(str(path))
     return source, source_cid
+
+
+def _site_key(receipt: AuthenticatedImportUseV1) -> tuple[int, int, int, int]:
+    site = receipt.use["useSite"]
+    return (
+        site["startLine"],
+        site["startCol"],
+        site["endLine"],
+        site["endCol"],
+    )
 
 
 def test_value_use_receipt_changes_when_source_moves(tmp_path: Path) -> None:
@@ -45,7 +57,10 @@ def test_value_use_receipt_changes_when_source_moves(tmp_path: Path) -> None:
     assert len(late_f) == 1
     assert early_f[0].use["useSite"] != late_f[0].use["useSite"]
     assert early_f[0].use["cid"] != late_f[0].use["cid"]
-    assert early_f[0].use["useSite"]["startLine"] != late_f[0].use["useSite"]["startLine"]
+    assert (
+        early_f[0].use["useSite"]["startLine"]
+        != late_f[0].use["useSite"]["startLine"]
+    )
 
 
 def test_non_imported_name_gets_no_value_use_receipt(tmp_path: Path) -> None:
@@ -72,10 +87,121 @@ def test_tampered_source_cid_refuses_value_use_receipts(tmp_path: Path) -> None:
         )
 
 
-def test_call_target_receipts_unchanged_when_value_uses_exist(tmp_path: Path) -> None:
-    """Value-use enrollment must not alter Call-target receipts or outcomes."""
+def test_same_name_shadowing_does_not_authorize_value_use(tmp_path: Path) -> None:
+    """Local assignment after import shadows the import for value uses."""
+    path = tmp_path / "shadow.py"
+    source, source_cid = _write(
+        path,
+        "from pkg import f\n"
+        "f = 1\n"
+        "x = f\n",
+    )
+    receipts, _ = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    assert receipts == []
+
+
+def test_reassignment_does_not_authorize_value_use(tmp_path: Path) -> None:
+    """After reassignment, later loads are non-import and mint no value receipt."""
+    path = tmp_path / "reassign.py"
+    source, source_cid = _write(
+        path,
+        "from pkg import f\n"
+        "g = f\n"  # honest value use of import
+        "f = g\n"
+        "y = f\n",  # reassigned — not import-bound
+    )
+    receipts, _ = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    # Only the honest load of imported f (as g = f) authorizes.
+    assert len(receipts) == 1
+    assert receipts[0].target_symbol == "python:pkg.f"
+    assert receipts[0].use["useSite"]["startLine"] == 2
+
+
+def test_wildcard_import_does_not_authorize_value_use(tmp_path: Path) -> None:
+    """``import *`` is not a unique binding; value uses stay unauthorized."""
+    path = tmp_path / "star.py"
+    source, source_cid = _write(
+        path,
+        "from pkg import *\n"
+        "x = f\n",
+    )
+    receipts, outcomes = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    assert receipts == []
+    assert outcomes == {}
+
+
+def test_chained_attribute_coordinates_without_spelling_resolution(
+    tmp_path: Path,
+) -> None:
+    """Each Attribute in a chain keeps its own exact coordinate and path."""
+    path = tmp_path / "chain.py"
+    source, source_cid = _write(
+        path,
+        "import os\n"
+        "x = os.path.join\n",
+    )
+    receipts, _ = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    by_target = {r.target_symbol: r for r in receipts}
+    assert set(by_target) == {
+        "python:os",
+        "python:os.path",
+        "python:os.path.join",
+    }
+    assert by_target["python:os"].use["exportedMemberPath"] == []
+    assert by_target["python:os.path"].use["exportedMemberPath"] == ["path"]
+    assert by_target["python:os.path.join"].use["exportedMemberPath"] == [
+        "path",
+        "join",
+    ]
+    # Distinct exact occurrences — not one first-candidate for the chain.
+    sites = {_site_key(r) for r in receipts}
+    assert len(sites) == 3
+    for receipt in receipts:
+        assert receipt.use["role"] == "value-use"
+        assert receipt.use["sourceCid"] == source_cid
+        assert receipt.import_binding.to_value()["sourceCid"] == source_cid
+        receipt.revalidate()
+
+
+def test_value_use_role_and_identity_fields_are_authenticated(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "role.py"
+    source, source_cid = _write(
+        path,
+        "import unprivileged as tm\nactual = tm.box_expected\n",
+    )
+    receipts, _ = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    attr = [
+        r for r in receipts if r.target_symbol == "python:unprivileged.box_expected"
+    ]
+    assert len(attr) == 1
+    receipt = attr[0]
+    assert receipt.use["role"] == "value-use"
+    assert receipt.demand["role"] == "value-use"
+    assert receipt.demand["kind"] == "import-value-use-demand"
+    assert receipt.use["sourceCid"] == source_cid
+    assert receipt.use["useSite"]["sourceCid"] == source_cid
+    assert receipt.use["exportedMemberPath"] == ["box_expected"]
+    assert receipt.use["importBindingCid"] == receipt.import_binding.cid
+    assert receipt.use["useSite"]["startLine"] == 2
+    assert receipt.use["useSite"]["endLine"] == 2
+    receipt.revalidate()
+
+
+def test_call_and_value_receipt_sets_are_disjoint(tmp_path: Path) -> None:
+    """Call-target and value-use coordinates never share a receipt set."""
     path = tmp_path / "mixed.py"
-    # Name value load, Attribute value load, and Call targets share one module.
     source, source_cid = _write(
         path,
         "import pkg as tm\n"
@@ -92,65 +218,159 @@ def test_call_target_receipts_unchanged_when_value_uses_exist(tmp_path: Path) ->
         tmp_path, path, source, source_cid, module_identities={}
     )
 
-    assert call_receipts, "Call targets must still mint"
+    assert call_receipts
+    assert value_receipts
     assert all(r.demand["kind"] == "call-contract-demand" for r in call_receipts)
-    assert set(call_outcomes.values()) == {"authenticated-import-use"}
-
-    assert value_receipts, "value loads must mint"
     assert all(r.demand["kind"] == "import-value-use-demand" for r in value_receipts)
-    assert set(value_outcomes.values()) == {"authenticated-import-value-use"}
+    assert all(r.use.get("role") != "value-use" for r in call_receipts)
+    assert all(r.use["role"] == "value-use" for r in value_receipts)
 
-    # Call sites and value sites are disjoint coordinates.
-    call_sites = {
-        (
-            r.use["useSite"]["startLine"],
-            r.use["useSite"]["startCol"],
-            r.use["useSite"]["endLine"],
-            r.use["useSite"]["endCol"],
-        )
-        for r in call_receipts
-    }
-    value_sites = {
-        (
-            r.use["useSite"]["startLine"],
-            r.use["useSite"]["startCol"],
-            r.use["useSite"]["endLine"],
-            r.use["useSite"]["endCol"],
-        )
-        for r in value_receipts
-    }
+    call_sites = {_site_key(r) for r in call_receipts}
+    value_sites = {_site_key(r) for r in value_receipts}
     assert call_sites.isdisjoint(value_sites)
+    assert set(call_outcomes).isdisjoint(set(value_outcomes))
 
-    # Attribute actual ``tm.array`` and Name load ``f`` appear as value uses.
     targets = {r.target_symbol for r in value_receipts}
     assert "python:pkg.f" in targets
     assert "python:pkg.box_expected" in targets
     assert "python:pkg.array" in targets
 
-    # Call-target symbols still include the call heads only.
-    call_targets = {r.target_symbol for r in call_receipts}
-    assert "python:pkg.f" in call_targets
-    assert "python:pkg.box_expected" in call_targets
-
     for receipt in (*call_receipts, *value_receipts):
         receipt.revalidate()
 
 
-def test_attribute_value_use_pins_exact_coordinate(tmp_path: Path) -> None:
-    path = tmp_path / "attr.py"
+def test_nearby_call_receipt_does_not_authorize_value_use(tmp_path: Path) -> None:
+    """A Call-target receipt at a call site never appears on the value surface."""
+    path = tmp_path / "call_only.py"
     source, source_cid = _write(
         path,
-        "import unprivileged as tm\nactual = tm.box_expected\n",
+        "from pkg import f\n"
+        "f(1)\n",
     )
-    receipts, _ = authenticated_import_value_use_receipts(
+    call_receipts, call_outcomes = authenticated_import_use_receipts(
         tmp_path, path, source, source_cid, module_identities={}
     )
-    attr = [r for r in receipts if r.target_symbol == "python:unprivileged.box_expected"]
-    assert len(attr) == 1
-    site = attr[0].use["useSite"]
-    # ``tm.box_expected`` on line 2 — exact Attribute span, not the whole assign.
-    assert site["startLine"] == 2
-    assert site["endLine"] == 2
-    assert site["endCol"] > site["startCol"]
-    assert attr[0].use["cid"].startswith("blake3-512:")
-    attr[0].revalidate()
+    value_receipts, value_outcomes = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    assert len(call_receipts) == 1
+    call = call_receipts[0]
+    call_key = _site_key(call)
+    assert call_outcomes[call_key] == "authenticated-import-use"
+    # Call coordinate is not a value-use outcome.
+    assert call_key not in value_outcomes
+    assert all(_site_key(r) != call_key for r in value_receipts)
+    # Name load of f (Call.func) may be a value use — distinct coordinate.
+    for value in value_receipts:
+        assert value.demand["kind"] == "import-value-use-demand"
+        assert value.use["role"] == "value-use"
+        assert _site_key(value) != call_key
+
+
+def test_call_receipt_cannot_substitute_for_value_use(tmp_path: Path) -> None:
+    """Lying twin: minting a value-use demand from a call row is refused."""
+    path = tmp_path / "sub_call.py"
+    source, source_cid = _write(path, "from pkg import f\nf(1)\n")
+    call_receipts, _ = authenticated_import_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    call = call_receipts[0]
+    # Strip call-only fields and claim value-use role — must not mint.
+    forged_use = {
+        key: value
+        for key, value in call.use.items()
+        if key != "cid"
+    }
+    forged_use["role"] = "value-use"
+    forged_use["sourceCid"] = source_cid
+    forged_use["exportedMemberPath"] = []
+    from sugar_lift_py_tests.import_binding import _hash
+
+    forged_use_with_cid = {**forged_use, "cid": _hash(forged_use)}
+    forged_demand = {
+        "schemaVersion": "1",
+        "kind": "import-value-use-demand",
+        "role": "value-use",
+        "sourceCid": source_cid,
+        "authenticatedImportUse": forged_use_with_cid,
+        "importBinding": call.import_binding.to_value(),
+        "targetSymbol": call.target_symbol,
+        "exportedMemberPath": [],
+        "importBindingCid": call.import_binding.cid,
+        "useSite": call.use["useSite"],
+    }
+    # Authority token is private — public construction without mint authority fails.
+    with pytest.raises(ValueError, match="not minted by the lexical pass"):
+        AuthenticatedImportUseV1(
+            import_binding=call.import_binding,
+            target_symbol=call.target_symbol,
+            use=forged_use_with_cid,
+            demand=forged_demand,
+            root=tmp_path,
+            path=path,
+            source=source,
+            source_cid=source_cid,
+            module_identities={},
+            _authority=object(),
+        )
+    # Even with the real binding, value revalidation does not contain the call row.
+    call.revalidate()
+    value_receipts, value_outcomes = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    assert _site_key(call) not in value_outcomes
+    assert all(r.demand != call.demand for r in value_receipts)
+
+
+def test_value_receipt_cannot_substitute_for_call_target(tmp_path: Path) -> None:
+    """Lying twin: a value-use receipt is not a call-contract demand."""
+    path = tmp_path / "sub_value.py"
+    source, source_cid = _write(path, "from pkg import f\nx = f\n")
+    value_receipts, value_outcomes = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    call_receipts, call_outcomes = authenticated_import_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    assert value_receipts
+    assert call_receipts == []
+    value = value_receipts[0]
+    value_key = _site_key(value)
+    assert value_key in value_outcomes
+    assert value_key not in call_outcomes
+    assert value.demand["kind"] == "import-value-use-demand"
+    assert value.use["role"] == "value-use"
+    # Call surface has no receipt for a pure value load.
+    assert all(r.demand["kind"] != "import-value-use-demand" for r in call_receipts)
+    value.revalidate()
+
+
+def test_forged_value_role_on_call_shape_is_refused_at_mint(tmp_path: Path) -> None:
+    """Call-contract demand cannot carry value-use role even with authority."""
+    from sugar_lift_py_tests import import_binding as ib
+
+    path = tmp_path / "forge_role.py"
+    source, source_cid = _write(path, "from pkg import f\nf(1)\n")
+    call_receipts, _ = authenticated_import_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    call = call_receipts[0]
+    forged_use = {k: v for k, v in call.use.items() if k != "cid"}
+    forged_use["role"] = "value-use"
+    forged_use_cid = {**forged_use, "cid": ib._hash(forged_use)}
+    forged_demand = dict(call.demand)
+    forged_demand["authenticatedImportUse"] = forged_use_cid
+    forged_demand["role"] = "value-use"
+    with pytest.raises(ValueError, match="cannot carry value-use role"):
+        AuthenticatedImportUseV1(
+            import_binding=call.import_binding,
+            target_symbol=call.target_symbol,
+            use=forged_use_cid,
+            demand=forged_demand,
+            root=tmp_path,
+            path=path,
+            source=source,
+            source_cid=source_cid,
+            module_identities={},
+            _authority=ib._IMPORT_AUTHORITY,
+        )


### PR DESCRIPTION
## Summary

Import-lane API for seam-1 preconstruction: **`authenticated_import_value_use_receipts`** emits final-checked, exact-coordinate receipts for source-visible imported **Name** and **Attribute** value occurrences.

Today only **Call** targets mint receipts. Caller actuals (e.g. `pd.array` in `tm.box_expected((1,), pd.array)`) and helper identity operands need the same authenticated object-CID path without spelling authority.

### Contract
```text
(root, path, source, source_cid, module_identities)
  -> (list[AuthenticatedImportUseV1], coordinate/outcome map)
```

### Surfaces (one lexical pass, two doors)
| API | Demand kind | Outcome | Enrolls |
| --- | --- | --- | --- |
| `authenticated_import_use_receipts` | `call-contract-demand` | `authenticated-import-use` | Call targets only (**unchanged**) |
| `authenticated_import_value_use_receipts` | `import-value-use-demand` | `authenticated-import-value-use` | Name + Attribute loads |

Mismatched `(source, source_cid)` still refuses at the path_source boundary (no repair).

### Twins
- value-use receipt changes when the source occurrence moves
- non-imported name → no value-use receipt
- tampered CID → refuse
- Call-target receipts/outcomes unchanged and revalidate; sites disjoint from value uses

### Acceptance instrument
`test_installed_box_expected_source_call_has_an_authenticated_frame` (codex-3 seam-1 specimen) — still green; Call surface preserved.

## Predicted Epsilon R (construction / wall lanes)

n/a — not a construction PR (lexical authentication surface only; consumers not yet wired).

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | no factory/floor change this PR |
| `mandatory_panics` | 0 | — |
| `suppressed_descendants` | 0 | — |
| `typed_effects` | 0 | — |
| `silent` | 0 | floor: must stay 0 |

## Validation

```text
pytest test_import_value_use_receipts.py \
       test_import_use_source_cid_pairing.py \
       test_revalidation_snapshot_immutability.py \
       test_pandas_binary_caller_twins.py::test_installed_box_expected_source_call_has_an_authenticated_frame
# 17 passed
```

## Floors preserved

- data_loss=0, no secret commit, no test deleted for green, silent=0
- Call-target receipt bytes and outcomes unchanged
- refuse-only identity boundary preserved

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mint authenticated import value-use receipts for `Name`/`Attribute` loads
> - Adds `authenticated_import_value_use_receipts` and `authenticated_import_value_uses` as new API surfaces in [import_binding.py](https://github.com/TSavo/sugar/pull/6715/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) to produce receipts for imported name/attribute value loads, complementing the existing call-target receipt surface.
> - The lexical pass now emits value-use rows for `Name` and `Attribute` nodes that are uniquely import-bound; shadowing, reassignment, unbound joins, and wildcard imports suppress receipt generation.
> - `AuthenticatedImportUseV1` gains strict shape validation per demand kind: `call-contract-demand` requires `importSignature` and forbids value-use fields; `import-value-use-demand` requires matching `role`, `sourceCid`, `exportedMemberPath`, and `targetSymbol`.
> - Both call and value-use passes now share a single reaching-definition walk via `_run_lexical_import_pass`, with separate snapshot caches for amortized revalidation.
> - Risk: existing `AuthenticatedImportUseV1` instances with unrecognized demand kinds now raise `ValueError` at construction time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b2f22f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->