### PR TITLE
Walrus-through-If temporal law (split #6723 first vertical)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -1041,8 +1041,9 @@ class FloorValue:
 
         if isinstance(other, GuardedValue):
             return other.predicate_from_left("less_than", self, site)
+        # RHS walrus: typed double-dispatch — never predicate_from_left(str).
         if isinstance(other, NamedExpressionValue):
-            return other.predicate_from_left("less_than", self, site)
+            return other.less_than_from_left(self, site)
 
         return Complete(
             PredicateValue(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -1025,31 +1025,33 @@ class FloorValue:
         )
 
     def less_than(self, other, site):
+        # Operator-owned double dispatch: the RHS answers ``less_than_from_left``.
+        # Default Floor emits the ordinary atom; GuardedValue distributes;
+        # NamedExpressionValue presents-and-carries. No concrete-kind membrane
+        # and no operation-string admission on this surface.
+        return other.less_than_from_left(self, site)
+
+    def less_than_from_left(self, left, site):
+        """Default RHS law for ``left < self`` — ordinary comparison atom.
+
+        Overrides (GuardedValue, NamedExpressionValue, …) replace this door.
+        Does not call ``left.less_than(self)`` (that would recurse).
+        """
         # Default: EMIT an operator-indexed atom. Fold when both sides are
         # ground (the literal pair overrides); emit when either side stands on
         # the term floor; panic only inside to_term when a side cannot enter
         # FOL at all. Vendor `<` is py.lt -- not SMT < -- so the sort universe
         # adjudicates (same NaN/reflexivity split as py.eq). Operand
         # CallSiteValues ride as operand_callsites.
-        from sugar_lift_py_tests.floor.guarded_value import GuardedValue
-        from sugar_lift_py_tests.floor.named_expression_value import (
-            NamedExpressionValue,
-        )
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
         from sugar_lift_py_tests.floor.comparison_atom import resolve_comparison_atom
         from sugar_lift_py_tests.outcome import Complete
 
-        if isinstance(other, GuardedValue):
-            return other.predicate_from_left("less_than", self, site)
-        # RHS walrus: typed double-dispatch — never predicate_from_left(str).
-        if isinstance(other, NamedExpressionValue):
-            return other.less_than_from_left(self, site)
-
         return Complete(
             PredicateValue(
-                resolve_comparison_atom("lt", self, other, owner=str(site)),
+                resolve_comparison_atom("lt", left, self, owner=str(site)),
                 site,
-                operand_callsites=(*self.callsites(), *other.callsites()),
+                operand_callsites=(*left.callsites(), *self.callsites()),
             )
         )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
@@ -249,6 +249,14 @@ class GuardedValue(FloorValue):
         )
         return _rejoin(joined)
 
+    def less_than_from_left(self, left, site):
+        """Typed Floor obligation: distribute ``left <`` across guarded arms.
+
+        Preserves existing guarded-predicate distribution; does not invent a
+        generic getattr/string surface on the Floor protocol.
+        """
+        return self.predicate_from_left("less_than", left, site)
+
     def predicate_from_left(self, method: str, left, site):
         """Distribute a binary predicate whose guarded value is the RHS."""
         return GuardedValue(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/named_expression_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/named_expression_value.py
@@ -7,7 +7,14 @@ from .floor_value import FloorValue
 
 @dataclass(frozen=True)
 class NamedExpressionValue(FloorValue):
-    """The inseparable value and temporal-bind faces of ``(name := value)``."""
+    """The inseparable value and temporal-bind faces of ``(name := value)``.
+
+    Comparison is Floor-owned through the **presented** face: this value only
+    contributes its temporal bind via ``_carry``. Left-hand ops dispatch to
+    ``presented_value.<op>(other)``; right-hand routing is the typed
+    ``less_than_from_left`` door that ``FloorValue.less_than`` already calls
+    via ``predicate_from_left`` (no string→method table, no peer unwrap).
+    """
 
     name: str
     assigned_value: FloorValue
@@ -25,6 +32,12 @@ class NamedExpressionValue(FloorValue):
         return carried
 
     def extend_scope(self, ctx):
+        # Root mint is Floor-owned when the reducer has no ambient context yet
+        # (function desugar(None) / SourceFile production tooth).
+        if ctx is None:
+            from sugar_lift_py_tests.context import ReduceContext
+
+            ctx = ReduceContext.root(owner="NamedExpressionValue")
         scoped = replace(
             ctx, temporal=ctx.temporal.bind_value(self.name, self.assigned_value)
         )
@@ -66,34 +79,48 @@ class NamedExpressionValue(FloorValue):
     def negate(self):
         return self.presented_value.negate().and_then(self._carry)
 
+    # --- left-hand: presented floor owns the comparison ---
+
     def is_identical(self, other, site):
-        peer = (
-            other.presented_value if isinstance(other, NamedExpressionValue) else other
-        )
-        return self.presented_value.is_identical(peer, site).and_then(self._carry)
+        return self.presented_value.is_identical(other, site).and_then(self._carry)
 
     def equals(self, other, site):
-        peer = (
-            other.presented_value if isinstance(other, NamedExpressionValue) else other
-        )
-        return self.presented_value.equals(peer, site).and_then(self._carry)
+        return self.presented_value.equals(other, site).and_then(self._carry)
 
     def less_than(self, other, site):
-        peer = (
-            other.presented_value if isinstance(other, NamedExpressionValue) else other
-        )
-        return self.presented_value.less_than(peer, site).and_then(self._carry)
+        return self.presented_value.less_than(other, site).and_then(self._carry)
+
+    def less_equal(self, other, site):
+        return self.presented_value.less_equal(other, site).and_then(self._carry)
+
+    def greater_than(self, other, site):
+        return self.presented_value.greater_than(other, site).and_then(self._carry)
+
+    def greater_equal(self, other, site):
+        return self.presented_value.greater_equal(other, site).and_then(self._carry)
+
+    # --- right-hand: typed door for FloorValue.less_than / GuardedValue ---
+
+    def less_than_from_left(self, left, site):
+        """``left < (n := e)`` — presented is the RHS; carry the walrus bind."""
+        return left.less_than(self.presented_value, site).and_then(self._carry)
 
     def predicate_from_left(self, operation: str, left, site):
-        if operation != "less_than":
-            return self._floor_gap(
-                owner="NamedExpressionValue",
-                blame=str(site),
-                observed=operation,
-                requested="predicate from left operand",
-                fix="write the named-expression predicate projection",
-            )
-        return left.less_than(self.presented_value, site).and_then(self._carry)
+        """Only ``less_than`` is admitted on this legacy string door.
+
+        Typed ``less_than_from_left`` is the real surface; this method exists
+        because ``FloorValue.less_than`` and ``GuardedValue`` still pass the
+        method name. No string→method table, no ``getattr``.
+        """
+        if operation == "less_than":
+            return self.less_than_from_left(left, site)
+        return self._floor_gap(
+            owner="NamedExpressionValue",
+            blame=str(site),
+            observed=operation,
+            requested="typed less_than_from_left on the presented floor",
+            fix="call less_than_from_left; never getattr a comparison method",
+        )
 
     def subscript(self, index, site):
         return self.presented_value.subscript(index, site).and_then(self._carry)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/named_expression_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/named_expression_value.py
@@ -11,9 +11,8 @@ class NamedExpressionValue(FloorValue):
 
     Comparison is Floor-owned through the **presented** face: this value only
     contributes its temporal bind via ``_carry``. Left-hand ops dispatch to
-    ``presented_value.<op>(other)``; right-hand routing is the typed
-    ``less_than_from_left`` door that ``FloorValue.less_than`` already calls
-    via ``predicate_from_left`` (no string→method table, no peer unwrap).
+    ``presented_value.<op>(other)``; right-hand routing is operator-owned typed
+    double-dispatch (``less_than_from_left``, …). No ``predicate_from_left(str)``.
     """
 
     name: str
@@ -99,28 +98,31 @@ class NamedExpressionValue(FloorValue):
     def greater_equal(self, other, site):
         return self.presented_value.greater_equal(other, site).and_then(self._carry)
 
-    # --- right-hand: typed door for FloorValue.less_than / GuardedValue ---
+    # --- right-hand: operator-owned typed double-dispatch (no string door) ---
 
     def less_than_from_left(self, left, site):
         """``left < (n := e)`` — presented is the RHS; carry the walrus bind."""
         return left.less_than(self.presented_value, site).and_then(self._carry)
 
-    def predicate_from_left(self, operation: str, left, site):
-        """Only ``less_than`` is admitted on this legacy string door.
+    def less_equal_from_left(self, left, site):
+        """``left <= (n := e)`` — typed RHS door; not string-admitted."""
+        return left.less_equal(self.presented_value, site).and_then(self._carry)
 
-        Typed ``less_than_from_left`` is the real surface; this method exists
-        because ``FloorValue.less_than`` and ``GuardedValue`` still pass the
-        method name. No string→method table, no ``getattr``.
-        """
-        if operation == "less_than":
-            return self.less_than_from_left(left, site)
-        return self._floor_gap(
-            owner="NamedExpressionValue",
-            blame=str(site),
-            observed=operation,
-            requested="typed less_than_from_left on the presented floor",
-            fix="call less_than_from_left; never getattr a comparison method",
-        )
+    def greater_than_from_left(self, left, site):
+        """``left > (n := e)`` — typed RHS door; not string-admitted."""
+        return left.greater_than(self.presented_value, site).and_then(self._carry)
+
+    def greater_equal_from_left(self, left, site):
+        """``left >= (n := e)`` — typed RHS door; not string-admitted."""
+        return left.greater_equal(self.presented_value, site).and_then(self._carry)
+
+    def equals_from_left(self, left, site):
+        """``left == (n := e)`` — typed RHS door; not string-admitted."""
+        return left.equals(self.presented_value, site).and_then(self._carry)
+
+    def is_identical_from_left(self, left, site):
+        """``left is (n := e)`` — typed RHS door; not string-admitted."""
+        return left.is_identical(self.presented_value, site).and_then(self._carry)
 
     def subscript(self, index, site):
         return self.presented_value.subscript(index, site).and_then(self._carry)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -187,15 +187,20 @@ class IfSugar(Sugar):
         # and preserve their guarded exits exactly as before.
         from sugar_lift_py_tests.outcome import ExitSet
 
+        # Walrus (and any FloorValue with non-identity extend_scope) binds
+        # before branch selection — Python makes the name visible in BOTH arms.
+        # Default FloorValue.extend_scope is identity.
+        branch_ctx = condition.extend_scope(ctx)
+
         if observed_formula == false_guard():
             then_exits = ExitSet(())
-            else_exits = reduce_block_to_exitset(self.else_body, ctx)
+            else_exits = reduce_block_to_exitset(self.else_body, branch_ctx)
         elif observed_formula == true_guard():
-            then_exits = reduce_block_to_exitset(self.then_body, ctx)
+            then_exits = reduce_block_to_exitset(self.then_body, branch_ctx)
             else_exits = ExitSet(())
         else:
-            then_exits = reduce_block_to_exitset(self.then_body, ctx)
-            else_exits = reduce_block_to_exitset(self.else_body, ctx)
+            then_exits = reduce_block_to_exitset(self.then_body, branch_ctx)
+            else_exits = reduce_block_to_exitset(self.else_body, branch_ctx)
 
         # If is union in the exit algebra: each branch is restricted to its
         # polarity, then the partitions normalize together. In particular, a

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/named_expr_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/named_expr_sugar.py
@@ -5,22 +5,30 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
 @dataclass(frozen=True)
-class NamedExprSugar(Sugar):
-    """A walrus: binds ``name`` (spent by substitute) and presents ``value``.
+class NamedExprSugar(ConstructedTermSugar):
+    """A walrus: binds ``name`` and presents ``value``.
 
-    The tree threads the binding into the enclosing block via
-    ``NamedExpr.substitution_binding``. At the meaning layer the expression
-    evaluates to the assigned value wrapped as ``NamedExpressionValue``.
+    Tree substitute threads the binding into the enclosing block. At the
+    meaning layer the expression evaluates to ``NamedExpressionValue``.
+
+    Enrolled as ``ConstructedTermSugar`` so Compare/Eq parents may carry the
+    walrus as an operand through the typed term surface (no spelling side-door).
     """
 
     name: str
-    value: Sugar
+    value: ConstructedTermSugar
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        require_constructed_term_sugar(self.value, owner="NamedExprSugar.value")
 
     @classmethod
     def witnesses(cls):
@@ -32,6 +40,19 @@ class NamedExprSugar(Sugar):
             owner_sugar="NamedExprSugar",
             truthful=prefix + "def test_a():\n    assert A([1, 2]) == 2\n",
             lying=prefix + "def test_a():\n    assert A([1, 2]) == 0\n",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:named-expr-construction",
+            (
+                self.occurrence_term(owner=owner),
+                str_const(self.name),
+                self.value.to_term(owner=owner),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/tests/test_walrus_operator_temporal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_walrus_operator_temporal.py
@@ -300,22 +300,39 @@ def test_no_string_predicate_from_left_door() -> None:
 
 
 def test_right_hand_zero_lt_walrus_reaches_typed_method() -> None:
-    """Production tooth: ``0 < (n := 5)`` → FloorValue.less_than → less_than_from_left."""
+    """Production tooth: ``0 < (n := 5)`` → Floor protocol less_than_from_left."""
     left = TermValue(0)
     right = NamedExpressionValue("n", TermValue(5))
-    # Must hit typed double-dispatch (not string predicate_from_left).
+    # General double-dispatch: left.less_than → other.less_than_from_left.
     out = left.less_than(right, SITE)
     assert isinstance(out, Complete)
     assert isinstance(out.value, NamedExpressionValue)
     assert out.value.name == "n"
     assert out.value.assigned_value == TermValue(5)
-    # Direct typed door matches Floor routing.
     direct = right.less_than_from_left(left, SITE)
     assert isinstance(direct, Complete)
     assert isinstance(direct.value, NamedExpressionValue)
     assert direct.value.assigned_value == TermValue(5)
     scoped = out.value.extend_scope(_root("rhs"))
     assert _name("n").desugar(scoped).value == TermValue(5)
+
+
+def test_ordinary_rhs_term_uses_default_less_than_from_left() -> None:
+    """Non-walrus Floor twin: ordinary RHS uses protocol less_than_from_left, not NEV."""
+    left = TermValue(0)
+    right = TermValue(5)
+    out = left.less_than(right, SITE)
+    assert isinstance(out, Complete)
+    # Not walrus-kind membrane: ordinary RHS never yields NamedExpressionValue.
+    assert not isinstance(out.value, NamedExpressionValue)
+    # Protocol default door is present on FloorValue (not a NEV-only arm).
+    assert hasattr(type(right), "less_than_from_left")
+    direct = right.less_than_from_left(left, SITE)
+    assert isinstance(direct, Complete)
+    assert not isinstance(direct.value, NamedExpressionValue)
+    # Ground 0 < 5 is decided true-ish, not false.
+    assert type(out.value).__name__ != "FalseBoolLiteralSugar"
+    assert type(direct.value).__name__ != "FalseBoolLiteralSugar"
 
 
 def test_rhs_walrus_via_comparison_op_sugar_lt() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_walrus_operator_temporal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_walrus_operator_temporal.py
@@ -292,18 +292,56 @@ def test_left_hand_comparison_presented_owns_and_carry_binds() -> None:
     assert _name("n").desugar(scoped).value == TermValue(5)
 
 
-def test_right_hand_less_than_from_left_typed_door() -> None:
-    """``0 < (n := 5)`` via FloorValue → less_than_from_left (typed)."""
+def test_no_string_predicate_from_left_door() -> None:
+    """NamedExpressionValue must not admit comparison via operation:str."""
+    assert "predicate_from_left" not in NamedExpressionValue.__dict__, (
+        "delete string admission; use less_than_from_left etc."
+    )
+
+
+def test_right_hand_zero_lt_walrus_reaches_typed_method() -> None:
+    """Production tooth: ``0 < (n := 5)`` → FloorValue.less_than → less_than_from_left."""
     left = TermValue(0)
     right = NamedExpressionValue("n", TermValue(5))
-    # FloorValue.less_than routes NamedExpressionValue RHS through
-    # predicate_from_left("less_than") → less_than_from_left.
+    # Must hit typed double-dispatch (not string predicate_from_left).
     out = left.less_than(right, SITE)
     assert isinstance(out, Complete)
     assert isinstance(out.value, NamedExpressionValue)
+    assert out.value.name == "n"
     assert out.value.assigned_value == TermValue(5)
+    # Direct typed door matches Floor routing.
+    direct = right.less_than_from_left(left, SITE)
+    assert isinstance(direct, Complete)
+    assert isinstance(direct.value, NamedExpressionValue)
+    assert direct.value.assigned_value == TermValue(5)
     scoped = out.value.extend_scope(_root("rhs"))
     assert _name("n").desugar(scoped).value == TermValue(5)
+
+
+def test_rhs_walrus_via_comparison_op_sugar_lt() -> None:
+    """``0 < (n := 5)`` through ComparisonOpSugar reaches typed RHS path."""
+    cmp = ComparisonOpSugar(
+        "Lt",
+        _int(0),
+        _walrus("n", _int(5)),
+        site=SITE,
+    )
+    out = cmp.desugar(_root("cmp-lt"))
+    assert isinstance(out, Complete)
+    # Completed predicate still carries the walrus face when RHS is NEV.
+    val = out.value
+    if isinstance(val, NamedExpressionValue):
+        assert val.assigned_value == TermValue(5)
+        scoped = val.extend_scope(_root("cmp-lt-bind"))
+        assert _name("n").desugar(scoped).value == TermValue(5)
+    else:
+        # Ground fold may present a bool-ish predicate; bind still carried if NEV.
+        assert type(val).__name__ in (
+            "PredicateValue",
+            "TrueBoolLiteralSugar",
+            "FalseBoolLiteralSugar",
+            "NamedExpressionValue",
+        ), type(val).__name__
 
 
 def test_if_comparison_left_carries_bind_through_if_sugar() -> None:
@@ -315,6 +353,22 @@ def test_if_comparison_left_carries_bind_through_if_sugar() -> None:
     )
     terms = _return_terms(sugar.desugar(_root("if-cmp")))
     assert TermValue(5) in terms, terms
+
+
+def test_lying_operator_token_twin_refuses_same_outcome() -> None:
+    """Lying operator token: ``Gt`` vs truthful ``Lt`` on ``0 ? (n := 5)`` refuse."""
+    truthful = ComparisonOpSugar(
+        "Lt", _int(0), _walrus("n", _int(5)), site=SITE
+    ).desugar(_root("op-true"))
+    lying = ComparisonOpSugar(
+        "Gt", _int(0), _walrus("n", _int(5)), site=SITE
+    ).desugar(_root("op-lie"))
+    assert isinstance(truthful, Complete)
+    assert isinstance(lying, Complete)
+    # Ground 0 < 5 vs 0 > 5 must not be outcome-identical.
+    assert type(truthful.value).__name__ != type(lying.value).__name__ or (
+        truthful.value != lying.value
+    ), (truthful.value, lying.value)
 
 
 def test_lying_comparison_twin_refuses_wrong_return() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_walrus_operator_temporal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_walrus_operator_temporal.py
@@ -1,0 +1,417 @@
+"""WALRUS-THROUGH-IF TEMPORAL LAW.
+
+Concrete:
+
+    if (n := expr):
+        use(n)      # then sees n
+    else:
+        use(n)      # else also sees n (Python binds before selection)
+
+Acceptance (this PR only):
+
+  - condition evaluates once
+  - successful walrus binding is visible to BOTH selected branches
+  - true/false selection preserves the same bound Floor value
+  - condition value halt bypasses both arms (no bind; branches do not run)
+  - comparison is Floor-owned: presented face owns the op; bind rides ``_carry``
+  - wrong-coordinate / lying comparison twins refuse
+  - real SourceFile production tooth
+
+Owner: ``NamedExprSugar`` / ``NamedExpressionValue`` / ``IfSugar`` branch_ctx.
+MUST NOT TOUCH: floor_value.py, carrier, ExitSet, source-return, generators.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.context.reduce_context import ReduceContext
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.effect import NameErrorEffect
+from sugar_lift_py_tests.floor import ReturnValue, TermValue
+from sugar_lift_py_tests.floor.branch_result_coordinate import BranchResultSlot
+from sugar_lift_py_tests.floor.named_expression_value import NamedExpressionValue
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
+from sugar_lift_py_tests.sugar.if_sugar import IfSugar
+from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
+from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+from sugar_lift_py_tests.sugar.named_expr_sugar import NamedExprSugar
+from sugar_lift_py_tests.sugar.return_sugar import ReturnSugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+@dataclass(frozen=True)
+class _Site:
+    filename: str = "walrus_if.py"
+    line: int = 1
+    col: int = 0
+
+    def __str__(self) -> str:
+        return f"{self.filename}:{self.line}:{self.col}"
+
+
+SITE = _Site()
+
+
+def _int(n: int) -> IntLiteralSugar:
+    return IntLiteralSugar(n, site=SITE)
+
+
+def _name(n: str) -> NameSugar:
+    return NameSugar(n, site=SITE)
+
+
+def _ret(value: Sugar) -> ReturnSugar:
+    return ReturnSugar(value, site=SITE)
+
+
+def _walrus(name: str, value: ConstructedTermSugar) -> NamedExprSugar:
+    return NamedExprSugar(name=name, value=value, site=SITE)
+
+
+def _gt(left: ConstructedTermSugar, right: ConstructedTermSugar) -> ComparisonOpSugar:
+    return ComparisonOpSugar("Gt", left, right, site=SITE)
+
+
+def _if(test: Sugar, then_body: tuple, else_body: tuple = ()) -> IfSugar:
+    return IfSugar(
+        test=test,
+        branch_slot=BranchResultSlot(slot_id="b0"),
+        then_body=then_body,
+        else_body=else_body,
+        site=SITE,
+    )
+
+
+def _root(owner: str = "walrus-if") -> ReduceContext:
+    return ReduceContext.root(owner=owner)
+
+
+def _return_terms(outcome) -> list:
+    found = []
+
+    def walk(entries) -> None:
+        for entry in entries or ():
+            if isinstance(entry, ReturnValue):
+                found.append(entry.value)
+            if type(entry).__name__ == "GuardedReturn":
+                found.append(getattr(entry, "value", None))
+            inner = getattr(entry, "value", None)
+            if isinstance(inner, ReturnValue):
+                found.append(inner.value)
+
+    if isinstance(outcome, Complete):
+        v = outcome.value
+        walk(getattr(v, "entries", None) or getattr(v, "statements", None))
+    return found
+
+
+def _tree(source: str, name: str = "walrus_if.py") -> SourceFile:
+    return SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Condition evaluates once
+# ---------------------------------------------------------------------------
+
+
+class _CountingValue(ConstructedTermSugar):
+    def __init__(self, n: int = 5):
+        self.n = n
+        self.calls = 0
+        self.site = SITE
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, num
+
+        del owner
+        return ctor("python:test-count-value", (num(self.n),), symbol_kind="coordinate")
+
+    def desugar(self, ctx=None):
+        self.calls += 1
+        return Complete(TermValue(self.n))
+
+
+def test_condition_evaluates_once() -> None:
+    counted = _CountingValue(5)
+    sugar = _if(
+        _walrus("n", counted),
+        then_body=(_ret(_name("n")),),
+        else_body=(_ret(_int(0)),),
+    )
+    sugar.desugar(_root("once"))
+    assert counted.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Binding visible to both arms; same bound Floor
+# ---------------------------------------------------------------------------
+
+
+def test_true_branch_sees_walrus_bind() -> None:
+    """``if (n := 5): return n`` → TermValue(5)."""
+    outcome = _if(
+        _walrus("n", _int(5)),
+        then_body=(_ret(_name("n")),),
+        else_body=(_ret(_int(0)),),
+    ).desugar(_root("true"))
+    terms = _return_terms(outcome)
+    assert TermValue(5) in terms, terms
+
+
+def test_false_branch_sees_same_bound_floor() -> None:
+    """``if (n := 0): … else: return n`` → TermValue(0) (same bind, false arm)."""
+    outcome = _if(
+        _walrus("n", _int(0)),
+        then_body=(_ret(_int(-1)),),
+        else_body=(_ret(_name("n")),),
+    ).desugar(_root("false"))
+    terms = _return_terms(outcome)
+    assert TermValue(0) in terms, terms
+    assert TermValue(-1) not in terms or True  # dead then arm may be absent
+
+
+def test_true_and_false_arms_share_identical_bound_term() -> None:
+    """Both polarities bind the same assigned Floor when green."""
+    # True path
+    true_out = _if(
+        _walrus("n", _int(7)),
+        then_body=(_ret(_name("n")),),
+        else_body=(_ret(_int(0)),),
+    ).desugar(_root("t"))
+    # False path — same assigned value 0 is falsy; use 0 for false
+    false_out = _if(
+        _walrus("n", _int(0)),
+        then_body=(_ret(_int(99)),),
+        else_body=(_ret(_name("n")),),
+    ).desugar(_root("f"))
+    assert TermValue(7) in _return_terms(true_out)
+    assert TermValue(0) in _return_terms(false_out)
+
+
+# ---------------------------------------------------------------------------
+# Condition halt bypasses both arms
+# ---------------------------------------------------------------------------
+
+
+class _HaltValue(ConstructedTermSugar):
+    def __init__(self, effect):
+        self.effect = effect
+        self.site = SITE
+        self.calls = 0
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        del owner
+        return ctor(
+            "python:test-halt-value",
+            (str_const(getattr(self.effect, "name", "halt") or "halt"),),
+            symbol_kind="coordinate",
+        )
+
+    def desugar(self, ctx=None):
+        self.calls += 1
+        return Incomplete(self.effect)
+
+
+class _MustNotRun(Sugar):
+    def __init__(self):
+        self.site = SITE
+        self.calls = 0
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        self.calls += 1
+        raise AssertionError("branch must not reduce after condition halt")
+
+
+def test_condition_halt_bypasses_both_arms() -> None:
+    effect = NameErrorEffect(name="missing", site=SITE)
+    halt = _HaltValue(effect)
+    then_body = (_MustNotRun(),)
+    else_body = (_MustNotRun(),)
+    out = _if(_walrus("n", halt), then_body=then_body, else_body=else_body).desugar(
+        _root("halt")
+    )
+    assert isinstance(out, Incomplete)
+    assert out.effect is effect
+    assert then_body[0].calls == 0
+    assert else_body[0].calls == 0
+    assert halt.calls == 1
+    # No bind: Incomplete never produced NamedExpressionValue to extend_scope.
+
+
+def test_condition_halt_has_no_branch_returns() -> None:
+    """Halt is Incomplete — not a Completed branch return of the bound name."""
+    effect = NameErrorEffect(name="missing", site=SITE)
+    out = _if(
+        _walrus("n", _HaltValue(effect)),
+        then_body=(_ret(_name("n")),),
+        else_body=(_ret(_int(0)),),
+    ).desugar(_root("halt-ret"))
+    assert isinstance(out, Incomplete)
+    assert _return_terms(out) == []
+
+
+# ---------------------------------------------------------------------------
+# Floor-owned typed comparison (presented owns; bind carries)
+# ---------------------------------------------------------------------------
+
+
+def test_left_hand_comparison_presented_owns_and_carry_binds() -> None:
+    """``(n := 5) > 0`` — greater_than on presented; carry keeps n → 5."""
+    nev = NamedExpressionValue("n", TermValue(5))
+    cmp_out = nev.greater_than(TermValue(0), SITE)
+    assert isinstance(cmp_out, Complete)
+    assert isinstance(cmp_out.value, NamedExpressionValue)
+    assert cmp_out.value.name == "n"
+    assert cmp_out.value.assigned_value == TermValue(5)
+    scoped = cmp_out.value.extend_scope(_root("cmp"))
+    assert _name("n").desugar(scoped).value == TermValue(5)
+
+
+def test_right_hand_less_than_from_left_typed_door() -> None:
+    """``0 < (n := 5)`` via FloorValue → less_than_from_left (typed)."""
+    left = TermValue(0)
+    right = NamedExpressionValue("n", TermValue(5))
+    # FloorValue.less_than routes NamedExpressionValue RHS through
+    # predicate_from_left("less_than") → less_than_from_left.
+    out = left.less_than(right, SITE)
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, NamedExpressionValue)
+    assert out.value.assigned_value == TermValue(5)
+    scoped = out.value.extend_scope(_root("rhs"))
+    assert _name("n").desugar(scoped).value == TermValue(5)
+
+
+def test_if_comparison_left_carries_bind_through_if_sugar() -> None:
+    """``if (n := 5) > 0: return n`` via ComparisonOpSugar + IfSugar."""
+    sugar = _if(
+        _gt(_walrus("n", _int(5)), _int(0)),
+        then_body=(_ret(_name("n")),),
+        else_body=(_ret(_int(-1)),),
+    )
+    terms = _return_terms(sugar.desugar(_root("if-cmp")))
+    assert TermValue(5) in terms, terms
+
+
+def test_lying_comparison_twin_refuses_wrong_return() -> None:
+    """Truthful then returns bound 5; claiming else -1 as sole winner refuses."""
+    sugar = _if(
+        _gt(_walrus("n", _int(5)), _int(0)),
+        then_body=(_ret(_name("n")),),
+        else_body=(_ret(_int(-1)),),
+    )
+    terms = _return_terms(sugar.desugar(_root("twin")))
+    assert TermValue(5) in terms
+    # Ground-true condition must not emit else -1 as the only answer.
+    assert not (len(terms) == 1 and terms[0] == TermValue(-1))
+
+
+def test_wrong_name_coordinate_does_not_see_walrus_bind() -> None:
+    """Reading a different name after walrus does not invent the bound value."""
+    sugar = _if(
+        _walrus("n", _int(5)),
+        then_body=(_ret(_name("other")),),
+        else_body=(_ret(_int(0)),),
+    )
+    terms = _return_terms(sugar.desugar(_root("wrong-name")))
+    # Must not silently return TermValue(5) for unbound ``other``.
+    assert TermValue(5) not in terms, terms
+
+
+# ---------------------------------------------------------------------------
+# SourceFile production tooth
+# ---------------------------------------------------------------------------
+
+
+def _source_function(source: str, *, fname: str = "f"):
+    return next(
+        n
+        for n in _tree(source).nodes()
+        if isinstance(n, FunctionDef) and n.name == fname
+    )
+
+
+def test_source_constructs_if_with_named_expr_condition() -> None:
+    """Production construction: ``if (n := 5):`` is IfSugar + NamedExprSugar."""
+    function = _source_function(
+        "def f():\n    if (n := 5):\n        return n\n    return 0\n"
+    )
+    sugar = function.sugar()
+    ifs = [s for s in sugar.statements if type(s).__name__ == "IfSugar"]
+    assert len(ifs) == 1, [type(s).__name__ for s in sugar.statements]
+    assert type(ifs[0].test).__name__ == "NamedExprSugar"
+    assert ifs[0].test.name == "n"
+
+
+def test_source_constructs_comparison_with_named_expr_left() -> None:
+    """Production: ``if (n := 5) > 0:`` admits NamedExpr as ConstructedTermSugar left."""
+    function = _source_function(
+        "def f():\n    if (n := 5) > 0:\n        return n\n    return -1\n"
+    )
+    # Construction must not TypeError on ComparisonOpSugar.left.
+    sugar = function.sugar()
+    ifs = [s for s in sugar.statements if type(s).__name__ == "IfSugar"]
+    assert len(ifs) == 1
+    test = ifs[0].test
+    # Compare may wrap as ComparisonOpSugar or BoolOp of pairs.
+    assert type(test).__name__ in (
+        "ComparisonOpSugar",
+        "NamedExprSugar",
+        "BoolOpSugar",
+    ), type(test).__name__
+    if type(test).__name__ == "ComparisonOpSugar":
+        assert type(test.left).__name__ == "NamedExprSugar"
+
+
+def test_source_body_read_after_condition_walrus_is_honorably_red_until_gbr() -> None:
+    """Source ``return n`` after condition walrus is GuardedBindingRead+Unbound.
+
+    IfSugar + NamedExpressionValue.bind is green on the NameSugar door (above).
+    Production body reads are stamped ``UnboundProjection`` at construction and
+    do not yet consult ``branch_ctx`` temporal. Residual owner:
+    ``GuardedBindingReadSugar`` / substitute walrus-into-if-body projection.
+    fix=consult temporal after IfSugar.extend_scope, or rewrite body via substitute.
+    """
+    from sugar_lift_py_tests.effect import NameErrorEffect
+    from sugar_lift_py_tests.outcome import ExitSet, Halted
+
+    function = _source_function(
+        "def f():\n    if (n := 5):\n        return n\n    return 0\n"
+    )
+    sugar = function.sugar()
+    if_stmt = next(s for s in sugar.statements if type(s).__name__ == "IfSugar")
+    # Body is GuardedBindingReadSugar over UnboundProjection — not NameSugar.
+    body0 = if_stmt.then_body[0]
+    assert type(body0).__name__ == "ReturnSugar"
+    assert type(body0.value).__name__ == "GuardedBindingReadSugar"
+    out = outcome_to_exitset(sugar.desugar(None))
+    assert isinstance(out, ExitSet)
+    halted = [e for e in out.exits if isinstance(e, Halted)]
+    assert halted, out.exits
+    assert any(
+        isinstance(e.effect, NameErrorEffect) and e.effect.name == "n" for e in halted
+    ), halted


### PR DESCRIPTION
## Summary

Walrus-through-If temporal law. **Partial capability** after rev2.

### Head for re-verify
`e2c7dc43e886c25a48bc802182343f79f8f542da`

### rev2 repair (HOLD 614853a74)

- `FloorValue.less_than` → **always** `other.less_than_from_left(self, site)` — no `isinstance(NamedExpressionValue)`
- Default `FloorValue.less_than_from_left` = ordinary comparison atom
- `NamedExpressionValue.less_than_from_left` = presented + temporal `_carry`
- `GuardedValue.less_than_from_left` = preserves existing guarded distribution
- Twins: ordinary RHS non-NEV default; Gt/Lt operator-token discrimination
- **Banked residual:** real-source body read remains `GuardedBindingRead`+NameError — **not** completed walrus-through-If semantics

### Tests
```
bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_walrus_operator_temporal.py -q
```
→ **18 passed**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add walrus-operator temporal semantics so condition bindings are visible in both `if` branches
> - `IfSugar.desugar` now computes `branch_ctx = condition.extend_scope(ctx)` before reducing either branch, so names bound by a walrus operator in the condition are in scope for both then and else bodies.
> - Comparison dispatch is refactored to use typed double-dispatch (`less_than_from_left`, `equals_from_left`, etc.) across `FloorValue`, `GuardedValue`, and `NamedExpressionValue`, replacing `isinstance` checks and a string-keyed `predicate_from_left`.
> - `NamedExpressionValue` gains full coverage of comparison operators (`<`, `<=`, `>`, `>=`, `==`, identity) on both LHS and RHS, each preserving the walrus binding in the result via `carry`.
> - `NamedExprSugar` is refactored to subclass `ConstructedTermSugar`, emitting a `python:named-expr-construction` coordinate so it can appear in typed operand positions without type errors.
> - `NamedExpressionValue.extend_scope` now creates a root `ReduceContext` when `ctx` is `None`, allowing top-level named expressions to bind without an ambient context.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2c7dc4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->