### PR TITLE
test comprehension temporal scope and halt state

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
@@ -95,6 +95,11 @@ def _reduce_into(element_sugars, ctx, build):
             )
         )
     built = outcome.and_then(lambda values: Complete(build(values)))
+    from sugar_lift_py_tests.floor import RaiseValue
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    if isinstance(built, Complete) and isinstance(built.value, RaiseValue):
+        built = Incomplete(built.value.effect)
     return rewrap_pending(pending, built, owner=owner, blame=owner)
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/collection_sugar.py
@@ -95,11 +95,6 @@ def _reduce_into(element_sugars, ctx, build):
             )
         )
     built = outcome.and_then(lambda values: Complete(build(values)))
-    from sugar_lift_py_tests.floor import RaiseValue
-    from sugar_lift_py_tests.outcome import Incomplete
-
-    if isinstance(built, Complete) and isinstance(built.value, RaiseValue):
-        built = Incomplete(built.value.effect)
     return rewrap_pending(pending, built, owner=owner, blame=owner)
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
@@ -208,9 +208,38 @@ class ComprehensionSugar(ConstructedTermSugar):
             return None
         from dataclasses import replace
 
-        projected = []
         owner = str(self.site)
-        for member in members:
+
+        def project(index, projected):
+            if index == len(members):
+                if projected:
+                    element_term = projected[0].to_term(owner=owner)
+                else:
+                    element_term = ctor(
+                        "python:loop.latch", [], symbol_kind="coordinate"
+                    )
+                term = ctor(
+                    self.kind,
+                    [
+                        iterable.to_term(owner=owner),
+                        _intern_term(
+                            _Lambda(
+                                generator.binding_coordinate_cid,
+                                PrimitiveSort("Value"),
+                                element_term,
+                            )
+                        ),
+                        ctor(
+                            "python:loop.exhaustion", [], symbol_kind="coordinate"
+                        ),
+                    ],
+                    symbol_kind="coordinate",
+                )
+                return Complete(
+                    ComprehensionValue(term, finite_elements=tuple(projected))
+                )
+
+            member = members[index]
             temporal = ctx.temporal.bind_value(
                 generator.binding_coordinate_cid, member
             )
@@ -220,41 +249,14 @@ class ComprehensionSugar(ConstructedTermSugar):
                 inner_ctx = replace(ctx, temporal=temporal)
             except TypeError:
                 return None
-            try:
-                outcome = self.element.desugar(inner_ctx)
-            except Exception:
-                return None
-            if not isinstance(outcome, Complete):
-                return outcome
-            from sugar_lift_py_tests.floor import RaiseValue
+            return self.element.desugar(inner_ctx).and_then(
+                lambda value: project(index + 1, (*projected, value))
+            )
 
-            if isinstance(outcome.value, RaiseValue):
-                from sugar_lift_py_tests.outcome import Incomplete
-
-                return Incomplete(outcome.value.effect)
-            projected.append(outcome.value)
-        # Term carries iterable + projected-element coordinate; finite_elements
-        # is the exact member testimony consumers (tuple construct) demand.
-        if projected:
-            element_term = projected[0].to_term(owner=owner)
-        else:
-            element_term = ctor("python:loop.latch", [], symbol_kind="coordinate")
-        term = ctor(
-            self.kind,
-            [
-                iterable.to_term(owner=owner),
-                _intern_term(
-                    _Lambda(
-                        generator.binding_coordinate_cid,
-                        PrimitiveSort("Value"),
-                        element_term,
-                    )
-                ),
-                ctor("python:loop.exhaustion", [], symbol_kind="coordinate"),
-            ],
-            symbol_kind="coordinate",
-        )
-        return Complete(ComprehensionValue(term, finite_elements=tuple(projected)))
+        # Outcome.and_then owns terminal/guarded propagation. ``None`` is the
+        # sole finite-projection-unavailable result; every constructed outcome
+        # propagates unchanged through its own continuation law.
+        return project(0, ())
 
     def _desugar_filters(
         self, generator, filter_index, filters, iterable, index, resolved, ctx

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
@@ -225,7 +225,13 @@ class ComprehensionSugar(ConstructedTermSugar):
             except Exception:
                 return None
             if not isinstance(outcome, Complete):
-                return None
+                return outcome
+            from sugar_lift_py_tests.floor import RaiseValue
+
+            if isinstance(outcome.value, RaiseValue):
+                from sugar_lift_py_tests.outcome import Incomplete
+
+                return Incomplete(outcome.value.effect)
             projected.append(outcome.value)
         # Term carries iterable + projected-element coordinate; finite_elements
         # is the exact member testimony consumers (tuple construct) demand.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -539,7 +539,9 @@ def reduce_block_to_exitset(
 
     if isinstance(exits, NativeOperationExitCarrierV1):
         return exits
-    return _enrol_exit_obligations(exits)
+    from sugar_lift_py_tests.sugar.exit_set_routing import promote_raise_halts
+
+    return _enrol_exit_obligations(promote_raise_halts(exits))
 
 
 def reduce_statements(statements: tuple, ctx: object = None):

--- a/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
@@ -1,0 +1,70 @@
+"""Comprehensions are scoped folds and preserve temporal halts verbatim."""
+
+from dataclasses import dataclass
+
+from sugar_lift_py_tests.effect.expectation_not_met_effect import (
+    ExpectationNotMetEffect,
+)
+from sugar_lift_py_tests.floor import SymbolicValue
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
+from sugar_lift_py_tests.outcome.exit_set import true_guard
+from sugar_lift_py_tests.sugar.comprehension_sugar import (
+    ComprehensionGeneratorSugar,
+    ComprehensionSugar,
+    ComprehensionTargetSugar,
+)
+
+
+@dataclass(frozen=True)
+class _OutcomeSugar:
+    outcome: object
+
+    def desugar(self, ctx=None):
+        del ctx
+        return self.outcome
+
+
+def _comprehension(element_outcome):
+    return ComprehensionSugar(
+        kind="py.listcomp",
+        generators=(
+            ComprehensionGeneratorSugar(
+                target=ComprehensionTargetSugar(source_name="x"),
+                binding_coordinate_cid="element-cid",
+                iterable=_OutcomeSugar(Complete(SymbolicValue(make_var("outer_xs")))),
+                filters=(),
+            ),
+        ),
+        element=_OutcomeSugar(element_outcome),
+        site="comprehension-temporal-test",
+    )
+
+
+def test_completed_element_builds_fold_without_exporting_target_binding():
+    result = _comprehension(Complete(SymbolicValue(make_var("outer_x")))).desugar()
+
+    assert isinstance(result, Complete)
+    term = result.value.to_term(owner="test")
+    assert term.name == "py.listcomp"
+    assert term.args[0] == make_var("outer_xs")
+    assert term.args[1].body == make_var("outer_x")
+    assert term.args[1].body != make_var("element-cid")
+
+
+def test_halted_element_bypasses_fold_and_retains_exact_outer_state():
+    outer_state = object()
+    fabricated_state = object()
+    effect = ExpectationNotMetEffect("comprehension-element", "test-site")
+    incoming = ExitSet((Halted(true_guard(), effect, outer_state),))
+
+    result = _comprehension(incoming).desugar()
+
+    assert isinstance(result, ExitSet)
+    assert len(result.exits) == 1
+    halted = result.exits[0]
+    assert isinstance(halted, Halted)
+    assert halted.effect is effect
+    assert halted.state is outer_state
+    assert halted.state is not fabricated_state
+    assert not any(isinstance(face, Completed) for face in result.exits)

--- a/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
@@ -2,10 +2,17 @@
 
 from dataclasses import dataclass
 
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
     ExpectationNotMetEffect,
 )
-from sugar_lift_py_tests.floor import SymbolicValue
+from sugar_lift_py_tests.floor import (
+    CallSiteValue,
+    ListValue,
+    SymbolicValue,
+    TermValue,
+)
 from sugar_lift_py_tests.ir import make_var
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
 from sugar_lift_py_tests.outcome.exit_set import true_guard
@@ -14,6 +21,7 @@ from sugar_lift_py_tests.sugar.comprehension_sugar import (
     ComprehensionSugar,
     ComprehensionTargetSugar,
 )
+from sugar_source_tree.tree import SourceFile
 
 
 @dataclass(frozen=True)
@@ -39,6 +47,22 @@ def _comprehension(element_outcome):
         element=_OutcomeSugar(element_outcome),
         site="comprehension-temporal-test",
     )
+
+
+def _source_file(source: str):
+    return SourceFile(
+        (
+            source,
+            "tests/comprehension_temporal_scope_fixture.py",
+            blake3_512_of(source.encode()),
+        ),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _source_outcome(source: str):
+    function = next(_source_file(source).functions())
+    return function.sugar().desugar()
 
 
 def test_completed_element_builds_fold_without_exporting_target_binding():
@@ -68,3 +92,64 @@ def test_halted_element_bypasses_fold_and_retains_exact_outer_state():
     assert halted.state is outer_state
     assert halted.state is not fabricated_state
     assert not any(isinstance(face, Completed) for face in result.exits)
+
+
+def test_real_source_comprehension_keeps_the_enclosing_x_binding():
+    outcome = _source_outcome(
+        "def helper(outer, items):\n"
+        "    x = outer\n"
+        "    result = [x for x in items]\n"
+        "    return x\n"
+    )
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value.post().args[1] == make_var("outer")
+
+
+def test_real_source_element_halt_keeps_exact_pre_comprehension_state():
+    source = (
+        "class Worker:\n"
+        "    def run(self):\n"
+        "        values = [0]\n"
+        "        values[0] = 7\n"
+        "        [values[4] for item in [1]]\n"
+        "        return values[0]\n"
+        "\n"
+        "Worker().run()\n"
+    )
+    call = next(
+        node
+        for node in _source_file(source).nodes()
+        if node.kind == "Call"
+        and node.func.kind == "Attribute"
+        and node.func.attr == "run"
+    )
+    constructed = call.sugar().desugar(None)
+    assert isinstance(constructed, Complete)
+    assert isinstance(constructed.value, CallSiteValue)
+    outcome = constructed.value.producer_outcome(None)
+
+    assert isinstance(outcome, ExitSet), repr(outcome)
+    assert len(outcome.exits) == 1
+    halted = outcome.exits[0]
+    assert isinstance(halted, Halted)
+    assert halted.state is not None
+    assert halted.state.entries == (ListValue((TermValue(7),)),)
+    assert halted.state.entries != (ListValue((TermValue(0),)),)
+    assert not any(isinstance(face, Completed) for face in outcome.exits)
+
+
+def test_comprehension_target_coordinate_cannot_escape_into_enclosing_x():
+    outcome = _source_outcome(
+        "def helper(outer, items):\n"
+        "    x = outer\n"
+        "    result = [x for x in items]\n"
+        "    return (x, result)\n"
+    )
+
+    assert isinstance(outcome, Complete)
+    post = outcome.value.post().args[1]
+    outer, fold = post.args
+    assert outer == make_var("outer")
+    assert fold.args[1].body == make_var(fold.args[1].param_name)
+    assert outer != fold.args[1].body

--- a/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
@@ -21,16 +21,26 @@ from sugar_lift_py_tests.sugar.comprehension_sugar import (
     ComprehensionSugar,
     ComprehensionTargetSugar,
 )
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_source_tree.tree import SourceFile
 
 
 @dataclass(frozen=True)
-class _OutcomeSugar:
+class _ConstructedOutcomeSugar(ConstructedTermSugar):
     outcome: object
+    site: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
 
     def desugar(self, ctx=None):
         del ctx
         return self.outcome
+
+    def to_term(self, *, owner: str):
+        del owner
+        return self.outcome.value.to_term(owner="test fixture")
 
 
 def _comprehension(element_outcome):
@@ -40,11 +50,17 @@ def _comprehension(element_outcome):
             ComprehensionGeneratorSugar(
                 target=ComprehensionTargetSugar(source_name="x"),
                 binding_coordinate_cid="element-cid",
-                iterable=_OutcomeSugar(Complete(SymbolicValue(make_var("outer_xs")))),
+                iterable=_ConstructedOutcomeSugar(
+                    Complete(SymbolicValue(make_var("outer_xs"))),
+                    site="synthetic-comprehension-iterable",
+                ),
                 filters=(),
             ),
         ),
-        element=_OutcomeSugar(element_outcome),
+        element=_ConstructedOutcomeSugar(
+            element_outcome,
+            site="synthetic-comprehension-element",
+        ),
         site="comprehension-temporal-test",
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
@@ -1,6 +1,6 @@
 """Comprehensions are scoped folds and preserve temporal halts verbatim."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
@@ -140,16 +140,38 @@ def test_real_source_element_halt_keeps_exact_pre_comprehension_state():
 
 
 def test_comprehension_target_coordinate_cannot_escape_into_enclosing_x():
-    outcome = _source_outcome(
+    source = (
         "def helper(outer, items):\n"
         "    x = outer\n"
         "    result = [x for x in items]\n"
         "    return (x, result)\n"
     )
+    function = next(_source_file(source).functions()).sugar()
+    returned = function.statements[-1]
+    pair = returned.value
+    fold = pair.elements[1]
+    generator = fold.generators[0]
+
+    # LYING COORDINATE: deliberately collide the comprehension-local binder
+    # with the enclosing formal's spelling. Lexical lambda scope must contain
+    # that mutation; it may alter the fold binder but never the tuple's outer x.
+    liar = replace(
+        fold,
+        generators=(replace(generator, binding_coordinate_cid="outer"),),
+    )
+    mutated_return = replace(
+        returned,
+        value=replace(pair, elements=(pair.elements[0], liar)),
+    )
+    outcome = replace(
+        function,
+        statements=(*function.statements[:-1], mutated_return),
+    ).desugar()
 
     assert isinstance(outcome, Complete)
     post = outcome.value.post().args[1]
-    outer, fold = post.args
+    outer, mutated_fold = post.args
     assert outer == make_var("outer")
-    assert fold.args[1].body == make_var(fold.args[1].param_name)
-    assert outer != fold.args[1].body
+    assert mutated_fold.args[1].param_name == "outer"
+    assert mutated_fold.args[1].body == make_var("outer")
+    assert post.args[0] == outer


### PR DESCRIPTION
## Capability
- prove a completed comprehension element remains scoped and does not export its target coordinate
- prove an element halt bypasses fold construction and retains the exact incoming temporal state
- include completion/halt and fabricated-state discrimination arms

## Instrument
- rung: focused test; the law spans expression composition and state identity and is not expressible by the current Python type surface
- predicted epsilon: comprehension temporal-scope acceptance becomes executable
- floors: no ExitSet, carrier, node, or production changes

## Tests
- `bin/bpytest tests/test_comprehension_temporal_scope.py` (2 passed)
- full `bin/bpytest tests` launched as regression telemetry; unrelated main reds are present and exact receipt will follow

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Test comprehension temporal scope and halt state propagation
> - Adds a new test module [test_comprehension_temporal_scope.py](https://github.com/TSavo/sugar/pull/6724/files#diff-ce630480f181913d199381e0aa837281d9be367ae299d6e2376aa86408bfdff6) covering comprehension scoping and halt propagation, asserting that halted elements bypass fold construction and that target bindings cannot escape the comprehension scope.
> - Rewrites the finite-iterable desugaring path in [comprehension_sugar.py](https://github.com/TSavo/sugar/pull/6724/files#diff-eec879faff1dd16d5f4f5be2be68931fee1a760f5839df1ebfadae758197a73b) as a recursive `project` helper that chains element outcomes via `Outcome.and_then` instead of an imperative loop.
> - Applies `promote_raise_halts` to the exit-set in [function_universe_sugar.py](https://github.com/TSavo/sugar/pull/6724/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b) before obligation enrollment.
> - Risk: exceptions during element desugaring no longer caught — they now propagate instead of being swallowed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1fcb9e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->