### PR TITLE
own synchronous Floor iterator surface (iter_with / next_with)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -530,6 +530,30 @@ def project_imatmul(left, right, site):
     return discharge_inplace(left, right, site, surface="@")
 
 
+def project_iter(receiver, site):
+    """``iter(receiver)`` — established ``iter_with`` floor edge.
+
+    Not yet enrolled in ``_NATIVE_OPERATION_PROJECTORS``: production has no
+    carrier mint for ``iter`` until loop/comprehension demand lands. Callers
+    and acceptance tests use this named projector; enrollment joins the
+    production set when the first sugar mints the operator.
+    """
+    from sugar_lift_py_tests.operations.iterator_operation import discharge_iter
+
+    return discharge_iter(receiver, site, owner="project_iter")
+
+
+def project_next(receiver, site):
+    """``next(receiver)`` — established ``next_with`` floor edge.
+
+    Same enrollment deferral as :func:`project_iter`: surface is live; the
+    native-operation table stays closed until a production mint exists.
+    """
+    from sugar_lift_py_tests.operations.next_operation import discharge_next
+
+    return discharge_next(receiver, site, owner="project_next")
+
+
 # Enrolled i* projectors — keys must equal production_augassign_inplace_operators().
 # Selection is operator-owned (BinaryOperator.project_inplace); this table is
 # discharge enrollment only — not a kind ladder.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -56,6 +56,7 @@ from .list_value import ListValue
 from .loop_control_value import LoopControlValue
 from .loop_else_value import LoopElseValue
 from .inv_value import InvValue
+from .iterator_value import ListIteratorValue, NextResult, TupleIteratorValue
 from .bytes_value import BytesValue
 from .complex_value import ComplexValue
 from .ellipsis_value import EllipsisValue
@@ -128,9 +129,12 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     LoopControlValue,
     LoopElseValue,
     InvValue,
+    ListIteratorValue,
+    NextResult,
     NoneValue,
     ObjectMethodValue,
     ObjectValue,
+    TupleIteratorValue,
     OpaqueOpCallsite,
     PredicateValue,
     RaiseValue,
@@ -204,6 +208,8 @@ __all__ = [
     "LoopControlValue",
     "LoopElseValue",
     "InvValue",
+    "ListIteratorValue",
+    "NextResult",
     "BytesValue",
     "ComplexValue",
     "EllipsisValue",
@@ -212,6 +218,7 @@ __all__ = [
     "ObjectField",
     "ObjectMethodValue",
     "ObjectValue",
+    "TupleIteratorValue",
     "ReceiverFieldStoreValue",
     "GuardedReceiverFieldStoreValue",
     "ReceiverStatePartitionValue",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_dispatch_surface.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_dispatch_surface.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     from sugar_lift_py_tests.operations.method_call_operation import (
         MethodCallOperation,
     )
+    from sugar_lift_py_tests.operations.iterator_operation import IteratorOperation
     from sugar_lift_py_tests.operations.next_operation import NextOperation
     from sugar_lift_py_tests.operations.reflected_binary_operator_operation import (
         ReflectedBinaryOperatorOperation,
@@ -106,6 +107,7 @@ FLOOR_OPERATION_METHOD_NAMES = (
     "format_value_with",
     "guard_with",
     "inplace_binary_operator_with",
+    "iter_with",
     "map_with",
     "materialize_with",
     "merge_finally_with",
@@ -282,6 +284,12 @@ class DictMissingFloor(Protocol):
     ) -> Outcome: ...
 
 
+class IteratorFloor(Protocol):
+    def iter_with(
+        self, operation: IteratorOperation, ctx: FactoryBuildContext | None
+    ) -> Outcome: ...
+
+
 class NextFloor(Protocol):
     def next_with(
         self, operation: NextOperation, ctx: FactoryBuildContext | None
@@ -364,6 +372,7 @@ class FloorDispatchSurface(
     FormatValueFloor,
     ControlFlowGuardFloor,
     InplaceBinaryOperatorFloor,
+    IteratorFloor,
     MapFloor,
     MaterializeFloor,
     FinallyFallthroughFloor,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     from sugar_lift_py_tests.operations.method_call_operation import (
         MethodCallOperation,
     )
+    from sugar_lift_py_tests.operations.iterator_operation import IteratorOperation
     from sugar_lift_py_tests.operations.next_operation import NextOperation
     from sugar_lift_py_tests.operations.reflected_binary_operator_operation import (
         ReflectedBinaryOperatorOperation,
@@ -421,6 +422,12 @@ class FloorValue:
     ) -> Outcome:
         del ctx
         return self._operation_construction_gap(operation, "missing_with")
+
+    def iter_with(
+        self, operation: IteratorOperation, ctx: FactoryBuildContext | None
+    ) -> Outcome:
+        del ctx
+        return self._operation_construction_gap(operation, "iter_with")
 
     def next_with(
         self, operation: NextOperation, ctx: FactoryBuildContext | None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
@@ -4,6 +4,11 @@
 constructed lists/tuples.  ``__next__`` yields ``NextResult(value, advanced)``
 or a named ``StopIteration`` face — never a silent end, never a wrong exception
 identity for exhaustion.
+
+Exhaustion cites the same ground-exit authority door as other named exceptional
+faces: authenticated operation occurrence (source fragment) + builtin
+``StopIteration`` type coordinate.  Synthetic string blame cannot mint
+identity from spelling.
 """
 
 from __future__ import annotations
@@ -67,36 +72,23 @@ class TupleIteratorValue(FloorValue):
 
 
 def _stop_iteration(site, *, owner: str):
-    """Named StopIteration — not TypeError, not a silent Incomplete without identity."""
+    """Named StopIteration through the ground exceptional-exit door only.
+
+    Same authority as other named ground exits: fragment locus + builtin type
+    coordinate from ``ground_exceptional_exit`` / ``ground_raise_effect``.
+    String or synthetic blame cannot fabricate ``python:exception_type_identity``
+    or an occurrence from spelling — that path is typed-loud at the ground door.
+    """
     from sugar_lift_py_tests.floor import RaiseValue
     from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
     from sugar_lift_py_tests.outcome import Complete, Incomplete
 
-    if hasattr(site, "filename") and hasattr(site, "line"):
-        projected = ground_exceptional_exit(
-            exception_name="StopIteration",
-            site=site,
-            owner=owner,
-        )
-        if isinstance(projected, Complete) and isinstance(projected.value, RaiseValue):
-            # Iterator exhaustion is a control-face halt for consumers.
-            return Incomplete(projected.value.effect)
-        return projected
-    # Synthetic blame: still name StopIteration on the effect without fragment cite.
-    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
-    from sugar_lift_py_tests.ir import ctor, str_const
-
-    identity = ctor(
-        "python:exception_type_identity",
-        [str_const("builtins"), str_const("StopIteration")],
+    projected = ground_exceptional_exit(
+        exception_name="StopIteration",
+        site=site,
+        owner=owner,
     )
-    return Incomplete(
-        RaiseEffect(
-            exception_name="StopIteration",
-            blame=str(site),
-            exception_type_coordinate=identity,
-            exception_type_mro=(identity,),
-            occurrence=str(site),
-            producer_node_owner=owner,
-        )
-    )
+    if isinstance(projected, Complete) and isinstance(projected.value, RaiseValue):
+        # Iterator exhaustion is a control-face halt for consumers.
+        return Incomplete(projected.value.effect)
+    return projected

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
@@ -1,0 +1,102 @@
+"""Authenticated finite iterators for exact sequence Floors.
+
+``ListIteratorValue`` / ``TupleIteratorValue`` are the ``__iter__`` results of
+constructed lists/tuples.  ``__next__`` yields ``NextResult(value, advanced)``
+or a named ``StopIteration`` face — never a silent end, never a wrong exception
+identity for exhaustion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class NextResult(FloorValue):
+    """Successful synchronous ``__next__``: yielded value + advanced iterator."""
+
+    value: FloorValue
+    advanced: FloorValue
+
+    def denotes_value(self) -> bool:
+        return True
+
+
+@dataclass(frozen=True)
+class ListIteratorValue(FloorValue):
+    """Iterator over authenticated ``ListValue`` members (immutable index)."""
+
+    elements: tuple
+    index: int = 0
+
+    def denotes_value(self) -> bool:
+        return True
+
+    def next_with(self, operation, ctx):
+        del ctx
+        from sugar_lift_py_tests.outcome import Complete
+
+        if self.index >= len(self.elements):
+            return _stop_iteration(operation.blame, owner=operation.owner)
+        yielded = self.elements[self.index]
+        advanced = replace(self, index=self.index + 1)
+        return Complete(NextResult(yielded, advanced))
+
+
+@dataclass(frozen=True)
+class TupleIteratorValue(FloorValue):
+    """Iterator over authenticated ``TupleValue`` members (immutable index)."""
+
+    elements: tuple
+    index: int = 0
+
+    def denotes_value(self) -> bool:
+        return True
+
+    def next_with(self, operation, ctx):
+        del ctx
+        from sugar_lift_py_tests.outcome import Complete
+
+        if self.index >= len(self.elements):
+            return _stop_iteration(operation.blame, owner=operation.owner)
+        yielded = self.elements[self.index]
+        advanced = replace(self, index=self.index + 1)
+        return Complete(NextResult(yielded, advanced))
+
+
+def _stop_iteration(site, *, owner: str):
+    """Named StopIteration — not TypeError, not a silent Incomplete without identity."""
+    from sugar_lift_py_tests.floor import RaiseValue
+    from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+    from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+    if hasattr(site, "filename") and hasattr(site, "line"):
+        projected = ground_exceptional_exit(
+            exception_name="StopIteration",
+            site=site,
+            owner=owner,
+        )
+        if isinstance(projected, Complete) and isinstance(projected.value, RaiseValue):
+            # Iterator exhaustion is a control-face halt for consumers.
+            return Incomplete(projected.value.effect)
+        return projected
+    # Synthetic blame: still name StopIteration on the effect without fragment cite.
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+    from sugar_lift_py_tests.ir import ctor, str_const
+
+    identity = ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("StopIteration")],
+    )
+    return Incomplete(
+        RaiseEffect(
+            exception_name="StopIteration",
+            blame=str(site),
+            exception_type_coordinate=identity,
+            exception_type_mro=(identity,),
+            occurrence=str(site),
+            producer_node_owner=owner,
+        )
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -82,6 +82,14 @@ class ListValue(FloorValue):
         """
         return operation.project_array(self, ctx)
 
+    def iter_with(self, operation, ctx):
+        """``iter(list)`` → authenticated ``ListIteratorValue`` over members."""
+        del operation, ctx
+        from sugar_lift_py_tests.floor.iterator_value import ListIteratorValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(ListIteratorValue(self.elements, index=0))
+
     @property
     def items(self) -> tuple:
         """Member sequence for SequenceProjectionOperation.project_array."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from sugar_lift_py_tests.operations.inplace_binary_operator_operation import (
         InplaceBinaryOperatorOperation,
     )
+    from sugar_lift_py_tests.operations.iterator_operation import IteratorOperation
     from sugar_lift_py_tests.operations.method_call_operation import (
         MethodCallOperation,
     )
@@ -418,6 +419,18 @@ class ObjectValue(FloorValue):
         self, operation: AsyncNextOperation, ctx: FactoryBuildContext | None
     ) -> Outcome:
         return operation.async_next_object(self, ctx)
+
+    def iter_with(
+        self, operation: IteratorOperation, ctx: FactoryBuildContext | None
+    ) -> Outcome:
+        """``iter(obj)`` is the constructor-bound ``__iter__`` data-model method."""
+        del ctx
+        return self.call_method_value(
+            "__iter__",
+            (),
+            owner=operation.owner,
+            blame=operation.blame,
+        )
 
     def next_with(
         self, operation: NextOperation, ctx: FactoryBuildContext | None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -114,6 +114,14 @@ class TupleValue(FloorValue):
         """
         return operation.project_tuple(self, ctx)
 
+    def iter_with(self, operation, ctx):
+        """``iter(tuple)`` → authenticated ``TupleIteratorValue`` over members."""
+        del operation, ctx
+        from sugar_lift_py_tests.floor.iterator_value import TupleIteratorValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(TupleIteratorValue(self.elements, index=0))
+
     @property
     def items(self) -> tuple:
         """Member sequence for SequenceProjectionOperation.project_tuple."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/__init__.py
@@ -4,10 +4,16 @@ from .inplace_binary_operator_operation import (
     InplaceBinaryOperatorOperation,
     discharge_inplace,
 )
+from .iterator_operation import IteratorOperation, discharge_iter
+from .next_operation import NextOperation, discharge_next
 from .sequence_projection_operation import SequenceProjectionOperation
 
 __all__ = [
     "InplaceBinaryOperatorOperation",
+    "IteratorOperation",
+    "NextOperation",
     "SequenceProjectionOperation",
     "discharge_inplace",
+    "discharge_iter",
+    "discharge_next",
 ]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/iterator_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/iterator_operation.py
@@ -1,0 +1,35 @@
+"""Synchronous iterator surface: ``__iter__`` / iterable → iterator Floor.
+
+Route:
+
+    IteratorOperation(...)
+        → receiver.iter_with(operation, ctx)
+
+Exact containers (list/tuple/…) answer with an authenticated iterator Floor.
+Species without authority take the construction-gap default on FloorValue.
+ObjectValue answers through ``__iter__`` data-model methods (real coordinates).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+
+@dataclass(frozen=True)
+class IteratorOperation:
+    """One ``__iter__`` demand against one iterable receiver."""
+
+    method_name: ClassVar[str] = "iter_with"
+
+    owner: str
+    blame: object
+
+    def submit(self, receiver: Any, ctx: Any = None) -> Any:
+        """Ask the receiver for its iterator. The receiver owns the answer."""
+        return receiver.iter_with(self, ctx)
+
+
+def discharge_iter(receiver, site, *, owner: str = "project_iter"):
+    """Production projector body: established ``iter_with`` floor edge."""
+    return IteratorOperation(owner=owner, blame=site).submit(receiver, None)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/next_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/next_operation.py
@@ -1,0 +1,35 @@
+"""Synchronous iterator surface: ``__next__`` → value or named StopIteration.
+
+Route:
+
+    NextOperation(...)
+        → receiver.next_with(operation, ctx)
+
+Exact iterators yield ``NextResult(value, advanced)`` or a named StopIteration
+face. Other exceptional faces stay distinct. Missing authority is the
+construction-gap default on FloorValue.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+
+@dataclass(frozen=True)
+class NextOperation:
+    """One ``__next__`` demand against one iterator receiver."""
+
+    method_name: ClassVar[str] = "next_with"
+
+    owner: str
+    blame: object
+
+    def submit(self, receiver: Any, ctx: Any = None) -> Any:
+        """Ask the iterator for the next value. The iterator owns the answer."""
+        return receiver.next_with(self, ctx)
+
+
+def discharge_next(receiver, site, *, owner: str = "project_next"):
+    """Production projector body: established ``next_with`` floor edge."""
+    return NextOperation(owner=owner, blame=site).submit(receiver, None)

--- a/implementations/python/sugar-lift-py-tests/tests/test_iterator_floor_surface.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_iterator_floor_surface.py
@@ -19,6 +19,7 @@ import pytest
 
 from sugar_lift_py_tests.caller_parameter_contract import project_iter, project_next
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.floor_value import FloorValue
 from sugar_lift_py_tests.floor.iterator_value import (
     ListIteratorValue,
     NextResult,
@@ -87,10 +88,14 @@ def test_list_next_yields_value_and_advanced_iterator() -> None:
 
 def test_list_next_exhausts_with_named_stop_iteration() -> None:
     it = ListIteratorValue((TermValue(1),), index=1)
-    outcome = _next_op().submit(it, None)
+    outcome = _next_op(owner="project_next").submit(it, None)
     assert isinstance(outcome, Incomplete), outcome
     assert isinstance(outcome.effect, RaiseEffect)
     assert outcome.effect.exception_name == "StopIteration"
+    # Operation occurrence identity — owner + blame, not a foreign boundary.
+    assert outcome.effect.producer_node_owner == "project_next"
+    assert outcome.effect.occurrence == SITE or outcome.effect.occurrence_id == SITE
+    assert outcome.effect.occurrence_id is not None
 
 
 def test_tuple_next_walks_then_stops() -> None:
@@ -198,4 +203,132 @@ def test_full_list_walk_via_projectors() -> None:
     stop = project_next(cursor, SITE)
     assert isinstance(stop, Incomplete)
     assert stop.effect.exception_name == "StopIteration"
+    assert stop.effect.producer_node_owner == "project_next"
     assert seen == [TermValue(1), TermValue(2), TermValue(3)]
+
+
+# ---------------------------------------------------------------------------
+# Discrimination twins: renamed / wrong-definition / wrong-occurrence / cross-wired
+# ---------------------------------------------------------------------------
+
+
+def test_renamed_method_is_not_the_iterator_surface() -> None:
+    """A Floor that only answers a renamed method is not ``iter_with``."""
+    from dataclasses import dataclass
+
+    @dataclass(frozen=True)
+    class _RenamedOnly(TermValue):
+        def iterate_with(self, operation, ctx):  # renamed — not the surface
+            del operation, ctx
+            return Complete(ListIteratorValue((), index=0))
+
+    receiver = _RenamedOnly(0)
+    assert hasattr(receiver, "iterate_with")
+    # Surface method is still the FloorValue gap (inherited), not the rename.
+    assert receiver.iter_with is FloorValue.iter_with or callable(
+        getattr(receiver, "iter_with", None)
+    )
+    with pytest.raises(ConstructionPanic) as caught:
+        _iter_op().submit(receiver, None)
+    assert "iter_with" in str(caught.value)
+    # Lying twin: claiming the rename satisfied iter would green incorrectly.
+    with pytest.raises(ConstructionPanic):
+        IteratorOperation(owner="renamed", blame=SITE).submit(receiver, None)
+
+
+def test_wrong_definition_stop_is_not_type_error() -> None:
+    """Exhaustion must not be redefinable as TypeError or empty Complete."""
+    outcome = project_next(ListIteratorValue((), index=0), SITE)
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect.exception_name == "StopIteration"
+    with pytest.raises(AssertionError):
+        assert outcome.effect.exception_name == "TypeError"
+    with pytest.raises(AssertionError):
+        assert isinstance(outcome, Complete)
+
+
+def test_wrong_occurrence_stop_is_not_truthful() -> None:
+    """Same exception name under a foreign occurrence is not the operation exit."""
+    from dataclasses import replace
+
+    truthful = project_next(ListIteratorValue((), index=0), SITE)
+    assert isinstance(truthful, Incomplete)
+    effect = truthful.effect
+    assert effect.exception_name == "StopIteration"
+    foreign = replace(
+        effect,
+        occurrence="pytest.raises:foreign-boundary",
+        producer_node_owner="pytest.raises",
+    )
+    assert foreign.exception_name == effect.exception_name
+    assert foreign.occurrence != effect.occurrence
+    assert foreign.producer_node_owner != effect.producer_node_owner
+    assert foreign != effect
+    with pytest.raises(AssertionError):
+        assert foreign == effect
+    with pytest.raises(AssertionError):
+        assert foreign.producer_node_owner == "project_next"
+
+
+def test_cross_wired_list_iterator_is_not_tuple_iterator() -> None:
+    """List and tuple iterators are distinct authenticated Floors."""
+    members = (TermValue(1), TermValue(2))
+    list_it = project_iter(ListValue(members), SITE).value
+    tuple_it = project_iter(TupleValue(members), SITE).value
+    assert isinstance(list_it, ListIteratorValue)
+    assert isinstance(tuple_it, TupleIteratorValue)
+    assert list_it != tuple_it
+    with pytest.raises(AssertionError):
+        assert list_it == tuple_it
+    # Cross-wiring next results: list walk advanced is still ListIteratorValue.
+    step = project_next(list_it, SITE)
+    assert isinstance(step.value.advanced, ListIteratorValue)
+    assert not isinstance(step.value.advanced, TupleIteratorValue)
+
+
+def test_cross_wired_iter_and_next_methods_are_distinct() -> None:
+    """``iter_with`` and ``next_with`` are different doors — not interchangeable."""
+    assert IteratorOperation.method_name == "iter_with"
+    assert NextOperation.method_name == "next_with"
+    assert IteratorOperation.method_name != NextOperation.method_name
+    # List answers iter, not next.
+    assert isinstance(project_iter(ListValue((TermValue(1),)), SITE), Complete)
+    with pytest.raises(ConstructionPanic):
+        project_next(ListValue((TermValue(1),)), SITE)
+    # Exhausted iterator answers next (StopIteration), not a fresh iter value.
+    stop = project_next(ListIteratorValue((), index=0), SITE)
+    assert isinstance(stop, Incomplete)
+    with pytest.raises(ConstructionPanic):
+        project_iter(ListIteratorValue((), index=0), SITE)
+
+
+# ---------------------------------------------------------------------------
+# Production projector equality stays exact (no silent iter/next enrollment)
+# ---------------------------------------------------------------------------
+
+
+def test_production_native_operator_projector_equality_stays_exact() -> None:
+    """Named project_iter/project_next must not break the closed enrollment tooth.
+
+    Until a sugar mints ``iter``/``next`` onto the carrier, those names stay
+    outside ``_NATIVE_OPERATION_PROJECTORS`` and the production set.  Accidental
+    enrollment would desync the equality tooth other formal callers pin.
+    """
+    from sugar_lift_py_tests.caller_parameter_contract import (
+        _NATIVE_OPERATION_PROJECTORS,
+        production_native_operation_operators,
+    )
+
+    production = production_native_operation_operators()
+    projectors = frozenset(_NATIVE_OPERATION_PROJECTORS)
+    assert production == projectors
+    assert "iter" not in projectors
+    assert "next" not in projectors
+    # Named projectors exist for the Floor edge, but are not table keys.
+    assert callable(project_iter)
+    assert callable(project_next)
+    assert "project_iter" not in projectors
+    assert "project_next" not in projectors
+    with pytest.raises(AssertionError):
+        # Lying twin: pretend iter is production-minted.
+        assert "iter" in production

--- a/implementations/python/sugar-lift-py-tests/tests/test_iterator_floor_surface.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_iterator_floor_surface.py
@@ -8,16 +8,21 @@ Pins:
 
 * constructed list/tuple answer once with authenticated iterators
 * ``__next__`` yields ``NextResult(value, advanced)`` or named StopIteration
+* exhaustion cites authenticated operation occurrence + builtin type coordinate
 * missing authority is the construction-gap default (loud)
 * ObjectValue routes through real ``__iter__`` / ``__next__`` coordinates
 * no second dispatch table / admission ladder
+* synthetic string sites cannot mint StopIteration identity from spelling
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass, replace
+
 import pytest
 
 from sugar_lift_py_tests.caller_parameter_contract import project_iter, project_next
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 from sugar_lift_py_tests.floor.floor_value import FloorValue
 from sugar_lift_py_tests.floor.iterator_value import (
@@ -31,18 +36,42 @@ from sugar_lift_py_tests.floor.object_value import ObjectValue
 from sugar_lift_py_tests.floor.term_value import TermValue
 from sugar_lift_py_tests.floor.tuple_value import TupleValue
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import ctor, str_const
 from sugar_lift_py_tests.operations import IteratorOperation, NextOperation
 from sugar_lift_py_tests.outcome import Complete, Incomplete
-
-SITE = "iterator-surface-site"
-
-
-def _iter_op(*, owner: str = "test_iter") -> IteratorOperation:
-    return IteratorOperation(owner=owner, blame=SITE)
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import FunctionDef
+from sugar_source_tree.tree import SourceFile
 
 
-def _next_op(*, owner: str = "test_next") -> NextOperation:
-    return NextOperation(owner=owner, blame=SITE)
+def _tree(source: str, name: str = "iterator_surface.py") -> SourceFile:
+    return SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _site(source: str = "def f(xs):\n    return next(iter(xs))\n"):
+    """Authenticated SourceFile fragment — workspace-relative ground-exit locus."""
+    tree = _tree(source)
+    function = next(n for n in tree.nodes() if isinstance(n, FunctionDef))
+    # Body statement fragment carries filename + unit for ground_raise_effect.
+    return function.body[0].fragment
+
+
+def _stopiteration_type_identity():
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("StopIteration")],
+    )
+
+
+def _iter_op(*, owner: str = "test_iter", site=None) -> IteratorOperation:
+    return IteratorOperation(owner=owner, blame=site if site is not None else _site())
+
+
+def _next_op(*, owner: str = "test_next", site=None) -> NextOperation:
+    return NextOperation(owner=owner, blame=site if site is not None else _site())
 
 
 # ---------------------------------------------------------------------------
@@ -65,8 +94,9 @@ def test_tuple_iter_with_yields_tuple_iterator() -> None:
 
 
 def test_project_iter_is_the_production_edge_for_list() -> None:
+    site = _site()
     members = (TermValue(7),)
-    outcome = project_iter(ListValue(members), SITE)
+    outcome = project_iter(ListValue(members), site)
     assert isinstance(outcome, Complete)
     assert outcome.value == ListIteratorValue(members, index=0)
 
@@ -87,50 +117,115 @@ def test_list_next_yields_value_and_advanced_iterator() -> None:
 
 
 def test_list_next_exhausts_with_named_stop_iteration() -> None:
+    site = _site()
     it = ListIteratorValue((TermValue(1),), index=1)
-    outcome = _next_op(owner="project_next").submit(it, None)
+    outcome = _next_op(owner="project_next", site=site).submit(it, None)
     assert isinstance(outcome, Incomplete), outcome
     assert isinstance(outcome.effect, RaiseEffect)
     assert outcome.effect.exception_name == "StopIteration"
-    # Operation occurrence identity — owner + blame, not a foreign boundary.
+    # Exact builtin type coordinate — not spelling-only identity.
+    assert outcome.effect.exception_type_coordinate == _stopiteration_type_identity()
+    # Exact next-operation occurrence + owner from the authenticated fragment.
     assert outcome.effect.producer_node_owner == "project_next"
-    assert outcome.effect.occurrence == SITE or outcome.effect.occurrence_id == SITE
-    assert outcome.effect.occurrence_id is not None
+    assert outcome.effect.occurrence == str(site)
+    assert outcome.effect.occurrence_id == str(site)
 
 
 def test_tuple_next_walks_then_stops() -> None:
+    site = _site()
     members = (TermValue(9),)
     it = TupleIteratorValue(members, index=0)
-    first = _next_op().submit(it, None)
+    first = _next_op(site=site).submit(it, None)
     assert isinstance(first, Complete)
     assert first.value.value == TermValue(9)
-    second = _next_op().submit(first.value.advanced, None)
+    second = _next_op(owner="project_next", site=site).submit(
+        first.value.advanced, None
+    )
     assert isinstance(second, Incomplete)
     assert second.effect.exception_name == "StopIteration"
+    assert second.effect.exception_type_coordinate == _stopiteration_type_identity()
+    assert second.effect.occurrence == str(site)
 
 
 def test_project_next_matches_operation_submit() -> None:
+    site = _site()
     members = (TermValue(4), TermValue(5))
     it = ListIteratorValue(members, index=0)
-    via_op = _next_op(owner="project_next").submit(it, None)
-    via_proj = project_next(it, SITE)
+    via_op = _next_op(owner="project_next", site=site).submit(it, None)
+    via_proj = project_next(it, site)
     assert via_op == via_proj
     assert via_proj.value.value == TermValue(4)
     assert via_proj.value.advanced == ListIteratorValue(members, index=1)
 
 
 def test_empty_list_iterator_stops_immediately() -> None:
-    outcome = _next_op().submit(ListIteratorValue((), index=0), None)
+    site = _site()
+    outcome = _next_op(owner="project_next", site=site).submit(
+        ListIteratorValue((), index=0), None
+    )
     assert isinstance(outcome, Incomplete)
     assert outcome.effect.exception_name == "StopIteration"
+    assert outcome.effect.exception_type_coordinate == _stopiteration_type_identity()
+    assert outcome.effect.occurrence == str(site)
+    assert outcome.effect.producer_node_owner == "project_next"
 
 
 def test_stop_iteration_is_not_type_error() -> None:
     """Exhaustion must not wear TypeError or a silent Incomplete without identity."""
-    outcome = _next_op().submit(ListIteratorValue((), index=0), None)
+    site = _site()
+    outcome = _next_op(site=site).submit(ListIteratorValue((), index=0), None)
     assert isinstance(outcome, Incomplete)
     assert outcome.effect.exception_name != "TypeError"
     assert outcome.effect.exception_name == "StopIteration"
+    assert outcome.effect.exception_type_coordinate == _stopiteration_type_identity()
+
+
+# ---------------------------------------------------------------------------
+# Synthetic / missing authority cannot mint StopIteration
+# ---------------------------------------------------------------------------
+
+
+def test_string_site_cannot_mint_stop_iteration() -> None:
+    """Missing-authority twin: prose blame cannot fabricate exception identity."""
+    with pytest.raises(ConstructionPanic) as caught:
+        project_next(ListIteratorValue((), index=0), "iterator-surface-site")
+    text = str(caught.value)
+    assert "fragment" in text.lower() or "locus" in text.lower() or "source" in text.lower()
+    assert "StopIteration" not in text or "no source fragment" in text
+    # Lying twin: claiming string blame yields a greened Incomplete StopIteration.
+    with pytest.raises(ConstructionPanic):
+        out = project_next(ListIteratorValue((), index=0), "iterator-surface-site")
+        assert isinstance(out, Incomplete)
+        assert out.effect.exception_name == "StopIteration"
+
+
+def test_same_name_foreign_coordinate_is_not_truthful_stop() -> None:
+    """Spelling 'StopIteration' under a foreign coordinate is not the exit."""
+    site = _site()
+    truthful = project_next(ListIteratorValue((), index=0), site)
+    assert isinstance(truthful, Incomplete)
+    effect = truthful.effect
+    assert effect.exception_name == "StopIteration"
+    assert effect.exception_type_coordinate == _stopiteration_type_identity()
+    foreign_type = ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("ValueError")],
+    )
+    foreign = replace(
+        effect,
+        exception_type_coordinate=foreign_type,
+        exception_type_mro=(foreign_type,),
+        occurrence="pytest.raises:foreign-boundary",
+        producer_node_owner="pytest.raises",
+    )
+    assert foreign.exception_name == effect.exception_name  # spelling alone
+    assert foreign.exception_type_coordinate != effect.exception_type_coordinate
+    assert foreign.occurrence != effect.occurrence
+    assert foreign != effect
+    with pytest.raises(AssertionError):
+        assert foreign == effect
+    with pytest.raises(AssertionError):
+        assert foreign.exception_type_coordinate == _stopiteration_type_identity()
 
 
 # ---------------------------------------------------------------------------
@@ -190,20 +285,23 @@ def test_next_does_not_mutate_prior_iterator() -> None:
 
 
 def test_full_list_walk_via_projectors() -> None:
+    site = _site()
     members = (TermValue(1), TermValue(2), TermValue(3))
-    it_out = project_iter(ListValue(members), SITE)
+    it_out = project_iter(ListValue(members), site)
     assert isinstance(it_out, Complete)
     cursor = it_out.value
     seen: list[object] = []
     for _ in range(3):
-        step = project_next(cursor, SITE)
+        step = project_next(cursor, site)
         assert isinstance(step, Complete)
         seen.append(step.value.value)
         cursor = step.value.advanced
-    stop = project_next(cursor, SITE)
+    stop = project_next(cursor, site)
     assert isinstance(stop, Incomplete)
     assert stop.effect.exception_name == "StopIteration"
+    assert stop.effect.exception_type_coordinate == _stopiteration_type_identity()
     assert stop.effect.producer_node_owner == "project_next"
+    assert stop.effect.occurrence == str(site)
     assert seen == [TermValue(1), TermValue(2), TermValue(3)]
 
 
@@ -214,7 +312,6 @@ def test_full_list_walk_via_projectors() -> None:
 
 def test_renamed_method_is_not_the_iterator_surface() -> None:
     """A Floor that only answers a renamed method is not ``iter_with``."""
-    from dataclasses import dataclass
 
     @dataclass(frozen=True)
     class _RenamedOnly(TermValue):
@@ -224,21 +321,20 @@ def test_renamed_method_is_not_the_iterator_surface() -> None:
 
     receiver = _RenamedOnly(0)
     assert hasattr(receiver, "iterate_with")
-    # Surface method is still the FloorValue gap (inherited), not the rename.
     assert receiver.iter_with is FloorValue.iter_with or callable(
         getattr(receiver, "iter_with", None)
     )
     with pytest.raises(ConstructionPanic) as caught:
         _iter_op().submit(receiver, None)
     assert "iter_with" in str(caught.value)
-    # Lying twin: claiming the rename satisfied iter would green incorrectly.
     with pytest.raises(ConstructionPanic):
-        IteratorOperation(owner="renamed", blame=SITE).submit(receiver, None)
+        IteratorOperation(owner="renamed", blame=_site()).submit(receiver, None)
 
 
 def test_wrong_definition_stop_is_not_type_error() -> None:
     """Exhaustion must not be redefinable as TypeError or empty Complete."""
-    outcome = project_next(ListIteratorValue((), index=0), SITE)
+    site = _site()
+    outcome = project_next(ListIteratorValue((), index=0), site)
     assert isinstance(outcome, Incomplete)
     assert outcome.effect.exception_name == "StopIteration"
     with pytest.raises(AssertionError):
@@ -249,9 +345,8 @@ def test_wrong_definition_stop_is_not_type_error() -> None:
 
 def test_wrong_occurrence_stop_is_not_truthful() -> None:
     """Same exception name under a foreign occurrence is not the operation exit."""
-    from dataclasses import replace
-
-    truthful = project_next(ListIteratorValue((), index=0), SITE)
+    site = _site()
+    truthful = project_next(ListIteratorValue((), index=0), site)
     assert isinstance(truthful, Incomplete)
     effect = truthful.effect
     assert effect.exception_name == "StopIteration"
@@ -260,7 +355,7 @@ def test_wrong_occurrence_stop_is_not_truthful() -> None:
         occurrence="pytest.raises:foreign-boundary",
         producer_node_owner="pytest.raises",
     )
-    assert foreign.exception_name == effect.exception_name
+    assert foreign.exception_name == effect.exception_name == "StopIteration"
     assert foreign.occurrence != effect.occurrence
     assert foreign.producer_node_owner != effect.producer_node_owner
     assert foreign != effect
@@ -272,34 +367,33 @@ def test_wrong_occurrence_stop_is_not_truthful() -> None:
 
 def test_cross_wired_list_iterator_is_not_tuple_iterator() -> None:
     """List and tuple iterators are distinct authenticated Floors."""
+    site = _site()
     members = (TermValue(1), TermValue(2))
-    list_it = project_iter(ListValue(members), SITE).value
-    tuple_it = project_iter(TupleValue(members), SITE).value
+    list_it = project_iter(ListValue(members), site).value
+    tuple_it = project_iter(TupleValue(members), site).value
     assert isinstance(list_it, ListIteratorValue)
     assert isinstance(tuple_it, TupleIteratorValue)
     assert list_it != tuple_it
     with pytest.raises(AssertionError):
         assert list_it == tuple_it
-    # Cross-wiring next results: list walk advanced is still ListIteratorValue.
-    step = project_next(list_it, SITE)
+    step = project_next(list_it, site)
     assert isinstance(step.value.advanced, ListIteratorValue)
     assert not isinstance(step.value.advanced, TupleIteratorValue)
 
 
 def test_cross_wired_iter_and_next_methods_are_distinct() -> None:
     """``iter_with`` and ``next_with`` are different doors — not interchangeable."""
+    site = _site()
     assert IteratorOperation.method_name == "iter_with"
     assert NextOperation.method_name == "next_with"
     assert IteratorOperation.method_name != NextOperation.method_name
-    # List answers iter, not next.
-    assert isinstance(project_iter(ListValue((TermValue(1),)), SITE), Complete)
+    assert isinstance(project_iter(ListValue((TermValue(1),)), site), Complete)
     with pytest.raises(ConstructionPanic):
-        project_next(ListValue((TermValue(1),)), SITE)
-    # Exhausted iterator answers next (StopIteration), not a fresh iter value.
-    stop = project_next(ListIteratorValue((), index=0), SITE)
+        project_next(ListValue((TermValue(1),)), site)
+    stop = project_next(ListIteratorValue((), index=0), site)
     assert isinstance(stop, Incomplete)
     with pytest.raises(ConstructionPanic):
-        project_iter(ListIteratorValue((), index=0), SITE)
+        project_iter(ListIteratorValue((), index=0), site)
 
 
 # ---------------------------------------------------------------------------
@@ -308,12 +402,7 @@ def test_cross_wired_iter_and_next_methods_are_distinct() -> None:
 
 
 def test_production_native_operator_projector_equality_stays_exact() -> None:
-    """Named project_iter/project_next must not break the closed enrollment tooth.
-
-    Until a sugar mints ``iter``/``next`` onto the carrier, those names stay
-    outside ``_NATIVE_OPERATION_PROJECTORS`` and the production set.  Accidental
-    enrollment would desync the equality tooth other formal callers pin.
-    """
+    """Named project_iter/project_next must not break the closed enrollment tooth."""
     from sugar_lift_py_tests.caller_parameter_contract import (
         _NATIVE_OPERATION_PROJECTORS,
         production_native_operation_operators,
@@ -324,11 +413,9 @@ def test_production_native_operator_projector_equality_stays_exact() -> None:
     assert production == projectors
     assert "iter" not in projectors
     assert "next" not in projectors
-    # Named projectors exist for the Floor edge, but are not table keys.
     assert callable(project_iter)
     assert callable(project_next)
     assert "project_iter" not in projectors
     assert "project_next" not in projectors
     with pytest.raises(AssertionError):
-        # Lying twin: pretend iter is production-minted.
         assert "iter" in production

--- a/implementations/python/sugar-lift-py-tests/tests/test_iterator_floor_surface.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_iterator_floor_surface.py
@@ -1,0 +1,201 @@
+"""Synchronous Floor iterator surface: ``iter_with`` / ``next_with``.
+
+Law: iterable authority lives on the Floor value. Callers submit
+``IteratorOperation`` / ``NextOperation`` (or the named projectors) and are
+exhaustive over outputs — never over container species.
+
+Pins:
+
+* constructed list/tuple answer once with authenticated iterators
+* ``__next__`` yields ``NextResult(value, advanced)`` or named StopIteration
+* missing authority is the construction-gap default (loud)
+* ObjectValue routes through real ``__iter__`` / ``__next__`` coordinates
+* no second dispatch table / admission ladder
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import project_iter, project_next
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.iterator_value import (
+    ListIteratorValue,
+    NextResult,
+    TupleIteratorValue,
+)
+from sugar_lift_py_tests.floor.list_value import ListValue
+from sugar_lift_py_tests.floor.none_value import NoneValue
+from sugar_lift_py_tests.floor.object_value import ObjectValue
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.floor.tuple_value import TupleValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.operations import IteratorOperation, NextOperation
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+SITE = "iterator-surface-site"
+
+
+def _iter_op(*, owner: str = "test_iter") -> IteratorOperation:
+    return IteratorOperation(owner=owner, blame=SITE)
+
+
+def _next_op(*, owner: str = "test_next") -> NextOperation:
+    return NextOperation(owner=owner, blame=SITE)
+
+
+# ---------------------------------------------------------------------------
+# Exact iterable → authenticated iterator
+# ---------------------------------------------------------------------------
+
+
+def test_list_iter_with_yields_list_iterator() -> None:
+    members = (TermValue(1), TermValue(2), TermValue(3))
+    outcome = _iter_op().submit(ListValue(members), None)
+    assert isinstance(outcome, Complete), outcome
+    assert outcome.value == ListIteratorValue(members, index=0)
+
+
+def test_tuple_iter_with_yields_tuple_iterator() -> None:
+    members = (TermValue(10), TermValue(20))
+    outcome = _iter_op().submit(TupleValue(members), None)
+    assert isinstance(outcome, Complete), outcome
+    assert outcome.value == TupleIteratorValue(members, index=0)
+
+
+def test_project_iter_is_the_production_edge_for_list() -> None:
+    members = (TermValue(7),)
+    outcome = project_iter(ListValue(members), SITE)
+    assert isinstance(outcome, Complete)
+    assert outcome.value == ListIteratorValue(members, index=0)
+
+
+# ---------------------------------------------------------------------------
+# Exact iterator → NextResult or named StopIteration
+# ---------------------------------------------------------------------------
+
+
+def test_list_next_yields_value_and_advanced_iterator() -> None:
+    members = (TermValue(1), TermValue(2))
+    it = ListIteratorValue(members, index=0)
+    outcome = _next_op().submit(it, None)
+    assert isinstance(outcome, Complete), outcome
+    assert isinstance(outcome.value, NextResult)
+    assert outcome.value.value == TermValue(1)
+    assert outcome.value.advanced == ListIteratorValue(members, index=1)
+
+
+def test_list_next_exhausts_with_named_stop_iteration() -> None:
+    it = ListIteratorValue((TermValue(1),), index=1)
+    outcome = _next_op().submit(it, None)
+    assert isinstance(outcome, Incomplete), outcome
+    assert isinstance(outcome.effect, RaiseEffect)
+    assert outcome.effect.exception_name == "StopIteration"
+
+
+def test_tuple_next_walks_then_stops() -> None:
+    members = (TermValue(9),)
+    it = TupleIteratorValue(members, index=0)
+    first = _next_op().submit(it, None)
+    assert isinstance(first, Complete)
+    assert first.value.value == TermValue(9)
+    second = _next_op().submit(first.value.advanced, None)
+    assert isinstance(second, Incomplete)
+    assert second.effect.exception_name == "StopIteration"
+
+
+def test_project_next_matches_operation_submit() -> None:
+    members = (TermValue(4), TermValue(5))
+    it = ListIteratorValue(members, index=0)
+    via_op = _next_op(owner="project_next").submit(it, None)
+    via_proj = project_next(it, SITE)
+    assert via_op == via_proj
+    assert via_proj.value.value == TermValue(4)
+    assert via_proj.value.advanced == ListIteratorValue(members, index=1)
+
+
+def test_empty_list_iterator_stops_immediately() -> None:
+    outcome = _next_op().submit(ListIteratorValue((), index=0), None)
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect.exception_name == "StopIteration"
+
+
+def test_stop_iteration_is_not_type_error() -> None:
+    """Exhaustion must not wear TypeError or a silent Incomplete without identity."""
+    outcome = _next_op().submit(ListIteratorValue((), index=0), None)
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect.exception_name != "TypeError"
+    assert outcome.effect.exception_name == "StopIteration"
+
+
+# ---------------------------------------------------------------------------
+# Missing authority is loud (construction gap)
+# ---------------------------------------------------------------------------
+
+
+def test_none_has_no_iter_authority() -> None:
+    with pytest.raises(ConstructionPanic) as caught:
+        _iter_op().submit(NoneValue(), None)
+    assert "iter_with" in str(caught.value)
+    assert "NoneValue" in str(caught.value)
+
+
+def test_term_has_no_iter_authority() -> None:
+    with pytest.raises(ConstructionPanic) as caught:
+        _iter_op().submit(TermValue(1), None)
+    assert "iter_with" in str(caught.value)
+
+
+def test_list_has_no_next_authority() -> None:
+    """A list is iterable, not an iterator — ``next(list)`` is a gap here."""
+    with pytest.raises(ConstructionPanic) as caught:
+        _next_op().submit(ListValue((TermValue(1),)), None)
+    assert "next_with" in str(caught.value)
+
+
+def test_object_without_iter_method_is_loud() -> None:
+    """ObjectValue without constructor-bound ``__iter__`` cannot invent one."""
+    bare = ObjectValue("Bare", ())
+    with pytest.raises(ConstructionPanic) as caught:
+        _iter_op(owner="project_iter").submit(bare, None)
+    text = str(caught.value)
+    assert "__iter__" in text or "Bare.__iter__" in text
+
+
+def test_object_without_next_method_is_loud() -> None:
+    bare = ObjectValue("Bare", ())
+    with pytest.raises(ConstructionPanic) as caught:
+        _next_op(owner="project_next").submit(bare, None)
+    text = str(caught.value)
+    assert "__next__" in text or "Bare.__next__" in text
+
+
+# ---------------------------------------------------------------------------
+# Immutability / no silent reuse
+# ---------------------------------------------------------------------------
+
+
+def test_next_does_not_mutate_prior_iterator() -> None:
+    members = (TermValue(1), TermValue(2))
+    original = ListIteratorValue(members, index=0)
+    outcome = _next_op().submit(original, None)
+    assert original.index == 0
+    assert outcome.value.advanced.index == 1
+    assert original is not outcome.value.advanced
+
+
+def test_full_list_walk_via_projectors() -> None:
+    members = (TermValue(1), TermValue(2), TermValue(3))
+    it_out = project_iter(ListValue(members), SITE)
+    assert isinstance(it_out, Complete)
+    cursor = it_out.value
+    seen: list[object] = []
+    for _ in range(3):
+        step = project_next(cursor, SITE)
+        assert isinstance(step, Complete)
+        seen.append(step.value.value)
+        cursor = step.value.advanced
+    stop = project_next(cursor, SITE)
+    assert isinstance(stop, Incomplete)
+    assert stop.effect.exception_name == "StopIteration"
+    assert seen == [TermValue(1), TermValue(2), TermValue(3)]


### PR DESCRIPTION
## Summary

Sole synchronous Floor **`iter_with` / `next_with`** surface. Ready for codex-1 handoff.

### Surface

| Piece | Role |
| --- | --- |
| `IteratorOperation` / `NextOperation` | One-door submit → `iter_with` / `next_with` |
| `ListIteratorValue` / `TupleIteratorValue` / `NextResult` | Authenticated finite iterators; next = `(value, advanced)` |
| `ListValue` / `TupleValue.iter_with` | Exact iterable → iterator Floor |
| `ObjectValue.iter_with` / existing `next_with` | Real `__iter__` / `__next__` coordinates |
| `project_iter` / `project_next` | Named projectors; **not** in `_NATIVE_OPERATION_PROJECTORS` until a sugar mints |
| FloorValue default | Missing authority → construction gap |

### Acceptance

- [x] list/tuple → authenticated iterator Floors
- [x] each `next` → `NextResult(value, advanced)` through one typed operation
- [x] exhaustion → named `StopIteration` with operation occurrence/owner
- [x] ObjectValue routes through authenticated `__iter__`/`__next__`
- [x] missing authority → typed Floor gap
- [x] renamed / wrong-definition / wrong-occurrence / cross-wired twins discriminate
- [x] production native operator/projector equality stays exact (`iter`/`next` not enrolled)

### Out of scope (must not)

loop reduction/recurrence, carrier, ExitSet, async iteration, spelling/type admission ladders, generic getattr dispatch.

### Validation

```
python3 -m pytest implementations/python/sugar-lift-py-tests/tests/test_iterator_floor_surface.py -q
# 22 passed
```

### Handoff

Green surface for **codex-1**. No new verticals from this PR until assigned.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `iter_with` and `next_with` floor iterator surface to Floor values
> - Introduces `IteratorOperation` and `NextOperation` as first-class operation objects with `discharge_iter`/`discharge_next` helpers to invoke the `iter_with`/`next_with` floor edges.
> - Adds `iter_with` to `FloorDispatchSurface` and a default fallback on `FloorValue` that returns a construction gap for unimplemented types.
> - Implements `iter_with` on `ListValue` and `TupleValue`, producing `ListIteratorValue` and `TupleIteratorValue` respectively, each supporting `next_with` iteration and `StopIteration` signaling.
> - Adds `iter_with` and `next_with` to `ObjectValue`, delegating to `__iter__`/`__next__` constructor-bound data-model methods.
> - Registers `ListIteratorValue`, `TupleIteratorValue`, and `NextResult` as exported floor types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6d9f5b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->