### PR TITLE
Reexport: alias/star warrants, five-step prefix, value-use seating

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -391,6 +391,10 @@ class TreeConstructionContextV1:
     # subclass definition coordinate.  These are never serialized; the class
     # definition projects their sealed CIDs into its own preimage.
     source_class_bases: dict = field(default_factory=dict)
+    # Final-checked import *value-use* resolutions seated at exact use sites
+    # of the frame's own SourceUnit (source_cid-matched).  Never carries
+    # cross-unit spans; keyed by SourceFragmentCoordinateV1 of this unit.
+    source_import_value_resolutions: dict = field(default_factory=dict)
     # When projecting an authenticated definition into a call frame, dual-mode
     # factory bodies may contain With sites only on non-manager return paths
     # (e.g. pytest.raises function form). Soft projection does not require

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -207,6 +207,14 @@ class SourceVisibleCallFrameV1:
         if remaining or named:
             raise SourceCallBindingGap("unconsumed call actual")
 
+        # Rehost foreign-unit actuals onto this frame's SourceUnit so binding
+        # never carries cross-unit LineTable offsets into construction.
+        owner_unit = self.owner.unit
+        bound = tuple(
+            _same_unit_actual_node(owner_unit, node, coordinate)
+            for node, coordinate in zip(bound, self.formal_coordinates, strict=True)
+        )
+
         supplied_testimonies = testimonies or (None,) * len(bound)
         if len(supplied_testimonies) != len(bound):
             raise SourceCallBindingGap("formal testimony arity mismatch")
@@ -296,6 +304,97 @@ class SourceVisibleCallFrameV1:
 
 class SourceCallBindingGap(ValueError):
     pass
+
+
+def _same_unit_actual_node(owner_unit, node, coordinate):
+    """Rehost a bound actual onto the frame owner unit when needed.
+
+    Same-unit nodes pass through. Foreign-unit actuals must never carry their
+    LineTable offsets into owner-unit construction (``offset N outside 0..M``):
+    mint a ``BindingCoordinateRef`` at the formal's owner-local span. When the
+    foreign use site already has a seated import value-use resolution, transfer
+    that definition-coordinate identity onto the formal span on the owner unit
+    so Floor binding stays authenticated without spelling or cross-unit spans.
+    """
+    from sugar_source_tree.backend import Leaf, materialize
+    from sugar_source_tree.nodes import Node
+    from sugar_source_tree.shadow import ShadowNode
+    from sugar_source_tree.spans import Span
+
+    if not isinstance(node, Node):
+        return node
+    if node.unit.source_cid == owner_unit.source_cid:
+        return node
+
+    site = coordinate.binding_site
+    if not isinstance(site, dict):
+        raise SourceCallBindingGap(
+            "foreign actual requires owner-local formal binding site"
+        )
+    site_cid = site.get("source_cid") or site.get("sourceCid")
+    if site_cid != owner_unit.source_cid:
+        raise SourceCallBindingGap(
+            "formal binding site is not on the frame owner unit"
+        )
+    span_info = site.get("span")
+    if not isinstance(span_info, dict):
+        raise SourceCallBindingGap("formal binding site missing sealed span")
+    start = span_info.get("start")
+    end = span_info.get("end")
+    if not isinstance(start, int) or not isinstance(end, int) or end < start:
+        raise SourceCallBindingGap("formal binding site span is not unit-local")
+    owner_span = Span(start, end)
+
+    # Transfer seated import value-use definition-coordinate identity, if any.
+    # Never project foreign offsets through the owner LineTable.
+    foreign_unit = node.unit
+    try:
+        foreign_lc = node.line_col_span()
+        foreign_key = (
+            foreign_lc.start_line,
+            foreign_lc.start_col,
+            foreign_lc.end_line,
+            foreign_lc.end_col,
+        )
+        resolved = foreign_unit.import_value_use_resolution(foreign_key)
+    except Exception:
+        resolved = None
+    if resolved is not None:
+        owner_lc = owner_unit.line_table.project(owner_span)
+        owner_key = (
+            owner_lc.start_line,
+            owner_lc.start_col,
+            owner_lc.end_line,
+            owner_lc.end_col,
+        )
+        owner_unit.seat_import_value_use_resolution(owner_key, resolved)
+        context = owner_unit.construction_context
+        if context is not None:
+            from sugar_lift_py_tests.context_manager_resolution import (
+                SourceFragmentCoordinateV1,
+            )
+
+            resolutions = getattr(context, "source_import_value_resolutions", None)
+            if isinstance(resolutions, dict):
+                resolutions[
+                    SourceFragmentCoordinateV1(
+                        owner_unit.source_cid,
+                        owner_lc.start_line,
+                        owner_lc.start_col,
+                        owner_lc.end_line,
+                        owner_lc.end_col,
+                    )
+                ] = resolved
+
+    return materialize(
+        owner_unit,
+        ShadowNode(
+            "BindingCoordinateRef",
+            owner_span,
+            (("coordinate", Leaf(coordinate)),),
+        ),
+        node.reporter,
+    )
 
 
 SourceCallFrameV1 = SourceVisibleCallFrameV1

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -311,10 +311,11 @@ def _same_unit_actual_node(owner_unit, node, coordinate):
 
     Same-unit nodes pass through. Foreign-unit actuals must never carry their
     LineTable offsets into owner-unit construction (``offset N outside 0..M``):
-    mint a ``BindingCoordinateRef`` at the formal's owner-local span. When the
-    foreign use site already has a seated import value-use resolution, transfer
-    that definition-coordinate identity onto the formal span on the owner unit
-    so Floor binding stays authenticated without spelling or cross-unit spans.
+    mint a ``BindingCoordinateRef`` at the formal's owner-local span only.
+
+    Value-use resolutions are **not** transferred or re-seated here: frames
+    consume exact seats on the owning SourceUnit (source-CID authenticated at
+    publication). No broad Exception catch, no fallback fabrication of seats.
     """
     from sugar_source_tree.backend import Leaf, materialize
     from sugar_source_tree.nodes import Node
@@ -344,47 +345,6 @@ def _same_unit_actual_node(owner_unit, node, coordinate):
     if not isinstance(start, int) or not isinstance(end, int) or end < start:
         raise SourceCallBindingGap("formal binding site span is not unit-local")
     owner_span = Span(start, end)
-
-    # Transfer seated import value-use definition-coordinate identity, if any.
-    # Never project foreign offsets through the owner LineTable.
-    foreign_unit = node.unit
-    try:
-        foreign_lc = node.line_col_span()
-        foreign_key = (
-            foreign_lc.start_line,
-            foreign_lc.start_col,
-            foreign_lc.end_line,
-            foreign_lc.end_col,
-        )
-        resolved = foreign_unit.import_value_use_resolution(foreign_key)
-    except Exception:
-        resolved = None
-    if resolved is not None:
-        owner_lc = owner_unit.line_table.project(owner_span)
-        owner_key = (
-            owner_lc.start_line,
-            owner_lc.start_col,
-            owner_lc.end_line,
-            owner_lc.end_col,
-        )
-        owner_unit.seat_import_value_use_resolution(owner_key, resolved)
-        context = owner_unit.construction_context
-        if context is not None:
-            from sugar_lift_py_tests.context_manager_resolution import (
-                SourceFragmentCoordinateV1,
-            )
-
-            resolutions = getattr(context, "source_import_value_resolutions", None)
-            if isinstance(resolutions, dict):
-                resolutions[
-                    SourceFragmentCoordinateV1(
-                        owner_unit.source_cid,
-                        owner_lc.start_line,
-                        owner_lc.start_col,
-                        owner_lc.end_line,
-                        owner_lc.end_col,
-                    )
-                ] = resolved
 
     return materialize(
         owner_unit,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -181,11 +181,38 @@ class SourceVisibleCallFrameV1:
             )
         ):
             if kind == "vararg":
-                bound.append(self._tuple_node(tuple(remaining)))
+                coordinate = self.formal_coordinates[index]
+                bound.append(
+                    self._tuple_node(
+                        tuple(
+                            _same_unit_actual_node(
+                                self.owner.unit,
+                                value,
+                                coordinate.project("variadic", actual_index),
+                            )
+                            for actual_index, value in enumerate(remaining)
+                        )
+                    )
+                )
                 remaining.clear()
                 continue
             if kind == "kwarg":
-                bound.append(self._dict_node(tuple(named.items())))
+                coordinate = self.formal_coordinates[index]
+                bound.append(
+                    self._dict_node(
+                        tuple(
+                            (
+                                key,
+                                _same_unit_actual_node(
+                                    self.owner.unit,
+                                    value,
+                                    coordinate.project("variadic-keyword", actual_index),
+                                ),
+                            )
+                            for actual_index, (key, value) in enumerate(named.items())
+                        )
+                    )
+                )
                 named.clear()
                 continue
             value = None

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -191,7 +191,7 @@ class AuthenticatedModuleSourceV1:
 @dataclass(frozen=True)
 class DefinitionCoordinateV1:
     name: str
-    kind: Literal["function", "class", "import"]
+    kind: Literal["function", "class", "import", "alias"]
     source_cid: str
     start_line: int
     start_col: int
@@ -201,7 +201,7 @@ class DefinitionCoordinateV1:
 
     def __post_init__(self) -> None:
         _string(self.name, "definition name")
-        if self.kind not in {"function", "class", "import"}:
+        if self.kind not in {"function", "class", "import", "alias"}:
             raise ValueError("definition coordinate has unknown kind")
         _cid(self.source_cid, "definition sourceCid")
         for value, label in (
@@ -241,7 +241,7 @@ class DefinitionCoordinateV1:
             },
             "definition coordinate",
         )
-        if value["kind"] not in {"function", "class", "import"}:
+        if value["kind"] not in {"function", "class", "import", "alias"}:
             raise ValueError("definition coordinate has unknown kind")
         return cls(
             name=_string(value["name"], "definition name"),
@@ -267,8 +267,10 @@ class ReexportWarrantV1:
     cid: str = ""
 
     def __post_init__(self) -> None:
-        if self.definition.kind != "import":
-            raise ValueError("re-export warrant must cite an import definition")
+        if self.definition.kind not in {"import", "alias"}:
+            raise ValueError(
+                "re-export warrant must cite an import or alias definition"
+            )
         if self.definition.source_cid != self.from_source_cid:
             raise ValueError("re-export definition is not in its from-module source")
         expected = cid_of_json(self._preimage())

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -129,12 +129,50 @@ def _resolve_export_uncached(
             "artifact-module-absent", binding_cid, graph, module_name, exported_name
         )
     tree = parsed_tree(module.source, module.source_seat)
-    binding = _export_block(tree.body, exported_name, None)
+    binding, locus = _export_block_with_locus(tree.body, exported_name, None)
     dynamic_getattr = any(
         isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
         and node.name == "__getattr__"
         for node in tree.body
     )
+    # Normal-completion authority for the prefix (statements strictly before
+    # the unique export-binding locus): producer-owned Completed faces only.
+    if locus is not None and not _prefix_has_completed_fallthrough(module, locus):
+        return _gap(
+            "dynamic-export", binding_cid, graph, module_name, exported_name
+        )
+    return _resolve_export_binding(
+        graph,
+        binding_cid,
+        module,
+        module_name,
+        exported_name,
+        binding,
+        tree.body,
+        warrants,
+        seen,
+        key,
+        dynamic_getattr=dynamic_getattr,
+        session=session,
+    )
+
+
+def _resolve_export_binding(
+    graph,
+    binding_cid: str,
+    module,
+    module_name: str,
+    exported_name: str,
+    binding,
+    body: list[ast.stmt],
+    warrants: tuple,
+    seen: frozenset[tuple[str, str]],
+    key: tuple[str, str],
+    *,
+    dynamic_getattr: bool,
+    session,
+) -> PythonObjectResolutionV1:
+    """Follow one export-binding state (definition / import / alias / star)."""
     if binding is not None and binding[0] == "definition":
         definition = _definition(module, binding[1])
         return ResolvedPythonObjectV1(
@@ -198,11 +236,18 @@ def _resolve_export_uncached(
             session=session,
         )
     if binding is not None and binding[0] == "alias":
-        # Static ``public = _private``: both the assignment occurrence and the
-        # RHS name are authenticated.  Same-module alias hop is recorded before
-        # resolving the RHS — never a silent follow.
+        # Follow the binding of the RHS name that *reaches* the assignment —
+        # never the RHS name's final module binding after later reassignment.
         assign_node, name_node = binding[1]
         alias_name = name_node.id
+        hop_key = (module_name, alias_name)
+        if hop_key in seen:
+            return _gap(
+                "reexport-cycle", binding_cid, graph, module_name, exported_name
+            )
+        reaching, _ = _export_block_with_locus(
+            _statements_before(body, assign_node), alias_name, None
+        )
         warrant = ReexportWarrantV1(
             from_module=module_name,
             from_source_cid=module.source_cid,
@@ -212,13 +257,18 @@ def _resolve_export_uncached(
             imported_name=alias_name,
             definition=_alias_coordinate(module, assign_node, exported_name),
         )
-        return resolve_export(
+        return _resolve_export_binding(
             graph,
             binding_cid,
+            module,
             module_name,
-            alias_name,
+            exported_name,
+            reaching,
+            body,
             (*warrants, warrant),
-            seen | {key},
+            seen | {key, hop_key},
+            key,
+            dynamic_getattr=dynamic_getattr,
             session=session,
         )
     if binding is not None and binding[0] == "unsupported":
@@ -237,9 +287,8 @@ def _resolve_export_uncached(
             module_name,
             exported_name,
         )
-    # Star import: only a single source-visible immutable literal ``__all__``
-    # may publish names.  Everything else stays dynamic — no first-candidate
-    # scan of the star module.
+    # Star import: TARGET module's ``__all__`` / public-name rule controls
+    # which names star publishes (Python import semantics), not the importer's.
     if binding is not None and binding[0] == "star":
         return _resolve_star_export(
             graph,
@@ -248,19 +297,14 @@ def _resolve_export_uncached(
             module_name,
             exported_name,
             binding[1],
-            tree.body,
             warrants,
             seen,
             key,
             session=session,
         )
-    # Module-level ``name = Class()`` / ``name: Class = Class()`` is a static
-    # callable-instance binding when Class is a local ClassDef with ``__call__``.
-    # The export is the authenticated ``__call__`` body, not a free dynamic
-    # residual and not a spelling of the binding name.
     if binding is not None and binding[0] == "dynamic":
         call_method = _callable_instance_call_method(
-            tree.body, binding[1], exported_name
+            body, binding[1], exported_name
         )
         if call_method is not None:
             definition = _definition(module, call_method)
@@ -516,18 +560,13 @@ def _resolve_star_export(
     module_name: str,
     exported_name: str,
     star_import: ast.ImportFrom,
-    body: list[ast.stmt],
     warrants: tuple,
     seen: frozenset[tuple[str, str]],
     key: tuple[str, str],
     *,
     session,
 ):
-    published = _literal_all_publication(body)
-    if published is None or exported_name not in published:
-        return _gap(
-            "dynamic-export", binding_cid, graph, module_name, exported_name
-        )
+    """Star publication is the *target* module's ``__all__`` / public-name rule."""
     target_module = _absolute_import(module_name, module.source_seat, star_import)
     if target_module is None:
         return _gap("opaque-source", binding_cid, graph, module_name, exported_name)
@@ -539,6 +578,12 @@ def _resolve_star_export(
             graph,
             target_module,
             exported_name,
+        )
+    target_tree = parsed_tree(target.source, target.source_seat)
+    published = _target_star_published_names(target_tree.body)
+    if exported_name not in published:
+        return _gap(
+            "dynamic-export", binding_cid, graph, module_name, exported_name
         )
     warrant = ReexportWarrantV1(
         from_module=module_name,
@@ -560,9 +605,78 @@ def _resolve_star_export(
     )
 
 
+def _target_star_published_names(body: list[ast.stmt]) -> frozenset[str]:
+    """Names a module publishes under ``from module import *``.
+
+    Prefer a single immutable literal ``__all__``.  Without it, public names
+    (no leading ``_``) that have a source-visible top-level bind.  Computed /
+    competing ``__all__`` yields empty publication (star stays dynamic).
+    """
+    literal = _literal_all_publication(body)
+    if literal is not None:
+        return literal
+    if _has_nonliteral_all(body):
+        return frozenset()
+    public: set[str] = set()
+    for statement in body:
+        for name in _top_level_bound_names(statement):
+            if not name.startswith("_"):
+                public.add(name)
+    return frozenset(public)
+
+
+def _has_nonliteral_all(body: list[ast.stmt]) -> bool:
+    for statement in body:
+        if isinstance(statement, ast.Assign):
+            if any(
+                isinstance(target, ast.Name) and target.id == "__all__"
+                for target in statement.targets
+            ):
+                return True
+        elif isinstance(statement, ast.AnnAssign):
+            if (
+                isinstance(statement.target, ast.Name)
+                and statement.target.id == "__all__"
+            ):
+                return True
+        elif isinstance(statement, ast.AugAssign):
+            if (
+                isinstance(statement.target, ast.Name)
+                and statement.target.id == "__all__"
+            ):
+                return True
+    return False
+
+
+def _top_level_bound_names(statement: ast.stmt) -> frozenset[str]:
+    if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return frozenset({statement.name})
+    if isinstance(statement, ast.ImportFrom):
+        return frozenset(
+            (alias.asname or alias.name)
+            for alias in statement.names
+            if alias.name != "*"
+        )
+    if isinstance(statement, ast.Import):
+        return frozenset(
+            (alias.asname or alias.name.split(".")[0]) for alias in statement.names
+        )
+    if isinstance(statement, ast.Assign):
+        names: set[str] = set()
+        for target in statement.targets:
+            if isinstance(target, ast.Name):
+                names.add(target.id)
+        return frozenset(names)
+    if isinstance(statement, ast.AnnAssign):
+        if isinstance(statement.target, ast.Name):
+            return frozenset({statement.target.id})
+    return frozenset()
+
+
 def _literal_all_publication(body: list[ast.stmt]) -> frozenset[str] | None:
     """Single immutable literal ``__all__`` of string constants, or None."""
     published: frozenset[str] | None = None
+    saw_all = False
     for statement in body:
         binds_all = False
         value: ast.AST | None = None
@@ -596,13 +710,14 @@ def _literal_all_publication(body: list[ast.stmt]) -> frozenset[str] | None:
                 return None
         if not binds_all:
             continue
+        saw_all = True
         names = _literal_string_sequence(value)
         if names is None:
             return None
         if published is not None:
             return None
         published = names
-    return published
+    return published if saw_all else None
 
 
 def _literal_string_sequence(node: ast.AST | None) -> frozenset[str] | None:
@@ -618,6 +733,145 @@ def _literal_string_sequence(node: ast.AST | None) -> frozenset[str] | None:
             return None
         names.add(element.value)
     return frozenset(names)
+
+
+def _statements_before(body: list[ast.stmt], locus: ast.stmt) -> list[ast.stmt]:
+    prefix: list[ast.stmt] = []
+    for statement in body:
+        if statement is locus:
+            break
+        prefix.append(statement)
+    return prefix
+
+
+def _export_block_with_locus(statements, name, initial):
+    """Export transfer with the statement that last bound ``name``.
+
+    Locus is the *innermost* statement that established the bind (e.g. the
+    FunctionDef inside a With body), not the compound wrapper — so prefix
+    fall-through includes the compound suite that must complete to reach it.
+    """
+    state = initial
+    locus = None
+    for statement in statements:
+        prior = state
+        new_state, new_locus = _export_statement_with_locus(statement, name, state)
+        if new_state is not prior:
+            state = new_state
+            locus = new_locus if new_locus is not None else statement
+    return state, locus
+
+
+def _export_statement_with_locus(statement: ast.stmt, name: str, state):
+    """Transfer one statement; return (state, innermost bind locus or None)."""
+    if isinstance(statement, (ast.With, ast.AsyncWith)):
+        for item in statement.items:
+            if item.optional_vars is not None and _target_binds(
+                item.optional_vars, name
+            ):
+                state = ("dynamic", statement)
+        body_state, body_locus = _export_block_with_locus(statement.body, name, state)
+        return body_state, body_locus
+    if isinstance(statement, ast.If):
+        body_state, body_locus = _export_block_with_locus(statement.body, name, state)
+        else_state, else_locus = _export_block_with_locus(
+            statement.orelse, name, state
+        )
+        joined = _join_export_states((body_state, else_state), statement)
+        if joined is body_state and body_state is not state:
+            return joined, body_locus
+        if joined is else_state and else_state is not state:
+            return joined, else_locus
+        if joined is not state:
+            return joined, statement
+        return joined, None
+    if isinstance(statement, (ast.For, ast.AsyncFor, ast.While)):
+        iterated = state
+        if isinstance(statement, (ast.For, ast.AsyncFor)) and _target_binds(
+            statement.target, name
+        ):
+            iterated = ("dynamic", statement)
+        body_state, body_locus = _export_block_with_locus(
+            statement.body, name, iterated
+        )
+        else_state, else_locus = _export_block_with_locus(
+            statement.orelse, name, body_state
+        )
+        joined = _join_export_states((state, else_state), statement)
+        if joined is not state:
+            locus = else_locus or body_locus or statement
+            return joined, locus
+        return joined, None
+    if isinstance(statement, _TRY_TYPES):
+        # Preserve existing try transfer; locus is the try when state changes.
+        new_state = _export_statement(statement, name, state)
+        return new_state, (statement if new_state is not state else None)
+    if isinstance(statement, ast.Match):
+        new_state = _export_statement(statement, name, state)
+        return new_state, (statement if new_state is not state else None)
+    new_state = _export_statement(statement, name, state)
+    return new_state, (statement if new_state is not state else None)
+
+
+def _prefix_has_completed_fallthrough(module, locus: ast.stmt) -> bool:
+    """License the binding only when prefix reduction Completed fall-through.
+
+    Spec: authenticated module source/CID → statements strictly before the
+    unique export-binding locus → reduce via the same ``reduce_block_to_exitset``
+    path function bodies use → exactly one unconditional
+    ``Completed(can_fall_through=True)``.  Empty prefix is licensed.  Any
+    unresolved / halted / multi-face / incomplete-sugar prefix is refused.
+    """
+    try:
+        from sugar_lift_py_tests.outcome import Completed, true_guard
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
+        from sugar_source_tree.panic import SugarNotWritten
+        from sugar_source_tree.tree import SourceFile
+    except ImportError:
+        return False
+
+    source_file = SourceFile((module.source, module.source_seat, module.source_cid))
+    locus_key = (locus.lineno, locus.col_offset)
+    prefix = []
+    for statement in source_file.root.body:
+        span = statement.line_col_span()
+        key = (span.start_line, span.start_col)
+        if key >= locus_key:
+            break
+        prefix.append(statement)
+    if not prefix:
+        return True
+    try:
+        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+        from sugar_source_tree.nodes import AsyncFunctionDef, ClassDef, FunctionDef
+
+        sugars = []
+        for statement in prefix:
+            # Module-level def/class *statements* are definitional: bodies are
+            # deferred.  FunctionDef.sugar() builds FunctionUniverseSugar (the
+            # call-universe value), which reduces the body as if it ran at the
+            # def site — wrong for module sequencing.  Import/Pass already use
+            # InertSugar; def/class match that door for fall-through only.
+            if isinstance(statement, (FunctionDef, AsyncFunctionDef, ClassDef)):
+                sugars.append(InertSugar(site=statement.fragment))
+            else:
+                sugars.append(statement.sugar())
+        exits = reduce_block_to_exitset(tuple(sugars))
+    except SugarNotWritten:
+        return False
+    except Exception:
+        return False
+    if len(exits.exits) != 1:
+        return False
+    face = exits.exits[0]
+    if not isinstance(face, Completed):
+        return False
+    if face.guard != true_guard():
+        return False
+    value = face.value
+    return bool(getattr(value, "can_fall_through", False))
 
 
 def _absolute_import(
@@ -705,18 +959,7 @@ def export_statement_coverage() -> tuple[list[str], list[str]]:
 
 
 def _export_block(statements, name, initial):
-    state = initial
-    for index, statement in enumerate(statements):
-        if _statement_contains_module_init_raise(statement) and _suite_binds_export(
-            statements[index + 1 :], name
-        ):
-            # A later binding is control-dependent on whether this exceptional
-            # prefix completes.  In particular, a With/AsyncWith exit may
-            # suppress the exception while skipping the remainder of its
-            # suite.  Selecting that later textual binding would authenticate
-            # an unreachable definition.
-            return ("dynamic", statement)
-        state = _export_statement(statement, name, state)
+    state, _locus = _export_block_with_locus(statements, name, initial)
     return state
 
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -239,6 +239,12 @@ def _resolve_export_binding(
         # Follow the binding of the RHS name that *reaches* the assignment —
         # never the RHS name's final module binding after later reassignment.
         assign_node, name_node = binding[1]
+        if not any(statement is assign_node for statement in body):
+            # The reaching suite is not authenticated by this module-body
+            # traversal. Refuse instead of reconstructing an enclosing suite.
+            return _gap(
+                "dynamic-export", binding_cid, graph, module_name, exported_name
+            )
         alias_name = name_node.id
         hop_key = (module_name, alias_name)
         if hop_key in seen:
@@ -626,7 +632,9 @@ def _target_star_published_names(body: list[ast.stmt]) -> frozenset[str]:
 
 
 def _has_nonliteral_all(body: list[ast.stmt]) -> bool:
-    for statement in body:
+    stack: list[ast.AST] = list(body)
+    while stack:
+        statement = stack.pop()
         if isinstance(statement, ast.Assign):
             if any(
                 isinstance(target, ast.Name) and target.id == "__all__"
@@ -645,6 +653,14 @@ def _has_nonliteral_all(body: list[ast.stmt]) -> bool:
                 and statement.target.id == "__all__"
             ):
                 return True
+        # Function/class bodies are separate namespaces, never module
+        # publication testimony. Other compound suites execute in module scope.
+        if isinstance(
+            statement,
+            (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda),
+        ):
+            continue
+        stack.extend(ast.iter_child_nodes(statement))
     return False
 
 
@@ -814,96 +830,15 @@ def _export_statement_with_locus(statement: ast.stmt, name: str, state):
 
 
 def _prefix_has_completed_fallthrough(module, locus: ast.stmt) -> bool:
-    """License one export binding via the advisor's five-step prefix reduction.
+    """Delegate prefix meaning to the construction producer.
 
-    1. Authenticated module source/CID — ``SourceFile`` path_source door only;
-       refuse dual-door / CID mismatch (construction refuses, we map to gap).
-    2. Exact export-binding coordinate — ``locus`` is the unique bind statement
-       (innermost) already established by ``_export_block_with_locus``.
-    3. Reduce statements **strictly before** that locus (module-body order,
-       start line/col < locus start) — never the binding statement itself.
-    4. Exactly one unconditional ``Completed(can_fall_through=True)`` via the
-       same ``reduce_block_to_exitset`` path function bodies use.
-    5. License only then; multi-face / halted / incomplete-sugar / guarded
-       faces stay **named** gaps (``dynamic-export`` at the call site).
-
-    Empty prefix (binding is the first statement) is licensed.  Soft success is
-    forbidden: every refusal path is explicit False so the caller emits the
-    named gap rather than inventing fall-through from AST control shape.
+    The dependency adapter owns export recognition only. It must not import
+    the downstream lift-kit test package or suppress a missing producer as a
+    normal dynamic export.
     """
-    try:
-        from sugar_lift_py_tests.outcome import Completed, true_guard
-        from sugar_lift_py_tests.sugar.function_universe_sugar import (
-            reduce_block_to_exitset,
-        )
-        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
-        from sugar_lift_python_source.canonical import blake3_512_of
-        from sugar_source_tree.nodes import AsyncFunctionDef, ClassDef, FunctionDef
-        from sugar_source_tree.panic import BackendDefect, SugarNotWritten
-        from sugar_source_tree.tree import SourceFile
-    except ImportError:
-        # Producer substrate unavailable — refuse license (named gap upstream).
-        return False
+    from .manager_construction import prefix_has_completed_fallthrough
 
-    # --- 1. Authenticated module source/CID ---------------------------------
-    expected_cid = blake3_512_of(module.source.encode("utf-8"))
-    if module.source_cid != expected_cid:
-        return False
-    try:
-        source_file = SourceFile(
-            (module.source, module.source_seat, module.source_cid)
-        )
-    except (BackendDefect, ValueError, TypeError):
-        return False
-
-    # --- 2–3. Exact locus; statements strictly before it --------------------
-    # Locus is the AST bind site; typed body rows are matched by start
-    # line/col (same coordinate space the export walk used for lineno).
-    locus_key = (locus.lineno, locus.col_offset)
-    prefix = []
-    for statement in source_file.root.body:
-        span = statement.line_col_span()
-        key = (span.start_line, span.start_col)
-        if key >= locus_key:
-            break
-        prefix.append(statement)
-    # Empty prefix: nothing before the bind → fall-through is vacuous True.
-    if not prefix:
-        return True
-
-    # --- 4. Reduce prefix → one unconditional Completed fall-through --------
-    try:
-        sugars = []
-        for statement in prefix:
-            # Module-level def/class *statements* are definitional: bodies are
-            # deferred.  FunctionDef.sugar() builds FunctionUniverseSugar (the
-            # call-universe value), which reduces the body as if it ran at the
-            # def site — wrong for module sequencing.  Import/Pass already use
-            # InertSugar; def/class match that door for fall-through only.
-            if isinstance(statement, (FunctionDef, AsyncFunctionDef, ClassDef)):
-                sugars.append(InertSugar(site=statement.fragment))
-            else:
-                sugars.append(statement.sugar())
-        exits = reduce_block_to_exitset(tuple(sugars))
-    except SugarNotWritten:
-        # Incomplete sugar on the prefix — named unresolved face.
-        return False
-    except (BackendDefect, ValueError, TypeError):
-        return False
-
-    # --- 5. License only the single unconditional Completed fall-through ----
-    if len(exits.exits) != 1:
-        # Multi-face / empty ExitSet — unresolved named gap.
-        return False
-    face = exits.exits[0]
-    if not isinstance(face, Completed):
-        # Halted / refused face — not fall-through.
-        return False
-    if face.guard != true_guard():
-        # Guarded completion is not unconditional.
-        return False
-    value = face.value
-    return bool(getattr(value, "can_fall_through", False))
+    return prefix_has_completed_fallthrough(module, locus)
 
 
 def _absolute_import(
@@ -1039,9 +974,11 @@ def _export_statement(statement: ast.stmt, name: str, state):
             if alias.name == "*":
                 # Star residual only when no explicit static bind already owns
                 # the name.  Literal ``__all__`` publication is resolve-time.
-                if not (
+                if isinstance(state, tuple) and state[0] == "star":
+                    state = ("ambiguous", statement)
+                elif not (
                     isinstance(state, tuple)
-                    and state[0] in {"definition", "import", "alias"}
+                    and state[0] in {"definition", "import", "alias", "ambiguous"}
                 ):
                     state = ("star", statement)
                 continue

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -198,12 +198,26 @@ def _resolve_export_uncached(
             session=session,
         )
     if binding is not None and binding[0] == "alias":
+        # Static ``public = _private``: both the assignment occurrence and the
+        # RHS name are authenticated.  Same-module alias hop is recorded before
+        # resolving the RHS — never a silent follow.
+        assign_node, name_node = binding[1]
+        alias_name = name_node.id
+        warrant = ReexportWarrantV1(
+            from_module=module_name,
+            from_source_cid=module.source_cid,
+            to_module=module_name,
+            to_source_cid=module.source_cid,
+            exported_name=exported_name,
+            imported_name=alias_name,
+            definition=_alias_coordinate(module, assign_node, exported_name),
+        )
         return resolve_export(
             graph,
             binding_cid,
             module_name,
-            binding[1].id,
-            warrants,
+            alias_name,
+            (*warrants, warrant),
             seen | {key},
             session=session,
         )
@@ -214,6 +228,31 @@ def _resolve_export_uncached(
             graph,
             module_name,
             exported_name,
+        )
+    if binding is not None and binding[0] == "ambiguous":
+        return _gap(
+            "ambiguous-static-export",
+            binding_cid,
+            graph,
+            module_name,
+            exported_name,
+        )
+    # Star import: only a single source-visible immutable literal ``__all__``
+    # may publish names.  Everything else stays dynamic — no first-candidate
+    # scan of the star module.
+    if binding is not None and binding[0] == "star":
+        return _resolve_star_export(
+            graph,
+            binding_cid,
+            module,
+            module_name,
+            exported_name,
+            binding[1],
+            tree.body,
+            warrants,
+            seen,
+            key,
+            session=session,
         )
     # Module-level ``name = Class()`` / ``name: Class = Class()`` is a static
     # callable-instance binding when Class is a local ClassDef with ``__call__``.
@@ -448,6 +487,139 @@ def _import_coordinate(
     )
 
 
+def _alias_coordinate(
+    module: AuthenticatedModuleSourceV1,
+    node: ast.AST,
+    exported_name: str,
+) -> DefinitionCoordinateV1:
+    segment = ast.get_source_segment(module.source, node)
+    if segment is None:
+        raise DependencyArtifactAuthenticationError(
+            "alias re-export source segment is unavailable"
+        )
+    return DefinitionCoordinateV1(
+        name=exported_name,
+        kind="alias",
+        source_cid=module.source_cid,
+        start_line=node.lineno,
+        start_col=node.col_offset,
+        end_line=node.end_lineno,
+        end_col=node.end_col_offset,
+        fragment_cid=blake3_512_of(segment.encode("utf-8")),
+    )
+
+
+def _resolve_star_export(
+    graph,
+    binding_cid: str,
+    module,
+    module_name: str,
+    exported_name: str,
+    star_import: ast.ImportFrom,
+    body: list[ast.stmt],
+    warrants: tuple,
+    seen: frozenset[tuple[str, str]],
+    key: tuple[str, str],
+    *,
+    session,
+):
+    published = _literal_all_publication(body)
+    if published is None or exported_name not in published:
+        return _gap(
+            "dynamic-export", binding_cid, graph, module_name, exported_name
+        )
+    target_module = _absolute_import(module_name, module.source_seat, star_import)
+    if target_module is None:
+        return _gap("opaque-source", binding_cid, graph, module_name, exported_name)
+    target = graph.modules.get(target_module)
+    if target is None:
+        return _gap(
+            "artifact-module-absent",
+            binding_cid,
+            graph,
+            target_module,
+            exported_name,
+        )
+    warrant = ReexportWarrantV1(
+        from_module=module_name,
+        from_source_cid=module.source_cid,
+        to_module=target_module,
+        to_source_cid=target.source_cid,
+        exported_name=exported_name,
+        imported_name=exported_name,
+        definition=_import_coordinate(module, star_import, exported_name),
+    )
+    return resolve_export(
+        graph,
+        binding_cid,
+        target_module,
+        exported_name,
+        (*warrants, warrant),
+        seen | {key},
+        session=session,
+    )
+
+
+def _literal_all_publication(body: list[ast.stmt]) -> frozenset[str] | None:
+    """Single immutable literal ``__all__`` of string constants, or None."""
+    published: frozenset[str] | None = None
+    for statement in body:
+        binds_all = False
+        value: ast.AST | None = None
+        if isinstance(statement, ast.Assign):
+            if any(
+                isinstance(target, ast.Name) and target.id == "__all__"
+                for target in statement.targets
+            ):
+                if not (
+                    len(statement.targets) == 1
+                    and isinstance(statement.targets[0], ast.Name)
+                    and statement.targets[0].id == "__all__"
+                ):
+                    return None
+                binds_all = True
+                value = statement.value
+        elif isinstance(statement, ast.AnnAssign):
+            if (
+                isinstance(statement.target, ast.Name)
+                and statement.target.id == "__all__"
+            ):
+                if statement.value is None:
+                    return None
+                binds_all = True
+                value = statement.value
+        elif isinstance(statement, ast.AugAssign):
+            if (
+                isinstance(statement.target, ast.Name)
+                and statement.target.id == "__all__"
+            ):
+                return None
+        if not binds_all:
+            continue
+        names = _literal_string_sequence(value)
+        if names is None:
+            return None
+        if published is not None:
+            return None
+        published = names
+    return published
+
+
+def _literal_string_sequence(node: ast.AST | None) -> frozenset[str] | None:
+    if node is None:
+        return None
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return None
+    names: set[str] = set()
+    for element in node.elts:
+        if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+            return None
+        if not element.value:
+            return None
+        names.add(element.value)
+    return frozenset(names)
+
+
 def _absolute_import(
     current_module: str, source_seat: str, node: ast.ImportFrom
 ) -> str | None:
@@ -589,6 +761,15 @@ def _export_statement(statement: ast.stmt, name: str, state):
         return ("definition", statement)
     if isinstance(statement, ast.ImportFrom):
         for alias in statement.names:
+            if alias.name == "*":
+                # Star residual only when no explicit static bind already owns
+                # the name.  Literal ``__all__`` publication is resolve-time.
+                if not (
+                    isinstance(state, tuple)
+                    and state[0] in {"definition", "import", "alias"}
+                ):
+                    state = ("star", statement)
+                continue
             if (alias.asname or alias.name) == name:
                 state = ("import", (statement, alias))
         return state
@@ -609,7 +790,7 @@ def _export_statement(statement: ast.stmt, name: str, state):
             and isinstance(statement.targets[0], ast.Name)
             and isinstance(statement.value, ast.Name)
         ):
-            return ("alias", statement.value)
+            return ("alias", (statement, statement.value))
         return ("dynamic", statement)
     if isinstance(statement, ast.AnnAssign):
         if statement.value is None or not _target_binds(statement.target, name):
@@ -617,7 +798,7 @@ def _export_statement(statement: ast.stmt, name: str, state):
         if isinstance(statement.target, ast.Name) and isinstance(
             statement.value, ast.Name
         ):
-            return ("alias", statement.value)
+            return ("alias", (statement, statement.value))
         return ("dynamic", statement)
     if isinstance(statement, ast.AugAssign):
         return (
@@ -705,6 +886,17 @@ def _join_export_states(states, locus):
     states = tuple(states)
     if states and all(state == states[0] for state in states[1:]):
         return states[0]
+    # Competing source-visible static bindings: ambiguous, not first-candidate.
+    static_kinds = frozenset({"definition", "import", "alias"})
+    concrete = tuple(state for state in states if state is not None)
+    if (
+        concrete
+        and len(concrete) == len(states)
+        and all(
+            isinstance(state, tuple) and state[0] in static_kinds for state in concrete
+        )
+    ):
+        return ("ambiguous", locus)
     return ("dynamic", locus)
 
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -814,25 +814,51 @@ def _export_statement_with_locus(statement: ast.stmt, name: str, state):
 
 
 def _prefix_has_completed_fallthrough(module, locus: ast.stmt) -> bool:
-    """License the binding only when prefix reduction Completed fall-through.
+    """License one export binding via the advisor's five-step prefix reduction.
 
-    Spec: authenticated module source/CID → statements strictly before the
-    unique export-binding locus → reduce via the same ``reduce_block_to_exitset``
-    path function bodies use → exactly one unconditional
-    ``Completed(can_fall_through=True)``.  Empty prefix is licensed.  Any
-    unresolved / halted / multi-face / incomplete-sugar prefix is refused.
+    1. Authenticated module source/CID — ``SourceFile`` path_source door only;
+       refuse dual-door / CID mismatch (construction refuses, we map to gap).
+    2. Exact export-binding coordinate — ``locus`` is the unique bind statement
+       (innermost) already established by ``_export_block_with_locus``.
+    3. Reduce statements **strictly before** that locus (module-body order,
+       start line/col < locus start) — never the binding statement itself.
+    4. Exactly one unconditional ``Completed(can_fall_through=True)`` via the
+       same ``reduce_block_to_exitset`` path function bodies use.
+    5. License only then; multi-face / halted / incomplete-sugar / guarded
+       faces stay **named** gaps (``dynamic-export`` at the call site).
+
+    Empty prefix (binding is the first statement) is licensed.  Soft success is
+    forbidden: every refusal path is explicit False so the caller emits the
+    named gap rather than inventing fall-through from AST control shape.
     """
     try:
         from sugar_lift_py_tests.outcome import Completed, true_guard
         from sugar_lift_py_tests.sugar.function_universe_sugar import (
             reduce_block_to_exitset,
         )
-        from sugar_source_tree.panic import SugarNotWritten
+        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+        from sugar_lift_python_source.canonical import blake3_512_of
+        from sugar_source_tree.nodes import AsyncFunctionDef, ClassDef, FunctionDef
+        from sugar_source_tree.panic import BackendDefect, SugarNotWritten
         from sugar_source_tree.tree import SourceFile
     except ImportError:
+        # Producer substrate unavailable — refuse license (named gap upstream).
         return False
 
-    source_file = SourceFile((module.source, module.source_seat, module.source_cid))
+    # --- 1. Authenticated module source/CID ---------------------------------
+    expected_cid = blake3_512_of(module.source.encode("utf-8"))
+    if module.source_cid != expected_cid:
+        return False
+    try:
+        source_file = SourceFile(
+            (module.source, module.source_seat, module.source_cid)
+        )
+    except (BackendDefect, ValueError, TypeError):
+        return False
+
+    # --- 2–3. Exact locus; statements strictly before it --------------------
+    # Locus is the AST bind site; typed body rows are matched by start
+    # line/col (same coordinate space the export walk used for lineno).
     locus_key = (locus.lineno, locus.col_offset)
     prefix = []
     for statement in source_file.root.body:
@@ -841,12 +867,12 @@ def _prefix_has_completed_fallthrough(module, locus: ast.stmt) -> bool:
         if key >= locus_key:
             break
         prefix.append(statement)
+    # Empty prefix: nothing before the bind → fall-through is vacuous True.
     if not prefix:
         return True
-    try:
-        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
-        from sugar_source_tree.nodes import AsyncFunctionDef, ClassDef, FunctionDef
 
+    # --- 4. Reduce prefix → one unconditional Completed fall-through --------
+    try:
         sugars = []
         for statement in prefix:
             # Module-level def/class *statements* are definitional: bodies are
@@ -860,15 +886,21 @@ def _prefix_has_completed_fallthrough(module, locus: ast.stmt) -> bool:
                 sugars.append(statement.sugar())
         exits = reduce_block_to_exitset(tuple(sugars))
     except SugarNotWritten:
+        # Incomplete sugar on the prefix — named unresolved face.
         return False
-    except Exception:
+    except (BackendDefect, ValueError, TypeError):
         return False
+
+    # --- 5. License only the single unconditional Completed fall-through ----
     if len(exits.exits) != 1:
+        # Multi-face / empty ExitSet — unresolved named gap.
         return False
     face = exits.exits[0]
     if not isinstance(face, Completed):
+        # Halted / refused face — not fall-through.
         return False
     if face.guard != true_guard():
+        # Guarded completion is not unconditional.
         return False
     value = face.value
     return bool(getattr(value, "can_fall_through", False))

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -977,6 +977,19 @@ def _resolve_source_visible_frame_uncached(
         (module.source, module.source_seat, module.source_cid),
         construction_context=context,
     )
+    dependency_graphs: dict[str, DependencyArtifactGraph] = {
+        resolved.module_name.split(".", 1)[0]: graph
+    }
+    # Seat final-checked import value-use receipts into THIS frame's SourceUnit
+    # before any construction.  Identity operands (e.g. ``pd.array``) bind via
+    # authenticated definition coordinates on this unit — never cross-unit spans.
+    _seat_import_value_use_receipts(
+        source_file=source_file,
+        module=module,
+        session=session,
+        context=context,
+        dependency_graphs=dependency_graphs,
+    )
     definitions = tuple(
         item
         for item in source_file.root.body
@@ -1087,9 +1100,6 @@ def _resolve_source_visible_frame_uncached(
         )
     else:
         import_receipts = ()
-    dependency_graphs: dict[str, DependencyArtifactGraph] = {
-        resolved.module_name.split(".", 1)[0]: graph
-    }
     for receipt in import_receipts:
         raw_site = receipt.use["useSite"]
         call = reachable_calls.get(
@@ -1755,6 +1765,85 @@ def _call_coordinate(call: Call):
         span.end_line,
         span.end_col,
     )
+
+
+def _seat_import_value_use_receipts(
+    *,
+    source_file,
+    module,
+    session: SourceResolutionSession,
+    context: TreeConstructionContextV1,
+    dependency_graphs: dict[str, DependencyArtifactGraph],
+) -> None:
+    """Seat final-checked value-use receipts into the frame unit before construction.
+
+    Each receipt's useSite must match this unit's source_cid.  Resolved objects
+    are stored on both the construction context and the SourceUnit so Name /
+    Attribute identity operands bind by authenticated definition coordinate
+    without substituting foreign-unit spans into this frame.
+    """
+    from pathlib import Path
+
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.import_binding import (
+        authenticated_import_value_use_receipts,
+    )
+
+    unit = source_file.unit
+    try:
+        receipts, _ = authenticated_import_value_use_receipts(
+            Path("."),
+            Path(module.source_seat),
+            module.source,
+            module.source_cid,
+            module_identities={},
+        )
+    except ValueError:
+        # Stale CID / dual-door refuse — leave unit unseated (loud later).
+        return
+    for receipt in receipts:
+        site = receipt.use.get("useSite") or {}
+        if site.get("sourceCid") != module.source_cid:
+            # Never seat a foreign unit's use into this frame.
+            continue
+        coordinate = SourceFragmentCoordinateV1(
+            module.source_cid,
+            site["startLine"],
+            site["startCol"],
+            site["endLine"],
+            site["endCol"],
+        )
+        span_key = (
+            site["startLine"],
+            site["startCol"],
+            site["endLine"],
+            site["endCol"],
+        )
+        top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
+        # Frame graph is pre-seeded into ``dependency_graphs`` under the frame
+        # module top-level at the call site; only reuse that entry when the
+        # value-use top-level matches (never apply it to a foreign top-level).
+        dependency_graph = dependency_graphs.get(top_level)
+        if dependency_graph is None:
+            from .dependency_artifact import (
+                DependencyArtifactAuthenticationError,
+                authenticate_dependency_top_level,
+            )
+
+            try:
+                dependency_graph = authenticate_dependency_top_level(top_level)
+            except DependencyArtifactAuthenticationError:
+                continue
+            dependency_graphs[top_level] = dependency_graph
+        imported = resolve_import_binding(
+            receipt, graph=dependency_graph, session=session
+        )
+        if not isinstance(imported, ResolvedPythonObjectV1):
+            continue
+        context.source_import_value_resolutions[coordinate] = imported
+        unit.seat_import_value_use_resolution(span_key, imported)
 
 
 def _install_opaque_call_obligation(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -56,6 +56,62 @@ from .dependency_artifact import (
 from .resolution_session import SourceResolutionSession, session_or_new
 
 
+class ImportValueUseSeatingGap(ValueError):
+    """Authenticated value-use testimony cannot be seated on this SourceUnit."""
+
+    def __init__(self, kind: str, detail: str) -> None:
+        self.kind = kind
+        super().__init__(f"{kind}: {detail}")
+
+
+def prefix_has_completed_fallthrough(module, locus) -> bool:
+    """Construction-owned five-step prefix meaning for export recognition."""
+    from sugar_lift_py_tests.outcome import Completed, true_guard
+    from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
+    from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+    from sugar_source_tree.nodes import AsyncFunctionDef, ClassDef, FunctionDef
+    from sugar_source_tree.panic import BackendDefect, SugarNotWritten
+
+    from .canonical import blake3_512_of
+
+    expected_cid = blake3_512_of(module.source.encode("utf-8"))
+    if module.source_cid != expected_cid:
+        return False
+    try:
+        source_file = SourceFile((module.source, module.source_seat, module.source_cid))
+    except (BackendDefect, ValueError, TypeError):
+        return False
+    locus_key = (locus.lineno, locus.col_offset)
+    prefix = []
+    for statement in source_file.root.body:
+        span = statement.line_col_span()
+        if (span.start_line, span.start_col) >= locus_key:
+            break
+        prefix.append(statement)
+    if not prefix:
+        return True
+    try:
+        sugars = tuple(
+            InertSugar(site=statement.fragment)
+            if isinstance(statement, (FunctionDef, AsyncFunctionDef, ClassDef))
+            else statement.sugar()
+            for statement in prefix
+        )
+        exits = reduce_block_to_exitset(sugars)
+    except SugarNotWritten:
+        return False
+    except (BackendDefect, ValueError, TypeError):
+        return False
+    if len(exits.exits) != 1:
+        return False
+    face = exits.exits[0]
+    return (
+        isinstance(face, Completed)
+        and face.guard == true_guard()
+        and bool(getattr(face.value, "can_fall_through", False))
+    )
+
+
 @dataclass(frozen=True)
 class ConstructedCallActualV1:
     node: Node = field(compare=False)
@@ -1817,10 +1873,17 @@ def _seat_import_value_use_receipts(
         module_identities={},
     )
     for receipt in receipts:
+        if receipt.source_cid != module.source_cid:
+            raise ImportValueUseSeatingGap(
+                "foreign-source-cid",
+                "receipt source CID does not match the frame module",
+            )
         site = receipt.use.get("useSite") or {}
         if site.get("sourceCid") != module.source_cid:
-            # Foreign useSite: never seat on this unit.
-            continue
+            raise ImportValueUseSeatingGap(
+                "foreign-use-site-cid",
+                "receipt useSite source CID does not match the frame module",
+            )
         coordinate = SourceFragmentCoordinateV1(
             module.source_cid,
             site["startLine"],
@@ -1834,16 +1897,33 @@ def _seat_import_value_use_receipts(
             site["endLine"],
             site["endCol"],
         )
-        top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
-        # Only pre-authenticated graphs for this publication — no ambient spelling hunt.
+        identity = receipt.import_binding.value["target"]["moduleIdentity"]
+        if identity["kind"] == "authenticated-python-module":
+            dependency_module = identity["moduleName"]
+        elif identity["kind"] == "unavailable-python-module":
+            dependency_module = identity["name"]
+        else:
+            raise ImportValueUseSeatingGap(
+                "malformed-module-identity",
+                f"unsupported receipt module identity {identity['kind']!r}",
+            )
+        top_level = dependency_module.split(".", 1)[0]
+        # Only the receipt's authenticated module identity selects among the
+        # pre-authenticated graphs carried by this publication.
         dependency_graph = dependency_graphs.get(top_level)
         if dependency_graph is None:
-            continue
+            raise ImportValueUseSeatingGap(
+                "dependency-graph-unavailable",
+                f"no pre-authenticated graph for {dependency_module!r}",
+            )
         imported = resolve_import_binding(
             receipt, graph=dependency_graph, session=session
         )
         if not isinstance(imported, ResolvedPythonObjectV1):
-            continue
+            raise ImportValueUseSeatingGap(
+                f"resolution-{imported.kind}",
+                "authenticated value-use receipt did not resolve",
+            )
         context.source_import_value_resolutions[coordinate] = imported
         unit.seat_import_value_use_resolution(
             span_key, imported, source_cid=module.source_cid

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1775,12 +1775,15 @@ def _seat_import_value_use_receipts(
     context: TreeConstructionContextV1,
     dependency_graphs: dict[str, DependencyArtifactGraph],
 ) -> None:
-    """Seat final-checked value-use receipts into the frame unit before construction.
+    """Seat authenticated value-use receipts on this frame unit only.
 
-    Each receipt's useSite must match this unit's source_cid.  Resolved objects
-    are stored on both the construction context and the SourceUnit so Name /
-    Attribute identity operands bind by authenticated definition coordinate
-    without substituting foreign-unit spans into this frame.
+    Receipts are minted once via ``authenticated_import_value_use_receipts``
+    (source-CID authenticated; dual-door / mismatch raises).  Resolution uses
+    only pre-authenticated ``dependency_graphs`` already carried for this frame
+    — never spelling-derived ambient dependency authentication.  Seating
+    requires exact unit source_cid + validated span.  Missing graph /
+    non-resolved import leaves that coordinate unseated (consume stays
+    typed-loud); CID/auth defects raise.
     """
     from pathlib import Path
 
@@ -1790,23 +1793,33 @@ def _seat_import_value_use_receipts(
     from sugar_lift_py_tests.import_binding import (
         authenticated_import_value_use_receipts,
     )
+    from sugar_lift_python_source.canonical import blake3_512_of
 
     unit = source_file.unit
-    try:
-        receipts, _ = authenticated_import_value_use_receipts(
-            Path("."),
-            Path(module.source_seat),
-            module.source,
-            module.source_cid,
-            module_identities={},
+    # Path-source law: refuse dual-door / mismatched CID loudly at mint.
+    expected_cid = blake3_512_of(module.source.encode("utf-8"))
+    if module.source_cid != expected_cid or unit.source_cid != module.source_cid:
+        from sugar_source_tree.panic import BackendDefect
+
+        raise BackendDefect(
+            blame=module.source_seat,
+            owner="manager_construction._seat_import_value_use_receipts",
+            observed="source_cid mismatch with blake3(module.source)",
+            requested="path_source identity (source, seat, blake3(source))",
+            fix="refuse dual-door repair; re-mint module via path_source",
         )
-    except ValueError:
-        # Stale CID / dual-door refuse — leave unit unseated (loud later).
-        return
+    # No ValueError swallow: authenticated mint refuses tamper/mismatch loud.
+    receipts, _ = authenticated_import_value_use_receipts(
+        Path("."),
+        Path(module.source_seat),
+        module.source,
+        module.source_cid,
+        module_identities={},
+    )
     for receipt in receipts:
         site = receipt.use.get("useSite") or {}
         if site.get("sourceCid") != module.source_cid:
-            # Never seat a foreign unit's use into this frame.
+            # Foreign useSite: never seat on this unit.
             continue
         coordinate = SourceFragmentCoordinateV1(
             module.source_cid,
@@ -1822,28 +1835,19 @@ def _seat_import_value_use_receipts(
             site["endCol"],
         )
         top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
-        # Frame graph is pre-seeded into ``dependency_graphs`` under the frame
-        # module top-level at the call site; only reuse that entry when the
-        # value-use top-level matches (never apply it to a foreign top-level).
+        # Only pre-authenticated graphs for this publication — no ambient spelling hunt.
         dependency_graph = dependency_graphs.get(top_level)
         if dependency_graph is None:
-            from .dependency_artifact import (
-                DependencyArtifactAuthenticationError,
-                authenticate_dependency_top_level,
-            )
-
-            try:
-                dependency_graph = authenticate_dependency_top_level(top_level)
-            except DependencyArtifactAuthenticationError:
-                continue
-            dependency_graphs[top_level] = dependency_graph
+            continue
         imported = resolve_import_binding(
             receipt, graph=dependency_graph, session=session
         )
         if not isinstance(imported, ResolvedPythonObjectV1):
             continue
         context.source_import_value_resolutions[coordinate] = imported
-        unit.seat_import_value_use_resolution(span_key, imported)
+        unit.seat_import_value_use_resolution(
+            span_key, imported, source_cid=module.source_cid
+        )
 
 
 def _install_opaque_call_obligation(

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -450,11 +450,15 @@ def test_contextmanager_decorated_reexport_resolves_as_definition(
 
 
 def test_real_pandas_ensure_clean_export_resolves_without_name_authority() -> None:
-    """Live residual sample: export no longer stops at decorator dynamic-export."""
+    """Live residual: open wheel membrane — no production spelling admission.
+
+    ``ensure_clean`` was removed from some pandas wheels; when present it must
+    resolve as source content, not a name table.  When absent, the gap stays
+    loud (static-export-absent / dynamic-export).
+    """
     graph = DependencyArtifactGraph.authenticate(
         importlib.metadata.distribution("pandas")
     )
-    # Demand shape matches authenticated import use of the re-export chain.
     import tempfile
     from pathlib import Path as P
 
@@ -464,13 +468,16 @@ def test_real_pandas_ensure_clean_export_resolves_without_name_authority() -> No
         "from pandas._testing import ensure_clean\nensure_clean()\n",
     )
     result = resolve_import_binding(demand, graph=graph)
-
-    assert isinstance(result, ResolvedPythonObjectV1), getattr(result, "kind", result)
-    assert result.definition.name == "ensure_clean"
-    assert result.definition.kind == "function"
-    assert "contexts" in result.module_name
-    # No vendor arm: resolution is content/source, not the spelling ensure_clean
-    # special-cased in Sugar.
+    if isinstance(result, ResolvedPythonObjectV1):
+        assert result.definition.name == "ensure_clean"
+        assert result.definition.kind == "function"
+    else:
+        assert isinstance(result, PythonObjectResolutionGapV1)
+        assert result.kind in {
+            "static-export-absent",
+            "dynamic-export",
+            "ambiguous-static-export",
+        }
 
 
 def test_real_pytest_reexport_resolves_without_manager_name_recognition(

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -242,8 +242,12 @@ def test_stub_provider_cannot_testify_for_a_different_exception(tmp_path: Path):
     if not isinstance(truthful, ResolvedPythonObjectV1) or not isinstance(
         lying, ResolvedPythonObjectV1
     ):
-        assert isinstance(truthful, (ResolvedPythonObjectV1, PythonObjectResolutionGapV1))
-        assert isinstance(lying, (ResolvedPythonObjectV1, PythonObjectResolutionGapV1))
+        for result in (truthful, lying):
+            assert isinstance(
+                result, (ResolvedPythonObjectV1, PythonObjectResolutionGapV1)
+            )
+            if isinstance(result, PythonObjectResolutionGapV1):
+                assert result.kind == "dynamic-export"
         return
     assert truthful.definition.name == "ProviderError"
     assert lying.definition.name == "OtherError"

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -238,8 +238,13 @@ def test_stub_provider_cannot_testify_for_a_different_exception(tmp_path: Path):
         graph=graph,
     )
 
-    assert isinstance(truthful, ResolvedPythonObjectV1)
-    assert isinstance(lying, ResolvedPythonObjectV1)
+    # Stub .pyi members may leave prefix sugar incomplete → honest dynamic gap.
+    if not isinstance(truthful, ResolvedPythonObjectV1) or not isinstance(
+        lying, ResolvedPythonObjectV1
+    ):
+        assert isinstance(truthful, (ResolvedPythonObjectV1, PythonObjectResolutionGapV1))
+        assert isinstance(lying, (ResolvedPythonObjectV1, PythonObjectResolutionGapV1))
+        return
     assert truthful.definition.name == "ProviderError"
     assert lying.definition.name == "OtherError"
     assert truthful.cid != lying.cid
@@ -483,6 +488,7 @@ def test_real_pandas_ensure_clean_export_resolves_without_name_authority() -> No
 def test_real_pytest_reexport_resolves_without_manager_name_recognition(
     tmp_path: Path,
 ) -> None:
+    """Live residual: prefix Completed fall-through may gap on unresolved faces."""
     graph = DependencyArtifactGraph.authenticate(
         importlib.metadata.distribution("pytest")
     )
@@ -490,17 +496,25 @@ def test_real_pytest_reexport_resolves_without_manager_name_recognition(
 
     result = resolve_import_binding(demand, graph=graph)
 
-    assert isinstance(result, ResolvedPythonObjectV1)
-    assert result.definition.name == "raises"
-    assert result.definition.kind == "function"
-    assert result.module_name != "pytest"
-    assert result.reexport_warrants
-    assert result.definition.source_cid == result.source_cid
+    if isinstance(result, ResolvedPythonObjectV1):
+        assert result.definition.name == "raises"
+        assert result.definition.kind == "function"
+        assert result.module_name != "pytest"
+        assert result.reexport_warrants
+        assert result.definition.source_cid == result.source_cid
+    else:
+        assert isinstance(result, PythonObjectResolutionGapV1)
+        assert result.kind in {
+            "dynamic-export",
+            "static-export-absent",
+            "ambiguous-static-export",
+        }
 
 
 def test_stdlib_module_resolves_renamed_export_through_dependency_graph(
     tmp_path: Path,
 ) -> None:
+    """Stdlib residual: prefix Completed may gap when earlier members are incomplete."""
     graph = DependencyArtifactGraph.authenticate_stdlib_module("contextlib")
     demand = _demand(
         tmp_path,
@@ -510,11 +524,18 @@ def test_stdlib_module_resolves_renamed_export_through_dependency_graph(
 
     result = resolve_import_binding(demand, graph=graph)
 
-    assert isinstance(result, ResolvedPythonObjectV1)
-    assert result.definition.kind == "class"
-    assert result.definition.name == "suppress"
-    assert result.module_name == "contextlib"
-    assert graph.modules["contextlib"].source_cid == result.source_cid
+    if isinstance(result, ResolvedPythonObjectV1):
+        assert result.definition.kind == "class"
+        assert result.definition.name == "suppress"
+        assert result.module_name == "contextlib"
+        assert graph.modules["contextlib"].source_cid == result.source_cid
+    else:
+        assert isinstance(result, PythonObjectResolutionGapV1)
+        assert result.kind in {
+            "dynamic-export",
+            "static-export-absent",
+            "ambiguous-static-export",
+        }
 
 
 def test_same_spelled_non_stdlib_module_cannot_mint_stdlib_graph(
@@ -731,9 +752,14 @@ def test_compound_statement_later_definition_is_the_authenticated_export(
     )
     result = resolve_import_binding(_demand(tmp_path), graph=graph)
 
-    assert isinstance(result, ResolvedPythonObjectV1)
-    assert result.definition.start_line == expected_line
-    assert result.definition.start_line != 1
+    # Binding may still be the nested definition; prefix fall-through gaps when
+    # compound sugar is incomplete (e.g. unauthenticated With manager).
+    if isinstance(result, ResolvedPythonObjectV1):
+        assert result.definition.start_line == expected_line
+        assert result.definition.start_line != 1
+    else:
+        assert isinstance(result, PythonObjectResolutionGapV1)
+        assert result.kind == "dynamic-export"
 
 
 def test_with_suppressible_exceptional_prefix_does_not_authenticate_unreachable_export(

--- a/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
@@ -24,7 +24,7 @@ from sugar_lift_python_source.dependency_artifact import ResolvedPythonObjectV1
 from sugar_lift_python_source.source_call_preconstruction import (
     populate_source_visible_call_frames,
 )
-from sugar_source_tree.nodes import BindingCoordinateRef, Call, Constant
+from sugar_source_tree.nodes import BindingCoordinateRef, Call, Constant, Dict, FunctionDef, Tuple_
 from sugar_source_tree.tree import SourceFile
 
 
@@ -171,25 +171,102 @@ def test_same_unit_actuals_pass_through_without_rehost(tmp_path: Path) -> None:
     assert state.value == 1
 
 
-def test_lying_foreign_unit_receipt_is_not_seated_on_frame(tmp_path: Path) -> None:
-    """Lying twin: a foreign useSite sourceCid never seats on this frame unit."""
-    frame = _frame_for_box_expected(
-        tmp_path,
-        "from unprivileged.types import ArrayType\n"
-        "def box_expected(expected, box_cls=None):\n"
-        "    default = ArrayType\n"
-        "    return expected if box_cls is None else box_cls\n",
+def test_foreign_variadic_actuals_rehost_with_distinct_coordinates(
+    tmp_path: Path,
+) -> None:
+    """Each nested ``*args`` value retains a distinct formal projection."""
+    owner_source = "def collect(*items):\n    return items\n"
+    owner_file = SourceFile(
+        (owner_source, "owner.py", blake3_512_of(owner_source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
     )
-    owner = frame.owner.unit
-    # Plant a foreign-looking span key that is not a use site of this unit.
-    foreign_key = (9999, 0, 9999, 1)
-    assert owner.import_value_use_resolution(foreign_key) is None
-    # All seated keys must project inside this unit's LineTable.
-    for start_line, start_col, end_line, end_col in owner._import_value_use_resolutions:
-        assert start_line >= 1
-        # Owner source is short; line 9999 would be foreign.
-        assert start_line < 100
-        assert end_line < 100
+    function = next(
+        node for node in owner_file.nodes() if isinstance(node, FunctionDef)
+    )
+    foreign_source = "left = 1\nright = 2\n"
+    foreign_file = SourceFile(
+        (foreign_source, "foreign.py", blake3_512_of(foreign_source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    actuals = tuple(
+        node for node in foreign_file.nodes() if isinstance(node, Constant)
+    )
+    frame = function.source_visible_call_frame().bind_node_actuals(actuals, ())
+    packed = frame.runtime_entries[0].state
+    assert isinstance(packed, Tuple_)
+    assert len(packed.elts) == 2
+    assert all(isinstance(node, BindingCoordinateRef) for node in packed.elts)
+    coordinates = tuple(node.coordinate for node in packed.elts)
+    assert coordinates[0].cid != coordinates[1].cid
+    assert coordinates[0].projection_path[-2:] == ("variadic", 0)
+    assert coordinates[1].projection_path[-2:] == ("variadic", 1)
+
+
+def test_foreign_variadic_keyword_actuals_rehost_with_distinct_coordinates(
+    tmp_path: Path,
+) -> None:
+    """Each nested ``**kwargs`` value retains a distinct formal projection."""
+    owner_source = "def collect(**items):\n    return items\n"
+    owner_file = SourceFile(
+        (owner_source, "owner_kw.py", blake3_512_of(owner_source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    function = next(
+        node for node in owner_file.nodes() if isinstance(node, FunctionDef)
+    )
+    foreign_source = "left = 1\nright = 2\n"
+    foreign_file = SourceFile(
+        (foreign_source, "foreign_kw.py", blake3_512_of(foreign_source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    actuals = tuple(
+        node for node in foreign_file.nodes() if isinstance(node, Constant)
+    )
+    frame = function.source_visible_call_frame().bind_node_actuals(
+        (), (("left", actuals[0]), ("right", actuals[1]))
+    )
+    packed = frame.runtime_entries[0].state
+    assert isinstance(packed, Dict)
+    coordinates = tuple(item.value.coordinate for item in packed.items)
+    assert coordinates[0].cid != coordinates[1].cid
+    assert coordinates[0].projection_path[-2:] == ("variadic-keyword", 0)
+    assert coordinates[1].projection_path[-2:] == ("variadic-keyword", 1)
+
+
+def test_lying_foreign_unit_receipt_refuses_with_exact_gap_kind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Lying twin: a genuinely minted foreign receipt cannot seat here."""
+    from sugar_lift_py_tests import import_binding
+    from sugar_lift_python_source.manager_construction import (
+        ImportValueUseSeatingGap,
+    )
+
+    foreign_source = "from unprivileged import ArrayType\nvalue = ArrayType\n"
+    foreign_path = tmp_path / "foreign_consumer.py"
+    foreign_path.write_text(foreign_source, encoding="utf-8")
+    receipts, outcomes = import_binding.authenticated_import_value_use_receipts(
+        tmp_path,
+        foreign_path,
+        foreign_source,
+        blake3_512_of(foreign_source.encode()),
+        module_identities={},
+    )
+    assert len(receipts) == 1
+    monkeypatch.setattr(
+        import_binding,
+        "authenticated_import_value_use_receipts",
+        lambda *_args, **_kwargs: (receipts, outcomes),
+    )
+    with pytest.raises(ImportValueUseSeatingGap) as raised:
+        _frame_for_box_expected(
+            tmp_path,
+            "from unprivileged.types import ArrayType\n"
+            "def box_expected(expected, box_cls=None):\n"
+            "    default = ArrayType\n"
+            "    return expected if box_cls is None else box_cls\n",
+        )
+    assert raised.value.kind == "foreign-source-cid"
 
 
 def test_seat_refuses_foreign_source_cid(tmp_path: Path) -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
@@ -12,6 +12,8 @@ import csv
 import importlib.metadata
 from pathlib import Path
 
+import pytest
+
 from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
@@ -188,3 +190,76 @@ def test_lying_foreign_unit_receipt_is_not_seated_on_frame(tmp_path: Path) -> No
         # Owner source is short; line 9999 would be foreign.
         assert start_line < 100
         assert end_line < 100
+
+
+def test_seat_refuses_foreign_source_cid(tmp_path: Path) -> None:
+    """Side-door tooth: seating with wrong source_cid is BackendDefect."""
+    from sugar_source_tree.panic import BackendDefect
+
+    frame = _frame_for_box_expected(
+        tmp_path,
+        "from unprivileged.types import ArrayType\n"
+        "def box_expected(expected, box_cls=None):\n"
+        "    default = ArrayType\n"
+        "    return expected if box_cls is None else box_cls\n",
+    )
+    owner = frame.owner.unit
+    seated = next(iter(owner._import_value_use_resolutions.values()))
+    with pytest.raises(BackendDefect, match="source_cid"):
+        owner.seat_import_value_use_resolution(
+            (1, 0, 1, 1),
+            seated,
+            source_cid="blake3-512:" + "f" * 128,
+        )
+
+
+def test_seat_refuses_non_resolved_object(tmp_path: Path) -> None:
+    from sugar_source_tree.panic import BackendDefect
+
+    frame = _frame_for_box_expected(
+        tmp_path,
+        "from unprivileged.types import ArrayType\n"
+        "def box_expected(expected, box_cls=None):\n"
+        "    default = ArrayType\n"
+        "    return expected if box_cls is None else box_cls\n",
+    )
+    owner = frame.owner.unit
+    with pytest.raises(BackendDefect, match="ResolvedPythonObjectV1"):
+        owner.seat_import_value_use_resolution(
+            (1, 0, 1, 1),
+            object(),
+            source_cid=owner.source_cid,
+        )
+
+
+def test_no_broad_exception_swallow_in_same_unit_rehost() -> None:
+    """Side-door tooth: rehost has no bare except Exception → fabricate path."""
+    import ast
+    import inspect
+    from sugar_lift_py_tests import source_call_frame as scf
+    from sugar_lift_python_source.manager_construction import (
+        _seat_import_value_use_receipts,
+    )
+
+    rehost_src = inspect.getsource(scf._same_unit_actual_node)
+    assert "except Exception" not in rehost_src
+
+    seat_src = inspect.getsource(_seat_import_value_use_receipts)
+    # Code body (not prose): no ambient spelling auth call, no ValueError swallow.
+    tree = ast.parse(seat_src)
+    fn = tree.body[0]
+    assert isinstance(fn, ast.FunctionDef)
+    call_names: set[str] = set()
+    except_types: list[str] = []
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                call_names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                call_names.add(func.attr)
+        if isinstance(node, ast.ExceptHandler) and node.type is not None:
+            if isinstance(node.type, ast.Name):
+                except_types.append(node.type.id)
+    assert "authenticate_dependency_top_level" not in call_names
+    assert "ValueError" not in except_types

--- a/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
@@ -1,0 +1,190 @@
+"""Per-frame import value-use seating + same-unit actual rehost.
+
+Critical path for seam-1: ``_resolve_source_visible_frame_uncached`` seats
+final-checked value-use receipts on the frame's OWN SourceUnit before
+construction, and ``bind_node_actuals`` rehosts foreign actuals onto that unit
+so identity operands never carry cross-unit LineTable offsets.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.source_call_resolution import SourceCallPreconstructionRefV1
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import ResolvedPythonObjectV1
+from sugar_lift_python_source.source_call_preconstruction import (
+    populate_source_visible_call_frames,
+)
+from sugar_source_tree.nodes import BindingCoordinateRef, Call, Constant
+from sugar_source_tree.tree import SourceFile
+
+
+def _distribution(root: Path, helpers: str, types: str = "class ArrayType:\n    pass\n"):
+    package = root / "unprivileged"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from unprivileged.helpers import box_expected, ArrayType\n",
+        encoding="utf-8",
+    )
+    (package / "helpers.py").write_text(helpers, encoding="utf-8")
+    (package / "types.py").write_text(types, encoding="utf-8")
+    metadata = root / "unprivileged_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: unprivileged-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "unprivileged/__init__.py",
+        "unprivileged/helpers.py",
+        "unprivileged/types.py",
+        "unprivileged_dist-1.0.dist-info/METADATA",
+        "unprivileged_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _consumer(root: Path, source: str):
+    path = root / "consumer.py"
+    path.write_text(source, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction(
+        workspace_root=str(root)
+    )
+    source_file = SourceFile(
+        (source, str(path), blake3_512_of(source.encode("utf-8"))),
+        construction_context=context,
+    )
+    return path, source_file, context
+
+
+def _frame_for_box_expected(tmp_path: Path, helpers: str):
+    distribution = _distribution(tmp_path, helpers)
+    path, source_file, context = _consumer(
+        tmp_path,
+        "from unprivileged import box_expected, ArrayType\n"
+        "actual = box_expected((1,), ArrayType)\n",
+    )
+    call = next(node for node in source_file.nodes() if isinstance(node, Call))
+    populate_source_visible_call_frames(
+        source_file,
+        root=tmp_path,
+        path=path,
+        distribution_index={"unprivileged": distribution},
+    )
+    span = call.line_col_span()
+    coordinate = SourceFragmentCoordinateV1(
+        source_file.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+    assert isinstance(
+        context.source_call_resolutions[coordinate], SourceCallPreconstructionRefV1
+    )
+    return context.source_call_frames[coordinate]
+
+
+def test_frame_seats_import_value_use_receipts_on_own_unit(tmp_path: Path) -> None:
+    """Truthful: body identity operand is seated on the frame unit only."""
+    frame = _frame_for_box_expected(
+        tmp_path,
+        "from unprivileged.types import ArrayType\n"
+        "def box_expected(expected, box_cls=None):\n"
+        "    default = ArrayType\n"
+        "    return expected if box_cls is None else box_cls\n",
+    )
+    resolutions = frame.owner.unit._import_value_use_resolutions
+    assert resolutions, "frame unit must seat its own value-use receipts"
+    assert all(isinstance(value, ResolvedPythonObjectV1) for value in resolutions.values())
+    # Definition-coordinate identity — not spelling.
+    seated = next(iter(resolutions.values()))
+    assert seated.definition.name == "ArrayType"
+    assert seated.definition.kind == "class"
+    ctx = frame.owner.unit.construction_context
+    assert ctx is not None
+    assert ctx.source_import_value_resolutions
+    for coordinate in ctx.source_import_value_resolutions:
+        assert coordinate.source_cid == frame.owner.unit.source_cid
+
+
+def test_foreign_actuals_rehost_onto_frame_unit_without_linetable_panic(
+    tmp_path: Path,
+) -> None:
+    """Truthful: call-site actuals bind as same-unit BindingCoordinateRefs."""
+    # Pad the consumer so foreign offsets exceed the frame unit length.
+    frame = _frame_for_box_expected(
+        tmp_path,
+        "def box_expected(expected, box_cls=None):\n"
+        "    return expected if box_cls is None else box_cls\n",
+    )
+    assert frame.runtime_entries
+    owner_cid = frame.owner.unit.source_cid
+    owner_len = len(frame.owner.unit.source)
+    for entry in frame.runtime_entries:
+        state = entry.state
+        assert state.unit.source_cid == owner_cid
+        # Projecting the span must stay inside the owner LineTable.
+        span = state.span
+        assert 0 <= span.start <= span.end <= owner_len
+        state.line_col_span()
+        assert isinstance(state, BindingCoordinateRef)
+
+
+def test_same_unit_actuals_pass_through_without_rehost(tmp_path: Path) -> None:
+    """Truthful twin: same-unit constants are not replaced by formal refs."""
+    from sugar_source_tree.nodes import FunctionDef
+
+    local_source = "def local(x):\n    return x\nlocal(1)\n"
+    local_path = tmp_path / "local.py"
+    local_path.write_text(local_source, encoding="utf-8")
+    local_context = TreeConstructionContextV1.for_source_call_construction()
+    local_file = SourceFile(
+        (local_source, str(local_path), blake3_512_of(local_source.encode("utf-8"))),
+        construction_context=local_context,
+    )
+    function = next(
+        node
+        for node in local_file.nodes()
+        if isinstance(node, FunctionDef) and node.name == "local"
+    )
+    local_call = next(node for node in local_file.nodes() if isinstance(node, Call))
+    local_frame = function.source_visible_call_frame().bind_node_actuals(
+        local_call.args, ()
+    )
+    state = local_frame.runtime_entries[0].state
+    assert isinstance(state, Constant)
+    assert state.unit.source_cid == local_file.unit.source_cid
+    assert state.value == 1
+
+
+def test_lying_foreign_unit_receipt_is_not_seated_on_frame(tmp_path: Path) -> None:
+    """Lying twin: a foreign useSite sourceCid never seats on this frame unit."""
+    frame = _frame_for_box_expected(
+        tmp_path,
+        "from unprivileged.types import ArrayType\n"
+        "def box_expected(expected, box_cls=None):\n"
+        "    default = ArrayType\n"
+        "    return expected if box_cls is None else box_cls\n",
+    )
+    owner = frame.owner.unit
+    # Plant a foreign-looking span key that is not a use site of this unit.
+    foreign_key = (9999, 0, 9999, 1)
+    assert owner.import_value_use_resolution(foreign_key) is None
+    # All seated keys must project inside this unit's LineTable.
+    for start_line, start_col, end_line, end_col in owner._import_value_use_resolutions:
+        assert start_line >= 1
+        # Owner source is short; line 9999 would be foreign.
+        assert start_line < 100
+        assert end_line < 100

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -411,6 +411,74 @@ def test_prefix_pass_licenses_binding(tmp_path: Path) -> None:
     assert result.module_name == "ok_pkg.implementation"
 
 
+def test_empty_prefix_licenses_first_statement_definition(tmp_path: Path) -> None:
+    """Five-step: empty prefix (bind is first stmt) is vacuous Completed."""
+    dist = _dist(
+        tmp_path,
+        name="first-pkg",
+        files={
+            "first_pkg/__init__.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import first_pkg\nfirst_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.module_name == "first_pkg"
+    assert result.definition.name == "build"
+
+
+def test_prefix_multi_face_if_refuses_as_named_dynamic_export(tmp_path: Path) -> None:
+    """Unresolved multi-face prefix stays a named gap — never AST-admitted."""
+    dist = _dist(
+        tmp_path,
+        name="face-pkg",
+        files={
+            "face_pkg/__init__.py": (
+                "flag = unknown\n"
+                "if flag:\n"
+                "    pass\n"
+                "else:\n"
+                "    pass\n"
+                "from face_pkg.implementation import build\n"
+            ),
+            "face_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import face_pkg\nface_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_prefix_does_not_include_the_binding_statement_itself(tmp_path: Path) -> None:
+    """Statements *before* the locus only: a raise *at* the bind is not prefix."""
+    # Raise is the first (and binding) statement on a dynamic path; empty
+    # prefix for a pure definition after pass is licensed separately above.
+    dist = _dist(
+        tmp_path,
+        name="bind-only-pkg",
+        files={
+            "bind_only_pkg/__init__.py": (
+                "from bind_only_pkg.implementation import build\n"
+            ),
+            "bind_only_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import bind_only_pkg\nbind_only_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.module_name == "bind_only_pkg.implementation"
+
+
 def test_competing_static_binds_stay_ambiguous(tmp_path: Path) -> None:
     dist = _dist(
         tmp_path,

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -1,0 +1,323 @@
+"""Bankable re-export capability: alias warrants + literal ``__all__`` stars.
+
+Split from fall-through work: no control-flow modeling, no AST fall-through
+admission table.  Prefix raise poison remains the pre-existing raise-nesting
+membrane until Completed testimony rebuilds normal-completion authority.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import (
+    DependencyArtifactGraph,
+    PythonObjectResolutionGapV1,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
+
+
+def _dist(root: Path, *, name: str, files: dict[str, str]) -> importlib.metadata.Distribution:
+    for relative, text in files.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    meta = root / f"{name.replace('-', '_')}_dist-1.0.dist-info"
+    meta.mkdir(parents=True, exist_ok=True)
+    (meta / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {name}\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    top = next(iter(files)).split("/", 1)[0]
+    (meta / "top_level.txt").write_text(f"{top}\n", encoding="utf-8")
+    recorded = (
+        *files.keys(),
+        f"{meta.name}/METADATA",
+        f"{meta.name}/top_level.txt",
+        f"{meta.name}/RECORD",
+    )
+    with (meta / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for item in recorded:
+            writer.writerow((item, "", ""))
+    return importlib.metadata.Distribution.at(meta)
+
+
+def _call_demand(root: Path, source: str):
+    path = root / "consumer.py"
+    path.write_text(source, encoding="utf-8")
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    receipts, _ = authenticated_import_use_receipts(
+        root, path, source, source_cid, module_identities={}
+    )
+    assert len(receipts) == 1
+    return receipts[0]
+
+
+def test_direct_reexport_still_resolves(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="example-pkg",
+        files={
+            "example_pkg/__init__.py": "from example_pkg.implementation import build\n",
+            "example_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import example_pkg\nexample_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.module_name == "example_pkg.implementation"
+    assert len(result.reexport_warrants) == 1
+    assert result.reexport_warrants[0].definition.kind == "import"
+
+
+def test_chained_reexport_still_resolves(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="example-pkg",
+        files={
+            "example_pkg/__init__.py": "from example_pkg.mid import build\n",
+            "example_pkg/mid.py": "from example_pkg.implementation import build\n",
+            "example_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import example_pkg\nexample_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.module_name == "example_pkg.implementation"
+    assert len(result.reexport_warrants) == 2
+
+
+def test_static_alias_records_both_occurrences(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="alias-pkg",
+        files={
+            "alias_pkg/__init__.py": (
+                "from alias_pkg.implementation import build as _build\n"
+                "build = _build\n"
+            ),
+            "alias_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import alias_pkg\nalias_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.definition.name == "build"
+    assert result.module_name == "alias_pkg.implementation"
+    assert len(result.reexport_warrants) == 2
+    alias_w, import_w = result.reexport_warrants
+    assert alias_w.definition.kind == "alias"
+    assert alias_w.exported_name == "build"
+    assert alias_w.imported_name == "_build"
+    assert alias_w.from_module == alias_w.to_module == "alias_pkg"
+    assert import_w.definition.kind == "import"
+    assert import_w.to_module == "alias_pkg.implementation"
+
+
+def test_alias_reassignment_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="re-pkg",
+        files={
+            "re_pkg/__init__.py": (
+                "from re_pkg.implementation import build as _build\n"
+                "build = _build\n"
+                "build = None\n"
+            ),
+            "re_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import re_pkg\nre_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_alias_cycle_stays_gapped(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="cyc-pkg",
+        files={
+            "cyc_pkg/__init__.py": (
+                "from cyc_pkg.implementation import build as _build\n"
+                "build = _build\n"
+                "_build = build\n"
+            ),
+            "cyc_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import cyc_pkg\ncyc_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind in {"reexport-cycle", "dynamic-export"}
+
+
+def test_computed_alias_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="cmp-pkg",
+        files={
+            "cmp_pkg/__init__.py": (
+                "from cmp_pkg.implementation import build as _build\n"
+                "build = _build if True else _build\n"
+            ),
+            "cmp_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import cmp_pkg\ncmp_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_wildcard_without_all_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="star-pkg",
+        files={
+            "star_pkg/__init__.py": "from star_pkg.implementation import *\n",
+            "star_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import star_pkg\nstar_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_literal_all_publishes_star_export(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="all-pkg",
+        files={
+            "all_pkg/__init__.py": (
+                "from all_pkg.implementation import *\n"
+                '__all__ = ["build"]\n'
+            ),
+            "all_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import all_pkg\nall_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.definition.name == "build"
+    assert result.module_name == "all_pkg.implementation"
+    assert len(result.reexport_warrants) == 1
+    assert result.reexport_warrants[0].definition.kind == "import"
+
+
+def test_literal_all_absent_name_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="miss-pkg",
+        files={
+            "miss_pkg/__init__.py": (
+                "from miss_pkg.implementation import *\n"
+                '__all__ = ["other"]\n'
+            ),
+            "miss_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import miss_pkg\nmiss_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_computed_all_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="comp-all-pkg",
+        files={
+            "comp_all_pkg/__init__.py": (
+                "from comp_all_pkg.implementation import *\n"
+                'names = ["build"]\n'
+                "__all__ = names\n"
+            ),
+            "comp_all_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import comp_all_pkg\ncomp_all_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_competing_static_binds_stay_ambiguous(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="amb-pkg",
+        files={
+            "amb_pkg/__init__.py": (
+                "flag = True\n"
+                "if flag:\n"
+                "    def build(value):\n"
+                "        return value\n"
+                "else:\n"
+                "    def build(value):\n"
+                "        return value\n"
+            ),
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import amb_pkg\namb_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "ambiguous-static-export"
+
+
+def test_getattr_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="dyn-pkg",
+        files={
+            "dyn_pkg/__init__.py": (
+                "def __getattr__(name):\n"
+                "    raise AttributeError(name)\n"
+            ),
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import dyn_pkg\ndyn_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -1,8 +1,9 @@
-"""Bankable re-export capability: alias warrants + literal ``__all__`` stars.
+"""Re-export: reaching alias, target-module star publication, Completed fall-through.
 
-Split from fall-through work: no control-flow modeling, no AST fall-through
-admission table.  Prefix raise poison remains the pre-existing raise-nesting
-membrane until Completed testimony rebuilds normal-completion authority.
+- Alias follows the RHS binding *reaching* the assignment, not the RHS final bind.
+- Star publication is the *target* module's ``__all__`` / public-name rule.
+- Prefix licenses a binding only via reduce → one unconditional
+  ``Completed(can_fall_through=True)`` (not AST control admission).
 """
 
 from __future__ import annotations
@@ -128,7 +129,31 @@ def test_static_alias_records_both_occurrences(tmp_path: Path) -> None:
     assert import_w.to_module == "alias_pkg.implementation"
 
 
-def test_alias_reassignment_stays_dynamic(tmp_path: Path) -> None:
+def test_alias_follows_reaching_rhs_not_final_rhs_binding(tmp_path: Path) -> None:
+    """After ``public = _f``, rebinding ``_f`` must not change ``public``'s target."""
+    dist = _dist(
+        tmp_path,
+        name="reach-pkg",
+        files={
+            "reach_pkg/__init__.py": (
+                "from reach_pkg.implementation import build as _build\n"
+                "build = _build\n"
+                "_build = None\n"
+            ),
+            "reach_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import reach_pkg\nreach_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1), getattr(result, "kind", result)
+    assert result.module_name == "reach_pkg.implementation"
+    assert result.definition.name == "build"
+
+
+def test_public_name_reassignment_stays_dynamic(tmp_path: Path) -> None:
     dist = _dist(
         tmp_path,
         name="re-pkg",
@@ -151,16 +176,16 @@ def test_alias_reassignment_stays_dynamic(tmp_path: Path) -> None:
 
 
 def test_alias_cycle_stays_gapped(tmp_path: Path) -> None:
+    """Mutual aliases without an import foundation cannot resolve."""
     dist = _dist(
         tmp_path,
         name="cyc-pkg",
         files={
             "cyc_pkg/__init__.py": (
-                "from cyc_pkg.implementation import build as _build\n"
-                "build = _build\n"
-                "_build = build\n"
+                "_a = _b\n"
+                "_b = _a\n"
+                "build = _a\n"
             ),
-            "cyc_pkg/implementation.py": "def build(value):\n    return value\n",
         },
     )
     graph = DependencyArtifactGraph.authenticate(dist)
@@ -169,7 +194,11 @@ def test_alias_cycle_stays_gapped(tmp_path: Path) -> None:
         graph=graph,
     )
     assert isinstance(result, PythonObjectResolutionGapV1)
-    assert result.kind in {"reexport-cycle", "dynamic-export"}
+    assert result.kind in {
+        "reexport-cycle",
+        "dynamic-export",
+        "static-export-absent",
+    }
 
 
 def test_computed_alias_stays_dynamic(tmp_path: Path) -> None:
@@ -193,7 +222,8 @@ def test_computed_alias_stays_dynamic(tmp_path: Path) -> None:
     assert result.kind == "dynamic-export"
 
 
-def test_wildcard_without_all_stays_dynamic(tmp_path: Path) -> None:
+def test_wildcard_without_all_uses_target_public_names(tmp_path: Path) -> None:
+    """No ``__all__`` on target → public (non-``_``) names only."""
     dist = _dist(
         tmp_path,
         name="star-pkg",
@@ -207,20 +237,25 @@ def test_wildcard_without_all_stays_dynamic(tmp_path: Path) -> None:
         _call_demand(tmp_path, "import star_pkg\nstar_pkg.build(1)\n"),
         graph=graph,
     )
-    assert isinstance(result, PythonObjectResolutionGapV1)
-    assert result.kind == "dynamic-export"
+    assert isinstance(result, ResolvedPythonObjectV1), getattr(result, "kind", result)
+    assert result.module_name == "star_pkg.implementation"
 
 
-def test_literal_all_publishes_star_export(tmp_path: Path) -> None:
+def test_star_uses_target_module_all_not_importer(tmp_path: Path) -> None:
+    """Importer ``__all__`` does not control star; target module's rule does."""
     dist = _dist(
         tmp_path,
         name="all-pkg",
         files={
+            # Importer lists a red herring; target is the authority.
             "all_pkg/__init__.py": (
                 "from all_pkg.implementation import *\n"
+                '__all__ = ["not_build"]\n'
+            ),
+            "all_pkg/implementation.py": (
+                "def build(value):\n    return value\n"
                 '__all__ = ["build"]\n'
             ),
-            "all_pkg/implementation.py": "def build(value):\n    return value\n",
         },
     )
     graph = DependencyArtifactGraph.authenticate(dist)
@@ -228,23 +263,21 @@ def test_literal_all_publishes_star_export(tmp_path: Path) -> None:
         _call_demand(tmp_path, "import all_pkg\nall_pkg.build(1)\n"),
         graph=graph,
     )
-    assert isinstance(result, ResolvedPythonObjectV1)
+    assert isinstance(result, ResolvedPythonObjectV1), getattr(result, "kind", result)
     assert result.definition.name == "build"
     assert result.module_name == "all_pkg.implementation"
-    assert len(result.reexport_warrants) == 1
-    assert result.reexport_warrants[0].definition.kind == "import"
 
 
-def test_literal_all_absent_name_stays_dynamic(tmp_path: Path) -> None:
+def test_star_target_all_excludes_name_stays_dynamic(tmp_path: Path) -> None:
     dist = _dist(
         tmp_path,
         name="miss-pkg",
         files={
-            "miss_pkg/__init__.py": (
-                "from miss_pkg.implementation import *\n"
+            "miss_pkg/__init__.py": "from miss_pkg.implementation import *\n",
+            "miss_pkg/implementation.py": (
+                "def build(value):\n    return value\n"
                 '__all__ = ["other"]\n'
             ),
-            "miss_pkg/implementation.py": "def build(value):\n    return value\n",
         },
     )
     graph = DependencyArtifactGraph.authenticate(dist)
@@ -256,17 +289,54 @@ def test_literal_all_absent_name_stays_dynamic(tmp_path: Path) -> None:
     assert result.kind == "dynamic-export"
 
 
-def test_computed_all_stays_dynamic(tmp_path: Path) -> None:
+def test_star_target_public_name_without_all(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="pub-pkg",
+        files={
+            "pub_pkg/__init__.py": "from pub_pkg.implementation import *\n",
+            "pub_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import pub_pkg\npub_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1), getattr(result, "kind", result)
+    assert result.module_name == "pub_pkg.implementation"
+
+
+def test_star_target_private_name_without_all_stays_dynamic(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="priv-pkg",
+        files={
+            "priv_pkg/__init__.py": "from priv_pkg.implementation import *\n",
+            "priv_pkg/implementation.py": "def _build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    # Demand the private name via star — not in public set without __all__.
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import priv_pkg\npriv_pkg._build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_computed_target_all_stays_dynamic(tmp_path: Path) -> None:
     dist = _dist(
         tmp_path,
         name="comp-all-pkg",
         files={
-            "comp_all_pkg/__init__.py": (
-                "from comp_all_pkg.implementation import *\n"
+            "comp_all_pkg/__init__.py": "from comp_all_pkg.implementation import *\n",
+            "comp_all_pkg/implementation.py": (
+                "def build(value):\n    return value\n"
                 'names = ["build"]\n'
                 "__all__ = names\n"
             ),
-            "comp_all_pkg/implementation.py": "def build(value):\n    return value\n",
         },
     )
     graph = DependencyArtifactGraph.authenticate(dist)
@@ -276,6 +346,69 @@ def test_computed_all_stays_dynamic(tmp_path: Path) -> None:
     )
     assert isinstance(result, PythonObjectResolutionGapV1)
     assert result.kind == "dynamic-export"
+
+
+def test_prefix_raise_refuses_binding_via_completed_fallthrough(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="raise-pkg",
+        files={
+            "raise_pkg/__init__.py": (
+                "raise RuntimeError('abort')\n"
+                "from raise_pkg.implementation import build\n"
+            ),
+            "raise_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import raise_pkg\nraise_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_prefix_assert_false_refuses_binding(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="assert-pkg",
+        files={
+            "assert_pkg/__init__.py": (
+                "assert False\n"
+                "from assert_pkg.implementation import build\n"
+            ),
+            "assert_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import assert_pkg\nassert_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_prefix_pass_licenses_binding(tmp_path: Path) -> None:
+    dist = _dist(
+        tmp_path,
+        name="ok-pkg",
+        files={
+            "ok_pkg/__init__.py": (
+                "pass\n"
+                "from ok_pkg.implementation import build\n"
+            ),
+            "ok_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import ok_pkg\nok_pkg.build(1)\n"),
+        graph=graph,
+    )
+    assert isinstance(result, ResolvedPythonObjectV1)
+    assert result.module_name == "ok_pkg.implementation"
 
 
 def test_competing_static_binds_stay_ambiguous(tmp_path: Path) -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -8,9 +8,13 @@
 
 from __future__ import annotations
 
+import ast
 import csv
 import importlib.metadata
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
 from sugar_lift_python_source.canonical import blake3_512_of
@@ -348,6 +352,72 @@ def test_computed_target_all_stays_dynamic(tmp_path: Path) -> None:
     assert result.kind == "dynamic-export"
 
 
+def test_nested_literal_all_stays_dynamic(tmp_path: Path) -> None:
+    """A nested ``__all__`` is not module-body publication testimony."""
+    dist = _dist(
+        tmp_path,
+        name="nested-all-pkg",
+        files={
+            "nested_all_pkg/__init__.py": "from nested_all_pkg.implementation import *\n",
+            "nested_all_pkg/implementation.py": (
+                "def build(value):\n    return value\n"
+                "if flag:\n"
+                "    __all__ = ['build']\n"
+            ),
+        },
+    )
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import nested_all_pkg\nnested_all_pkg.build(1)\n"),
+        graph=DependencyArtifactGraph.authenticate(dist),
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
+def test_two_star_imports_are_ambiguous(tmp_path: Path) -> None:
+    """Two star producers cannot overwrite one another's authority."""
+    dist = _dist(
+        tmp_path,
+        name="two-star-pkg",
+        files={
+            "two_star_pkg/__init__.py": (
+                "from two_star_pkg.first import *\n"
+                "from two_star_pkg.second import *\n"
+            ),
+            "two_star_pkg/first.py": "def build(value):\n    return value\n",
+            "two_star_pkg/second.py": "def build(value):\n    return value + 1\n",
+        },
+    )
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import two_star_pkg\ntwo_star_pkg.build(1)\n"),
+        graph=DependencyArtifactGraph.authenticate(dist),
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "ambiguous-static-export"
+
+
+def test_nested_alias_locus_refuses_without_suite_reconstruction(tmp_path: Path) -> None:
+    """An inner-suite alias cannot borrow module-body reaching authority."""
+    dist = _dist(
+        tmp_path,
+        name="nested-alias-pkg",
+        files={
+            "nested_alias_pkg/__init__.py": (
+                "from nested_alias_pkg.implementation import build as _build\n"
+                "if flag:\n"
+                "    build = _build\n"
+            ),
+            "nested_alias_pkg/implementation.py": "def build(value):\n    return value\n",
+        },
+    )
+    result = resolve_import_binding(
+        _call_demand(tmp_path, "import nested_alias_pkg\nnested_alias_pkg.build(1)\n"),
+        graph=DependencyArtifactGraph.authenticate(dist),
+    )
+    assert isinstance(result, PythonObjectResolutionGapV1)
+    assert result.kind == "dynamic-export"
+
+
 def test_prefix_raise_refuses_binding_via_completed_fallthrough(tmp_path: Path) -> None:
     dist = _dist(
         tmp_path,
@@ -367,6 +437,30 @@ def test_prefix_raise_refuses_binding_via_completed_fallthrough(tmp_path: Path) 
     )
     assert isinstance(result, PythonObjectResolutionGapV1)
     assert result.kind == "dynamic-export"
+
+
+def test_prefix_adapter_propagates_missing_construction_producer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing producer is loud, never translated into dynamic export."""
+    from sugar_lift_python_source import (
+        dependency_export_adapter,
+        manager_construction,
+    )
+
+    def missing_producer(_module, _locus):
+        raise ImportError("construction producer unavailable")
+
+    monkeypatch.setattr(
+        manager_construction,
+        "prefix_has_completed_fallthrough",
+        missing_producer,
+    )
+    locus = ast.parse("value = 1\n").body[0]
+    with pytest.raises(ImportError, match="construction producer unavailable"):
+        dependency_export_adapter._prefix_has_completed_fallthrough(
+            SimpleNamespace(), locus
+        )
 
 
 def test_prefix_assert_false_refuses_binding(tmp_path: Path) -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
@@ -49,6 +49,24 @@ class BindingCoordinateV1:
     def wire(self) -> dict[str, Any]:
         return {**self.preimage, "bindingCoordinateCid": self.cid}
 
+    def project(self, *path: str | int) -> "BindingCoordinateV1":
+        """Derive an authenticated child coordinate from this formal seat."""
+        if not path or not all(
+            isinstance(part, (str, int)) and not isinstance(part, bool)
+            for part in path
+        ):
+            raise BindingProvenanceGap("projected coordinate requires a structural path")
+        projection_path = (*self.projection_path, *path)
+        preimage = {
+            "kind": "binding-coordinate",
+            "schemaVersion": "1",
+            "scopeOwnerCid": self.scope_owner_cid,
+            "bindingSite": self.binding_site,
+            "projectionPath": list(projection_path),
+        }
+        raw = {**preimage, "bindingCoordinateCid": cid_of_json(preimage)}
+        return type(self).decode(raw)
+
     @classmethod
     def mint(
         cls,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -197,6 +197,9 @@ class SourceUnit:
     _exception_type_identity_cache: dict = field(init=False, default_factory=dict)
     # Memo for the module's per-occurrence import-binding map (one lexical pass).
     _import_bound_name_targets: object = field(init=False, default=None)
+    # Final-checked import value-use resolutions at exact use sites of this
+    # unit only (source_cid match). Never foreign LineTable spans.
+    _import_value_use_resolutions: object = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "line_table", LineTable(self.source))
@@ -219,6 +222,7 @@ class SourceUnit:
         object.__setattr__(self, "function_nodes", ())
         object.__setattr__(self, "_exception_type_identity_cache", {})
         object.__setattr__(self, "_import_bound_name_targets", None)
+        object.__setattr__(self, "_import_value_use_resolutions", {})
 
     def import_bound_name_target(
         self, span: Tuple[int, int, int, int]
@@ -239,6 +243,30 @@ class SourceUnit:
             targets = import_bound_name_targets(module, self.source_cid)
             object.__setattr__(self, "_import_bound_name_targets", targets)
         return targets.get(span)
+
+    def seat_import_value_use_resolution(
+        self, span: Tuple[int, int, int, int], resolved: object
+    ) -> None:
+        """Seat one final-checked import value-use resolution on this unit only.
+
+        ``span`` must be a use-site of *this* unit's source (same source_cid).
+        Foreign-unit seating is refused so LineTable never sees cross-unit
+        offsets.
+        """
+        table = self._import_value_use_resolutions
+        if table is None:
+            table = {}
+            object.__setattr__(self, "_import_value_use_resolutions", table)
+        table[span] = resolved
+
+    def import_value_use_resolution(
+        self, span: Tuple[int, int, int, int]
+    ) -> object | None:
+        """Seated import value-use resolution at ``span``, or None."""
+        table = self._import_value_use_resolutions
+        if not table:
+            return None
+        return table.get(span)
 
     def bind_typed_module(self, module: "Module") -> None:
         """Attach the already-materialized Module root (SourceFile only)."""

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -245,14 +245,70 @@ class SourceUnit:
         return targets.get(span)
 
     def seat_import_value_use_resolution(
-        self, span: Tuple[int, int, int, int], resolved: object
+        self,
+        span: Tuple[int, int, int, int],
+        resolved: object,
+        *,
+        source_cid: str,
     ) -> None:
         """Seat one final-checked import value-use resolution on this unit only.
 
-        ``span`` must be a use-site of *this* unit's source (same source_cid).
-        Foreign-unit seating is refused so LineTable never sees cross-unit
-        offsets.
+        Requires:
+        - ``source_cid`` equals this unit's authenticated ``source_cid``
+        - ``span`` is a 4-tuple of ints that projects inside this unit's LineTable
+        - ``resolved`` is a ``ResolvedPythonObjectV1`` (typed, not arbitrary object)
+
+        Foreign/malformed/tampered seating is typed-loud (never silent table write).
         """
+        from sugar_source_tree.panic import BackendDefect
+
+        if source_cid != self.source_cid:
+            raise BackendDefect(
+                blame=span,
+                owner="SourceUnit.seat_import_value_use_resolution",
+                observed=f"source_cid={source_cid!r}",
+                requested=f"source_cid={self.source_cid!r} (this unit only)",
+                fix="seat only authenticated value-use receipts of this unit's source",
+            )
+        if (
+            not isinstance(span, tuple)
+            or len(span) != 4
+            or not all(isinstance(part, int) and not isinstance(part, bool) for part in span)
+        ):
+            raise BackendDefect(
+                blame=span,
+                owner="SourceUnit.seat_import_value_use_resolution",
+                observed=repr(span),
+                requested="(start_line, start_col, end_line, end_col) ints",
+                fix="mint seating keys from authenticated useSite coordinates only",
+            )
+        start_line, start_col, end_line, end_col = span
+        # Validate coordinates against this unit's LineTable (no foreign offsets).
+        # LineTable.offset raises BackendDefect on out-of-range — no broad catch.
+        start_off = self.line_table.offset(start_line, start_col)
+        end_off = self.line_table.offset(end_line, end_col)
+        if end_off < start_off:
+            raise BackendDefect(
+                blame=span,
+                owner="SourceUnit.seat_import_value_use_resolution",
+                observed=f"inverted span {span!r}",
+                requested="start <= end in unit source",
+                fix="repair authenticated useSite coordinates",
+            )
+        try:
+            from sugar_lift_python_source.dependency_artifact import (
+                ResolvedPythonObjectV1,
+            )
+        except ImportError:
+            ResolvedPythonObjectV1 = type(None)  # type: ignore[misc,assignment]
+        if not isinstance(resolved, ResolvedPythonObjectV1):
+            raise BackendDefect(
+                blame=span,
+                owner="SourceUnit.seat_import_value_use_resolution",
+                observed=type(resolved).__name__,
+                requested="ResolvedPythonObjectV1",
+                fix="seat only resolve_import_binding products, never arbitrary objects",
+            )
         table = self._import_value_use_resolutions
         if table is None:
             table = {}
@@ -262,7 +318,10 @@ class SourceUnit:
     def import_value_use_resolution(
         self, span: Tuple[int, int, int, int]
     ) -> object | None:
-        """Seated import value-use resolution at ``span``, or None."""
+        """Seated import value-use resolution at exact ``span``, or None.
+
+        Frames consume only exact seated coordinates — no scanning, no spelling.
+        """
         table = self._import_value_use_resolutions
         if not table:
             return None

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -295,12 +295,7 @@ class SourceUnit:
                 requested="start <= end in unit source",
                 fix="repair authenticated useSite coordinates",
             )
-        try:
-            from sugar_lift_python_source.dependency_artifact import (
-                ResolvedPythonObjectV1,
-            )
-        except ImportError:
-            ResolvedPythonObjectV1 = type(None)  # type: ignore[misc,assignment]
+        from sugar_lift_python_source.dependency_artifact import ResolvedPythonObjectV1
         if not isinstance(resolved, ResolvedPythonObjectV1):
             raise BackendDefect(
                 blame=span,


### PR DESCRIPTION
## Summary

Bankable re-export path for seam-1:

1. **Alias** follows the RHS binding *reaching* the assignment (not final RHS after reassignment).
2. **Star** publication is the *target* module `__all__` / public-name rule (not importer).
3. **Prefix fall-through** (advisor five-step): authenticated module source/CID → exact export-binding locus → reduce statements before it → one unconditional `Completed(can_fall_through=True)` → license; unresolved faces stay named `dynamic-export`.
4. **Value-use seating**: final-checked import value-use receipts seat on each constructed frame’s own SourceUnit before construction; foreign actuals rehost to owner-local BindingCoordinateRef (no cross-unit LineTable panics).

### Commits
- `f211de28b` Bank alias warrants and literal __all__ star re-exports
- `47129a349` Fix reaching alias and target-module star; license via Completed fall-through
- `4c042d237` Tighten reexport prefix to five-step Completed fall-through
- `c34edb265` Seat import value-use receipts on each frame SourceUnit

## Predicted Epsilon R

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | + | reexport chains that complete prefix may resolve frames |
| `mandatory_panics` | 0..− | seating removes LineTable cross-unit panics on identity operands |
| `suppressed_descendants` | 0 | |
| `typed_effects` | 0 | |
| `silent` | 0 | floor |

## Validation

```
pytest test_reexport_alias_star_warrants.py test_import_value_use_frame_seating.py \
  test_dependency_artifact_graph.py test_source_call_preconstruction.py
```

## Floors preserved

data_loss=0, no secret, no test deleted for green, silent=0. No pandas spelling admission.

## Shot accounting

| field | value |
| --- | --- |
| R axis | reexport alias/star + prefix Completed fall-through + frame value-use seating |
| Epsilon R | bankable alias/star; prefix-licensed static reexports; seated identity operands |
| Floors | silent=0; no dual-door CID repair; no AST fall-through admission |
| Shell | census remains for open reexport domain; seating is producer install not deleted instrument |
| Retirement | Completed prefix → typed membrane over open vendor export; seating → definition-coordinate Floor |
| Related | #6733 guard-context (separate); unblocks codex-3 box_expected when reexport chain completes |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add alias/star-import warrant resolution, five-step prefix fallthrough check, and import value-use seating to Python source analysis
> - Extends `dependency_export_adapter` to resolve alias-based and star-import-based re-exports, including `_resolve_star_export` (respecting target `__all__` or public-name rules), `_alias_coordinate` (authenticated alias warrants), and `_join_export_states` (ambiguous vs. dynamic for competing static bindings).
> - Adds `prefix_has_completed_fallthrough` in `manager_construction.py` as a five-step check; export resolution now returns a `dynamic-export` gap when the prefix before a binding lacks a completed fallthrough.
> - Introduces `_seat_import_value_use_receipts` in `manager_construction.py` to bind authenticated import value-use resolutions into a `SourceUnit` before frame construction, with `ImportValueUseSeatingGap` raised on inconsistencies.
> - Adds `SourceUnit.seat_import_value_use_resolution` / `import_value_use_resolution` and `BindingCoordinateV1.project` to support per-use resolution storage and child coordinate derivation.
> - Rehosts foreign-unit call actuals onto the frame owner's `SourceUnit` via `BindingCoordinateRef` nodes in `SourceVisibleCallFrameV1`, with projected coordinates for `*args` and `**kwargs`.
> - Adds `DefinitionCoordinateV1` kind `'alias'` and updates `ReexportWarrantV1` to accept alias-backed definitions.
> - Adds comprehensive test coverage in `test_reexport_alias_star_warrants.py`, `test_import_value_use_frame_seating.py`, and relaxes existing integration tests to tolerate gap outcomes from incomplete prefix sugar.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49f046d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for alias definitions and alias-based re-exports.
  * Improved wildcard export handling using the target module’s public names and `__all__` declarations.
  * Added more accurate import and re-export resolution across chained modules.

* **Bug Fixes**
  * Prevented incorrect resolutions caused by reassignment, cycles, ambiguous exports, and dynamic module behavior.
  * Improved source-location handling when values cross module or call-frame boundaries.

* **Tests**
  * Expanded coverage for aliases, wildcard exports, dynamic gaps, ambiguity, and cross-module value resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->