### PR TITLE
Starred-target store: LTR typed targets + positional roster

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/__init__.py
@@ -6,13 +6,19 @@ from .inplace_binary_operator_operation import (
 )
 from .iterator_operation import IteratorOperation, discharge_iter
 from .next_operation import NextOperation, discharge_next
+from .positional_unpack_operation import (
+    PositionalUnpackOperation,
+    UnpackMemberRoster,
+)
 from .sequence_projection_operation import SequenceProjectionOperation
 
 __all__ = [
     "InplaceBinaryOperatorOperation",
     "IteratorOperation",
     "NextOperation",
+    "PositionalUnpackOperation",
     "SequenceProjectionOperation",
+    "UnpackMemberRoster",
     "discharge_inplace",
     "discharge_iter",
     "discharge_next",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/positional_unpack_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/positional_unpack_operation.py
@@ -1,0 +1,190 @@
+"""Positional UNPACK roster — members by source-leaf order, no lexical keys.
+
+Sibling of ``SequenceProjectionOperation`` (name-keyed ScopeRebinds).  Store
+and mixed unpack need authenticated members in **source leaf order** without
+fabricating string binding identities for non-name targets.
+
+Same floor door: ``project_sequence_with``.  Same arity / opaque laws.
+Star middle is a ``ListValue`` in the roster at the star leaf position.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+
+@dataclass(frozen=True)
+class UnpackMemberRoster:
+    """Authenticated finite UNPACK result: one member per source target leaf.
+
+    Star positions hold ``ListValue`` of the middle slice.  No string keys —
+    consumers zip with typed projection targets by position.
+    """
+
+    members: tuple  # FloorValue per leaf, source order
+
+
+@dataclass(frozen=True)
+class PositionalUnpackOperation:
+    """UNPACK demand that returns ``UnpackMemberRoster`` (positional).
+
+    ``fixed_prefix`` / ``fixed_suffix`` count fixed leaves around an optional
+    star.  ``has_star`` selects UNPACK_EX vs UNPACK_SEQUENCE cardinality.
+    """
+
+    method_name: ClassVar[str] = "project_sequence_with"
+
+    fixed_prefix: int
+    fixed_suffix: int
+    has_star: bool
+    owner: str
+    blame: object
+
+    def __post_init__(self) -> None:
+        if self.fixed_prefix < 0 or self.fixed_suffix < 0:
+            raise ValueError("fixed_prefix/fixed_suffix must be non-negative")
+        if not self.has_star and self.fixed_suffix:
+            raise ValueError("fixed_suffix requires has_star")
+
+    @property
+    def arity(self) -> int:
+        return self.fixed_prefix + self.fixed_suffix
+
+    @property
+    def is_starred(self) -> bool:
+        return self.has_star
+
+    def submit(self, value: Any, ctx: Any) -> Any:
+        return value.project_sequence_with(self, ctx)
+
+    def project_tuple(self, value: Any, ctx: Any) -> Any:
+        del ctx
+        return self._authenticated_members(value, value.items, "tuple")
+
+    def project_array(self, value: Any, ctx: Any) -> Any:
+        del ctx
+        return self._authenticated_members(value, value.items, "array")
+
+    def project_comprehension(self, value: Any, ctx: Any) -> Any:
+        del ctx
+        if value.finite_elements is None:
+            return self._runtime_cardinality(value)
+        return self._authenticated_members(
+            value, value.finite_elements, "comprehension"
+        )
+
+    def project_symbolic(self, value: Any, ctx: Any) -> Any:
+        del ctx
+        return self._runtime_cardinality(value)
+
+    def project_object(self, value: Any, ctx: Any) -> Any:
+        del ctx
+        return self._runtime_cardinality(value)
+
+    def _authenticated_members(self, value: Any, members: tuple, display: str) -> Any:
+        from sugar_lift_py_tests.floor.list_value import ListValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        if not self.has_star:
+            if len(members) != self.arity:
+                return self._arity_mismatch_exit(value, len(members), display)
+            return Complete(UnpackMemberRoster(members))
+
+        fixed = self.arity
+        if len(members) < fixed:
+            return self._arity_mismatch_exit(value, len(members), display)
+        pre_n = self.fixed_prefix
+        suf_n = self.fixed_suffix
+        prefix_vals = members[:pre_n]
+        if suf_n:
+            mid_vals = members[pre_n : len(members) - suf_n]
+            suffix_vals = members[len(members) - suf_n :]
+        else:
+            mid_vals = members[pre_n:]
+            suffix_vals = ()
+        roster = (
+            *prefix_vals,
+            ListValue(tuple(mid_vals)),
+            *suffix_vals,
+        )
+        return Complete(UnpackMemberRoster(roster))
+
+    def _runtime_cardinality(self, value: Any) -> Any:
+        from sugar_lift_py_tests.effect import (
+            SequenceUnpackRuntimeEffect,
+            runtime_effect_evidence_from_terms,
+        )
+        from sugar_lift_py_tests.ir import ctor, num
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        term = value.to_term(owner=f"{self.owner}.value")
+        operation = ctor(
+            "python:unpack.destructure",
+            [term, num(self.arity)],
+            symbol_kind="coordinate",
+        )
+        if not self.has_star:
+            demand = f"exactly {self.arity} members for positional targets"
+        else:
+            demand = (
+                f"at least {self.arity} members for starred positional targets "
+                f"(prefix={self.fixed_prefix}, suffix={self.fixed_suffix})"
+            )
+        return Incomplete(
+            SequenceUnpackRuntimeEffect(
+                "sequence unpack runtime boundary: unpack demands "
+                f"{demand} but the right-hand side "
+                "carries no authenticated cardinality -- iteration count "
+                "belongs to Python's runtime __iter__; "
+                f"arity={self.arity} starred={self.has_star} "
+                f"site={self.blame}",
+                **runtime_effect_evidence_from_terms(operation, operation, self.blame),
+            )
+        )
+
+    def _arity_mismatch_exit(self, value: Any, members: int, display: str) -> Any:
+        """Named ValueError for decidable too-few / too-many (same door as name unpack)."""
+        from sugar_lift_py_tests.floor import RaiseValue
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+        from sugar_lift_py_tests.gap.panic import ConstructionPanic, construction_panic
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+        relation = "not enough" if members < self.arity else "too many"
+        observed = (
+            f"{type(value).__name__} of {members} members unpacked into "
+            f"{self.arity} fixed targets ({relation} values)"
+        )
+        if hasattr(self.blame, "filename") and hasattr(self.blame, "line"):
+            try:
+                projected = ground_exceptional_exit(
+                    exception_name="ValueError",
+                    site=self.blame,
+                    owner=f"{self.owner}.arity_mismatch",
+                )
+            except ConstructionPanic:
+                projected = None
+            else:
+                if isinstance(projected, Complete) and isinstance(
+                    projected.value, RaiseValue
+                ):
+                    return Incomplete(projected.value.effect)
+                return projected
+        construction_panic(
+            ConstructionGap(
+                owner=self.owner,
+                blame=str(self.blame),
+                observed=observed,
+                requested=(
+                    "ground ValueError exceptional exit for a decidable "
+                    f"{display} unpack arity mismatch"
+                ),
+                fix=(
+                    "thread a workspace-relative source fragment as blame so "
+                    "the ground ValueError exit can cite it"
+                ),
+                gap_kind=GapKind.FLOOR,
+                gap_locus=GapLocus.CONSTRUCTION,
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/positional_unpack_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/positional_unpack_operation.py
@@ -6,6 +6,10 @@ fabricating string binding identities for non-name targets.
 
 Same floor door: ``project_sequence_with``.  Same arity / opaque laws.
 Star middle is a ``ListValue`` in the roster at the star leaf position.
+
+Successful rosters carry the authenticated unpack **occurrence** and
+**demand_cid** (content address of site + arity layout) so consumers can
+testify which source unpack produced the members.
 """
 
 from __future__ import annotations
@@ -20,9 +24,26 @@ class UnpackMemberRoster:
 
     Star positions hold ``ListValue`` of the middle slice.  No string keys —
     consumers zip with typed projection targets by position.
+
+    ``occurrence`` and ``demand_cid`` are the unpack operation's authority:
+    which source unpack demand produced these members.  A roster of bare
+    members without them is unconstructable.
     """
 
     members: tuple  # FloorValue per leaf, source order
+    occurrence: object  # authenticated source fragment (operation blame)
+    demand_cid: str  # content address of unpack demand (site + arity)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.demand_cid, str) or not self.demand_cid:
+            raise ValueError(
+                "UnpackMemberRoster requires a nonempty demand_cid from the "
+                "positional unpack operation"
+            )
+        if self.occurrence is None:
+            raise ValueError(
+                "UnpackMemberRoster requires an authenticated unpack occurrence"
+            )
 
 
 @dataclass(frozen=True)
@@ -54,6 +75,46 @@ class PositionalUnpackOperation:
     @property
     def is_starred(self) -> bool:
         return self.has_star
+
+    def demand_cid(self) -> str:
+        """Content address of this unpack demand (site + arity layout)."""
+        from sugar_lift_py_tests.caller_parameter_contract import _cid, source_coordinate
+
+        try:
+            source_node = source_coordinate(self.blame)
+            source_wire = source_node.wire()
+        except (AttributeError, TypeError) as exc:
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner=f"{self.owner}.demand_cid",
+                blame=self.blame,
+                observed=f"{type(self.blame).__name__} cannot source-coordinate",
+                requested="authenticated source fragment for positional unpack",
+                fix=(
+                    "thread the statement fragment as PositionalUnpackOperation.blame "
+                    f"(cause={exc})"
+                ),
+            )
+        preimage = {
+            "kind": "positional-unpack-demand",
+            "schemaVersion": "1",
+            "owner": self.owner,
+            "sourceNode": source_wire,
+            "fixedPrefix": self.fixed_prefix,
+            "fixedSuffix": self.fixed_suffix,
+            "hasStar": self.has_star,
+            "arity": self.arity,
+        }
+        return _cid(preimage)
+
+    def mint_roster(self, members: tuple) -> UnpackMemberRoster:
+        """Seal members under this operation's occurrence and demand_cid."""
+        return UnpackMemberRoster(
+            members=members,
+            occurrence=self.blame,
+            demand_cid=self.demand_cid(),
+        )
 
     def submit(self, value: Any, ctx: Any) -> Any:
         return value.project_sequence_with(self, ctx)
@@ -89,7 +150,7 @@ class PositionalUnpackOperation:
         if not self.has_star:
             if len(members) != self.arity:
                 return self._arity_mismatch_exit(value, len(members), display)
-            return Complete(UnpackMemberRoster(members))
+            return Complete(self.mint_roster(members))
 
         fixed = self.arity
         if len(members) < fixed:
@@ -108,7 +169,7 @@ class PositionalUnpackOperation:
             ListValue(tuple(mid_vals)),
             *suffix_vals,
         )
-        return Complete(UnpackMemberRoster(roster))
+        return Complete(self.mint_roster(roster))
 
     def _runtime_cardinality(self, value: Any) -> Any:
         from sugar_lift_py_tests.effect import (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
@@ -144,6 +144,100 @@ class _PreconstructedStoreSugar(Sugar):
 
 
 @dataclass(frozen=True)
+class DynamicUnpackStoreAssignSugar(Sugar):
+    """Non-display RHS: flat Name|Attribute|Subscript|*Name unpack (LTR).
+
+    Python: evaluate RHS **once**, UNPACK materializes all members, then each
+    target applies its member **left-to-right**.  A halt on an earlier target
+    leaves later names unbound and later stores unrun; earlier completed
+    rebinds/stores survive on the halted face state.
+
+    Projection is positional (``PositionalUnpackOperation`` →
+    ``UnpackMemberRoster``) — no fabricated synthetic lexical binding keys.
+    Targets are typed variants (``unpack_projection_targets``) owning apply.
+    """
+
+    value: Sugar
+    targets: tuple  # Name|Star|Attribute|Subscript unpack targets, source order
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return typed_red_effect_witness(
+            name="dynamic_unpack_store_star",
+            owner_sugar="DynamicUnpackStoreAssignSugar",
+            source=(
+                "def A(o, xs):\n"
+                "    o.x, *rest = xs\n"
+                "    return rest\n"
+            ),
+            effect_class="SequenceUnpackRuntimeEffect",
+            reason_needle="sequence unpack",
+            blame_needle="at least 1 members",
+            wrong_reason_needle="unpack demands exactly 3 members",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.operations.positional_unpack_operation import (
+            PositionalUnpackOperation,
+        )
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
+        from sugar_lift_py_tests.sugar.unpack_projection_targets import (
+            ApplyUnpackMemberSugar,
+            AttributeUnpackTarget,
+            NameUnpackTarget,
+            StarUnpackTarget,
+            SubscriptUnpackTarget,
+        )
+
+        prefix, suffix, has_star = self._fixed_counts()
+        operation = PositionalUnpackOperation(
+            fixed_prefix=prefix,
+            fixed_suffix=suffix,
+            has_star=has_star,
+            owner=type(self).__name__,
+            blame=self.site,
+        )
+        return self.value.desugar(ctx).and_then(
+            lambda value: operation.submit(value, ctx).and_then(
+                lambda roster: reduce_block_to_exitset(
+                    tuple(
+                        ApplyUnpackMemberSugar(target, member, self.site)
+                        for target, member in zip(
+                            self.targets, roster.members, strict=True
+                        )
+                    ),
+                    ctx,
+                )
+            )
+        )
+
+    def _fixed_counts(self) -> tuple[int, int, bool]:
+        from sugar_lift_py_tests.sugar.unpack_projection_targets import (
+            StarUnpackTarget,
+        )
+
+        prefix = 0
+        suffix = 0
+        has_star = False
+        seen_star = False
+        for target in self.targets:
+            if isinstance(target, StarUnpackTarget):
+                if has_star:
+                    raise AssertionError("at most one star unpack target")
+                has_star = True
+                seen_star = True
+                continue
+            if seen_star:
+                suffix += 1
+            else:
+                prefix += 1
+        return prefix, suffix, has_star
+
+
+@dataclass(frozen=True)
 class UnpackStoreAssignSugar(Sugar):
     """Flat display unpack with Attribute/Subscript store leaves (and optional Names).
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
@@ -203,18 +203,71 @@ class DynamicUnpackStoreAssignSugar(Sugar):
             owner=type(self).__name__,
             blame=self.site,
         )
+        expected_demand_cid = operation.demand_cid()
         return self.value.desugar(ctx).and_then(
             lambda value: operation.submit(value, ctx).and_then(
-                lambda roster: reduce_block_to_exitset(
-                    tuple(
-                        ApplyUnpackMemberSugar(target, member, self.site)
-                        for target, member in zip(
-                            self.targets, roster.members, strict=True
-                        )
-                    ),
-                    ctx,
+                lambda roster: self._apply_authenticated_roster(
+                    roster,
+                    expected_demand_cid=expected_demand_cid,
+                    ctx=ctx,
                 )
             )
+        )
+
+    def _apply_authenticated_roster(
+        self, roster, *, expected_demand_cid: str, ctx
+    ):
+        """Zip targets only after the roster testifies this unpack occurrence."""
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        from sugar_lift_py_tests.operations.positional_unpack_operation import (
+            UnpackMemberRoster,
+        )
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
+        from sugar_lift_py_tests.sugar.unpack_projection_targets import (
+            ApplyUnpackMemberSugar,
+        )
+
+        if not isinstance(roster, UnpackMemberRoster):
+            construction_panic_gap(
+                owner=type(self).__name__,
+                blame=self.site,
+                observed=type(roster).__name__,
+                requested="UnpackMemberRoster with occurrence and demand_cid",
+                fix="mint members through PositionalUnpackOperation.mint_roster",
+            )
+        if roster.demand_cid != expected_demand_cid:
+            construction_panic_gap(
+                owner=type(self).__name__,
+                blame=self.site,
+                observed=f"roster demand_cid={roster.demand_cid!r}",
+                requested=f"unpack demand_cid={expected_demand_cid!r}",
+                fix=(
+                    "apply only the roster minted by this statement's "
+                    "PositionalUnpackOperation; same members under a foreign "
+                    "occurrence/demand are not this unpack"
+                ),
+            )
+        if roster.occurrence is not self.site and roster.occurrence != self.site:
+            construction_panic_gap(
+                owner=type(self).__name__,
+                blame=self.site,
+                observed=f"roster occurrence={roster.occurrence!r}",
+                requested=f"unpack occurrence={self.site!r}",
+                fix=(
+                    "require the roster occurrence to be this statement fragment; "
+                    "same members under a substituted occurrence are refused"
+                ),
+            )
+        return reduce_block_to_exitset(
+            tuple(
+                ApplyUnpackMemberSugar(target, member, self.site)
+                for target, member in zip(
+                    self.targets, roster.members, strict=True
+                )
+            ),
+            ctx,
         )
 
     def _fixed_counts(self) -> tuple[int, int, bool]:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
@@ -186,12 +186,15 @@ class DynamicUnpackStoreAssignSugar(Sugar):
         )
         from sugar_lift_py_tests.sugar.unpack_projection_targets import (
             ApplyUnpackMemberSugar,
-            AttributeUnpackTarget,
-            NameUnpackTarget,
-            StarUnpackTarget,
-            SubscriptUnpackTarget,
+            UnpackProjectionTarget,
         )
 
+        for target in self.targets:
+            if not isinstance(target, UnpackProjectionTarget):
+                raise TypeError(
+                    "DynamicUnpackStoreAssignSugar.targets must be "
+                    f"UnpackProjectionTarget; got {type(target).__name__}"
+                )
         prefix, suffix, has_star = self._fixed_counts()
         operation = PositionalUnpackOperation(
             fixed_prefix=prefix,
@@ -215,16 +218,17 @@ class DynamicUnpackStoreAssignSugar(Sugar):
         )
 
     def _fixed_counts(self) -> tuple[int, int, bool]:
-        from sugar_lift_py_tests.sugar.unpack_projection_targets import (
-            StarUnpackTarget,
-        )
+        """Positional UNPACK layout from target-owned star-slot testimony.
 
+        Star position is an obligation method on ``UnpackProjectionTarget`` —
+        not a kinds ``isinstance`` ladder over concrete leaf classes.
+        """
         prefix = 0
         suffix = 0
         has_star = False
         seen_star = False
         for target in self.targets:
-            if isinstance(target, StarUnpackTarget):
+            if target.occupies_star_slot():
                 if has_star:
                     raise AssertionError("at most one star unpack target")
                 has_star = True

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
@@ -202,19 +202,31 @@ class SubscriptStoreEffectSugar(Sugar):
     def desugar_store(self, ctx: object, value) -> Outcome:
         return self.receiver.desugar(ctx).and_then(
             lambda receiver: self.index.desugar(ctx).and_then(
-                lambda index: self._store(receiver, index, value)
+                lambda index: self.project_setitem(
+                    receiver, index, value, self.site
+                )
             )
         )
 
     def _store(self, receiver, index, value) -> Outcome:
+        return self.project_setitem(receiver, index, value, self.site)
+
+    @staticmethod
+    def project_setitem(receiver, index, value, site) -> Outcome:
+        """Producer-owned subscript **store** projection (one door).
+
+        Shared by ordinary ``SubscriptStoreEffectSugar`` and unpack store
+        targets that already hold a pre-reduced member Floor value — the
+        member never re-enters as a desugared child.
+        """
         coordinates = tuple(
             getattr(operand, "formal_coordinate", None)
             for operand in (receiver, index, value)
         )
         if any(coordinate is not None for coordinate in coordinates):
             # Undischarged demand awaiting caller actuals — not a refusal.
-            return self.mint_setitem_carrier(
-                site=self.site,
+            return SubscriptStoreEffectSugar.mint_setitem_carrier(
+                site=site,
                 receiver=receiver,
                 index=index,
                 value=value,
@@ -223,8 +235,8 @@ class SubscriptStoreEffectSugar(Sugar):
             from sugar_source_tree.panic import SugarNotWritten
 
             raise SugarNotWritten(
-                owner="SubscriptStoreEffectSugar._store",
-                blame=self.site,
+                owner="SubscriptStoreEffectSugar.project_setitem",
+                blame=site,
                 observed="undischarged subscript store over runtime-selected receiver",
                 requested=(
                     "NativeOperationExitCarrierV1 n-ary setitem demand over "
@@ -232,7 +244,7 @@ class SubscriptStoreEffectSugar(Sugar):
                 ),
                 fix="attach the three-operand carrier seam owned by 9883",
             )
-        projected = receiver.setitem(index, value, self.site)
+        projected = receiver.setitem(index, value, site)
         from sugar_lift_py_tests.floor import RaiseValue
         from sugar_lift_py_tests.outcome import Complete, Incomplete
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unpack_projection_targets.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unpack_projection_targets.py
@@ -1,0 +1,134 @@
+"""Typed unpack projection targets — each owns how one member is applied.
+
+Replaces string-tag leaf ladders (``\"name\"`` / ``\"attr\"`` / …) with closed
+variants: Name, Star, Attribute store, Subscript store.  Application is
+left-to-right over an ``UnpackMemberRoster`` (positional members).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+
+@dataclass(frozen=True)
+class NameUnpackTarget:
+    """Lexical name: rebind to the projected member."""
+
+    name: str
+
+    def apply_member(self, member, ctx) -> Outcome:
+        del ctx
+        from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind
+
+        return Complete(ScopeRebind(self.name, member))
+
+
+@dataclass(frozen=True)
+class StarUnpackTarget:
+    """Starred name: rebind to the projected middle ``ListValue``."""
+
+    name: str
+
+    def apply_member(self, member, ctx) -> Outcome:
+        del ctx
+        from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind
+
+        return Complete(ScopeRebind(self.name, member))
+
+
+@dataclass(frozen=True)
+class AttributeUnpackTarget:
+    """Attribute store leaf: ``receiver.attr = member`` via shared setattr door."""
+
+    receiver: Sugar
+    attr: str
+    site: object = dataclass_field(compare=False)
+
+    def apply_member(self, member, ctx) -> Outcome:
+        from sugar_lift_py_tests.sugar.store_effect_sugar import (
+            AttributeStoreEffectSugar,
+        )
+
+        return AttributeStoreEffectSugar(
+            receiver=self.receiver,
+            value=_MemberViaDesugarStore(),
+            attr=self.attr,
+            site=self.site,
+        ).desugar_store(ctx, member)
+
+
+@dataclass(frozen=True)
+class SubscriptUnpackTarget:
+    """Subscript store leaf: ``receiver[index] = member`` via shared setitem door."""
+
+    receiver: Sugar
+    index: Sugar
+    site: object = dataclass_field(compare=False)
+
+    def apply_member(self, member, ctx) -> Outcome:
+        from sugar_lift_py_tests.sugar.store_effect_sugar import (
+            SubscriptStoreEffectSugar,
+        )
+
+        return SubscriptStoreEffectSugar(
+            receiver=self.receiver,
+            index=self.index,
+            value=_MemberViaDesugarStore(),
+            site=self.site,
+        ).desugar_store(ctx, member)
+
+
+# Closed set of projection-target kinds (construction admits only these).
+UNPACK_PROJECTION_TARGET_TYPES = (
+    NameUnpackTarget,
+    StarUnpackTarget,
+    AttributeUnpackTarget,
+    SubscriptUnpackTarget,
+)
+
+
+@dataclass(frozen=True)
+class _MemberViaDesugarStore(Sugar):
+    """Placeholder value field — member arrives only via ``desugar_store``."""
+
+    @classmethod
+    def witnesses(cls):
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="pre-reduced unpack member",
+            reason="unpack store targets receive members via desugar_store",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        del ctx
+        raise AssertionError(
+            "unpack store member must arrive via desugar_store, not value.desugar"
+        )
+
+
+@dataclass(frozen=True)
+class ApplyUnpackMemberSugar(Sugar):
+    """One left-to-right step: typed target applies one roster member."""
+
+    target: object  # one of UNPACK_PROJECTION_TARGET_TYPES
+    member: object  # FloorValue
+    site: object = dataclass_field(compare=False, default=None)
+
+    @classmethod
+    def witnesses(cls):
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="unpack target apply",
+            reason="DynamicUnpackStoreAssignSugar sequences ApplyUnpackMemberSugar",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        if not isinstance(self.target, UNPACK_PROJECTION_TARGET_TYPES):
+            raise AssertionError(
+                f"unknown unpack projection target: {type(self.target).__name__}"
+            )
+        return self.target.apply_member(self.member, ctx)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unpack_projection_targets.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unpack_projection_targets.py
@@ -1,8 +1,9 @@
-"""Typed unpack projection targets — each owns how one member is applied.
+"""Typed unpack projection targets — one obligation owns ``apply_member``.
 
-Replaces string-tag leaf ladders (``\"name\"`` / ``\"attr\"`` / …) with closed
-variants: Name, Star, Attribute store, Subscript store.  Application is
-left-to-right over an ``UnpackMemberRoster`` (positional members).
+Replaces string-tag leaf ladders with closed variants under a single typed
+base: ``UnpackProjectionTarget``.  Application is left-to-right over an
+``UnpackMemberRoster`` (positional members).  There is no kinds-tuple
+``isinstance`` membrane at apply time — the target *is* the obligation.
 
 Store leaves route the **already-reduced** roster member through the shared
 store projection doors (``AttributeStoreEffectSugar.project_setattr`` /
@@ -12,6 +13,7 @@ Sugar stands in for the member field.
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
@@ -19,8 +21,24 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
 
 
+class UnpackProjectionTarget(ABC):
+    """One unpack leaf: owns how its positional roster member is applied.
+
+    Construction (tree / tests) admits only concrete subclasses.  Apply is
+    dispatch on the target object — never a closed-type ladder at the sugar.
+    """
+
+    @abstractmethod
+    def apply_member(self, member, ctx) -> Outcome:
+        """Apply one authenticated roster member to this target leaf."""
+
+    def occupies_star_slot(self) -> bool:
+        """True only for the single starred middle leaf (UNPACK_EX layout)."""
+        return False
+
+
 @dataclass(frozen=True)
-class NameUnpackTarget:
+class NameUnpackTarget(UnpackProjectionTarget):
     """Lexical name: rebind to the projected member."""
 
     name: str
@@ -33,10 +51,13 @@ class NameUnpackTarget:
 
 
 @dataclass(frozen=True)
-class StarUnpackTarget:
+class StarUnpackTarget(UnpackProjectionTarget):
     """Starred name: rebind to the projected middle ``ListValue``."""
 
     name: str
+
+    def occupies_star_slot(self) -> bool:
+        return True
 
     def apply_member(self, member, ctx) -> Outcome:
         del ctx
@@ -46,7 +67,7 @@ class StarUnpackTarget:
 
 
 @dataclass(frozen=True)
-class AttributeUnpackTarget:
+class AttributeUnpackTarget(UnpackProjectionTarget):
     """Attribute store leaf: ``receiver.attr = member`` via shared setattr door."""
 
     receiver: Sugar
@@ -68,7 +89,7 @@ class AttributeUnpackTarget:
 
 
 @dataclass(frozen=True)
-class SubscriptUnpackTarget:
+class SubscriptUnpackTarget(UnpackProjectionTarget):
     """Subscript store leaf: ``receiver[index] = member`` via shared setitem door."""
 
     receiver: Sugar
@@ -89,22 +110,20 @@ class SubscriptUnpackTarget:
         )
 
 
-# Closed set of projection-target kinds (construction admits only these).
-UNPACK_PROJECTION_TARGET_TYPES = (
-    NameUnpackTarget,
-    StarUnpackTarget,
-    AttributeUnpackTarget,
-    SubscriptUnpackTarget,
-)
-
-
 @dataclass(frozen=True)
 class ApplyUnpackMemberSugar(Sugar):
     """One left-to-right step: typed target applies one roster member."""
 
-    target: object  # one of UNPACK_PROJECTION_TARGET_TYPES
+    target: UnpackProjectionTarget
     member: object  # FloorValue
     site: object = dataclass_field(compare=False, default=None)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.target, UnpackProjectionTarget):
+            raise TypeError(
+                "ApplyUnpackMemberSugar.target must be UnpackProjectionTarget; "
+                f"got {type(self.target).__name__}"
+            )
 
     @classmethod
     def witnesses(cls):
@@ -115,8 +134,5 @@ class ApplyUnpackMemberSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        if not isinstance(self.target, UNPACK_PROJECTION_TARGET_TYPES):
-            raise AssertionError(
-                f"unknown unpack projection target: {type(self.target).__name__}"
-            )
+        # One obligation: the target owns apply_member. No kinds ladder.
         return self.target.apply_member(self.member, ctx)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unpack_projection_targets.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unpack_projection_targets.py
@@ -3,6 +3,11 @@
 Replaces string-tag leaf ladders (``\"name\"`` / ``\"attr\"`` / …) with closed
 variants: Name, Star, Attribute store, Subscript store.  Application is
 left-to-right over an ``UnpackMemberRoster`` (positional members).
+
+Store leaves route the **already-reduced** roster member through the shared
+store projection doors (``AttributeStoreEffectSugar.project_setattr`` /
+``SubscriptStoreEffectSugar.project_setitem``).  No panic-on-desugar placeholder
+Sugar stands in for the member field.
 """
 
 from __future__ import annotations
@@ -53,12 +58,13 @@ class AttributeUnpackTarget:
             AttributeStoreEffectSugar,
         )
 
-        return AttributeStoreEffectSugar(
-            receiver=self.receiver,
-            value=_MemberViaDesugarStore(),
-            attr=self.attr,
-            site=self.site,
-        ).desugar_store(ctx, member)
+        # Member is already reduced (roster FloorValue). Shared projection —
+        # never a second value.desugar, never a panic placeholder Sugar field.
+        return self.receiver.desugar(ctx).and_then(
+            lambda receiver: AttributeStoreEffectSugar.project_setattr(
+                receiver, self.attr, member, self.site
+            )
+        )
 
 
 @dataclass(frozen=True)
@@ -74,12 +80,13 @@ class SubscriptUnpackTarget:
             SubscriptStoreEffectSugar,
         )
 
-        return SubscriptStoreEffectSugar(
-            receiver=self.receiver,
-            index=self.index,
-            value=_MemberViaDesugarStore(),
-            site=self.site,
-        ).desugar_store(ctx, member)
+        return self.receiver.desugar(ctx).and_then(
+            lambda receiver: self.index.desugar(ctx).and_then(
+                lambda index: SubscriptStoreEffectSugar.project_setitem(
+                    receiver, index, member, self.site
+                )
+            )
+        )
 
 
 # Closed set of projection-target kinds (construction admits only these).
@@ -89,25 +96,6 @@ UNPACK_PROJECTION_TARGET_TYPES = (
     AttributeUnpackTarget,
     SubscriptUnpackTarget,
 )
-
-
-@dataclass(frozen=True)
-class _MemberViaDesugarStore(Sugar):
-    """Placeholder value field — member arrives only via ``desugar_store``."""
-
-    @classmethod
-    def witnesses(cls):
-        return NotVerdictBearing(
-            sugar_name=cls.__name__,
-            floor_name="pre-reduced unpack member",
-            reason="unpack store targets receive members via desugar_store",
-        )
-
-    def desugar(self, ctx: object = None) -> Outcome:
-        del ctx
-        raise AssertionError(
-            "unpack store member must arrive via desugar_store, not value.desugar"
-        )
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
@@ -322,11 +322,40 @@ def test_discrimination_double_rhs_detected() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Arity + opaque
+# Arity + opaque + occurrence / coordinate teeth
 # ---------------------------------------------------------------------------
 
 
+def _valueerror_type_identity():
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("ValueError")],
+    )
+
+
+def _arity_mismatch_effect(outcome):
+    """Normalize Complete/Incomplete/ExitSet shells to the RaiseEffect face."""
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.floor import RaiseValue
+
+    if isinstance(outcome, Incomplete):
+        effect = outcome.effect
+    elif isinstance(outcome, Complete) and isinstance(outcome.value, RaiseValue):
+        effect = outcome.value.effect
+    elif isinstance(outcome, ExitSet):
+        halted = [e for e in outcome.exits if isinstance(e, Halted)]
+        assert halted, outcome.exits
+        effect = halted[0].effect
+    else:
+        raise AssertionError(f"unexpected arity-mismatch shell: {type(outcome)!r}")
+    assert isinstance(effect, RaiseEffect), type(effect)
+    return effect
+
+
 def test_exact_arity_valueerror_identity() -> None:
+    """Named ValueError with exact type + operation occurrence (not spelling-only)."""
     site = _site("def f(obj, xs):\n    obj.x, obj.y = xs\n")
     sugar = DynamicUnpackStoreAssignSugar(
         value=_FloorSugar(ListValue((TermValue(1),))),  # need 2
@@ -340,19 +369,144 @@ def test_exact_arity_valueerror_identity() -> None:
         ),
         site=site,
     )
-    out = sugar.desugar(None)
-    if isinstance(out, Incomplete):
-        assert out.effect.exception_name == "ValueError"
-    elif isinstance(out, Complete):
-        from sugar_lift_py_tests.floor import RaiseValue
+    effect = _arity_mismatch_effect(sugar.desugar(None))
+    assert effect.exception_name == "ValueError"
+    assert effect.exception_type_coordinate == _valueerror_type_identity()
+    assert (
+        effect.producer_node_owner
+        == "DynamicUnpackStoreAssignSugar.arity_mismatch"
+    )
+    # Operation occurrence cites the unpack site — not a foreign boundary.
+    assert effect.occurrence == str(site) or effect.occurrence_id == str(site)
+    assert effect.occurrence_id is not None
 
-        assert isinstance(out.value, RaiseValue)
-        assert out.value.effect.exception_name == "ValueError"
-    else:
-        assert isinstance(out, ExitSet)
-        halted = [e for e in out.exits if isinstance(e, Halted)]
-        assert halted
-        assert getattr(halted[0].effect, "exception_name", None) == "ValueError"
+
+def test_arity_valueerror_wrong_occurrence_is_not_truthful() -> None:
+    """Same type name under a foreign occurrence is not the unpack exit."""
+    from dataclasses import replace
+
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    site = _site("def f(obj, xs):\n    obj.x, obj.y = xs\n")
+    sugar = DynamicUnpackStoreAssignSugar(
+        value=_FloorSugar(ListValue((TermValue(1),))),
+        targets=(
+            AttributeUnpackTarget(
+                _FloorSugar(ObjectValue("W", (), (), (), "w5")), "x", site
+            ),
+            AttributeUnpackTarget(
+                _FloorSugar(ObjectValue("W", (), (), (), "w6")), "y", site
+            ),
+        ),
+        site=site,
+    )
+    truthful = _arity_mismatch_effect(sugar.desugar(None))
+    foreign = replace(
+        truthful,
+        occurrence="pytest.raises:foreign-boundary",
+        producer_node_owner="pytest.raises",
+    )
+    assert isinstance(foreign, RaiseEffect)
+    assert foreign.exception_name == truthful.exception_name == "ValueError"
+    assert foreign.occurrence != truthful.occurrence
+    assert foreign.producer_node_owner != truthful.producer_node_owner
+    assert foreign != truthful
+    with pytest.raises(AssertionError):
+        assert foreign == truthful
+    with pytest.raises(AssertionError):
+        assert foreign.producer_node_owner == (
+            "DynamicUnpackStoreAssignSugar.arity_mismatch"
+        )
+
+
+def test_missing_wrong_positional_coordinate_is_loud() -> None:
+    """Roster is positional — wrong index / missing formal coordinate stays loud.
+
+    1. Positional roster members zip by source leaf index, never by name keys.
+    2. Formal setitem store leaf mints discharge coordinates (receiver, index,
+       value); a lying twin with swapped index/value slots is distinguishable.
+    3. A formal missing from discharge actuals cannot silently complete.
+    """
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        NativeOperationExitCarrierV1,
+    )
+    from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+    from sugar_lift_py_tests.ir import make_var
+    from sugar_lift_py_tests.operations.positional_unpack_operation import (
+        PositionalUnpackOperation,
+        UnpackMemberRoster,
+    )
+
+    site = _site("def f(a, i, xs):\n    a[i], name = xs\n")
+    # --- positional roster: members by index, no string keys ---
+    op = PositionalUnpackOperation(
+        fixed_prefix=2,
+        fixed_suffix=0,
+        has_star=False,
+        owner="positional_coord",
+        blame=site,
+    )
+    roster_out = op.submit(ListValue((TermValue(10), TermValue(20))), None)
+    assert isinstance(roster_out, Complete)
+    assert isinstance(roster_out.value, UnpackMemberRoster)
+    assert roster_out.value.members[0] == TermValue(10)
+    assert roster_out.value.members[1] == TermValue(20)
+    assert not hasattr(roster_out.value, "bindings")
+    # Wrong position twin: swapping members is not the truthful roster.
+    lying_roster = UnpackMemberRoster((TermValue(20), TermValue(10)))
+    assert lying_roster != roster_out.value
+    with pytest.raises(AssertionError):
+        assert lying_roster == roster_out.value
+
+    # --- formal setitem leaf: discharge coordinates must stay ordered ---
+    coord_a = SimpleNamespace(coordinate_cid="cid:a")
+    coord_i = SimpleNamespace(coordinate_cid="cid:i")
+    formal_receiver = SymbolicValue(make_var("a"), formal_coordinate=coord_a)
+    formal_index = SymbolicValue(make_var("i"), formal_coordinate=coord_i)
+    target = SubscriptUnpackTarget(
+        _FloorSugar(formal_receiver),
+        _FloorSugar(formal_index),
+        site,
+    )
+    member = TermValue(99)
+    projected = target.apply_member(member, None)
+    assert isinstance(projected, NativeOperationExitCarrierV1), projected
+    assert projected.demand.operator == "setitem"
+    # Discharge order: receiver, index, value — not value-first.
+    assert len(projected.operands) == 3
+    assert projected.operands[2] == member
+    cids = projected.demand.operand_coordinate_cids
+    assert cids[0] == "cid:a"
+    assert cids[1] == "cid:i"
+    # Member is ground — no formal coordinate on the value slot.
+    assert cids[2] is None
+    truthful_coords = projected.coordinates
+    # Wrong-order twin swaps index and value coordinate slots.
+    lying = NativeOperationExitCarrierV1.mint(
+        site=site,
+        operator="setitem",
+        operands=(
+            projected.operands[0],
+            projected.operands[2],
+            projected.operands[1],
+        ),
+        coordinates=(
+            truthful_coords[0],
+            truthful_coords[2],
+            truthful_coords[1],
+        ),
+    )
+    assert lying.demand.operand_coordinate_cids != cids
+    with pytest.raises(AssertionError):
+        assert lying.demand.operand_coordinate_cids == cids
+    # Missing a formal among the discharge map cannot complete the store.
+    with pytest.raises(Exception):
+        projected.discharge({})
+    # Supplying only one of two formals is still incomplete / loud.
+    with pytest.raises(Exception):
+        projected.discharge({"cid:a": ListValue((TermValue(0),))})
 
 
 def test_opaque_formal_is_sequence_unpack_effect() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
@@ -1,0 +1,404 @@
+"""Starred-target store: LTR mixed Name/Attribute/Subscript/*Name unpack.
+
+Advisor acceptance:
+
+  - Interleaved name→store→name→store ordering (not batch rebinds first)
+  - First-store halt blocks all later targets; earlier targets survive
+  - RHS evaluated once
+  - Attribute + subscript through production construction
+  - Missing/wrong coordinates loud (no fabricated __unpack_store_* identities)
+  - Exact arity exception identity (named ValueError)
+  - Zero fabricated binding identities
+
+Projection: positional ``UnpackMemberRoster``; targets are typed variants.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.context import ReduceContext
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.effect import SequenceUnpackRuntimeEffect
+from sugar_lift_py_tests.floor import ListValue, ObjectValue, TermValue
+from sugar_lift_py_tests.floor.floor_value import FloorValue
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
+from sugar_lift_py_tests.sugar.assign_sugar import (
+    DynamicUnpackStoreAssignSugar,
+    UnpackStoreAssignSugar,
+)
+from sugar_lift_py_tests.sugar.dynamic_unpack_assign_sugar import (
+    DynamicUnpackAssignSugar,
+)
+from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.unpack_projection_targets import (
+    AttributeUnpackTarget,
+    NameUnpackTarget,
+    StarUnpackTarget,
+    SubscriptUnpackTarget,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _tree(source: str, name: str = "star_store.py") -> SourceFile:
+    return SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _helper(source: str):
+    tree = _tree(source, "helper.py")
+    function = next(n for n in tree.nodes() if isinstance(n, FunctionDef))
+    return function, function.sugar().desugar(None)
+
+
+def _site(source: str = "def f(obj, xs):\n    obj.x, *rest = xs\n"):
+    tree = _tree(source)
+    function = next(n for n in tree.nodes() if isinstance(n, FunctionDef))
+    return function.body[0].fragment
+
+
+@dataclass(frozen=True)
+class _FloorSugar(Sugar):
+    value: object
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+@dataclass(frozen=True)
+class _CountingRhs(Sugar):
+    box: dict
+    value: object
+
+    def desugar(self, ctx=None):
+        del ctx
+        self.box["n"] = self.box.get("n", 0) + 1
+        return Complete(self.value)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+# ---------------------------------------------------------------------------
+# Construction / discrimination
+# ---------------------------------------------------------------------------
+
+
+def test_star_store_constructs_typed_targets_not_string_tags() -> None:
+    function, _ = _helper(
+        "def helper(obj, xs):\n    obj.x, *rest = xs\n    return rest\n"
+    )
+    stmt = next(
+        s
+        for s in function.sugar().statements
+        if isinstance(s, DynamicUnpackStoreAssignSugar)
+    )
+    assert isinstance(stmt.targets[0], AttributeUnpackTarget)
+    assert isinstance(stmt.targets[1], StarUnpackTarget)
+    assert stmt.targets[0].attr == "x"
+    assert stmt.targets[1].name == "rest"
+    # No fabricated synthetic name map on the sugar.
+    assert not hasattr(stmt, "leaves")
+
+
+def test_pure_name_star_stays_dynamic_unpack() -> None:
+    function, _ = _helper("def helper(xs):\n    a, *rest = xs\n    return a\n")
+    kinds = [type(s).__name__ for s in function.sugar().statements]
+    assert "DynamicUnpackAssignSugar" in kinds
+    assert "DynamicUnpackStoreAssignSugar" not in kinds
+
+
+def test_display_star_store_stays_unpack_store_assign() -> None:
+    function, _ = _helper(
+        "def helper(obj):\n    obj.x, *rest = 1, 2, 3\n    return rest\n"
+    )
+    kinds = [type(s).__name__ for s in function.sugar().statements]
+    assert "UnpackStoreAssignSugar" in kinds
+    assert "DynamicUnpackStoreAssignSugar" not in kinds
+
+
+def test_attribute_and_subscript_production_construction() -> None:
+    function, _ = _helper(
+        "def helper(obj, d, k, xs):\n    obj.x, d[k], *rest = xs\n    return rest\n"
+    )
+    stmt = next(
+        s
+        for s in function.sugar().statements
+        if isinstance(s, DynamicUnpackStoreAssignSugar)
+    )
+    assert isinstance(stmt.targets[0], AttributeUnpackTarget)
+    assert isinstance(stmt.targets[1], SubscriptUnpackTarget)
+    assert isinstance(stmt.targets[2], StarUnpackTarget)
+
+
+def test_name_store_name_interleaved_constructs() -> None:
+    function, _ = _helper(
+        "def helper(obj, xs):\n    a, obj.x, b = xs\n    return a\n"
+    )
+    stmt = next(
+        s
+        for s in function.sugar().statements
+        if isinstance(s, DynamicUnpackStoreAssignSugar)
+    )
+    types = tuple(type(t) for t in stmt.targets)
+    assert types == (NameUnpackTarget, AttributeUnpackTarget, NameUnpackTarget)
+
+
+# ---------------------------------------------------------------------------
+# Ground LTR + halt law
+# ---------------------------------------------------------------------------
+
+
+def test_ground_star_store_rest_and_field() -> None:
+    site = _site()
+    receiver = ObjectValue("W", (), (), (), "w0")
+    sugar = DynamicUnpackStoreAssignSugar(
+        value=_FloorSugar(ListValue((TermValue(1), TermValue(2), TermValue(3)))),
+        targets=(
+            AttributeUnpackTarget(_FloorSugar(receiver), "x", site),
+            StarUnpackTarget("rest"),
+        ),
+        site=site,
+    )
+    exits = reduce_block_to_exitset(
+        (sugar,), ReduceContext.root(owner="ground_star")
+    )
+    assert isinstance(exits.exits[0], Completed)
+    state = exits.exits[0].value
+    assert state.context.temporal.value_if_bound("rest") == ListValue(
+        (TermValue(2), TermValue(3))
+    )
+    objs = [s for s in state.entries if isinstance(s, ObjectValue)]
+    assert {f.name: f.value for f in objs[-1].fields}["x"] == TermValue(1)
+
+
+def test_interleaved_name_store_name_order() -> None:
+    """name → store → name applies in source order (not batched rebinds first)."""
+    site = _site("def f(obj, xs):\n    a, obj.x, b = xs\n")
+    order: list[str] = []
+
+    @dataclass(frozen=True)
+    class _OrderName(NameUnpackTarget):
+        def apply_member(self, member, ctx):
+            order.append(f"name:{self.name}")
+            return super().apply_member(member, ctx)
+
+    @dataclass(frozen=True)
+    class _OrderAttr(AttributeUnpackTarget):
+        def apply_member(self, member, ctx):
+            order.append(f"attr:{self.attr}")
+            return super().apply_member(member, ctx)
+
+    receiver = ObjectValue("W", (), (), (), "w1")
+    sugar = DynamicUnpackStoreAssignSugar(
+        value=_FloorSugar(
+            ListValue((TermValue(1), TermValue(2), TermValue(3)))
+        ),
+        targets=(
+            _OrderName("a"),
+            _OrderAttr(_FloorSugar(receiver), "x", site),
+            _OrderName("b"),
+        ),
+        site=site,
+    )
+    exits = reduce_block_to_exitset((sugar,), ReduceContext.root(owner="ltr"))
+    assert isinstance(exits.exits[0], Completed)
+    assert order == ["name:a", "attr:x", "name:b"]
+    temporal = exits.exits[0].value.context.temporal
+    assert temporal.value_if_bound("a") == TermValue(1)
+    assert temporal.value_if_bound("b") == TermValue(3)
+
+
+def test_first_store_halt_blocks_later_name() -> None:
+    """obj.x, name = rhs — setattr halt leaves name unbound; no later apply."""
+    site = _site("def f(obj, xs):\n    obj.x, name = xs\n")
+
+    class _RefuseSet(ObjectValue):
+        def setattr(self, name, value, site_):
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+            return ground_exceptional_exit(
+                exception_name="AttributeError",
+                site=site_,
+                owner="_RefuseSet.setattr",
+            )
+
+    receiver = _RefuseSet("W", (), (), (), "refuse")
+    sugar = DynamicUnpackStoreAssignSugar(
+        value=_FloorSugar(ListValue((TermValue(1), TermValue(2)))),
+        targets=(
+            AttributeUnpackTarget(_FloorSugar(receiver), "x", site),
+            NameUnpackTarget("name"),
+        ),
+        site=site,
+    )
+    exits = reduce_block_to_exitset((sugar,), ReduceContext.root(owner="halt"))
+    halted = [e for e in exits.exits if isinstance(e, Halted)]
+    assert halted, exits.exits
+    # name must not be bound on any continuing completed face that ran the store halt.
+    for face in exits.exits:
+        if isinstance(face, Completed):
+            temporal = face.value.context.temporal if face.value.context else None
+            if temporal is not None:
+                assert temporal.value_if_bound("name") is None
+        if isinstance(face, Halted) and face.state is not None:
+            ctx = face.state.context
+            if ctx is not None:
+                assert ctx.temporal.value_if_bound("name") is None
+
+
+def test_earlier_name_survives_later_store_halt() -> None:
+    """name, obj.x = rhs — name rebind survives setattr halt."""
+    site = _site("def f(obj, xs):\n    name, obj.x = xs\n")
+
+    class _RefuseSet(ObjectValue):
+        def setattr(self, name, value, site_):
+            from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+            return ground_exceptional_exit(
+                exception_name="AttributeError",
+                site=site_,
+                owner="_RefuseSet.setattr",
+            )
+
+    sugar = DynamicUnpackStoreAssignSugar(
+        value=_FloorSugar(ListValue((TermValue(7), TermValue(8)))),
+        targets=(
+            NameUnpackTarget("name"),
+            AttributeUnpackTarget(
+                _FloorSugar(_RefuseSet("W", (), (), (), "r2")), "x", site
+            ),
+        ),
+        site=site,
+    )
+    exits = reduce_block_to_exitset((sugar,), ReduceContext.root(owner="survive"))
+    halted = [e for e in exits.exits if isinstance(e, Halted)]
+    assert halted
+    # Pre-halt state carries the earlier name rebind.
+    state = halted[0].state
+    assert state is not None and state.context is not None
+    assert state.context.temporal.value_if_bound("name") == TermValue(7)
+
+
+def test_rhs_evaluated_once() -> None:
+    site = _site()
+    box: dict = {}
+    sugar = DynamicUnpackStoreAssignSugar(
+        value=_CountingRhs(box, ListValue((TermValue(1), TermValue(2)))),
+        targets=(
+            NameUnpackTarget("a"),
+            NameUnpackTarget("b"),
+        ),
+        site=site,
+    )
+    # Exact arity two names — still DynamicUnpackStore if we force targets...
+    # Use store+name so we hit this sugar; or construct directly with two names
+    # only if construction requires store — construct sugar directly.
+    reduce_block_to_exitset((sugar,), ReduceContext.root(owner="once"))
+    assert box["n"] == 1
+
+
+def test_discrimination_double_rhs_detected() -> None:
+    box: dict = {}
+    rhs = _CountingRhs(box, ListValue((TermValue(1),)))
+    rhs.desugar(None)
+    rhs.desugar(None)
+    assert box["n"] == 2
+    with pytest.raises(AssertionError):
+        assert box["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Arity + opaque
+# ---------------------------------------------------------------------------
+
+
+def test_exact_arity_valueerror_identity() -> None:
+    site = _site("def f(obj, xs):\n    obj.x, obj.y = xs\n")
+    sugar = DynamicUnpackStoreAssignSugar(
+        value=_FloorSugar(ListValue((TermValue(1),))),  # need 2
+        targets=(
+            AttributeUnpackTarget(
+                _FloorSugar(ObjectValue("W", (), (), (), "w3")), "x", site
+            ),
+            AttributeUnpackTarget(
+                _FloorSugar(ObjectValue("W", (), (), (), "w4")), "y", site
+            ),
+        ),
+        site=site,
+    )
+    out = sugar.desugar(None)
+    if isinstance(out, Incomplete):
+        assert out.effect.exception_name == "ValueError"
+    elif isinstance(out, Complete):
+        from sugar_lift_py_tests.floor import RaiseValue
+
+        assert isinstance(out.value, RaiseValue)
+        assert out.value.effect.exception_name == "ValueError"
+    else:
+        assert isinstance(out, ExitSet)
+        halted = [e for e in out.exits if isinstance(e, Halted)]
+        assert halted
+        assert getattr(halted[0].effect, "exception_name", None) == "ValueError"
+
+
+def test_opaque_formal_is_sequence_unpack_effect() -> None:
+    _, pending = _helper(
+        "def helper(obj, xs):\n    obj.x, *rest = xs\n    return rest\n"
+    )
+    assert not isinstance(pending, Complete)
+    if isinstance(pending, Incomplete):
+        assert isinstance(pending.effect, SequenceUnpackRuntimeEffect)
+    elif isinstance(pending, ExitSet):
+        assert any(
+            isinstance(getattr(e, "effect", None), SequenceUnpackRuntimeEffect)
+            for e in pending.exits
+        )
+
+
+def test_no_fabricated_unpack_store_identity_in_module() -> None:
+    """Zero fabricated __unpack_store_* string binding identities in source."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+    offenders = []
+    for path in root.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        if "__unpack_store_" in text:
+            offenders.append(str(path))
+    assert offenders == [], offenders
+
+
+def test_positional_roster_has_no_string_keys() -> None:
+    from sugar_lift_py_tests.operations.positional_unpack_operation import (
+        PositionalUnpackOperation,
+        UnpackMemberRoster,
+    )
+
+    op = PositionalUnpackOperation(
+        fixed_prefix=1,
+        fixed_suffix=0,
+        has_star=True,
+        owner="test",
+        blame=_site(),
+    )
+    out = op.submit(ListValue((TermValue(1), TermValue(2), TermValue(3))), None)
+    assert isinstance(out, Complete)
+    assert isinstance(out.value, UnpackMemberRoster)
+    assert out.value.members[0] == TermValue(1)
+    assert out.value.members[1] == ListValue((TermValue(2), TermValue(3)))
+    # Roster is positional tuple only — not a name map.
+    assert not hasattr(out.value, "bindings")

--- a/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
@@ -536,6 +536,26 @@ def test_no_fabricated_unpack_store_identity_in_module() -> None:
     assert offenders == [], offenders
 
 
+def test_no_kinds_tuple_isinstance_membrane_at_apply() -> None:
+    """Apply is one typed obligation — not a closed kinds-tuple ladder."""
+    import sugar_lift_py_tests.sugar.unpack_projection_targets as targets
+
+    assert not hasattr(targets, "UNPACK_PROJECTION_TARGET_TYPES")
+    assert not hasattr(targets, "_MemberViaDesugarStore")
+    # Non-obligation target is refused at construction of the apply sugar.
+    from sugar_lift_py_tests.sugar.unpack_projection_targets import (
+        ApplyUnpackMemberSugar,
+        UnpackProjectionTarget,
+    )
+
+    assert issubclass(NameUnpackTarget, UnpackProjectionTarget)
+    assert issubclass(StarUnpackTarget, UnpackProjectionTarget)
+    assert issubclass(AttributeUnpackTarget, UnpackProjectionTarget)
+    assert issubclass(SubscriptUnpackTarget, UnpackProjectionTarget)
+    with pytest.raises(TypeError, match="UnpackProjectionTarget"):
+        ApplyUnpackMemberSugar(target=object(), member=TermValue(1), site=_site())
+
+
 def test_positional_roster_has_no_string_keys() -> None:
     from sugar_lift_py_tests.operations.positional_unpack_operation import (
         PositionalUnpackOperation,

--- a/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
@@ -425,7 +425,8 @@ def test_missing_wrong_positional_coordinate_is_loud() -> None:
     1. Positional roster members zip by source leaf index, never by name keys.
     2. Formal setitem store leaf mints discharge coordinates (receiver, index,
        value); a lying twin with swapped index/value slots is distinguishable.
-    3. A formal missing from discharge actuals cannot silently complete.
+    3. A formal missing from discharge actuals is the typed SugarNotWritten
+       undischarged refusal — never a silent Complete.
     """
     from types import SimpleNamespace
 
@@ -438,6 +439,7 @@ def test_missing_wrong_positional_coordinate_is_loud() -> None:
         PositionalUnpackOperation,
         UnpackMemberRoster,
     )
+    from sugar_source_tree.panic import SugarNotWritten
 
     site = _site("def f(a, i, xs):\n    a[i], name = xs\n")
     # --- positional roster: members by index, no string keys ---
@@ -454,8 +456,14 @@ def test_missing_wrong_positional_coordinate_is_loud() -> None:
     assert roster_out.value.members[0] == TermValue(10)
     assert roster_out.value.members[1] == TermValue(20)
     assert not hasattr(roster_out.value, "bindings")
+    assert roster_out.value.occurrence is site
+    assert roster_out.value.demand_cid == op.demand_cid()
     # Wrong position twin: swapping members is not the truthful roster.
-    lying_roster = UnpackMemberRoster((TermValue(20), TermValue(10)))
+    lying_roster = UnpackMemberRoster(
+        (TermValue(20), TermValue(10)),
+        occurrence=roster_out.value.occurrence,
+        demand_cid=roster_out.value.demand_cid,
+    )
     assert lying_roster != roster_out.value
     with pytest.raises(AssertionError):
         assert lying_roster == roster_out.value
@@ -501,12 +509,93 @@ def test_missing_wrong_positional_coordinate_is_loud() -> None:
     assert lying.demand.operand_coordinate_cids != cids
     with pytest.raises(AssertionError):
         assert lying.demand.operand_coordinate_cids == cids
-    # Missing a formal among the discharge map cannot complete the store.
-    with pytest.raises(Exception):
+    # Missing formals → typed undischarged refusal, never Complete.
+    with pytest.raises(SugarNotWritten, match="authenticated caller actual absent") as missing:
         projected.discharge({})
-    # Supplying only one of two formals is still incomplete / loud.
-    with pytest.raises(Exception):
+    assert "cid:a" in str(missing.value)
+    # Lying twin: claiming missing actuals greened a Complete is impossible.
+    with pytest.raises(SugarNotWritten, match="authenticated caller actual absent"):
+        out = projected.discharge({})
+        assert isinstance(out, Complete)
+    with pytest.raises(SugarNotWritten, match="authenticated caller actual absent") as partial:
         projected.discharge({"cid:a": ListValue((TermValue(0),))})
+    assert "cid:i" in str(partial.value)
+    with pytest.raises(SugarNotWritten, match="authenticated caller actual absent"):
+        out = projected.discharge({"cid:a": ListValue((TermValue(0),))})
+        assert isinstance(out, Complete)
+
+
+def test_successful_roster_carries_authenticated_unpack_occurrence() -> None:
+    """Successful roster testifies which source unpack demand produced it."""
+    from dataclasses import replace
+
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.operations.positional_unpack_operation import (
+        PositionalUnpackOperation,
+        UnpackMemberRoster,
+    )
+
+    site = _site("def f(obj, xs):\n    a, b = xs\n")
+    foreign_site = _site("def g(obj, ys):\n    c, d = ys\n")
+    op = PositionalUnpackOperation(
+        fixed_prefix=2,
+        fixed_suffix=0,
+        has_star=False,
+        owner="DynamicUnpackStoreAssignSugar",
+        blame=site,
+    )
+    out = op.submit(ListValue((TermValue(1), TermValue(2))), None)
+    assert isinstance(out, Complete)
+    roster = out.value
+    assert isinstance(roster, UnpackMemberRoster)
+    assert roster.occurrence is site
+    assert roster.demand_cid == op.demand_cid()
+    assert roster.demand_cid.startswith("blake3-512:")
+    # Same members under a foreign occurrence/demand are not this unpack.
+    foreign_op = PositionalUnpackOperation(
+        fixed_prefix=2,
+        fixed_suffix=0,
+        has_star=False,
+        owner="DynamicUnpackStoreAssignSugar",
+        blame=foreign_site,
+    )
+    assert foreign_op.demand_cid() != roster.demand_cid
+    wrong_occurrence = replace(roster, occurrence=foreign_site)
+    assert wrong_occurrence.members == roster.members
+    assert wrong_occurrence.demand_cid == roster.demand_cid
+    sugar = DynamicUnpackStoreAssignSugar(
+        value=_FloorSugar(ListValue((TermValue(1), TermValue(2)))),
+        targets=(NameUnpackTarget("a"), NameUnpackTarget("b")),
+        site=site,
+    )
+    with pytest.raises(ConstructionPanic, match="occurrence") as caught:
+        sugar._apply_authenticated_roster(
+            wrong_occurrence,
+            expected_demand_cid=roster.demand_cid,
+            ctx=None,
+        )
+    assert "occurrence" in str(caught.value).lower()
+    wrong_demand = replace(roster, demand_cid=foreign_op.demand_cid())
+    with pytest.raises(ConstructionPanic, match="demand_cid") as demand_caught:
+        sugar._apply_authenticated_roster(
+            wrong_demand,
+            expected_demand_cid=roster.demand_cid,
+            ctx=None,
+        )
+    assert "demand_cid" in str(demand_caught.value)
+    # Missing occurrence is unconstructable on the roster type.
+    with pytest.raises(ValueError, match="occurrence"):
+        UnpackMemberRoster(
+            members=(TermValue(1), TermValue(2)),
+            occurrence=None,
+            demand_cid=roster.demand_cid,
+        )
+    with pytest.raises(ValueError, match="demand_cid"):
+        UnpackMemberRoster(
+            members=(TermValue(1), TermValue(2)),
+            occurrence=site,
+            demand_cid="",
+        )
 
 
 def test_opaque_formal_is_sequence_unpack_effect() -> None:
@@ -562,12 +651,13 @@ def test_positional_roster_has_no_string_keys() -> None:
         UnpackMemberRoster,
     )
 
+    site = _site()
     op = PositionalUnpackOperation(
         fixed_prefix=1,
         fixed_suffix=0,
         has_star=True,
         owner="test",
-        blame=_site(),
+        blame=site,
     )
     out = op.submit(ListValue((TermValue(1), TermValue(2), TermValue(3))), None)
     assert isinstance(out, Complete)
@@ -576,3 +666,5 @@ def test_positional_roster_has_no_string_keys() -> None:
     assert out.value.members[1] == ListValue((TermValue(2), TermValue(3)))
     # Roster is positional tuple only — not a name map.
     assert not hasattr(out.value, "bindings")
+    assert out.value.occurrence is site
+    assert out.value.demand_cid == op.demand_cid()

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3747,6 +3747,64 @@ class Assign(Statement):
                 suffix.append(element.id)
         return (tuple(prefix), star.value.id, tuple(suffix))
 
+    def _flat_mixed_unpack_targets(self, target):
+        """Parse flat Name|Attribute|Subscript|*Name into typed unpack targets.
+
+        At most one ``*Name``. Nested / ``*attr`` stay unadmitted. Pure Name
+        leaves return ``None`` (DynamicUnpackAssignSugar owns that path).
+        """
+        if not isinstance(target, (Tuple_, List)):
+            return None
+        star_indices = [
+            index
+            for index, element in enumerate(target.elts)
+            if isinstance(element, Starred)
+        ]
+        if len(star_indices) > 1:
+            return None
+        from sugar_lift_py_tests.sugar.unpack_projection_targets import (
+            AttributeUnpackTarget,
+            NameUnpackTarget,
+            StarUnpackTarget,
+            SubscriptUnpackTarget,
+        )
+
+        targets: list[object] = []
+        has_store = False
+        for element in target.elts:
+            if isinstance(element, Name):
+                targets.append(NameUnpackTarget(element.id))
+                continue
+            if isinstance(element, Starred):
+                if not isinstance(element.value, Name):
+                    return None
+                targets.append(StarUnpackTarget(element.value.id))
+                continue
+            if isinstance(element, Attribute):
+                has_store = True
+                targets.append(
+                    AttributeUnpackTarget(
+                        receiver=element.value.sugar(),
+                        attr=element.attr,
+                        site=element.fragment,
+                    )
+                )
+                continue
+            if isinstance(element, Subscript):
+                has_store = True
+                targets.append(
+                    SubscriptUnpackTarget(
+                        receiver=element.value.sugar(),
+                        index=element.slice_.sugar(),
+                        site=element.fragment,
+                    )
+                )
+                continue
+            return None
+        if not has_store:
+            return None
+        return tuple(targets)
+
     def _flat_store_unpack_pairs(self):
         """Flat Name|Attribute|Subscript leaves against a display RHS.
 
@@ -4191,6 +4249,18 @@ class Assign(Statement):
                         star_name=star_name,
                         prefix_names=prefix,
                         suffix_names=suffix,
+                    )
+                # Store leaves (+ optional *Name) against non-display RHS.
+                mixed = self._flat_mixed_unpack_targets(target)
+                if mixed is not None:
+                    from sugar_lift_py_tests.sugar.assign_sugar import (
+                        DynamicUnpackStoreAssignSugar,
+                    )
+
+                    return DynamicUnpackStoreAssignSugar(
+                        value=self.value.sugar(),
+                        targets=mixed,
+                        site=self.fragment,
                     )
             return super()._construct_sugar()
 


### PR DESCRIPTION
## Summary

**Split from rejected #6734** (slice stack). This PR is starred-target store only, rebased on main.

Advisor defects fixed:

| Defect | Fix |
| --- | --- |
| (a) Batch name rebinds before stores | LTR interleaved: each typed target applies its member in source order |
| (b) Fabricated `__unpack_store_*` string keys | `PositionalUnpackOperation` → `UnpackMemberRoster` (positional members only) |
| (c) String-tag kind ladder | `NameUnpackTarget` / `StarUnpackTarget` / `AttributeUnpackTarget` / `SubscriptUnpackTarget` own `apply_member` |

## Law

```
RHS once → PositionalUnpackOperation (project_sequence_with)
         → UnpackMemberRoster (positional)
         → for each target LTR: target.apply_member(member)
```

- First-store halt → later names unbound / later stores unrun
- Earlier name rebind survives on halted pre-effect state
- Opaque formal RHS → `SequenceUnpackRuntimeEffect`
- Exact arity mismatch → named `ValueError`
- Zero fabricated synthetic binding identities in source

## Files

- `operations/positional_unpack_operation.py` — roster projection
- `sugar/unpack_projection_targets.py` — typed targets
- `sugar/assign_sugar.py` — `DynamicUnpackStoreAssignSugar`
- `nodes.py` — `_flat_mixed_unpack_targets` admission
- `tests/test_starred_target_store_formal_caller.py` — required teeth

## Validation

```
bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py -q
# 15 passed
```

## 8-field record

| Field | Value |
| --- | --- |
| **R axis** | Starred-target store LTR + positional roster |
| **Epsilon R** | Constructs; ground LTR complete; halt blocks later; no fabricated IDs |
| **Floors** | Shared project_sequence_with; no loop/carrier/ExitSet edits |
| **Instrument** | `test_starred_target_store_formal_caller.py` |
| **Shell deleted** | Assign.sugar gap; synthetic name map; string-tag leaf ladder |
| **Retirement path** | Formal sequence unpack carrier (shared open with pure-Name dynamic) |
| **Validation** | 15 green |
| **Next** | Synchronous Floor iterator surface (advisor new ownership) |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add typed unpack targets and positional roster for starred-target store assignments
> - Introduces `PositionalUnpackOperation` and `UnpackMemberRoster` to handle positional unpacking with fixed prefix/suffix and optional starred middle slot, producing either an authenticated `Complete` roster or a runtime `Incomplete` effect.
> - Adds an `UnpackProjectionTarget` ABC with concrete implementations for `Name`, `Star`, `Attribute`, and `Subscript` targets, each applying a roster member via scope rebind or store projection.
> - Introduces `DynamicUnpackStoreAssignSugar` to desugar mixed LHS unpack assignments (e.g. `obj.x, d[k], *rest = xs`) by evaluating the RHS once and applying authenticated members left-to-right.
> - Extends `Assign._flat_store_unpack_pairs` to detect mixed store targets on the LHS and route them to `DynamicUnpackStoreAssignSugar` when the RHS is not a display.
> - Refactors `SubscriptStoreEffectSugar` to expose a static `project_setitem` method shared by both direct store and unpack target paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c22adf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->