### PR TITLE
test: pin mixed BoolOp halt state

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from sugar_lift_py_tests.caller_parameter_contract import source_coordinate
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import RaiseValue
 from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted
@@ -130,7 +129,7 @@ def _only_halted(outcome) -> Halted:
 
 
 def _formal_occurrence(compare: Compare) -> str:
-    return str(source_coordinate(compare.sugar().site).wire())
+    return str(compare.sugar().site)
 
 
 def test_first_leg_halt_blocks_toxic_and_safe_membership_with_exact_state() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from sugar_lift_py_tests.caller_parameter_contract import source_coordinate
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import RaiseValue
 from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted
 from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
 from sugar_lift_python_source.canonical import blake3_512_of
-from sugar_source_tree.nodes import BoolOp, Compare
+from sugar_source_tree.nodes import BoolOp, Call, Compare
 from sugar_source_tree.tree import SourceFile
 
 
@@ -98,3 +99,61 @@ def test_swapping_families_swaps_laws_without_collapsing_occurrences() -> None:
     assert {exit_.effect.occurrence_id for exit_ in halted} == {
         str(compare.sugar().site) for compare in comparisons
     }
+
+
+def _caller_outcomes(calls: str):
+    source = (
+        "def mixed(a, b, c, d):\n"
+        "    return a < b and c in d\n"
+        f"\n{calls}"
+    )
+    tree = SourceFile(
+        (source, "boolop-mixed-caller.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    comparisons = tuple(node for node in tree.nodes() if isinstance(node, Compare))
+    outcomes = tuple(
+        node.sugar().desugar(None)
+        for node in tree.nodes()
+        if isinstance(node, Call)
+    )
+    assert len(comparisons) == 2
+    return outcomes, comparisons
+
+
+def _only_halted(outcome) -> Halted:
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    halted = outcome.exits[0]
+    assert isinstance(halted, Halted)
+    return halted
+
+
+def _formal_occurrence(compare: Compare) -> str:
+    return str(source_coordinate(compare.sugar().site).wire())
+
+
+def test_first_leg_halt_blocks_toxic_and_safe_membership_with_exact_state() -> None:
+    (toxic, safe), comparisons = _caller_outcomes(
+        "mixed(None, 1, None, 3)\n"
+        "mixed(None, 1, 1, [1])\n"
+    )
+    toxic_halt = _only_halted(toxic)
+    safe_halt = _only_halted(safe)
+
+    first_occurrence = str(comparisons[0].sugar().site)
+    assert toxic_halt.effect.occurrence_id == first_occurrence
+    assert safe_halt.effect.occurrence_id == first_occurrence
+    assert toxic_halt.effect.occurrence_id != _formal_occurrence(comparisons[1])
+    assert toxic_halt.state is not None
+    assert safe_halt.state is not None
+    assert toxic_halt.state == safe_halt.state
+
+
+def test_truthful_first_leg_routes_membership_halt_to_second_occurrence_and_state() -> None:
+    (outcome,), comparisons = _caller_outcomes("mixed(1, 2, None, 3)\n")
+    halted = _only_halted(outcome)
+
+    assert halted.effect.occurrence_id == _formal_occurrence(comparisons[1])
+    assert halted.effect.occurrence_id != _formal_occurrence(comparisons[0])
+    assert halted.state is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_if_branch_result_slot.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_if_branch_result_slot.py
@@ -261,3 +261,90 @@ def test_boolean_continuing_face_returns_the_exact_second_operand(
 
     assert hasattr(outcome, "value")
     assert outcome.value is right
+
+
+@pytest.mark.parametrize(
+    ("condition_is_true", "selected_index"),
+    ((True, 0), (False, 1)),
+    ids=("truthful", "falsey-twin"),
+)
+def test_ifexp_returns_exact_selected_operand_and_never_evaluates_peer(
+    condition_is_true: bool, selected_index: int
+) -> None:
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
+    from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    condition_type = (
+        TrueBoolLiteralSugar if condition_is_true else FalseBoolLiteralSugar
+    )
+    condition = condition_type("ifexp-condition")
+    selected = TermValue(11 if condition_is_true else 22)
+
+    class Selected(ConstructedTermSugar):
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+        def desugar(self, ctx=None):
+            return Complete(selected)
+
+        def to_term(self, *, owner: str):
+            return selected.to_term(owner=owner)
+
+    class Skipped(ConstructedTermSugar):
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+        def desugar(self, ctx=None):
+            raise AssertionError("unchosen IfExp operand was evaluated")
+
+        def to_term(self, *, owner: str):
+            raise AssertionError("unchosen IfExp operand was projected")
+
+    arms = (Selected(), Skipped()) if selected_index == 0 else (Skipped(), Selected())
+    outcome = IfExpSugar(condition, arms[0], arms[1], "ifexp-site").desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value is selected
+
+
+def test_ifexp_condition_halt_bypasses_both_operands_with_effect_identity() -> None:
+    from sugar_lift_py_tests.effect import ExpectationNotMetEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+    from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
+    from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+
+    effect = ExpectationNotMetEffect("ifexp-condition", "condition-site")
+
+    class HaltingCondition(ConstructedTermSugar):
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+        def desugar(self, ctx=None):
+            return Incomplete(effect)
+
+        def to_term(self, *, owner: str):
+            raise AssertionError("halting condition was projected")
+
+    class Skipped(ConstructedTermSugar):
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+        def desugar(self, ctx=None):
+            raise AssertionError("IfExp arm ran after condition halt")
+
+        def to_term(self, *, owner: str):
+            raise AssertionError("IfExp arm projected after condition halt")
+
+    outcome = IfExpSugar(
+        HaltingCondition(), Skipped(), Skipped(), "ifexp-site"
+    ).desugar(None)
+
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect is effect

--- a/implementations/python/sugar-lift-py-tests/tests/test_if_branch_result_slot.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_if_branch_result_slot.py
@@ -348,3 +348,61 @@ def test_ifexp_condition_halt_bypasses_both_operands_with_effect_identity() -> N
 
     assert isinstance(outcome, Incomplete)
     assert outcome.effect is effect
+
+
+@pytest.mark.parametrize(
+    ("condition_is_true", "selected_index"),
+    ((True, 0), (False, 1)),
+    ids=("body-halts", "orelse-halts-arm-swap"),
+)
+def test_ifexp_selected_halt_preserves_its_occurrence_and_skips_peer(
+    condition_is_true: bool, selected_index: int
+) -> None:
+    from sugar_lift_py_tests.effect import ExpectationNotMetEffect
+    from sugar_lift_py_tests.outcome import Incomplete
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
+    from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    condition_type = (
+        TrueBoolLiteralSugar if condition_is_true else FalseBoolLiteralSugar
+    )
+    selected_effect = ExpectationNotMetEffect(
+        "selected-ifexp-arm", f"arm-{selected_index}-occurrence"
+    )
+
+    class SelectedHalt(ConstructedTermSugar):
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+        def desugar(self, ctx=None):
+            return Incomplete(selected_effect)
+
+        def to_term(self, *, owner: str):
+            raise AssertionError("selected halting arm was projected as a value")
+
+    class Skipped(ConstructedTermSugar):
+        @classmethod
+        def witnesses(cls):
+            return ()
+
+        def desugar(self, ctx=None):
+            raise AssertionError("unchosen IfExp arm emitted an occurrence")
+
+        def to_term(self, *, owner: str):
+            raise AssertionError("unchosen IfExp arm was projected")
+
+    arms = (
+        (SelectedHalt(), Skipped())
+        if selected_index == 0
+        else (Skipped(), SelectedHalt())
+    )
+    outcome = IfExpSugar(
+        condition_type("ifexp-condition"), arms[0], arms[1], "ifexp-site"
+    ).desugar(None)
+
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect is selected_effect
+    assert outcome.effect.site == f"arm-{selected_index}-occurrence"

--- a/implementations/python/sugar-lift-py-tests/tests/test_if_branch_result_slot.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_if_branch_result_slot.py
@@ -220,14 +220,22 @@ def test_boolean_short_circuit_returns_the_exact_stopping_operand(
 ) -> None:
     from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
     from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
     from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 
     literal = TrueBoolLiteralSugar if stopping_type else FalseBoolLiteralSugar
     left = literal("left-occurrence")
 
-    class Skipped:
+    class Skipped(ConstructedTermSugar):
+        @classmethod
+        def witnesses(cls):
+            return ()
+
         def desugar(self, ctx=None):
             raise AssertionError("short-circuited operand was evaluated")
+
+        def to_term(self, *, owner: str):
+            raise AssertionError("short-circuited operand was projected")
 
     outcome = BoolOpSugar(kind, (left, Skipped()), "boolop-site").desugar(None)
 
@@ -245,17 +253,25 @@ def test_boolean_continuing_face_returns_the_exact_second_operand(
 ) -> None:
     from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
     from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
     from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 
     literal = TrueBoolLiteralSugar if continuing_type else FalseBoolLiteralSugar
     left = literal("left-occurrence")
     right = TermValue(7)
 
-    class Right:
+    class Right(ConstructedTermSugar):
+        @classmethod
+        def witnesses(cls):
+            return ()
+
         def desugar(self, ctx=None):
             from sugar_lift_py_tests.outcome import Complete
 
             return Complete(right)
+
+        def to_term(self, *, owner: str):
+            return right.to_term(owner=owner)
 
     outcome = BoolOpSugar(kind, (left, Right()), "boolop-site").desugar(None)
 


### PR DESCRIPTION
## Carrier defect instrument\n\nExtends the mixed ordering/membership BoolOp vertical with real source callers:\n- first-leg TypeError blocks both toxic and safe membership twins\n- first-leg halt preserves the exact non-null pre-effect state\n- second-leg membership halt retains its own authenticated occurrence\n- second-leg membership halt must preserve pre-effect state\n\nThe last assertion is an honest red exposing a frozen-carrier defect. No production, carrier, ExitSet, reducer, or boundary files changed.\n\n## Exact defect\n\n`implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py:1005-1008`, `NativeOperationExitCarrierV1.discharge`: when a continuation returns the second-leg carrier, it calls `next_outcome.discharge(...)` while that carrier has `pre_effect_state=None`. Expected: inherit the reducer-issued pre-effect-state testimony from the enclosing carrier before discharging the continuation. Actual: the correctly attributed membership `Halted` has `state=None`.\n\n## Test\n\n`../../../bin/bpytest tests/test_boolop_mixed_compare_families.py -q` — 6 passed, 1 failed.\n\nRed: `assert halted.state is not None` / `Halted.state == None`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin mixed BoolOp halt state in desugaring tests
> - Adds tests in [test_boolop_mixed_compare_families.py](https://github.com/TSavo/sugar/pull/6736/files#diff-0b47988eb948affd4c920a6196e74b659bf6adc452eae4669a19b9b5c4fa3027) that verify a first-leg halt short-circuits both toxic and safe membership checks, preserves identical state, and routes occurrence attribution correctly when the first leg is truthful.
> - Extends [test_if_branch_result_slot.py](https://github.com/TSavo/sugar/pull/6736/files#diff-8082a1f14323374d0403bd91768678a1bbd222d9e3b8b4ceb8059f7549a923df) with `IfExpSugar` tests covering exact operand identity on selection, condition halt bypassing both arms, and selected-arm halt preserving occurrence site while skipping the peer.
> - Updates existing `BoolOpSugar` tests to use `ConstructedTermSugar` subclasses, adding `to_term` coverage to confirm skipped operands are never projected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35c4757.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->