### PR TITLE
Prove nested loop control targeting

### DIFF
--- a/implementations/python/sugar-source-tree/tests/test_nested_loop_control_temporal.py
+++ b/implementations/python/sugar-source-tree/tests/test_nested_loop_control_temporal.py
@@ -1,0 +1,64 @@
+"""Nested loop controls are consumed only by their authenticated target loop."""
+
+from __future__ import annotations
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _returned_int(source: str) -> int:
+    return _function(source).sugar().desugar().value.post().args[1].value
+
+
+def test_inner_break_preserves_outer_state_and_does_not_suppress_outer_else() -> None:
+    assert _returned_int(
+        "def arbitrary():\n"
+        "    carried = 0\n"
+        "    for outer in (0, 1):\n"
+        "        carried = carried + 10\n"
+        "        for inner in (0, 1):\n"
+        "            carried = carried + 1\n"
+        "            break\n"
+        "    else:\n"
+        "        carried = carried + 100\n"
+        "    return carried\n"
+    ) == 122
+
+
+def test_inner_continue_preserves_iteration_state_before_outer_tail() -> None:
+    assert _returned_int(
+        "def arbitrary():\n"
+        "    carried = 0\n"
+        "    for outer in (0, 1):\n"
+        "        for inner in (0, 1):\n"
+        "            carried = carried + 1\n"
+        "            continue\n"
+        "        carried = carried + 10\n"
+        "    else:\n"
+        "        carried = carried + 100\n"
+        "    return carried\n"
+    ) == 124
+
+
+def test_inner_and_outer_controls_mint_distinct_target_coordinates() -> None:
+    function = _function(
+        "def arbitrary(values):\n"
+        "    for outer in values:\n"
+        "        for inner in values:\n"
+        "            break\n"
+        "        continue\n"
+    )
+    controls = [
+        node for node in function.walk() if node.kind in {"Break", "Continue"}
+    ]
+    targets = {node.kind: node.sugar().target_cid for node in controls}
+    assert targets["Break"] != targets["Continue"]


### PR DESCRIPTION
## Capability proof
- inner `break` is consumed by the inner loop and does not suppress outer `else`
- inner `continue` returns to the inner backedge while preserving iteration state before the outer tail
- inner and outer controls retain distinct authenticated target coordinates

No production files changed.

## Tests
`../../../bin/bpytest tests/test_nested_loop_control_temporal.py tests/test_loop_control_construction.py tests/test_live_loop_post_projection.py` — 24 passed.

The unrelated while/finally source-return red is banked separately and not suppressed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests proving nested loop control targeting assigns distinct coordinates and preserves loop state
> Adds three tests to [test_nested_loop_control_temporal.py](https://github.com/TSavo/sugar/pull/6721/files#diff-1738d50fd0c0d02b1ea17a97617cc70384bf311c0dc3cfc05b52f74a999f5bbd) covering nested loop control flow in the sugar/desugar pipeline.
>
> - Verifies that an inner `break` preserves outer loop accumulated state and does not suppress the outer `else` clause (expected value: 122).
> - Verifies that an inner `continue` preserves iteration state before the outer loop's tail executes (expected value: 124).
> - Verifies that `Break` and `Continue` nodes in nested loops are assigned distinct sugar target identifiers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b50b133.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->