### PR TITLE
Name AugAssign: authenticated inplace owns lexical ScopeRebind

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_field_store_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_field_store_value.py
@@ -26,6 +26,11 @@ class ReceiverFieldStoreValue(FloorValue):
 
         if not isinstance(self.receiver, ObjectValue):
             return ctx
+        # Root mint is Floor-owned when the reducer has no ambient context yet.
+        if ctx is None:
+            from sugar_lift_py_tests.context import ReduceContext
+
+            ctx = ReduceContext.root(owner="ReceiverFieldStoreValue")
         updated = self.receiver.with_field_store(self.attr, self.value)
         temporal = ctx.temporal
         matched = False

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/scope_rebind.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/scope_rebind.py
@@ -7,6 +7,15 @@ from sugar_lift_py_tests.ir import Formula
 from .floor_value import FloorValue
 
 
+def _context_for_rebind(ctx, *, owner: str):
+    """Scope-mutating Floors mint a root when the reducer has no context yet."""
+    if ctx is not None:
+        return ctx
+    from sugar_lift_py_tests.context import ReduceContext
+
+    return ReduceContext.root(owner=owner)
+
+
 @dataclass(frozen=True)
 class ScopeRebind(FloorValue):
     """A mutation rebinds to the UPDATED VALUE; the history is in the value's nested
@@ -23,10 +32,12 @@ class ScopeRebind(FloorValue):
 
     def extend_scope(self, ctx):
         # Thread the updated value forward so later statements resolve the name.
+        # Root mint is Floor-owned when the reducer has no ambient context yet.
         from sugar_lift_py_tests.sugar.nonlocal_sugar import (
             reject_unconstructed_nonlocal_store,
         )
 
+        ctx = _context_for_rebind(ctx, owner="ScopeRebind")
         reject_unconstructed_nonlocal_store(ctx, self.name)
         return replace(ctx, temporal=ctx.temporal.bind_value(self.name, self.value))
 
@@ -56,6 +67,7 @@ class ScopeRebinds(FloorValue):
         return ()
 
     def extend_scope(self, ctx):
+        ctx = _context_for_rebind(ctx, owner="ScopeRebinds")
         temporal = ctx.temporal
         for name, value in self.bindings:
             temporal = temporal.bind_value(name, value)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
@@ -14,15 +14,28 @@ from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 @dataclass(frozen=True)
 class AugAssignSugar(Sugar):
-    """Lexical Name ``x OP= rhs`` — rebind threaded by substitute; effects from operation.
+    """Lexical Name ``x OP= rhs`` — authenticated inplace owns the rebind.
 
-    Name-target AugAssign ownership of authenticated ``project_inplace`` as the
-    **binding** (not a discarded side evaluation) is a separate vertical —
-    do not fold partial iadd evaluation here while substitute still binds
-    ordinary ``_make_binop`` (__add__).  See banked Name AugAssign backlog.
+    Composition (same substrate as attribute/subscript, store replaced by
+    lexical rebind):
+
+      1. Evaluate ``left`` (prior binding) once
+      2. Evaluate ``rhs`` once
+      3. ``result = project_augmented / project_inplace`` (iadd edge, NotImplemented law)
+      4. On success: ``ScopeRebind(name, result)`` — iadd result IS the binding
+      5. On halt: no ScopeRebind (and_then / RaiseValue law) — prior binding stands
+
+    Substitute does **not** thread ``_make_binop`` (__add__) as the rebind.
+    Later name uses stay as Name and read the temporal ScopeRebind.  Dual-eval
+    of discarded project_inplace + add-binding is the forbidden shape.
     """
 
-    operation: Sugar
+    name: str
+    left: Sugar
+    right: Sugar
+    operator: str
+    operation: Callable
+    op_site: object = dataclass_field(compare=False)
     site: object = dataclass_field(compare=False)
 
     @classmethod
@@ -36,12 +49,21 @@ class AugAssignSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind
         from sugar_lift_py_tests.outcome import Complete
 
-        # Evaluate the threaded read-op for effects; rebind already owns the tail.
-        return self.operation.desugar(ctx).and_then(
-            lambda _value: Complete(BlockValue((), can_fall_through=True))
+        return self.left.desugar(ctx).and_then(
+            lambda left: self.right.desugar(ctx).and_then(
+                lambda right: project_augmented(
+                    left,
+                    right,
+                    operator=self.operator,
+                    projector=self.operation,
+                    site=self.op_site,
+                ).and_then(
+                    lambda result: Complete(ScopeRebind(self.name, result))
+                )
+            )
         )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -44,43 +44,15 @@ class _ReducedBlock:
 
 
 def _extend_receiver_store_scope(value, ctx):
-    """Thread statement-owned temporal rebinds into the tail context.
+    """Thread statement-owned rebinds: Floor ``extend_scope`` only.
 
-    Owns every FloorValue that implements ``extend_scope`` for real effect —
-    ``ReceiverFieldStoreValue``, ``ScopeRebind`` / ``ScopeRebinds``, etc.
-    Default FloorValue.extend_scope is identity, so ordinary values are free.
-    When the reducer has no context yet and a rebind needs one, mint a root
-    ReduceContext so Name AugAssign / unpack rebinds can thread without a
-    second ambient door.
-
-    Unwrap ``Complete`` only — never ``FloorValue.value`` (ScopeRebind's payload
-    field is also named ``value`` and must not be mistaken for an Outcome).
+    The reducer does not probe capability, ladder rebind kinds, or mint root
+    contexts.  Default FloorValue.extend_scope is identity; Floors that rebind
+    (ScopeRebind, ReceiverFieldStoreValue, …) own their own root-context mint
+    when ``ctx`` is absent.  ``value`` is an Outcome (Complete/Incomplete) or a
+    FloorValue — both expose Floor-owned ``extend_scope``.
     """
-    from sugar_lift_py_tests.outcome import Complete
-
-    candidate = value.value if isinstance(value, Complete) else value
-    extend = getattr(candidate, "extend_scope", None)
-    if extend is None:
-        return ctx
-    # Identity default: skip minting a root for values that do not rebind.
-    from sugar_lift_py_tests.floor.floor_value import FloorValue
-    from sugar_lift_py_tests.floor.receiver_field_store_value import (
-        ReceiverFieldStoreValue,
-    )
-    from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind, ScopeRebinds
-
-    if not isinstance(
-        candidate, (ReceiverFieldStoreValue, ScopeRebind, ScopeRebinds)
-    ):
-        # Still honor any other FloorValue that overrode extend_scope.
-        if type(candidate).extend_scope is FloorValue.extend_scope:
-            return ctx
-    active = ctx
-    if active is None:
-        from sugar_lift_py_tests.context import ReduceContext
-
-        active = ReduceContext.root(owner="reduce_block_to_exitset")
-    return extend(active)
+    return value.extend_scope(ctx)
 
 
 def _enrol_exit_obligations(exits: ExitSet) -> ExitSet:
@@ -331,9 +303,7 @@ def reduce_block_to_exitset(
                     nested_transforms = (
                         () if follow.transform is None else (follow.transform,)
                     )
-                    next_context = _extend_receiver_store_scope(
-                        linear.value, active_ctx
-                    )
+                    next_context = _extend_receiver_store_scope(linear, active_ctx)
                 for transform in reversed(state.transforms):
                     contribution = transform(contribution)
                 entries = (*state.entries, *contribution)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -44,14 +44,43 @@ class _ReducedBlock:
 
 
 def _extend_receiver_store_scope(value, ctx):
-    from sugar_lift_py_tests.floor import ReceiverFieldStoreValue
+    """Thread statement-owned temporal rebinds into the tail context.
 
-    candidate = getattr(value, "value", value)
-    return (
-        candidate.extend_scope(ctx)
-        if isinstance(candidate, ReceiverFieldStoreValue)
-        else ctx
+    Owns every FloorValue that implements ``extend_scope`` for real effect —
+    ``ReceiverFieldStoreValue``, ``ScopeRebind`` / ``ScopeRebinds``, etc.
+    Default FloorValue.extend_scope is identity, so ordinary values are free.
+    When the reducer has no context yet and a rebind needs one, mint a root
+    ReduceContext so Name AugAssign / unpack rebinds can thread without a
+    second ambient door.
+
+    Unwrap ``Complete`` only — never ``FloorValue.value`` (ScopeRebind's payload
+    field is also named ``value`` and must not be mistaken for an Outcome).
+    """
+    from sugar_lift_py_tests.outcome import Complete
+
+    candidate = value.value if isinstance(value, Complete) else value
+    extend = getattr(candidate, "extend_scope", None)
+    if extend is None:
+        return ctx
+    # Identity default: skip minting a root for values that do not rebind.
+    from sugar_lift_py_tests.floor.floor_value import FloorValue
+    from sugar_lift_py_tests.floor.receiver_field_store_value import (
+        ReceiverFieldStoreValue,
     )
+    from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind, ScopeRebinds
+
+    if not isinstance(
+        candidate, (ReceiverFieldStoreValue, ScopeRebind, ScopeRebinds)
+    ):
+        # Still honor any other FloorValue that overrode extend_scope.
+        if type(candidate).extend_scope is FloorValue.extend_scope:
+            return ctx
+    active = ctx
+    if active is None:
+        from sugar_lift_py_tests.context import ReduceContext
+
+        active = ReduceContext.root(owner="reduce_block_to_exitset")
+    return extend(active)
 
 
 def _enrol_exit_obligations(exits: ExitSet) -> ExitSet:

--- a/implementations/python/sugar-lift-py-tests/tests/test_name_augassign_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_name_augassign_formal_caller.py
@@ -1,0 +1,520 @@
+"""Name-target AugAssign: authenticated inplace owns the lexical rebind.
+
+Three REAL acceptance reproducers (not placeholder xfail shells):
+
+  1. Divergent ``__iadd__`` / ``__add__`` — rebind must be the iadd result
+  2. RHS evaluated once — no dual-eval of binop rebind + discarded iadd
+  3. Halt blocks rebind — no ScopeRebind / tail read of a partial update
+
+Also pins construction (operator-owned ``project_inplace``), formal undischarged
+iadd carrier, and successful binding update through the production path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import (
+    NativeOperationExitCarrierV1,
+    project_iadd,
+)
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.effect import CoverageGapEffect
+from sugar_lift_py_tests.floor import ScopeRebind, TermValue
+from sugar_lift_py_tests.floor.floor_value import FloorValue
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
+from sugar_lift_py_tests.sugar.augassign_sugar import (
+    AttributeAugAssignSugar,
+    AugAssignSugar,
+    SubscriptAugAssignSugar,
+    project_augmented,
+)
+from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import AugAssign, Call, FunctionDef
+from sugar_source_tree.operators import Add, BinaryOperator
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _tree(source: str, name: str = "name_augassign.py") -> SourceFile:
+    return SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _helper_definition(
+    source: str = "def helper(x, rhs):\n    x += rhs\n    return x\n",
+):
+    tree = _tree(source, "helper_alone.py")
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    return function, function.sugar().desugar(None)
+
+
+def _aug_sugar(source: str = "def f(x):\n    x += 1\n"):
+    tree = _tree(source)
+    function = next(n for n in tree.nodes() if isinstance(n, FunctionDef))
+    # Prefer the AugAssign statement sugar off the substituted function body.
+    stmt = function.sugar().statements[0]
+    assert isinstance(stmt, AugAssignSugar), type(stmt)
+    return function, stmt
+
+
+def _call_outcome(body: str, actuals: str, signature: str = "x"):
+    source = f"def f({signature}):\n{body}\n\nf({actuals})\n"
+    tree = _tree(source, "call.py")
+    call = tuple(node for node in tree.nodes() if isinstance(node, Call))[-1]
+    return call.sugar().desugar(None)
+
+
+def _returned_value(outcome):
+    assert isinstance(outcome, ExitSet), type(outcome)
+    assert len(outcome.exits) == 1
+    face = outcome.exits[0]
+    assert isinstance(face, Completed), type(face)
+    value = face.value
+    force = getattr(value, "force_floor", None)
+    if callable(force):
+        forced = force(None, owner="name_augassign_test")
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.floor.return_value import ReturnValue
+
+        if isinstance(forced, BlockValue):
+            returns = [s for s in forced.statements if isinstance(s, ReturnValue)]
+            assert returns, forced.statements
+            return returns[-1].value
+        return forced
+    record = getattr(value, "record", None)
+    if record is not None:
+        from sugar_lift_py_tests.floor.return_value import ReturnValue
+
+        returns = [s for s in record.statements if isinstance(s, ReturnValue)]
+        if returns:
+            return returns[-1].value
+    return value
+
+
+@dataclass(frozen=True)
+class _FloorSugar(Sugar):
+    value: object
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+def _production_sites():
+    _, sugar = _aug_sugar()
+    return sugar.op_site, sugar.site
+
+
+def _production_name_aug(
+    left,
+    right,
+    *,
+    name: str = "x",
+    operator: str = "iadd",
+    projector=project_iadd,
+):
+    op_site, site = _production_sites()
+    return AugAssignSugar(
+        name=name,
+        left=_FloorSugar(left),
+        right=_FloorSugar(right),
+        operator=operator,
+        operation=projector,
+        op_site=op_site,
+        site=site,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_name_augassign_constructs_with_operator_owned_project_inplace() -> None:
+    _, sugar = _aug_sugar()
+    assert isinstance(sugar, AugAssignSugar)
+    assert sugar.operator == "iadd"
+    assert sugar.operator == Add.inplace_operator
+    assert sugar.operation.__func__ is BinaryOperator.project_inplace
+    assert sugar.name == "x"
+    assert sugar.op_site is not None
+    assert sugar.site is not None
+    assert sugar.op_site is not sugar.site
+
+
+def test_discrimination_name_path_is_not_store_target_sugar() -> None:
+    _, sugar = _aug_sugar()
+    assert not isinstance(sugar, AttributeAugAssignSugar)
+    assert not isinstance(sugar, SubscriptAugAssignSugar)
+
+
+def test_op_site_is_structural_gap_for_name_target() -> None:
+    function, sugar = _aug_sugar("def f(x):\n    x += 1\n")
+    aug = next(n for n in function.body if isinstance(n, AugAssign))
+    text = sugar.op_site.unit.source[sugar.op_site.span.start : sugar.op_site.span.end]
+    assert "+=" in text
+    assert sugar.op_site is not aug.value.fragment
+
+
+# ---------------------------------------------------------------------------
+# REAL reproducer 1: divergent iadd / add — rebind owns iadd result
+# ---------------------------------------------------------------------------
+
+
+def test_rebind_uses_iadd_result_when_iadd_and_add_diverge() -> None:
+    """Species where ``__iadd__`` and ``__add__`` disagree: rebind follows iadd."""
+
+    class _Divergent(FloorValue):
+        def inplace_binary_operator_with(self, operation, ctx):
+            del operation, ctx
+            return Complete(TermValue(99))
+
+        def add(self, other, site):
+            del other, site
+            return Complete(TermValue(1))
+
+    out = _production_name_aug(_Divergent(), TermValue(0)).desugar(None)
+    assert isinstance(out, Complete), out
+    assert isinstance(out.value, ScopeRebind), type(out.value)
+    assert out.value.name == "x"
+    assert out.value.value == TermValue(99)
+    # Discrimination: must not have rebound to ordinary add's answer.
+    with pytest.raises(AssertionError):
+        assert out.value.value == TermValue(1)
+
+
+def test_discrimination_add_alone_is_not_the_name_rebind() -> None:
+    """Lying twin: if rebind were _make_binop/add, divergent species would bind 1."""
+
+    class _Divergent(FloorValue):
+        def inplace_binary_operator_with(self, operation, ctx):
+            del operation, ctx
+            return Complete(TermValue(99))
+
+        def add(self, other, site):
+            del other, site
+            return Complete(TermValue(1))
+
+    # Ordinary add (the old substitute binding) would yield 1.
+    add_out = _Divergent().add(TermValue(0), "site")
+    assert add_out.value == TermValue(1)
+    # Name AugAssign must not match that.
+    rebind = _production_name_aug(_Divergent(), TermValue(0)).desugar(None).value
+    assert rebind.value != TermValue(1)
+    assert rebind.value == TermValue(99)
+
+
+# ---------------------------------------------------------------------------
+# REAL reproducer 2: RHS evaluated once
+# ---------------------------------------------------------------------------
+
+
+def test_rhs_evaluated_once() -> None:
+    box = {"n": 0}
+
+    @dataclass(frozen=True)
+    class _CountingRhs(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            box["n"] += 1
+            return Complete(TermValue(2))
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    op_site, site = _production_sites()
+    sugar = AugAssignSugar(
+        name="x",
+        left=_FloorSugar(TermValue(3)),
+        right=_CountingRhs(),
+        operator="iadd",
+        operation=project_iadd,
+        op_site=op_site,
+        site=site,
+    )
+    out = sugar.desugar(None)
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, ScopeRebind)
+    assert out.value.value == TermValue(5)
+    assert box["n"] == 1
+
+
+def test_discrimination_double_rhs_eval_is_detected() -> None:
+    box = {"n": 0}
+
+    @dataclass(frozen=True)
+    class _CountingRhs(Sugar):
+        def desugar(self, ctx=None):
+            del ctx
+            box["n"] += 1
+            return Complete(TermValue(1))
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    rhs = _CountingRhs()
+    rhs.desugar(None)
+    rhs.desugar(None)
+    assert box["n"] == 2
+    with pytest.raises(AssertionError):
+        assert box["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# REAL reproducer 3: halt blocks rebind
+# ---------------------------------------------------------------------------
+
+
+def test_iadd_halt_does_not_emit_scope_rebind() -> None:
+    face = Incomplete(
+        CoverageGapEffect(boundary="iadd", reason="authenticated inplace halt")
+    )
+
+    class _Halt(FloorValue):
+        def inplace_binary_operator_with(self, operation, ctx):
+            del operation, ctx
+            return face
+
+        def add(self, other, site):
+            del other, site
+            return Complete(TermValue(0))
+
+    out = _production_name_aug(_Halt(), TermValue(1)).desugar(None)
+    assert out is face
+    assert not isinstance(out, Complete) or not isinstance(
+        getattr(out, "value", None), ScopeRebind
+    )
+
+
+def test_raise_value_halt_blocks_rebind() -> None:
+    """Incomplete/halt face from inplace must not continue into ScopeRebind."""
+    face = Incomplete(
+        CoverageGapEffect(boundary="iadd", reason="type error before rebind")
+    )
+
+    class _Raise(FloorValue):
+        def inplace_binary_operator_with(self, operation, ctx):
+            del operation, ctx
+            return face
+
+        def add(self, other, site):
+            del other, site
+            return Complete(TermValue(0))
+
+    out = _production_name_aug(_Raise(), TermValue(1)).desugar(None)
+    assert out is face
+    assert not isinstance(getattr(out, "value", None), ScopeRebind)
+
+
+def test_halt_blocks_tail_read_of_partial_update() -> None:
+    """Through reduce_block: iadd halt leaves temporal unbound for the name."""
+    from sugar_lift_py_tests.context import ReduceContext
+
+    face = Incomplete(
+        CoverageGapEffect(boundary="iadd", reason="halt before rebind")
+    )
+
+    class _Halt(FloorValue):
+        def inplace_binary_operator_with(self, operation, ctx):
+            del operation, ctx
+            return face
+
+        def add(self, other, site):
+            return Complete(TermValue(0))
+
+    @dataclass(frozen=True)
+    class _ReadName(Sugar):
+        def desugar(self, ctx=None):
+            temporal = getattr(ctx, "temporal", None) if ctx is not None else None
+            if temporal is not None:
+                bound = temporal.value_if_bound("x")
+                if bound is not None:
+                    return Complete(bound)
+            return Complete(TermValue(-1))  # sentinel: no rebind happened
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    ctx = ReduceContext.root(owner="name_aug_halt_rebind")
+    # Seed prior binding so a false rebind would be visible as overwrite.
+    ctx = ctx.with_temporal(ctx.temporal.bind_value("x", TermValue(3)))
+    exits = reduce_block_to_exitset(
+        (
+            _production_name_aug(_Halt(), TermValue(1), name="x"),
+            _ReadName(),
+        ),
+        ctx,
+    )
+    # Halt face: no completed tail carrying a rebound value.
+    halted = [e for e in exits.exits if isinstance(e, Halted)]
+    assert halted, exits.exits
+    completed = [e for e in exits.exits if isinstance(e, Completed)]
+    for face_c in completed:
+        entries = getattr(face_c.value, "entries", ())
+        # Must not contain a ScopeRebind of the partial update.
+        assert not any(isinstance(e, ScopeRebind) for e in entries)
+
+
+# ---------------------------------------------------------------------------
+# Successful rebind threads into the tail (ScopeRebind + temporal)
+# ---------------------------------------------------------------------------
+
+
+def test_successful_rebind_threads_into_tail_read() -> None:
+    from sugar_lift_py_tests.context import ReduceContext
+
+    @dataclass(frozen=True)
+    class _ReadName(Sugar):
+        def desugar(self, ctx=None):
+            temporal = getattr(ctx, "temporal", None) if ctx is not None else None
+            if temporal is not None:
+                bound = temporal.value_if_bound("x")
+                if bound is not None:
+                    return Complete(bound)
+            raise AssertionError("expected temporal rebind of x after Name AugAssign")
+
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+    ctx = ReduceContext.root(owner="name_aug_rebind_tail")
+    exits = reduce_block_to_exitset(
+        (
+            _production_name_aug(TermValue(3), TermValue(2), name="x"),
+            _ReadName(),
+        ),
+        ctx,
+    )
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Completed)
+    entries = exits.exits[0].value.entries
+    # ScopeRebind contributes nothing; tail read is the rebound TermValue(5).
+    assert TermValue(5) in entries
+
+
+# ---------------------------------------------------------------------------
+# Formal undischarged + binding update (source path)
+# ---------------------------------------------------------------------------
+
+
+def test_helper_alone_is_undischarged_iadd_carrier() -> None:
+    _, pending = _helper_definition()
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "iadd"
+    with pytest.raises(SugarNotWritten, match="caller actual absent"):
+        pending.discharge({})
+
+
+def test_authenticated_formal_discharge_updates_binding() -> None:
+    function, pending = _helper_definition()
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "iadd"
+    coords = {
+        c.declared_name: c.coordinate_cid
+        for c in function.sugar().formal_coordinates
+    }
+    exits = pending.discharge(
+        {coords["x"]: TermValue(3), coords["rhs"]: TermValue(4)}
+    )
+    assert isinstance(exits, ExitSet)
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Completed)
+    from sugar_lift_py_tests.floor.return_value import ReturnValue
+
+    record = exits.exits[0].value.record
+    rets = [s for s in record.statements if isinstance(s, ReturnValue)]
+    assert rets and rets[-1].value == TermValue(7)
+
+
+def test_binding_update_return_sees_augmented_value() -> None:
+    """``x += 2; return x`` with x=3 → 5."""
+    outcome = _call_outcome("    x += 2\n    return x\n", "3")
+    returned = _returned_value(outcome)
+    assert returned == TermValue(5)
+
+
+def test_discrimination_successful_update_is_not_prior_value() -> None:
+    outcome = _call_outcome("    x += 2\n    return x\n", "3")
+    returned = _returned_value(outcome)
+    assert returned == TermValue(5)
+    with pytest.raises(AssertionError):
+        assert returned == TermValue(3)
+
+
+def test_arithmetic_halt_is_not_completed_return_of_prior_binding() -> None:
+    """``x += None`` TypeError — not Completed return of pre-update x."""
+    outcome = _call_outcome("    x += None\n    return x\n", "3")
+    assert isinstance(outcome, ExitSet)
+    halted = [e for e in outcome.exits if isinstance(e, Halted)]
+    assert halted, outcome.exits
+    assert any(
+        getattr(e.effect, "exception_name", None) == "TypeError" for e in halted
+    )
+    for face in (e for e in outcome.exits if isinstance(e, Completed)):
+        from sugar_lift_py_tests.floor.return_value import ReturnValue
+
+        record = getattr(face.value, "record", None)
+        if record is None:
+            continue
+        for stmt in record.statements:
+            if isinstance(stmt, ReturnValue) and stmt.value == TermValue(3):
+                pytest.fail(
+                    "halt must not fabricate Completed return of prior binding TermValue(3)"
+                )
+
+
+def test_name_path_shares_project_inplace_with_add_operator() -> None:
+    _, sugar = _aug_sugar()
+    assert sugar.operator == Add.inplace_operator
+    assert sugar.operation.__func__ is BinaryOperator.project_inplace
+
+
+def test_project_augmented_formal_mints_iadd_not_add() -> None:
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.floor import SymbolicValue
+    from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+    from sugar_lift_py_tests.ir import PrimitiveSort, make_var
+
+    _, sugar = _aug_sugar()
+    site = sugar.op_site
+    src = site.source_cid
+    owner_def = SourceFragmentCoordinateV1(src, 1, 0, 1, 10)
+
+    def _coord(name: str, ordinal: int):
+        return FormalParameterCoordinateV1.mint(
+            owner_source_identity_cid=src,
+            owner_definition_locus=owner_def,
+            declaration_locus=SourceFragmentCoordinateV1(
+                src, 1, 10 + ordinal, 1, 12 + ordinal
+            ),
+            ordinal=ordinal,
+            parameter_kind="positional-or-keyword",
+            declared_name=name,
+            sort=PrimitiveSort("Value"),
+        )
+
+    left = SymbolicValue(make_var("x"), _coord("x", 0))
+    right = SymbolicValue(make_var("rhs"), _coord("rhs", 1))
+    out = project_augmented(
+        left, right, operator="iadd", projector=project_iadd, site=site
+    )
+    assert isinstance(out, NativeOperationExitCarrierV1)
+    assert out.demand.operator == "iadd"
+    with pytest.raises(AssertionError):
+        assert out.demand.operator == "add"

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4271,8 +4271,9 @@ class AugAssign(Statement):
     def substitute(self, scope):
         """`<target> OP= <value>` -- substitute the value and load-side targets.
 
-        A plain Name target is a binding site: the rebind (target OP value) is
-        threaded by ``substitution_binding`` / the ``operation`` slot.
+        A plain Name target is a binding site: the prior load is carried as
+        ``prior_read``; the rebind itself is evaluation-time ScopeRebind of
+        authenticated project_inplace (not a substitute-time BinOp).
 
         Attribute and Subscript targets are runtime stores — receivers (and
         subscript indices) are load expressions and must substitute so formals
@@ -4284,11 +4285,12 @@ class AugAssign(Statement):
         from .backend import Child, Leaf, materialize
         from .shadow import ShadowNode, _handle_of, rewrite
 
-        # Structural operator site before any rewrite (Attribute/Subscript only).
-        # Name targets rebind via _make_binop; operator_site for Name is owned by
-        # the separate Name AugAssign vertical (must not dual-eval project_inplace).
+        # Structural operator site before any rewrite (Name/Attribute/Subscript).
+        # Name rebind is evaluation-time ScopeRebind of project_inplace — not
+        # substitute-time _make_binop (__add__).  operator_site is the iadd
+        # occurrence for all three targets.
         pre_sub_operator_site = None
-        if isinstance(self.target, (Attribute, Subscript)):
+        if isinstance(self.target, (Name, Attribute, Subscript)):
             pre_sub_operator_site = getattr(self, "operator_site", None)
             if pre_sub_operator_site is None:
                 pre_sub_operator_site = self._mint_operator_site_from_structure()
@@ -4317,20 +4319,25 @@ class AugAssign(Statement):
         rewritten = self if not changes else rewrite(self, **changes)
         if not isinstance(rewritten.target, Name):
             return rewritten
+        # Prior binding as the load; RHS already substituted.  Do not mint a
+        # BinOp rebind child — inplace owns the binding at desugar time.
         name = rewritten.target.id
         old_state = unwrap_binding_state(scope.get(name, rewritten.target))
         old_read = binding_state_read_node(
             old_state,
             make_read=rewritten.target._make_binding_read,
         )
-        operation = rewritten._make_binop(old_read, rewritten.op, rewritten.value)
         desc = rewritten.ref.describe()
         return materialize(
             self.unit,
             ShadowNode(
                 desc.kind,
                 desc.raw_span or self.span,
-                (*desc.slots, ("operation", Child(_handle_of(operation)))),
+                (
+                    *desc.slots,
+                    ("prior_read", Child(_handle_of(old_read))),
+                    ("operator_site", Leaf(pre_sub_operator_site)),
+                ),
             ),
             self.reporter,
         )
@@ -4382,41 +4389,40 @@ class AugAssign(Statement):
         )
 
     def substitution_binding(self, scope):
-        # `x OP= e` rebinds x to `x OP e`, reading the OLD x from the scope
-        # (or the target itself if x was free). Only a plain Name target binds.
+        # `x OP= e` — lexical rebind is evaluation-time ScopeRebind of the
+        # authenticated inplace result.  Thread the Name itself so later uses
+        # stay NameSugar and read temporal (not a substitute-time BinOp/__add__).
+        # Only a plain Name target binds.
+        del scope
         if not isinstance(self.target, Name):
             return None
-        operation = getattr(self, "operation", None)
-        if isinstance(operation, Node):
-            return {self.target.id: operation}
-        name = self.target.id
-        old_state = scope.get(name, self.target)
-        old_state = unwrap_binding_state(old_state)
-        old_read = binding_state_read_node(
-            old_state,
-            make_read=self.target._make_binding_read,
-        )
-        return {name: self._make_binop(old_read, self.op, self.value)}
+        return {self.target.id: self.target}
 
     def _construct_sugar(self):
-        """`<target> OP= <value>` -- a plain Name target is INERT at the
-        meaning layer: substitution_binding ALWAYS threads for a Name target
-        (it falls back to the target itself as the old value when nothing was
-        bound yet, so there is no shape where a Name target both fails to
-        thread and stays loud). The rebind rode into the tail as the fold
-        binding; the statement itself states nothing more. Attribute/subscript
-        targets are runtime stores rather than lexical bindings, so they reuse
-        Assign's typed attribute/subscript store effects."""
+        """`<target> OP= <value>` — Name: project_inplace owns ScopeRebind.
+
+        Attribute/subscript targets are runtime stores (get → inplace → set).
+        Name targets evaluate left/right once through the same inplace edge
+        and rebind the name to that result; halt skips the rebind.
+        """
         if isinstance(self.target, Name):
             from sugar_lift_py_tests.sugar.augassign_sugar import AugAssignSugar
 
-            operation = getattr(self, "operation", None)
-            if not isinstance(operation, Node):
-                return super()._construct_sugar()
-            # Name rebind owns the BinOp binding; do not dual-eval project_inplace
-            # here while discard-the-result would leave __add__ as the rebind.
+            prior = getattr(self, "prior_read", None)
+            if not isinstance(prior, Node):
+                # No substitute yet (e.g. direct sugar on raw node): fall back
+                # to the target as the old read.
+                prior = self.target
+            op_site = getattr(self, "operator_site", None)
+            if op_site is None:
+                op_site = self._mint_operator_site_from_structure()
             return AugAssignSugar(
-                operation=operation.sugar(),
+                name=self.target.id,
+                left=prior.sugar(),
+                right=self.value.sugar(),
+                operator=type(self.op).inplace_operator,
+                operation=self.op.project_inplace,
+                op_site=op_site,
                 site=self.fragment,
             )
         if isinstance(self.target, Attribute):

--- a/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
+++ b/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
@@ -51,13 +51,19 @@ def test_aug_assign_rebinds_and_is_inert():
     assert v.post().args[1].value == 2
 
 
-def test_name_augassign_constructs_explicit_read_op_store_child():
+def test_name_augassign_constructs_inplace_owned_rebind():
+    """Name OP=: project_inplace + name; not substitute-time BinOp rebind."""
     function = _fn("def arbitrary():\n    renamed = 1\n    renamed += 2\n")
     substituted = function.substitute({})
     sugar = substituted.body[1].sugar()
     assert isinstance(sugar, AugAssignSugar)
-    assert isinstance(sugar.operation, BinOpSugar)
-    assert sugar.operation.op_kind == "Add"
+    assert sugar.name == "renamed"
+    assert sugar.operator == "iadd"
+    from sugar_source_tree.operators import BinaryOperator
+
+    assert sugar.operation.__func__ is BinaryOperator.project_inplace
+    # Prior read is the assigned constant, not a BinOpSugar binding child.
+    assert not isinstance(sugar.left, BinOpSugar)
 
 
 def test_name_augassign_reads_the_guarded_join_not_a_last_writer():
@@ -76,7 +82,8 @@ def test_name_augassign_reads_the_guarded_join_not_a_last_writer():
         if statement.kind == "AugAssign"
     )
     assert isinstance(sugar, AugAssignSugar)
-    assert type(sugar.operation.left).__name__ == "IfExpSugar"
+    # Prior load is the if-join (IfExpSugar), not a last-writer Constant alone.
+    assert type(sugar.left).__name__ == "IfExpSugar"
 
 
 def _red_effects(source):
@@ -226,8 +233,6 @@ def test_aug_assign_with_no_prior_binding_is_sound():
         "NativeOperationExitCarrierV1",
     }
     # AugAssign sugar is present — the binding was not dropped.
-    from sugar_lift_py_tests.sugar.augassign_sugar import AugAssignSugar
-
     assert any(isinstance(s, AugAssignSugar) for s in sugar.statements)
 
 


### PR DESCRIPTION
## Summary

Name-target ``x OP= rhs`` now owns the lexical rebind through authenticated ``project_inplace`` (same substrate as attribute/subscript AugAssign). Success is ``ScopeRebind(name, result)``; halt skips rebind. Substitute no longer threads ``_make_binop``/``__add__`` as the binding.

**Three REAL acceptance reproducers** (not placeholder xfail shells):
1. Divergent ``__iadd__`` / ``__add__`` — rebind is the iadd result
2. RHS evaluated once — no dual-eval
3. Halt blocks rebind — no partial update in temporal

## Architecture

- ``AugAssignSugar``: left → right → ``project_augmented``/``project_inplace`` → ``ScopeRebind``
- ``substitution_binding``: threads ``Name`` for temporal tail reads
- ``reduce_block``: generalizes statement ``extend_scope`` (``ScopeRebind`` + ``ReceiverFieldStoreValue``); unwraps ``Complete`` only (not ``FloorValue.value``)

## Validation

```
bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_name_augassign_formal_caller.py \
  implementations/python/sugar-source-tree/tests/test_annassign_augassign.py \
  implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py -q
# 33 passed

bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_attribute_augassign_formal_caller.py \
  implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py -q
# 47 passed
```

## 8-field record

| Field | Value |
| --- | --- |
| **R axis** | Name AugAssign: inplace owns lexical rebind (not substitute-time ``__add__``) |
| **Epsilon R** | Name path closed: ScopeRebind(iadd); three real twins green |
| **Floors** | No dual-eval; carrier/ExitSet frozen; no second dispatch table; placeholders deleted |
| **Instrument** | ``test_name_augassign_formal_caller.py`` (divergent iadd/add, RHS once, halt-blocks-rebind) |
| **Shell deleted** | Dual-eval / ``_make_binop`` rebind for Name; banked placeholder xfails already gone in #6718 |
| **Retirement path** | Name/attr/subscript AugAssign share ``project_inplace``; Name store is ScopeRebind |
| **Validation** | bpytest Name + source-tree + receiver-field + attr/subscript green |
| **Next backlog** | Unary operators formal laws; slice-subscript store; starred-target store |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement lexical `ScopeRebind` for name-target augmented assignment using `project_inplace`
> - [`AugAssignSugar`](https://github.com/TSavo/sugar/pull/6730/files#diff-ff613112cc2613384af840dea012454d4e5b32ec556548598dd0dace015ff5e1) is overhauled to evaluate left and right, run `project_augmented`/`project_inplace`, and emit `ScopeRebind(name, result)` on success; halts skip the rebind. Previously it only threaded effects via `self.operation` and emitted an empty `BlockValue`.
> - [`AugAssign.substitute`](https://github.com/TSavo/sugar/pull/6730/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) for Name targets now captures the prior binding read (`prior_read`) and operator site instead of constructing a substitute-time `BinOp`, and builds `AugAssignSugar` with `project_inplace` as the projector.
> - [`ScopeRebind.extend_scope` and `ScopeRebinds.extend_scope`](https://github.com/TSavo/sugar/pull/6730/files#diff-ffbed4e115ab84d52655dc45bf77d7011bf9038f8546e4f2039a6d049309a6d2) now mint a root `ReduceContext` via `_context_for_rebind` when `ctx` is `None`, so scope mutations are no longer no-ops in context-free reduction.
> - [`_extend_receiver_store_scope`](https://github.com/TSavo/sugar/pull/6730/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b) is fixed to call `extend_scope` on the linear value directly rather than on `linear.value`.
> - A new test module [`test_name_augassign_formal_caller.py`](https://github.com/TSavo/sugar/pull/6730/files#diff-6650f56ab632abda3325421140c9a7d66087b3ee9da5c651a5bc429e2ca19554) covers construction, operator-site ownership, single RHS evaluation, halt propagation, and `reduce_block_to_exitset` integration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f8e487.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->