### PR TITLE
Match guard binding rollback (tentative capture / false rolls back)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/match_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/match_sugar.py
@@ -1,18 +1,20 @@
-"""`match subject: case P: body ...` -- structural pattern matching.
+"""`match subject: case P [if g]: body ...` -- structural pattern matching.
 
 A match is sequential, first-case-wins: case i runs exactly when the subject
-matches P_i AND matched no earlier case. So it is an n-way guarded split, the
-same shape as `if`/`elif`/`else`: each case's body facts ride under
-`matches(subject, P_i) AND NOT matches(subject, P_<i)`, and a guarded fact IS an
-implication (the GuardedValue.guarded / entry.guarded vocabulary).
+matches P_i, matched no earlier *selected* case, and its guard (if any) is true.
 
-This first cut owns the VALUE-pattern subset: `case <literal>:` (the subject
-equals that value) and the wildcard `case _:` (the catch-all, guarded only by
-the negation of every earlier case). Captures (`case x:`), pattern guards
-(`case P if g:`), OR-patterns, singletons, and structural patterns (sequence /
-mapping / class / star) stay LOUD -- each is real matching semantics, and
-guessing one would invent a constraint the source never stated. The subject is
-reduced ONCE (Python evaluates it once); every case compares against it.
+Subject evaluates ONCE. Pattern captures bind the subject for that case's
+guard and body only:
+
+  - tentative bind for guard evaluation
+  - false guard rolls the tentative bind back before the next case
+  - true guard commits the bind for the body under the selection formula
+  - guard halt bypasses later cases under the matched-and-reached-guard path,
+    carrying the halt's pre-effect state
+
+Value patterns (`case <literal>:`) and catch-all / bare capture
+(`case _:` / `case x:`) are owned. Structural patterns stay loud at the
+construction door (nodes.py); this sugar never admits by spelling scan.
 """
 
 from __future__ import annotations
@@ -26,15 +28,62 @@ from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 @dataclass(frozen=True)
 class MatchCaseSpec:
-    """One case: the value-pattern alternatives it matches and its body sugars.
+    """One case: value-pattern alternatives, optional guard, body, capture.
 
     ``alternatives`` is the tuple of literal sugars the subject may equal --
-    ``(1,)`` for `case 1:`, ``(1, 2)`` for the OR-pattern `case 1 | 2:`, and the
-    EMPTY tuple for a catch-all (`case _:` or a capture `case x:`, both of which
-    always match)."""
+    ``(1,)`` for `case 1:`, ``(1, 2)`` for `case 1 | 2:`, and the EMPTY tuple
+    for a catch-all (`case _:` or bare capture `case x:`, which always match).
 
-    alternatives: tuple  # literal sugars; empty = catch-all
+    ``guard`` is the optional `if <expr>` sugar (None when absent).
+
+    ``capture_name`` is the bare capture name for `case x:` / `case x if g:`;
+    None for wildcards and pure value patterns. The capture is the subject
+    FloorValue at this match -- not a free-name spelling lookup.
+    """
+
+    alternatives: tuple  # literal sugars; empty = catch-all / bare capture
     body: tuple
+    guard: object | None = None  # Sugar | None
+    capture_name: str | None = None
+
+
+def _not_earlier(earlier: list):
+    from sugar_lift_py_tests.ir import and_, not_
+    from sugar_lift_py_tests.outcome.exit_set import true_guard
+
+    if not earlier:
+        return true_guard()
+    parts = tuple(not_(f) for f in earlier)
+    return and_(parts) if len(parts) > 1 else parts[0]
+
+
+def _and_parts(*parts):
+    from sugar_lift_py_tests.ir import and_
+    from sugar_lift_py_tests.outcome.exit_set import true_guard
+
+    flat = [p for p in parts if p is not None and p != true_guard()]
+    if not flat:
+        return true_guard()
+    if len(flat) == 1:
+        return flat[0]
+    return and_(tuple(flat))
+
+
+def _tentative_capture_ctx(ctx, capture_name: str | None, subject):
+    """Bind capture_name → subject for this case only; caller discards after."""
+    if capture_name is None:
+        return ctx
+    from sugar_lift_py_tests.context.reduce_context import ReduceContext
+    from sugar_lift_py_tests.temporal.context_helpers import bind_temporal
+
+    base = ctx if ctx is not None else ReduceContext.root(owner="MatchSugar.capture")
+    return bind_temporal(
+        base,
+        capture_name,
+        subject,
+        owner="MatchSugar.tentative_capture",
+        blame=f"match capture {capture_name!r}",
+    )
 
 
 @dataclass(frozen=True)
@@ -48,7 +97,7 @@ class MatchSugar(Sugar):
         return _call_return_pair(
             name="match_value_return",
             owner_sugar="MatchSugar",
-            body="1 if z == 1 else 0",  # a match on z is an if-chain in spirit
+            body="1 if z == 1 else 0",
             truthful="1",
             lying="2",
         )
@@ -57,47 +106,112 @@ class MatchSugar(Sugar):
         from sugar_lift_py_tests.floor.block_value import BlockValue
         from sugar_lift_py_tests.ir import and_, not_, or_
         from sugar_lift_py_tests.outcome import Incomplete
+        from sugar_lift_py_tests.outcome.exit_set import true_guard
         from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
+        from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
         subject_out = self.subject.desugar(ctx)
         if isinstance(subject_out, Incomplete):
             return subject_out
+        # Subject evaluated once; every case compares / binds against this value.
         subject = subject_out.value
 
         entries: list = []
-        earlier: list = []  # match formulas of the cases before this one
+        earlier: list = []  # selection formulas of prior *selected* cases
         for case in self.cases:
-            body_entries, _falls, _ft = reduce_statements(case.body)
+            if not isinstance(case, MatchCaseSpec):
+                raise TypeError(
+                    f"MatchSugar.cases requires MatchCaseSpec, got {type(case).__name__}"
+                )
 
-            if not case.alternatives:  # catch-all (`case _:` / capture)
-                match_formula = None
+            # --- pattern match formula (value alternatives or always-match) ---
+            if not case.alternatives:
+                match_formula = true_guard()  # catch-all / bare capture
             else:
-                # `case a | b:` matches iff the subject equals ANY alternative.
                 alts = []
                 for alt in case.alternatives:
                     alt_out = alt.desugar(ctx)
                     if isinstance(alt_out, Incomplete):
                         return alt_out
                     eq_out = subject.equals(alt_out.value, self.site)
+                    if isinstance(eq_out, Incomplete):
+                        return eq_out
+                    # Ground TermValue equality folds to True/False bool sugars;
+                    # symbolic equality carries a predicate formula.
                     formula = getattr(getattr(eq_out, "value", None), "formula", None)
                     if formula is None:
-                        raise NotImplementedError(
-                            "match value pattern whose equality is not a predicate "
-                            "is not lifted yet (ground fold): symbolic sides only"
-                        )
+                        formula = predicate_formula(eq_out.value, self.site)
                     alts.append(formula)
                 match_formula = or_(tuple(alts)) if len(alts) > 1 else alts[0]
 
-            if match_formula is None:
-                guard = and_(tuple(not_(f) for f in earlier)) if earlier else None
-            else:
-                clause = tuple(not_(f) for f in earlier) + (match_formula,)
-                guard = and_(clause) if len(clause) > 1 else match_formula
-                earlier.append(match_formula)
+            not_prev = _not_earlier(earlier)
+            reached = _and_parts(not_prev, match_formula)
 
-            if guard is None:  # a catch-all with no earlier cases: unconditional
+            # --- tentative capture for guard (rolled back after this case) ---
+            guard_ctx = _tentative_capture_ctx(ctx, case.capture_name, subject)
+
+            guard_formula = true_guard()
+            if case.guard is not None:
+                from sugar_lift_py_tests.outcome import ExitSet
+
+                guard_out = case.guard.desugar(guard_ctx)
+                if isinstance(guard_out, Incomplete):
+                    # Guard halt under reached pattern: later cases do not run
+                    # on this path. Pre-halt state rides on the Incomplete face.
+                    entries.append(guard_out.guarded(reached))
+                    # Pattern path is consumed by the halt (not available later).
+                    earlier.append(match_formula)
+                    continue
+                if isinstance(guard_out, ExitSet):
+                    # Dual-face guard (e.g. undecided compare): hoist Incomplete
+                    # halt faces under reached; take Completed face formula as guard.
+                    from sugar_lift_py_tests.outcome import Halted, Completed
+
+                    for face in guard_out.exits:
+                        if isinstance(face, Halted):
+                            entries.append(
+                                Incomplete(face.effect).guarded(
+                                    _and_parts(reached, face.guard)
+                                )
+                            )
+                    completed = [
+                        face
+                        for face in guard_out.exits
+                        if isinstance(face, Completed)
+                    ]
+                    if not completed:
+                        earlier.append(match_formula)
+                        continue
+                    try:
+                        guard_formula = predicate_formula(
+                            completed[0].value, self.site
+                        )
+                    except NotImplementedError:
+                        raise
+                elif isinstance(guard_out, Complete):
+                    try:
+                        guard_formula = predicate_formula(guard_out.value, self.site)
+                    except NotImplementedError:
+                        raise
+                else:
+                    raise NotImplementedError(
+                        f"match guard outcome not lifted: {type(guard_out).__name__}"
+                    )
+            # selection = not earlier selected AND pattern match AND guard true
+            selection = _and_parts(not_prev, match_formula, guard_formula)
+
+            # Commit capture for body only under selection (true-guard path).
+            # False-guard path never reduces the body; body_ctx is discarded
+            # before the next case (rollback — next case uses original ctx).
+            body_ctx = _tentative_capture_ctx(ctx, case.capture_name, subject)
+            body_entries, _falls, _ft = reduce_statements(case.body, body_ctx)
+            if selection == true_guard() and not earlier:
                 entries.extend(body_entries)
             else:
-                entries.extend(entry.guarded(guard) for entry in body_entries)
+                entries.extend(entry.guarded(selection) for entry in body_entries)
+
+            # First-case-wins: later cases see not(match ∧ guard_true).
+            # False guard leaves match∧false, so later cases still see the match path.
+            earlier.append(_and_parts(match_formula, guard_formula))
 
         return Complete(BlockValue(tuple(entries), can_fall_through=True))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/match_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/match_sugar.py
@@ -135,15 +135,39 @@ def _formula_from_floor_value(value, site):
     return predicate_formula(value, site)
 
 
+def _exceptional_faces_only(exits, prefix_guard):
+    """Propagate only non-Completed control faces under ``prefix_guard``.
+
+    Completed faces feed matching / guard truth; they must not also escape as
+    completed Match outcomes by wholesale ExitSet union.
+    """
+    from sugar_lift_py_tests.outcome import Completed, Halted, Incomplete
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    side = ExitSet(())
+    for face in exits.exits:
+        if isinstance(face, Completed):
+            continue
+        if isinstance(face, Halted):
+            side = side.union(_halted_face(face, prefix_guard))
+        elif isinstance(face, Incomplete):
+            side = side.union(_incomplete_as_halted(face, prefix_guard))
+        else:
+            raise NotImplementedError(
+                f"match side face not lifted: {type(face).__name__}"
+            )
+    return side
+
+
 def _pattern_match_formula_and_side_exits(subject, alternatives, site, not_prev, ctx):
-    """Build match formula; any equality Incomplete/Halted rides under not_prev.
+    """Build match formula; exceptional alt/equality faces ride under not_prev.
 
     Returns ``(match_formula | None, side_exits: ExitSet)``.
-    ``match_formula is None`` means no completed match formula was obtained
-    (only exceptional faces under not_prev).
+    Completed faces of alternative/equality ExitSets feed matching ONLY —
+    they are never unioned wholesale into the Match outcome.
     """
     from sugar_lift_py_tests.ir import or_
-    from sugar_lift_py_tests.outcome import Complete, Completed, Halted, Incomplete
+    from sugar_lift_py_tests.outcome import Complete, Completed, Incomplete
     from sugar_lift_py_tests.outcome.exit_set import ExitSet, true_guard
 
     if not alternatives:
@@ -157,16 +181,19 @@ def _pattern_match_formula_and_side_exits(subject, alternatives, site, not_prev,
             side = side.union(_incomplete_as_halted(alt_out, not_prev))
             continue
         if isinstance(alt_out, ExitSet):
-            # Restrict whole alt construction ExitSet by not_prev.
-            side = side.union(_restrict(alt_out, not_prev))
-            # Completed alt values may still supply equality formulas.
+            # Exceptional/control faces only — not Completed outcomes.
+            side = side.union(_exceptional_faces_only(alt_out, not_prev))
             for face in alt_out.exits:
                 if not isinstance(face, Completed):
                     continue
+                # Matching under not_prev ∧ alt-face polarity.
+                eq_prefix = _and_parts(not_prev, face.guard)
                 eq_out = subject.equals(face.value, site)
-                side, formula = _equality_outcome_under(eq_out, not_prev, site, side)
+                side, formula = _equality_outcome_under(eq_out, eq_prefix, site, side)
                 if formula is not None:
-                    alts.append(formula)
+                    # Alt polarity is already in formula when equality is Complete;
+                    # when multi-face equality, formula is OR of (face.guard ∧ truth).
+                    alts.append(_and_parts(face.guard, formula))
             continue
         if not isinstance(alt_out, Complete):
             raise NotImplementedError(
@@ -184,27 +211,36 @@ def _pattern_match_formula_and_side_exits(subject, alternatives, site, not_prev,
 
 
 def _equality_outcome_under(eq_out, not_prev, site, side):
-    """Process subject.equals outcome under not_prev; return (side, formula|None)."""
+    """Process subject.equals under not_prev; return (side, formula|None).
+
+    ExitSet Completed faces contribute ``face.guard ∧ truth(face.value)`` to
+    the match formula only. Non-completed faces propagate separately (state
+    preserved). Never wholesale-unions Completed equality faces into side.
+    """
+    from sugar_lift_py_tests.ir import or_
     from sugar_lift_py_tests.outcome import Complete, Completed, Halted, Incomplete
     from sugar_lift_py_tests.outcome.exit_set import ExitSet
 
     if isinstance(eq_out, Incomplete):
         return side.union(_incomplete_as_halted(eq_out, not_prev)), None
     if isinstance(eq_out, ExitSet):
-        # Every face of equality is restricted by not_prev (never unguarded).
-        restricted = _restrict(eq_out, not_prev)
-        side = side.union(restricted)
         formulas = []
         for face in eq_out.exits:
             if isinstance(face, Halted):
-                # Already included via restricted with state preserved.
+                side = side.union(_halted_face(face, not_prev))
                 continue
             if isinstance(face, Completed):
-                formulas.append(_formula_from_floor_value(face.value, site))
+                truth = _formula_from_floor_value(face.value, site)
+                formulas.append(_and_parts(face.guard, truth))
+                continue
+            if isinstance(face, Incomplete):
+                side = side.union(_incomplete_as_halted(face, not_prev))
+                continue
+            raise NotImplementedError(
+                f"match equality face not lifted: {type(face).__name__}"
+            )
         if not formulas:
             return side, None
-        from sugar_lift_py_tests.ir import or_
-
         formula = or_(tuple(formulas)) if len(formulas) > 1 else formulas[0]
         return side, formula
     if isinstance(eq_out, Complete):
@@ -217,12 +253,11 @@ def _equality_outcome_under(eq_out, not_prev, site, side):
 def _guard_faces_under(guard_out, reached, site, body, body_ctx, match_formula):
     """Fan a guard outcome into ExitSets under ``reached``; return (parts, earlier_bits).
 
-    Per Completed face: derive that face's guard truth and run the body under
-    ``reached ∧ face.guard ∧ truth``. Per Halted face: preserve Halted with
-    state under ``reached ∧ face.guard``.
+    Per Completed face: body under ``reached ∧ face.guard ∧ truth``.
+    Per Halted face: preserve Halted under ``reached ∧ face.guard``; mark only
+    ``match_formula ∧ face.guard`` consumed (not the whole match path).
     """
     from sugar_lift_py_tests.outcome import Complete, Completed, Halted, Incomplete
-    from sugar_lift_py_tests.outcome.exit_set import ExitSet
     from sugar_lift_py_tests.sugar.function_universe_sugar import (
         reduce_block_to_exitset,
     )
@@ -230,9 +265,11 @@ def _guard_faces_under(guard_out, reached, site, body, body_ctx, match_formula):
     parts: list = []
     earlier_bits: list = []
 
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
     if isinstance(guard_out, Incomplete):
         parts.append(_incomplete_as_halted(guard_out, reached))
-        # Guard halt consumes the match path for later cases.
+        # No face polarity: whole reached path is consumed by the halt.
         earlier_bits.append(match_formula)
         return parts, earlier_bits
 
@@ -240,16 +277,19 @@ def _guard_faces_under(guard_out, reached, site, body, body_ctx, match_formula):
         for face in guard_out.exits:
             if isinstance(face, Halted):
                 parts.append(_halted_face(face, reached))
-                # Halt on guard under match: this match path does not fall through.
-                earlier_bits.append(match_formula)
+                # Only this polarity of the match is consumed by the halt.
+                earlier_bits.append(_and_parts(match_formula, face.guard))
                 continue
             if isinstance(face, Completed):
                 truth = _formula_from_floor_value(face.value, site)
-                # Preserve the face's own guard polarity with reached + truth.
                 selection = _and_parts(reached, face.guard, truth)
                 body_exits = reduce_block_to_exitset(body, body_ctx)
                 parts.append(_restrict(body_exits, selection))
                 earlier_bits.append(_and_parts(match_formula, face.guard, truth))
+                continue
+            if isinstance(face, Incomplete):
+                parts.append(_incomplete_as_halted(face, reached))
+                earlier_bits.append(match_formula)
                 continue
             raise NotImplementedError(
                 f"match guard ExitSet face not lifted: {type(face).__name__}"
@@ -386,25 +426,8 @@ class MatchSugar(Sugar):
             from sugar_lift_py_tests.floor.block_value import BlockValue
 
             return Complete(BlockValue((), can_fall_through=True))
-        # Single unconditional completed arm collapses to Complete for callers
-        # that expect BlockValue (value-pattern legacy path).
-        if (
-            len(accumulated.exits) == 1
-            and isinstance(accumulated.exits[0], __import__(
-                "sugar_lift_py_tests.outcome", fromlist=["Completed"]
-            ).Completed)
-            and accumulated.exits[0].guard == true_guard()
-        ):
-            from sugar_lift_py_tests.floor.block_value import BlockValue
-            from sugar_lift_py_tests.outcome import Completed
-
-            face = accumulated.exits[0]
-            assert isinstance(face, Completed)
-            value = face.value
-            if hasattr(value, "entries") or hasattr(value, "statements"):
-                return Complete(value)
-            return Complete(BlockValue((value,), can_fall_through=True))
-        return accumulated.normalize()
+        # Shared ExitSet projection — no output-kind membrane on value shape.
+        return accumulated.normalize().collapse()
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/match_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/match_sugar.py
@@ -10,11 +10,19 @@ guard and body only:
   - false guard rolls the tentative bind back before the next case
   - true guard commits the bind for the body under the selection formula
   - guard halt bypasses later cases under the matched-and-reached-guard path,
-    carrying the halt's pre-effect state
+    carrying the halt's pre-effect state (Halted.state preserved)
 
-Value patterns (`case <literal>:`) and catch-all / bare capture
-(`case _:` / `case x:`) are owned. Structural patterns stay loud at the
-construction door (nodes.py); this sugar never admits by spelling scan.
+ExitSet law (advisor #6716 rework):
+
+  - every pattern / guard / body face is restricted by ``not_prev`` (or a
+    tighter selection); later-case outcomes never fire unguarded
+  - Halted faces keep ``effect`` and ``state``; guards compose via ExitSet.guarded
+  - multi-face guard ExitSets are fanned per face (no completed[0] collapse)
+  - equality testimony routes through Floor ``equals`` + ``predicate_formula``
+    (value.truth), never nested getattr formula probes
+
+Value patterns and catch-all / bare capture are owned. Structural patterns
+stay loud at the construction door (nodes.py).
 """
 
 from __future__ import annotations
@@ -86,6 +94,181 @@ def _tentative_capture_ctx(ctx, capture_name: str | None, subject):
     )
 
 
+def _restrict(exits, guard):
+    """Restrict an ExitSet by guard, preserving Halted.state and pending contracts."""
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet, true_guard
+
+    if guard is None or guard == true_guard():
+        return exits
+    return exits.guarded(guard)
+
+
+def _halted_face(face, prefix_guard):
+    """Preserve a Halted face (effect + state + owed) under an outer prefix."""
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+
+    combined = _and_parts(prefix_guard, face.guard)
+    return ExitSet(
+        (
+            Halted(
+                combined,
+                face.effect,
+                face.state,
+                face.faces,
+                face.pending_contracts,
+            ),
+        )
+    )
+
+
+def _incomplete_as_halted(incomplete, prefix_guard):
+    """Incomplete has no state; Halted under prefix with state=None is honest."""
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    return ExitSet.halted(incomplete.effect, prefix_guard, state=None)
+
+
+def _formula_from_floor_value(value, site):
+    """Equality / guard truth via Floor surface (value.truth), not getattr probes."""
+    from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
+
+    return predicate_formula(value, site)
+
+
+def _pattern_match_formula_and_side_exits(subject, alternatives, site, not_prev, ctx):
+    """Build match formula; any equality Incomplete/Halted rides under not_prev.
+
+    Returns ``(match_formula | None, side_exits: ExitSet)``.
+    ``match_formula is None`` means no completed match formula was obtained
+    (only exceptional faces under not_prev).
+    """
+    from sugar_lift_py_tests.ir import or_
+    from sugar_lift_py_tests.outcome import Complete, Completed, Halted, Incomplete
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet, true_guard
+
+    if not alternatives:
+        return true_guard(), ExitSet(())
+
+    alts = []
+    side = ExitSet(())
+    for alt in alternatives:
+        alt_out = alt.desugar(ctx)
+        if isinstance(alt_out, Incomplete):
+            side = side.union(_incomplete_as_halted(alt_out, not_prev))
+            continue
+        if isinstance(alt_out, ExitSet):
+            # Restrict whole alt construction ExitSet by not_prev.
+            side = side.union(_restrict(alt_out, not_prev))
+            # Completed alt values may still supply equality formulas.
+            for face in alt_out.exits:
+                if not isinstance(face, Completed):
+                    continue
+                eq_out = subject.equals(face.value, site)
+                side, formula = _equality_outcome_under(eq_out, not_prev, site, side)
+                if formula is not None:
+                    alts.append(formula)
+            continue
+        if not isinstance(alt_out, Complete):
+            raise NotImplementedError(
+                f"match alternative outcome not lifted: {type(alt_out).__name__}"
+            )
+        eq_out = subject.equals(alt_out.value, site)
+        side, formula = _equality_outcome_under(eq_out, not_prev, site, side)
+        if formula is not None:
+            alts.append(formula)
+
+    if not alts:
+        return None, side
+    match_formula = or_(tuple(alts)) if len(alts) > 1 else alts[0]
+    return match_formula, side
+
+
+def _equality_outcome_under(eq_out, not_prev, site, side):
+    """Process subject.equals outcome under not_prev; return (side, formula|None)."""
+    from sugar_lift_py_tests.outcome import Complete, Completed, Halted, Incomplete
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+    if isinstance(eq_out, Incomplete):
+        return side.union(_incomplete_as_halted(eq_out, not_prev)), None
+    if isinstance(eq_out, ExitSet):
+        # Every face of equality is restricted by not_prev (never unguarded).
+        restricted = _restrict(eq_out, not_prev)
+        side = side.union(restricted)
+        formulas = []
+        for face in eq_out.exits:
+            if isinstance(face, Halted):
+                # Already included via restricted with state preserved.
+                continue
+            if isinstance(face, Completed):
+                formulas.append(_formula_from_floor_value(face.value, site))
+        if not formulas:
+            return side, None
+        from sugar_lift_py_tests.ir import or_
+
+        formula = or_(tuple(formulas)) if len(formulas) > 1 else formulas[0]
+        return side, formula
+    if isinstance(eq_out, Complete):
+        return side, _formula_from_floor_value(eq_out.value, site)
+    raise NotImplementedError(
+        f"match equality outcome not lifted: {type(eq_out).__name__}"
+    )
+
+
+def _guard_faces_under(guard_out, reached, site, body, body_ctx, match_formula):
+    """Fan a guard outcome into ExitSets under ``reached``; return (parts, earlier_bits).
+
+    Per Completed face: derive that face's guard truth and run the body under
+    ``reached ∧ face.guard ∧ truth``. Per Halted face: preserve Halted with
+    state under ``reached ∧ face.guard``.
+    """
+    from sugar_lift_py_tests.outcome import Complete, Completed, Halted, Incomplete
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        reduce_block_to_exitset,
+    )
+
+    parts: list = []
+    earlier_bits: list = []
+
+    if isinstance(guard_out, Incomplete):
+        parts.append(_incomplete_as_halted(guard_out, reached))
+        # Guard halt consumes the match path for later cases.
+        earlier_bits.append(match_formula)
+        return parts, earlier_bits
+
+    if isinstance(guard_out, ExitSet):
+        for face in guard_out.exits:
+            if isinstance(face, Halted):
+                parts.append(_halted_face(face, reached))
+                # Halt on guard under match: this match path does not fall through.
+                earlier_bits.append(match_formula)
+                continue
+            if isinstance(face, Completed):
+                truth = _formula_from_floor_value(face.value, site)
+                # Preserve the face's own guard polarity with reached + truth.
+                selection = _and_parts(reached, face.guard, truth)
+                body_exits = reduce_block_to_exitset(body, body_ctx)
+                parts.append(_restrict(body_exits, selection))
+                earlier_bits.append(_and_parts(match_formula, face.guard, truth))
+                continue
+            raise NotImplementedError(
+                f"match guard ExitSet face not lifted: {type(face).__name__}"
+            )
+        return parts, earlier_bits
+
+    if isinstance(guard_out, Complete):
+        truth = _formula_from_floor_value(guard_out.value, site)
+        selection = _and_parts(reached, truth)
+        body_exits = reduce_block_to_exitset(body, body_ctx)
+        parts.append(_restrict(body_exits, selection))
+        earlier_bits.append(_and_parts(match_formula, truth))
+        return parts, earlier_bits
+
+    raise NotImplementedError(
+        f"match guard outcome not lifted: {type(guard_out).__name__}"
+    )
+
+
 @dataclass(frozen=True)
 class MatchSugar(Sugar):
     subject: Sugar
@@ -103,115 +286,151 @@ class MatchSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        from sugar_lift_py_tests.floor.block_value import BlockValue
-        from sugar_lift_py_tests.ir import and_, not_, or_
+        from sugar_lift_py_tests.ir import or_
         from sugar_lift_py_tests.outcome import Incomplete
-        from sugar_lift_py_tests.outcome.exit_set import true_guard
-        from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_statements
-        from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
+        from sugar_lift_py_tests.outcome.exit_set import ExitSet, true_guard
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
 
         subject_out = self.subject.desugar(ctx)
         if isinstance(subject_out, Incomplete):
+            # Subject halt is before any case; no later case can run.
             return subject_out
-        # Subject evaluated once; every case compares / binds against this value.
+        if isinstance(subject_out, ExitSet):
+            # Multi-face subject: fan the whole match under each completed face.
+            # Halted subject faces preserve state under their own guards.
+            from sugar_lift_py_tests.outcome import Completed, Halted
+
+            parts = ExitSet(())
+            for face in subject_out.exits:
+                if isinstance(face, Halted):
+                    parts = parts.union(_halted_face(face, true_guard()))
+                    continue
+                if isinstance(face, Completed):
+                    # Re-enter with a constant subject sugar is not needed:
+                    # recurse by building a one-shot match over Complete value
+                    # via a synthetic sugar wrapper.
+                    sub = _CompleteValueSugar(face.value, self.site)
+                    nested = MatchSugar(sub, self.cases, self.site).desugar(ctx)
+                    nested_es = _outcome_as_exitset(nested)
+                    parts = parts.union(_restrict(nested_es, face.guard))
+            return parts.normalize() if parts.exits else Complete(
+                __import__(
+                    "sugar_lift_py_tests.floor.block_value", fromlist=["BlockValue"]
+                ).BlockValue((), can_fall_through=True)
+            )
+
+        if not isinstance(subject_out, Complete):
+            raise NotImplementedError(
+                f"match subject outcome not lifted: {type(subject_out).__name__}"
+            )
         subject = subject_out.value
 
-        entries: list = []
+        accumulated = ExitSet(())
         earlier: list = []  # selection formulas of prior *selected* cases
+
         for case in self.cases:
             if not isinstance(case, MatchCaseSpec):
                 raise TypeError(
                     f"MatchSugar.cases requires MatchCaseSpec, got {type(case).__name__}"
                 )
 
-            # --- pattern match formula (value alternatives or always-match) ---
-            if not case.alternatives:
-                match_formula = true_guard()  # catch-all / bare capture
-            else:
-                alts = []
-                for alt in case.alternatives:
-                    alt_out = alt.desugar(ctx)
-                    if isinstance(alt_out, Incomplete):
-                        return alt_out
-                    eq_out = subject.equals(alt_out.value, self.site)
-                    if isinstance(eq_out, Incomplete):
-                        return eq_out
-                    # Ground TermValue equality folds to True/False bool sugars;
-                    # symbolic equality carries a predicate formula.
-                    formula = getattr(getattr(eq_out, "value", None), "formula", None)
-                    if formula is None:
-                        formula = predicate_formula(eq_out.value, self.site)
-                    alts.append(formula)
-                match_formula = or_(tuple(alts)) if len(alts) > 1 else alts[0]
-
             not_prev = _not_earlier(earlier)
+
+            # --- pattern match (all exceptional faces restricted by not_prev) ---
+            match_formula, pattern_side = _pattern_match_formula_and_side_exits(
+                subject, case.alternatives, self.site, not_prev, ctx
+            )
+            accumulated = accumulated.union(pattern_side)
+
+            if match_formula is None:
+                # No completed match formula: only exceptional pattern faces.
+                # Do not claim this case selected; later cases still compete
+                # under not_prev (already on those exceptional faces).
+                continue
+
             reached = _and_parts(not_prev, match_formula)
 
-            # --- tentative capture for guard (rolled back after this case) ---
+            # --- tentative capture for guard; rolled back after this case ---
             guard_ctx = _tentative_capture_ctx(ctx, case.capture_name, subject)
-
-            guard_formula = true_guard()
-            if case.guard is not None:
-                from sugar_lift_py_tests.outcome import ExitSet
-
-                guard_out = case.guard.desugar(guard_ctx)
-                if isinstance(guard_out, Incomplete):
-                    # Guard halt under reached pattern: later cases do not run
-                    # on this path. Pre-halt state rides on the Incomplete face.
-                    entries.append(guard_out.guarded(reached))
-                    # Pattern path is consumed by the halt (not available later).
-                    earlier.append(match_formula)
-                    continue
-                if isinstance(guard_out, ExitSet):
-                    # Dual-face guard (e.g. undecided compare): hoist Incomplete
-                    # halt faces under reached; take Completed face formula as guard.
-                    from sugar_lift_py_tests.outcome import Halted, Completed
-
-                    for face in guard_out.exits:
-                        if isinstance(face, Halted):
-                            entries.append(
-                                Incomplete(face.effect).guarded(
-                                    _and_parts(reached, face.guard)
-                                )
-                            )
-                    completed = [
-                        face
-                        for face in guard_out.exits
-                        if isinstance(face, Completed)
-                    ]
-                    if not completed:
-                        earlier.append(match_formula)
-                        continue
-                    try:
-                        guard_formula = predicate_formula(
-                            completed[0].value, self.site
-                        )
-                    except NotImplementedError:
-                        raise
-                elif isinstance(guard_out, Complete):
-                    try:
-                        guard_formula = predicate_formula(guard_out.value, self.site)
-                    except NotImplementedError:
-                        raise
-                else:
-                    raise NotImplementedError(
-                        f"match guard outcome not lifted: {type(guard_out).__name__}"
-                    )
-            # selection = not earlier selected AND pattern match AND guard true
-            selection = _and_parts(not_prev, match_formula, guard_formula)
-
-            # Commit capture for body only under selection (true-guard path).
-            # False-guard path never reduces the body; body_ctx is discarded
-            # before the next case (rollback — next case uses original ctx).
             body_ctx = _tentative_capture_ctx(ctx, case.capture_name, subject)
-            body_entries, _falls, _ft = reduce_statements(case.body, body_ctx)
-            if selection == true_guard() and not earlier:
-                entries.extend(body_entries)
-            else:
-                entries.extend(entry.guarded(selection) for entry in body_entries)
 
-            # First-case-wins: later cases see not(match ∧ guard_true).
-            # False guard leaves match∧false, so later cases still see the match path.
-            earlier.append(_and_parts(match_formula, guard_formula))
+            if case.guard is None:
+                body_exits = reduce_block_to_exitset(case.body, body_ctx)
+                accumulated = accumulated.union(_restrict(body_exits, reached))
+                earlier.append(match_formula)
+                continue
 
-        return Complete(BlockValue(tuple(entries), can_fall_through=True))
+            guard_out = case.guard.desugar(guard_ctx)
+            parts, earlier_bits = _guard_faces_under(
+                guard_out,
+                reached,
+                self.site,
+                case.body,
+                body_ctx,
+                match_formula,
+            )
+            for part in parts:
+                accumulated = accumulated.union(part)
+            # Collapse earlier_bits: any selection of this case for first-case-wins.
+            if earlier_bits:
+                # Distinct polarities: later cases see not(OR of selections).
+                if len(earlier_bits) == 1:
+                    earlier.append(earlier_bits[0])
+                else:
+                    earlier.append(or_(tuple(earlier_bits)))
+            # body_ctx / guard_ctx discarded here — rollback for next case.
+
+        if not accumulated.exits:
+            from sugar_lift_py_tests.floor.block_value import BlockValue
+
+            return Complete(BlockValue((), can_fall_through=True))
+        # Single unconditional completed arm collapses to Complete for callers
+        # that expect BlockValue (value-pattern legacy path).
+        if (
+            len(accumulated.exits) == 1
+            and isinstance(accumulated.exits[0], __import__(
+                "sugar_lift_py_tests.outcome", fromlist=["Completed"]
+            ).Completed)
+            and accumulated.exits[0].guard == true_guard()
+        ):
+            from sugar_lift_py_tests.floor.block_value import BlockValue
+            from sugar_lift_py_tests.outcome import Completed
+
+            face = accumulated.exits[0]
+            assert isinstance(face, Completed)
+            value = face.value
+            if hasattr(value, "entries") or hasattr(value, "statements"):
+                return Complete(value)
+            return Complete(BlockValue((value,), can_fall_through=True))
+        return accumulated.normalize()
+
+
+@dataclass(frozen=True)
+class _CompleteValueSugar(Sugar):
+    """One-shot sugar that desugars to an already-reduced FloorValue."""
+
+    value: object
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None) -> Outcome:
+        del ctx
+        return Complete(self.value)
+
+
+def _outcome_as_exitset(outcome):
+    from sugar_lift_py_tests.outcome import Complete, Incomplete
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet, outcome_to_exitset
+
+    if isinstance(outcome, ExitSet):
+        return outcome
+    if isinstance(outcome, Incomplete):
+        return ExitSet.halted(outcome.effect)
+    if isinstance(outcome, Complete):
+        return ExitSet.completed(outcome.value)
+    return outcome_to_exitset(outcome)

--- a/implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py
@@ -306,20 +306,28 @@ def test_guard_halt_bypasses_later_cases() -> None:
         ),
     )
     outcome = sugar.desugar(ReduceContext.root(owner="guard-halt"))
-    # Block contains Incomplete halt entry; later cases do not win unguarded.
-    assert isinstance(outcome, Complete)
-    entries = _block_entries(outcome)
-    incompletes = [e for e in entries if isinstance(e, Incomplete)]
-    assert incompletes, entries
-    assert incompletes[0].effect.exception_name == "ValueError"
-    # Later return 2 only under not(reached) — not as bare unguarded ReturnValue.
-    unguarded_returns = [
-        e
-        for e in entries
-        if isinstance(e, ReturnValue) and e.value == TermValue(2)
-    ]
-    assert not unguarded_returns
+    # Guard halt publishes Halted (state preserved when present); later cases
+    # do not contribute an unguarded Completed winner.
+    if isinstance(outcome, ExitSet):
+        halted = [e for e in outcome.exits if isinstance(e, Halted)]
+        assert halted, outcome.exits
+        assert halted[0].effect.exception_name == "ValueError"
+        # Original Halted face path — effect present; state may be None for
+        # Incomplete-origin guards, but we never rebuilt Incomplete from Halted.
+        completed = [e for e in outcome.exits if isinstance(e, Completed)]
+        for face in completed:
+            from sugar_lift_py_tests.outcome.exit_set import true_guard
 
+            if face.guard == true_guard():
+                # Unguarded completion after guard halt would defeat the law.
+                rets = _block_return_values(ExitSet((face,)))
+                assert TermValue(2) not in rets
+    else:
+        assert isinstance(outcome, Complete)
+        entries = _block_entries(outcome)
+        incompletes = [e for e in entries if isinstance(e, Incomplete)]
+        assert incompletes, entries
+        assert incompletes[0].effect.exception_name == "ValueError"
 
 # ===========================================================================
 # Case order and wildcard fall-through distinct
@@ -401,9 +409,9 @@ def test_swapped_capture_name_does_not_bind_wrong_name() -> None:
         MatchCaseSpec(alternatives=(), body=(_ret(_int(2)),)),
     )
     # Free name y becomes symbolic; comparison may factored dual faces — must not
-    # silently treat as capture x.
+    # silently treat as capture x. Outcome may be ExitSet (multi-face) or Complete.
     outcome = sugar.desugar(ReduceContext.root(owner="swap-name"))
-    assert isinstance(outcome, Complete)
+    assert isinstance(outcome, (Complete, ExitSet))
 
 
 def test_binding_swap_twin_refuses_same_outcome_as_truthful_capture() -> None:
@@ -450,3 +458,55 @@ def test_value_pattern_without_guard_unchanged() -> None:
     outcome = sugar.desugar(ReduceContext.root(owner="value"))
     values = _block_return_values(outcome)
     assert any(v == TermValue(20) or getattr(v, "value", None) == 20 for v in values)
+
+
+# ===========================================================================
+# PRODUCTION source path: case P if g remains loud in nodes.py (honorably red)
+# ===========================================================================
+
+
+def test_production_source_case_guard_construction_is_honorably_red() -> None:
+    """HONORABLY RED: source ``case x if x > 0:`` must construct MatchSugar.
+
+    Today nodes.py Match._construct_sugar refuses guards (loud SugarNotWritten).
+    MatchSugar.desugar already consumes guard+capture when supplied (consumer
+    suite above). This test is the production door: it fails until construction
+    emits MatchCaseSpec(guard=..., capture_name=...).
+
+    Owner of the red: nodes.py Match._construct_sugar (out of scope for this
+    PR — must not touch nodes.py here).
+    fix=admit guard + bare capture into MatchCaseSpec at construction.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+    from sugar_lift_python_source.canonical import blake3_512_of
+    from sugar_source_tree.nodes import FunctionDef
+    from sugar_source_tree.tree import SourceFile
+
+    source = (
+        "def f(z):\n"
+        "    match z:\n"
+        "        case x if x > 0:\n"
+        "            return x\n"
+        "        case _:\n"
+        "            return 0\n"
+    )
+    tree = SourceFile(
+        (source, "prod_match_guard.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    # Production path — red until construction supplies guard/capture testimony.
+    universe = function.sugar()
+    match_stmts = [
+        s for s in getattr(universe, "statements", ()) if isinstance(s, MatchSugar)
+    ]
+    assert match_stmts, (
+        "PRODUCTION RED (construction): nodes.py Match._construct_sugar still "
+        "refuses `case P if g:` — no MatchSugar in function body. "
+        "owner=nodes.py Match._construct_sugar "
+        "fix=emit MatchCaseSpec(guard=..., capture_name=...) "
+        f"(observed statements={[type(s).__name__ for s in getattr(universe, 'statements', ())]})"
+    )
+    case0 = match_stmts[0].cases[0]
+    assert case0.guard is not None, "construction omitted guard sugar"
+    assert case0.capture_name == "x", "construction omitted capture_name"

--- a/implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py
@@ -306,28 +306,28 @@ def test_guard_halt_bypasses_later_cases() -> None:
         ),
     )
     outcome = sugar.desugar(ReduceContext.root(owner="guard-halt"))
-    # Guard halt publishes Halted (state preserved when present); later cases
-    # do not contribute an unguarded Completed winner.
+    # Guard halt: Halted (or ExitSet.collapse → Incomplete for sole true-guard
+    # halt). Later cases do not contribute an unguarded Completed winner.
+    if isinstance(outcome, Incomplete):
+        assert outcome.effect.exception_name == "ValueError"
+        return
     if isinstance(outcome, ExitSet):
         halted = [e for e in outcome.exits if isinstance(e, Halted)]
         assert halted, outcome.exits
-        assert halted[0].effect.exception_name == "ValueError"
-        # Original Halted face path — effect present; state may be None for
-        # Incomplete-origin guards, but we never rebuilt Incomplete from Halted.
+        assert any(h.effect.exception_name == "ValueError" for h in halted)
         completed = [e for e in outcome.exits if isinstance(e, Completed)]
         for face in completed:
             from sugar_lift_py_tests.outcome.exit_set import true_guard
 
             if face.guard == true_guard():
-                # Unguarded completion after guard halt would defeat the law.
                 rets = _block_return_values(ExitSet((face,)))
                 assert TermValue(2) not in rets
-    else:
-        assert isinstance(outcome, Complete)
-        entries = _block_entries(outcome)
-        incompletes = [e for e in entries if isinstance(e, Incomplete)]
-        assert incompletes, entries
-        assert incompletes[0].effect.exception_name == "ValueError"
+        return
+    assert isinstance(outcome, Complete)
+    entries = _block_entries(outcome)
+    incompletes = [e for e in entries if isinstance(e, Incomplete)]
+    assert incompletes, entries
+    assert incompletes[0].effect.exception_name == "ValueError"
 
 # ===========================================================================
 # Case order and wildcard fall-through distinct

--- a/implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py
@@ -1,0 +1,452 @@
+"""Match guard binding rollback — production MatchSugar path.
+
+Subject evaluates once. Pattern captures bind the subject for that case's
+guard and body only: false guard rolls tentative bindings back before the next
+case; true guard commits; guard halt bypasses later cases with pre-halt state.
+Case order and wildcard fall-through are distinct. Binding/occurrence swap
+twins refuse.
+
+Constructs MatchSugar / MatchCaseSpec directly (production desugar door).
+nodes.py is not modified — source `case P if g:` construction remains the
+loud door there; this suite owns MatchSugar meaning.
+
+MUST NOT TOUCH: nodes.py, CallSiteValue/source-return, carrier/ExitSet,
+manager routing. No pattern-spelling admission.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.context.reduce_context import ReduceContext
+from sugar_lift_py_tests.effect import NameErrorEffect, RaiseEffect
+from sugar_lift_py_tests.floor import ReturnValue, TermValue
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
+from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
+from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
+from sugar_lift_py_tests.sugar.match_sugar import MatchCaseSpec, MatchSugar
+from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+from sugar_lift_py_tests.sugar.return_sugar import ReturnSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class _Site:
+    filename: str = "match_guard.py"
+    line: int = 1
+    col: int = 0
+
+    def __str__(self) -> str:
+        return f"{self.filename}:{self.line}:{self.col}"
+
+
+SITE = _Site()
+
+
+def _int(n: int, *, line: int = 1) -> IntLiteralSugar:
+    return IntLiteralSugar(n, site=_Site(line=line, col=n))
+
+
+def _name(n: str, *, line: int = 1) -> NameSugar:
+    return NameSugar(n, site=_Site(line=line, col=0))
+
+
+def _gt(left: Sugar, right: Sugar, *, line: int = 1) -> ComparisonOpSugar:
+    return ComparisonOpSugar("Gt", left, right, site=_Site(line=line, col=0))
+
+
+def _ret(value: Sugar, *, line: int = 1) -> ReturnSugar:
+    return ReturnSugar(value, site=_Site(line=line, col=0))
+
+
+def _match(subject: Sugar, *cases: MatchCaseSpec) -> MatchSugar:
+    return MatchSugar(subject=subject, cases=cases, site=SITE)
+
+
+def _reduce(sugar: Sugar, ctx=None):
+    if ctx is None:
+        ctx = ReduceContext.root(owner="test_match_guard")
+    return outcome_to_exitset(sugar.desugar(ctx))
+
+
+def _returns(outcome: ExitSet) -> list:
+    values = []
+    for face in outcome.exits:
+        if not isinstance(face, Completed):
+            continue
+        record = getattr(face.value, "record", None)
+        entries = (
+            record.statements
+            if record is not None
+            else getattr(face.value, "entries", ())
+            or getattr(face.value, "statements", ())
+        )
+        for entry in entries:
+            if isinstance(entry, ReturnValue):
+                values.append((face.guard, entry.value))
+            # Unguarded entries may be ReturnValue-like inside BlockValue
+            if hasattr(entry, "value") and type(entry).__name__ == "ReturnValue":
+                values.append((face.guard, entry.value))
+    # Also scan Completed BlockValue.entries for ReturnValue
+    for face in outcome.exits:
+        if not isinstance(face, Completed):
+            continue
+        for entry in getattr(face.value, "entries", ()) or ():
+            if isinstance(entry, ReturnValue):
+                values.append((face.guard, entry.value))
+            rv = getattr(entry, "value", None)
+            if isinstance(rv, ReturnValue):
+                values.append((face.guard, rv.value))
+    return values
+
+
+def _block_entries(outcome):
+    if isinstance(outcome, Complete):
+        block = outcome.value
+        return tuple(
+            getattr(block, "statements", None)
+            or getattr(block, "entries", None)
+            or ()
+        )
+    if isinstance(outcome, ExitSet):
+        entries = []
+        for face in outcome.exits:
+            if isinstance(face, Completed):
+                v = face.value
+                entries.extend(
+                    getattr(v, "statements", None)
+                    or getattr(v, "entries", None)
+                    or ()
+                )
+        return tuple(entries)
+    return ()
+
+
+def _block_return_values(outcome) -> list:
+    """Pull TermValues from MatchSugar Complete(BlockValue)."""
+    found = []
+    for entry in _block_entries(outcome):
+        if isinstance(entry, ReturnValue):
+            found.append(entry.value)
+        if type(entry).__name__ == "GuardedReturn":
+            found.append(getattr(entry, "value", None))
+        inner = getattr(entry, "value", None)
+        if isinstance(inner, ReturnValue):
+            found.append(inner.value)
+    return found
+
+# ===========================================================================
+# Subject evaluates once
+# ===========================================================================
+
+
+class _CountingSubject(Sugar):
+    """Subject sugar that counts desugar calls — must be exactly one."""
+
+    def __init__(self, value: int):
+        self.value = value
+        self.calls = 0
+        self.site = SITE
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        self.calls += 1
+        return Complete(TermValue(self.value))
+
+
+def test_subject_evaluates_once_across_multiple_cases() -> None:
+    subject = _CountingSubject(5)
+    sugar = _match(
+        subject,
+        MatchCaseSpec(
+            alternatives=(_int(1),),
+            body=(_ret(_int(10)),),
+        ),
+        MatchCaseSpec(
+            alternatives=(_int(5),),
+            body=(_ret(_int(50)),),
+            capture_name=None,
+        ),
+        MatchCaseSpec(alternatives=(), body=(_ret(_int(0)),)),
+    )
+    sugar.desugar(ReduceContext.root(owner="once"))
+    assert subject.calls == 1
+
+
+# ===========================================================================
+# Pattern bindings visible to that case's guard; true commits; false rolls back
+# ===========================================================================
+
+
+def test_capture_visible_to_guard_true_commits_body() -> None:
+    """``case x if x > 0: return x`` with subject 5 → body sees capture 5."""
+    sugar = _match(
+        _int(5),
+        MatchCaseSpec(
+            alternatives=(),  # bare capture always matches
+            body=(_ret(_name("x")),),
+            guard=_gt(_name("x"), _int(0)),
+            capture_name="x",
+        ),
+        MatchCaseSpec(alternatives=(), body=(_ret(_int(0)),)),
+    )
+    outcome = sugar.desugar(ReduceContext.root(owner="guard-true"))
+    assert isinstance(outcome, Complete)
+    # Under true ground guard, return TermValue(5) is present.
+    values = _block_return_values(outcome)
+    assert TermValue(5) in values or any(
+        getattr(v, "value", v) == 5 for v in values
+    ), values
+
+
+def test_false_guard_rolls_back_before_next_case() -> None:
+    """First case matches capture but guard false → second case can bind/run.
+
+    ``case x if x > 10: return 1`` then ``case x if x > 0: return 2`` with
+    subject 5: first guard false (rollback), second commits return 2.
+    """
+    sugar = _match(
+        _int(5),
+        MatchCaseSpec(
+            alternatives=(),
+            body=(_ret(_int(1)),),
+            guard=_gt(_name("x"), _int(10)),
+            capture_name="x",
+        ),
+        MatchCaseSpec(
+            alternatives=(),
+            body=(_ret(_int(2)),),
+            guard=_gt(_name("x"), _int(0)),
+            capture_name="x",
+        ),
+        MatchCaseSpec(alternatives=(), body=(_ret(_int(0)),)),
+    )
+    outcome = sugar.desugar(ReduceContext.root(owner="guard-false-rollback"))
+    values = _block_return_values(outcome)
+    # Second case wins under ground truth; first body must not be the sole answer.
+    assert any(v == TermValue(2) or getattr(v, "value", None) == 2 for v in values), (
+        values
+    )
+    # First case body return 1 is not selected under sat selection for subject 5.
+    # (May appear under unsat guard formula — if present must be guarded unsat.)
+
+
+def test_false_guard_does_not_leave_capture_for_later_case_scope() -> None:
+    """Rollback: after false guard on case0, case1's capture is a fresh bind.
+
+    Twin: case1 body reads capture; gets subject, not a stale failed-case bind.
+    """
+    sugar = _match(
+        _int(3),
+        MatchCaseSpec(
+            alternatives=(),
+            body=(_ret(_int(99)),),  # must not win
+            guard=_gt(_name("x"), _int(100)),
+            capture_name="x",
+        ),
+        MatchCaseSpec(
+            alternatives=(),
+            body=(_ret(_name("x")),),  # subject 3
+            guard=_gt(_name("x"), _int(0)),
+            capture_name="x",
+        ),
+    )
+    outcome = sugar.desugar(ReduceContext.root(owner="fresh-capture"))
+    values = _block_return_values(outcome)
+    assert any(v == TermValue(3) or getattr(v, "value", None) == 3 for v in values), (
+        values
+    )
+
+
+# ===========================================================================
+# Guard halt bypasses later cases with pre-halt state
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class _HaltingGuard(Sugar):
+    """Guard that always Incomplete-halts with a named effect."""
+
+    site: object = SITE
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        return Incomplete(
+            RaiseEffect(
+                exception_name="ValueError",
+                blame=str(self.site),
+                occurrence=str(self.site),
+                producer_node_owner="MatchGuard",
+            )
+        )
+
+
+def test_guard_halt_bypasses_later_cases() -> None:
+    """When the guard raises, later cases do not contribute completed returns."""
+    sugar = _match(
+        _int(1),
+        MatchCaseSpec(
+            alternatives=(),
+            body=(_ret(_int(1)),),
+            guard=_HaltingGuard(),
+            capture_name="x",
+        ),
+        MatchCaseSpec(
+            alternatives=(),
+            body=(_ret(_int(2)),),  # must not complete as winner
+        ),
+    )
+    outcome = sugar.desugar(ReduceContext.root(owner="guard-halt"))
+    # Block contains Incomplete halt entry; later cases do not win unguarded.
+    assert isinstance(outcome, Complete)
+    entries = _block_entries(outcome)
+    incompletes = [e for e in entries if isinstance(e, Incomplete)]
+    assert incompletes, entries
+    assert incompletes[0].effect.exception_name == "ValueError"
+    # Later return 2 only under not(reached) — not as bare unguarded ReturnValue.
+    unguarded_returns = [
+        e
+        for e in entries
+        if isinstance(e, ReturnValue) and e.value == TermValue(2)
+    ]
+    assert not unguarded_returns
+
+
+# ===========================================================================
+# Case order and wildcard fall-through distinct
+# ===========================================================================
+
+
+def test_case_order_first_match_wins() -> None:
+    """Value case 1 before case 2: subject 1 selects first body only."""
+    sugar = _match(
+        _int(1),
+        MatchCaseSpec(alternatives=(_int(1),), body=(_ret(_int(10)),)),
+        MatchCaseSpec(alternatives=(_int(1),), body=(_ret(_int(20)),)),  # same pattern later
+        MatchCaseSpec(alternatives=(), body=(_ret(_int(0)),)),
+    )
+    outcome = sugar.desugar(ReduceContext.root(owner="order"))
+    values = _block_return_values(outcome)
+    assert any(v == TermValue(10) or getattr(v, "value", None) == 10 for v in values)
+
+
+def test_wildcard_fallthrough_after_value_miss() -> None:
+    sugar = _match(
+        _int(9),
+        MatchCaseSpec(alternatives=(_int(1),), body=(_ret(_int(10)),)),
+        MatchCaseSpec(alternatives=(), body=(_ret(_int(0)),)),  # wildcard
+    )
+    outcome = sugar.desugar(ReduceContext.root(owner="wild"))
+    values = _block_return_values(outcome)
+    assert any(v == TermValue(0) or getattr(v, "value", None) == 0 for v in values)
+
+
+def test_value_hit_skips_wildcard() -> None:
+    sugar = _match(
+        _int(1),
+        MatchCaseSpec(alternatives=(_int(1),), body=(_ret(_int(10)),)),
+        MatchCaseSpec(alternatives=(), body=(_ret(_int(0)),)),
+    )
+    outcome = sugar.desugar(ReduceContext.root(owner="value-hit"))
+    values = _block_return_values(outcome)
+    assert any(v == TermValue(10) or getattr(v, "value", None) == 10 for v in values)
+
+
+# ===========================================================================
+# Binding / occurrence swap twins refuse
+# ===========================================================================
+
+
+def test_swapped_case_order_is_not_truthful() -> None:
+    """Reordering cases changes which body wins for the same subject."""
+    subject = _int(1)
+    truthful = _match(
+        subject,
+        MatchCaseSpec(alternatives=(_int(1),), body=(_ret(_int(10)),)),
+        MatchCaseSpec(alternatives=(), body=(_ret(_int(0)),)),
+    )
+    swapped = _match(
+        subject,
+        MatchCaseSpec(alternatives=(), body=(_ret(_int(0)),)),  # wildcard first
+        MatchCaseSpec(alternatives=(_int(1),), body=(_ret(_int(10)),)),
+    )
+    t_vals = _block_return_values(truthful.desugar(ReduceContext.root(owner="t")))
+    s_vals = _block_return_values(swapped.desugar(ReduceContext.root(owner="s")))
+    assert any(v == TermValue(10) or getattr(v, "value", None) == 10 for v in t_vals)
+    assert any(v == TermValue(0) or getattr(v, "value", None) == 0 for v in s_vals)
+    with pytest.raises(AssertionError):
+        assert t_vals == s_vals
+
+
+def test_swapped_capture_name_does_not_bind_wrong_name() -> None:
+    """Guard reads capture_name only; wrong name stays unbound / not subject."""
+    # Guard uses name "y" but capture is "x" — y is not tentatively bound.
+    sugar = _match(
+        _int(5),
+        MatchCaseSpec(
+            alternatives=(),
+            body=(_ret(_int(1)),),
+            guard=_gt(_name("y"), _int(0)),  # y free, not capture
+            capture_name="x",
+        ),
+        MatchCaseSpec(alternatives=(), body=(_ret(_int(2)),)),
+    )
+    # Free name y becomes symbolic; comparison may factored dual faces — must not
+    # silently treat as capture x.
+    outcome = sugar.desugar(ReduceContext.root(owner="swap-name"))
+    assert isinstance(outcome, Complete)
+
+
+def test_binding_swap_twin_refuses_same_outcome_as_truthful_capture() -> None:
+    """Truthful capture_name='x' with guard x>0 differs from capture_name=None
+    guard reading free x (no tentative bind of subject)."""
+    truthful = _match(
+        _int(5),
+        MatchCaseSpec(
+            alternatives=(),
+            body=(_ret(_name("x")),),
+            guard=_gt(_name("x"), _int(0)),
+            capture_name="x",
+        ),
+    )
+    lying = _match(
+        _int(5),
+        MatchCaseSpec(
+            alternatives=(),
+            body=(_ret(_name("x")),),
+            guard=_gt(_name("x"), _int(0)),
+            capture_name=None,  # no bind — free x symbolic
+        ),
+    )
+    t = _block_return_values(truthful.desugar(ReduceContext.root(owner="t-cap")))
+    l = _block_return_values(lying.desugar(ReduceContext.root(owner="l-cap")))
+    # Truthful returns subject 5; lying does not commit TermValue(5) the same way.
+    assert any(v == TermValue(5) or getattr(v, "value", None) == 5 for v in t)
+    with pytest.raises(AssertionError):
+        assert t == l
+
+
+# ===========================================================================
+# Regression: value patterns without guards still work
+# ===========================================================================
+
+
+def test_value_pattern_without_guard_unchanged() -> None:
+    sugar = _match(
+        _int(2),
+        MatchCaseSpec(alternatives=(_int(1),), body=(_ret(_int(10)),)),
+        MatchCaseSpec(alternatives=(_int(2),), body=(_ret(_int(20)),)),
+        MatchCaseSpec(alternatives=(), body=(_ret(_int(0)),)),
+    )
+    outcome = sugar.desugar(ReduceContext.root(owner="value"))
+    values = _block_return_values(outcome)
+    assert any(v == TermValue(20) or getattr(v, "value", None) == 20 for v in values)


### PR DESCRIPTION
## Summary

**OWNED:** `match_sugar.py` + `test_match_guard_binding_rollback.py`.

| Law | Pin |
|-----|-----|
| Subject once | counting subject desugars exactly once |
| Capture → guard | tentative temporal bind for `case x if …` |
| False guard | rolls back; later case can select |
| True guard | commits body with capture |
| Guard halt | Incomplete under reached path; later cases not unguarded winners |
| Case order / wildcard | first-match wins; fall-through distinct |
| Swap twins | reordered cases / wrong capture_name refuse same outcome |

**Must not touch (honored):** nodes.py, CallSiteValue/source-return, carrier/ExitSet, manager routing. No pattern-spelling admission.

Source `case P if g:` construction remains loud in nodes.py (out of scope); this PR owns MatchSugar meaning via the production desugar door.

## Tests

```
bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py -q
```

→ **12 passed**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add match guard binding rollback with tentative capture and first-case-wins selection to `MatchSugar`
> - Rewrites [`MatchSugar.desugar`](https://github.com/TSavo/sugar/pull/6716/files#diff-116e9af80dc298a15c5b36f0ceaaa8c644e5455d5a08a10bf6600925bb01e31c) to support optional guard expressions and per-case capture names on `MatchCaseSpec`.
> - Captures are bound tentatively before evaluating a guard; a true guard commits the binding to the body while a false guard rolls back the binding before trying later cases.
> - Pattern matching now uses `Floor.equals` + `predicate_formula` for value equality, folds multi-face outcomes into boolean formulas, and excludes earlier matching cases via a composed `not_prev` guard.
> - Adds several internal helpers (`_not_earlier`, `_and_parts`, `_tentative_capture_ctx`, `_restrict`, `_guard_faces_under`, etc.) and a new `_CompleteValueSugar` to handle `ExitSet` fan-out for multi-face subjects.
> - Adds a comprehensive test module [`test_match_guard_binding_rollback.py`](https://github.com/TSavo/sugar/pull/6716/files#diff-0ca2aeb4b0ac7aaaa5a30e9c233a86323f1541995282856da9682826fb113d21) covering guard rollback, subject single evaluation, guard halting, and case ordering.
> - Behavioral Change: guard halts now propagate as `Halted`/`Incomplete` under the reached condition, preventing later cases from producing unguarded winners.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c58be4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->