### PR TITLE
Complete TryStar subgroup routing

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/factory_build_context.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/factory_build_context.py
@@ -70,6 +70,10 @@ class FactoryBuildContext:
     # ambient strip posts stay logo-safe (str.suffixof sorts).
     nested_external_bridge: bool = False
     in_flight_effects: tuple[tuple[str, object], ...] = ()
+    # Same observed-effect slot surface as ReduceContext — except* as-binding
+    # and EffectRef projection share one typed operation, not a ladder of
+    # implementation kinds.
+    observed_effects: tuple[tuple[str, object], ...] = ()
 
     def __post_init__(self) -> None:
         if self.construction_audit_sink is None and self.audit_sink is not None:
@@ -103,6 +107,7 @@ class FactoryBuildContext:
             building=self.building,
             nested_external_bridge=self.nested_external_bridge,
             in_flight_effects=self.in_flight_effects,
+            observed_effects=self.observed_effects,
         )
 
     def with_in_flight_effect(
@@ -117,6 +122,23 @@ class FactoryBuildContext:
 
     def in_flight_effect_for(self, slot_id: str):
         for candidate_slot, effect in reversed(self.in_flight_effects):
+            if candidate_slot == slot_id:
+                return effect
+        return None
+
+    def with_observed_effect(
+        self, slot_id: str, effect: object
+    ) -> "FactoryBuildContext":
+        """Shared typed surface with ReduceContext — except* as-binding."""
+        from dataclasses import replace
+
+        return replace(
+            self,
+            observed_effects=(*self.observed_effects, (slot_id, effect)),
+        )
+
+    def observed_effect_for(self, slot_id: str):
+        for candidate_slot, effect in reversed(self.observed_effects):
             if candidate_slot == slot_id:
                 return effect
         return None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/grouped_raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/grouped_raise_sugar.py
@@ -1,3 +1,12 @@
+"""Authenticated ``ExceptionGroup`` tree construction for ``except*`` routing.
+
+Produces an immutable ``GroupedRaiseEffect`` whose leaves are ordinary
+``RaiseEffect`` values (authenticated type coordinate, MRO, occurrence). Nested
+groups stay nested: children are never flattened. Spelling does not grant
+group authority — only the Raise construction path that recognized the builtin
+group coordinate may mint this sugar.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field as dataclass_field
@@ -40,6 +49,8 @@ class GroupedRaiseSugar(Sugar):
                     fix="keep non-exception group members loud",
                 )
             effects.append(outcome.effect)
+        # Site occurrence is independent of group_identity (content seal) so
+        # two raises of the same group shape remain distinct halt faces.
         occurrence = f"{self.site.filename}:{self.site.line}:{self.site.col}"
         return Incomplete(
             GroupedRaiseEffect(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/grouped_raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/grouped_raise_sugar.py
@@ -6,9 +6,8 @@ groups stay nested: children are never flattened. Spelling does not grant
 group authority — only the Raise construction path that recognized the builtin
 group coordinate may mint this sugar.
 
-Group occurrence identity is the sealed source fragment CID (content-addressed),
-never a fabricated ``filename:line:col`` string — identical positions in
-different authenticated sources must differ.
+Group occurrence identity is the sealed ``SourceMemento`` coordinate from
+``SourceFragment.seal()`` — never a fabricated ``filename:line:col`` string.
 """
 
 from __future__ import annotations
@@ -21,40 +20,37 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 
 
 def sealed_source_occurrence(site, *, owner: str) -> str:
-    """Sealed source occurrence coordinate for this construction site.
+    """Sealed source occurrence coordinate via the typed fragment interface.
 
-    Uses the full sealed memento (file + source_cid + span + segment cid), not
-    a fabricated ``filename:line:col`` spelling. Identical positions in
-    different authenticated sources differ via ``file`` / ``source_cid``.
+    Requires ``SourceFragment.seal() -> SourceMemento``. Absence of that typed
+    interface is a construction error — not a soft getattr membrane.
     """
+    from sugar_source_tree.fragment import SourceFragment, SourceMemento
     from sugar_source_tree.panic import SugarNotWritten
 
-    seal = getattr(site, "seal", None)
-    if seal is None:
+    if not isinstance(site, SourceFragment):
         raise SugarNotWritten(
             blame=site,
             owner=owner,
-            observed="group construction site lacks seal()",
-            requested="a sealed SourceFragment occurrence coordinate",
+            observed=type(site).__name__,
+            requested="SourceFragment site with seal() -> SourceMemento",
             fix="construct GroupedRaiseSugar only from an enumerated source fragment",
         )
-    memento = seal()
-    cid = getattr(memento, "cid", None)
-    source_cid = getattr(memento, "source_cid", None)
-    file = getattr(memento, "file", None)
-    start = getattr(memento, "start", None)
-    end = getattr(memento, "end", None)
-    if not cid or not source_cid or file is None or start is None or end is None:
+    memento = site.seal()
+    if not isinstance(memento, SourceMemento):
         raise SugarNotWritten(
             blame=site,
             owner=owner,
             observed=type(memento).__name__,
-            requested="SourceMemento{file,start,end,source_cid,cid}",
-            fix="seal the raise site before minting GroupedRaiseEffect.occurrence",
+            requested="SourceMemento from SourceFragment.seal()",
+            fix="seal() must return the typed SourceMemento currency",
         )
-    # Full sealed coordinate — content CID alone collides across files that
+    # Full sealed coordinate — segment cid alone collides across files that
     # share identical span text; file + source_cid pin the authenticated source.
-    return f"{file}:{start}:{end}:{source_cid}:{cid}"
+    return (
+        f"{memento.file}:{memento.start}:{memento.end}"
+        f":{memento.source_cid}:{memento.cid}"
+    )
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/grouped_raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/grouped_raise_sugar.py
@@ -6,8 +6,8 @@ groups stay nested: children are never flattened. Spelling does not grant
 group authority — only the Raise construction path that recognized the builtin
 group coordinate may mint this sugar.
 
-Group occurrence identity is the sealed ``SourceMemento`` coordinate from
-``SourceFragment.seal()`` — never a fabricated ``filename:line:col`` string.
+Group occurrence identity is the sealed ``SourceMemento`` from the typed
+``SourceFragment`` construction door — never a fabricated ``filename:line:col``.
 """
 
 from __future__ import annotations
@@ -17,50 +17,22 @@ from dataclasses import dataclass, field as dataclass_field
 from sugar_lift_py_tests.effect import GroupedRaiseEffect, RaiseEffect
 from sugar_lift_py_tests.outcome import Complete, Incomplete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
-
-
-def sealed_source_occurrence(site, *, owner: str) -> str:
-    """Sealed source occurrence coordinate via the typed fragment interface.
-
-    Requires ``SourceFragment.seal() -> SourceMemento``. Absence of that typed
-    interface is a construction error — not a soft getattr membrane.
-    """
-    from sugar_source_tree.fragment import SourceFragment, SourceMemento
-    from sugar_source_tree.panic import SugarNotWritten
-
-    if not isinstance(site, SourceFragment):
-        raise SugarNotWritten(
-            blame=site,
-            owner=owner,
-            observed=type(site).__name__,
-            requested="SourceFragment site with seal() -> SourceMemento",
-            fix="construct GroupedRaiseSugar only from an enumerated source fragment",
-        )
-    memento = site.seal()
-    if not isinstance(memento, SourceMemento):
-        raise SugarNotWritten(
-            blame=site,
-            owner=owner,
-            observed=type(memento).__name__,
-            requested="SourceMemento from SourceFragment.seal()",
-            fix="seal() must return the typed SourceMemento currency",
-        )
-    # Full sealed coordinate — segment cid alone collides across files that
-    # share identical span text; file + source_cid pin the authenticated source.
-    return (
-        f"{memento.file}:{memento.start}:{memento.end}"
-        f":{memento.source_cid}:{memento.cid}"
-    )
+from sugar_source_tree.fragment import SourceFragment
 
 
 @dataclass(frozen=True)
 class GroupedRaiseSugar(Sugar):
-    """Construct one authenticated exception-group tree without flattening it."""
+    """Construct one authenticated exception-group tree without flattening it.
+
+    Construction door: ``site`` is a typed ``SourceFragment``. The producer
+    (Raise → GroupedRaiseSugar) must pass an enumerated fragment; there is no
+    runtime kind-admission membrane over seal/memento.
+    """
 
     group_identity: str
     message: Sugar
     children: tuple[Sugar, ...]
-    site: object = dataclass_field(compare=False)
+    site: SourceFragment = dataclass_field(compare=False)
 
     @classmethod
     def witnesses(cls):
@@ -86,8 +58,13 @@ class GroupedRaiseSugar(Sugar):
                     fix="keep non-exception group members loud",
                 )
             effects.append(outcome.effect)
-        occurrence = sealed_source_occurrence(
-            self.site, owner="GroupedRaiseSugar.desugar"
+        # Typed door: site is SourceFragment; seal() returns SourceMemento.
+        memento = self.site.seal()
+        # Full sealed coordinate — segment cid alone collides across files that
+        # share identical span text; file + source_cid pin the authenticated source.
+        occurrence = (
+            f"{memento.file}:{memento.start}:{memento.end}"
+            f":{memento.source_cid}:{memento.cid}"
         )
         return Incomplete(
             GroupedRaiseEffect(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/grouped_raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/grouped_raise_sugar.py
@@ -5,6 +5,10 @@ Produces an immutable ``GroupedRaiseEffect`` whose leaves are ordinary
 groups stay nested: children are never flattened. Spelling does not grant
 group authority — only the Raise construction path that recognized the builtin
 group coordinate may mint this sugar.
+
+Group occurrence identity is the sealed source fragment CID (content-addressed),
+never a fabricated ``filename:line:col`` string — identical positions in
+different authenticated sources must differ.
 """
 
 from __future__ import annotations
@@ -14,6 +18,43 @@ from dataclasses import dataclass, field as dataclass_field
 from sugar_lift_py_tests.effect import GroupedRaiseEffect, RaiseEffect
 from sugar_lift_py_tests.outcome import Complete, Incomplete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+def sealed_source_occurrence(site, *, owner: str) -> str:
+    """Sealed source occurrence coordinate for this construction site.
+
+    Uses the full sealed memento (file + source_cid + span + segment cid), not
+    a fabricated ``filename:line:col`` spelling. Identical positions in
+    different authenticated sources differ via ``file`` / ``source_cid``.
+    """
+    from sugar_source_tree.panic import SugarNotWritten
+
+    seal = getattr(site, "seal", None)
+    if seal is None:
+        raise SugarNotWritten(
+            blame=site,
+            owner=owner,
+            observed="group construction site lacks seal()",
+            requested="a sealed SourceFragment occurrence coordinate",
+            fix="construct GroupedRaiseSugar only from an enumerated source fragment",
+        )
+    memento = seal()
+    cid = getattr(memento, "cid", None)
+    source_cid = getattr(memento, "source_cid", None)
+    file = getattr(memento, "file", None)
+    start = getattr(memento, "start", None)
+    end = getattr(memento, "end", None)
+    if not cid or not source_cid or file is None or start is None or end is None:
+        raise SugarNotWritten(
+            blame=site,
+            owner=owner,
+            observed=type(memento).__name__,
+            requested="SourceMemento{file,start,end,source_cid,cid}",
+            fix="seal the raise site before minting GroupedRaiseEffect.occurrence",
+        )
+    # Full sealed coordinate — content CID alone collides across files that
+    # share identical span text; file + source_cid pin the authenticated source.
+    return f"{file}:{start}:{end}:{source_cid}:{cid}"
 
 
 @dataclass(frozen=True)
@@ -49,9 +90,9 @@ class GroupedRaiseSugar(Sugar):
                     fix="keep non-exception group members loud",
                 )
             effects.append(outcome.effect)
-        # Site occurrence is independent of group_identity (content seal) so
-        # two raises of the same group shape remain distinct halt faces.
-        occurrence = f"{self.site.filename}:{self.site.line}:{self.site.col}"
+        occurrence = sealed_source_occurrence(
+            self.site, owner="GroupedRaiseSugar.desugar"
+        )
         return Incomplete(
             GroupedRaiseEffect(
                 self.group_identity,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
@@ -1,6 +1,19 @@
+"""``except*`` subgroup routing over authenticated ``GroupedRaiseEffect`` trees.
+
+Laws (owned here; ExitSet/carrier untouched):
+
+- Partition each body ``GroupedRaiseEffect`` by authenticated handler type.
+- Matching subgroup reaches its handler once (type-tuple = one body run).
+- Unmatched residual continues to subsequent handlers in source order.
+- Handler halt effects regroup with residual; empty residual completes.
+- Finally restore preserves residual; finally terminate overrides.
+- Leaf occurrence identities and nested topology survive partition/regroup.
+- Ordinary ``RaiseEffect`` under ``except*`` stays loud (distinct from Try).
+"""
+
 from __future__ import annotations
 
-from dataclasses import dataclass, field as dataclass_field
+from dataclasses import dataclass, field as dataclass_field, replace
 
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
@@ -57,7 +70,11 @@ class TryStarSugar(Sugar):
             original = exit_.effect
             residual = original
             handler_effects = []
-            completed_states = []
+            # Temporal fragments from handlers that complete or halt — merged
+            # into the outgoing face so assignments before a handler raise /
+            # pass survive into residual propagation (occurrence identities
+            # already live on the RaiseEffect leaves themselves).
+            temporal_fragments = []
             for matchers, handler_body, slot_id in self.handlers:
                 # One handler, one body run, however many types it lists. Each
                 # type partitions what the previous type left behind, and the
@@ -115,24 +132,17 @@ class TryStarSugar(Sugar):
                 for handler_exit in handler_exits.exits:
                     if isinstance(handler_exit, Halted):
                         handler_effects.append(handler_exit.effect)
+                        temporal_fragments.append(handler_exit.state)
                     elif isinstance(handler_exit, Completed):
-                        completed_states.append(handler_exit.value)
+                        temporal_fragments.append(handler_exit.value)
             outgoing = list(handler_effects)
             if residual.children:
                 outgoing.append(residual)
             regrouped = regroup_except_star(original, outgoing)
-            state = exit_.state
-            if isinstance(state, _ReducedBlock):
-                entries = list(state.entries)
-                for completed in completed_states:
-                    if isinstance(completed, _ReducedBlock):
-                        entries.extend(completed.entries)
-                from dataclasses import replace
-
-                state = replace(state, entries=tuple(entries))
+            state = _merge_temporal_state(exit_.state, temporal_fragments)
             if regrouped is not None:
                 parts.append(ExitSet((Halted(exit_.guard, regrouped, state),)))
-            elif completed_states:
+            elif temporal_fragments:
                 parts.append(ExitSet((Completed(exit_.guard, state),)))
             else:
                 parts.append(ExitSet.completed(state))
@@ -143,6 +153,7 @@ class TryStarSugar(Sugar):
         if self.finalbody:
             cleanup = reduce_block_to_exitset(self.finalbody, ctx)
             from sugar_lift_py_tests.floor.return_value import ReturnValue
+            from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
 
             def restores(value):
                 return not (
@@ -155,3 +166,33 @@ class TryStarSugar(Sugar):
 
             result = result.and_finally(lambda: cleanup, cleanup_restores=restores)
         return exitset_to_outcome(result)
+
+
+def _merge_temporal_state(base, fragments):
+    """Fold handler temporal fragments into the body halt state.
+
+    Entries/transforms from completed or halted handlers append onto the body
+    halt's ``_ReducedBlock`` so residual propagation retains work the handlers
+    performed. Non-block bases pass through unchanged when nothing merges.
+    """
+    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+
+    if not fragments:
+        return base
+    if not isinstance(base, _ReducedBlock):
+        # Prefer the last fragment when the body halt carried no block state.
+        for fragment in reversed(fragments):
+            if isinstance(fragment, _ReducedBlock):
+                return fragment
+        return base
+    entries = list(base.entries)
+    transforms = list(getattr(base, "transforms", ()) or ())
+    for fragment in fragments:
+        if isinstance(fragment, _ReducedBlock):
+            entries.extend(fragment.entries)
+            transforms.extend(getattr(fragment, "transforms", ()) or ())
+    return replace(
+        base,
+        entries=tuple(entries),
+        transforms=tuple(transforms),
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
@@ -7,7 +7,9 @@ Laws (owned here; ExitSet/carrier untouched):
 - Unmatched residual continues to subsequent handlers in source order.
 - Temporal state is an ExitSet of **per-face** handler states — never a single
   scalar accumulator. Each handler face branches the frontier independently.
-- Every ExitSet face is retained with the enclosing body guard conjoined.
+- Every ExitSet face carries the enclosing body guard conjoined.
+- Handler fall-through is **not** a try* completed edge while residual remains;
+  residual continues and ultimately halts unless later consumed.
 - Exceptional raise effects regroup **only within equal guards** (never AND
   mutually exclusive alternative faces into one impossible guard).
 - Finally restore preserves residual; finally terminate overrides.
@@ -147,8 +149,9 @@ class TryStarSugar(Sugar):
                         base_ctx, slot_id, matched, blame=self.site
                     )
                     if slot_id is not None:
-                        handler_ctx = _with_observed_effect(
-                            handler_ctx, slot_id, matched, blame=self.site
+                        # Shared typed surface (ReduceContext / FactoryBuildContext).
+                        handler_ctx = handler_ctx.with_observed_effect(
+                            slot_id, matched
                         )
                     seed = replace(face.state, context=handler_ctx)
                     handler_exits = promote_raise_halts(
@@ -184,6 +187,7 @@ class TryStarSugar(Sugar):
                             )
                             continue
                         if isinstance(handler_exit, Halted):
+                            # Non-raise halt leaves the residual walk as an exit.
                             retained.append(
                                 Halted(
                                     guard,
@@ -210,9 +214,10 @@ class TryStarSugar(Sugar):
                             )
                             continue
                         if isinstance(handler_exit, Completed):
-                            retained.append(
-                                Completed(guard, handler_exit.value, faces, owed)
-                            )
+                            # Handler fall-through is NOT a try* completed edge
+                            # while an unmatched residual remains — Python has
+                            # no completed edge there. Only advance temporal
+                            # state on the residual/exceptional frontier.
                             next_state = (
                                 handler_exit.value
                                 if isinstance(handler_exit.value, _ReducedBlock)
@@ -247,6 +252,7 @@ class TryStarSugar(Sugar):
 
             # Emit residual / exceptional per face — regroup only within a face
             # (equal guard path). Never AND guards across alternative faces.
+            # Completed only when residual is empty and no exceptional remains.
             for face in frontier:
                 effects = list(face.exceptional)
                 if face.residual.children:
@@ -262,10 +268,6 @@ class TryStarSugar(Sugar):
                                 face.faces,
                                 face.pending,
                             )
-                        )
-                    elif not face.exceptional and not face.residual.children:
-                        retained.append(
-                            Completed(face.guard, face.state, face.faces, face.pending)
                         )
                 else:
                     retained.append(
@@ -323,28 +325,6 @@ def _seed_temporal(state, ctx):
         can_fall_through=True,
         fall_through=(),
         context=ctx,
-    )
-
-
-def _with_observed_effect(ctx, slot_id, effect, *, blame):
-    """Typed ``ReduceContext.with_observed_effect`` — no exception capability probe."""
-    from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
-    from sugar_lift_py_tests.context.reduce_context import ReduceContext
-    from sugar_source_tree.panic import SugarNotWritten
-
-    if isinstance(ctx, ReduceContext):
-        return ctx.with_observed_effect(slot_id, effect)
-    if isinstance(ctx, FactoryBuildContext):
-        # Typed front door: derive ReduceContext, then the typed method.
-        return ReduceContext.derived(
-            ctx, owner="TryStarSugar.desugar"
-        ).with_observed_effect(slot_id, effect)
-    raise SugarNotWritten(
-        blame=blame,
-        owner="TryStarSugar.desugar",
-        observed=type(ctx).__name__ if ctx is not None else "None",
-        requested="ReduceContext.with_observed_effect for except* as-binding",
-        fix="route except* handlers through the shared ReduceContext",
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
@@ -5,11 +5,11 @@ Laws (owned here; ExitSet/carrier untouched):
 - Partition each body ``GroupedRaiseEffect`` by authenticated handler type.
 - Matching subgroup reaches its handler once (type-tuple = one body run).
 - Unmatched residual continues to subsequent handlers in source order.
-- Handlers execute temporally: each handler begins from the prior handler's
-  resulting state (not a fresh original ctx / concatenated fragment merge).
-- Every ExitSet face is retained (Completed including terminal return, Halted,
-  and any future face); only exceptional raise faces are regrouped.
-- Handler-exit guards are conjoined with the body halt guard on every face.
+- Temporal state is an ExitSet of **per-face** handler states — never a single
+  scalar accumulator. Each handler face branches the frontier independently.
+- Every ExitSet face is retained with the enclosing body guard conjoined.
+- Exceptional raise effects regroup **only within equal guards** (never AND
+  mutually exclusive alternative faces into one impossible guard).
 - Finally restore preserves residual; finally terminate overrides.
 - Leaf occurrence identities and nested topology survive partition/regroup.
 - Ordinary ``RaiseEffect`` under ``except*`` stays loud (distinct from Try).
@@ -21,6 +21,19 @@ from dataclasses import dataclass, field as dataclass_field, replace
 
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class _StarFace:
+    """One except* routing face: residual + temporal state under one guard."""
+
+    guard: object
+    residual: object  # GroupedRaiseEffect
+    state: object  # _ReducedBlock
+    faces: frozenset
+    pending: tuple
+    # Exceptional raises collected on THIS face's guard path only.
+    exceptional: tuple
 
 
 @dataclass(frozen=True)
@@ -38,7 +51,6 @@ class TryStarSugar(Sugar):
     def desugar(self, ctx=None):
         from sugar_lift_py_tests.caller_parameter_contract import merge_pending
         from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
-        from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
         from sugar_lift_py_tests.effect_router import (
             regroup_except_star,
             route_except_star,
@@ -79,133 +91,196 @@ class TryStarSugar(Sugar):
                     fix="keep ordinary except and except* distinct",
                 )
             original = exit_.effect
-            residual = original
-            # Temporal seed: body halt state, carrying context for the first
-            # matching handler. Each subsequent matching handler begins from
-            # the previous handler's resulting state — not original ctx.
-            temporal = _seed_temporal(exit_.state, ctx)
-            # Exceptional raise effects for regroup only (not Completed/return).
-            exceptional_effects: list = []
-            exceptional_guards: list = []
-            # Every non-exceptional face retained with conjoined guards.
+            # Frontier: one face per body halt, then each handler branches it.
+            frontier: list[_StarFace] = [
+                _StarFace(
+                    guard=exit_.guard,
+                    residual=original,
+                    state=_seed_temporal(exit_.state, ctx),
+                    faces=exit_.faces,
+                    pending=exit_.pending_contracts,
+                    exceptional=(),
+                )
+            ]
+            # Faces that leave the residual walk (unknown control / terminal).
             retained: list = []
 
             for matchers, handler_body, slot_id in self.handlers:
-                # One handler, one body run, however many types it lists. Each
-                # type partitions what the previous type left behind, and the
-                # matched pieces are regrouped into ONE subgroup carrying the
-                # original topology -- so `except* (A, B)` over a group holding
-                # both binds a single group of both leaves rather than entering
-                # the body twice.
                 if not isinstance(matchers, tuple):
                     matchers = (matchers,)
-                handler_residual = residual
-                matched_parts = []
-                for matcher in matchers:
-                    expected = matcher.desugar(temporal.context)
-                    if not isinstance(expected, Complete):
-                        raise SugarNotWritten(
-                            blame=self.site,
-                            owner="TryStarSugar.desugar",
-                            observed="symbolic except* type",
-                            requested="authenticated subtype partition operand",
-                            fix="keep symbolic subtype partition typed loud",
+                next_frontier: list[_StarFace] = []
+                for face in frontier:
+                    handler_residual = face.residual
+                    matched_parts = []
+                    for matcher in matchers:
+                        expected = matcher.desugar(face.state.context)
+                        if not isinstance(expected, Complete):
+                            raise SugarNotWritten(
+                                blame=self.site,
+                                owner="TryStarSugar.desugar",
+                                observed="symbolic except* type",
+                                requested="authenticated subtype partition operand",
+                                fix="keep symbolic subtype partition typed loud",
+                            )
+                        routed = route_except_star(
+                            handler_residual,
+                            expected.value,
+                            slot_id=slot_id,
+                            site=self.site,
                         )
-                    routed = route_except_star(
-                        handler_residual,
-                        expected.value,
-                        slot_id=slot_id,
-                        site=self.site,
-                    )
-                    if routed is None:
+                        if routed is None:
+                            continue
+                        if routed.matched.children:
+                            matched_parts.append(routed.matched)
+                        handler_residual = routed.residual
+                    if not matched_parts:
+                        # This face does not match this handler — residual continues.
+                        next_frontier.append(face)
                         continue
-                    if routed.matched.children:
-                        matched_parts.append(routed.matched)
-                    handler_residual = routed.residual
-                if not matched_parts:
-                    continue
-                matched = regroup_except_star(residual, matched_parts)
-                residual = handler_residual
-
-                base_ctx = (
-                    temporal.context if temporal.context is not None else ctx
-                )
-                handler_ctx = bind_in_flight_effect(
-                    base_ctx, slot_id, matched, blame=self.site
-                )
-                if slot_id is not None:
-                    handler_ctx = _with_observed_effect(
-                        handler_ctx, slot_id, matched, blame=self.site
+                    matched = regroup_except_star(face.residual, matched_parts)
+                    base_ctx = (
+                        face.state.context
+                        if face.state.context is not None
+                        else ctx
                     )
-                seed = replace(temporal, context=handler_ctx)
-                handler_exits = promote_raise_halts(
-                    _reduce_block_from_state(handler_body, seed)
-                )
-
-                for handler_exit in handler_exits.exits:
-                    guard = _and_guards(exit_.guard, handler_exit.guard)
-                    faces = exit_.faces | handler_exit.faces
-                    owed = merge_pending(
-                        exit_.pending_contracts, handler_exit.pending_contracts
+                    handler_ctx = bind_in_flight_effect(
+                        base_ctx, slot_id, matched, blame=self.site
                     )
-                    if isinstance(handler_exit, Halted) and _is_exceptional_raise(
-                        handler_exit.effect
-                    ):
-                        # Regroup exceptional raises only; do not emit raw face.
-                        exceptional_effects.append(handler_exit.effect)
-                        exceptional_guards.append(guard)
-                        if isinstance(handler_exit.state, _ReducedBlock):
-                            temporal = handler_exit.state
-                        continue
-                    if isinstance(handler_exit, Halted):
+                    if slot_id is not None:
+                        handler_ctx = _with_observed_effect(
+                            handler_ctx, slot_id, matched, blame=self.site
+                        )
+                    seed = replace(face.state, context=handler_ctx)
+                    handler_exits = promote_raise_halts(
+                        _reduce_block_from_state(handler_body, seed)
+                    )
+                    # Branch the frontier: one next face per handler exit face.
+                    for handler_exit in handler_exits.exits:
+                        guard = _and_guards(face.guard, handler_exit.guard)
+                        faces = face.faces | handler_exit.faces
+                        owed = merge_pending(
+                            face.pending, handler_exit.pending_contracts
+                        )
+                        if isinstance(handler_exit, Halted) and _is_exceptional_raise(
+                            handler_exit.effect
+                        ):
+                            next_state = (
+                                handler_exit.state
+                                if isinstance(handler_exit.state, _ReducedBlock)
+                                else face.state
+                            )
+                            next_frontier.append(
+                                _StarFace(
+                                    guard=guard,
+                                    residual=handler_residual,
+                                    state=next_state,
+                                    faces=faces,
+                                    pending=owed,
+                                    exceptional=(
+                                        *face.exceptional,
+                                        handler_exit.effect,
+                                    ),
+                                )
+                            )
+                            continue
+                        if isinstance(handler_exit, Halted):
+                            retained.append(
+                                Halted(
+                                    guard,
+                                    handler_exit.effect,
+                                    handler_exit.state,
+                                    faces,
+                                    owed,
+                                )
+                            )
+                            next_state = (
+                                handler_exit.state
+                                if isinstance(handler_exit.state, _ReducedBlock)
+                                else face.state
+                            )
+                            next_frontier.append(
+                                _StarFace(
+                                    guard=guard,
+                                    residual=handler_residual,
+                                    state=next_state,
+                                    faces=faces,
+                                    pending=owed,
+                                    exceptional=face.exceptional,
+                                )
+                            )
+                            continue
+                        if isinstance(handler_exit, Completed):
+                            retained.append(
+                                Completed(guard, handler_exit.value, faces, owed)
+                            )
+                            next_state = (
+                                handler_exit.value
+                                if isinstance(handler_exit.value, _ReducedBlock)
+                                else face.state
+                            )
+                            next_frontier.append(
+                                _StarFace(
+                                    guard=guard,
+                                    residual=handler_residual,
+                                    state=next_state,
+                                    faces=faces,
+                                    pending=owed,
+                                    exceptional=face.exceptional,
+                                )
+                            )
+                            continue
+                        # Unknown face: still conjoin enclosing guard; retain.
                         retained.append(
-                            Halted(
-                                guard,
-                                handler_exit.effect,
-                                handler_exit.state,
-                                faces,
-                                owed,
+                            _rebind_face_guard(handler_exit, guard, faces, owed)
+                        )
+                        next_frontier.append(
+                            _StarFace(
+                                guard=guard,
+                                residual=handler_residual,
+                                state=face.state,
+                                faces=faces,
+                                pending=owed,
+                                exceptional=face.exceptional,
                             )
                         )
-                        if isinstance(handler_exit.state, _ReducedBlock):
-                            temporal = handler_exit.state
-                        continue
-                    if isinstance(handler_exit, Completed):
+                frontier = next_frontier
+
+            # Emit residual / exceptional per face — regroup only within a face
+            # (equal guard path). Never AND guards across alternative faces.
+            for face in frontier:
+                effects = list(face.exceptional)
+                if face.residual.children:
+                    effects.append(face.residual)
+                if effects:
+                    regrouped = regroup_except_star(original, effects)
+                    if regrouped is not None:
                         retained.append(
-                            Completed(guard, handler_exit.value, faces, owed)
+                            Halted(
+                                face.guard,
+                                regrouped,
+                                face.state,
+                                face.faces,
+                                face.pending,
+                            )
                         )
-                        if isinstance(handler_exit.value, _ReducedBlock):
-                            temporal = handler_exit.value
-                        continue
-                    # Unknown face kinds must not disappear — retain as-is under
-                    # the conjoined guard when the face carries one.
-                    retained.append(handler_exit)
+                    elif not face.exceptional and not face.residual.children:
+                        retained.append(
+                            Completed(face.guard, face.state, face.faces, face.pending)
+                        )
+                else:
+                    retained.append(
+                        Completed(face.guard, face.state, face.faces, face.pending)
+                    )
 
-            if residual.children:
-                exceptional_effects.append(residual)
-                exceptional_guards.append(exit_.guard)
-
-            regrouped = (
-                regroup_except_star(original, exceptional_effects)
-                if exceptional_effects
-                else None
-            )
-            if regrouped is not None:
-                regroup_guard = exit_.guard
-                for g in exceptional_guards:
-                    regroup_guard = _and_guards(regroup_guard, g)
+            if not retained:
                 retained.append(
-                    Halted(
-                        regroup_guard,
-                        regrouped,
-                        temporal,
+                    Completed(
+                        exit_.guard,
+                        _seed_temporal(exit_.state, ctx),
                         exit_.faces,
                         exit_.pending_contracts,
                     )
                 )
-            elif not retained:
-                retained.append(Completed(exit_.guard, temporal, exit_.faces))
-
             parts.append(ExitSet(tuple(retained)).normalize())
 
         result = parts[0] if parts else ExitSet.completed(None)
@@ -252,36 +327,48 @@ def _seed_temporal(state, ctx):
 
 
 def _with_observed_effect(ctx, slot_id, effect, *, blame):
-    """Require the typed observed-effect operation — no getattr soft-probe."""
+    """Typed ``ReduceContext.with_observed_effect`` — no exception capability probe."""
+    from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
+    from sugar_lift_py_tests.context.reduce_context import ReduceContext
     from sugar_source_tree.panic import SugarNotWritten
 
-    if ctx is None:
-        raise SugarNotWritten(
-            blame=blame,
-            owner="TryStarSugar.desugar",
-            observed="None",
-            requested="ReduceContext.with_observed_effect for except* as-binding",
-            fix="route except* handlers through the shared ReduceContext",
-        )
-    try:
+    if isinstance(ctx, ReduceContext):
         return ctx.with_observed_effect(slot_id, effect)
-    except AttributeError as exc:
-        raise SugarNotWritten(
-            blame=blame,
-            owner="TryStarSugar.desugar",
-            observed=type(ctx).__name__,
-            requested="ReduceContext.with_observed_effect for except* as-binding",
-            fix="route except* handlers through the shared ReduceContext",
-        ) from exc
+    if isinstance(ctx, FactoryBuildContext):
+        # Typed front door: derive ReduceContext, then the typed method.
+        return ReduceContext.derived(
+            ctx, owner="TryStarSugar.desugar"
+        ).with_observed_effect(slot_id, effect)
+    raise SugarNotWritten(
+        blame=blame,
+        owner="TryStarSugar.desugar",
+        observed=type(ctx).__name__ if ctx is not None else "None",
+        requested="ReduceContext.with_observed_effect for except* as-binding",
+        fix="route except* handlers through the shared ReduceContext",
+    )
+
+
+def _rebind_face_guard(face, guard, faces, owed):
+    """Retain a face with the enclosing guard conjoined (all faces, no drop)."""
+    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+    from sugar_source_tree.panic import SugarNotWritten
+
+    if isinstance(face, Halted):
+        return Halted(guard, face.effect, face.state, faces, owed)
+    if isinstance(face, Completed):
+        return Completed(guard, face.value, faces, owed)
+    raise SugarNotWritten(
+        blame=None,
+        owner="TryStarSugar.desugar",
+        observed=type(face).__name__,
+        requested="Completed|Halted ExitSet face with conjoined body guard",
+        fix="extend TryStarSugar face retention for the new ExitSet face kind",
+    )
 
 
 def _reduce_block_from_state(statements, state):
-    """Reduce ``statements`` continuing from an existing temporal ``state``.
-
-    Unlike ``reduce_block_to_exitset`` (always empty seed), each statement
-    begins from the prior face's state so earlier handler work is visible.
-    """
-    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+    """Reduce ``statements`` continuing from an existing temporal ``state``."""
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet
     from sugar_lift_py_tests.sugar.function_universe_sugar import (
         _ReducedBlock,
         reduce_block_to_exitset,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
@@ -5,7 +5,11 @@ Laws (owned here; ExitSet/carrier untouched):
 - Partition each body ``GroupedRaiseEffect`` by authenticated handler type.
 - Matching subgroup reaches its handler once (type-tuple = one body run).
 - Unmatched residual continues to subsequent handlers in source order.
-- Handler halt effects regroup with residual; empty residual completes.
+- Handlers execute temporally: each handler begins from the prior handler's
+  resulting state (not a fresh original ctx / concatenated fragment merge).
+- Every ExitSet face is retained (Completed including terminal return, Halted,
+  and any future face); only exceptional raise faces are regrouped.
+- Handler-exit guards are conjoined with the body halt guard on every face.
 - Finally restore preserves residual; finally terminate overrides.
 - Leaf occurrence identities and nested topology survive partition/regroup.
 - Ordinary ``RaiseEffect`` under ``except*`` stays loud (distinct from Try).
@@ -32,13 +36,20 @@ class TryStarSugar(Sugar):
         return ()
 
     def desugar(self, ctx=None):
+        from sugar_lift_py_tests.caller_parameter_contract import merge_pending
         from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
+        from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
         from sugar_lift_py_tests.effect_router import (
             regroup_except_star,
             route_except_star,
         )
         from sugar_lift_py_tests.in_flight_effect import bind_in_flight_effect
-        from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+        from sugar_lift_py_tests.outcome.exit_set import (
+            Completed,
+            ExitSet,
+            Halted,
+            _and_guards,
+        )
         from sugar_lift_py_tests.sugar.exit_set_routing import (
             exitset_to_outcome,
             promote_raise_halts,
@@ -69,12 +80,16 @@ class TryStarSugar(Sugar):
                 )
             original = exit_.effect
             residual = original
-            handler_effects = []
-            # Temporal fragments from handlers that complete or halt — merged
-            # into the outgoing face so assignments before a handler raise /
-            # pass survive into residual propagation (occurrence identities
-            # already live on the RaiseEffect leaves themselves).
-            temporal_fragments = []
+            # Temporal seed: body halt state, carrying context for the first
+            # matching handler. Each subsequent matching handler begins from
+            # the previous handler's resulting state — not original ctx.
+            temporal = _seed_temporal(exit_.state, ctx)
+            # Exceptional raise effects for regroup only (not Completed/return).
+            exceptional_effects: list = []
+            exceptional_guards: list = []
+            # Every non-exceptional face retained with conjoined guards.
+            retained: list = []
+
             for matchers, handler_body, slot_id in self.handlers:
                 # One handler, one body run, however many types it lists. Each
                 # type partitions what the previous type left behind, and the
@@ -87,7 +102,7 @@ class TryStarSugar(Sugar):
                 handler_residual = residual
                 matched_parts = []
                 for matcher in matchers:
-                    expected = matcher.desugar(ctx)
+                    expected = matcher.desugar(temporal.context)
                     if not isinstance(expected, Complete):
                         raise SugarNotWritten(
                             blame=self.site,
@@ -111,41 +126,87 @@ class TryStarSugar(Sugar):
                     continue
                 matched = regroup_except_star(residual, matched_parts)
                 residual = handler_residual
+
+                base_ctx = (
+                    temporal.context if temporal.context is not None else ctx
+                )
                 handler_ctx = bind_in_flight_effect(
-                    ctx, slot_id, matched, blame=self.site
+                    base_ctx, slot_id, matched, blame=self.site
                 )
                 if slot_id is not None:
-                    observer = getattr(handler_ctx, "with_observed_effect", None)
-                    if observer is not None:
-                        handler_ctx = observer(slot_id, matched)
-                handler_exits = promote_raise_halts(
-                    reduce_block_to_exitset(handler_body, handler_ctx)
-                )
-                if len(handler_exits.exits) != 1:
-                    raise SugarNotWritten(
-                        blame=self.site,
-                        owner="TryStarSugar.desugar",
-                        observed="symbolically branching except* handler",
-                        requested="one closed handler exit for exact regrouping",
-                        fix="keep unresolved handler regrouping typed loud",
+                    handler_ctx = _with_observed_effect(
+                        handler_ctx, slot_id, matched, blame=self.site
                     )
+                seed = replace(temporal, context=handler_ctx)
+                handler_exits = promote_raise_halts(
+                    _reduce_block_from_state(handler_body, seed)
+                )
+
                 for handler_exit in handler_exits.exits:
+                    guard = _and_guards(exit_.guard, handler_exit.guard)
+                    faces = exit_.faces | handler_exit.faces
+                    owed = merge_pending(
+                        exit_.pending_contracts, handler_exit.pending_contracts
+                    )
+                    if isinstance(handler_exit, Halted) and _is_exceptional_raise(
+                        handler_exit.effect
+                    ):
+                        # Regroup exceptional raises only; do not emit raw face.
+                        exceptional_effects.append(handler_exit.effect)
+                        exceptional_guards.append(guard)
+                        if isinstance(handler_exit.state, _ReducedBlock):
+                            temporal = handler_exit.state
+                        continue
                     if isinstance(handler_exit, Halted):
-                        handler_effects.append(handler_exit.effect)
-                        temporal_fragments.append(handler_exit.state)
-                    elif isinstance(handler_exit, Completed):
-                        temporal_fragments.append(handler_exit.value)
-            outgoing = list(handler_effects)
+                        retained.append(
+                            Halted(
+                                guard,
+                                handler_exit.effect,
+                                handler_exit.state,
+                                faces,
+                                owed,
+                            )
+                        )
+                        if isinstance(handler_exit.state, _ReducedBlock):
+                            temporal = handler_exit.state
+                        continue
+                    if isinstance(handler_exit, Completed):
+                        retained.append(
+                            Completed(guard, handler_exit.value, faces, owed)
+                        )
+                        if isinstance(handler_exit.value, _ReducedBlock):
+                            temporal = handler_exit.value
+                        continue
+                    # Unknown face kinds must not disappear — retain as-is under
+                    # the conjoined guard when the face carries one.
+                    retained.append(handler_exit)
+
             if residual.children:
-                outgoing.append(residual)
-            regrouped = regroup_except_star(original, outgoing)
-            state = _merge_temporal_state(exit_.state, temporal_fragments)
+                exceptional_effects.append(residual)
+                exceptional_guards.append(exit_.guard)
+
+            regrouped = (
+                regroup_except_star(original, exceptional_effects)
+                if exceptional_effects
+                else None
+            )
             if regrouped is not None:
-                parts.append(ExitSet((Halted(exit_.guard, regrouped, state),)))
-            elif temporal_fragments:
-                parts.append(ExitSet((Completed(exit_.guard, state),)))
-            else:
-                parts.append(ExitSet.completed(state))
+                regroup_guard = exit_.guard
+                for g in exceptional_guards:
+                    regroup_guard = _and_guards(regroup_guard, g)
+                retained.append(
+                    Halted(
+                        regroup_guard,
+                        regrouped,
+                        temporal,
+                        exit_.faces,
+                        exit_.pending_contracts,
+                    )
+                )
+            elif not retained:
+                retained.append(Completed(exit_.guard, temporal, exit_.faces))
+
+            parts.append(ExitSet(tuple(retained)).normalize())
 
         result = parts[0] if parts else ExitSet.completed(None)
         for part in parts[1:]:
@@ -168,31 +229,121 @@ class TryStarSugar(Sugar):
         return exitset_to_outcome(result)
 
 
-def _merge_temporal_state(base, fragments):
-    """Fold handler temporal fragments into the body halt state.
+def _is_exceptional_raise(effect) -> bool:
+    from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 
-    Entries/transforms from completed or halted handlers append onto the body
-    halt's ``_ReducedBlock`` so residual propagation retains work the handlers
-    performed. Non-block bases pass through unchanged when nothing merges.
-    """
+    return isinstance(effect, (RaiseEffect, GroupedRaiseEffect))
+
+
+def _seed_temporal(state, ctx):
     from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
 
-    if not fragments:
-        return base
-    if not isinstance(base, _ReducedBlock):
-        # Prefer the last fragment when the body halt carried no block state.
-        for fragment in reversed(fragments):
-            if isinstance(fragment, _ReducedBlock):
-                return fragment
-        return base
-    entries = list(base.entries)
-    transforms = list(getattr(base, "transforms", ()) or ())
-    for fragment in fragments:
-        if isinstance(fragment, _ReducedBlock):
-            entries.extend(fragment.entries)
-            transforms.extend(getattr(fragment, "transforms", ()) or ())
-    return replace(
-        base,
-        entries=tuple(entries),
-        transforms=tuple(transforms),
+    if isinstance(state, _ReducedBlock):
+        if state.context is None and ctx is not None:
+            return replace(state, context=ctx)
+        return state
+    return _ReducedBlock(
+        entries=(),
+        can_fall_through=True,
+        fall_through=(),
+        context=ctx,
     )
+
+
+def _with_observed_effect(ctx, slot_id, effect, *, blame):
+    """Require the typed observed-effect operation — no getattr soft-probe."""
+    from sugar_source_tree.panic import SugarNotWritten
+
+    if ctx is None:
+        raise SugarNotWritten(
+            blame=blame,
+            owner="TryStarSugar.desugar",
+            observed="None",
+            requested="ReduceContext.with_observed_effect for except* as-binding",
+            fix="route except* handlers through the shared ReduceContext",
+        )
+    try:
+        return ctx.with_observed_effect(slot_id, effect)
+    except AttributeError as exc:
+        raise SugarNotWritten(
+            blame=blame,
+            owner="TryStarSugar.desugar",
+            observed=type(ctx).__name__,
+            requested="ReduceContext.with_observed_effect for except* as-binding",
+            fix="route except* handlers through the shared ReduceContext",
+        ) from exc
+
+
+def _reduce_block_from_state(statements, state):
+    """Reduce ``statements`` continuing from an existing temporal ``state``.
+
+    Unlike ``reduce_block_to_exitset`` (always empty seed), each statement
+    begins from the prior face's state so earlier handler work is visible.
+    """
+    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        _ReducedBlock,
+        reduce_block_to_exitset,
+    )
+
+    if not isinstance(state, _ReducedBlock):
+        return reduce_block_to_exitset(statements, None)
+
+    exits = ExitSet.completed(state)
+    for statement in statements:
+        exits = exits.sequence(
+            lambda s, stmt=statement: _reduce_one_from(s, stmt)
+        )
+    return exits
+
+
+def _reduce_one_from(state, statement):
+    """Reduce one statement after ``state``; prefix entries; keep new context."""
+    from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        _ReducedBlock,
+        reduce_block_to_exitset,
+    )
+
+    if not state.can_fall_through:
+        return ExitSet.completed(state)
+
+    following = reduce_block_to_exitset((statement,), state.context)
+    out = []
+    for face in following.exits:
+        if isinstance(face, Completed) and isinstance(face.value, _ReducedBlock):
+            out.append(
+                Completed(
+                    face.guard,
+                    replace(
+                        face.value,
+                        entries=(*state.entries, *face.value.entries),
+                        transforms=(*state.transforms, *face.value.transforms),
+                    ),
+                    face.faces,
+                    face.pending_contracts,
+                )
+            )
+        elif isinstance(face, Halted):
+            halt_state = face.state
+            if isinstance(halt_state, _ReducedBlock):
+                halt_state = replace(
+                    halt_state,
+                    entries=(*state.entries, *halt_state.entries),
+                    transforms=(*state.transforms, *halt_state.transforms),
+                )
+            elif halt_state is None:
+                halt_state = state
+            out.append(
+                Halted(
+                    face.guard,
+                    face.effect,
+                    halt_state,
+                    face.faces,
+                    face.pending_contracts,
+                )
+            )
+        else:
+            out.append(face)
+    return ExitSet(tuple(out)).normalize()

--- a/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
@@ -475,3 +475,363 @@ def test_grouped_raise_constructs_nested_tree_without_flattening():
         "KeyError",
     ]
     assert nested.children[0].occurrence != nested.children[1].occurrence
+
+
+def test_grouped_raise_occurrence_is_sealed_coordinate_not_line_col_spelling():
+    """Group occurrence is the sealed memento coordinate, not filename:line:col."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    raise ExceptionGroup('g', [ValueError()])\n",
+            name="sealed_occ_a.py",
+        )
+    )
+    assert effect.occurrence is not None
+    # Sealed coordinate carries blake3 CIDs; fabricated line-col is "file:N:M".
+    assert "blake3" in effect.occurrence
+    assert effect.occurrence.count(":") >= 4  # file:start:end:source_cid:cid
+    other = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    raise ExceptionGroup('g', [ValueError()])\n",
+            name="sealed_occ_b.py",
+        )
+    )
+    # Different authenticated source files differ even with identical span text.
+    assert effect.occurrence != other.occurrence
+
+
+# ---------------------------------------------------------------------------
+# Advisor repairs: temporal threading, Returned face, guard conjunction
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_class(name: str):
+    """One shared ClassValue identity for matcher/leaf (is-subtype uses `is`)."""
+    from sugar_lift_py_tests.floor import BlockValue, ClassValue
+    from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
+        AuthenticatedExceptionTypeValue,
+    )
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    identity = ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
+    cls = ClassValue(name, (), BlockValue(()))
+    typed = AuthenticatedExceptionTypeValue(cls, identity, (identity,), class_value=cls)
+    return cls, typed, identity
+
+
+def test_second_handler_reads_first_handler_temporal_binding():
+    """Handlers execute temporally — later handler sees prior handler state.
+
+    Fixed sugars pin TryStarSugar threading (nodes.py substitute frozen).
+    ClassValue instances are shared so subtype partition uses `is` identity.
+    """
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context.reduce_context import ReduceContext
+    from sugar_lift_py_tests.floor import TermValue
+    from sugar_lift_py_tests.outcome import Complete, Incomplete
+    from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+    from sugar_lift_py_tests.sugar.try_star_sugar import TryStarSugar
+
+    site = SimpleNamespace(
+        filename="temporal_thread.py",
+        line=1,
+        col=0,
+        unit=SimpleNamespace(source="try-star"),
+    )
+    _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
+    _te_cls, te_typed, te_id = _synthetic_class("TypeError")
+
+    ve_leaf = RaiseEffect(
+        exception_name="ValueError",
+        occurrence="leaf:ve",
+        exception_type_coordinate=ve_id,
+        exception_type_mro=(ve_id,),
+        raised_value=ve_typed,
+    )
+    te_leaf = RaiseEffect(
+        exception_name="TypeError",
+        occurrence="leaf:te",
+        exception_type_coordinate=te_id,
+        exception_type_mro=(te_id,),
+        raised_value=te_typed,
+    )
+    group = GroupedRaiseEffect(
+        "group:root", "g", (ve_leaf, te_leaf), occurrence="group:root"
+    )
+
+    class Fixed(Sugar):
+        def __init__(self, outcome):
+            self.outcome = outcome
+
+        def desugar(self, ctx=None):
+            del ctx
+            return self.outcome
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    class BindX(Sugar):
+        def desugar(self, ctx=None):
+            from sugar_lift_py_tests.outcome.exit_set import ExitSet
+
+            if ctx is None:
+                ctx = ReduceContext.root(owner="BindX")
+            bound = ctx.with_temporal(ctx.temporal.bind_value("x", TermValue(1)))
+            # ExitSet face carries _ReducedBlock.context (Complete(floor) cannot).
+            return ExitSet.completed(
+                _ReducedBlock(
+                    entries=(),
+                    can_fall_through=True,
+                    fall_through=(),
+                    context=bound,
+                )
+            )
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    class ReadXOrHalt(Sugar):
+        def desugar(self, ctx=None):
+            temporal = getattr(ctx, "temporal", None) if ctx is not None else None
+            bound = temporal.value_if_bound("x") if temporal is not None else None
+            if bound is None:
+                return Incomplete(
+                    RaiseEffect(
+                        exception_name="NameError",
+                        occurrence="read-x-missing",
+                    )
+                )
+            return Incomplete(
+                RaiseEffect(
+                    exception_name="RuntimeError",
+                    occurrence="read-x-ok",
+                )
+            )
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    class MatchType(Sugar):
+        def __init__(self, typed):
+            self.typed = typed
+
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(self.typed)
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    sugar = TryStarSugar(
+        body=(Fixed(Incomplete(group)),),
+        handlers=(
+            ((MatchType(ve_typed),), (BindX(),), "slot-ve"),
+            ((MatchType(te_typed),), (ReadXOrHalt(),), "slot-te"),
+        ),
+        site=site,
+    )
+    outcome = sugar.desugar(ReduceContext.root(owner="temporal_twin"))
+    # Retained faces (handler completion + exceptional regroup) collapse to a
+    # linear Complete carrying Incomplete entries — project raise names from both.
+    names: list[str] = []
+
+    def collect(obj):
+        if isinstance(obj, Incomplete):
+            if isinstance(obj.effect, GroupedRaiseEffect):
+                names.extend(leaf.exception_name for leaf in _leaves(obj.effect))
+            elif isinstance(obj.effect, RaiseEffect):
+                names.append(obj.effect.exception_name)
+        elif isinstance(obj, Complete):
+            record = getattr(obj.value, "record", obj.value)
+            for stmt in getattr(record, "statements", ()) or getattr(
+                record, "entries", ()
+            ):
+                collect(stmt)
+        elif isinstance(obj, ExitSet):
+            for face in obj.exits:
+                if isinstance(face, Halted):
+                    if isinstance(face.effect, GroupedRaiseEffect):
+                        names.extend(
+                            leaf.exception_name for leaf in _leaves(face.effect)
+                        )
+                    elif isinstance(face.effect, RaiseEffect):
+                        names.append(face.effect.exception_name)
+
+    collect(outcome)
+    assert "RuntimeError" in names, (names, outcome)
+    assert "NameError" not in names, names
+
+
+def test_handler_terminal_return_face_is_retained_not_dropped():
+    """Completed terminal return (finally override) is retained, not dropped."""
+    outcome = _desugar(
+        "def f():\n"
+        "    try:\n"
+        "        raise ExceptionGroup('g', [ValueError()])\n"
+        "    except* ValueError:\n"
+        "        pass\n"
+        "    finally:\n"
+        "        return 7\n",
+        name="handler_return_face.py",
+    )
+    assert isinstance(outcome, Complete), outcome
+    returns = [
+        s for s in outcome.value.record.statements if isinstance(s, ReturnValue)
+    ]
+    assert returns and returns[0].value.value == 7
+
+
+def test_handler_completion_and_residual_both_retained_as_faces():
+    """Non-exceptional completion is retained; residual regroup is separate halt.
+
+    Discriminates the old bug that only kept Halted|Completed-via-merge and
+    dropped other faces when residual remained after a completing handler.
+    """
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+            "    except* ValueError:\n"
+            "        pass\n",
+            name="retain_completion.py",
+        )
+    )
+    # Residual TypeError only — handler completed (pass) was not exceptional,
+    # so regroup is residual alone (not dropped, not rewritten to ValueError).
+    assert [leaf.exception_name for leaf in _leaves(effect)] == ["TypeError"]
+
+
+def test_guarded_handler_faces_conjoin_body_guard():
+    """Handler-exit guards are conjoined with the body halt guard."""
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context.reduce_context import ReduceContext
+    from sugar_lift_py_tests.ir import atomic, str_const
+    from sugar_lift_py_tests.outcome import Complete, Incomplete
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted, true_guard
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+    from sugar_lift_py_tests.sugar.try_star_sugar import TryStarSugar
+
+    site = SimpleNamespace(
+        filename="guard_conj.py",
+        line=1,
+        col=0,
+        unit=SimpleNamespace(source="try-star"),
+    )
+    _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
+    leaf = RaiseEffect(
+        exception_name="ValueError",
+        occurrence="leaf:ve",
+        exception_type_coordinate=ve_id,
+        exception_type_mro=(ve_id,),
+        raised_value=ve_typed,
+    )
+    group = GroupedRaiseEffect("group:root", "g", (leaf,), occurrence="group:root")
+    body_atom = atomic("body.guard", [str_const("body")])
+    handler_atom = atomic("handler.guard", [str_const("handler")])
+
+    class Fixed(Sugar):
+        def __init__(self, outcome):
+            self.outcome = outcome
+
+        def desugar(self, ctx=None):
+            del ctx
+            return self.outcome
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    class MatchVE(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(ve_typed)
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    class GuardedRaise(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            return ExitSet(
+                (
+                    Halted(
+                        handler_atom,
+                        RaiseEffect(
+                            exception_name="RuntimeError",
+                            occurrence="handler:re",
+                        ),
+                        None,
+                    ),
+                )
+            )
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    class BodyHalt(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            return ExitSet((Halted(body_atom, group, None),))
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    sugar = TryStarSugar(
+        body=(BodyHalt(),),
+        handlers=(((MatchVE(),), (GuardedRaise(),), "slot-ve"),),
+        site=site,
+    )
+    # Bypass exitset_to_outcome to observe conjoined guards on ExitSet faces.
+    from sugar_lift_py_tests.sugar.exit_set_routing import (
+        exitset_to_outcome,
+        promote_raise_halts,
+    )
+    from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
+
+    # Call desugar but intercept: reimplement observation via direct ExitSet
+    # by temporarily patching exitset_to_outcome to identity.
+    captured = {}
+
+    def capture(es):
+        captured["es"] = es
+        return exitset_to_outcome(es)
+
+    import sugar_lift_py_tests.sugar.exit_set_routing as esr
+
+    real = esr.exitset_to_outcome
+    esr.exitset_to_outcome = capture
+    try:
+        outcome = sugar.desugar(ReduceContext.root(owner="guard_twin"))
+    finally:
+        esr.exitset_to_outcome = real
+
+    es = captured.get("es")
+    assert es is not None, outcome
+    halted = [face for face in es.exits if isinstance(face, Halted)]
+    assert halted, es.exits
+    text = str(halted[0].guard)
+    # Conjunction must mention both body and handler guard atoms.
+    assert "body.guard" in text or "body" in text, text
+    assert "handler.guard" in text or "handler" in text, text
+    effect = halted[0].effect
+    if isinstance(effect, RaiseEffect):
+        assert effect.exception_name == "RuntimeError"
+    else:
+        assert any(
+            leaf.exception_name == "RuntimeError" for leaf in _leaves(effect)
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
@@ -1,0 +1,477 @@
+"""TryStar subgroup routing — production laws.
+
+ExceptionGroup testimony is partitioned by authenticated handler type through
+``TryStarSugar`` + ``GroupedRaiseSugar`` only:
+
+- matching subgroup reaches its handler (as-binding / bare re-raise / from)
+- unmatched residual continues to subsequent handlers (source order)
+- handler halt regroups with residual; finally restore / terminate override
+- leaf occurrence identities and nested group topology survive partition
+- ordinary ``Try`` never consumes grouped testimony
+- type and occurrence lying twins refuse
+
+Does not touch nodes.py, ExitSet/carrier algebra, assertion/resource routing,
+or exception spelling rules. Acceptance is this file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.effect_coordinate import ObservedEffectValue
+from sugar_lift_py_tests.floor.return_value import ReturnValue
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _desugar(source: str, *, name: str = "trystar_subgroup.py"):
+    tree = SourceFile(
+        (source, name, blake3_512_of(source.encode("utf-8"))),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    return list(tree.functions())[-1].sugar().desugar()
+
+
+def _leaves(effect) -> list[RaiseEffect]:
+    out: list[RaiseEffect] = []
+
+    def walk(node):
+        if isinstance(node, RaiseEffect):
+            out.append(node)
+        elif isinstance(node, GroupedRaiseEffect):
+            for child in node.children:
+                walk(child)
+
+    walk(effect)
+    return out
+
+
+def _halt_effect(outcome):
+    """Project the single halt effect from Incomplete or a one-face ExitSet."""
+    if isinstance(outcome, Incomplete):
+        return outcome.effect
+    if isinstance(outcome, ExitSet):
+        halted = [face for face in outcome.exits if isinstance(face, Halted)]
+        assert len(halted) == 1, outcome.exits
+        return halted[0].effect
+    raise AssertionError(f"expected Incomplete|ExitSet halt, got {type(outcome)}")
+
+
+def _grouped_halt(outcome) -> GroupedRaiseEffect:
+    effect = _halt_effect(outcome)
+    assert isinstance(effect, GroupedRaiseEffect), type(effect)
+    return effect
+
+
+# ---------------------------------------------------------------------------
+# Partition: authenticated type, residual continues, topology preserved
+# ---------------------------------------------------------------------------
+
+
+def test_partition_by_authenticated_type_keeps_unmatched_residual():
+    """except* ValueError extracts VE leaves; TypeError residual continues."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError('a'), TypeError('b')])\n"
+            "    except* ValueError:\n"
+            "        pass\n",
+            name="part_residual.py",
+        )
+    )
+    names = [leaf.exception_name for leaf in _leaves(effect)]
+    assert names == ["TypeError"], names
+
+
+def test_nested_group_topology_survives_partial_partition():
+    """Inner ExceptionGroup remains nested after a leaf is extracted."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup(\n"
+            "            'outer',\n"
+            "            [TypeError(), ExceptionGroup('inner', [ValueError(), KeyError()])],\n"
+            "        )\n"
+            "    except* ValueError:\n"
+            "        pass\n",
+            name="nested_topology.py",
+        )
+    )
+    assert isinstance(effect.children[0], RaiseEffect)
+    assert effect.children[0].exception_name == "TypeError"
+    nested = effect.children[1]
+    assert isinstance(nested, GroupedRaiseEffect)
+    assert [leaf.exception_name for leaf in nested.children] == ["KeyError"]
+
+
+def test_all_matching_leaves_of_same_type_are_extracted():
+    """except* never selects only the first leaf of a repeated type."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup(\n"
+            "            'g', [TypeError(), ValueError('a'), ValueError('b')]\n"
+            "        )\n"
+            "    except* ValueError:\n"
+            "        pass\n",
+            name="all_leaves.py",
+        )
+    )
+    assert [leaf.exception_name for leaf in _leaves(effect)] == ["TypeError"]
+
+
+# ---------------------------------------------------------------------------
+# Matching subgroup reaches handler; handlers in source order
+# ---------------------------------------------------------------------------
+
+
+def test_matched_subgroup_reaches_handler_as_binding():
+    """``except* ValueError as e`` binds only the VE subgroup, not the residual."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError('a'), TypeError('b')])\n"
+            "    except* ValueError as e:\n"
+            "        raise RuntimeError('from-handler') from e\n",
+            name="matched_binding.py",
+        )
+    )
+    primary = effect.children[0]
+    assert isinstance(primary, RaiseEffect)
+    assert primary.exception_name == "RuntimeError"
+    assert isinstance(primary.cause_value, ObservedEffectValue)
+    cause_leaves = _leaves(primary.cause_value.effect)
+    assert [leaf.exception_name for leaf in cause_leaves] == ["ValueError"]
+    residual = effect.children[1]
+    assert isinstance(residual, GroupedRaiseEffect)
+    assert [leaf.exception_name for leaf in _leaves(residual)] == ["TypeError"]
+
+
+def test_handlers_run_in_source_order_not_group_leaf_order():
+    """Second source handler runs after the first even if its type is earlier in the group."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup(\n"
+            "            'g', [ValueError(), TypeError(), KeyError()]\n"
+            "        )\n"
+            "    except* TypeError:\n"
+            "        raise OSError('type-handler')\n"
+            "    except* ValueError:\n"
+            "        raise RuntimeError('value-handler')\n",
+            name="source_order.py",
+        )
+    )
+    # Source order: TypeError arm first, then ValueError arm, then residual KeyError.
+    assert isinstance(effect.children[0], RaiseEffect)
+    assert effect.children[0].exception_name == "OSError"
+    assert isinstance(effect.children[1], RaiseEffect)
+    assert effect.children[1].exception_name == "RuntimeError"
+    residual = effect.children[2]
+    assert isinstance(residual, GroupedRaiseEffect)
+    assert [leaf.exception_name for leaf in _leaves(residual)] == ["KeyError"]
+
+
+def test_subsequent_handler_consumes_prior_residual():
+    """Unmatched remainder after first arm is available to the next arm."""
+    outcome = _desugar(
+        "def f():\n"
+        "    try:\n"
+        "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+        "    except* ValueError:\n"
+        "        pass\n"
+        "    except* TypeError:\n"
+        "        pass\n",
+        name="subsequent.py",
+    )
+    assert isinstance(outcome, Complete), outcome
+
+
+def test_type_tuple_handler_runs_body_once_for_all_listed_types():
+    """``except* (A, B)`` is one handler: one body run over the union subgroup."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup(\n"
+            "            'g', [ValueError(), TypeError(), KeyError()]\n"
+            "        )\n"
+            "    except* (ValueError, TypeError):\n"
+            "        raise RuntimeError('once')\n",
+            name="type_tuple_once.py",
+        )
+    )
+    names = [leaf.exception_name for leaf in _leaves(effect)]
+    # One RuntimeError (not two) + unmatched KeyError.
+    assert names == ["RuntimeError", "KeyError"], names
+
+
+# ---------------------------------------------------------------------------
+# Handler halt regroup; finally restore / terminate override
+# ---------------------------------------------------------------------------
+
+
+def test_handler_halt_regroups_with_unmatched_residual():
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+            "    except* ValueError:\n"
+            "        raise KeyError('from-handler')\n",
+            name="handler_halt.py",
+        )
+    )
+    assert isinstance(effect.children[0], RaiseEffect)
+    assert effect.children[0].exception_name == "KeyError"
+    assert isinstance(effect.children[1], GroupedRaiseEffect)
+    assert [leaf.exception_name for leaf in _leaves(effect.children[1])] == [
+        "TypeError"
+    ]
+
+
+def test_bare_reraise_regroups_matched_subgroup_with_residual():
+    """Bare raise reconstructs original leaf set (matched + residual), no flatten."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+            "    except* ValueError:\n"
+            "        raise\n",
+            name="bare_reraise.py",
+        )
+    )
+    names = [leaf.exception_name for leaf in _leaves(effect)]
+    assert names == ["ValueError", "TypeError"], names
+
+
+def test_finally_restore_preserves_residual_group():
+    """Inert finally restores: residual TypeError still propagates."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+            "    except* ValueError:\n"
+            "        pass\n"
+            "    finally:\n"
+            "        x = 1\n",
+            name="finally_restore.py",
+        )
+    )
+    assert [leaf.exception_name for leaf in _leaves(effect)] == ["TypeError"]
+
+
+def test_finally_raise_overrides_residual_group():
+    """Terminal finally raise supersedes residual ExceptionGroup."""
+    outcome = _desugar(
+        "def f():\n"
+        "    try:\n"
+        "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+        "    except* ValueError:\n"
+        "        pass\n"
+        "    finally:\n"
+        "        raise RuntimeError('finally-wins')\n",
+        name="finally_raise.py",
+    )
+    assert isinstance(outcome, Incomplete), outcome
+    assert isinstance(outcome.effect, RaiseEffect)
+    assert outcome.effect.exception_name == "RuntimeError"
+
+
+def test_finally_return_overrides_residual_group():
+    """Terminal finally return supersedes residual ExceptionGroup."""
+    outcome = _desugar(
+        "def f():\n"
+        "    try:\n"
+        "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+        "    except* ValueError:\n"
+        "        pass\n"
+        "    finally:\n"
+        "        return 99\n",
+        name="finally_return.py",
+    )
+    assert isinstance(outcome, Complete), outcome
+    record = outcome.value.record
+    returns = [s for s in record.statements if isinstance(s, ReturnValue)]
+    assert returns, record.statements
+    assert returns[0].value.value == 99
+
+
+# ---------------------------------------------------------------------------
+# Occurrence identity survival; type / occurrence lying twins
+# ---------------------------------------------------------------------------
+
+
+def test_leaf_occurrence_identities_survive_partition_and_reraise():
+    """Two same-type leaves keep distinct occurrences through bare re-raise."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup(\n"
+            "            'g', [ValueError('a'), ValueError('b'), TypeError()]\n"
+            "        )\n"
+            "    except* ValueError:\n"
+            "        raise\n",
+            name="occurrence_survive.py",
+        )
+    )
+    leaves = _leaves(effect)
+    value_errors = [leaf for leaf in leaves if leaf.exception_name == "ValueError"]
+    type_errors = [leaf for leaf in leaves if leaf.exception_name == "TypeError"]
+    assert len(value_errors) == 2
+    assert len(type_errors) == 1
+    assert value_errors[0].occurrence is not None
+    assert value_errors[1].occurrence is not None
+    assert value_errors[0].occurrence != value_errors[1].occurrence
+    assert type_errors[0].occurrence is not None
+    assert type_errors[0].occurrence != value_errors[0].occurrence
+
+
+def test_renamed_subclass_matches_by_mro_identity():
+    """Subclass constructed in source matches except* base via authenticated MRO."""
+    effect = _grouped_halt(
+        _desugar(
+            "class Renamed(ValueError):\n"
+            "    pass\n"
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [Renamed(), TypeError()])\n"
+            "    except* ValueError:\n"
+            "        pass\n",
+            name="renamed_mro.py",
+        )
+    )
+    assert [leaf.exception_name for leaf in _leaves(effect)] == ["TypeError"]
+
+
+def test_type_lying_twin_wrong_handler_type_does_not_match():
+    """except* OSError must not absorb a ValueError leaf (spelling-adjacent twin)."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError('a')])\n"
+            "    except* OSError:\n"
+            "        raise RuntimeError('must-not-run')\n",
+            name="type_lie.py",
+        )
+    )
+    names = [leaf.exception_name for leaf in _leaves(effect)]
+    assert names == ["ValueError"], names
+    assert "RuntimeError" not in names
+
+
+def test_occurrence_lying_twin_matched_binding_is_not_residual_leaf():
+    """Handler cause observation is the matched subgroup, never a residual sibling."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError('ve'), TypeError('te')])\n"
+            "    except* ValueError as e:\n"
+            "        raise RuntimeError('outer') from e\n",
+            name="occ_lie.py",
+        )
+    )
+    primary = effect.children[0]
+    assert isinstance(primary.cause_value, ObservedEffectValue)
+    cause_leaves = _leaves(primary.cause_value.effect)
+    assert len(cause_leaves) == 1
+    assert cause_leaves[0].exception_name == "ValueError"
+    residual_leaves = _leaves(effect.children[1])
+    assert [leaf.exception_name for leaf in residual_leaves] == ["TypeError"]
+    # Distinct occurrences: cause leaf is not the residual TypeError occurrence.
+    assert cause_leaves[0].occurrence != residual_leaves[0].occurrence
+
+
+# ---------------------------------------------------------------------------
+# Ordinary Try / TryStar membrane
+# ---------------------------------------------------------------------------
+
+
+def test_ordinary_try_cannot_consume_grouped_testimony():
+    """Ordinary except ValueError leaves ExceptionGroup intact (not rewritten)."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError()])\n"
+            "    except ValueError:\n"
+            "        pass\n",
+            name="ordinary_try.py",
+        )
+    )
+    assert isinstance(effect, GroupedRaiseEffect)
+    assert [leaf.exception_name for leaf in _leaves(effect)] == ["ValueError"]
+
+
+def test_ordinary_try_except_exceptiongroup_still_does_not_split():
+    """Even except ExceptionGroup on ordinary Try does not enter TryStar partition."""
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ExceptionGroup('g', [ValueError()])\n"
+            "    except ExceptionGroup:\n"
+            "        pass\n",
+            name="ordinary_eg.py",
+        )
+    )
+    assert [leaf.exception_name for leaf in _leaves(effect)] == ["ValueError"]
+
+
+def test_trystar_refuses_ordinary_raise_effect():
+    """except* over a non-group RaiseEffect stays loud (distinct routers)."""
+    with pytest.raises(SugarNotWritten) as excinfo:
+        _desugar(
+            "def f():\n"
+            "    try:\n"
+            "        raise ValueError('alone')\n"
+            "    except* ValueError:\n"
+            "        pass\n",
+            name="star_on_ordinary.py",
+        )
+    assert "TryStarSugar" in str(excinfo.value)
+    assert "GroupedRaiseEffect" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# GroupedRaiseSugar construction (nested, non-flattening)
+# ---------------------------------------------------------------------------
+
+
+def test_grouped_raise_constructs_nested_tree_without_flattening():
+    effect = _grouped_halt(
+        _desugar(
+            "def f():\n"
+            "    raise ExceptionGroup(\n"
+            "        'outer',\n"
+            "        [ValueError(), ExceptionGroup('inner', [TypeError(), KeyError()])],\n"
+            "    )\n",
+            name="construct_nested.py",
+        )
+    )
+    assert len(effect.children) == 2
+    assert isinstance(effect.children[0], RaiseEffect)
+    assert effect.children[0].exception_name == "ValueError"
+    nested = effect.children[1]
+    assert isinstance(nested, GroupedRaiseEffect)
+    assert [leaf.exception_name for leaf in nested.children] == [
+        "TypeError",
+        "KeyError",
+    ]
+    assert nested.children[0].occurrence != nested.children[1].occurrence

--- a/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
@@ -691,25 +691,85 @@ def test_handler_terminal_return_face_is_retained_not_dropped():
     assert returns and returns[0].value.value == 7
 
 
-def test_handler_completion_and_residual_both_retained_as_faces():
-    """Non-exceptional completion is retained; residual regroup is separate halt.
+def _capture_trystar_exitset(sugar, ctx):
+    """Desugar TryStar but capture the ExitSet before exitset_to_outcome."""
+    import sugar_lift_py_tests.sugar.exit_set_routing as esr
 
-    Discriminates the old bug that only kept Halted|Completed-via-merge and
-    dropped other faces when residual remained after a completing handler.
+    captured = {}
+    real = esr.exitset_to_outcome
+
+    def capture(es):
+        captured["es"] = es
+        return real(es)
+
+    esr.exitset_to_outcome = capture
+    try:
+        sugar.desugar(ctx)
+    finally:
+        esr.exitset_to_outcome = real
+    assert "es" in captured
+    return captured["es"]
+
+
+def test_handler_pass_with_residual_is_not_a_completed_edge():
+    """Handler fall-through is not a try* completed edge while residual remains.
+
+    Python has no completed edge when except* handles part of a group and an
+    unmatched subgroup continues — the residual must ultimately halt unless
+    later consumed. Discriminates the false-Completed emission bug.
     """
-    effect = _grouped_halt(
-        _desugar(
-            "def f():\n"
-            "    try:\n"
-            "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
-            "    except* ValueError:\n"
-            "        pass\n",
-            name="retain_completion.py",
-        )
+    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+    from sugar_lift_py_tests.sugar.try_star_sugar import TryStarSugar
+    from sugar_source_tree.nodes import TryStar
+
+    source = (
+        "def f():\n"
+        "    try:\n"
+        "        raise ExceptionGroup('g', [ValueError(), TypeError()])\n"
+        "    except* ValueError:\n"
+        "        pass\n"
     )
-    # Residual TypeError only — handler completed (pass) was not exceptional,
-    # so regroup is residual alone (not dropped, not rewritten to ValueError).
+    outcome = _desugar(source, name="residual_not_complete.py")
+    # Must halt with residual TypeError — never Complete at the function edge.
+    assert not isinstance(outcome, Complete), outcome
+    effect = _grouped_halt(outcome)
     assert [leaf.exception_name for leaf in _leaves(effect)] == ["TypeError"]
+
+    tree = SourceFile(
+        (source, "residual_faces.py", blake3_512_of(source.encode("utf-8"))),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    fn = list(tree.functions())[-1]
+
+    def find_trystar(node):
+        if isinstance(node, TryStar):
+            return node
+        for field in getattr(node, "_child_fields", ()):
+            child = getattr(node, field, None)
+            if isinstance(child, tuple):
+                for item in child:
+                    found = find_trystar(item)
+                    if found is not None:
+                        return found
+            elif child is not None:
+                found = find_trystar(child)
+                if found is not None:
+                    return found
+        return None
+
+    sugar = find_trystar(fn).sugar()
+    assert isinstance(sugar, TryStarSugar)
+    es = _capture_trystar_exitset(sugar, None)
+    completed = [face for face in es.exits if isinstance(face, Completed)]
+    halted = [face for face in es.exits if isinstance(face, Halted)]
+    assert halted, es.exits
+    # No Completed face while residual still lives.
+    assert not completed, completed
+    assert all(
+        isinstance(face.effect, GroupedRaiseEffect)
+        and [leaf.exception_name for leaf in _leaves(face.effect)] == ["TypeError"]
+        for face in halted
+    )
 
 
 def test_guarded_handler_faces_conjoin_body_guard():
@@ -809,26 +869,6 @@ def test_guarded_handler_faces_conjoin_body_guard():
         assert any(
             leaf.exception_name == "RuntimeError" for leaf in _leaves(effect)
         )
-
-
-def _capture_trystar_exitset(sugar, ctx):
-    """Desugar TryStar but capture the ExitSet before exitset_to_outcome."""
-    import sugar_lift_py_tests.sugar.exit_set_routing as esr
-
-    captured = {}
-    real = esr.exitset_to_outcome
-
-    def capture(es):
-        captured["es"] = es
-        return real(es)
-
-    esr.exitset_to_outcome = capture
-    try:
-        sugar.desugar(ctx)
-    finally:
-        esr.exitset_to_outcome = real
-    assert "es" in captured
-    return captured["es"]
 
 
 def test_alternative_exceptional_faces_keep_separate_guards():

--- a/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
@@ -713,13 +713,13 @@ def test_handler_completion_and_residual_both_retained_as_faces():
 
 
 def test_guarded_handler_faces_conjoin_body_guard():
-    """Handler-exit guards are conjoined with the body halt guard."""
+    """Handler-exit guards are conjoined with the body halt guard on THAT face."""
     from types import SimpleNamespace
 
     from sugar_lift_py_tests.context.reduce_context import ReduceContext
     from sugar_lift_py_tests.ir import atomic, str_const
-    from sugar_lift_py_tests.outcome import Complete, Incomplete
-    from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted, true_guard
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
     from sugar_lift_py_tests.sugar.sugar_base import Sugar
     from sugar_lift_py_tests.sugar.try_star_sugar import TryStarSugar
 
@@ -796,36 +796,10 @@ def test_guarded_handler_faces_conjoin_body_guard():
         handlers=(((MatchVE(),), (GuardedRaise(),), "slot-ve"),),
         site=site,
     )
-    # Bypass exitset_to_outcome to observe conjoined guards on ExitSet faces.
-    from sugar_lift_py_tests.sugar.exit_set_routing import (
-        exitset_to_outcome,
-        promote_raise_halts,
-    )
-    from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
-
-    # Call desugar but intercept: reimplement observation via direct ExitSet
-    # by temporarily patching exitset_to_outcome to identity.
-    captured = {}
-
-    def capture(es):
-        captured["es"] = es
-        return exitset_to_outcome(es)
-
-    import sugar_lift_py_tests.sugar.exit_set_routing as esr
-
-    real = esr.exitset_to_outcome
-    esr.exitset_to_outcome = capture
-    try:
-        outcome = sugar.desugar(ReduceContext.root(owner="guard_twin"))
-    finally:
-        esr.exitset_to_outcome = real
-
-    es = captured.get("es")
-    assert es is not None, outcome
+    es = _capture_trystar_exitset(sugar, ReduceContext.root(owner="guard_twin"))
     halted = [face for face in es.exits if isinstance(face, Halted)]
     assert halted, es.exits
     text = str(halted[0].guard)
-    # Conjunction must mention both body and handler guard atoms.
     assert "body.guard" in text or "body" in text, text
     assert "handler.guard" in text or "handler" in text, text
     effect = halted[0].effect
@@ -835,3 +809,120 @@ def test_guarded_handler_faces_conjoin_body_guard():
         assert any(
             leaf.exception_name == "RuntimeError" for leaf in _leaves(effect)
         )
+
+
+def _capture_trystar_exitset(sugar, ctx):
+    """Desugar TryStar but capture the ExitSet before exitset_to_outcome."""
+    import sugar_lift_py_tests.sugar.exit_set_routing as esr
+
+    captured = {}
+    real = esr.exitset_to_outcome
+
+    def capture(es):
+        captured["es"] = es
+        return real(es)
+
+    esr.exitset_to_outcome = capture
+    try:
+        sugar.desugar(ctx)
+    finally:
+        esr.exitset_to_outcome = real
+    assert "es" in captured
+    return captured["es"]
+
+
+def test_alternative_exceptional_faces_keep_separate_guards():
+    """Regroup never ANDs guards from mutually exclusive exceptional exits.
+
+    A handler that splits into two exceptional faces under g1|g2 must emit
+    two residual/exception faces, each under its own guard — not one face
+    under g1∧g2 (impossible).
+    """
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context.reduce_context import ReduceContext
+    from sugar_lift_py_tests.ir import atomic, str_const
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+    from sugar_lift_py_tests.sugar.sugar_base import Sugar
+    from sugar_lift_py_tests.sugar.try_star_sugar import TryStarSugar
+
+    site = SimpleNamespace(
+        filename="guard_split.py",
+        line=1,
+        col=0,
+        unit=SimpleNamespace(source="try-star"),
+    )
+    _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
+    leaf = RaiseEffect(
+        exception_name="ValueError",
+        occurrence="leaf:ve",
+        exception_type_coordinate=ve_id,
+        exception_type_mro=(ve_id,),
+        raised_value=ve_typed,
+    )
+    group = GroupedRaiseEffect("group:root", "g", (leaf,), occurrence="group:root")
+    body_atom = atomic("body.guard", [str_const("body")])
+    g1 = atomic("alt.one", [str_const("1")])
+    g2 = atomic("alt.two", [str_const("2")])
+
+    class MatchVE(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(ve_typed)
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    class SplitRaise(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            return ExitSet(
+                (
+                    Halted(
+                        g1,
+                        RaiseEffect(exception_name="KeyError", occurrence="a1"),
+                        None,
+                    ),
+                    Halted(
+                        g2,
+                        RaiseEffect(exception_name="OSError", occurrence="a2"),
+                        None,
+                    ),
+                )
+            )
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    class BodyHalt(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            return ExitSet((Halted(body_atom, group, None),))
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    sugar = TryStarSugar(
+        body=(BodyHalt(),),
+        handlers=(((MatchVE(),), (SplitRaise(),), "slot-ve"),),
+        site=site,
+    )
+    es = _capture_trystar_exitset(sugar, ReduceContext.root(owner="split_twin"))
+    halted = [face for face in es.exits if isinstance(face, Halted)]
+    assert len(halted) >= 2, es.exits
+    texts = [str(face.guard) for face in halted]
+    assert any("alt.one" in t or "1" in t for t in texts), texts
+    assert any("alt.two" in t or "2" in t for t in texts), texts
+    if len(halted) == 1:
+        raise AssertionError(f"alts collapsed into one face: {texts}")
+    names = []
+    for face in halted:
+        if isinstance(face.effect, RaiseEffect):
+            names.append(face.effect.exception_name)
+        elif isinstance(face.effect, GroupedRaiseEffect):
+            names.extend(leaf.exception_name for leaf in _leaves(face.effect))
+    assert "KeyError" in names and "OSError" in names, names


### PR DESCRIPTION
## Summary

- **TryStarSugar**: complete except* subgroup routing — authenticated type partition, matched subgroup to handler (as-binding / bare re-raise / from), residual to subsequent handlers in source order, handler-halt regroup with residual, finally restore vs terminate override, temporal fragment merge onto outgoing faces.
- **GroupedRaiseSugar**: document non-flattening nested construction and site-occurrence identity (distinct from content `group_identity`).
- **Acceptance**: new focused production law file `test_trystar_subgroup_routing.py` (20 tests).

## Laws pinned

| Law | Coverage |
| --- | --- |
| Partition by authenticated type | residual TypeError after except* ValueError |
| Nested topology preserved | inner group keeps KeyError only |
| All same-type leaves extracted | never first-leaf only |
| Matched subgroup reaches handler | `from e` cause is VE subgroup only |
| Handlers source order | TE arm before VE arm despite group leaf order |
| Type-tuple one body run | single RuntimeError, not two |
| Handler halt regroup | KeyError + residual TypeError |
| Bare re-raise | reconstructs original leaves |
| Finally restore / raise / return | residual preserved or overridden |
| Occurrence survival | two ValueErrors keep distinct occurrences |
| Renamed subclass MRO | matches base; TypeError residual |
| Type / occurrence lying twins | wrong type no match; cause ≠ residual occ |
| Ordinary Try membrane | cannot consume grouped testimony |
| TryStar refuses ordinary raise | SugarNotWritten |
| Nested construction | GroupedRaiseSugar non-flattening |

## Floors

- **Must not touch**: nodes.py, carrier/ExitSet, assertion/resource routing, exception spelling rules — preserved.
- ExitSet used only via existing `and_finally` / union APIs (no ExitSet edits).

## Validation

```
bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py -q
# 20 passed
```

## Shell

Production law instrument for TryStar subgroup routing (fleet acceptance). No census.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Complete TryStar subgroup routing in `TryStarSugar.desugar`
> - Rewrites the `except*` routing algorithm in [`try_star_sugar.py`](https://github.com/TSavo/sugar/pull/6717/files#diff-99f26fcb4995527f2b79466b9e0376e13c152b9d06b39e9e4c6eec4ba4fc8f0e) to branch per face and per handler exit, conjoining guards and threading temporal state across handlers.
> - Introduces `_StarFace` dataclass to track per-face state (guard, residual, temporal, accumulated faces, pending contracts, and observed exceptional raises).
> - Adds helpers `_seed_temporal`, `_reduce_block_from_state`, `_reduce_one_from`, `_rebind_face_guard`, and `_is_exceptional_raise` to support the new routing logic.
> - Extends [`FactoryBuildContext`](https://github.com/TSavo/sugar/pull/6717/files#diff-8888e1ac8a7e9b98ec1507ea8a382cf28c654dab41441546fb3bf8cf6bf307ae) with `observed_effects`, `with_observed_effect`, and `observed_effect_for` to mirror `ReduceContext`'s observed-effect surface.
> - Updates `GroupedRaiseSugar.desugar` to use a sealed `SourceMemento` for occurrence construction instead of a plain `filename:line:col` string.
> - Adds a new test module [`test_trystar_subgroup_routing.py`](https://github.com/TSavo/sugar/pull/6717/files#diff-556a21d45c7b68e3f1b955eb2125256ca76ae87d366521422d319b84ae49e393) covering subgroup routing, temporal threading, guard conjunction, regrouping, and authenticated occurrence construction.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d521bcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->