### PR TITLE
Project authenticated AsyncWith manager calls for publication

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -2565,13 +2565,15 @@ def _projected_manager_call_uses(source_file):
     from sugar_lift_py_tests.context_manager_resolution import (
         SourceFragmentCoordinateV1,
     )
-    from sugar_source_tree.nodes import Call, With
+    from sugar_source_tree.nodes import AsyncWith, Call, With
+
+    manager_scope_types = (With, AsyncWith)
 
     uses = {}
 
     def collect(root, *, projected_names: bool) -> None:
         for node in root.walk():
-            if not isinstance(node, With):
+            if not isinstance(node, manager_scope_types):
                 continue
             for item in node.items:
                 expr = item.context_expr

--- a/implementations/python/sugar-lift-python-source/tests/test_async_generator_manager_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_async_generator_manager_publication.py
@@ -1,0 +1,149 @@
+"""Publication-door laws for source-defined async generator managers.
+
+Async lifecycle consumption is deliberately outside this module.  These tests
+pin the publication boundary: direct and reaching-assignment ``AsyncWith``
+calls are projected at their authenticated use occurrence, without borrowing
+the synchronous ``With`` protocol.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+from sugar_lift_py_tests.canonicalizer import blake3_512_of
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerResolutionGapV1,
+    SourceDerivedGeneratorResourceRefV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_python_source.manager_summary_derivation import (
+    _projected_manager_call_uses,
+    populate_source_derived_resource_refs,
+)
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _tree(source: str) -> SourceFile:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    return SourceFile(
+        (
+            source,
+            "async_manager_specimen.py",
+            blake3_512_of(source.encode("utf-8")),
+        ),
+        construction_context=context,
+    )
+
+
+def test_direct_async_manager_call_enters_publication_projection():
+    tree = _tree(
+        "from resource_pkg import renamed_resource\n"
+        "async def consume():\n"
+        "    async with renamed_resource(1) as entered:\n"
+        "        return entered\n"
+    )
+
+    projected = _projected_manager_call_uses(tree)
+
+    assert len(projected) == 1
+    coordinate, call, exit_face_id = next(iter(projected.values()))
+    assert coordinate.source_cid == tree.unit.source_cid
+    assert coordinate.start_line == 3
+    assert call.kind == "Call"
+    assert exit_face_id
+
+
+def test_renamed_assigned_async_manager_stays_unprojected_without_async_substitution():
+    tree = _tree(
+        "from resource_pkg import first_resource as renamed_resource\n"
+        "async def consume():\n"
+        "    held = renamed_resource(1)\n"
+        "    async with held as entered:\n"
+        "        return entered\n"
+    )
+
+    projected = _projected_manager_call_uses(tree)
+
+    assert projected == {}
+
+
+def test_plain_async_manager_name_without_authenticated_call_stays_unprojected():
+    tree = _tree(
+        "async def consume(manager):\n"
+        "    async with manager as entered:\n"
+        "        return entered\n"
+    )
+
+    assert _projected_manager_call_uses(tree) == {}
+
+
+def _async_distribution(root: Path):
+    package = root / "resource_pkg"
+    package.mkdir()
+    files = {
+        "__init__.py": "from resource_pkg.factory import renamed_resource\n",
+        "factory.py": (
+            "from resource_pkg.wrapper import resource_manager\n"
+            "@resource_manager\n"
+            "async def renamed_resource(value):\n"
+            "    yield value\n"
+        ),
+        "wrapper.py": (
+            "class AsyncResource:\n"
+            "    def __init__(self, generator):\n"
+            "        self.generator = generator\n"
+            "    async def __aenter__(self):\n"
+            "        return await self.generator.__anext__()\n"
+            "    async def __aexit__(self, kind, value, traceback):\n"
+            "        return False\n"
+            "def resource_manager(function):\n"
+            "    def helper(*args, **kwargs):\n"
+            "        return AsyncResource(function(*args, **kwargs))\n"
+            "    return helper\n"
+        ),
+    }
+    for relative, source in files.items():
+        (package / relative).write_text(source, encoding="utf-8")
+    metadata = root / "resource_pkg_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: resource-pkg-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for relative in files:
+            writer.writerow((f"resource_pkg/{relative}", "", ""))
+        writer.writerow(("resource_pkg_dist-1.0.dist-info/METADATA", "", ""))
+        writer.writerow(("resource_pkg_dist-1.0.dist-info/RECORD", "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def test_async_generator_without_async_frame_protocol_stays_typed_gap(tmp_path: Path):
+    distribution = _async_distribution(tmp_path)
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "from resource_pkg import renamed_resource\n"
+        "async def consume():\n"
+        "    async with renamed_resource(1) as entered:\n"
+        "        return entered\n",
+        encoding="utf-8",
+    )
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(path_source(str(consumer)), construction_context=context)
+
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=consumer,
+        distribution_index={"resource_pkg": distribution},
+    )
+
+    assert len(context.source_derived_contract_refs) == 1
+    ref = next(iter(context.source_derived_contract_refs.values()))
+    assert isinstance(ref, ContextManagerResolutionGapV1)
+    assert not isinstance(ref, SourceDerivedGeneratorResourceRefV1)
+    assert context.contract_refs.native_definitions == {}


### PR DESCRIPTION
Projects direct AsyncWith Call heads through the same authenticated manager-use publication door without adding a manager-name arm.

Assigned async managers remain honestly unprojected because AsyncWith substitution is still a sacred typed panic; no synchronous generator ref or native definitions are fabricated.

Focused bpytest: 18 passed, 2 warnings (new async laws plus existing assigned With projections).

R vector: direct_async_call_projection 1 -> 0; assigned_async_substitution remains 1 and is named by AsyncContextManagerUnsupported. Floors: no Carrier/ExitSet changes, no sync lifecycle borrowing, no vendor spelling dispatch.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend `_projected_manager_call_uses` to handle `async with` context managers
> - Updates `_projected_manager_call_uses` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6728/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to check for both `With` and `AsyncWith` nodes instead of only `With`.
> - Adds a new test module covering four cases: direct async manager call projection, renamed async manager assignment, plain async manager name without an authenticated call, and async generator gap typing without the async frame protocol.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef5af78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->