### PR TITLE
Instrument contextlib source resource publication

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_contextlib_source_resource_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_contextlib_source_resource_publication.py
@@ -1,0 +1,54 @@
+"""Installed source-defined contextlib managers publish through the class door."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.canonicalizer import blake3_512_of
+from sugar_lift_py_tests.context_manager_resolution import (
+    NativeProtocolSlot,
+    SourceDerivedContextManagerRefV1,
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_python_source.manager_summary_derivation import (
+    populate_source_derived_resource_refs,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+@pytest.mark.parametrize("call", ("renamed_suppress(ValueError)", "RenamedStack()"))
+def test_installed_renamed_contextlib_class_manager_publishes_native_definitions(
+    tmp_path: Path, call: str
+):
+    source = (
+        "from contextlib import suppress as renamed_suppress\n"
+        "from contextlib import ExitStack as RenamedStack\n"
+        "def consume():\n"
+        f"    with {call}:\n"
+        "        pass\n"
+    )
+    path = tmp_path / "consumer.py"
+    path.write_text(source, encoding="utf-8")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (source, str(path), blake3_512_of(source.encode("utf-8"))),
+        construction_context=context,
+    )
+
+    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+
+    assert len(context.source_derived_contract_refs) == 1
+    receiver, ref = next(iter(context.source_derived_contract_refs.items()))
+    assert isinstance(ref, SourceDerivedContextManagerRefV1), type(ref)
+    enter = context.contract_refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_ENTER
+    )
+    exit_ = context.contract_refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_EXIT
+    )
+    assert isinstance(enter, SourceFragmentCoordinateV1)
+    assert isinstance(exit_, SourceFragmentCoordinateV1)
+    assert enter != exit_


### PR DESCRIPTION
Red publication instrument for installed renamed contextlib class managers.

Current authenticated 3.12.13 verdict: 2 failed. suppress reaches source __exit__ and remains exit-may-halt (__exit__ ExitSet); ExitStack remains force-floor (helper receiver-field projection requires one positional actual). No fallback, spelling arm, Carrier, or ExitSet change is included.

This draft intentionally banks the exact remaining producer work.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for renamed contextlib class manager source resource publication
> Adds a parametrized pytest test in [test_contextlib_source_resource_publication.py](https://github.com/TSavo/sugar/pull/6729/files#diff-740879f09329ecdbac79801f4289ea692ceb4eb9d4195a03e64710c96221d42e) covering `renamed_suppress(ValueError)` and `RenamedStack()` invocations. The test verifies that `populate_source_derived_resource_refs` produces exactly one contract ref and that both `CONTEXT_ENTER` and `CONTEXT_EXIT` slots resolve to distinct `SourceFragmentCoordinateV1` instances.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9941802.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->