### PR TITLE
Retain live iterable through loop recurrence

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
@@ -8,7 +8,7 @@ child references are required before a loop graph becomes construction input.
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from .canonicalizer import blake3_512_of, encode_jcs
@@ -427,9 +427,24 @@ class LoopConstructionV1:
     completed_faces: tuple[LoopCompletedFaceV1, ...]
     loop_construction_cid: str
     _graph: dict[str, Any]
+    iterable_sugar: object | None = field(default=None, compare=False, repr=False)
 
     def wire_graph(self) -> dict[str, Any]:
         return deepcopy(self._graph)
+
+    @property
+    def iterable_value_construction_cid(self) -> str | None:
+        """Return the authenticated iterable occurrence owned by a for-loop."""
+        if self.operation.kind != "for-operation":
+            return None
+        iterator_cid = self.operation.raw["iteratorTestimonyCid"]
+        (iterator,) = (
+            record
+            for record in self._graph["records"]
+            if record.get("kind") == "loop-iterator-testimony"
+            and record.get("iteratorTestimonyCid") == iterator_cid
+        )
+        return iterator["iterableValueConstructionCid"]
 
     # ------------------------------------------------------------------
     # The authenticated native identity of this constructed value.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
@@ -94,6 +94,21 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
         )
 
     def desugar(self, ctx=None):
+        from sugar_lift_py_tests.loop_construction import LoopWireError
+
+        iterable_sugar = self.construction.iterable_sugar
+        iterable_cid = self.construction.iterable_value_construction_cid
+        if iterable_cid is None:
+            return self._desugar_with_iterable(None, ctx)
+        if iterable_sugar is None:
+            raise LoopWireError("for recurrence omitted its live iterable sugar")
+        if iterable_sugar.site.seal().cid != iterable_cid:
+            raise LoopWireError("loop recurrence iterable occurrence mismatch")
+        return iterable_sugar.desugar(ctx).and_then(
+            lambda iterable: self._desugar_with_iterable(iterable, ctx)
+        )
+
+    def _desugar_with_iterable(self, iterable, ctx):
         from sugar_lift_py_tests.floor import InvValue
         from sugar_lift_py_tests.floor.block_value import BlockValue
 
@@ -106,7 +121,15 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
             )
             step = ctor(
                 "python:loop.step",
-                [h, str_const(self.loop_construction_cid)],
+                [
+                    h,
+                    str_const(self.loop_construction_cid),
+                    *(
+                        ()
+                        if iterable is None
+                        else (iterable.to_term(owner="LoopRecurrenceSugar"),)
+                    ),
+                ],
                 symbol_kind="coordinate",
             )
             recurrences.append(InvValue(atomic("=", [h, step]), self.site))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -666,6 +666,8 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
     )
     records = _conserve_unique_records(records)
     construction = decode_loop_construction_v1({"root": root, "records": records})
+    if isinstance(loop, For):
+        construction = replace(construction, iterable_sugar=loop.iter.sugar())
 
     bindings = {}
     for name, entry in zip(carried_names, pre_entries, strict=True):

--- a/implementations/python/sugar-source-tree/tests/test_loop_recurrence_term.py
+++ b/implementations/python/sugar-source-tree/tests/test_loop_recurrence_term.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import pytest
@@ -12,6 +12,7 @@ from sugar_lift_python_source.source_oracle import path_source
 from sugar_lift_py_tests.generator_construction import _generator_value_testimony
 from sugar_lift_py_tests.ir import _term_content_cid, ctor, str_const
 from sugar_lift_py_tests.loop_construction import LoopWireError
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.outcome.resource_bindings import ManagerBinding
 from sugar_source_tree.tree import SourceFile
 
@@ -33,6 +34,32 @@ _BASE = (
     "        pass\n"
     "    return xs\n"
 )
+
+_CARRIED = (
+    "def exercise(xs):\n"
+    "    total = 0\n"
+    "    for item in xs:\n"
+    "        total = total + item\n"
+    "    return total\n"
+)
+
+
+@dataclass(frozen=True)
+class _CountingIterableSugar(ConstructedTermSugar):
+    delegate: ConstructedTermSugar
+    calls: list[int]
+    site: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        self.calls.append(1)
+        return self.delegate.desugar(ctx)
+
+    def to_term(self, *, owner: str):
+        return self.delegate.to_term(owner=owner)
 
 
 _OLD_TERM_CONSUMERS = (
@@ -134,3 +161,47 @@ def test_loop_term_occurrence_migration_reaches_every_existing_consumer(
     observed_consumers.append("ManagerBinding fact testimony")
 
     assert tuple(observed_consumers) == _OLD_TERM_CONSUMERS
+
+
+def test_loop_recurrence_evaluates_iterable_once_and_retains_live_floor(
+    tmp_path: Path,
+):
+    loop = _loop(tmp_path, _CARRIED, "retained.py")
+    iterable = loop.construction.iterable_sugar
+    calls: list[int] = []
+    counting = _CountingIterableSugar(iterable, calls, iterable.site)
+    construction = replace(loop.construction, iterable_sugar=counting)
+
+    outcome = replace(loop, construction=construction).desugar()
+
+    assert calls == [1]
+    (equation,) = outcome.value.inv_contribution()
+    step = equation.args[1]
+    assert step.name == "python:loop.step"
+    assert step.args[2] == iterable.desugar().value.to_term(owner="test")
+
+
+def test_loop_recurrence_rejects_lying_iterable_occurrence(tmp_path: Path):
+    truthful = _loop(tmp_path, _CARRIED, "truthful.py")
+    lying = _loop(
+        tmp_path,
+        _CARRIED.replace("exercise(xs)", "exercise(xs, ys)").replace(
+            "in xs", "in ys"
+        ),
+        "lying.py",
+    )
+    construction = replace(
+        truthful.construction,
+        iterable_sugar=lying.construction.iterable_sugar,
+    )
+
+    with pytest.raises(LoopWireError, match="iterable occurrence mismatch"):
+        replace(truthful, construction=construction).desugar()
+
+
+def test_for_recurrence_refuses_missing_live_iterable(tmp_path: Path):
+    loop = _loop(tmp_path, _CARRIED, "missing.py")
+    construction = replace(loop.construction, iterable_sugar=None)
+
+    with pytest.raises(LoopWireError, match="omitted its live iterable sugar"):
+        replace(loop, construction=construction).desugar()


### PR DESCRIPTION
## What changed
- retain the source-constructed iterable sugar beside the decoded loop construction without changing its sealed wire identity
- authenticate the retained occurrence against `iterableValueConstructionCid`
- evaluate the iterable exactly once and transport its live Floor term into `python:loop.step`
- refuse missing and cross-wired iterable testimony loudly

The synchronous iterator operation surface remains owned by grok-2; this PR contains only loop recurrence retention/transport.

## Verification
- `../../../bin/bpytest tests/test_loop_recurrence_term.py tests/test_live_loop_post_projection.py` — 17 passed
- `../../../bin/bpytest tests/test_loop_construction_wire.py tests/test_guarded_loop_recurrence_idd.py tests/test_loop_construction_acceptance_fixture.py` — 29 passed

Floors preserved: ExitSet and carrier classes untouched; no CID reconstruction; lying occurrence refuses.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retain live iterable through for-loop recurrence desugaring in `LoopRecurrenceSugar`
> - `LoopConstructionV1` gains an optional `iterable_sugar` field and an `iterable_value_construction_cid` property that looks up the authenticated iterable CID for for-loop operations.
> - `LoopRecurrenceSugar.desugar` now validates that the live iterable sugar's occurrence CID matches the authenticated CID, desugars it exactly once, and passes the resulting term as a third argument to `python:loop.step`.
> - `construct_live_loop_recurrence` attaches the live iterable sugar to the construction for for-loops.
> - Three new tests cover: iterable desugared exactly once, error on CID mismatch, and error when iterable sugar is missing for a for-loop.
> - Behavioral Change: for-loop recurrence desugaring now raises `LoopWireError` if the live iterable sugar is absent or its CID does not match the authenticated value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cbb0d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->