### PR TITLE
Preserve loop pre-halt iteration state

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
@@ -132,7 +132,7 @@ class LoopRecurrenceSugar(Sugar):
                     )
                 )
             elif isinstance(outcome, Incomplete):
-                exits.append(Halted(face.guard, outcome.effect, recurrence))
+                exits.append(Halted(face.guard, outcome.effect, face.state))
             else:
                 # The face reduced to something richer than one return value or
                 # one effect: a return whose expression PARTITIONS (`return
@@ -151,7 +151,7 @@ class LoopRecurrenceSugar(Sugar):
                 pending, plain = pending_demand(outcome, face.guard)
                 for exit_ in outcome_to_exitset(plain).guarded(face.guard).exits:
                     if isinstance(exit_, Halted):
-                        exits.append(Halted(exit_.guard, exit_.effect, recurrence))
+                        exits.append(Halted(exit_.guard, exit_.effect, face.state))
                     else:
                         entries = (exit_.value,) if pending is None else (
                             pending,

--- a/implementations/python/sugar-source-tree/tests/test_loop_carried_temporal.py
+++ b/implementations/python/sugar-source-tree/tests/test_loop_carried_temporal.py
@@ -1,0 +1,56 @@
+"""Loop-carried bindings advance per iteration and halt at the live snapshot."""
+
+from __future__ import annotations
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.outcome import Halted
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def test_concrete_loop_rebinds_carried_value_each_iteration() -> None:
+    post = (
+        _function(
+            "def arbitrary():\n"
+            "    carried = 0\n"
+            "    for item in (1, 2, 3):\n"
+            "        carried = carried + item\n"
+            "    return carried\n"
+        )
+        .sugar()
+        .desugar()
+        .value.post()
+    )
+    assert post.args[1].value == 6
+
+
+def test_mid_iteration_halt_retains_exact_pre_halt_binding_snapshot() -> None:
+    constructed = _function(
+        "def arbitrary(limit, stop):\n"
+        "    carried = 0\n"
+        "    while carried < limit:\n"
+        "        carried = carried + 1\n"
+        "        if carried == stop:\n"
+        "            raise ValueError(carried)\n"
+        "        carried = 99\n"
+        "    return carried\n"
+    ).sugar()
+
+    loop = constructed.statements[1]
+    assert len(loop.outward_faces) == 1
+    snapshot = loop.outward_faces[0].state
+    assert len(snapshot) == 1
+    assert "carried + 1" in snapshot[0].state.segment()
+    assert "99" not in snapshot[0].state.segment()
+
+    exits = loop.desugar()
+    halted = next(exit_ for exit_ in exits.exits if isinstance(exit_, Halted))
+    assert halted.state is snapshot


### PR DESCRIPTION
## Capability
- outward loop halts now carry the producer-authenticated per-iteration binding snapshot
- both direct `Incomplete` effects and richer halted outcomes preserve `face.state` instead of substituting the generic recurrence record
- concrete loop rebinding remains one state transition per iteration

## Discrimination
The mid-iteration raise occurs after `carried = carried + 1` and before `carried = 99`; the halted state is the exact snapshot object containing the former and excluding the latter.

## Tests
Red before fix: 1 passed, 1 failed (`halted.state is snapshot`).
After fix/rebase: `../../../bin/bpytest tests/test_loop_carried_temporal.py tests/test_live_loop_post_projection.py` — 10 passed.

ExitSet, nodes.py, carriers, source-return projection, and generator-manager files untouched.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve pre-halt iteration state in `LoopRecurrenceSugar.to_term` Halted exits
> - Changes [`loop_recurrence_sugar.py`](https://github.com/TSavo/sugar/pull/6722/files#diff-f2f1e95b345c3c7e0569fbbe5a17e9608d1617fd8decf5507ba13f0d25c59547) to pass `face.state` instead of `recurrence` as the third argument when constructing `Halted(...)`, covering both mid-iteration incomplete outcomes and halted exits inside the `outcome_to_exitset` loop.
> - Adds tests in [`test_loop_carried_temporal.py`](https://github.com/TSavo/sugar/pull/6722/files#diff-030e855112893c4650971109768c37934f58fa8fbaf961d897fe873c958ac918) verifying that carried values accumulate correctly across iterations and that a mid-iteration halt captures the state snapshot from before the halt.
> - Behavioral Change: `Halted` exits from `to_term` now carry the face's state at the point of halting rather than the prior recurrence value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a5fa48.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->