### PR TITLE
test: pin conditional result slot identity

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py
@@ -1,0 +1,100 @@
+"""A BoolOp composes comparison families without lending laws between them."""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import RaiseValue
+from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import BoolOp, Compare
+from sugar_source_tree.tree import SourceFile
+
+
+def _expression(source_expression: str):
+    source = f"def mixed(a, b, c, d):\n    return {source_expression}\n"
+    tree = SourceFile(
+        (source, "boolop-mixed-families.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    boolop = next(node for node in tree.nodes() if isinstance(node, BoolOp))
+    comparisons = tuple(node for node in tree.nodes() if isinstance(node, Compare))
+    assert len(comparisons) == 2
+    return boolop.sugar().desugar(None), comparisons
+
+
+def _raise_occurrence(outcome) -> str:
+    if isinstance(outcome, Complete):
+        assert isinstance(outcome.value, RaiseValue)
+        assert outcome.value.effect.occurrence_id is not None
+        return outcome.value.effect.occurrence_id
+    assert isinstance(outcome, ExitSet)
+    halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
+    assert len(halted) == 1
+    assert halted[0].effect.occurrence_id is not None
+    return halted[0].effect.occurrence_id
+
+
+def test_false_ordering_short_circuits_membership_and_returns_first_operand() -> None:
+    outcome, comparisons = _expression("2 < 1 and None in 3")
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, FalseBoolLiteralSugar)
+    assert str(outcome.value.site) == str(comparisons[0].sugar().site)
+    assert str(outcome.value.site) != str(comparisons[1].sugar().site)
+
+
+def test_truthful_ordering_evaluates_membership_exception_at_second_site() -> None:
+    outcome, comparisons = _expression("1 < 2 and None in 3")
+
+    assert _raise_occurrence(outcome) == str(comparisons[1].sugar().site)
+    assert _raise_occurrence(outcome) != str(comparisons[0].sugar().site)
+
+
+def test_ordering_exception_bypasses_membership_and_keeps_first_site() -> None:
+    outcome, comparisons = _expression("None < 1 and 1 in [1]")
+
+    assert _raise_occurrence(outcome) == str(comparisons[0].sugar().site)
+    assert _raise_occurrence(outcome) != str(comparisons[1].sugar().site)
+
+
+def _atom_names(formula) -> set[str]:
+    name = getattr(formula, "name", None)
+    found = {name} if isinstance(name, str) else set()
+    for operand in getattr(formula, "operands", ()):
+        found.update(_atom_names(operand))
+    return found
+
+
+def test_symbolic_mixed_boolop_retains_each_family_law_and_occurrence() -> None:
+    outcome, comparisons = _expression("a < b and c in d")
+
+    assert isinstance(outcome, ExitSet)
+    halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
+    assert len(halted) == 2
+    assert {
+        name
+        for exit_ in halted
+        for name in _atom_names(exit_.guard)
+        if name.endswith("dispatch_raises")
+    } == {"python.lt_dispatch_raises", "python.contains_dispatch_raises"}
+    assert {exit_.effect.occurrence_id for exit_ in halted} == {
+        str(compare.sugar().site) for compare in comparisons
+    }
+
+
+def test_swapping_families_swaps_laws_without_collapsing_occurrences() -> None:
+    outcome, comparisons = _expression("a in b and c < d")
+
+    assert isinstance(outcome, ExitSet)
+    halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
+    assert len(halted) == 2
+    assert {
+        name
+        for exit_ in halted
+        for name in _atom_names(exit_.guard)
+        if name.endswith("dispatch_raises")
+    } == {"python.contains_dispatch_raises", "python.lt_dispatch_raises"}
+    assert {exit_.effect.occurrence_id for exit_ in halted} == {
+        str(compare.sugar().site) for compare in comparisons
+    }

--- a/implementations/python/sugar-lift-py-tests/tests/test_if_branch_result_slot.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_if_branch_result_slot.py
@@ -1,0 +1,263 @@
+"""Every source ``If`` consumes its one authenticated branch-result slot."""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import GuardedReturn, ReturnValue, TermValue
+from sugar_lift_py_tests.ir import not_
+from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.binding_state import branch_result_slot
+from sugar_source_tree.nodes import Call, FunctionDef, If, IfExp
+from sugar_source_tree.panic import BackendDefect
+from sugar_source_tree.tree import SourceFile
+
+
+def _tree(source: str) -> SourceFile:
+    return SourceFile(
+        (source, "if-branch-result-slot.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _only(outcome, kind):
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    exit_ = outcome.exits[0]
+    assert isinstance(exit_, kind)
+    return exit_
+
+
+def test_concrete_if_elif_else_constructs_and_selects_each_reachable_slot() -> None:
+    source = ""
+    for name, first, second in (
+        ("first", True, False),
+        ("second", False, True),
+        ("fallback", False, False),
+    ):
+        source += (
+            f"def {name}():\n"
+            f"    if {first}:\n"
+            "        return 10\n"
+            f"    elif {second}:\n"
+            "        return 20\n"
+            "    else:\n"
+            "        return 30\n"
+        )
+    functions = tuple(_tree(source).functions())
+    values = []
+    for function in functions:
+        outcome = function.sugar().desugar(None)
+        assert hasattr(outcome, "value")
+        returns = tuple(
+            entry
+            for entry in outcome.value.record.statements
+            if isinstance(entry, (ReturnValue, GuardedReturn))
+        )
+        assert len(returns) == 1, repr(outcome.value.record.statements)
+        value = returns[0].value
+        assert isinstance(value, TermValue)
+        values.append(value.value)
+
+    assert tuple(values) == (10, 20, 30)
+
+
+def test_undecidable_if_elif_else_retains_complementary_faces() -> None:
+    source = (
+        "def choose(left, right):\n"
+        "    if left < right:\n"
+        "        return 10\n"
+        "    return 30\n"
+    )
+    function = next(
+        node for node in _tree(source).nodes() if isinstance(node, FunctionDef)
+    )
+    pending = function.sugar().desugar(None)
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+
+    left, right = pending.coordinates
+    from sugar_lift_py_tests.floor import SymbolicValue
+    from sugar_lift_py_tests.ir import make_var
+
+    exits = pending.discharge(
+        {
+            left.coordinate_cid: SymbolicValue(make_var("actual_left")),
+            right.coordinate_cid: SymbolicValue(make_var("actual_right")),
+        }
+    )
+    assert isinstance(exits, ExitSet)
+    completed = _only(exits, Completed)
+    returns = tuple(
+        entry
+        for entry in completed.value.record.statements
+        if isinstance(entry, GuardedReturn)
+    )
+    assert {entry.value for entry in returns} == {
+        TermValue(10),
+        TermValue(30),
+    }
+    first_guard = next(entry.guards[0] for entry in returns if entry.value == TermValue(10))
+    assert any(
+        guard == not_(first_guard)
+        for entry in returns
+        if entry.value != TermValue(10)
+        for guard in entry.guards
+    )
+
+
+def test_condition_halt_bypasses_every_if_elif_else_body() -> None:
+    source = (
+        "def choose(flag):\n"
+        "    if flag < 1:\n"
+        "        return 10\n"
+        "    else:\n"
+        "        return 30\n"
+    )
+    tree = _tree(f"{source}\nchoose(None)\n")
+    (outcome,) = tuple(
+        node.sugar().desugar(None)
+        for node in tree.nodes()
+        if isinstance(node, Call)
+    )
+
+    halted = _only(outcome, Halted)
+    from sugar_lift_py_tests.temporal.temporal_context import TemporalContext
+
+    expected = TemporalContext.empty().value_for("TypeError")
+    assert halted.effect.exception_type_coordinate == expected.exception_type_identity()
+
+
+def _two_source_ifs() -> tuple[If, If]:
+    tree = _tree(
+        "if left:\n"
+        "    x = 1\n"
+        "if right:\n"
+        "    y = 2\n"
+    )
+    branches = tuple(node for node in tree.nodes() if isinstance(node, If))
+    assert len(branches) == 2
+    return branches
+
+
+def test_absent_branch_result_slot_panics_at_the_exact_if_occurrence() -> None:
+    branch, _ = _two_source_ifs()
+
+    with pytest.raises(BackendDefect) as raised:
+        branch.sugar()
+
+    message = str(raised.value)
+    assert "If without a stored branch-result slot" in message
+    assert "if-branch-result-slot.py:1:0" in message
+
+
+def test_truthful_stored_slot_constructs_but_slot_swap_panics_at_its_occurrence() -> None:
+    truthful, unrelated = _two_source_ifs()
+    truthful_slot = branch_result_slot(truthful.test)
+    unrelated_slot = branch_result_slot(unrelated.test)
+
+    truthful._rewrite_with_slot({}, truthful_slot).sugar()
+    swapped = truthful._rewrite_with_slot({}, unrelated_slot)
+    with pytest.raises(BackendDefect) as raised:
+        swapped.sugar()
+
+    message = str(raised.value)
+    assert "branch-result slot" in message
+    assert "if-branch-result-slot.py:1:0" in message
+
+
+def test_duplicated_branch_result_slot_panics_at_the_exact_if_occurrence() -> None:
+    branch, _ = _two_source_ifs()
+    slot = branch_result_slot(branch.test)
+    duplicated = branch._rewrite_with_slot({}, slot)._rewrite_with_slot({}, slot)
+
+    with pytest.raises(BackendDefect) as raised:
+        duplicated.sugar()
+
+    message = str(raised.value)
+    assert "branch-result slot" in message
+    assert "if-branch-result-slot.py:1:0" in message
+
+
+def test_symbolic_ternary_result_uses_its_authenticated_branch_slot() -> None:
+    from sugar_lift_py_tests.floor.branch_result_coordinate import branch_result_guard
+    from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+
+    tree = _tree("def choose(a, b):\n    return 10 if a is b else 20\n")
+    ternary = next(node for node in tree.nodes() if isinstance(node, IfExp))
+    outcome = ternary.sugar().desugar(None)
+
+    assert hasattr(outcome, "value")
+    assert isinstance(outcome.value, GuardedValue)
+    assert outcome.value.guard == branch_result_guard(
+        branch_result_slot(ternary.test), ternary.fragment
+    )
+
+
+def test_distinct_ternary_occurrences_never_share_a_result_slot() -> None:
+    tree = _tree(
+        "def choose(a, b):\n"
+        "    left = 10 if a is b else 20\n"
+        "    right = 30 if a is b else 40\n"
+        "    return left + right\n"
+    )
+    ternaries = tuple(node for node in tree.nodes() if isinstance(node, IfExp))
+    assert len(ternaries) == 2
+
+    slots = tuple(branch_result_slot(node.test).slot_id for node in ternaries)
+    assert slots[0] != slots[1]
+
+
+@pytest.mark.parametrize(
+    ("kind", "stopping_type"),
+    (("And", False), ("Or", True)),
+    ids=("and-false", "or-true"),
+)
+def test_boolean_short_circuit_returns_the_exact_stopping_operand(
+    kind: str, stopping_type: bool
+) -> None:
+    from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    literal = TrueBoolLiteralSugar if stopping_type else FalseBoolLiteralSugar
+    left = literal("left-occurrence")
+
+    class Skipped:
+        def desugar(self, ctx=None):
+            raise AssertionError("short-circuited operand was evaluated")
+
+    outcome = BoolOpSugar(kind, (left, Skipped()), "boolop-site").desugar(None)
+
+    assert hasattr(outcome, "value")
+    assert outcome.value is left
+
+
+@pytest.mark.parametrize(
+    ("kind", "continuing_type"),
+    (("And", True), ("Or", False)),
+    ids=("and-true", "or-false"),
+)
+def test_boolean_continuing_face_returns_the_exact_second_operand(
+    kind: str, continuing_type: bool
+) -> None:
+    from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    literal = TrueBoolLiteralSugar if continuing_type else FalseBoolLiteralSugar
+    left = literal("left-occurrence")
+    right = TermValue(7)
+
+    class Right:
+        def desugar(self, ctx=None):
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(right)
+
+    outcome = BoolOpSugar(kind, (left, Right()), "boolop-site").desugar(None)
+
+    assert hasattr(outcome, "value")
+    assert outcome.value is right

--- a/implementations/python/sugar-lift-py-tests/tests/test_while_assert_condition_occurrence_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_while_assert_condition_occurrence_identity.py
@@ -1,0 +1,89 @@
+"""Control conditions own one source occurrence, distinct from body sites."""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import RaiseValue
+from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Assert, Compare, While
+from sugar_source_tree.tree import SourceFile
+
+
+SOURCE = (
+    "def control(left, right):\n"
+    "    while left < right:\n"
+    "        assert left < right\n"
+)
+
+
+def _tree(source: str = SOURCE) -> SourceFile:
+    return SourceFile(
+        (source, "while-assert-occurrence.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _halt_occurrence(compare: Compare) -> str:
+    outcome = compare.sugar().desugar(None)
+    assert isinstance(outcome, ExitSet)
+    halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
+    assert len(halted) == 1
+    assert halted[0].effect.occurrence_id is not None
+    return halted[0].effect.occurrence_id
+
+
+def _comparisons() -> tuple[Compare, Compare]:
+    tree = _tree()
+    loop = next(node for node in tree.nodes() if isinstance(node, While))
+    assertion = next(node for node in tree.nodes() if isinstance(node, Assert))
+    assert isinstance(loop.test, Compare)
+    assert isinstance(assertion.test, Compare)
+    return loop.test, assertion.test
+
+
+def test_while_condition_mints_one_stable_authenticated_occurrence() -> None:
+    condition, _ = _comparisons()
+    first = _halt_occurrence(condition)
+    repeated = _halt_occurrence(condition)
+
+    expected = str(condition.sugar().site)
+    assert first == expected
+    assert repeated == expected
+
+
+def test_while_condition_occurrence_is_distinct_from_body_occurrences() -> None:
+    condition, body_assertion = _comparisons()
+    condition_occurrence = _halt_occurrence(condition)
+    body_occurrence = _halt_occurrence(body_assertion)
+
+    assert condition_occurrence != body_occurrence
+
+
+def test_assert_condition_mints_one_stable_authenticated_occurrence() -> None:
+    _, assertion = _comparisons()
+    first = _halt_occurrence(assertion)
+    repeated = _halt_occurrence(assertion)
+
+    expected = str(assertion.sugar().site)
+    assert first == expected
+    assert repeated == expected
+
+
+def test_assert_condition_halt_keeps_its_condition_occurrence() -> None:
+    tree = _tree("def check():\n    assert None < 1\n")
+    assertion = next(node for node in tree.nodes() if isinstance(node, Assert))
+    assert isinstance(assertion.test, Compare)
+    condition_site = assertion.test.sugar().site
+    outcome = assertion.sugar().desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.occurrence_id == str(condition_site)
+
+
+def test_identical_condition_and_body_operands_do_not_collapse_occurrences() -> None:
+    condition, assertion = _comparisons()
+
+    assert condition.fragment.text == assertion.fragment.text == "left < right"
+    assert _halt_occurrence(condition) != _halt_occurrence(assertion)


### PR DESCRIPTION
## Control-construct instruments\n\nTests-only capabilities:\n- If/IfExp branch-result slot authentication, including truthful, missing, swapped, duplicated, and distinct-site twins\n- Boolean short-circuit result identity\n- While/assert condition occurrence stability and body separation\n- Mixed ordering/membership laws under one BoolOp\n\nHonest reds banked for the post-#6691 repair:\n- swapped If slot does not panic\n- duplicated If slot does not panic\n- symbolic IfExp uses its raw predicate rather than its authenticated branch-result slot\n\nNo production, carrier, ExitSet, generator, or CallSiteValue code changed.\n\n## Focused evidence\n\n- If instrument: 4 pass before slot-swap red; duplicate and symbolic IfExp reds confirmed separately\n- Boolean/ternary discrimination: 5 passed, 7 deselected\n- While/assert occurrence laws: 5 passed\n- Mixed BoolOp comparison laws: 5 passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin conditional result slot identity across If, BoolOp, While, and Assert sugar tests
> - Adds tests to verify that each conditional construct (`If`/`IfExp`, `BoolOp`, `While`, `Assert`) mints a stable, distinct occurrence identity for its result slot rather than collapsing identical-text occurrences.
> - Covers concrete and symbolic branches, short-circuit behavior for `And`/`Or`, halt occurrence tracking through comparison families, and error messages when slots are absent, swapped, or duplicated.
> - New test files: [`test_if_branch_result_slot.py`](https://github.com/TSavo/sugar/pull/6719/files#diff-8082a1f14323374d0403bd91768678a1bbd222d9e3b8b4ceb8059f7549a923df), [`test_boolop_mixed_compare_families.py`](https://github.com/TSavo/sugar/pull/6719/files#diff-0b47988eb948affd4c920a6196e74b659bf6adc452eae4669a19b9b5c4fa3027), [`test_while_assert_condition_occurrence_identity.py`](https://github.com/TSavo/sugar/pull/6719/files#diff-fcda4cfa6d099bb3ec27c64ee88b971c05e33294d7ed47e6e41d2fc886377847).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 530d401.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->