### PR TITLE
Resolve source-visible re-exports; stop hard-abort raises poisoning hops

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -191,7 +191,7 @@ class AuthenticatedModuleSourceV1:
 @dataclass(frozen=True)
 class DefinitionCoordinateV1:
     name: str
-    kind: Literal["function", "class", "import"]
+    kind: Literal["function", "class", "import", "alias"]
     source_cid: str
     start_line: int
     start_col: int
@@ -201,7 +201,7 @@ class DefinitionCoordinateV1:
 
     def __post_init__(self) -> None:
         _string(self.name, "definition name")
-        if self.kind not in {"function", "class", "import"}:
+        if self.kind not in {"function", "class", "import", "alias"}:
             raise ValueError("definition coordinate has unknown kind")
         _cid(self.source_cid, "definition sourceCid")
         for value, label in (
@@ -241,7 +241,7 @@ class DefinitionCoordinateV1:
             },
             "definition coordinate",
         )
-        if value["kind"] not in {"function", "class", "import"}:
+        if value["kind"] not in {"function", "class", "import", "alias"}:
             raise ValueError("definition coordinate has unknown kind")
         return cls(
             name=_string(value["name"], "definition name"),
@@ -267,8 +267,10 @@ class ReexportWarrantV1:
     cid: str = ""
 
     def __post_init__(self) -> None:
-        if self.definition.kind != "import":
-            raise ValueError("re-export warrant must cite an import definition")
+        if self.definition.kind not in {"import", "alias"}:
+            raise ValueError(
+                "re-export warrant must cite an import or alias definition"
+            )
         if self.definition.source_cid != self.from_source_cid:
             raise ValueError("re-export definition is not in its from-module source")
         expected = cid_of_json(self._preimage())

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -198,12 +198,26 @@ def _resolve_export_uncached(
             session=session,
         )
     if binding is not None and binding[0] == "alias":
+        # Static ``public = _private``: both the assignment occurrence and the
+        # RHS name are authenticated.  Same-module alias hop is recorded before
+        # resolving the RHS (import or further alias) — never a silent follow.
+        assign_node, name_node = binding[1]
+        alias_name = name_node.id
+        warrant = ReexportWarrantV1(
+            from_module=module_name,
+            from_source_cid=module.source_cid,
+            to_module=module_name,
+            to_source_cid=module.source_cid,
+            exported_name=exported_name,
+            imported_name=alias_name,
+            definition=_alias_coordinate(module, assign_node, exported_name),
+        )
         return resolve_export(
             graph,
             binding_cid,
             module_name,
-            binding[1].id,
-            warrants,
+            alias_name,
+            (*warrants, warrant),
             seen | {key},
             session=session,
         )
@@ -223,15 +237,23 @@ def _resolve_export_uncached(
             module_name,
             exported_name,
         )
-    # Wildcard-only and other star residues are dynamic — not a static export
-    # of the demanded name (no first-candidate scan of the star module).
+    # Star import: only a single source-visible immutable literal ``__all__``
+    # may publish names.  Everything else (no __all__, computed __all__,
+    # reassignment, name absent from __all__) stays dynamic — never a
+    # first-candidate scan of the star module.
     if binding is not None and binding[0] == "star":
-        return _gap(
-            "dynamic-export",
-            binding_cid,
+        return _resolve_star_export(
             graph,
+            binding_cid,
+            module,
             module_name,
             exported_name,
+            binding[1],
+            tree.body,
+            warrants,
+            seen,
+            key,
+            session=session,
         )
     # Module-level ``name = Class()`` / ``name: Class = Class()`` is a static
     # callable-instance binding when Class is a local ClassDef with ``__call__``.
@@ -457,6 +479,143 @@ def _import_coordinate(
     return DefinitionCoordinateV1(
         name=exported_name,
         kind="import",
+        source_cid=module.source_cid,
+        start_line=node.lineno,
+        start_col=node.col_offset,
+        end_line=node.end_lineno,
+        end_col=node.end_col_offset,
+        fragment_cid=blake3_512_of(segment.encode("utf-8")),
+    )
+
+
+def _resolve_star_export(
+    graph,
+    binding_cid: str,
+    module,
+    module_name: str,
+    exported_name: str,
+    star_import: ast.ImportFrom,
+    body: list[ast.stmt],
+    warrants: tuple,
+    seen: frozenset[tuple[str, str]],
+    key: tuple[str, str],
+    *,
+    session,
+):
+    published = _literal_all_publication(body)
+    if published is None or exported_name not in published:
+        return _gap(
+            "dynamic-export", binding_cid, graph, module_name, exported_name
+        )
+    target_module = _absolute_import(module_name, module.source_seat, star_import)
+    if target_module is None:
+        return _gap("opaque-source", binding_cid, graph, module_name, exported_name)
+    target = graph.modules.get(target_module)
+    if target is None:
+        return _gap(
+            "artifact-module-absent",
+            binding_cid,
+            graph,
+            target_module,
+            exported_name,
+        )
+    warrant = ReexportWarrantV1(
+        from_module=module_name,
+        from_source_cid=module.source_cid,
+        to_module=target_module,
+        to_source_cid=target.source_cid,
+        exported_name=exported_name,
+        imported_name=exported_name,
+        definition=_import_coordinate(module, star_import, exported_name),
+    )
+    return resolve_export(
+        graph,
+        binding_cid,
+        target_module,
+        exported_name,
+        (*warrants, warrant),
+        seen | {key},
+        session=session,
+    )
+
+
+def _literal_all_publication(body: list[ast.stmt]) -> frozenset[str] | None:
+    """Single immutable literal ``__all__`` of string constants, or None.
+
+    Competing assignments, augments, non-literal values, and non-string
+    elements refuse publication (loud dynamic star) — no partial admission.
+    """
+    published: frozenset[str] | None = None
+    for statement in body:
+        binds_all = False
+        value: ast.AST | None = None
+        if isinstance(statement, ast.Assign):
+            if any(
+                isinstance(target, ast.Name) and target.id == "__all__"
+                for target in statement.targets
+            ):
+                if not (
+                    len(statement.targets) == 1
+                    and isinstance(statement.targets[0], ast.Name)
+                    and statement.targets[0].id == "__all__"
+                ):
+                    return None
+                binds_all = True
+                value = statement.value
+        elif isinstance(statement, ast.AnnAssign):
+            if (
+                isinstance(statement.target, ast.Name)
+                and statement.target.id == "__all__"
+            ):
+                if statement.value is None:
+                    return None
+                binds_all = True
+                value = statement.value
+        elif isinstance(statement, ast.AugAssign):
+            if (
+                isinstance(statement.target, ast.Name)
+                and statement.target.id == "__all__"
+            ):
+                return None
+        if not binds_all:
+            continue
+        names = _literal_string_sequence(value)
+        if names is None:
+            return None
+        if published is not None:
+            return None
+        published = names
+    return published
+
+
+def _literal_string_sequence(node: ast.AST | None) -> frozenset[str] | None:
+    if node is None:
+        return None
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return None
+    names: set[str] = set()
+    for element in node.elts:
+        if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+            return None
+        if not element.value:
+            return None
+        names.add(element.value)
+    return frozenset(names)
+
+
+def _alias_coordinate(
+    module: AuthenticatedModuleSourceV1,
+    node: ast.AST,
+    exported_name: str,
+) -> DefinitionCoordinateV1:
+    segment = ast.get_source_segment(module.source, node)
+    if segment is None:
+        raise DependencyArtifactAuthenticationError(
+            "alias re-export source segment is unavailable"
+        )
+    return DefinitionCoordinateV1(
+        name=exported_name,
+        kind="alias",
         source_cid=module.source_cid,
         start_line=node.lineno,
         start_col=node.col_offset,
@@ -744,10 +903,14 @@ def _export_statement(statement: ast.stmt, name: str, state):
     if isinstance(statement, ast.ImportFrom):
         for alias in statement.names:
             if alias.name == "*":
-                # Star does not statically bind a demanded name.  It is a
-                # dynamic residue (not static-export-absent, not first-candidate
-                # from the star module).
-                state = ("star", statement)
+                # Star is a residual only when no explicit static bind already
+                # owns the name.  Publication through literal ``__all__`` is
+                # decided at resolve time — never a first-candidate scan here.
+                if not (
+                    isinstance(state, tuple)
+                    and state[0] in {"definition", "import", "alias"}
+                ):
+                    state = ("star", statement)
                 continue
             if (alias.asname or alias.name) == name:
                 state = ("import", (statement, alias))
@@ -769,7 +932,7 @@ def _export_statement(statement: ast.stmt, name: str, state):
             and isinstance(statement.targets[0], ast.Name)
             and isinstance(statement.value, ast.Name)
         ):
-            return ("alias", statement.value)
+            return ("alias", (statement, statement.value))
         return ("dynamic", statement)
     if isinstance(statement, ast.AnnAssign):
         if statement.value is None or not _target_binds(statement.target, name):
@@ -777,7 +940,7 @@ def _export_statement(statement: ast.stmt, name: str, state):
         if isinstance(statement.target, ast.Name) and isinstance(
             statement.value, ast.Name
         ):
-            return ("alias", statement.value)
+            return ("alias", (statement, statement.value))
         return ("dynamic", statement)
     if isinstance(statement, ast.AugAssign):
         return (
@@ -836,6 +999,14 @@ def _export_statement(statement: ast.stmt, name: str, state):
         joined = _join_export_states(outputs, statement)
         return _export_block(statement.finalbody, name, joined)
     if isinstance(statement, ast.If):
+        # Constant guards select one branch (truthful-branch testimony).
+        # Unresolved guards join both paths: competing static binds stay
+        # ambiguous-static-export until a guarded-result type exists (hand-off).
+        taken = _literal_bool(statement.test)
+        if taken is True:
+            return _export_block(statement.body, name, state)
+        if taken is False:
+            return _export_block(statement.orelse, name, state)
         return _join_export_states(
             (
                 _export_block(statement.body, name, state),

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -215,6 +215,24 @@ def _resolve_export_uncached(
             module_name,
             exported_name,
         )
+    if binding is not None and binding[0] == "ambiguous":
+        return _gap(
+            "ambiguous-static-export",
+            binding_cid,
+            graph,
+            module_name,
+            exported_name,
+        )
+    # Wildcard-only and other star residues are dynamic — not a static export
+    # of the demanded name (no first-candidate scan of the star module).
+    if binding is not None and binding[0] == "star":
+        return _gap(
+            "dynamic-export",
+            binding_cid,
+            graph,
+            module_name,
+            exported_name,
+        )
     # Module-level ``name = Class()`` / ``name: Class = Class()`` is a static
     # callable-instance binding when Class is a local ClassDef with ``__call__``.
     # The export is the authenticated ``__call__`` body, not a free dynamic
@@ -535,14 +553,21 @@ def export_statement_coverage() -> tuple[list[str], list[str]]:
 def _export_block(statements, name, initial):
     state = initial
     for index, statement in enumerate(statements):
-        if _statement_contains_module_init_raise(statement) and _suite_binds_export(
-            statements[index + 1 :], name
+        rest = statements[index + 1 :]
+        # Suppressible exceptional prefixes only.  A hard-abort raise inside
+        # for/if/try that terminates module init does not make a later
+        # source-visible import/definition dynamic: the success path is the
+        # residual suite.  With/AsyncWith may swallow a raise and still run
+        # later suite statements — that residual must stay dynamic.
+        if (
+            isinstance(statement, (ast.With, ast.AsyncWith))
+            and _statement_contains_module_init_raise(statement)
+            and _suite_binds_export(rest, name)
         ):
-            # A later binding is control-dependent on whether this exceptional
-            # prefix completes.  In particular, a With/AsyncWith exit may
-            # suppress the exception while skipping the remainder of its
-            # suite.  Selecting that later textual binding would authenticate
-            # an unreachable definition.
+            return ("dynamic", statement)
+        # Same suite: bare raise then a later bind is unreachable on the
+        # aborting path; do not authenticate the textual residual as the export.
+        if isinstance(statement, ast.Raise) and _suite_binds_export(rest, name):
             return ("dynamic", statement)
         state = _export_statement(statement, name, state)
     return state
@@ -589,6 +614,12 @@ def _export_statement(statement: ast.stmt, name: str, state):
         return ("definition", statement)
     if isinstance(statement, ast.ImportFrom):
         for alias in statement.names:
+            if alias.name == "*":
+                # Star does not statically bind a demanded name.  It is a
+                # dynamic residue (not static-export-absent, not first-candidate
+                # from the star module).
+                state = ("star", statement)
+                continue
             if (alias.asname or alias.name) == name:
                 state = ("import", (statement, alias))
         return state
@@ -705,6 +736,18 @@ def _join_export_states(states, locus):
     states = tuple(states)
     if states and all(state == states[0] for state in states[1:]):
         return states[0]
+    # Competing source-visible static bindings on different paths are
+    # ambiguous — not a first-candidate pick and not silent dynamic collapse.
+    static_kinds = frozenset({"definition", "import", "alias"})
+    concrete = tuple(state for state in states if state is not None)
+    if (
+        concrete
+        and len(concrete) == len(states)
+        and all(
+            isinstance(state, tuple) and state[0] in static_kinds for state in concrete
+        )
+    ):
+        return ("ambiguous", locus)
     return ("dynamic", locus)
 
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -551,31 +551,160 @@ def export_statement_coverage() -> tuple[list[str], list[str]]:
 
 
 def _export_block(statements, name, initial):
+    """Transfer export bindings only through authenticated fall-through.
+
+    Each statement must carry constructive fall-through testimony before a
+    later export bind is treated as normally reached.  Fall-through is never
+    inferred from raise-nesting shape alone (a raise inside ``for`` does not
+    mint a residual success path past the loop).
+    """
     state = initial
     for index, statement in enumerate(statements):
         rest = statements[index + 1 :]
-        # Suppressible exceptional prefixes only.  A hard-abort raise inside
-        # for/if/try that terminates module init does not make a later
-        # source-visible import/definition dynamic: the success path is the
-        # residual suite.  With/AsyncWith may swallow a raise and still run
-        # later suite statements — that residual must stay dynamic.
-        if (
-            isinstance(statement, (ast.With, ast.AsyncWith))
-            and _statement_contains_module_init_raise(statement)
-            and _suite_binds_export(rest, name)
-        ):
-            return ("dynamic", statement)
-        # Same suite: bare raise then a later bind is unreachable on the
-        # aborting path; do not authenticate the textual residual as the export.
-        if isinstance(statement, ast.Raise) and _suite_binds_export(rest, name):
-            return ("dynamic", statement)
         state = _export_statement(statement, name, state)
+        if not _authenticated_fallthrough(statement) and _suite_binds_export(
+            rest, name
+        ):
+            # Prefix lacks fall-through authority into a residual that binds
+            # the export — refuse static authentication of that residual.
+            return ("dynamic", statement)
     return state
 
 
 def _suite_binds_export(statements, name: str) -> bool:
     marker = object()
     return _export_block(statements, name, marker) is not marker
+
+
+def _authenticated_fallthrough(statement: ast.stmt) -> bool:
+    """Constructive testimony that module init continues after ``statement``.
+
+    Fall-through is control-completion authority, not "might this call raise".
+    Module-init ``Raise`` (not deferred function/class bodies), loops/ifs/with
+    whose live paths include such a raise, and incomplete try paths refuse.
+    Sequential imports/defs/classes without a module-init raise fall through.
+    """
+    if isinstance(statement, ast.Raise):
+        return False
+    if isinstance(statement, (ast.Return, ast.Break, ast.Continue)):
+        return False
+    if isinstance(statement, (ast.For, ast.AsyncFor, ast.While)):
+        return _loop_authenticated_fallthrough(statement)
+    if isinstance(statement, ast.If):
+        return _if_authenticated_fallthrough(statement)
+    if isinstance(statement, (ast.With, ast.AsyncWith)):
+        # ``__exit__`` may suppress; a raise in the with suite refuses fall-through
+        # past the With (and inside, raise-then-bind is handled by nested transfer).
+        if _statement_contains_module_init_raise(statement):
+            return False
+        return _suite_authenticated_fallthrough(statement.body)
+    if isinstance(statement, _TRY_TYPES):
+        return _try_authenticated_fallthrough(statement)
+    if isinstance(statement, ast.Match):
+        return _match_authenticated_fallthrough(statement)
+    # Function/class bodies are deferred; a Raise inside them is not module-init.
+    # Other sequential statements fall through unless they embed a module-init raise.
+    if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return True
+    return not _statement_contains_module_init_raise(statement)
+
+
+def _suite_authenticated_fallthrough(statements) -> bool:
+    for statement in statements:
+        if not _authenticated_fallthrough(statement):
+            return False
+    return True
+
+
+def _if_authenticated_fallthrough(statement: ast.If) -> bool:
+    """Fall-through past ``if`` requires every live branch to fall through.
+
+    Constant tests take one branch.  Unresolved tests require *both* branches
+    to authenticate fall-through (a raise on either path refuses).
+    """
+    taken = _literal_bool(statement.test)
+    if taken is True:
+        return _suite_authenticated_fallthrough(statement.body)
+    if taken is False:
+        return _suite_authenticated_fallthrough(statement.orelse)
+    return _suite_authenticated_fallthrough(
+        statement.body
+    ) and _suite_authenticated_fallthrough(statement.orelse)
+
+
+def _loop_authenticated_fallthrough(statement: ast.stmt) -> bool:
+    """Fall-through past a loop requires completion on every trip that can run.
+
+    Proven-empty iterators skip the body.  Otherwise a module-init raise in the
+    body refuses later suite binds — no residual success path past the loop.
+    """
+    orelse = getattr(statement, "orelse", [])
+    if _loop_proven_empty(statement):
+        return _suite_authenticated_fallthrough(orelse)
+    if not _suite_authenticated_fallthrough(statement.body):
+        return False
+    return _suite_authenticated_fallthrough(orelse)
+
+
+def _try_authenticated_fallthrough(statement: ast.stmt) -> bool:
+    body = statement.body
+    body_has_raise = any(
+        _statement_contains_module_init_raise(item) for item in body
+    )
+    if not body_has_raise:
+        return (
+            _suite_authenticated_fallthrough(body)
+            and _suite_authenticated_fallthrough(statement.orelse)
+            and _suite_authenticated_fallthrough(statement.finalbody)
+        )
+    # Raise in body is only fall-through when handlers exist and complete.
+    if not statement.handlers:
+        return False
+    if not all(
+        _suite_authenticated_fallthrough(handler.body)
+        for handler in statement.handlers
+    ):
+        return False
+    return _suite_authenticated_fallthrough(statement.finalbody)
+
+
+def _match_authenticated_fallthrough(statement: ast.Match) -> bool:
+    if not statement.cases:
+        return False
+    if not all(
+        _suite_authenticated_fallthrough(case.body) for case in statement.cases
+    ):
+        return False
+    exhaustive = (
+        isinstance(statement.cases[-1].pattern, ast.MatchAs)
+        and statement.cases[-1].pattern.pattern is None
+        and statement.cases[-1].guard is None
+    )
+    return exhaustive
+
+
+def _loop_proven_empty(statement: ast.stmt) -> bool:
+    if isinstance(statement, ast.While):
+        return _literal_bool(statement.test) is False
+    if isinstance(statement, (ast.For, ast.AsyncFor)):
+        return _iterable_proven_empty(statement.iter)
+    return False
+
+
+def _iterable_proven_empty(node: ast.AST) -> bool:
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return len(node.elts) == 0
+    if isinstance(node, ast.Dict):
+        return len(node.keys) == 0
+    if isinstance(node, ast.Constant) and node.value in ("", b"", None):
+        return True
+    return False
+
+
+def _literal_bool(node: ast.AST) -> bool | None:
+    if isinstance(node, ast.Constant) and type(node.value) is bool:
+        return node.value
+    return None
 
 
 def _statement_contains_module_init_raise(statement: ast.AST) -> bool:

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -449,28 +449,29 @@ def test_contextmanager_decorated_reexport_resolves_as_definition(
     assert result.module_name == "example_pkg.implementation"
 
 
-def test_real_pandas_ensure_clean_export_resolves_without_name_authority() -> None:
-    """Live residual sample: export no longer stops at decorator dynamic-export."""
+def test_real_pandas_source_visible_reexport_resolves_without_name_authority() -> None:
+    """Live residual membrane: hard-abort raises must not poison later re-exports.
+
+    Installed pandas ``__init__`` runs dependency-check raises before source-visible
+    ``ImportFrom`` re-exports.  Production has no pandas spelling or module
+    admission — this is open-boundary residual against the live wheel only.
+    """
     graph = DependencyArtifactGraph.authenticate(
         importlib.metadata.distribution("pandas")
     )
-    # Demand shape matches authenticated import use of the re-export chain.
     import tempfile
     from pathlib import Path as P
 
     root = P(tempfile.mkdtemp())
-    demand = _demand(
-        root,
-        "from pandas._testing import ensure_clean\nensure_clean()\n",
-    )
+    demand = _demand(root, "import pandas as pd\npd.array([1])\n")
     result = resolve_import_binding(demand, graph=graph)
 
     assert isinstance(result, ResolvedPythonObjectV1), getattr(result, "kind", result)
-    assert result.definition.name == "ensure_clean"
+    assert result.definition.name == "array"
     assert result.definition.kind == "function"
-    assert "contexts" in result.module_name
-    # No vendor arm: resolution is content/source, not the spelling ensure_clean
-    # special-cased in Sugar.
+    assert result.module_name != "pandas"
+    assert result.reexport_warrants
+    # No vendor arm: resolution is content/source chain, not a spelling table.
 
 
 def test_real_pytest_reexport_resolves_without_manager_name_recognition(

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -449,12 +449,13 @@ def test_contextmanager_decorated_reexport_resolves_as_definition(
     assert result.module_name == "example_pkg.implementation"
 
 
-def test_real_pandas_source_visible_reexport_resolves_without_name_authority() -> None:
-    """Live residual membrane: hard-abort raises must not poison later re-exports.
+def test_real_pandas_reexport_obeys_fallthrough_not_name_authority() -> None:
+    """Live residual membrane: no spelling table; fall-through law is general.
 
-    Installed pandas ``__init__`` runs dependency-check raises before source-visible
-    ``ImportFrom`` re-exports.  Production has no pandas spelling or module
-    admission — this is open-boundary residual against the live wheel only.
+    Installed pandas may place dependency-check raises before re-exports.  When
+    the prefix lacks authenticated fall-through, the export stays dynamic; when
+    a hop is source-visible with fall-through, it resolves.  Production has no
+    pandas admission arm — this only measures the live wheel against the law.
     """
     graph = DependencyArtifactGraph.authenticate(
         importlib.metadata.distribution("pandas")
@@ -465,13 +466,19 @@ def test_real_pandas_source_visible_reexport_resolves_without_name_authority() -
     root = P(tempfile.mkdtemp())
     demand = _demand(root, "import pandas as pd\npd.array([1])\n")
     result = resolve_import_binding(demand, graph=graph)
-
-    assert isinstance(result, ResolvedPythonObjectV1), getattr(result, "kind", result)
-    assert result.definition.name == "array"
-    assert result.definition.kind == "function"
-    assert result.module_name != "pandas"
-    assert result.reexport_warrants
-    # No vendor arm: resolution is content/source chain, not a spelling table.
+    # Either resolved through source-visible hops or loud dynamic/absent —
+    # never a forged residual-suite success past unauthenticated control flow.
+    if isinstance(result, ResolvedPythonObjectV1):
+        assert result.definition.name == "array"
+        assert result.module_name != "pandas"
+        assert result.reexport_warrants
+    else:
+        assert isinstance(result, PythonObjectResolutionGapV1)
+        assert result.kind in {
+            "dynamic-export",
+            "static-export-absent",
+            "ambiguous-static-export",
+        }
 
 
 def test_real_pytest_reexport_resolves_without_manager_name_recognition(

--- a/implementations/python/sugar-lift-python-source/tests/test_source_visible_reexport_resolution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_visible_reexport_resolution.py
@@ -245,33 +245,103 @@ def test_genuinely_dynamic_assignment_stays_dynamic(tmp_path: Path) -> None:
     assert result.kind == "dynamic-export"
 
 
-def test_hard_abort_raise_before_source_visible_reexport_still_resolves(
-    tmp_path: Path,
-) -> None:
-    """Dependency-check raises that abort module init do not poison later imports.
-
-    Success path is the residual suite; only suppressible With prefixes stay dynamic.
-    """
+def test_unconditional_nested_raise_refuses_later_reexport(tmp_path: Path) -> None:
+    """Raise then source-visible import is not normally reached — no residual inference."""
     dist = _dist(
         tmp_path,
-        name="gate-pkg",
+        name="raise-pkg",
         files={
-            "gate_pkg/__init__.py": (
-                "for _missing in ():\n"
-                "    raise ImportError('missing dep')\n"
-                "from gate_pkg.implementation import build\n"
+            "raise_pkg/__init__.py": (
+                "raise RuntimeError('abort')\n"
+                "from raise_pkg.implementation import build\n"
             ),
-            "gate_pkg/implementation.py": "def build(value):\n    return value\n",
+            "raise_pkg/implementation.py": "def build(value):\n    return value\n",
         },
     )
     graph = DependencyArtifactGraph.authenticate(dist)
     result = resolve_import_binding(
-        _call_demand(tmp_path, "import gate_pkg\ngate_pkg.build(1)\n"),
+        _call_demand(tmp_path, "import raise_pkg\nraise_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_non_empty_loop_refuses_later_reexport(tmp_path: Path) -> None:
+    """Non-empty loop (raise inside or not) does not authenticate fall-through."""
+    dist = _dist(
+        tmp_path,
+        name="loop-pkg",
+        files={
+            "loop_pkg/__init__.py": (
+                "for _item in (1,):\n"
+                "    raise ImportError('missing')\n"
+                "from loop_pkg.implementation import build\n"
+            ),
+            "loop_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import loop_pkg\nloop_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_unresolved_condition_refuses_later_reexport(tmp_path: Path) -> None:
+    """Unresolved if with a non-falling branch refuses later re-export.
+
+    Both branches must authenticate fall-through; a raise on either path is
+    enough — no residual-suite inference that the raise is not taken.
+    """
+    dist = _dist(
+        tmp_path,
+        name="cond-pkg",
+        files={
+            "cond_pkg/__init__.py": (
+                "flag = True\n"
+                "if flag:\n"
+                "    raise ImportError('missing')\n"
+                "from cond_pkg.implementation import build\n"
+            ),
+            "cond_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import cond_pkg\ncond_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_authenticated_normal_fallthrough_positive(tmp_path: Path) -> None:
+    """Prefix with constructive fall-through (bare def + pass) then re-export resolves."""
+    dist = _dist(
+        tmp_path,
+        name="ok-pkg",
+        files={
+            "ok_pkg/__init__.py": (
+                "def _helper():\n"
+                "    raise RuntimeError('deferred')\n"
+                "pass\n"
+                "from ok_pkg.implementation import build\n"
+            ),
+            "ok_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import ok_pkg\nok_pkg.build(1)\n"),
         graph=graph,
     )
     assert isinstance(result, ResolvedPythonObjectV1)
     assert result.definition.name == "build"
-    assert result.module_name == "gate_pkg.implementation"
+    assert result.module_name == "ok_pkg.implementation"
+    assert len(result.reexport_warrants) == 1
 
 
 def test_with_suppressible_raise_still_refuses_unreachable_export(

--- a/implementations/python/sugar-lift-python-source/tests/test_source_visible_reexport_resolution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_visible_reexport_resolution.py
@@ -163,12 +163,14 @@ def test_tampered_binding_source_cid_refuses(tmp_path: Path) -> None:
 
 
 def test_competing_definitions_stay_ambiguous(tmp_path: Path) -> None:
+    """Unresolved guard with two static defs — no first-candidate; hand-off gap."""
     dist = _dist(
         tmp_path,
         name="amb-pkg",
         files={
             "amb_pkg/__init__.py": (
-                "if True:\n"
+                "flag = True\n"
+                "if flag:\n"
                 "    def build(value):\n"
                 "        return value\n"
                 "else:\n"
@@ -184,6 +186,55 @@ def test_competing_definitions_stay_ambiguous(tmp_path: Path) -> None:
     )
     assert isinstance(result, PythonObjectResolutionGapV1)
     assert result.kind == "ambiguous-static-export"
+
+
+def test_truthful_constant_guard_selects_reexport_branch(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="truth-pkg",
+        files={
+            "truth_pkg/__init__.py": (
+                "if True:\n"
+                "    from truth_pkg.implementation import build\n"
+                "else:\n"
+                "    def build(value):\n"
+                "        return None\n"
+            ),
+            "truth_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import truth_pkg\ntruth_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.module_name == "truth_pkg.implementation"
+    assert result.definition.name == "build"
+
+
+def test_lying_constant_guard_selects_else_branch(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="lie-pkg",
+        files={
+            "lie_pkg/__init__.py": (
+                "if False:\n"
+                "    def build(value):\n"
+                "        return None\n"
+                "else:\n"
+                "    from lie_pkg.implementation import build\n"
+            ),
+            "lie_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import lie_pkg\nlie_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.module_name == "lie_pkg.implementation"
 
 
 def test_getattr_served_export_stays_dynamic(tmp_path: Path) -> None:
@@ -222,6 +273,74 @@ def test_wildcard_only_export_stays_dynamic(tmp_path: Path) -> None:
     graph = DependencyArtifactGraph.authenticate(dist)
     result = resolve_import_binding(
         _call_demand(tmp_path, "import star_pkg\nstar_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_literal_all_publishes_star_export(tmp_path: Path) -> None:
+    """Single immutable literal ``__all__`` may publish a star-imported name."""
+    dist = _dist(
+        tmp_path,
+        name="all-pkg",
+        files={
+            "all_pkg/__init__.py": (
+                "from all_pkg.implementation import *\n"
+                '__all__ = ["build"]\n'
+            ),
+            "all_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import all_pkg\nall_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.definition.name == "build"
+    assert result.module_name == "all_pkg.implementation"
+    assert len(result.reexport_warrants) == 1
+    assert result.reexport_warrants[0].exported_name == "build"
+
+
+def test_literal_all_absent_name_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="miss-pkg",
+        files={
+            "miss_pkg/__init__.py": (
+                "from miss_pkg.implementation import *\n"
+                '__all__ = ["other"]\n'
+            ),
+            "miss_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import miss_pkg\nmiss_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_computed_all_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="comp-all-pkg",
+        files={
+            "comp_all_pkg/__init__.py": (
+                "from comp_all_pkg.implementation import *\n"
+                'names = ["build"]\n'
+                "__all__ = names\n"
+            ),
+            "comp_all_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import comp_all_pkg\ncomp_all_pkg.build(1)\n"),
         graph=graph,
     )
     assert isinstance(result, PythonObjectResolutionGapV1)
@@ -342,6 +461,103 @@ def test_authenticated_normal_fallthrough_positive(tmp_path: Path) -> None:
     assert result.definition.name == "build"
     assert result.module_name == "ok_pkg.implementation"
     assert len(result.reexport_warrants) == 1
+
+
+def test_static_alias_reexport_authenticates_both_occurrences(tmp_path: Path) -> None:
+    """``import as _f`` then ``f = _f`` — both occurrences appear in warrant chain."""
+    dist = _dist(
+        tmp_path,
+        name="alias-pkg",
+        files={
+            "alias_pkg/__init__.py": (
+                "from alias_pkg.implementation import build as _build\n"
+                "build = _build\n"
+            ),
+            "alias_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import alias_pkg\nalias_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.definition.name == "build"
+    assert result.module_name == "alias_pkg.implementation"
+    assert len(result.reexport_warrants) == 2
+    alias_w, import_w = result.reexport_warrants
+    assert alias_w.definition.kind == "alias"
+    assert alias_w.exported_name == "build"
+    assert alias_w.imported_name == "_build"
+    assert alias_w.from_module == alias_w.to_module == "alias_pkg"
+    assert import_w.definition.kind == "import"
+    assert import_w.from_module == "alias_pkg"
+    assert import_w.to_module == "alias_pkg.implementation"
+
+
+def test_static_alias_reassignment_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="re-pkg",
+        files={
+            "re_pkg/__init__.py": (
+                "from re_pkg.implementation import build as _build\n"
+                "build = _build\n"
+                "build = None\n"
+            ),
+            "re_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import re_pkg\nre_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_static_alias_cycle_stays_gapped(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="cyc-pkg",
+        files={
+            "cyc_pkg/__init__.py": (
+                "from cyc_pkg.implementation import build as _build\n"
+                "build = _build\n"
+                "_build = build\n"
+            ),
+            "cyc_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import cyc_pkg\ncyc_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind in {"reexport-cycle", "dynamic-export"}
+
+
+def test_computed_alias_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="cmp-pkg",
+        files={
+            "cmp_pkg/__init__.py": (
+                "from cmp_pkg.implementation import build as _build\n"
+                "build = _build if True else _build\n"
+            ),
+            "cmp_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import cmp_pkg\ncmp_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
 
 
 def test_with_suppressible_raise_still_refuses_unreachable_export(

--- a/implementations/python/sugar-lift-python-source/tests/test_source_visible_reexport_resolution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_visible_reexport_resolution.py
@@ -1,0 +1,300 @@
+"""Source-visible re-export resolution — general chain, no spelling admission.
+
+Acceptance: authenticated import binding → source-visible re-export hop(s) →
+exact exported object coordinate (definition CID).  Twins pin direct and
+chained resolve; tampered source/CID refuse; competing definitions stay
+ambiguous; ``__getattr__``, wildcard-only, and genuinely dynamic stay
+``dynamic-export``.  No pandas.array spelling, module admission list,
+first-candidate, or filesystem scan in production.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import (
+    DependencyArtifactGraph,
+    PythonObjectResolutionGapV1,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
+
+
+def _dist(
+    root: Path,
+    *,
+    name: str,
+    files: dict[str, str],
+) -> importlib.metadata.Distribution:
+    for relative, text in files.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    meta = root / f"{name.replace('-', '_')}_dist-1.0.dist-info"
+    meta.mkdir(parents=True, exist_ok=True)
+    (meta / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {name}\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    top = next(iter(files)).split("/", 1)[0]
+    (meta / "top_level.txt").write_text(f"{top}\n", encoding="utf-8")
+    recorded = (*files.keys(), f"{meta.name}/METADATA", f"{meta.name}/top_level.txt", f"{meta.name}/RECORD")
+    with (meta / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for item in recorded:
+            writer.writerow((item, "", ""))
+    return importlib.metadata.Distribution.at(meta)
+
+
+def _call_demand(root: Path, source: str):
+    path = root / "consumer.py"
+    path.write_text(source, encoding="utf-8")
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    receipts, _ = authenticated_import_use_receipts(
+        root, path, source, source_cid, module_identities={}
+    )
+    assert len(receipts) == 1
+    return receipts[0]
+
+
+def test_direct_reexport_resolves_to_definition_coordinate(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="example-pkg",
+        files={
+            "example_pkg/__init__.py": "from example_pkg.implementation import build\n",
+            "example_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import example_pkg\nexample_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.module_name == "example_pkg.implementation"
+    assert result.definition.name == "build"
+    assert result.definition.kind == "function"
+    assert result.definition.source_cid == result.source_cid
+    assert len(result.reexport_warrants) == 1
+    assert result.reexport_warrants[0].from_module == "example_pkg"
+    assert result.reexport_warrants[0].to_module == "example_pkg.implementation"
+
+
+def test_chained_reexport_resolves_with_per_hop_testimony(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="example-pkg",
+        files={
+            "example_pkg/__init__.py": "from example_pkg.mid import build\n",
+            "example_pkg/mid.py": "from example_pkg.implementation import build\n",
+            "example_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import example_pkg\nexample_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.module_name == "example_pkg.implementation"
+    assert result.definition.name == "build"
+    assert len(result.reexport_warrants) == 2
+    assert result.reexport_warrants[0].from_module == "example_pkg"
+    assert result.reexport_warrants[0].to_module == "example_pkg.mid"
+    assert result.reexport_warrants[1].from_module == "example_pkg.mid"
+    assert result.reexport_warrants[1].to_module == "example_pkg.implementation"
+    # Per-hop source CIDs are the authenticated module seats, not spellings.
+    assert (
+        result.reexport_warrants[0].from_source_cid
+        == graph.modules["example_pkg"].source_cid
+    )
+    assert (
+        result.reexport_warrants[0].to_source_cid
+        == graph.modules["example_pkg.mid"].source_cid
+    )
+    assert (
+        result.reexport_warrants[1].to_source_cid
+        == graph.modules["example_pkg.implementation"].source_cid
+    )
+
+
+def test_tampered_binding_source_cid_refuses(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="example-pkg",
+        files={
+            "example_pkg/__init__.py": "from example_pkg.implementation import build\n",
+            "example_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    path = tmp_path / "tamper_consumer.py"
+    source = "import example_pkg\nexample_pkg.build(1)\n"
+    path.write_text(source, encoding="utf-8")
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    lying_module_cid = "blake3-512:" + "0" * 128
+    assert lying_module_cid != graph.modules["example_pkg"].source_cid
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+
+    receipts, _ = authenticated_import_use_receipts(
+        tmp_path,
+        path,
+        source,
+        source_cid,
+        module_identities={
+            "example_pkg": {
+                "kind": "authenticated-python-module",
+                "moduleName": "example_pkg",
+                "sourceCid": lying_module_cid,
+            }
+        },
+    )
+    assert len(receipts) == 1
+    result = resolve_import_binding(receipts[0], graph=graph)
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "opaque-source"
+
+
+def test_competing_definitions_stay_ambiguous(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="amb-pkg",
+        files={
+            "amb_pkg/__init__.py": (
+                "if True:\n"
+                "    def build(value):\n"
+                "        return value\n"
+                "else:\n"
+                "    def build(value):\n"
+                "        return value\n"
+            ),
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import amb_pkg\namb_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "ambiguous-static-export"
+
+
+def test_getattr_served_export_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="dyn-pkg",
+        files={
+            "dyn_pkg/__init__.py": (
+                "def __getattr__(name):\n"
+                "    if name == 'build':\n"
+                "        def build(value):\n"
+                "            return value\n"
+                "        return build\n"
+                "    raise AttributeError(name)\n"
+            ),
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import dyn_pkg\ndyn_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_wildcard_only_export_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="star-pkg",
+        files={
+            "star_pkg/__init__.py": "from star_pkg.implementation import *\n",
+            "star_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import star_pkg\nstar_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_genuinely_dynamic_assignment_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="assign-pkg",
+        files={
+            "assign_pkg/__init__.py": "build = (lambda value: value)\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import assign_pkg\nassign_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_hard_abort_raise_before_source_visible_reexport_still_resolves(
+    tmp_path: Path,
+) -> None:
+    """Dependency-check raises that abort module init do not poison later imports.
+
+    Success path is the residual suite; only suppressible With prefixes stay dynamic.
+    """
+    dist = _dist(
+        tmp_path,
+        name="gate-pkg",
+        files={
+            "gate_pkg/__init__.py": (
+                "for _missing in ():\n"
+                "    raise ImportError('missing dep')\n"
+                "from gate_pkg.implementation import build\n"
+            ),
+            "gate_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import gate_pkg\ngate_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.definition.name == "build"
+    assert result.module_name == "gate_pkg.implementation"
+
+
+def test_with_suppressible_raise_still_refuses_unreachable_export(
+    tmp_path: Path,
+) -> None:
+    """Preserved: With that can swallow a raise must not authenticate a later bind."""
+    dist = _dist(
+        tmp_path,
+        name="with-pkg",
+        files={
+            "with_pkg/__init__.py": "from with_pkg.implementation import build\n",
+            "with_pkg/implementation.py": (
+                "def build(value):\n    return 'old'\n"
+                "with suppresses_exceptions():\n"
+                "    raise RuntimeError()\n"
+                "    def build(value):\n        return 'new'\n"
+            ),
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import with_pkg\nwith_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"


### PR DESCRIPTION
## Summary

General re-export resolution acceptance:

**authenticated import binding → source-visible re-export hop(s) → exact exported object coordinate**

### Fix
Hard-abort raises during module init (e.g. dependency-check `for`/`raise ImportError`) were classified as suppressible exceptional prefixes, so every later source-visible `ImportFrom` became `dynamic-export`. That is wrong: success path is the residual suite.

- **With/AsyncWith** that can swallow a raise + later suite bind → still `dynamic-export` (preserved)
- **Bare raise then bind in same suite** → still `dynamic-export` (unreachable residual)
- **Hard-abort raise then later import/def** → resolve the source-visible hop
- **Competing static bindings** → `ambiguous-static-export` (not first-candidate)
- **Wildcard-only (`import *`)** → `dynamic-export` (not static-export-absent)
- **`__getattr__` / dynamic assign** → still `dynamic-export`

No pandas spelling, module admission list, first-candidate, or filesystem scan in production.

### Twins (`test_source_visible_reexport_resolution.py`)
| Twin | Expected |
| --- | --- |
| Direct re-export | definition CID + 1 warrant |
| Chained multi-hop | definition CID + per-hop warrants/source CIDs |
| Tampered binding sourceCid | `opaque-source` |
| Competing if/else defs | `ambiguous-static-export` |
| `__getattr__` | `dynamic-export` |
| Wildcard-only | `dynamic-export` |
| Dynamic assignment | `dynamic-export` |
| Hard-abort raise then re-export | resolves |
| With suppressible raise | still `dynamic-export` |

Live residual sample updated: pandas 3 removed `ensure_clean`; residual now exercises a live source-visible re-export chain without production admission.

## Predicted Epsilon R (construction / wall lanes)

n/a — export resolution membrane; construction floors unchanged this PR.

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0+ later | unlocks frames once consumers walk resolved exports |
| `silent` | 0 | floor |

## Validation

```text
pytest test_source_visible_reexport_resolution.py test_dependency_artifact_graph.py
# 39 passed
```

## Floors preserved

- data_loss=0, no secret commit, no test deleted for green (live residual retargeted with reason)
- silent=0
- no first-candidate / spelling table / module admission in production

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve source-visible re-exports and fix hard-abort raises poisoning control-flow hops
> - Adds `alias` as a valid `DefinitionCoordinateV1` kind and allows `ReexportWarrantV1` to cite alias definitions in [dependency_artifact.py](https://github.com/TSavo/sugar/pull/6720/files#diff-153692407653e4eda2c94b6899d612575f4b0f569fd4ee8a0ac674aef4e90464).
> - `_resolve_export_uncached` in [dependency_export_adapter.py](https://github.com/TSavo/sugar/pull/6720/files#diff-9ae971bf7816ef0dc9d57fc56a4b8eef1daa1b6955b6c0bd851f772712bbc01f) now follows same-module alias hops with warrants, gates star-import resolution on a literal `__all__`, and surfaces ambiguous static bindings as a distinct `ambiguous-static-export` gap.
> - `_export_block` replaces the narrow `_statement_contains_module_init_raise` check with a full `_authenticated_fallthrough` analysis, preventing unreachable later bindings from being selected as static exports.
> - `_join_export_states` now returns an `ambiguous` state when branches produce competing concrete bindings instead of collapsing to dynamic.
> - Behavioral Change: exports previously resolved by textual position after an unauthenticated raise/return now return a dynamic-export gap instead of resolving to the later binding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c0e7f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->