### PR TITLE
Carry sealed generator bindings into pre-yield guard temporal (#6691)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -19,6 +19,18 @@ def _require_constructed_term(value: object, *, owner: str) -> None:
 
 
 @dataclass(frozen=True)
+class _GeneratorReduceCtx:
+    """Minimal reduction context for pre-yield guard / step Sugar.
+
+    Only ``temporal`` is required: BindingCoordinateRefSugar.desugar reads
+    ``ctx.temporal.value_if_bound(coordinate.cid)``.  No name map, no
+    coordinate scan, no second door.
+    """
+
+    temporal: object
+
+
+@dataclass(frozen=True)
 class YieldStepV1:
     value: ConstructedTermSugar | None
 
@@ -725,6 +737,66 @@ class GeneratorConstructionV1:
         )
         return _replace(self, steps=steps)
 
+    def _guard_evaluation_context(self):
+        """Temporal context carrying this machine's authenticated sealed bindings.
+
+        Pre-yield guards desugar BindingCoordinateRefSugar at exact formal
+        coordinates.  The producer installs only sealed BindingEntryV1 values
+        (coordinate.cid → FloorValue) and post-assign names already reduced on
+        this machine.  Absent/tampered/unsealed testimony is not installed —
+        BindingCoordinateRefSugar.desugar remains the sole refusal boundary
+        (no name lookup, coordinate scanning, or unspecialized-formal fallback
+        there).
+        """
+        from sugar_lift_py_tests.temporal.temporal_context import TemporalContext
+        from sugar_source_tree.binding_state import BindingEntryV1
+
+        temporal = TemporalContext()
+        for item in self.binding_state:
+            if isinstance(item, BindingEntryV1):
+                # Seal is mandatory at allocate; skip anything that lost it.
+                if item.constructed_value_testimony is None:
+                    continue
+                floor = self._floor_from_sealed_binding_entry(item)
+                if floor is None:
+                    continue
+                temporal = temporal.bind_value(item.coordinate.cid, floor)
+                continue
+            if isinstance(item, GeneratorAssignBindingV1):
+                # Assign already reduced to Floor on this machine; expose by name
+                # for later pre-yield steps that read the bound name.
+                if item.value is not None:
+                    temporal = temporal.bind_value(item.name, item.value)
+        return _GeneratorReduceCtx(temporal)
+
+    @staticmethod
+    def _floor_from_sealed_binding_entry(entry) -> object | None:
+        """Recover the FloorValue of one sealed formal binding.
+
+        The live Node state is the constructed actual.  It desugars without the
+        formal temporal (actuals are not BindingCoordinateRefs of *this*
+        frame).  When recovery fails, the formal stays absent and the guard
+        consumer refuses loudly.
+        """
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.sugar_base import Sugar
+        from sugar_source_tree.nodes import Node
+
+        state = entry.state
+        if not isinstance(state, Node):
+            return None
+        try:
+            sugar = state.sugar()
+        except Exception:
+            return None
+        if not isinstance(sugar, Sugar):
+            return None
+        # No formal temporal here: the actual must stand as constructed content.
+        outcome = sugar.desugar()
+        if not isinstance(outcome, Complete):
+            return None
+        return outcome.value
+
     def _guard_truth(self, guard: object):
         """The guard's TRUTH as a floor value, or None if it cannot stand.
 
@@ -734,13 +806,25 @@ class GeneratorConstructionV1:
         weaker copy of that law: `NoneValue.truth` is False, a container's is
         its non-emptiness, and a symbolic value's is a predicate. Routing
         through `truth` keeps one owner for the question.
+
+        Guard Sugar is reduced under :meth:`_guard_evaluation_context` so
+        BindingCoordinateRefSugar resolves sealed formal actuals at the exact
+        coordinate CID (and only there).
         """
         from sugar_lift_py_tests.outcome import Complete
         from sugar_lift_py_tests.sugar.sugar_base import Sugar
+        from sugar_source_tree.panic import SugarNotWritten
 
         value = guard
         if isinstance(guard, Sugar):
-            outcome = guard.desugar()
+            ctx = self._guard_evaluation_context()
+            try:
+                outcome = guard.desugar(ctx)
+            except SugarNotWritten:
+                # Unspecialized / wrong-coordinate formal: not a ground truth.
+                # Surface as undecided (None) so the branch stays a loud gap or
+                # partition path rather than inventing a default.
+                return None
             if not isinstance(outcome, Complete):
                 return None
             value = outcome.value
@@ -789,10 +873,15 @@ class GeneratorConstructionV1:
             return None
         from sugar_lift_py_tests.outcome import Complete
         from sugar_lift_py_tests.sugar.sugar_base import Sugar
+        from sugar_source_tree.panic import SugarNotWritten
 
         if not isinstance(value, Sugar):
             return value
-        outcome = value.desugar()
+        ctx = self._guard_evaluation_context()
+        try:
+            outcome = value.desugar(ctx)
+        except SugarNotWritten as exc:
+            return self._gap(requested, str(exc.observed) if hasattr(exc, "observed") else type(exc).__name__)
         if isinstance(outcome, Complete):
             return outcome.value
         return self._gap(requested, type(outcome).__name__)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -19,12 +19,24 @@ def _require_constructed_term(value: object, *, owner: str) -> None:
 
 
 @dataclass(frozen=True)
-class _GeneratorReduceCtx:
-    """Minimal reduction context for pre-yield guard / step Sugar.
+class FormalFloorBindingV1:
+    """One formal coordinate paired with its binder-produced Floor actual.
 
-    Only ``temporal`` is required: BindingCoordinateRefSugar.desugar reads
-    ``ctx.temporal.value_if_bound(coordinate.cid)``.  No name map, no
-    coordinate scan, no second door.
+    Minted at the SourceCallFrame.bind_actuals boundary: the Floor is the exact
+    object bind_actuals returned, never a consumer-side Node/Sugar rebuild.
+    """
+
+    coordinate_cid: str
+    floor_value: object = field(compare=False, repr=False)
+
+
+@dataclass(frozen=True)
+class _BinderOnlyReduceCtx:
+    """Unit-test / no-caller shell: temporal is the only field that exists.
+
+    Production allocate always carries the authenticated caller reduction
+    context and extends it.  This shell is only for allocate sites that never
+    had a caller context (focused machine twins).
     """
 
     temporal: object
@@ -410,6 +422,15 @@ class GeneratorConstructionV1:
     instance_coordinate: str
     cursor: int = 0
     suspended_resume_coordinate: str | None = None
+    # Binder-produced formal Floors (coordinate.cid → FloorValue identity).
+    # Guard temporal installs these directly — never Node.sugar()/desugar().
+    formal_floor_bindings: tuple[FormalFloorBindingV1, ...] = field(
+        default=(), compare=False, repr=False
+    )
+    # Caller reduction context preserved from CallSiteSugar.desugar; guard
+    # evaluation extends its temporal rather than fabricating a temporal-only
+    # substitute context.
+    reduction_context: object | None = field(default=None, compare=False, repr=False)
 
     @classmethod
     def allocate(
@@ -419,6 +440,8 @@ class GeneratorConstructionV1:
         frame_coordinate: str,
         binding_state: tuple[object, ...],
         steps: tuple[GeneratorStepV1, ...],
+        formal_floor_bindings: tuple[FormalFloorBindingV1, ...] = (),
+        reduction_context: object | None = None,
     ) -> "GeneratorConstructionV1":
         from sugar_source_tree.binding_state import seal_generator_binding_state_v1
 
@@ -426,6 +449,7 @@ class GeneratorConstructionV1:
         # before the instance exists. Unavailable testimony gaps here, never as
         # a delayed BindingStateWireGap on a "successfully" sealed state.
         binding_state = seal_generator_binding_state_v1(binding_state)
+        formal_floor_bindings = tuple(formal_floor_bindings)
         instance_coordinate = cid_of_json(
             {
                 "kind": "python-generator-instance",
@@ -433,6 +457,9 @@ class GeneratorConstructionV1:
                 "allocationCoordinate": allocation_coordinate,
                 "frameCoordinate": frame_coordinate,
                 "bindingState": [repr(item) for item in binding_state],
+                "formalFloorCoordinateCids": [
+                    item.coordinate_cid for item in formal_floor_bindings
+                ],
             }
         )
         return cls(
@@ -441,6 +468,8 @@ class GeneratorConstructionV1:
             binding_state=binding_state,
             steps=tuple(steps),
             instance_coordinate=instance_coordinate,
+            formal_floor_bindings=formal_floor_bindings,
+            reduction_context=reduction_context,
         )
 
     def construction_term_preimage(self) -> dict:
@@ -738,64 +767,41 @@ class GeneratorConstructionV1:
         return _replace(self, steps=steps)
 
     def _guard_evaluation_context(self):
-        """Temporal context carrying this machine's authenticated sealed bindings.
+        """Caller reduction context extended with binder-produced formal Floors.
 
-        Pre-yield guards desugar BindingCoordinateRefSugar at exact formal
-        coordinates.  The producer installs only sealed BindingEntryV1 values
-        (coordinate.cid → FloorValue) and post-assign names already reduced on
-        this machine.  Absent/tampered/unsealed testimony is not installed —
-        BindingCoordinateRefSugar.desugar remains the sole refusal boundary
-        (no name lookup, coordinate scanning, or unspecialized-formal fallback
-        there).
+        Installs each :class:`FormalFloorBindingV1` by coordinate CID into the
+        temporal table (object identity of the binder Floor).  Also installs
+        post-assign names already reduced on this machine.  Extends the
+        authenticated caller context when one was carried into allocate; never
+        fabricates a temporal-only substitute that discards caller fields.
+        BindingCoordinateRefSugar.desugar remains the sole consumer door.
         """
         from sugar_lift_py_tests.temporal.temporal_context import TemporalContext
-        from sugar_source_tree.binding_state import BindingEntryV1
 
-        temporal = TemporalContext()
+        base = self.reduction_context
+        if base is not None and hasattr(base, "temporal"):
+            temporal = base.temporal
+        else:
+            temporal = TemporalContext()
+
+        for binding in self.formal_floor_bindings:
+            temporal = temporal.bind_value(
+                binding.coordinate_cid, binding.floor_value
+            )
         for item in self.binding_state:
-            if isinstance(item, BindingEntryV1):
-                # Seal is mandatory at allocate; skip anything that lost it.
-                if item.constructed_value_testimony is None:
-                    continue
-                floor = self._floor_from_sealed_binding_entry(item)
-                if floor is None:
-                    continue
-                temporal = temporal.bind_value(item.coordinate.cid, floor)
-                continue
-            if isinstance(item, GeneratorAssignBindingV1):
-                # Assign already reduced to Floor on this machine; expose by name
-                # for later pre-yield steps that read the bound name.
-                if item.value is not None:
-                    temporal = temporal.bind_value(item.name, item.value)
-        return _GeneratorReduceCtx(temporal)
+            if isinstance(item, GeneratorAssignBindingV1) and item.value is not None:
+                temporal = temporal.bind_value(item.name, item.value)
 
-    @staticmethod
-    def _floor_from_sealed_binding_entry(entry) -> object | None:
-        """Recover the FloorValue of one sealed formal binding.
+        if base is not None and hasattr(base, "with_temporal"):
+            return base.with_temporal(temporal)
+        if base is not None:
+            from dataclasses import fields, is_dataclass, replace
 
-        The live Node state is the constructed actual.  It desugars without the
-        formal temporal (actuals are not BindingCoordinateRefs of *this*
-        frame).  When recovery fails, the formal stays absent and the guard
-        consumer refuses loudly.
-        """
-        from sugar_lift_py_tests.outcome import Complete
-        from sugar_lift_py_tests.sugar.sugar_base import Sugar
-        from sugar_source_tree.nodes import Node
-
-        state = entry.state
-        if not isinstance(state, Node):
-            return None
-        try:
-            sugar = state.sugar()
-        except Exception:
-            return None
-        if not isinstance(sugar, Sugar):
-            return None
-        # No formal temporal here: the actual must stand as constructed content.
-        outcome = sugar.desugar()
-        if not isinstance(outcome, Complete):
-            return None
-        return outcome.value
+            if is_dataclass(base) and any(f.name == "temporal" for f in fields(base)):
+                return replace(base, temporal=temporal)
+        # No caller context (unit-test allocate): a context with only the
+        # binder floors is honest — there is nothing authenticated to discard.
+        return _BinderOnlyReduceCtx(temporal)
 
     def _guard_truth(self, guard: object):
         """The guard's TRUTH as a floor value, or None if it cannot stand.
@@ -808,7 +814,7 @@ class GeneratorConstructionV1:
         through `truth` keeps one owner for the question.
 
         Guard Sugar is reduced under :meth:`_guard_evaluation_context` so
-        BindingCoordinateRefSugar resolves sealed formal actuals at the exact
+        BindingCoordinateRefSugar resolves binder Floors at the exact
         coordinate CID (and only there).
         """
         from sugar_lift_py_tests.outcome import Complete
@@ -881,7 +887,8 @@ class GeneratorConstructionV1:
         try:
             outcome = value.desugar(ctx)
         except SugarNotWritten as exc:
-            return self._gap(requested, str(exc.observed) if hasattr(exc, "observed") else type(exc).__name__)
+            observed = getattr(exc, "observed", type(exc).__name__)
+            return self._gap(requested, str(observed))
         if isinstance(outcome, Complete):
             return outcome.value
         return self._gap(requested, type(outcome).__name__)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -18,25 +18,48 @@ def _require_constructed_term(value: object, *, owner: str) -> None:
         )
 
 
+class FormalFloorBindingGap(ValueError):
+    """Formal floor roster cannot enter GeneratorConstructionV1.allocate."""
+
+
 @dataclass(frozen=True)
 class FormalFloorBindingV1:
     """One formal coordinate paired with its binder-produced Floor actual.
 
     Minted at the SourceCallFrame.bind_actuals boundary: the Floor is the exact
     object bind_actuals returned, never a consumer-side Node/Sugar rebuild.
+    ``coordinate_cid`` must be an authenticated binding-coordinate CID;
+    ``floor_value`` must be a FloorValue.
     """
 
     coordinate_cid: str
     floor_value: object = field(compare=False, repr=False)
 
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.coordinate_cid, str)
+            or not self.coordinate_cid.startswith("blake3-512:")
+        ):
+            raise FormalFloorBindingGap(
+                "FormalFloorBindingV1.coordinate_cid must be an authenticated "
+                f"blake3-512 CID, got {self.coordinate_cid!r}"
+            )
+        from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+        if not isinstance(self.floor_value, FloorValue):
+            raise FormalFloorBindingGap(
+                "FormalFloorBindingV1.floor_value must be a FloorValue, "
+                f"got {type(self.floor_value).__name__}"
+            )
+
 
 @dataclass(frozen=True)
 class _BinderOnlyReduceCtx:
-    """Unit-test / no-caller shell: temporal is the only field that exists.
+    """Context-free test shell: temporal is the only field that exists.
 
-    Production allocate always carries the authenticated caller reduction
-    context and extends it.  This shell is only for allocate sites that never
-    had a caller context (focused machine twins).
+    Used only when allocate is invoked with ``reduction_context=None``
+    (focused machine twins).  Production CallSiteSugar always passes the
+    authenticated caller context, which must expose ``with_temporal``.
     """
 
     temporal: object
@@ -443,13 +466,43 @@ class GeneratorConstructionV1:
         formal_floor_bindings: tuple[FormalFloorBindingV1, ...] = (),
         reduction_context: object | None = None,
     ) -> "GeneratorConstructionV1":
-        from sugar_source_tree.binding_state import seal_generator_binding_state_v1
+        from sugar_source_tree.binding_state import (
+            BindingEntryV1,
+            seal_generator_binding_state_v1,
+        )
 
         # Producer seal: every BindingEntryV1 carries ConstructedValueTestimonyV1
         # before the instance exists. Unavailable testimony gaps here, never as
         # a delayed BindingStateWireGap on a "successfully" sealed state.
         binding_state = seal_generator_binding_state_v1(binding_state)
         formal_floor_bindings = tuple(formal_floor_bindings)
+        # Roster law: every sealed formal BindingEntryV1 has exactly one
+        # FormalFloorBindingV1 at the same coordinate CID, and no foreign
+        # coordinates are admitted.  Unrelated coordinate + arbitrary object
+        # cannot resolve a guard.
+        sealed_formal_cids = tuple(
+            entry.coordinate.cid
+            for entry in binding_state
+            if isinstance(entry, BindingEntryV1)
+        )
+        floor_cids = tuple(item.coordinate_cid for item in formal_floor_bindings)
+        if len(floor_cids) != len(set(floor_cids)):
+            raise FormalFloorBindingGap(
+                "formal floor bindings must not duplicate a formal coordinate"
+            )
+        if set(floor_cids) != set(sealed_formal_cids):
+            raise FormalFloorBindingGap(
+                "formal floor coordinate roster must equal sealed BindingEntryV1 "
+                f"formal roster; floors={sorted(floor_cids)!r} "
+                f"sealed={sorted(sealed_formal_cids)!r}"
+            )
+        if reduction_context is not None and not callable(
+            getattr(reduction_context, "with_temporal", None)
+        ):
+            raise TypeError(
+                "reduction_context must expose with_temporal(temporal) when "
+                f"provided; got {type(reduction_context).__name__}"
+            )
         instance_coordinate = cid_of_json(
             {
                 "kind": "python-generator-instance",
@@ -771,18 +824,22 @@ class GeneratorConstructionV1:
 
         Installs each :class:`FormalFloorBindingV1` by coordinate CID into the
         temporal table (object identity of the binder Floor).  Also installs
-        post-assign names already reduced on this machine.  Extends the
-        authenticated caller context when one was carried into allocate; never
-        fabricates a temporal-only substitute that discards caller fields.
-        BindingCoordinateRefSugar.desugar remains the sole consumer door.
+        post-assign names already reduced on this machine.
+
+        When a caller ``reduction_context`` was carried into allocate it **must**
+        expose ``with_temporal`` (FactoryBuildContext / ReduceContext); the
+        typed surface is required — no hasattr/dataclass probe ladder.  The
+        binder-only shell is only for explicitly context-free test allocate
+        (``reduction_context=None``).  BindingCoordinateRefSugar.desugar remains
+        the sole consumer door.
         """
         from sugar_lift_py_tests.temporal.temporal_context import TemporalContext
 
         base = self.reduction_context
-        if base is not None and hasattr(base, "temporal"):
-            temporal = base.temporal
-        else:
+        if base is None:
             temporal = TemporalContext()
+        else:
+            temporal = base.temporal
 
         for binding in self.formal_floor_bindings:
             temporal = temporal.bind_value(
@@ -792,16 +849,9 @@ class GeneratorConstructionV1:
             if isinstance(item, GeneratorAssignBindingV1) and item.value is not None:
                 temporal = temporal.bind_value(item.name, item.value)
 
-        if base is not None and hasattr(base, "with_temporal"):
-            return base.with_temporal(temporal)
-        if base is not None:
-            from dataclasses import fields, is_dataclass, replace
-
-            if is_dataclass(base) and any(f.name == "temporal" for f in fields(base)):
-                return replace(base, temporal=temporal)
-        # No caller context (unit-test allocate): a context with only the
-        # binder floors is honest — there is nothing authenticated to discard.
-        return _BinderOnlyReduceCtx(temporal)
+        if base is None:
+            return _BinderOnlyReduceCtx(temporal)
+        return base.with_temporal(temporal)
 
     def _guard_truth(self, guard: object):
         """The guard's TRUTH as a floor value, or None if it cannot stand.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -271,15 +271,30 @@ class CallSiteSugar(ConstructedTermSugar):
             kw_values = ()
             if self.source_call_frame.generator_steps is not None:
                 from sugar_lift_py_tests.generator_construction import (
+                    FormalFloorBindingV1,
                     GeneratorConstructionV1,
                 )
 
+                # Binder boundary: pair each formal coordinate with the exact
+                # Floor actual bind_actuals already produced (object identity).
+                # Guard temporal installs these Floors; it never rebuilds from
+                # runtime_entries Nodes via sugar()/desugar().
+                formal_floor_bindings = tuple(
+                    FormalFloorBindingV1(coordinate.cid, floor)
+                    for coordinate, floor in zip(
+                        self.source_call_frame.formal_coordinates,
+                        positional,
+                        strict=True,
+                    )
+                )
                 return Complete(
                     GeneratorConstructionV1.allocate(
                         allocation_coordinate=str(self.site),
                         frame_coordinate=self.source_call_frame.frame_cid,
                         binding_state=self.source_call_frame.runtime_entries,
                         steps=self.source_call_frame.generator_steps,
+                        formal_floor_bindings=formal_floor_bindings,
+                        reduction_context=ctx,
                     )
                 )
         callsite = CallSiteValue(

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
@@ -1,18 +1,12 @@
-"""#6691 guard-context producer: binder Floors into pre-yield guard temporal.
+"""#6691 guard-context: binder Floors into pre-yield guard temporal (rev2 teeth).
 
 Governing law
 -------------
 SourceCallFrame.bind_actuals produces formal-ordered Floor actuals.  Those
 Floors are paired with formal coordinate CIDs at the binder boundary and
-carried into GeneratorConstructionV1.allocate.  Guard evaluation installs
-those Floors by identity into (an extension of) the caller reduction context.
-BindingCoordinateRefSugar.desugar remains the sole consumer door.
-
-Forbidden
----------
-- Node.state → sugar() → desugar() reconstruction inside the consumer
-- temporal-only fabricated context that discards authenticated caller context
-- broad Exception catch converting construction defects to absent testimony
+carried into GeneratorConstructionV1.allocate, which verifies the roster
+against sealed BindingEntryV1 formals.  Guard evaluation installs those Floors
+by identity via the caller's ``with_temporal`` surface.
 """
 
 from __future__ import annotations
@@ -22,8 +16,16 @@ from dataclasses import replace
 
 import pytest
 
+from sugar_lift_py_tests.claim.sugar_catalog import SugarCatalog
+from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.floor_value import FloorValue
 from sugar_lift_py_tests.generator_construction import (
+    FormalFloorBindingGap,
     FormalFloorBindingV1,
     GeneratorConstructionV1,
     GeneratorTerminationV1,
@@ -33,22 +35,25 @@ from sugar_lift_py_tests.generator_construction import (
     YieldEffect,
     YieldStepV1,
 )
-from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
 from sugar_lift_py_tests.sugar.binding_coordinate_ref_sugar import (
     BindingCoordinateRefSugar,
 )
+from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
 from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
 from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 from sugar_lift_py_tests.temporal.temporal_context import TemporalContext
-from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.binding_state import (
     BindingEntryV1,
     RuntimeBindingEntryFactoryV1,
     seal_bound_binding_entry_v1,
 )
+from sugar_source_tree.nodes import Call, FunctionDef
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
@@ -60,8 +65,7 @@ def _function(source: str):
     return next(SourceFile(path_source(path)).functions())
 
 
-def _formal_entry_and_coordinate(*, truth: bool = True):
-    """Sealed BindingEntryV1 for runtime_entries + its coordinate CID."""
+def _formal_entry(*, truth: bool = True):
     literal = "True" if truth else "False"
     function = _function(f"def option_context(enabled):\n    flag = {literal}\n")
     assignment = next(node for node in function.walk() if node.kind == "Assign")
@@ -79,23 +83,10 @@ def _formal_entry_and_coordinate(*, truth: bool = True):
     return function, param, entry
 
 
-def _machine(
-    *,
-    entry: BindingEntryV1,
-    floor,
-    guard=None,
-    then_steps=None,
-    else_steps=(),
-    reduction_context=None,
-    formal_floor_bindings=None,
-):
+def _machine(*, entry, floor, guard=None, then_steps=None, else_steps=(), ctx=None):
     then_steps = then_steps or (YieldStepV1(IntLiteralSugar(1, site="then")),)
     if guard is None:
         guard = BindingCoordinateRefSugar(entry.coordinate, entry.state.fragment)
-    if formal_floor_bindings is None:
-        formal_floor_bindings = (
-            FormalFloorBindingV1(entry.coordinate.cid, floor),
-        )
     return GeneratorConstructionV1.allocate(
         allocation_coordinate="call:option_context:1",
         frame_coordinate="frame:option_context",
@@ -104,35 +95,232 @@ def _machine(
             IfStepV1(guard, then_steps, else_steps, "frag:guard"),
             ReturnStepV1(),
         ),
-        formal_floor_bindings=formal_floor_bindings,
-        reduction_context=reduction_context,
+        formal_floor_bindings=(FormalFloorBindingV1(entry.coordinate.cid, floor),),
+        reduction_context=ctx,
     )
 
 
+def _call_coordinate(call: Call) -> SourceFragmentCoordinateV1:
+    span = call.line_col_span()
+    return SourceFragmentCoordinateV1(
+        call.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _production_generator_call(source: str):
+    """Parse generator + call; return (tree, function, call, bound_frame)."""
+    construction = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (source, "prod_guard.py", blake3_512_of(source.encode("utf-8"))),
+        construction_context=construction,
+    )
+    function = next(
+        node for node in tree.nodes() if isinstance(node, FunctionDef)
+    )
+    call = next(node for node in tree.nodes() if isinstance(node, Call))
+    frame = function.source_visible_call_frame().bind_node_actuals(
+        call.args,
+        tuple(
+            (kw.arg, kw.value) for kw in call.keywords if kw.arg is not None
+        ),
+    )
+    construction.source_call_frames[_call_coordinate(call)] = frame
+    return tree, function, call, frame, construction
+
+
 # ---------------------------------------------------------------------------
-# Binder Floor reaches the guard BY IDENTITY
+# 1. Roster law at allocate + substitution lying twin
+# ---------------------------------------------------------------------------
+
+
+def test_unrelated_coordinate_with_floor_refuses_at_allocate() -> None:
+    """Lying: foreign coordinate CID is not a sealed formal on this machine."""
+    _fn, param, entry = _formal_entry(truth=True)
+    floor = TrueBoolLiteralSugar(site=param.fragment)
+    foreign_cid = "blake3-512:" + "b" * 128
+    with pytest.raises(FormalFloorBindingGap, match="roster must equal"):
+        GeneratorConstructionV1.allocate(
+            allocation_coordinate="call:lie",
+            frame_coordinate="frame:lie",
+            binding_state=(entry,),
+            steps=(ReturnStepV1(),),
+            formal_floor_bindings=(FormalFloorBindingV1(foreign_cid, floor),),
+        )
+
+
+def test_non_floor_object_refuses_formal_floor_binding() -> None:
+    with pytest.raises(FormalFloorBindingGap, match="FloorValue"):
+        FormalFloorBindingV1("blake3-512:" + "c" * 128, object())
+
+
+def test_unconstrained_string_coordinate_refuses() -> None:
+    with pytest.raises(FormalFloorBindingGap, match="blake3-512"):
+        FormalFloorBindingV1("not-a-cid", TrueBoolLiteralSugar(site="s"))
+
+
+def test_missing_floor_for_sealed_formal_refuses_at_allocate() -> None:
+    _fn, _param, entry = _formal_entry(truth=True)
+    with pytest.raises(FormalFloorBindingGap, match="roster must equal"):
+        GeneratorConstructionV1.allocate(
+            allocation_coordinate="call:missing",
+            frame_coordinate="frame:missing",
+            binding_state=(entry,),
+            steps=(ReturnStepV1(),),
+            formal_floor_bindings=(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Production binder tooth — positional and keyword/default
+# ---------------------------------------------------------------------------
+
+
+def test_production_positional_bind_actuals_floor_reaches_guard_by_identity() -> None:
+    """ONE production positional call: binder Floor is guard identity."""
+    source = (
+        "def option_context(enabled):\n"
+        "    if enabled:\n"
+        "        yield 1\n"
+        "option_context(True)\n"
+    )
+    _tree, function, call, frame, _construction = _production_generator_call(source)
+    assert frame.generator_steps is not None
+    true_arg = TrueBoolLiteralSugar(site=call.args[0].fragment)
+    # Production binder: bind_actuals then CallSiteSugar.allocate path.
+    bound_floors = frame.bind_actuals((true_arg,), ())
+    assert bound_floors[0] is true_arg
+    assert isinstance(bound_floors[0], FloorValue)
+
+    caller = FactoryBuildContext(filename="prod.py", catalog=SugarCatalog())
+    sugar = CallSiteSugar(
+        target_name="option_context",
+        args=(true_arg,),
+        site=call.fragment,
+        source_call_frame=frame,
+    )
+    outcome = sugar.desugar(caller)
+    assert isinstance(outcome, Complete)
+    machine = outcome.value
+    assert isinstance(machine, GeneratorConstructionV1)
+    assert len(machine.formal_floor_bindings) == 1
+    assert machine.formal_floor_bindings[0].floor_value is true_arg
+    assert (
+        machine.formal_floor_bindings[0].coordinate_cid
+        == frame.formal_coordinates[0].cid
+    )
+    # Guard table holds binder identity.
+    assert machine._guard_evaluation_context().temporal.value_if_bound(
+        frame.formal_coordinates[0].cid
+    ) is true_arg
+    # Guard resolves and splices then-branch.
+    result = machine.resume()
+    assert isinstance(result, YieldEffect)
+
+
+def test_production_keyword_and_default_bind_actuals_floor_by_identity() -> None:
+    """ONE keyword call + default formal: same binder → Floor identity table."""
+    source = (
+        "def option_context(enabled, flag=True):\n"
+        "    if enabled:\n"
+        "        yield 1\n"
+        "option_context(enabled=True)\n"
+    )
+    _tree, function, call, frame, _construction = _production_generator_call(source)
+    assert frame.parameters == ("enabled", "flag")
+    enabled_floor = TrueBoolLiteralSugar(site="kw:enabled")
+    # Keyword for enabled; flag takes default via bind_actuals.
+    bound = frame.bind_actuals((), (("enabled", enabled_floor),))
+    assert bound[0] is enabled_floor
+    assert isinstance(bound[1], FloorValue)  # default True
+
+    sugar = CallSiteSugar(
+        target_name="option_context",
+        args=(),
+        keywords=(("enabled", enabled_floor),),
+        site=call.fragment,
+        source_call_frame=frame,
+    )
+    outcome = sugar.desugar(
+        FactoryBuildContext(filename="prod_kw.py", catalog=SugarCatalog())
+    )
+    assert isinstance(outcome, Complete)
+    machine = outcome.value
+    assert isinstance(machine, GeneratorConstructionV1)
+    assert len(machine.formal_floor_bindings) == 2
+    by_cid = {
+        item.coordinate_cid: item.floor_value
+        for item in machine.formal_floor_bindings
+    }
+    assert by_cid[frame.formal_coordinates[0].cid] is enabled_floor
+    # Default formal is the exact object bind_actuals returned.
+    assert by_cid[frame.formal_coordinates[1].cid] is bound[1]
+    assert machine._guard_evaluation_context().temporal.value_if_bound(
+        frame.formal_coordinates[0].cid
+    ) is enabled_floor
+
+
+# ---------------------------------------------------------------------------
+# 3. with_temporal required; no probe ladder
+# ---------------------------------------------------------------------------
+
+
+def test_caller_context_requires_with_temporal_surface() -> None:
+    _fn, param, entry = _formal_entry(truth=True)
+    floor = TrueBoolLiteralSugar(site=param.fragment)
+
+    class _NoWithTemporal:
+        temporal = TemporalContext()
+
+    with pytest.raises(TypeError, match="with_temporal"):
+        GeneratorConstructionV1.allocate(
+            allocation_coordinate="call:probe",
+            frame_coordinate="frame:probe",
+            binding_state=(entry,),
+            steps=(ReturnStepV1(),),
+            formal_floor_bindings=(
+                FormalFloorBindingV1(entry.coordinate.cid, floor),
+            ),
+            reduction_context=_NoWithTemporal(),
+        )
+
+
+def test_caller_with_temporal_is_extended_not_replaced() -> None:
+    _fn, param, entry = _formal_entry(truth=True)
+    floor = TrueBoolLiteralSugar(site=param.fragment)
+    marker = TrueBoolLiteralSugar(site="caller-marker")
+    caller = FactoryBuildContext(
+        filename="caller.py",
+        catalog=SugarCatalog(),
+        temporal=TemporalContext().bind_value("caller_marker", marker),
+    )
+    machine = _machine(entry=entry, floor=floor, ctx=caller)
+    ctx = machine._guard_evaluation_context()
+    assert ctx.filename == "caller.py"
+    assert ctx.temporal.value_if_bound("caller_marker") is marker
+    assert ctx.temporal.value_if_bound(entry.coordinate.cid) is floor
+
+
+# ---------------------------------------------------------------------------
+# Core acceptance (identity, refuse, rename, hostile sugar, halt)
 # ---------------------------------------------------------------------------
 
 
 def test_binder_floor_reaches_guard_by_identity() -> None:
-    """Truthful: the exact bind_actuals Floor object is what the guard resolves."""
-    _fn, param, entry = _formal_entry_and_coordinate(truth=True)
+    _fn, param, entry = _formal_entry(truth=True)
     floor = TrueBoolLiteralSugar(site=param.fragment)
     machine = _machine(entry=entry, floor=floor)
-
-    outcome = machine.resume()
-
-    assert isinstance(outcome, YieldEffect)
-    # Install table holds the same object the binder produced.
-    ctx = machine._guard_evaluation_context()
-    resolved = ctx.temporal.value_if_bound(entry.coordinate.cid)
-    assert resolved is floor
-    assert len(outcome.machine.binding_state) == 1
-    assert outcome.machine.binding_state[0].coordinate.cid == entry.coordinate.cid
+    assert isinstance(machine.resume(), YieldEffect)
+    assert machine._guard_evaluation_context().temporal.value_if_bound(
+        entry.coordinate.cid
+    ) is floor
 
 
 def test_binder_false_floor_splices_else_branch() -> None:
-    _fn, param, entry = _formal_entry_and_coordinate(truth=False)
+    _fn, param, entry = _formal_entry(truth=False)
     floor = FalseBoolLiteralSugar(site=param.fragment)
     machine = _machine(
         entry=entry,
@@ -140,13 +328,7 @@ def test_binder_false_floor_splices_else_branch() -> None:
         then_steps=(YieldStepV1(IntLiteralSugar(1, site="then")),),
         else_steps=(),
     )
-
-    outcome = machine.resume()
-
-    assert isinstance(outcome, GeneratorTerminationV1)
-    assert machine._guard_evaluation_context().temporal.value_if_bound(
-        entry.coordinate.cid
-    ) is floor
+    assert isinstance(machine.resume(), GeneratorTerminationV1)
 
 
 def test_renamed_formal_uses_coordinate_not_spelling() -> None:
@@ -165,34 +347,14 @@ def test_renamed_formal_uses_coordinate_not_spelling() -> None:
     )
     floor = TrueBoolLiteralSugar(site=param.fragment)
     machine = _machine(entry=entry, floor=floor)
-
-    outcome = machine.resume()
-
-    assert isinstance(outcome, YieldEffect)
+    assert isinstance(machine.resume(), YieldEffect)
     assert machine._guard_evaluation_context().temporal.value_if_bound(
         entry.coordinate.cid
     ) is floor
 
 
-def test_default_and_keyword_binder_path_is_the_same_floor_table() -> None:
-    """Defaults/keywords land through bind_actuals formal order — same install."""
-    _fn, param, entry = _formal_entry_and_coordinate(truth=True)
-    # Simulate a keyword-bound formal: still one FormalFloorBindingV1 at the cid.
-    floor = TrueBoolLiteralSugar(site="kw-bound")
-    machine = _machine(entry=entry, floor=floor)
-
-    assert machine.formal_floor_bindings[0].coordinate_cid == entry.coordinate.cid
-    assert machine.formal_floor_bindings[0].floor_value is floor
-    assert isinstance(machine.resume(), YieldEffect)
-
-
-# ---------------------------------------------------------------------------
-# Wrong coordinate / absent floor — loud
-# ---------------------------------------------------------------------------
-
-
-def test_wrong_coordinate_does_not_resolve_binder_floor() -> None:
-    _fn, param, entry = _formal_entry_and_coordinate(truth=True)
+def test_wrong_coordinate_guard_refuses_when_roster_is_honest() -> None:
+    _fn, param, entry = _formal_entry(truth=True)
     floor = TrueBoolLiteralSugar(site=param.fragment)
     other = _function("def other(x):\n    x = False\n")
     other_param = other.params[0]
@@ -206,48 +368,33 @@ def test_wrong_coordinate_does_not_resolve_binder_floor() -> None:
             state=next(n for n in other.walk() if n.kind == "Assign").value,
         )
     )
-    # Guard points at *other* coordinate; machine only carries *entry*'s floor.
     guard = BindingCoordinateRefSugar(other_entry.coordinate, other_param.fragment)
     machine = _machine(entry=entry, floor=floor, guard=guard)
-
-    outcome = machine.resume()
-
-    assert isinstance(outcome, GeneratorTransitionGapV1)
-    assert (
-        machine._guard_evaluation_context().temporal.value_if_bound(
-            other_entry.coordinate.cid
-        )
-        is None
-    )
+    assert isinstance(machine.resume(), GeneratorTransitionGapV1)
 
 
-def test_absent_formal_floor_binding_refuses() -> None:
-    """No FormalFloorBindingV1 install → consumer refuses (no reconstruction)."""
-    function, param, entry = _formal_entry_and_coordinate(truth=True)
-    guard = BindingCoordinateRefSugar(entry.coordinate, param.fragment)
-    machine = GeneratorConstructionV1.allocate(
-        allocation_coordinate="call:absent",
-        frame_coordinate="frame:absent",
-        binding_state=(entry,),
-        steps=(
-            IfStepV1(
-                guard,
-                (YieldStepV1(IntLiteralSugar(1, site="t")),),
-                (),
-                "frag",
-            ),
-            ReturnStepV1(),
-        ),
-        formal_floor_bindings=(),  # empty — must not rebuild from entry.state
-    )
+def test_node_sugar_never_invoked_on_guard_path() -> None:
+    function, param, entry = _formal_entry(truth=True)
+    floor = TrueBoolLiteralSugar(site=param.fragment)
+    machine = _machine(entry=entry, floor=floor)
+    sugar_calls: list[object] = []
+    original = type(entry.state).sugar
 
-    outcome = machine.resume()
+    def _boom(self, *a, **k):
+        sugar_calls.append(self)
+        raise RuntimeError("consumer reconstruction forbidden")
 
-    assert isinstance(outcome, GeneratorTransitionGapV1)
+    type(entry.state).sugar = _boom  # type: ignore[method-assign]
+    try:
+        assert isinstance(machine.resume(), YieldEffect)
+        assert sugar_calls == []
+        assert not hasattr(GeneratorConstructionV1, "_floor_from_sealed_binding_entry")
+    finally:
+        type(entry.state).sugar = original  # type: ignore[method-assign]
 
 
 def test_binding_coordinate_ref_consumer_stays_the_refusal_boundary() -> None:
-    function, param, entry = _formal_entry_and_coordinate(truth=True)
+    function, param, entry = _formal_entry(truth=True)
     guard = BindingCoordinateRefSugar(entry.coordinate, param.fragment)
 
     class _Empty:
@@ -257,82 +404,8 @@ def test_binding_coordinate_ref_consumer_stays_the_refusal_boundary() -> None:
         guard.desugar(_Empty())
 
 
-def test_node_whose_sugar_would_panic_still_succeeds_without_consumer_rebuild() -> None:
-    """Consumer never invokes state.sugar() — Floor comes only from the binder."""
-    function, param, entry = _formal_entry_and_coordinate(truth=True)
-    floor = TrueBoolLiteralSugar(site=param.fragment)
-    machine = GeneratorConstructionV1.allocate(
-        allocation_coordinate="call:hostile",
-        frame_coordinate="frame:hostile",
-        binding_state=(entry,),
-        steps=(
-            IfStepV1(
-                BindingCoordinateRefSugar(entry.coordinate, param.fragment),
-                (YieldStepV1(IntLiteralSugar(1, site="t")),),
-                (),
-                "frag",
-            ),
-            ReturnStepV1(),
-        ),
-        formal_floor_bindings=(FormalFloorBindingV1(entry.coordinate.cid, floor),),
-    )
-    # After seal: any guard-path rebuild would call Node.sugar() on the bound state.
-    sugar_calls: list[object] = []
-    original_sugar = type(entry.state).sugar
-
-    def _tracking_sugar(self, *args, **kwargs):
-        sugar_calls.append(self)
-        raise RuntimeError("consumer reconstruction is forbidden")
-
-    type(entry.state).sugar = _tracking_sugar  # type: ignore[method-assign]
-    try:
-        outcome = machine.resume()
-        assert isinstance(outcome, YieldEffect)
-        assert sugar_calls == [], "guard path must not call Node.sugar()"
-        assert machine._guard_evaluation_context().temporal.value_if_bound(
-            entry.coordinate.cid
-        ) is floor
-        assert not hasattr(
-            GeneratorConstructionV1, "_floor_from_sealed_binding_entry"
-        )
-    finally:
-        type(entry.state).sugar = original_sugar  # type: ignore[method-assign]
-
-
-# ---------------------------------------------------------------------------
-# Caller context extended, not discarded
-# ---------------------------------------------------------------------------
-
-
-def test_caller_reduction_context_is_extended_not_replaced() -> None:
-    from sugar_lift_py_tests.claim.sugar_catalog import SugarCatalog
-    from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
-
-    _fn, param, entry = _formal_entry_and_coordinate(truth=True)
-    floor = TrueBoolLiteralSugar(site=param.fragment)
-    marker = TrueBoolLiteralSugar(site="caller-marker")
-    caller = FactoryBuildContext(
-        filename="caller.py",
-        catalog=SugarCatalog(),
-        temporal=TemporalContext().bind_value("caller_marker", marker),
-    )
-    machine = _machine(entry=entry, floor=floor, reduction_context=caller)
-    ctx = machine._guard_evaluation_context()
-
-    assert hasattr(ctx, "filename") and ctx.filename == "caller.py"
-    assert ctx.temporal.value_if_bound("caller_marker") is marker
-    assert ctx.temporal.value_if_bound(entry.coordinate.cid) is floor
-
-
-# ---------------------------------------------------------------------------
-# Undecidable + halt retain formal floor install
-# ---------------------------------------------------------------------------
-
-
 def test_undecidable_guard_faces_retain_formal_floor_bindings() -> None:
-    from sugar_lift_py_tests.outcome.exit_set import Completed
-
-    _fn, param, entry = _formal_entry_and_coordinate(truth=True)
+    _fn, param, entry = _formal_entry(truth=True)
     floor = TrueBoolLiteralSugar(site=param.fragment)
     machine = _machine(
         entry=entry,
@@ -341,17 +414,14 @@ def test_undecidable_guard_faces_retain_formal_floor_bindings() -> None:
         then_steps=(YieldStepV1(IntLiteralSugar(1, site="t")),),
         else_steps=(YieldStepV1(IntLiteralSugar(0, site="e")),),
     )
-
     outcome = machine.resume()
-
     assert isinstance(outcome, ExitSet)
-    completed = [exit_ for exit_ in outcome.exits if isinstance(exit_, Completed)]
+    completed = [e for e in outcome.exits if isinstance(e, Completed)]
     assert completed
 
     def _check(value):
         if isinstance(value, GeneratorConstructionV1):
             assert value.formal_floor_bindings[0].floor_value is floor
-            assert value.formal_floor_bindings[0].coordinate_cid == entry.coordinate.cid
             return
         inner = getattr(value, "value", None) or getattr(value, "machine", None)
         if inner is not None and inner is not value:
@@ -362,20 +432,17 @@ def test_undecidable_guard_faces_retain_formal_floor_bindings() -> None:
 
 
 def test_guard_halt_retains_exact_pre_halt_formal_floors() -> None:
-    _fn, param, entry = _formal_entry_and_coordinate(truth=True)
+    _fn, param, entry = _formal_entry(truth=True)
     floor = TrueBoolLiteralSugar(site=param.fragment)
     machine = _machine(entry=entry, floor=floor)
-
     halted = machine.throw(
         RaiseEffect(exception_name="HaltProbe", occurrence="guard:halt")
     )
-
     assert isinstance(halted, ExitSet)
-    halted_exits = [exit_ for exit_ in halted.exits if isinstance(exit_, Halted)]
-    assert halted_exits
-    for exit_ in halted_exits:
+    for exit_ in halted.exits:
+        if not isinstance(exit_, Halted):
+            continue
         state = exit_.state
         assert isinstance(state, GeneratorConstructionV1)
         assert state.formal_floor_bindings[0].floor_value is floor
         assert state.cursor == machine.cursor
-        assert state.instance_coordinate == machine.instance_coordinate

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
@@ -39,8 +39,8 @@ from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 from sugar_lift_py_tests.sugar.binding_coordinate_ref_sugar import (
     BindingCoordinateRefSugar,
 )
-from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
-from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
+from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 from sugar_lift_py_tests.temporal.temporal_context import TemporalContext
 from sugar_lift_python_source.canonical import cid_of_json
 from sugar_lift_python_source.source_oracle import path_source
@@ -83,7 +83,8 @@ def _guard_ref(function, param, coordinate) -> BindingCoordinateRefSugar:
 
 
 def _machine_with_guard(entry: BindingEntryV1, guard, *, then_steps=None, else_steps=()):
-    then_steps = then_steps or (YieldStepV1(TrueBoolLiteralSugar(site="then")),)
+    # #6738: step values must be ConstructedTermSugar (not ir.num stubs).
+    then_steps = then_steps or (YieldStepV1(IntLiteralSugar(1, site="then")),)
     steps = (
         IfStepV1(guard, then_steps, else_steps, "frag:guard"),
         ReturnStepV1(),
@@ -126,7 +127,7 @@ def test_bound_false_formal_splices_else_branch() -> None:
     machine = _machine_with_guard(
         entry,
         guard,
-        then_steps=(YieldStepV1(TrueBoolLiteralSugar(site="then")),),
+        then_steps=(YieldStepV1(IntLiteralSugar(1, site="then")),),
         else_steps=(),
     )
 
@@ -211,7 +212,7 @@ def test_absent_testimony_is_not_installed_into_guard_temporal() -> None:
         steps=(
             IfStepV1(
                 guard,
-                (YieldStepV1(TrueBoolLiteralSugar(site="t")),),
+                (YieldStepV1(IntLiteralSugar(1, site="t")),),
                 (),
                 "frag",
             ),
@@ -260,17 +261,17 @@ def test_tampered_coordinate_cid_does_not_hit_sealed_entry() -> None:
 
 
 def test_undecidable_guard_faces_retain_the_same_sealed_binding_state() -> None:
-    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-    from sugar_lift_py_tests.ir import atomic
     from sugar_lift_py_tests.outcome.exit_set import Completed
 
     _fn, _param, entry = _bool_formal_entry(truth=True)
-    guard = PredicateValue(atomic("symbolic_guard", ()), "s")
+    # Free NameSugar is ConstructedTermSugar and undecided under empty temporal
+    # (same door as #6738-migrated if_step twins).
+    guard = NameSugar("symbolic_guard", site="s")
     machine = _machine_with_guard(
         entry,
         guard,
-        then_steps=(YieldStepV1(TrueBoolLiteralSugar(site="t")),),
-        else_steps=(YieldStepV1(FalseBoolLiteralSugar(site="e")),),
+        then_steps=(YieldStepV1(IntLiteralSugar(1, site="t")),),
+        else_steps=(YieldStepV1(IntLiteralSugar(0, site="e")),),
     )
 
     outcome = machine.resume()

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
@@ -1,0 +1,331 @@
+"""#6691 guard-context producer: sealed binding state into pre-yield guard temporal.
+
+Governing law
+-------------
+GeneratorConstructionV1 carries authenticated sealed BindingEntryV1 state into
+the temporal context used for pre-yield guard evaluation.  The sole consumer
+door remains BindingCoordinateRefSugar.desugar (exact coordinate.cid lookup).
+No name lookup, coordinate scanning, or unspecialized-formal fallback is added
+to that door.
+
+Acceptance
+----------
+- real bound option_context-style actual resolves at the guard's exact formal
+  coordinate
+- renamed twin uses the same path
+- wrong coordinate / tampered / absent testimony stay loud
+- undecidable guard retains complementary faces with the same sealed state
+- guard halt retains exact pre-halt state
+"""
+
+from __future__ import annotations
+
+import tempfile
+from dataclasses import replace
+
+import pytest
+
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    GeneratorTerminationV1,
+    GeneratorTransitionGapV1,
+    IfStepV1,
+    ReturnStepV1,
+    YieldEffect,
+    YieldStepV1,
+)
+from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.sugar.binding_coordinate_ref_sugar import (
+    BindingCoordinateRefSugar,
+)
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_py_tests.temporal.temporal_context import TemporalContext
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
+from sugar_source_tree.binding_state import (
+    BindingEntryV1,
+    RuntimeBindingEntryFactoryV1,
+    seal_bound_binding_entry_v1,
+)
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _bool_formal_entry(*, truth: bool):
+    """One sealed formal binding whose actual is a ground bool Constant."""
+    literal = "True" if truth else "False"
+    function = _function(f"def option_context(enabled):\n    flag = {literal}\n")
+    assignment = next(node for node in function.walk() if node.kind == "Assign")
+    param = function.params[0]
+    factory = RuntimeBindingEntryFactoryV1(
+        cid_of_json({"scope": function.fragment.seal().to_dict()})
+    )
+    entry = factory.mint_entry(
+        binding_site=param.fragment,
+        projection_path=("formal", 0),
+        state=assignment.value,
+    )
+    return function, param, seal_bound_binding_entry_v1(entry)
+
+
+def _guard_ref(function, param, coordinate) -> BindingCoordinateRefSugar:
+    return BindingCoordinateRefSugar(coordinate, param.fragment)
+
+
+def _machine_with_guard(entry: BindingEntryV1, guard, *, then_steps=None, else_steps=()):
+    then_steps = then_steps or (YieldStepV1(TrueBoolLiteralSugar(site="then")),)
+    steps = (
+        IfStepV1(guard, then_steps, else_steps, "frag:guard"),
+        ReturnStepV1(),
+    )
+    return GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:option_context:1",
+        frame_coordinate="frame:option_context",
+        binding_state=(entry,),
+        steps=steps,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Real bound actual resolves at the exact formal coordinate
+# ---------------------------------------------------------------------------
+
+
+def test_bound_option_context_actual_resolves_at_exact_formal_coordinate() -> None:
+    """Truthful: sealed formal True splices the then-branch at its coordinate."""
+    function, param, entry = _bool_formal_entry(truth=True)
+    guard = _guard_ref(function, param, entry.coordinate)
+    machine = _machine_with_guard(entry, guard)
+
+    outcome = machine.resume()
+
+    assert isinstance(outcome, YieldEffect)
+    # Sealed state is unchanged across the decided branch.
+    assert len(outcome.machine.binding_state) == 1
+    sealed = outcome.machine.binding_state[0]
+    assert isinstance(sealed, BindingEntryV1)
+    assert sealed.coordinate.cid == entry.coordinate.cid
+    assert sealed.require_constructed_value_testimony().cid == (
+        entry.require_constructed_value_testimony().cid
+    )
+
+
+def test_bound_false_formal_splices_else_branch() -> None:
+    function, param, entry = _bool_formal_entry(truth=False)
+    guard = _guard_ref(function, param, entry.coordinate)
+    machine = _machine_with_guard(
+        entry,
+        guard,
+        then_steps=(YieldStepV1(TrueBoolLiteralSugar(site="then")),),
+        else_steps=(),
+    )
+
+    outcome = machine.resume()
+
+    # False guard + empty else → termination (no yield).
+    assert isinstance(outcome, GeneratorTerminationV1)
+    assert outcome.binding_state[0].coordinate.cid == entry.coordinate.cid
+
+
+def test_renamed_twin_resolves_on_the_same_coordinate_path() -> None:
+    """Renamed formal spelling does not change coordinate-keyed resolution."""
+    # Same projection path / sealed actual; only the source param name differs.
+    function, param, entry = _bool_formal_entry(truth=True)
+    # Rebuild under a renamed source function; coordinate identity is the seal.
+    renamed = _function("def option_context_renamed(flag):\n    flag = True\n")
+    renamed_param = renamed.params[0]
+    factory = RuntimeBindingEntryFactoryV1(
+        cid_of_json({"scope": renamed.fragment.seal().to_dict()})
+    )
+    assignment = next(node for node in renamed.walk() if node.kind == "Assign")
+    renamed_entry = seal_bound_binding_entry_v1(
+        factory.mint_entry(
+            binding_site=renamed_param.fragment,
+            projection_path=("formal", 0),
+            state=assignment.value,
+        )
+    )
+    guard = BindingCoordinateRefSugar(
+        renamed_entry.coordinate, renamed_param.fragment
+    )
+    machine = _machine_with_guard(renamed_entry, guard)
+
+    outcome = machine.resume()
+
+    assert isinstance(outcome, YieldEffect)
+    assert outcome.machine.binding_state[0].coordinate.cid == renamed_entry.coordinate.cid
+
+
+# ---------------------------------------------------------------------------
+# Wrong coordinate / tampered / absent testimony — loud
+# ---------------------------------------------------------------------------
+
+
+def test_wrong_coordinate_does_not_resolve_another_formal() -> None:
+    """Lying: a nearby formal coordinate is not this guard's binding."""
+    _fn, _param, entry = _bool_formal_entry(truth=True)
+    other = _function("def other(x):\n    x = False\n")
+    other_param = other.params[0]
+    factory = RuntimeBindingEntryFactoryV1(
+        cid_of_json({"scope": other.fragment.seal().to_dict()})
+    )
+    other_entry = seal_bound_binding_entry_v1(
+        factory.mint_entry(
+            binding_site=other_param.fragment,
+            projection_path=("formal", 0),
+            state=next(n for n in other.walk() if n.kind == "Assign").value,
+        )
+    )
+    # Guard points at *other* coordinate while machine holds *entry*.
+    guard = BindingCoordinateRefSugar(other_entry.coordinate, other_param.fragment)
+    machine = _machine_with_guard(entry, guard)
+
+    outcome = machine.resume()
+
+    # Wrong coordinate → unspecialized formal → undecided → loud gap.
+    assert isinstance(outcome, GeneratorTransitionGapV1)
+
+
+def test_absent_testimony_is_not_installed_into_guard_temporal() -> None:
+    """Lying: unsealed binding state does not authorize formal resolution."""
+    function, param, sealed = _bool_formal_entry(truth=True)
+    # Strip seal: runtime entry without sealed_state.
+    unsealed = BindingEntryV1(sealed.coordinate, sealed.state, None)
+    assert unsealed.constructed_value_testimony is None
+    guard = _guard_ref(function, param, sealed.coordinate)
+    # allocate will re-seal — so allocate with unsealed and then replace state.
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:absent",
+        frame_coordinate="frame:absent",
+        binding_state=(unsealed,),
+        steps=(
+            IfStepV1(
+                guard,
+                (YieldStepV1(TrueBoolLiteralSugar(site="t")),),
+                (),
+                "frag",
+            ),
+            ReturnStepV1(),
+        ),
+    )
+    # allocate seals; force-absent for the twin:
+    machine = replace(
+        machine,
+        binding_state=(BindingEntryV1(sealed.coordinate, sealed.state, None),),
+    )
+    # Producer installs nothing; consumer refuses → undecided gap.
+    outcome = machine.resume()
+    assert isinstance(outcome, GeneratorTransitionGapV1)
+
+
+def test_binding_coordinate_ref_consumer_stays_the_refusal_boundary() -> None:
+    """BindingCoordinateRefSugar.desugar is still the sole consumer door."""
+    function, param, entry = _bool_formal_entry(truth=True)
+    guard = _guard_ref(function, param, entry.coordinate)
+    # Empty temporal: exact consumer refusal, not a generator-side rewrite.
+    class _Empty:
+        temporal = TemporalContext()
+
+    with pytest.raises(SugarNotWritten, match="unspecialized source-call formal"):
+        guard.desugar(_Empty())
+
+
+def test_tampered_coordinate_cid_does_not_hit_sealed_entry() -> None:
+    function, param, entry = _bool_formal_entry(truth=True)
+    tampered = replace(
+        entry.coordinate,
+        cid="blake3-512:" + "a" * 128,
+    )
+    guard = BindingCoordinateRefSugar(tampered, param.fragment)
+    machine = _machine_with_guard(entry, guard)
+
+    outcome = machine.resume()
+
+    assert isinstance(outcome, GeneratorTransitionGapV1)
+
+
+# ---------------------------------------------------------------------------
+# Undecidable guard: complementary faces keep the same sealed state
+# ---------------------------------------------------------------------------
+
+
+def test_undecidable_guard_faces_retain_the_same_sealed_binding_state() -> None:
+    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+    from sugar_lift_py_tests.ir import atomic
+    from sugar_lift_py_tests.outcome.exit_set import Completed
+
+    _fn, _param, entry = _bool_formal_entry(truth=True)
+    guard = PredicateValue(atomic("symbolic_guard", ()), "s")
+    machine = _machine_with_guard(
+        entry,
+        guard,
+        then_steps=(YieldStepV1(TrueBoolLiteralSugar(site="t")),),
+        else_steps=(YieldStepV1(FalseBoolLiteralSugar(site="e")),),
+    )
+
+    outcome = machine.resume()
+
+    assert isinstance(outcome, ExitSet)
+    completed = [exit_ for exit_ in outcome.exits if isinstance(exit_, Completed)]
+    assert len(completed) >= 1
+    # Factor may collapse to one GuardedValue arm; every successor machine that
+    # still carries generator state must retain the sealed formal binding.
+    sealed_cid = entry.require_constructed_value_testimony().cid
+
+    def _check_state(value):
+        if isinstance(value, GeneratorConstructionV1):
+            assert len(value.binding_state) == 1
+            bound = value.binding_state[0]
+            assert isinstance(bound, BindingEntryV1)
+            assert bound.coordinate.cid == entry.coordinate.cid
+            assert bound.require_constructed_value_testimony().cid == sealed_cid
+            return
+        # GuardedValue / factored forms may wrap the machine.
+        inner = getattr(value, "value", None) or getattr(value, "machine", None)
+        if inner is not None and inner is not value:
+            _check_state(inner)
+        for face in getattr(value, "faces", ()) or ():
+            _check_state(getattr(face, "value", face))
+
+    for exit_ in completed:
+        _check_state(exit_.value)
+
+
+# ---------------------------------------------------------------------------
+# Guard halt retains exact pre-halt state
+# ---------------------------------------------------------------------------
+
+
+def test_guard_halt_retains_exact_pre_halt_sealed_state() -> None:
+    function, param, entry = _bool_formal_entry(truth=True)
+    guard = _guard_ref(function, param, entry.coordinate)
+    machine = _machine_with_guard(entry, guard)
+
+    effect = RaiseEffect(exception_name="HaltProbe", occurrence="guard:halt")
+    halted = machine.throw(effect)
+
+    assert isinstance(halted, ExitSet)
+    halted_exits = [exit_ for exit_ in halted.exits if isinstance(exit_, Halted)]
+    assert halted_exits
+    for exit_ in halted_exits:
+        state = exit_.state
+        assert isinstance(state, GeneratorConstructionV1)
+        assert len(state.binding_state) == 1
+        assert state.binding_state[0].coordinate.cid == entry.coordinate.cid
+        assert state.binding_state[0].require_constructed_value_testimony().cid == (
+            entry.require_constructed_value_testimony().cid
+        )
+        # Cursor / steps unchanged: pre-halt snapshot.
+        assert state.cursor == machine.cursor
+        assert state.steps == machine.steps
+        assert state.instance_coordinate == machine.instance_coordinate

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
@@ -1,21 +1,18 @@
-"""#6691 guard-context producer: sealed binding state into pre-yield guard temporal.
+"""#6691 guard-context producer: binder Floors into pre-yield guard temporal.
 
 Governing law
 -------------
-GeneratorConstructionV1 carries authenticated sealed BindingEntryV1 state into
-the temporal context used for pre-yield guard evaluation.  The sole consumer
-door remains BindingCoordinateRefSugar.desugar (exact coordinate.cid lookup).
-No name lookup, coordinate scanning, or unspecialized-formal fallback is added
-to that door.
+SourceCallFrame.bind_actuals produces formal-ordered Floor actuals.  Those
+Floors are paired with formal coordinate CIDs at the binder boundary and
+carried into GeneratorConstructionV1.allocate.  Guard evaluation installs
+those Floors by identity into (an extension of) the caller reduction context.
+BindingCoordinateRefSugar.desugar remains the sole consumer door.
 
-Acceptance
-----------
-- real bound option_context-style actual resolves at the guard's exact formal
-  coordinate
-- renamed twin uses the same path
-- wrong coordinate / tampered / absent testimony stay loud
-- undecidable guard retains complementary faces with the same sealed state
-- guard halt retains exact pre-halt state
+Forbidden
+---------
+- Node.state → sugar() → desugar() reconstruction inside the consumer
+- temporal-only fabricated context that discards authenticated caller context
+- broad Exception catch converting construction defects to absent testimony
 """
 
 from __future__ import annotations
@@ -25,7 +22,9 @@ from dataclasses import replace
 
 import pytest
 
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 from sugar_lift_py_tests.generator_construction import (
+    FormalFloorBindingV1,
     GeneratorConstructionV1,
     GeneratorTerminationV1,
     GeneratorTransitionGapV1,
@@ -35,16 +34,16 @@ from sugar_lift_py_tests.generator_construction import (
     YieldStepV1,
 )
 from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
-from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 from sugar_lift_py_tests.sugar.binding_coordinate_ref_sugar import (
     BindingCoordinateRefSugar,
 )
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
 from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
 from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 from sugar_lift_py_tests.temporal.temporal_context import TemporalContext
 from sugar_lift_python_source.canonical import cid_of_json
 from sugar_lift_python_source.source_oracle import path_source
-from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
 from sugar_source_tree.binding_state import (
     BindingEntryV1,
     RuntimeBindingEntryFactoryV1,
@@ -61,8 +60,8 @@ def _function(source: str):
     return next(SourceFile(path_source(path)).functions())
 
 
-def _bool_formal_entry(*, truth: bool):
-    """One sealed formal binding whose actual is a ground bool Constant."""
+def _formal_entry_and_coordinate(*, truth: bool = True):
+    """Sealed BindingEntryV1 for runtime_entries + its coordinate CID."""
     literal = "True" if truth else "False"
     function = _function(f"def option_context(enabled):\n    flag = {literal}\n")
     assignment = next(node for node in function.walk() if node.kind == "Assign")
@@ -70,111 +69,131 @@ def _bool_formal_entry(*, truth: bool):
     factory = RuntimeBindingEntryFactoryV1(
         cid_of_json({"scope": function.fragment.seal().to_dict()})
     )
-    entry = factory.mint_entry(
-        binding_site=param.fragment,
-        projection_path=("formal", 0),
-        state=assignment.value,
+    entry = seal_bound_binding_entry_v1(
+        factory.mint_entry(
+            binding_site=param.fragment,
+            projection_path=("formal", 0),
+            state=assignment.value,
+        )
     )
-    return function, param, seal_bound_binding_entry_v1(entry)
+    return function, param, entry
 
 
-def _guard_ref(function, param, coordinate) -> BindingCoordinateRefSugar:
-    return BindingCoordinateRefSugar(coordinate, param.fragment)
-
-
-def _machine_with_guard(entry: BindingEntryV1, guard, *, then_steps=None, else_steps=()):
-    # #6738: step values must be ConstructedTermSugar (not ir.num stubs).
+def _machine(
+    *,
+    entry: BindingEntryV1,
+    floor,
+    guard=None,
+    then_steps=None,
+    else_steps=(),
+    reduction_context=None,
+    formal_floor_bindings=None,
+):
     then_steps = then_steps or (YieldStepV1(IntLiteralSugar(1, site="then")),)
-    steps = (
-        IfStepV1(guard, then_steps, else_steps, "frag:guard"),
-        ReturnStepV1(),
-    )
+    if guard is None:
+        guard = BindingCoordinateRefSugar(entry.coordinate, entry.state.fragment)
+    if formal_floor_bindings is None:
+        formal_floor_bindings = (
+            FormalFloorBindingV1(entry.coordinate.cid, floor),
+        )
     return GeneratorConstructionV1.allocate(
         allocation_coordinate="call:option_context:1",
         frame_coordinate="frame:option_context",
         binding_state=(entry,),
-        steps=steps,
+        steps=(
+            IfStepV1(guard, then_steps, else_steps, "frag:guard"),
+            ReturnStepV1(),
+        ),
+        formal_floor_bindings=formal_floor_bindings,
+        reduction_context=reduction_context,
     )
 
 
 # ---------------------------------------------------------------------------
-# Real bound actual resolves at the exact formal coordinate
+# Binder Floor reaches the guard BY IDENTITY
 # ---------------------------------------------------------------------------
 
 
-def test_bound_option_context_actual_resolves_at_exact_formal_coordinate() -> None:
-    """Truthful: sealed formal True splices the then-branch at its coordinate."""
-    function, param, entry = _bool_formal_entry(truth=True)
-    guard = _guard_ref(function, param, entry.coordinate)
-    machine = _machine_with_guard(entry, guard)
+def test_binder_floor_reaches_guard_by_identity() -> None:
+    """Truthful: the exact bind_actuals Floor object is what the guard resolves."""
+    _fn, param, entry = _formal_entry_and_coordinate(truth=True)
+    floor = TrueBoolLiteralSugar(site=param.fragment)
+    machine = _machine(entry=entry, floor=floor)
 
     outcome = machine.resume()
 
     assert isinstance(outcome, YieldEffect)
-    # Sealed state is unchanged across the decided branch.
+    # Install table holds the same object the binder produced.
+    ctx = machine._guard_evaluation_context()
+    resolved = ctx.temporal.value_if_bound(entry.coordinate.cid)
+    assert resolved is floor
     assert len(outcome.machine.binding_state) == 1
-    sealed = outcome.machine.binding_state[0]
-    assert isinstance(sealed, BindingEntryV1)
-    assert sealed.coordinate.cid == entry.coordinate.cid
-    assert sealed.require_constructed_value_testimony().cid == (
-        entry.require_constructed_value_testimony().cid
-    )
+    assert outcome.machine.binding_state[0].coordinate.cid == entry.coordinate.cid
 
 
-def test_bound_false_formal_splices_else_branch() -> None:
-    function, param, entry = _bool_formal_entry(truth=False)
-    guard = _guard_ref(function, param, entry.coordinate)
-    machine = _machine_with_guard(
-        entry,
-        guard,
+def test_binder_false_floor_splices_else_branch() -> None:
+    _fn, param, entry = _formal_entry_and_coordinate(truth=False)
+    floor = FalseBoolLiteralSugar(site=param.fragment)
+    machine = _machine(
+        entry=entry,
+        floor=floor,
         then_steps=(YieldStepV1(IntLiteralSugar(1, site="then")),),
         else_steps=(),
     )
 
     outcome = machine.resume()
 
-    # False guard + empty else → termination (no yield).
     assert isinstance(outcome, GeneratorTerminationV1)
-    assert outcome.binding_state[0].coordinate.cid == entry.coordinate.cid
+    assert machine._guard_evaluation_context().temporal.value_if_bound(
+        entry.coordinate.cid
+    ) is floor
 
 
-def test_renamed_twin_resolves_on_the_same_coordinate_path() -> None:
-    """Renamed formal spelling does not change coordinate-keyed resolution."""
-    # Same projection path / sealed actual; only the source param name differs.
-    function, param, entry = _bool_formal_entry(truth=True)
-    # Rebuild under a renamed source function; coordinate identity is the seal.
+def test_renamed_formal_uses_coordinate_not_spelling() -> None:
     renamed = _function("def option_context_renamed(flag):\n    flag = True\n")
-    renamed_param = renamed.params[0]
+    param = renamed.params[0]
     factory = RuntimeBindingEntryFactoryV1(
         cid_of_json({"scope": renamed.fragment.seal().to_dict()})
     )
     assignment = next(node for node in renamed.walk() if node.kind == "Assign")
-    renamed_entry = seal_bound_binding_entry_v1(
+    entry = seal_bound_binding_entry_v1(
         factory.mint_entry(
-            binding_site=renamed_param.fragment,
+            binding_site=param.fragment,
             projection_path=("formal", 0),
             state=assignment.value,
         )
     )
-    guard = BindingCoordinateRefSugar(
-        renamed_entry.coordinate, renamed_param.fragment
-    )
-    machine = _machine_with_guard(renamed_entry, guard)
+    floor = TrueBoolLiteralSugar(site=param.fragment)
+    machine = _machine(entry=entry, floor=floor)
 
     outcome = machine.resume()
 
     assert isinstance(outcome, YieldEffect)
-    assert outcome.machine.binding_state[0].coordinate.cid == renamed_entry.coordinate.cid
+    assert machine._guard_evaluation_context().temporal.value_if_bound(
+        entry.coordinate.cid
+    ) is floor
+
+
+def test_default_and_keyword_binder_path_is_the_same_floor_table() -> None:
+    """Defaults/keywords land through bind_actuals formal order — same install."""
+    _fn, param, entry = _formal_entry_and_coordinate(truth=True)
+    # Simulate a keyword-bound formal: still one FormalFloorBindingV1 at the cid.
+    floor = TrueBoolLiteralSugar(site="kw-bound")
+    machine = _machine(entry=entry, floor=floor)
+
+    assert machine.formal_floor_bindings[0].coordinate_cid == entry.coordinate.cid
+    assert machine.formal_floor_bindings[0].floor_value is floor
+    assert isinstance(machine.resume(), YieldEffect)
 
 
 # ---------------------------------------------------------------------------
-# Wrong coordinate / tampered / absent testimony — loud
+# Wrong coordinate / absent floor — loud
 # ---------------------------------------------------------------------------
 
 
-def test_wrong_coordinate_does_not_resolve_another_formal() -> None:
-    """Lying: a nearby formal coordinate is not this guard's binding."""
-    _fn, _param, entry = _bool_formal_entry(truth=True)
+def test_wrong_coordinate_does_not_resolve_binder_floor() -> None:
+    _fn, param, entry = _formal_entry_and_coordinate(truth=True)
+    floor = TrueBoolLiteralSugar(site=param.fragment)
     other = _function("def other(x):\n    x = False\n")
     other_param = other.params[0]
     factory = RuntimeBindingEntryFactoryV1(
@@ -187,28 +206,29 @@ def test_wrong_coordinate_does_not_resolve_another_formal() -> None:
             state=next(n for n in other.walk() if n.kind == "Assign").value,
         )
     )
-    # Guard points at *other* coordinate while machine holds *entry*.
+    # Guard points at *other* coordinate; machine only carries *entry*'s floor.
     guard = BindingCoordinateRefSugar(other_entry.coordinate, other_param.fragment)
-    machine = _machine_with_guard(entry, guard)
+    machine = _machine(entry=entry, floor=floor, guard=guard)
 
     outcome = machine.resume()
 
-    # Wrong coordinate → unspecialized formal → undecided → loud gap.
     assert isinstance(outcome, GeneratorTransitionGapV1)
+    assert (
+        machine._guard_evaluation_context().temporal.value_if_bound(
+            other_entry.coordinate.cid
+        )
+        is None
+    )
 
 
-def test_absent_testimony_is_not_installed_into_guard_temporal() -> None:
-    """Lying: unsealed binding state does not authorize formal resolution."""
-    function, param, sealed = _bool_formal_entry(truth=True)
-    # Strip seal: runtime entry without sealed_state.
-    unsealed = BindingEntryV1(sealed.coordinate, sealed.state, None)
-    assert unsealed.constructed_value_testimony is None
-    guard = _guard_ref(function, param, sealed.coordinate)
-    # allocate will re-seal — so allocate with unsealed and then replace state.
+def test_absent_formal_floor_binding_refuses() -> None:
+    """No FormalFloorBindingV1 install → consumer refuses (no reconstruction)."""
+    function, param, entry = _formal_entry_and_coordinate(truth=True)
+    guard = BindingCoordinateRefSugar(entry.coordinate, param.fragment)
     machine = GeneratorConstructionV1.allocate(
         allocation_coordinate="call:absent",
         frame_coordinate="frame:absent",
-        binding_state=(unsealed,),
+        binding_state=(entry,),
         steps=(
             IfStepV1(
                 guard,
@@ -218,22 +238,18 @@ def test_absent_testimony_is_not_installed_into_guard_temporal() -> None:
             ),
             ReturnStepV1(),
         ),
+        formal_floor_bindings=(),  # empty — must not rebuild from entry.state
     )
-    # allocate seals; force-absent for the twin:
-    machine = replace(
-        machine,
-        binding_state=(BindingEntryV1(sealed.coordinate, sealed.state, None),),
-    )
-    # Producer installs nothing; consumer refuses → undecided gap.
+
     outcome = machine.resume()
+
     assert isinstance(outcome, GeneratorTransitionGapV1)
 
 
 def test_binding_coordinate_ref_consumer_stays_the_refusal_boundary() -> None:
-    """BindingCoordinateRefSugar.desugar is still the sole consumer door."""
-    function, param, entry = _bool_formal_entry(truth=True)
-    guard = _guard_ref(function, param, entry.coordinate)
-    # Empty temporal: exact consumer refusal, not a generator-side rewrite.
+    function, param, entry = _formal_entry_and_coordinate(truth=True)
+    guard = BindingCoordinateRefSugar(entry.coordinate, param.fragment)
+
     class _Empty:
         temporal = TemporalContext()
 
@@ -241,35 +257,87 @@ def test_binding_coordinate_ref_consumer_stays_the_refusal_boundary() -> None:
         guard.desugar(_Empty())
 
 
-def test_tampered_coordinate_cid_does_not_hit_sealed_entry() -> None:
-    function, param, entry = _bool_formal_entry(truth=True)
-    tampered = replace(
-        entry.coordinate,
-        cid="blake3-512:" + "a" * 128,
+def test_node_whose_sugar_would_panic_still_succeeds_without_consumer_rebuild() -> None:
+    """Consumer never invokes state.sugar() — Floor comes only from the binder."""
+    function, param, entry = _formal_entry_and_coordinate(truth=True)
+    floor = TrueBoolLiteralSugar(site=param.fragment)
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:hostile",
+        frame_coordinate="frame:hostile",
+        binding_state=(entry,),
+        steps=(
+            IfStepV1(
+                BindingCoordinateRefSugar(entry.coordinate, param.fragment),
+                (YieldStepV1(IntLiteralSugar(1, site="t")),),
+                (),
+                "frag",
+            ),
+            ReturnStepV1(),
+        ),
+        formal_floor_bindings=(FormalFloorBindingV1(entry.coordinate.cid, floor),),
     )
-    guard = BindingCoordinateRefSugar(tampered, param.fragment)
-    machine = _machine_with_guard(entry, guard)
+    # After seal: any guard-path rebuild would call Node.sugar() on the bound state.
+    sugar_calls: list[object] = []
+    original_sugar = type(entry.state).sugar
 
-    outcome = machine.resume()
+    def _tracking_sugar(self, *args, **kwargs):
+        sugar_calls.append(self)
+        raise RuntimeError("consumer reconstruction is forbidden")
 
-    assert isinstance(outcome, GeneratorTransitionGapV1)
+    type(entry.state).sugar = _tracking_sugar  # type: ignore[method-assign]
+    try:
+        outcome = machine.resume()
+        assert isinstance(outcome, YieldEffect)
+        assert sugar_calls == [], "guard path must not call Node.sugar()"
+        assert machine._guard_evaluation_context().temporal.value_if_bound(
+            entry.coordinate.cid
+        ) is floor
+        assert not hasattr(
+            GeneratorConstructionV1, "_floor_from_sealed_binding_entry"
+        )
+    finally:
+        type(entry.state).sugar = original_sugar  # type: ignore[method-assign]
 
 
 # ---------------------------------------------------------------------------
-# Undecidable guard: complementary faces keep the same sealed state
+# Caller context extended, not discarded
 # ---------------------------------------------------------------------------
 
 
-def test_undecidable_guard_faces_retain_the_same_sealed_binding_state() -> None:
+def test_caller_reduction_context_is_extended_not_replaced() -> None:
+    from sugar_lift_py_tests.claim.sugar_catalog import SugarCatalog
+    from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
+
+    _fn, param, entry = _formal_entry_and_coordinate(truth=True)
+    floor = TrueBoolLiteralSugar(site=param.fragment)
+    marker = TrueBoolLiteralSugar(site="caller-marker")
+    caller = FactoryBuildContext(
+        filename="caller.py",
+        catalog=SugarCatalog(),
+        temporal=TemporalContext().bind_value("caller_marker", marker),
+    )
+    machine = _machine(entry=entry, floor=floor, reduction_context=caller)
+    ctx = machine._guard_evaluation_context()
+
+    assert hasattr(ctx, "filename") and ctx.filename == "caller.py"
+    assert ctx.temporal.value_if_bound("caller_marker") is marker
+    assert ctx.temporal.value_if_bound(entry.coordinate.cid) is floor
+
+
+# ---------------------------------------------------------------------------
+# Undecidable + halt retain formal floor install
+# ---------------------------------------------------------------------------
+
+
+def test_undecidable_guard_faces_retain_formal_floor_bindings() -> None:
     from sugar_lift_py_tests.outcome.exit_set import Completed
 
-    _fn, _param, entry = _bool_formal_entry(truth=True)
-    # Free NameSugar is ConstructedTermSugar and undecided under empty temporal
-    # (same door as #6738-migrated if_step twins).
-    guard = NameSugar("symbolic_guard", site="s")
-    machine = _machine_with_guard(
-        entry,
-        guard,
+    _fn, param, entry = _formal_entry_and_coordinate(truth=True)
+    floor = TrueBoolLiteralSugar(site=param.fragment)
+    machine = _machine(
+        entry=entry,
+        floor=floor,
+        guard=NameSugar("symbolic_guard", site="s"),
         then_steps=(YieldStepV1(IntLiteralSugar(1, site="t")),),
         else_steps=(YieldStepV1(IntLiteralSugar(0, site="e")),),
     )
@@ -278,42 +346,29 @@ def test_undecidable_guard_faces_retain_the_same_sealed_binding_state() -> None:
 
     assert isinstance(outcome, ExitSet)
     completed = [exit_ for exit_ in outcome.exits if isinstance(exit_, Completed)]
-    assert len(completed) >= 1
-    # Factor may collapse to one GuardedValue arm; every successor machine that
-    # still carries generator state must retain the sealed formal binding.
-    sealed_cid = entry.require_constructed_value_testimony().cid
+    assert completed
 
-    def _check_state(value):
+    def _check(value):
         if isinstance(value, GeneratorConstructionV1):
-            assert len(value.binding_state) == 1
-            bound = value.binding_state[0]
-            assert isinstance(bound, BindingEntryV1)
-            assert bound.coordinate.cid == entry.coordinate.cid
-            assert bound.require_constructed_value_testimony().cid == sealed_cid
+            assert value.formal_floor_bindings[0].floor_value is floor
+            assert value.formal_floor_bindings[0].coordinate_cid == entry.coordinate.cid
             return
-        # GuardedValue / factored forms may wrap the machine.
         inner = getattr(value, "value", None) or getattr(value, "machine", None)
         if inner is not None and inner is not value:
-            _check_state(inner)
-        for face in getattr(value, "faces", ()) or ():
-            _check_state(getattr(face, "value", face))
+            _check(inner)
 
     for exit_ in completed:
-        _check_state(exit_.value)
+        _check(exit_.value)
 
 
-# ---------------------------------------------------------------------------
-# Guard halt retains exact pre-halt state
-# ---------------------------------------------------------------------------
+def test_guard_halt_retains_exact_pre_halt_formal_floors() -> None:
+    _fn, param, entry = _formal_entry_and_coordinate(truth=True)
+    floor = TrueBoolLiteralSugar(site=param.fragment)
+    machine = _machine(entry=entry, floor=floor)
 
-
-def test_guard_halt_retains_exact_pre_halt_sealed_state() -> None:
-    function, param, entry = _bool_formal_entry(truth=True)
-    guard = _guard_ref(function, param, entry.coordinate)
-    machine = _machine_with_guard(entry, guard)
-
-    effect = RaiseEffect(exception_name="HaltProbe", occurrence="guard:halt")
-    halted = machine.throw(effect)
+    halted = machine.throw(
+        RaiseEffect(exception_name="HaltProbe", occurrence="guard:halt")
+    )
 
     assert isinstance(halted, ExitSet)
     halted_exits = [exit_ for exit_ in halted.exits if isinstance(exit_, Halted)]
@@ -321,12 +376,6 @@ def test_guard_halt_retains_exact_pre_halt_sealed_state() -> None:
     for exit_ in halted_exits:
         state = exit_.state
         assert isinstance(state, GeneratorConstructionV1)
-        assert len(state.binding_state) == 1
-        assert state.binding_state[0].coordinate.cid == entry.coordinate.cid
-        assert state.binding_state[0].require_constructed_value_testimony().cid == (
-            entry.require_constructed_value_testimony().cid
-        )
-        # Cursor / steps unchanged: pre-halt snapshot.
+        assert state.formal_floor_bindings[0].floor_value is floor
         assert state.cursor == machine.cursor
-        assert state.steps == machine.steps
         assert state.instance_coordinate == machine.instance_coordinate


### PR DESCRIPTION
## Summary

Generator lifecycle machine now installs authenticated **sealed** `BindingEntryV1` formals (and reduced assign bindings) into the temporal context used for pre-yield guard evaluation. `BindingCoordinateRefSugar.desugar` remains the sole consumer/refusal boundary — exact `coordinate.cid` lookup only; no name map, coordinate scan, or unspecialized-formal fallback on that door.

Closes the #6691 guard-context producer gap (seam 2 completion order).

### Producer (`GeneratorConstructionV1`)
- `_guard_evaluation_context()` — sealed formal `coordinate.cid → FloorValue`; assign names already reduced on the machine
- `_floor_from_sealed_binding_entry` — Floor from live actual Node (no formal temporal)
- `_guard_truth` / `_reduce_value` desugar under that context
- Unsealed / unrecoverable entries stay absent → consumer refuses loud

### Acceptance twins (`test_generator_guard_context_binding.py`)
| Twin | Evidence |
| --- | --- |
| Real bound option_context-style actual at exact formal coordinate | then-branch splice; sealed state retained |
| Bound false formal | else path / termination |
| Renamed twin | same coordinate-keyed path |
| Wrong coordinate | `GeneratorTransitionGapV1` |
| Absent testimony | gap (not installed into temporal) |
| Tampered coordinate CID | gap |
| Consumer door still refuses empty temporal | `SugarNotWritten` |
| Undecidable guard faces | same sealed formal on successor state |
| Guard halt | exact pre-halt sealed state / cursor / instance |

### Scope fences
Owned: generator construction/lifecycle producer + focused tests only.  
No WithResourceSugar / ExitSet consumer / carrier / spelling edits.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0..+ | pre-yield guards that previously gap on unspecialized formals may now decide |
| `mandatory_panics` | 0..− | sealed formals no longer leave BindingCoordinateRef unspecialized at guard eval |
| `suppressed_descendants` | 0 | no suppression path touched |
| `typed_effects` | 0 | no effect routing change |
| `silent` | 0 | floor: must stay 0 |

## Validation

```text
PYTHONPATH=implementations/python/sugar-lift-python-source/src:implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src \
  python3 -m pytest \
  implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py \
  implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py \
  implementations/python/sugar-lift-py-tests/tests/test_generator_binding_testimony_term.py \
  -q
# 33 passed
```

Focused guard-context suite alone: **9 passed**.

## Floors preserved

- data_loss=0
- no secret commit
- no test deleted for green
- silent=0
- BindingCoordinateRefSugar consumer contract unchanged (still refuses empty temporal)

## Shot accounting

| field | value |
| --- | --- |
| R axis | #6691 pre-yield guard formal resolution (generator lifecycle producer) |
| Epsilon R | sealed formals resolve at guard eval; R_guard_context → 0 on instrumented twins |
| Floors | silent=0; no consumer-door rewrite; no WithResourceSugar/ExitSet/carrier/spelling |
| Shell deleted | none yet (auditor/test still watches open domain of formal-bearing guards) |
| Retirement path | seal + temporal install is the type-level path for this axis; further Floor promotion of sealed actuals can delete recovery desugar later |
| Validation | 33 focused passed (guard-context + if-step + binding testimony) |
| Follow-on | queue: bounded prefix reduction → receipt seating → #6726 |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Carry sealed generator bindings into pre-yield guard temporal context
> - Extends `GeneratorConstructionV1.allocate` to accept `formal_floor_bindings` and `reduction_context`, validating that the provided floor CID roster exactly matches the sealed formal binding roster before storing them on the instance.
> - Adds `_guard_evaluation_context` to build a temporal context seeded with formal floor bindings and generator assign bindings, reusing the caller's `reduction_context` when present.
> - Updates `_guard_truth` and `_reduce_value` to desugar with the temporal-aware context; unspecialized (`SugarNotWritten`) guards now return undecided instead of raising, and unspecialized values produce a `GeneratorTransitionGapV1`.
> - Updates `CallSiteSugar.desugar` to construct `FormalFloorBindingV1` entries from positional actuals and pass them alongside the caller context to `allocate`.
> - Behavioral Change: `allocate` now rejects duplicate or mismatched formal floor coordinate rosters with `FormalFloorBindingGap`, and instance coordinate derivation now incorporates formal floor coordinate CIDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82bff89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->