### PR TITLE
Preserve state through continuation carriers

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -749,8 +749,8 @@ class NativeOperationExitCarrierV1:
             site=site,
         )
 
-    def and_then(self, step, *, pre_effect_state=_PRE_EFFECT_STATE_UNSET):
-        """Retain work and, at the reducer seam, the exact pre-effect state."""
+    def _enroll_pre_effect_state(self, pre_effect_state):
+        """Enroll reducer testimony without adding an expression continuation."""
         testimony = self.pre_effect_state
         if pre_effect_state is not _PRE_EFFECT_STATE_UNSET:
             if not isinstance(pre_effect_state, ReducerPreEffectStateV1):
@@ -775,10 +775,14 @@ class NativeOperationExitCarrierV1:
                 )
             if testimony is None:
                 testimony = pre_effect_state
+        return replace(self, pre_effect_state=testimony)
+
+    def and_then(self, step, *, pre_effect_state=_PRE_EFFECT_STATE_UNSET):
+        """Retain work and, at the reducer seam, the exact pre-effect state."""
+        enrolled = self._enroll_pre_effect_state(pre_effect_state)
         return replace(
-            self,
-            continuations=(*self.continuations, step),
-            pre_effect_state=testimony,
+            enrolled,
+            continuations=(*enrolled.continuations, step),
         )
 
     def guarded(self, guard, face=None):
@@ -1005,6 +1009,10 @@ class NativeOperationExitCarrierV1:
             def resume(value, *, step=continuation):
                 next_outcome = step(value)
                 if isinstance(next_outcome, NativeOperationExitCarrierV1):
+                    if self.pre_effect_state is not None:
+                        next_outcome = next_outcome._enroll_pre_effect_state(
+                            self.pre_effect_state
+                        )
                     return next_outcome.discharge(actuals_by_formal_coordinate)
                 return next_outcome
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -267,6 +267,65 @@ def test_short_circuit_missing_second_leg_actual_remains_explicitly_undischarged
         composed.discharge({left.coordinate_cid: TermValue(1)})
 
 
+def test_continuation_carrier_inherits_enclosing_reducer_pre_effect_state():
+    first, left, right = _carrier(operator="less_than")
+    second_left = _coordinate("second_left", 2)
+    second_right = _coordinate("second_right", 3)
+    second = NativeOperationExitCarrierV1.mint(
+        site=_site(),
+        operator="less_than",
+        operands=(
+            SymbolicValue(make_var("second_left"), second_left),
+            SymbolicValue(make_var("second_right"), second_right),
+        ),
+        coordinates=(second_left, second_right),
+    )
+    state = _ReducedBlock((TermValue(71),), True, ())
+    testimony = ReducerPreEffectStateV1._from_reducer(state)
+    chained = first.and_then(
+        lambda _value: second,
+        pre_effect_state=testimony,
+    )
+
+    exits = chained.discharge(
+        {
+            left.coordinate_cid: TermValue(1),
+            right.coordinate_cid: TermValue(2),
+            second_left.coordinate_cid: NoneValue(),
+            second_right.coordinate_cid: TermValue(2),
+        }
+    )
+
+    halted = next(exit_ for exit_ in exits.exits if isinstance(exit_, Halted))
+    assert halted.state is state
+
+
+def test_continuation_carrier_rejects_conflicting_pre_effect_state():
+    first, left, right = _carrier(operator="less_than")
+    outer_state = _ReducedBlock((TermValue(71),), True, ())
+    conflicting_state = _ReducedBlock((TermValue(72),), True, ())
+    second, _second_left, _second_right = _carrier(operator="less_than")
+    second = second.and_then(
+        lambda value: Complete(value),
+        pre_effect_state=ReducerPreEffectStateV1._from_reducer(conflicting_state),
+    )
+    chained = first.and_then(
+        lambda _value: second,
+        pre_effect_state=ReducerPreEffectStateV1._from_reducer(outer_state),
+    )
+
+    with pytest.raises(
+        ConstructionPanic,
+        match="a second conflicting reducer pre-effect state",
+    ):
+        chained.discharge(
+            {
+                left.coordinate_cid: TermValue(1),
+                right.coordinate_cid: TermValue(2),
+            }
+        )
+
+
 @pytest.mark.parametrize(
     ("method", "operator"),
     (


### PR DESCRIPTION
## What changed
- transfer reducer-issued pre-effect testimony into a continuation-produced native-operation carrier before discharge
- reuse the existing enrollment conflict check without adding a fake expression continuation
- prove authentic state survival and conflicting-state panic

## Verification
- `../../../bin/bpytest tests/test_native_operation_exit_carrier.py tests/test_chained_compare_production_instrument.py tests/test_native_operation_pre_effect_state.py` — 73 passed

Predicted epsilon: continuation-carrier missing-state red goes to zero. Floors preserved: ExitSet untouched; conflicting testimony remains a ConstructionPanic.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve reducer pre-effect state through continuation carriers in `NativeOperationExitCarrierV1`
> - Adds `_enroll_pre_effect_state` to [`caller_parameter_contract.py`](https://github.com/TSavo/sugar/pull/6737/files#diff-5136726cb5a60b48beb30152aecb6eca8ad0173bdefc676eb112b1c1b2acbf57) to validate and attach a `ReducerPreEffectStateV1` to a carrier independently of adding continuations.
> - Updates `discharge` to propagate the enclosing carrier's pre-effect state into any carrier returned by a continuation, ensuring state is not lost across continuation chains.
> - Raises a `construction_panic_gap` if an inner continuation carrier has a conflicting pre-effect state during discharge.
> - Risk: existing code that produces conflicting reducer states across nested carriers will now raise a `ConstructionPanic` at discharge time rather than silently discarding the outer state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ea6273.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->