### PR TITLE
Instrument while temporal recurrence state reentry

### DIFF
--- a/implementations/python/sugar-source-tree/tests/test_while_temporal_recurrence.py
+++ b/implementations/python/sugar-source-tree/tests/test_while_temporal_recurrence.py
@@ -1,0 +1,51 @@
+"""Production laws for temporal recurrence of source-constructed ``while``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.nodes import While
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(tmp_path: Path, source: str):
+    path = tmp_path / "while_temporal_recurrence.py"
+    path.write_text(source, encoding="utf-8")
+    return next(SourceFile(path_source(path)).functions())
+
+
+def _record(graph, kind: str):
+    return next(record for record in graph["records"] if record["kind"] == kind)
+
+
+def test_body_state_is_the_next_condition_input_not_the_stale_initial_state(
+    tmp_path: Path,
+):
+    function = _function(
+        tmp_path,
+        "def helper(limit):\n"
+        "    current = 0\n"
+        "    while current < limit:\n"
+        "        current = current + 1\n"
+        "    return current\n",
+    )
+    while_node = next(node for node in function.walk() if isinstance(node, While))
+    loop = next(
+        statement
+        for statement in function.sugar().statements
+        if type(statement).__name__ == "LoopRecurrenceSugar"
+    )
+    graph = loop.construction.wire_graph()
+    test_transform = _record(graph, "loop-test-transform")
+    latch = _record(graph, "loop-latch-obligation")
+
+    assert test_transform["testValueConstructionCid"] == (
+        while_node.test.fragment.seal().cid
+    )
+    assert latch["successorTransformCid"] == test_transform["testTransformCid"]
+    assert latch["inputStateCid"] != graph["root"]["preStateCid"]
+    assert test_transform["inputStateCid"] == latch["inputStateCid"], (
+        "the reached next condition must consume the body-completed state; "
+        "reusing preStateCid is the stale-initial-state lying twin"
+    )


### PR DESCRIPTION
Honorably red production instrument.

Real SourceFile construction proves the condition occurrence and latch target are authenticated, then rejects stale initial-state reuse: the latch carries the body-completed state but `live_loop_construction.py` seals `loop-test-transform.inputStateCid` to the distinct pre-loop state.

First red, per stop rule:
`../../../bin/bpytest tests/test_while_temporal_recurrence.py` — 1 failed

`AssertionError: the reached next condition must consume the body-completed state; reusing preStateCid is the stale-initial-state lying twin`

No production files changed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for while loop temporal recurrence state reentry in wire graph
> Adds a pytest module ([test_while_temporal_recurrence.py](https://github.com/TSavo/sugar/pull/6742/files#diff-096e4a6c29d269bc8e329de4e7e189bd0ff1ca9679392b53fb5ca221ac0907d0)) that verifies the wire graph correctly threads state through while loop recurrence.
>
> - The core test asserts that `latch.inputStateCid` differs from the root `preStateCid`, confirming the loop condition re-evaluates against the post-body state rather than the stale initial state.
> - Also asserts that `testValueConstructionCid` matches the While test fragment sealed CID and that `test_transform.inputStateCid` equals `latch.inputStateCid`.
> - Adds `_function` and `_record` test helpers for parsing source into a function object and locating graph records by kind.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 083fe70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->