### PR TITLE
test: instrument If branch-result slot producer

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_if_construct_sugar_slot_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_if_construct_sugar_slot_producer.py
@@ -1,0 +1,140 @@
+"""The source ``If`` producer must supply one condition-owned result slot."""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor.branch_result_coordinate import (
+    BranchResultAuthentication,
+    branch_result_guard,
+)
+from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.binding_state import branch_result_slot
+from sugar_source_tree.nodes import Call, If
+from sugar_source_tree.panic import BackendDefect
+from sugar_source_tree.tree import SourceFile
+
+
+def _tree(source: str) -> SourceFile:
+    return SourceFile(
+        (source, "if-construct-slot.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _two_ifs() -> tuple[If, If]:
+    branches = tuple(
+        node
+        for node in _tree(
+            "if left is right:\n"
+            "    assert left is right\n"
+            "else:\n"
+            "    assert left is not right\n"
+            "if nearby:\n"
+            "    pass\n"
+        ).nodes()
+        if isinstance(node, If)
+    )
+    assert len(branches) == 2
+    return branches
+
+
+def test_raw_source_if_names_the_exact_missing_slot_producer() -> None:
+    branch, _ = _two_ifs()
+
+    with pytest.raises(BackendDefect) as raised:
+        branch.sugar()
+
+    message = str(raised.value)
+    assert "If._construct_sugar" in message
+    assert "If without a stored branch-result slot" in message
+    assert "consume the slot minted once by If.substitute" in message
+    assert "if-construct-slot.py:1:0" in message
+
+
+def test_condition_owned_slot_constructs_one_authenticated_guard() -> None:
+    branch, _ = _two_ifs()
+    slot = branch_result_slot(branch.test)
+    rewritten = branch._rewrite_with_slot({}, slot)
+
+    sugar = rewritten.sugar()
+    outcome = sugar.desugar(None)
+
+    assert sugar.branch_slot == slot
+    assert isinstance(outcome, Complete)
+    guarded = outcome.value
+    assert guarded.guard == branch_result_guard(slot, rewritten.fragment)
+    assert len(guarded.unconditional_entries) == 1
+    authentication = guarded.unconditional_entries[0]
+    assert isinstance(authentication, BranchResultAuthentication)
+    assert authentication.slot == slot
+
+
+def test_nearby_condition_slot_is_rejected_at_the_if_occurrence() -> None:
+    branch, nearby = _two_ifs()
+    wrong_slot = branch_result_slot(nearby.test)
+    rewritten = branch._rewrite_with_slot({}, wrong_slot)
+
+    with pytest.raises(BackendDefect) as raised:
+        rewritten.sugar()
+
+    message = str(raised.value)
+    assert "If._construct_sugar" in message
+    assert "branch-result slot" in message
+    assert "if-construct-slot.py:1:0" in message
+
+
+def test_condition_halt_bypasses_both_if_bodies() -> None:
+    source = (
+        "def choose(value):\n"
+        "    if value < 1:\n"
+        "        return 10\n"
+        "    else:\n"
+        "        return 20\n"
+        "\n"
+        "choose(None)\n"
+    )
+    outcomes = tuple(
+        node.sugar().desugar(None)
+        for node in _tree(source).nodes()
+        if isinstance(node, Call)
+    )
+
+    assert len(outcomes) == 1
+    outcome = outcomes[0]
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    halted = outcome.exits[0]
+    assert isinstance(halted, Halted)
+    assert halted.effect.occurrence_id is not None
+    assert halted.state is not None
+
+
+def test_complementary_results_share_only_the_condition_owned_slot() -> None:
+    branch, _ = _two_ifs()
+    slot = branch_result_slot(branch.test)
+    rewritten = branch._rewrite_with_slot({}, slot)
+
+    outcome = rewritten.sugar().desugar(None)
+
+    assert isinstance(outcome, Complete)
+    guarded = outcome.value
+    expected = branch_result_guard(slot, rewritten.fragment)
+    assert guarded.guard == expected
+    assert len(guarded.entries) == 2
+    then_formula = guarded.entries[0].formula
+    else_formula = guarded.entries[1].formula
+    assert then_formula.kind == "implies"
+    assert then_formula.operands[0] == expected
+    assert else_formula.kind == "implies"
+    assert else_formula.operands[0].kind == "not"
+    assert else_formula.operands[0].operands[0] == expected
+    authentications = tuple(
+        entry
+        for entry in guarded.unconditional_entries
+        if isinstance(entry, BranchResultAuthentication)
+    )
+    assert len(authentications) == 1
+    assert authentications[0].slot == slot

--- a/implementations/python/sugar-lift-py-tests/tests/test_if_construct_sugar_slot_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_if_construct_sugar_slot_producer.py
@@ -12,7 +12,7 @@ from sugar_lift_py_tests.floor.branch_result_coordinate import (
 from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.binding_state import branch_result_slot
-from sugar_source_tree.nodes import Call, If
+from sugar_source_tree.nodes import Call, Compare, If
 from sugar_source_tree.panic import BackendDefect
 from sugar_source_tree.tree import SourceFile
 
@@ -112,6 +112,36 @@ def test_condition_halt_bypasses_both_if_bodies() -> None:
     assert halted.state is not None
 
 
+def test_condition_halt_emits_no_occurrence_from_toxic_body_twins() -> None:
+    source = (
+        "def choose(value):\n"
+        "    if value < 1:\n"
+        "        return None < 2\n"
+        "    else:\n"
+        "        return 2 < None\n"
+        "\n"
+        "choose(None)\n"
+    )
+    tree = _tree(source)
+    comparisons = tuple(node for node in tree.nodes() if isinstance(node, Compare))
+    assert len(comparisons) == 3
+    (outcome,) = tuple(
+        node.sugar().desugar(None)
+        for node in tree.nodes()
+        if isinstance(node, Call)
+    )
+
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    halted = outcome.exits[0]
+    assert isinstance(halted, Halted)
+    condition_occurrence = str(comparisons[0].sugar().site)
+    body_occurrences = {str(node.sugar().site) for node in comparisons[1:]}
+    assert halted.effect.occurrence_id == condition_occurrence
+    assert halted.effect.occurrence_id not in body_occurrences
+    assert halted.state is not None
+
+
 def test_complementary_results_share_only_the_condition_owned_slot() -> None:
     branch, _ = _two_ifs()
     slot = branch_result_slot(branch.test)
@@ -138,3 +168,48 @@ def test_complementary_results_share_only_the_condition_owned_slot() -> None:
     )
     assert len(authentications) == 1
     assert authentications[0].slot == slot
+
+
+def test_identical_condition_spellings_at_distinct_ifs_do_not_share_slots() -> None:
+    branches = tuple(
+        node
+        for node in _tree(
+            "if left is right:\n"
+            "    assert left is right\n"
+            "else:\n"
+            "    assert left is not right\n"
+            "if left is right:\n"
+            "    assert left is right\n"
+            "else:\n"
+            "    assert left is not right\n"
+        ).nodes()
+        if isinstance(node, If)
+    )
+    assert len(branches) == 2
+
+    slots = tuple(branch_result_slot(branch.test) for branch in branches)
+    rewritten = tuple(
+        branch._rewrite_with_slot({}, slot)
+        for branch, slot in zip(branches, slots, strict=True)
+    )
+    outcomes = tuple(branch.sugar().desugar(None) for branch in rewritten)
+
+    assert slots[0] != slots[1]
+    expected_guards = tuple(
+        branch_result_guard(slot, branch.fragment)
+        for branch, slot in zip(rewritten, slots, strict=True)
+    )
+    assert expected_guards[0] != expected_guards[1]
+    for outcome, slot, expected in zip(
+        outcomes, slots, expected_guards, strict=True
+    ):
+        assert isinstance(outcome, Complete)
+        guarded = outcome.value
+        assert guarded.guard == expected
+        authentications = tuple(
+            entry
+            for entry in guarded.unconditional_entries
+            if isinstance(entry, BranchResultAuthentication)
+        )
+        assert len(authentications) == 1
+        assert authentications[0].slot == slot


### PR DESCRIPTION
## Instrument

Adds one focused real-`SourceFile` construction instrument for the condition-owned `If` branch-result slot. It proves the missing-slot producer diagnostic, truthful slot construction, condition-halt bypass, and complementary guarded results with one authenticated slot identity. The nearby-condition lying twin remains loudly red.

No production files changed. In particular this does not touch `nodes.py`, carrier, `ExitSet`, reducers, boundaries, projectors, generator-step production, or route-time reconstruction.

## Exact producer red

`implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:5274`, `If._construct_sugar(self)`: expected it to authenticate `BranchResultSlot(self.branch_result_slot_id)` against `branch_result_slot(self.test)` and panic at the If occurrence when they differ; actual behavior accepts a slot minted by a nearby unrelated condition.

## Test

`../../../bin/bpytest tests/test_if_construct_sugar_slot_producer.py -q` — **4 passed, 1 failed in 0.79s**

Red: `FAILED tests/test_if_construct_sugar_slot_producer.py::test_nearby_condition_slot_is_rejected_at_the_if_occurrence` / `Failed: DID NOT RAISE BackendDefect`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for If branch-result slot production and validation
> Adds a pytest module in [test_if_construct_sugar_slot_producer.py](https://github.com/TSavo/sugar/pull/6743/files#diff-e7fc71aee3c31d7a24ffb291b543b584b713d9150bf2b9bf0c838f9fe6a1b0b2) with seven tests covering the `If` sugar construction and branch-result slot lifecycle.
>
> - Tests verify that calling `branch.sugar()` without a stored slot raises `BackendDefect` with a specific error message and site reference.
> - Tests confirm that a condition-owned slot produces the correct authenticated guard and a single unconditional `BranchResultAuthentication` entry.
> - Tests cover halt propagation: when the If condition halts, both bodies are bypassed and the occurrence id belongs to the condition node, not the body nodes.
> - Tests assert that syntactically identical Ifs at distinct locations mint distinct slots and produce distinct guards.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b271f74.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->