### PR TITLE
Migrate generator step fixtures to constructed sugars

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
@@ -42,7 +42,6 @@ import tempfile
 
 import pytest
 
-from sugar_lift_py_tests.floor.term_value import TermValue
 from sugar_lift_py_tests.generator_construction import (
     GeneratorConstructionV1,
     GeneratorTerminationV1,
@@ -55,6 +54,8 @@ from sugar_lift_py_tests.generator_construction import (
 )
 from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet
 from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
+from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
@@ -155,7 +156,10 @@ def test_pre_yield_if_with_raise_stays_opaque_and_loud() -> None:
 
 def test_a_ground_true_guard_splices_the_then_branch() -> None:
     step = IfStepV1(
-        TrueBoolLiteralSugar(site="s"), (YieldStepV1(TermValue(1)),), (), "frag"
+        TrueBoolLiteralSugar(site="s"),
+        (YieldStepV1(IntLiteralSugar(1, site="yield:1")),),
+        (),
+        "frag",
     )
 
     assert isinstance(_machine((step, ReturnStepV1())).resume(), YieldEffect)
@@ -163,7 +167,10 @@ def test_a_ground_true_guard_splices_the_then_branch() -> None:
 
 def test_a_ground_false_guard_splices_the_else_branch() -> None:
     step = IfStepV1(
-        FalseBoolLiteralSugar(site="s"), (YieldStepV1(TermValue(1)),), (), "frag"
+        FalseBoolLiteralSugar(site="s"),
+        (YieldStepV1(IntLiteralSugar(1, site="yield:1")),),
+        (),
+        "frag",
     )
 
     assert isinstance(_machine((step, ReturnStepV1())).resume(), GeneratorTerminationV1)
@@ -187,11 +194,12 @@ def test_a_branch_with_k_suspensions_stays_one_arm(branch_suspensions) -> None:
     ever reports the branch count instead of 1, sequencing has gone exponential
     and the defect surfaces as a corpus timeout days later, never in a twin.
     """
-    branch = tuple(YieldStepV1(TermValue(n)) for n in range(branch_suspensions))
-    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-    from sugar_lift_py_tests.ir import atomic
+    branch = tuple(
+        YieldStepV1(IntLiteralSugar(n, site=f"yield:{n}"))
+        for n in range(branch_suspensions)
+    )
 
-    step = IfStepV1(PredicateValue(atomic("c", ()), "s"), branch, (), "frag")
+    step = IfStepV1(NameSugar("c", site="s"), branch, (), "frag")
     outcome = _machine((step, ReturnStepV1())).resume()
 
     assert len(_completed(outcome)) == 1
@@ -199,13 +207,10 @@ def test_a_branch_with_k_suspensions_stays_one_arm(branch_suspensions) -> None:
 
 def test_sequential_branches_stay_one_arm() -> None:
     """k branches in sequence would be 2 ** k unfactored."""
-    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-    from sugar_lift_py_tests.ir import atomic
-
     steps = tuple(
         IfStepV1(
-            PredicateValue(atomic(f"c{n}", ()), "s"),
-            (YieldStepV1(TermValue(n)),),
+            NameSugar(f"c{n}", site=f"guard:{n}"),
+            (YieldStepV1(IntLiteralSugar(n, site=f"yield:{n}")),),
             (),
             f"frag{n}",
         )

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
@@ -22,7 +22,7 @@ import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
-from sugar_lift_py_tests.floor import BlockValue, ReturnValue, TermValue
+from sugar_lift_py_tests.floor import BlockValue, ReturnValue, StringValue, TermValue
 from sugar_lift_py_tests.generator_construction import (
     GeneratorConstructionV1,
     InertStepV1,
@@ -31,6 +31,9 @@ from sugar_lift_py_tests.generator_construction import (
     YieldStepV1,
 )
 from sugar_lift_py_tests.outcome import Complete, Incomplete, outcome_to_exitset
+from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
+from sugar_lift_py_tests.sugar.none_literal_sugar import NoneLiteralSugar
+from sugar_lift_py_tests.sugar.string_literal_sugar import StringLiteralSugar
 from sugar_lift_python_source.canonical import cid_of_json
 from sugar_lift_python_source.manager_protocol_construction import (
     EnteredGeneratorManagerStateV1,
@@ -48,7 +51,10 @@ def _coords():
 
 def _frame(*, steps=None, frame_cid=None, bindings=()):
     if steps is None:
-        steps = (YieldStepV1(TermValue(17)), ReturnStepV1(None))
+        steps = (
+            YieldStepV1(IntLiteralSugar(17, site="yield:17")),
+            ReturnStepV1(None),
+        )
     cid = frame_cid or cid_of_json({"frame": "generator-lifecycle-test"})
     return SimpleNamespace(
         frame_cid=cid,
@@ -155,7 +161,7 @@ def test_pre_yield_inert_step_then_yield_still_enters():
             steps=(
                 InertStepV1("Expr"),
                 InertStepV1("Pass"),
-                YieldStepV1(TermValue(99)),
+                YieldStepV1(IntLiteralSugar(99, site="yield:99")),
                 ReturnStepV1(None),
             ),
             frame_cid=cid_of_json({"frame": "pre-yield-inert"}),
@@ -204,8 +210,10 @@ def test_pre_yield_assign_then_yield_enters_with_resource():
     protocol = _protocol(
         frame=_frame(
             steps=(
-                AssignStepV1("prior", TermValue(None), "frag:prior"),
-                YieldStepV1(TermValue(42)),
+                AssignStepV1(
+                    "prior", NoneLiteralSugar(site="assign:prior"), "frag:prior"
+                ),
+                YieldStepV1(IntLiteralSugar(42, site="yield:42")),
                 ReturnStepV1(None),
             ),
             frame_cid=cid_of_json({"frame": "pre-yield-assign"}),
@@ -237,7 +245,11 @@ def test_pre_yield_suspension_assign_twin_does_not_impersonate_ordinary_assign()
             steps=(
                 OpaqueStepV1("Assign", carries_suspension=True),
                 # Trailing yield only if suspension Assign is wrongly skipped.
-                YieldStepV1(TermValue("should-not-steal")),
+                YieldStepV1(
+                    StringLiteralSugar(
+                        "should-not-steal", site="yield:should-not-steal"
+                    )
+                ),
                 ReturnStepV1(None),
             ),
             frame_cid=cid_of_json({"frame": "pre-yield-suspension-assign"}),
@@ -263,7 +275,7 @@ def test_pre_yield_suspension_assign_twin_does_not_impersonate_ordinary_assign()
     entered = outcome.value
     assert isinstance(entered, EnteredGeneratorManagerStateV1)
     # Trailing "should-not-steal" would mean the suspension Assign was skipped.
-    assert entered.enter_value != TermValue("should-not-steal"), (
+    assert entered.enter_value != StringValue("should-not-steal"), (
         "suspension-carrying Assign was stepped past as if inert; resume-value "
         "binding was dropped"
     )
@@ -277,8 +289,10 @@ def test_pre_yield_assign_and_inert_prefix_compose_then_yield():
         frame=_frame(
             steps=(
                 InertStepV1("Expr"),
-                AssignStepV1("prior", TermValue(None), "frag:prior2"),
-                YieldStepV1(TermValue(7)),
+                AssignStepV1(
+                    "prior", NoneLiteralSugar(site="assign:prior2"), "frag:prior2"
+                ),
+                YieldStepV1(IntLiteralSugar(7, site="yield:7")),
                 ReturnStepV1(None),
             ),
             frame_cid=cid_of_json({"frame": "inert-then-assign-then-yield"}),

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_nested_managers.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_nested_managers.py
@@ -35,7 +35,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     TreeConstructionContextV1,
 )
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
-from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.floor import StringValue, TermValue
 from sugar_lift_py_tests.generator_construction import (
     NestedEnteredBindingV1,
     NestedManagerExitStepV1,
@@ -46,6 +46,7 @@ from sugar_lift_py_tests.generator_construction import (
     ReturnStepV1,
 )
 from sugar_lift_py_tests.outcome import Complete, Incomplete, outcome_to_exitset
+from sugar_lift_py_tests.sugar.string_literal_sugar import StringLiteralSugar
 from sugar_lift_python_source.canonical import cid_of_json
 from sugar_lift_python_source.manager_protocol_construction import (
     EnteredGeneratorManagerStateV1,
@@ -278,7 +279,10 @@ def test_planted_nested_manager_step_lifecycle_performance() -> None:
     """Planted NestedManagerStep (no nodes emission) enters/exits nested once."""
     inner_frame = SimpleNamespace(
         frame_cid=cid_of_json({"frame": "inner-nested"}),
-        generator_steps=(YieldStepV1(TermValue("inner")), ReturnStepV1(None)),
+        generator_steps=(
+            YieldStepV1(StringLiteralSugar("inner", site="nested:inner-yield")),
+            ReturnStepV1(None),
+        ),
         runtime_entries=(),
     )
     enter = SourceFragmentCoordinateV1("blake3-512:" + "a" * 128, 1, 0, 2, 0)
@@ -293,7 +297,9 @@ def test_planted_nested_manager_step_lifecycle_performance() -> None:
     outer_steps = (
         NestedManagerStepV1(
             nested_protocol=inner_protocol,
-            body_steps=(YieldStepV1(TermValue("outer")),),
+            body_steps=(
+                YieldStepV1(StringLiteralSugar("outer", site="nested:outer-yield")),
+            ),
             fragment_cid="blake3-512:" + "d" * 128,
             occurrence_cid="blake3-512:" + "e" * 128,
         ),
@@ -316,7 +322,7 @@ def test_planted_nested_manager_step_lifecycle_performance() -> None:
     outcome = outer_protocol.enter_resource_outcome()
     assert isinstance(outcome, Complete)
     entered = outcome.value
-    assert entered.enter_value == TermValue("outer")
+    assert entered.enter_value == StringValue("outer")
     assert any(isinstance(b, NestedEnteredBindingV1) for b in entered.machine.binding_state)
     # Exit outer: NestedManagerExitStep exits nested then terminates.
     exit_outcome = outer_protocol.exit_outcome_for(entered)


### PR DESCRIPTION
## What changed

Migrates every stale planted `TermValue` / `PredicateValue` generator-step payload in the three owning test files to its corresponding `ConstructedTermSugar` literal or reference. Existing assertions are retained; string expectations now use the canonical `StringValue` floor produced by `StringLiteralSugar`.

## Root cause

The ConstructedTermSugar promotion correctly made invalid generator payloads unconstructable, but its migration omitted direct test constructions, leaving main red at constructor admission.

## Validation

- `bin/bpytest` over all three owning files: 36 passed
- stale constructor grep: 0 matches
- assertion count: 90 before, 90 after

R axis: stale planted generator-step payload constructors 14 -> 0. Floors preserved: no production changes; no assertions deleted; loud type admission remains intact.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate generator step test fixtures to use sugar literal classes
> Replaces `TermValue` and `PredicateValue` usages in generator step test fixtures with sugar-layer equivalents (`IntLiteralSugar`, `NameSugar`, `StringLiteralSugar`, `NoneLiteralSugar`). Assertions that previously compared against `TermValue` now compare against the corresponding value types (e.g. `StringValue`). The change affects test files across `test_generator_if_step.py`, `test_generator_lifecycle_performance.py`, and `test_generator_nested_managers.py`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c76f80b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated generator tests to use typed integer, string, name, and `None` literal values.
  * Added explicit metadata to yield and assignment test scenarios.
  * Updated lifecycle, branching, suspension, and nested manager assertions to reflect the revised value representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->