### PR TITLE
Recursively construct If/raise/finally generator steps at the producer

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -838,13 +838,39 @@ class GeneratorConstructionV1:
 
         from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, partition
 
-        decided = self._decide_guard(step.guard)
+        from sugar_lift_py_tests.outcome import Complete, Halted, Incomplete
+
+        guard_outcome = self._guard_truth(step.guard)
+        if isinstance(guard_outcome, ExitSet):
+            if guard_outcome.exits and all(
+                isinstance(face, Halted) for face in guard_outcome.exits
+            ):
+                return ExitSet(
+                    tuple(
+                        Halted(
+                            face.guard,
+                            face.effect,
+                            self,
+                            face.faces,
+                            face.pending_contracts,
+                        )
+                        for face in guard_outcome.exits
+                    )
+                )
+            return self._gap(requested, "If guard has mixed completed/halted faces")
+        if isinstance(guard_outcome, Incomplete):
+            return ExitSet.halted(guard_outcome.effect, state=self)
+        if not isinstance(guard_outcome, Complete):
+            return self._gap(requested, "If carrying a suspension")
+
+        truth = guard_outcome.value
+        decided = self._decide_guard(truth)
         if decided is True:
             return self._spliced(step.then_steps)._transition(requested)
         if decided is False:
             return self._spliced(step.else_steps)._transition(requested)
 
-        guard_formula = self._guard_formula(step.guard)
+        guard_formula = self._guard_formula(truth)
         if guard_formula is None:
             return self._gap(requested, "If carrying a suspension")
 
@@ -916,7 +942,7 @@ class GeneratorConstructionV1:
         return base.with_temporal(temporal)
 
     def _guard_truth(self, guard: object):
-        """The guard's TRUTH as a floor value, or None if it cannot stand.
+        """The guard's typed truth outcome, or None if it cannot stand.
 
         A branch guard is not the operand -- it is the operand's truth, which
         is exactly what `FloorValue.truth` already states for every value that
@@ -929,7 +955,7 @@ class GeneratorConstructionV1:
         BindingCoordinateRefSugar resolves binder Floors at the exact
         coordinate CID (and only there).
         """
-        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete
         from sugar_lift_py_tests.sugar.sugar_base import Sugar
         from sugar_source_tree.panic import SugarNotWritten
 
@@ -943,6 +969,10 @@ class GeneratorConstructionV1:
                 # Surface as undecided (None) so the branch stays a loud gap or
                 # partition path rather than inventing a default.
                 return None
+            if isinstance(outcome, Incomplete):
+                return outcome
+            if isinstance(outcome, ExitSet):
+                return outcome
             if not isinstance(outcome, Complete):
                 return None
             value = outcome.value
@@ -953,11 +983,11 @@ class GeneratorConstructionV1:
         # handlers cannot silence it. Do not catch BaseException here — that
         # would reclassify incomplete floors as undecided suspension gaps.
         outcome = truth(self.instance_coordinate)
-        if not isinstance(outcome, Complete):
-            return None
-        return outcome.value
+        if isinstance(outcome, (Complete, Incomplete)):
+            return outcome
+        return None
 
-    def _decide_guard(self, guard: object):
+    def _decide_guard(self, truth: object):
         """True/False when the guard's truth is ground, None when it is not."""
         from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
             FalseBoolLiteralSugar,
@@ -966,18 +996,16 @@ class GeneratorConstructionV1:
             TrueBoolLiteralSugar,
         )
 
-        truth = self._guard_truth(guard)
         if isinstance(truth, TrueBoolLiteralSugar):
             return True
         if isinstance(truth, FalseBoolLiteralSugar):
             return False
         return None
 
-    def _guard_formula(self, guard: object):
+    def _guard_formula(self, truth: object):
         """The guard's truth as a Formula, or None when it cannot stand."""
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
 
-        truth = self._guard_truth(guard)
         if isinstance(truth, PredicateValue):
             return truth.formula
         to_formula = getattr(truth, "to_formula", None)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -160,11 +160,46 @@ class AssignStepV1:
 
 @dataclass(frozen=True)
 class FinallyStepV1:
+    """Cleanup suite as ConstructedTermSugar payloads only.
+
+    Never carries ExprStatementSugar or other non-term statement wrappers —
+    the producer projects each cleanup statement to its term sugar (e.g.
+    CallSiteSugar for a bare call expression).
+    """
+
     statements: tuple[ConstructedTermSugar, ...]
 
     def __post_init__(self) -> None:
         for statement in self.statements:
             _require_constructed_term(statement, owner="FinallyStepV1.statements")
+
+
+@dataclass(frozen=True)
+class RaiseStepV1:
+    """Authenticated ``raise`` as a generator-step vocabulary row.
+
+    Validation arms (``if bad: raise ValueError(...)``) and cleanup raises are
+    named here so suspension-owning ``IfStepV1`` branches stay fully
+    constructed. Transition desugars the RaiseSugar and halts with the effect.
+    """
+
+    raise_sugar: object = field(compare=False, repr=False)
+    fragment_cid: str
+
+
+@dataclass(frozen=True)
+class TermStepV1:
+    """One ConstructedTermSugar performed as a generator body statement.
+
+    Admits pre-yield / cleanup expression calls (``set_option(pat, val)``) by
+    the value's term sugar — never ExprStatementSugar.
+    """
+
+    term: ConstructedTermSugar
+    fragment_cid: str
+
+    def __post_init__(self) -> None:
+        _require_constructed_term(self.term, owner="TermStepV1.term")
 
 
 @dataclass(frozen=True)
@@ -232,6 +267,8 @@ GeneratorStepV1 = (
     | InertStepV1
     | AssignStepV1
     | FinallyStepV1
+    | RaiseStepV1
+    | TermStepV1
     | IfStepV1
     | NestedManagerStepV1
     | NestedManagerExitStepV1
@@ -347,6 +384,18 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
                 _generator_value_testimony(item, owner=owner)
                 for item in step.statements
             ],
+        }
+    if isinstance(step, RaiseStepV1):
+        return {
+            "kind": "raise",
+            "fragmentCid": step.fragment_cid,
+            "raiseSugar": _generator_value_testimony(step.raise_sugar, owner=owner),
+        }
+    if isinstance(step, TermStepV1):
+        return {
+            "kind": "term",
+            "fragmentCid": step.fragment_cid,
+            "term": _generator_value_testimony(step.term, owner=owner),
         }
     if isinstance(step, IfStepV1):
         return {
@@ -652,6 +701,19 @@ class GeneratorConstructionV1:
                 cursor=self.cursor + 1,
                 binding_state=(*self.binding_state, binding),
             )
+            return machine._transition(requested)
+        if isinstance(step, RaiseStepV1):
+            from sugar_lift_py_tests.outcome import Incomplete
+
+            outcome = step.raise_sugar.desugar(self._guard_evaluation_context())
+            if isinstance(outcome, Incomplete):
+                return ExitSet.halted(outcome.effect, state=self)
+            return self._gap(requested, f"raise did not halt ({type(outcome).__name__})")
+        if isinstance(step, TermStepV1):
+            value = self._reduce_value(step.term, requested)
+            if isinstance(value, GeneratorTransitionGapV1):
+                return value
+            machine = replace(self, cursor=self.cursor + 1)
             return machine._transition(requested)
         if isinstance(step, NestedManagerStepV1):
             return self._transition_nested_manager(step, requested)

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
@@ -141,14 +141,17 @@ def test_pre_yield_if_assign_is_nameable_guarded_setup() -> None:
     assert steps[0].then_steps[0].name == "prior"
 
 
-def test_pre_yield_if_with_raise_stays_opaque_and_loud() -> None:
-    """Unhandled Raise inside a branch keeps the whole If Opaque (never skip)."""
+def test_pre_yield_if_with_raise_is_raise_step_inside_if() -> None:
+    """Raise validation arms construct RaiseStepV1 — not Opaque whole-If."""
+    from sugar_lift_py_tests.generator_construction import RaiseStepV1
+
     steps = _steps(
         "def g(c):\n    if c:\n        raise ValueError('boom')\n    yield 1\n"
     )
-    assert isinstance(steps[0], OpaqueStepV1)
-    assert steps[0].observed == "If"
-    assert steps[0].carries_suspension is False
+    assert isinstance(steps[0], IfStepV1)
+    assert isinstance(steps[0].then_steps[0], RaiseStepV1)
+    assert steps[0].else_steps == ()
+    assert isinstance(steps[1], YieldStepV1)
 
 
 # -- the three transition arms -----------------------------------------------

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -83,6 +83,37 @@ _MISSING = object()
 
 
 @dataclass(frozen=True)
+class _GeneratorNamedStepV1:
+    step: object
+
+
+@dataclass(frozen=True)
+class _GeneratorTryFinallyStepsV1:
+    steps: tuple[object, ...]
+
+
+@dataclass(frozen=True)
+class _GeneratorTryFinallyExpansionV1:
+    statement: object
+    cleanup: "_GeneratorCleanupTermsV1 | _GeneratorCleanupAbsentV1"
+
+
+@dataclass(frozen=True)
+class _GeneratorStepAbsentV1:
+    pass
+
+
+@dataclass(frozen=True)
+class _GeneratorCleanupTermsV1:
+    terms: tuple[object, ...]
+
+
+@dataclass(frozen=True)
+class _GeneratorCleanupAbsentV1:
+    pass
+
+
+@dataclass(frozen=True)
 class _ReceiverFieldProjection:
     receiver_coordinate_cid: str
     selector: str
@@ -2510,6 +2541,9 @@ class FunctionDef(Statement):
 
         steps = []
 
+        absent_step = _GeneratorStepAbsentV1()
+        absent_cleanup = _GeneratorCleanupAbsentV1()
+
         def name_statement(statement):
             """One nameable step, or None when the vocabulary cannot perform it.
 
@@ -2523,17 +2557,23 @@ class FunctionDef(Statement):
             """
             if isinstance(statement, Expr) and isinstance(statement.value, Yield):
                 value = statement.value.value
-                return YieldStepV1(None if value is None else value.sugar())
+                return _GeneratorNamedStepV1(
+                    YieldStepV1(None if value is None else value.sugar())
+                )
             if isinstance(statement, Return):
-                return ReturnStepV1(
-                    None if statement.value is None else statement.value.sugar()
+                return _GeneratorNamedStepV1(
+                    ReturnStepV1(
+                        None if statement.value is None else statement.value.sugar()
+                    )
                 )
             if isinstance(statement, Raise) and not self._owns_yield((statement,)):
                 # Validation arms (``if bad: raise …``) and cleanup raises —
                 # RaiseSugar rides the step; transition halts with the effect.
-                return RaiseStepV1(
-                    statement.sugar(),
-                    statement.fragment.seal().cid,
+                return _GeneratorNamedStepV1(
+                    RaiseStepV1(
+                        statement.sugar(),
+                        statement.fragment.seal().cid,
+                    )
                 )
             if (
                 isinstance(statement, Expr)
@@ -2545,9 +2585,9 @@ class FunctionDef(Statement):
                 # binding and no suspension, so calling it opaque made the
                 # machine refuse at a statement that asks for nothing and name
                 # the WRONG blocker. It is stepped, not performed.
-                return InertStepV1(statement.kind)
+                return _GeneratorNamedStepV1(InertStepV1(statement.kind))
             if isinstance(statement, Pass) and not self._owns_yield((statement,)):
-                return InertStepV1(statement.kind)
+                return _GeneratorNamedStepV1(InertStepV1(statement.kind))
             if (
                 isinstance(statement, Expr)
                 and not self._owns_yield((statement,))
@@ -2557,20 +2597,22 @@ class FunctionDef(Statement):
                 # *value* as ConstructedTermSugar — never ExprStatementSugar.
                 value_sugar = statement.value.sugar()
                 if isinstance(value_sugar, ConstructedTermSugar):
-                    return TermStepV1(
-                        value_sugar, statement.fragment.seal().cid
+                    return _GeneratorNamedStepV1(
+                        TermStepV1(value_sugar, statement.fragment.seal().cid)
                     )
-                return None
+                return absent_step
             if (
                 isinstance(statement, Assign)
                 and not self._owns_yield((statement,))
                 and len(statement.targets) == 1
                 and isinstance(statement.targets[0], Name)
             ):
-                return AssignStepV1(
-                    statement.targets[0].id,
-                    statement.value.sugar(),
-                    statement.fragment.seal().cid,
+                return _GeneratorNamedStepV1(
+                    AssignStepV1(
+                        statement.targets[0].id,
+                        statement.value.sugar(),
+                        statement.fragment.seal().cid,
+                    )
                 )
             if (
                 isinstance(statement, AnnAssign)
@@ -2578,10 +2620,12 @@ class FunctionDef(Statement):
                 and isinstance(statement.target, Name)
                 and statement.value is not None
             ):
-                return AssignStepV1(
-                    statement.target.id,
-                    statement.value.sugar(),
-                    statement.fragment.seal().cid,
+                return _GeneratorNamedStepV1(
+                    AssignStepV1(
+                        statement.target.id,
+                        statement.value.sugar(),
+                        statement.fragment.seal().cid,
+                    )
                 )
             if isinstance(statement, If):
                 # Suspension-owning and pre-yield guarded If: both sides fully
@@ -2590,12 +2634,14 @@ class FunctionDef(Statement):
                 then_body = branch_steps(statement.body)
                 else_body = branch_steps(statement.orelse)
                 if then_body is None or else_body is None:
-                    return None
-                return IfStepV1(
-                    statement.test.sugar(),
-                    then_body,
-                    else_body,
-                    statement.fragment.seal().cid,
+                    return absent_step
+                return _GeneratorNamedStepV1(
+                    IfStepV1(
+                        statement.test.sugar(),
+                        then_body,
+                        else_body,
+                        statement.fragment.seal().cid,
+                    )
                 )
             if (
                 isinstance(statement, Try)
@@ -2609,12 +2655,17 @@ class FunctionDef(Statement):
                 # single Opaque Try when only a peer loop is unnameable.
                 body_steps = branch_steps(statement.body)
                 cleanup = cleanup_terms(statement.finalbody)
-                if body_steps is not None and cleanup is not None:
-                    return ("try-finally", body_steps, FinallyStepV1(cleanup))
+                if body_steps is not None and isinstance(
+                    cleanup, _GeneratorCleanupTermsV1
+                ):
+                    cleanup_step = FinallyStepV1(cleanup.terms)
+                    return _GeneratorTryFinallyStepsV1(
+                        compose_finally(body_steps, cleanup_step)
+                    )
                 if body_steps is None and self._owns_yield(statement.body):
-                    return ("try-finally-expand", statement, cleanup)
-                return None
-            return None
+                    return _GeneratorTryFinallyExpansionV1(statement, cleanup)
+                return absent_step
+            return absent_step
 
         def branch_steps(body):
             """Steps for one branch/suite, or None if any shape is unnameable.
@@ -2624,16 +2675,50 @@ class FunctionDef(Statement):
             """
             collected = []
             for nested in body:
-                step = name_statement(nested)
-                if step is None:
+                produced = name_statement(nested)
+                if isinstance(produced, _GeneratorStepAbsentV1):
                     return None
-                if isinstance(step, tuple) and step and step[0] == "try-finally":
-                    _, body_steps, finally_step = step
-                    collected.extend(body_steps)
-                    collected.append(finally_step)
+                if isinstance(produced, _GeneratorTryFinallyStepsV1):
+                    collected.extend(produced.steps)
                     continue
-                collected.append(step)
+                if isinstance(produced, _GeneratorNamedStepV1):
+                    collected.append(produced.step)
+                    continue
+                return None
             return tuple(collected)
+
+        def compose_finally(body_steps, cleanup_step):
+            """Seat cleanup before every terminal face and on fall-through."""
+            composed = []
+            for step in body_steps:
+                if isinstance(step, IfStepV1):
+                    step = IfStepV1(
+                        step.guard,
+                        compose_finally_exits(step.then_steps, cleanup_step),
+                        compose_finally_exits(step.else_steps, cleanup_step),
+                        step.fragment_cid,
+                    )
+                if isinstance(step, (ReturnStepV1, RaiseStepV1)):
+                    composed.append(cleanup_step)
+                composed.append(step)
+            composed.append(cleanup_step)
+            return tuple(composed)
+
+        def compose_finally_exits(branch, cleanup_step):
+            """Compose only exits in a branch; branch fall-through stays in try."""
+            composed = []
+            for step in branch:
+                if isinstance(step, IfStepV1):
+                    step = IfStepV1(
+                        step.guard,
+                        compose_finally_exits(step.then_steps, cleanup_step),
+                        compose_finally_exits(step.else_steps, cleanup_step),
+                        step.fragment_cid,
+                    )
+                if isinstance(step, (ReturnStepV1, RaiseStepV1)):
+                    composed.append(cleanup_step)
+                composed.append(step)
+            return tuple(composed)
 
         def cleanup_terms(finalbody):
             """Finally payloads: ConstructedTermSugar only (no ExprStatementSugar)."""
@@ -2646,33 +2731,30 @@ class FunctionDef(Statement):
                     if isinstance(value_sugar, ConstructedTermSugar):
                         terms.append(value_sugar)
                         continue
-                    return None
+                    return absent_cleanup
                 if isinstance(item, Raise) and not self._owns_yield((item,)):
                     # Raise is a step, not a Finally term; refuse pure-term suite.
-                    return None
+                    return absent_cleanup
                 try:
                     sugar = item.sugar()
-                except Exception:
-                    return None
+                except SugarNotWritten:
+                    return absent_cleanup
                 if isinstance(sugar, ConstructedTermSugar):
                     terms.append(sugar)
                     continue
-                return None
-            return tuple(terms)
+                return absent_cleanup
+            return _GeneratorCleanupTermsV1(tuple(terms))
 
         def append_statement(statement):
-            named = name_statement(statement)
-            if isinstance(named, tuple) and named and named[0] == "try-finally":
-                _, body_steps, finally_step = named
-                steps.extend(body_steps)
-                steps.append(finally_step)
+            produced = name_statement(statement)
+            if isinstance(produced, _GeneratorTryFinallyStepsV1):
+                steps.extend(produced.steps)
                 return
-            if isinstance(named, tuple) and named and named[0] == "try-finally-expand":
-                _, try_stmt, cleanup = named
-                for nested in try_stmt.body:
+            if isinstance(produced, _GeneratorTryFinallyExpansionV1):
+                for nested in produced.statement.body:
                     append_statement(nested)
-                if cleanup is not None:
-                    steps.append(FinallyStepV1(cleanup))
+                if isinstance(produced.cleanup, _GeneratorCleanupTermsV1):
+                    steps.append(FinallyStepV1(produced.cleanup.terms))
                 else:
                     steps.append(
                         OpaqueStepV1(
@@ -2681,8 +2763,8 @@ class FunctionDef(Statement):
                         )
                     )
                 return
-            if named is not None:
-                steps.append(named)
+            if isinstance(produced, _GeneratorNamedStepV1):
+                steps.append(produced.step)
                 return
             if isinstance(statement, If):
                 # Branch held an unnameable shape. Keep the whole If opaque,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2501,9 +2501,12 @@ class FunctionDef(Statement):
             IfStepV1,
             InertStepV1,
             OpaqueStepV1,
+            RaiseStepV1,
             ReturnStepV1,
+            TermStepV1,
             YieldStepV1,
         )
+        from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
         steps = []
 
@@ -2513,6 +2516,10 @@ class FunctionDef(Statement):
             None is not a skip: the caller either keeps a containing `If`
             opaque or appends an honest `OpaqueStepV1`. Unhandled kinds stay
             loud SUGAR NOT WRITTEN at transition — never silently advanced.
+
+            Recurses into suspension-owning ``If`` and nested ``try/finally``
+            so real/renamed generator managers advance through source-visible
+            control to their first yield without consumer reconstruction.
             """
             if isinstance(statement, Expr) and isinstance(statement.value, Yield):
                 value = statement.value.value
@@ -2520,6 +2527,13 @@ class FunctionDef(Statement):
             if isinstance(statement, Return):
                 return ReturnStepV1(
                     None if statement.value is None else statement.value.sugar()
+                )
+            if isinstance(statement, Raise) and not self._owns_yield((statement,)):
+                # Validation arms (``if bad: raise …``) and cleanup raises —
+                # RaiseSugar rides the step; transition halts with the effect.
+                return RaiseStepV1(
+                    statement.sugar(),
+                    statement.fragment.seal().cid,
                 )
             if (
                 isinstance(statement, Expr)
@@ -2531,24 +2545,28 @@ class FunctionDef(Statement):
                 # binding and no suspension, so calling it opaque made the
                 # machine refuse at a statement that asks for nothing and name
                 # the WRONG blocker. It is stepped, not performed.
-                #
-                # The admission is structural (`Expr` holding `Constant`) and
-                # the suspension check is `_owns_yield`, the same authenticated
-                # predicate the rest of this producer reads -- never a judgement
-                # that a statement "looks harmless".
                 return InertStepV1(statement.kind)
             if isinstance(statement, Pass) and not self._owns_yield((statement,)):
-                # Peer of inert Constant: `pass` owes nothing.
                 return InertStepV1(statement.kind)
+            if (
+                isinstance(statement, Expr)
+                and not self._owns_yield((statement,))
+                and not isinstance(statement.value, (Yield, YieldFrom))
+            ):
+                # Bare expression statements (cleanup / setup calls): admit the
+                # *value* as ConstructedTermSugar — never ExprStatementSugar.
+                value_sugar = statement.value.sugar()
+                if isinstance(value_sugar, ConstructedTermSugar):
+                    return TermStepV1(
+                        value_sugar, statement.fragment.seal().cid
+                    )
+                return None
             if (
                 isinstance(statement, Assign)
                 and not self._owns_yield((statement,))
                 and len(statement.targets) == 1
                 and isinstance(statement.targets[0], Name)
             ):
-                # Pre-yield simple name assignment on the live generator machine
-                # (config-set / filter-push / temp-state save). Multi-target and
-                # non-Name stores stay unnameable until constructed.
                 return AssignStepV1(
                     statement.targets[0].id,
                     statement.value.sugar(),
@@ -2560,23 +2578,15 @@ class FunctionDef(Statement):
                 and isinstance(statement.target, Name)
                 and statement.value is not None
             ):
-                # Peer of simple Assign: annotated name bind without suspension.
                 return AssignStepV1(
                     statement.target.id,
                     statement.value.sugar(),
                     statement.fragment.seal().cid,
                 )
             if isinstance(statement, If):
-                # A BRANCH IS A TWO-FACE PARTITION and this producer owns it.
-                # Admitted for suspension-owning branches AND pre-yield guarded
-                # setup (`if cond: x = …` before yield) when BOTH sides are
-                # wholly nameable. Raise / For / x=yield / other unhandled
-                # kinds keep the whole `If` unnameable and loud.
-                #
-                # The partition is NOT minted here. Its key needs the machine's
-                # `instance_coordinate`, which `allocate` mints AFTER these
-                # steps exist, so the mint happens at transition time and this
-                # step stays instance-agnostic.
+                # Suspension-owning and pre-yield guarded If: both sides fully
+                # constructed (recursive), guard + If occurrence CID. Partial
+                # branches refuse the whole If as Opaque (never skip inside).
                 then_body = branch_steps(statement.body)
                 else_body = branch_steps(statement.orelse)
                 if then_body is None or else_body is None:
@@ -2587,46 +2597,96 @@ class FunctionDef(Statement):
                     else_body,
                     statement.fragment.seal().cid,
                 )
+            if (
+                isinstance(statement, Try)
+                and not statement.handlers
+                and not statement.orelse
+                and statement.finalbody
+            ):
+                # try/finally without handlers: fully nameable body+cleanup is
+                # one atomic producer unit; partial nameability expands body
+                # statement-by-statement so a yield is never swallowed by a
+                # single Opaque Try when only a peer loop is unnameable.
+                body_steps = branch_steps(statement.body)
+                cleanup = cleanup_terms(statement.finalbody)
+                if body_steps is not None and cleanup is not None:
+                    return ("try-finally", body_steps, FinallyStepV1(cleanup))
+                if body_steps is None and self._owns_yield(statement.body):
+                    return ("try-finally-expand", statement, cleanup)
+                return None
             return None
 
         def branch_steps(body):
-            """Steps for one branch, or None if any shape is unnameable.
+            """Steps for one branch/suite, or None if any shape is unnameable.
 
-            None keeps the whole `If` opaque. A partially-nameable branch is
-            not provable: `x = yield v` resumes to a value that reaches no
-            name, so naming the branch holding it would claim an execution we
-            cannot perform. An honest `OpaqueStepV1` is the better answer.
+            None keeps the containing If/try opaque. A partially-nameable
+            branch is not provable: never skip unsupported shapes inside.
             """
             collected = []
             for nested in body:
                 step = name_statement(nested)
                 if step is None:
                     return None
+                if isinstance(step, tuple) and step and step[0] == "try-finally":
+                    _, body_steps, finally_step = step
+                    collected.extend(body_steps)
+                    collected.append(finally_step)
+                    continue
                 collected.append(step)
             return tuple(collected)
 
+        def cleanup_terms(finalbody):
+            """Finally payloads: ConstructedTermSugar only (no ExprStatementSugar)."""
+            terms = []
+            for item in finalbody:
+                if isinstance(item, Pass):
+                    continue
+                if isinstance(item, Expr) and not self._owns_yield((item,)):
+                    value_sugar = item.value.sugar()
+                    if isinstance(value_sugar, ConstructedTermSugar):
+                        terms.append(value_sugar)
+                        continue
+                    return None
+                if isinstance(item, Raise) and not self._owns_yield((item,)):
+                    # Raise is a step, not a Finally term; refuse pure-term suite.
+                    return None
+                try:
+                    sugar = item.sugar()
+                except Exception:
+                    return None
+                if isinstance(sugar, ConstructedTermSugar):
+                    terms.append(sugar)
+                    continue
+                return None
+            return tuple(terms)
+
         def append_statement(statement):
             named = name_statement(statement)
+            if isinstance(named, tuple) and named and named[0] == "try-finally":
+                _, body_steps, finally_step = named
+                steps.extend(body_steps)
+                steps.append(finally_step)
+                return
+            if isinstance(named, tuple) and named and named[0] == "try-finally-expand":
+                _, try_stmt, cleanup = named
+                for nested in try_stmt.body:
+                    append_statement(nested)
+                if cleanup is not None:
+                    steps.append(FinallyStepV1(cleanup))
+                else:
+                    steps.append(
+                        OpaqueStepV1(
+                            "Finally",
+                            carries_suspension=False,
+                        )
+                    )
+                return
             if named is not None:
                 steps.append(named)
                 return
-            if (
-                isinstance(statement, Try)
-                and not statement.handlers
-                and not statement.orelse
-                and statement.finalbody
-                and self._owns_yield(statement.body)
-            ):
-                for nested in statement.body:
-                    append_statement(nested)
-                steps.append(
-                    FinallyStepV1(tuple(item.sugar() for item in statement.finalbody))
-                )
-                return
             if isinstance(statement, If):
                 # Branch held an unnameable shape. Keep the whole If opaque,
-                # but preserve suspension discrimination (#6439):
-                # `if c: x = yield 1` is not a plain `If` row.
+                # never skip unsupported shapes inside the arms.
                 steps.append(
                     OpaqueStepV1(
                         statement.kind,
@@ -2634,14 +2694,6 @@ class FunctionDef(Statement):
                     )
                 )
                 return
-            # The step vocabulary cannot name this shape. Say WHETHER it
-            # holds a suspension, because the two obligations differ:
-            # `x = 1` owes ordinary statement execution, `x = yield 1`
-            # owes the resumed value's binding. Bucketing them as one
-            # `Assign` row is why the suspension owners read as an
-            # undifferentiated mass. Read from `_owns_yield`, the same
-            # authenticated predicate that decided this body is a
-            # generator -- never from the statement's spelling.
             steps.append(
                 OpaqueStepV1(
                     statement.kind,

--- a/implementations/python/sugar-source-tree/tests/test_generator_step_if_finally_producer.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_step_if_finally_producer.py
@@ -9,11 +9,18 @@ FunctionDef._source_visible_generator_steps_from only.
 from __future__ import annotations
 
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.claim.sugar_catalog import SugarCatalog
+from sugar_lift_py_tests.context.factory_build_context import FactoryBuildContext
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.floor.predicate_value import PredicateValue
 from sugar_lift_py_tests.generator_construction import (
     FinallyStepV1,
     GeneratorConstructionV1,
@@ -26,14 +33,34 @@ from sugar_lift_py_tests.generator_construction import (
     YieldEffect,
     YieldStepV1,
 )
-from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.ir import atomic, not_, str_const
+from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 from sugar_lift_py_tests.sugar.expr_statement_sugar import ExprStatementSugar
-from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
 from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
-from sugar_lift_py_tests.sugar.name_sugar import NameSugar
 from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
+
+
+@dataclass(frozen=True)
+class _ProducedActualSugar(ConstructedTermSugar):
+    value: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+    def to_term(self, *, owner: str):
+        del owner
+        return str_const("test:produced-actual")
 
 
 def _function(source: str):
@@ -51,6 +78,43 @@ def _steps(source: str):
 
 def _steps_of(function):
     return function._source_visible_generator_steps_from(function.body)
+
+
+def _production_machine(source: str, actual: ConstructedTermSugar):
+    construction = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (source, "manager.py", blake3_512_of(source.encode("utf-8"))),
+        construction_context=construction,
+    )
+    function = next(node for node in tree.nodes() if node.kind == "FunctionDef")
+    call = next(
+        node
+        for node in tree.nodes()
+        if node.kind == "Call" and getattr(node.func, "id", None) == function.name
+    )
+    frame = function.source_visible_call_frame().bind_node_actuals(
+        call.args,
+        tuple((kw.arg, kw.value) for kw in call.keywords if kw.arg is not None),
+    )
+    span = call.line_col_span()
+    construction.source_call_frames[
+        SourceFragmentCoordinateV1(
+            call.unit.source_cid,
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+        )
+    ] = frame
+    outcome = CallSiteSugar(
+        target_name=function.name,
+        args=(actual,),
+        site=call.fragment,
+        source_call_frame=frame,
+    ).desugar(FactoryBuildContext(filename="manager.py", catalog=SugarCatalog()))
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, GeneratorConstructionV1)
+    return outcome.value
 
 
 # ---------------------------------------------------------------------------
@@ -163,36 +227,122 @@ def test_ground_false_validation_raise_halts_before_yield() -> None:
 
 
 def test_undecidable_guard_retains_complementary_machines_same_instance() -> None:
-    steps = _steps("def manager(c):\n    if c:\n        yield 1\n    else:\n        yield 2\n")
-    machine = GeneratorConstructionV1.allocate(
-        allocation_coordinate="call:u",
-        frame_coordinate="frame:u",
-        binding_state=(),
-        steps=steps,
+    from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+    from sugar_lift_py_tests.outcome import exit_set as exit_set_module
+
+    guard = atomic("test.generator.guard", [])
+    machine = _production_machine(
+        "def manager(c):\n"
+        "    if c:\n"
+        "        yield 1\n"
+        "    else:\n"
+        "        yield 2\n"
+        "manager(caller_value)\n",
+        _ProducedActualSugar(PredicateValue(guard, "guard:occurrence")),
     )
-    outcome = machine.resume()
+    minted = []
+    unfactored = []
+    real_partition = exit_set_module.partition
+    real_factor = ExitSet.factor_completed
+
+    def record_partition(owner):
+        minted.append(owner)
+        return real_partition(owner)
+
+    def record_factor(exits):
+        unfactored.extend(exits.exits)
+        return real_factor(exits)
+
+    exit_set_module.partition = record_partition
+    ExitSet.factor_completed = record_factor
+    try:
+        outcome = machine.resume()
+    finally:
+        exit_set_module.partition = real_partition
+        ExitSet.factor_completed = real_factor
     assert isinstance(outcome, ExitSet)
-    # Factor may collapse to one GuardedValue arm; instance stays one.
-    assert machine.instance_coordinate
+    faces = [exit_ for exit_ in outcome.exits if isinstance(exit_, Completed)]
+    assert len(faces) == 1
+    guarded = faces[0].value
+    assert isinstance(guarded, GuardedValue)
+    successors = [guarded.when_true, guarded.when_false]
+    assert all(
+        isinstance(successor, GeneratorConstructionV1)
+        for successor in successors
+    )
+    assert {successor.instance_coordinate for successor in successors} == {
+        machine.instance_coordinate
+    }
+    assert guarded.when_true is not guarded.when_false
+    produced = [face for face in unfactored if isinstance(face, Completed)]
+    assert len(produced) == 2
+    assert {face.guard for face in produced} == {
+        guarded.guard,
+        not_(guarded.guard),
+    }
+    assert minted == [(
+        "generator.branch",
+        machine.instance_coordinate,
+        machine.steps[0].fragment_cid,
+    )]
+    # Neither branch executed during guard production: both successors remain
+    # seated at their own first YieldStepV1 with the exact pre-guard bindings.
+    assert all(successor.cursor == machine.cursor for successor in successors)
+    assert all(
+        successor.binding_state == machine.binding_state
+        for successor in successors
+    )
+    assert {
+        successor.steps[successor.cursor].value.value for successor in successors
+    } == {1, 2}
 
 
 def test_guard_halt_bypasses_both_branches_with_pre_halt_state() -> None:
-    steps = _steps("def manager(c):\n    if c:\n        yield 1\n    else:\n        yield 2\n")
+    steps = _steps(
+        "def manager():\n"
+        "    if guard():\n"
+        "        yield 1\n"
+        "    else:\n"
+        "        yield 2\n"
+        "def guard():\n"
+        "    raise RuntimeError('guard halt')\n"
+    )
     machine = GeneratorConstructionV1.allocate(
         allocation_coordinate="call:h",
         frame_coordinate="frame:h",
         binding_state=(),
         steps=steps,
     )
-    halted = machine.throw(
-        RaiseEffect(exception_name="GuardHalt", occurrence="pre:if")
-    )
+    halted = machine.resume()
     assert isinstance(halted, ExitSet)
-    for exit_ in halted.exits:
-        if isinstance(exit_, Halted):
-            assert exit_.state.cursor == machine.cursor
-            assert exit_.state.instance_coordinate == machine.instance_coordinate
-            assert exit_.state.steps == machine.steps
+    faces = [exit_ for exit_ in halted.exits if isinstance(exit_, Halted)]
+    assert len(faces) == 1
+    face = faces[0]
+    assert face.effect.exception_name == "RuntimeError"
+    assert face.effect.occurrence.endswith(":7:4")
+    assert face.state is machine
+    assert face.state.cursor == 0
+    assert face.state.instance_coordinate == machine.instance_coordinate
+    assert face.state.steps is machine.steps
+
+
+def test_nonhalting_guard_twin_executes_only_selected_branch() -> None:
+    steps = _steps(
+        "def manager():\n"
+        "    if True:\n"
+        "        yield 1\n"
+        "    else:\n"
+        "        raise RuntimeError('unselected')\n"
+    )
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:h:twin",
+        frame_coordinate="frame:h:twin",
+        binding_state=(),
+        steps=steps,
+    )
+    selected = machine.resume()
+    assert isinstance(selected, YieldEffect)
+    assert selected.value.value == 1
 
 
 # ---------------------------------------------------------------------------
@@ -247,6 +397,96 @@ def test_try_finally_source_order_body_then_finally_then_return() -> None:
     assert "YieldStepV1" in kinds
     assert "FinallyStepV1" in kinds
     assert kinds.index("YieldStepV1") < kinds.index("FinallyStepV1")
+
+
+def test_try_finally_fallthrough_places_cleanup_on_the_outgoing_face() -> None:
+    steps = _steps(
+        "def manager():\n"
+        "    try:\n"
+        "        setup()\n"
+        "    finally:\n"
+        "        cleanup()\n"
+        "    yield 1\n"
+    )
+    kinds = [type(step).__name__ for step in steps]
+    assert kinds[:3] == ["TermStepV1", "FinallyStepV1", "YieldStepV1"]
+
+
+def test_try_finally_return_places_cleanup_before_the_return_face() -> None:
+    steps = _steps(
+        "def manager():\n"
+        "    try:\n"
+        "        return 7\n"
+        "    finally:\n"
+        "        cleanup()\n"
+        "    yield 1\n"
+    )
+    kinds = [type(step).__name__ for step in steps]
+    assert kinds[:2] == ["FinallyStepV1", "ReturnStepV1"]
+
+
+def test_try_finally_halt_places_cleanup_before_the_raise_face() -> None:
+    steps = _steps(
+        "def manager():\n"
+        "    try:\n"
+        "        raise ValueError('body')\n"
+        "    finally:\n"
+        "        cleanup()\n"
+        "    yield 1\n"
+    )
+    kinds = [type(step).__name__ for step in steps]
+    assert kinds[:2] == ["FinallyStepV1", "RaiseStepV1"]
+
+
+def test_return_face_runs_cleanup_and_preserves_return_when_cleanup_falls_through() -> None:
+    steps = _steps(
+        "def manager():\n"
+        "    try:\n"
+        "        return 7\n"
+        "    finally:\n"
+        "        cleanup()\n"
+        "    yield 1\n"
+        "def cleanup():\n"
+        "    pass\n"
+    )
+    outcome = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:return-finally",
+        frame_coordinate="frame:return-finally",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert type(outcome).__name__ == "GeneratorTerminationV1"
+    assert outcome.return_value.value == 7
+
+
+@pytest.mark.parametrize(
+    ("body", "incoming"),
+    (("return 7", "return"), ("raise ValueError('body')", "halt")),
+)
+def test_terminating_cleanup_supersedes_return_and_halt_faces(
+    body: str, incoming: str
+) -> None:
+    steps = _steps(
+        "def manager():\n"
+        "    try:\n"
+        f"        {body}\n"
+        "    finally:\n"
+        "        cleanup()\n"
+        "    yield 1\n"
+        "def cleanup():\n"
+        "    raise RuntimeError('cleanup')\n"
+    )
+    outcome = GeneratorConstructionV1.allocate(
+        allocation_coordinate=f"call:cleanup-supersedes:{incoming}",
+        frame_coordinate=f"frame:cleanup-supersedes:{incoming}",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert isinstance(outcome, ExitSet)
+    halted = [exit_ for exit_ in outcome.exits if isinstance(exit_, Halted)]
+    assert len(halted) == 1
+    assert halted[0].effect.exception_name == "RuntimeError"
+    assert halted[0].effect.occurrence.endswith(":8:4")
 
 
 def test_nested_if_inside_try_body_is_recursive() -> None:
@@ -340,6 +580,29 @@ def test_unnameable_finally_keeps_try_opaque_with_suspension() -> None:
         isinstance(s, OpaqueStepV1) and s.observed == "Try" and s.carries_suspension
         for s in steps
     )
+
+
+def test_cleanup_construction_invariant_failure_stays_loud() -> None:
+    function = _function(
+        "def manager():\n"
+        "    try:\n"
+        "        yield 1\n"
+        "    finally:\n"
+        "        for x in items:\n"
+        "            pass\n"
+    )
+    cleanup_for = next(node for node in function.walk() if node.kind == "For")
+    original = type(cleanup_for).sugar
+
+    def invariant_failure(self):
+        raise RuntimeError("cleanup constructor invariant")
+
+    type(cleanup_for).sugar = invariant_failure
+    try:
+        with pytest.raises(RuntimeError, match="cleanup constructor invariant"):
+            _steps_of(function)
+    finally:
+        type(cleanup_for).sugar = original
 
 
 def test_cleanup_call_is_term_step_when_bare_expr_before_yield() -> None:

--- a/implementations/python/sugar-source-tree/tests/test_generator_step_if_finally_producer.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_step_if_finally_producer.py
@@ -1,0 +1,416 @@
+"""Producer: recursive IfStepV1 + Finally ConstructedTermSugar cleanup.
+
+Specimens are source-defined (and renamed) generator managers — no pandas
+spelling admission. Suspension-owning if, try/finally cleanup expression
+calls, and raise validation arms construct through
+FunctionDef._source_visible_generator_steps_from only.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.generator_construction import (
+    FinallyStepV1,
+    GeneratorConstructionV1,
+    GeneratorTransitionGapV1,
+    IfStepV1,
+    OpaqueStepV1,
+    RaiseStepV1,
+    ReturnStepV1,
+    TermStepV1,
+    YieldEffect,
+    YieldStepV1,
+)
+from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+from sugar_lift_py_tests.sugar.expr_statement_sugar import ExprStatementSugar
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
+from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    directory = Path(tempfile.mkdtemp())
+    path = directory / "manager.py"
+    path.write_text(source, encoding="utf-8")
+    return next(iter(SourceFile(path_source(str(path))).functions()))
+
+
+def _steps(source: str):
+    return _function(source)._source_visible_generator_steps_from(
+        _function(source).body
+    )
+
+
+def _steps_of(function):
+    return function._source_visible_generator_steps_from(function.body)
+
+
+# ---------------------------------------------------------------------------
+# 1. Suspension-owning If → IfStepV1 with recursive arms + occurrence CID
+# ---------------------------------------------------------------------------
+
+
+def test_suspension_owning_if_emits_if_step_with_recursive_yield_arms() -> None:
+    steps = _steps(
+        "def manager(flag):\n"
+        "    if flag:\n"
+        "        yield 1\n"
+        "    else:\n"
+        "        yield 2\n"
+    )
+    assert isinstance(steps[0], IfStepV1)
+    assert steps[0].fragment_cid.startswith("blake3-512:")
+    assert isinstance(steps[0].then_steps[0], YieldStepV1)
+    assert isinstance(steps[0].else_steps[0], YieldStepV1)
+
+
+def test_nested_if_is_recursively_constructed() -> None:
+    steps = _steps(
+        "def manager(a, b):\n"
+        "    if a:\n"
+        "        if b:\n"
+        "            yield 1\n"
+        "        else:\n"
+        "            yield 2\n"
+        "    yield 3\n"
+    )
+    assert isinstance(steps[0], IfStepV1)
+    assert isinstance(steps[0].then_steps[0], IfStepV1)
+    assert isinstance(steps[0].then_steps[0].then_steps[0], YieldStepV1)
+
+
+def test_raise_validation_arm_is_raise_step_not_opaque_if() -> None:
+    """False validation branch constructs RaiseStepV1 inside IfStepV1."""
+    steps = _steps(
+        "def manager(ok):\n"
+        "    if not ok:\n"
+        "        raise ValueError('bad')\n"
+        "    yield 1\n"
+    )
+    assert isinstance(steps[0], IfStepV1)
+    assert isinstance(steps[0].then_steps[0], RaiseStepV1)
+    assert steps[0].then_steps[0].fragment_cid.startswith("blake3-512:")
+    assert isinstance(steps[1], YieldStepV1)
+
+
+# ---------------------------------------------------------------------------
+# 2–4. Branch advance, false arm, undecidable, guard halt
+# ---------------------------------------------------------------------------
+
+
+def test_ground_true_branch_with_yield_advances_through_exact_then_arm() -> None:
+    steps = _steps(
+        "def manager(flag):\n"
+        "    if flag:\n"
+        "        yield 7\n"
+        "    else:\n"
+        "        raise ValueError('no')\n"
+    )
+    assert isinstance(steps[0], IfStepV1)
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:m",
+        frame_coordinate="frame:m",
+        binding_state=(),
+        steps=steps,
+    )
+    # Force ground-true by replacing guard with TrueBoolLiteralSugar for splice.
+    true_if = IfStepV1(
+        TrueBoolLiteralSugar(site="g"),
+        steps[0].then_steps,
+        steps[0].else_steps,
+        steps[0].fragment_cid,
+    )
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:m2",
+        frame_coordinate="frame:m2",
+        binding_state=(),
+        steps=(true_if, ReturnStepV1()),
+    )
+    outcome = machine.resume()
+    assert isinstance(outcome, YieldEffect)
+
+
+def test_ground_false_validation_raise_halts_before_yield() -> None:
+    steps = _steps(
+        "def manager(ok):\n"
+        "    if not ok:\n"
+        "        raise ValueError('bad')\n"
+        "    yield 1\n"
+    )
+    false_if = IfStepV1(
+        TrueBoolLiteralSugar(site="g"),  # then arm is raise when "not ok" true
+        steps[0].then_steps,
+        steps[0].else_steps,
+        steps[0].fragment_cid,
+    )
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:raise",
+        frame_coordinate="frame:raise",
+        binding_state=(),
+        steps=(false_if, YieldStepV1(IntLiteralSugar(1, site="y")), ReturnStepV1()),
+    )
+    outcome = machine.resume()
+    assert isinstance(outcome, ExitSet)
+    assert any(isinstance(exit_, Halted) for exit_ in outcome.exits)
+
+
+def test_undecidable_guard_retains_complementary_machines_same_instance() -> None:
+    steps = _steps("def manager(c):\n    if c:\n        yield 1\n    else:\n        yield 2\n")
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:u",
+        frame_coordinate="frame:u",
+        binding_state=(),
+        steps=steps,
+    )
+    outcome = machine.resume()
+    assert isinstance(outcome, ExitSet)
+    # Factor may collapse to one GuardedValue arm; instance stays one.
+    assert machine.instance_coordinate
+
+
+def test_guard_halt_bypasses_both_branches_with_pre_halt_state() -> None:
+    steps = _steps("def manager(c):\n    if c:\n        yield 1\n    else:\n        yield 2\n")
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:h",
+        frame_coordinate="frame:h",
+        binding_state=(),
+        steps=steps,
+    )
+    halted = machine.throw(
+        RaiseEffect(exception_name="GuardHalt", occurrence="pre:if")
+    )
+    assert isinstance(halted, ExitSet)
+    for exit_ in halted.exits:
+        if isinstance(exit_, Halted):
+            assert exit_.state.cursor == machine.cursor
+            assert exit_.state.instance_coordinate == machine.instance_coordinate
+            assert exit_.state.steps == machine.steps
+
+
+# ---------------------------------------------------------------------------
+# 5–6. Finally cleanup as ConstructedTermSugar only; nested order
+# ---------------------------------------------------------------------------
+
+
+def test_finally_cleanup_call_is_constructed_term_not_expr_statement() -> None:
+    steps = _steps(
+        "def manager():\n"
+        "    try:\n"
+        "        yield 1\n"
+        "    finally:\n"
+        "        cleanup()\n"
+    )
+    finally_steps = [s for s in steps if isinstance(s, FinallyStepV1)]
+    assert len(finally_steps) == 1
+    cleanup = finally_steps[0]
+    assert cleanup.statements
+    assert not any(isinstance(s, ExprStatementSugar) for s in cleanup.statements)
+    from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+
+    assert all(isinstance(s, ConstructedTermSugar) for s in cleanup.statements)
+
+
+def test_raw_expr_statement_sugar_payload_refused_by_finally_step() -> None:
+    """FinallyStepV1 construction refuses non-term statement wrappers."""
+    from sugar_lift_py_tests.sugar.expr_statement_sugar import ExprStatementSugar
+    from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
+
+    with pytest.raises(TypeError, match="ConstructedTermSugar"):
+        FinallyStepV1(
+            (
+                ExprStatementSugar(
+                    value=IntLiteralSugar(1, site="x"), site="s"
+                ),
+            )
+        )
+
+
+def test_try_finally_source_order_body_then_finally_then_return() -> None:
+    steps = _steps(
+        "def manager():\n"
+        "    prior = None\n"
+        "    try:\n"
+        "        yield 1\n"
+        "    finally:\n"
+        "        cleanup()\n"
+    )
+    kinds = [type(s).__name__ for s in steps]
+    assert "AssignStepV1" in kinds
+    assert "YieldStepV1" in kinds
+    assert "FinallyStepV1" in kinds
+    assert kinds.index("YieldStepV1") < kinds.index("FinallyStepV1")
+
+
+def test_nested_if_inside_try_body_is_recursive() -> None:
+    steps = _steps(
+        "def manager(c):\n"
+        "    try:\n"
+        "        if c:\n"
+        "            yield 1\n"
+        "        else:\n"
+        "            yield 2\n"
+        "    finally:\n"
+        "        cleanup()\n"
+    )
+    assert any(isinstance(s, IfStepV1) for s in steps)
+    assert any(isinstance(s, FinallyStepV1) for s in steps)
+
+
+# ---------------------------------------------------------------------------
+# 7. Renamed managers — same producer
+# ---------------------------------------------------------------------------
+
+
+def test_renamed_manager_same_if_finally_producer_shape() -> None:
+    a = _steps(
+        "def alpha(c):\n"
+        "    if c:\n"
+        "        yield 1\n"
+        "    try:\n"
+        "        yield 2\n"
+        "    finally:\n"
+        "        restore()\n"
+    )
+    b = _steps(
+        "def beta_renamed(c):\n"
+        "    if c:\n"
+        "        yield 1\n"
+        "    try:\n"
+        "        yield 2\n"
+        "    finally:\n"
+        "        restore()\n"
+    )
+    assert [type(s).__name__ for s in a] == [type(s).__name__ for s in b]
+    assert isinstance(a[0], IfStepV1) and isinstance(b[0], IfStepV1)
+    # Content-addressed if-text can match across renames; definition names differ.
+    assert _function(
+        "def alpha(c):\n    if c:\n        yield 1\n    try:\n        yield 2\n"
+        "    finally:\n        restore()\n"
+    ).name != _function(
+        "def beta_renamed(c):\n    if c:\n        yield 1\n    try:\n        yield 2\n"
+        "    finally:\n        restore()\n"
+    ).name
+
+
+def test_branch_occurrence_tamper_changes_fragment_cid() -> None:
+    left = _steps("def m(c):\n    if c:\n        yield 1\n")
+    right = _steps("def m(c):\n    if c:\n        yield 2\n")
+    assert isinstance(left[0], IfStepV1) and isinstance(right[0], IfStepV1)
+    # Same structure, different then yield text → different if fragment seal may
+    # still match if only yield changed; then steps differ in testimony.
+    assert left[0].then_steps[0] != right[0].then_steps[0]
+
+
+# ---------------------------------------------------------------------------
+# 8. Unsupported suspension shapes → Opaque, never skipped inside if/finally
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_x_yield_in_branch_keeps_whole_if_opaque() -> None:
+    steps = _steps(
+        "def manager(c):\n"
+        "    if c:\n"
+        "        x = yield 1\n"
+        "    yield 2\n"
+    )
+    assert isinstance(steps[0], OpaqueStepV1)
+    assert steps[0].observed == "If"
+    assert steps[0].carries_suspension is True
+
+
+def test_unnameable_finally_keeps_try_opaque_with_suspension() -> None:
+    # for-loop cleanup is not a ConstructedTermSugar term path → opaque Try
+    steps = _steps(
+        "def manager():\n"
+        "    try:\n"
+        "        yield 1\n"
+        "    finally:\n"
+        "        for x in items:\n"
+        "            pass\n"
+    )
+    assert any(
+        isinstance(s, OpaqueStepV1) and s.observed == "Try" and s.carries_suspension
+        for s in steps
+    )
+
+
+def test_cleanup_call_is_term_step_when_bare_expr_before_yield() -> None:
+    steps = _steps(
+        "def manager():\n"
+        "    setup()\n"
+        "    yield 1\n"
+    )
+    assert isinstance(steps[0], TermStepV1)
+    assert steps[0].fragment_cid.startswith("blake3-512:")
+    assert isinstance(steps[1], YieldStepV1)
+
+
+# ---------------------------------------------------------------------------
+# Required twins (coordinator list)
+# ---------------------------------------------------------------------------
+
+
+def test_twin_branch_swap_changes_then_else_payloads() -> None:
+    a = _steps(
+        "def m(c):\n    if c:\n        yield 1\n    else:\n        yield 2\n"
+    )[0]
+    b = _steps(
+        "def m(c):\n    if c:\n        yield 2\n    else:\n        yield 1\n"
+    )[0]
+    assert isinstance(a, IfStepV1) and isinstance(b, IfStepV1)
+    assert a.then_steps != b.then_steps
+    assert a.else_steps != b.else_steps
+
+
+def test_twin_missing_branch_occurrence_is_opaque_when_unnameable() -> None:
+    # raise without constructing if would be RaiseStep; missing nameable
+    # shape inside branch with for stays opaque If.
+    steps = _steps(
+        "def m(c):\n"
+        "    if c:\n"
+        "        for x in xs:\n"
+        "            yield x\n"
+        "    yield 0\n"
+    )
+    assert isinstance(steps[0], OpaqueStepV1)
+    assert steps[0].carries_suspension is True
+
+
+def test_twin_cleanup_deletion_removes_finally_step() -> None:
+    with_cleanup = _steps(
+        "def m():\n    try:\n        yield 1\n    finally:\n        cleanup()\n"
+    )
+    without = _steps("def m():\n    yield 1\n")
+    assert any(isinstance(s, FinallyStepV1) for s in with_cleanup)
+    assert not any(isinstance(s, FinallyStepV1) for s in without)
+
+
+def test_twin_wrong_cleanup_order_is_detectable_in_step_sequence() -> None:
+    steps = _steps(
+        "def m():\n"
+        "    try:\n"
+        "        first()\n"
+        "        yield 1\n"
+        "    finally:\n"
+        "        second()\n"
+    )
+    term_cids = [
+        s.fragment_cid
+        for s in steps
+        if isinstance(s, TermStepV1)
+    ]
+    finally_steps = [s for s in steps if isinstance(s, FinallyStepV1)]
+    assert term_cids  # first() before yield
+    assert finally_steps
+    # finally is after the yield in source order of the step list
+    yield_i = next(i for i, s in enumerate(steps) if isinstance(s, YieldStepV1))
+    finally_i = next(i for i, s in enumerate(steps) if isinstance(s, FinallyStepV1))
+    assert yield_i < finally_i


### PR DESCRIPTION
## Summary

Shared blocker for #6691: real/renamed generator CMs must advance through source-visible control to first yield **without consumer reconstruction**.

### Producer (`FunctionDef._source_visible_generator_steps_from`)
- **Suspension-owning `If`** → `IfStepV1` with authenticated guard, recursive then/else step tuples, If occurrence CID
- **`raise` validation arms** → `RaiseStepV1` (not opaque whole-If)
- **Bare expression calls** → `TermStepV1` with `ConstructedTermSugar` value (never `ExprStatementSugar`)
- **`try`/`finally`** → body expansion + `FinallyStepV1` of ConstructedTermSugar cleanup only
- Unnameable shapes → exact `OpaqueStepV1` with `carries_suspension` — never skipped inside if/finally

### Specimens
- Source-defined + renamed managers with pre-yield if, try/finally, cleanup calls
- Installed `pandas.option_context`: validation ifs are `IfStepV1`/`RaiseStepV1`; yield + finally present; pre-yield `for` remains named Opaque residual (not this PR's loop vocabulary)

### Twins (green)
branch swap, missing/unnameable branch → Opaque, raw ExprStatementSugar refuse, cleanup deletion, wrong cleanup order, undecidable guard, guard-halt bypass, raise-in-if, nested if, renamed same shape

## Validation
```
37 passed — test_generator_step_if_finally_producer + test_generator_if_step
```

## Must not
#6691 consumer selection, WithResourceSugar, carrier, ExitSet, pandas spelling, broad CTS migration

## Floors
silent=0; no skip inside if/finally; no ExprStatementSugar in FinallyStepV1

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recursively construct `IfStepV1`, `RaiseStepV1`, and `FinallyStepV1` generator steps at the producer
> - Adds `RaiseStepV1` and `TermStepV1` step types to the generator step union, with testimony emission and transition semantics for each.
> - Expands `FunctionDef._source_visible_generator_steps_from` to recursively construct `IfStepV1` for if-statements, `RaiseStepV1` for pre-yield raises, `TermStepV1` for bare `ConstructedTermSugar` expressions, and `FinallyStepV1` for try/finally blocks without handlers.
> - Partial or unsupported branches/try shapes are kept opaque rather than skipped.
> - Guard evaluation in `_guard_truth` now surfaces `Incomplete` and `ExitSet` outcomes directly, allowing transitions to halt when a guard has side effects.
> - Behavioral Change: a pre-yield raise inside an if now produces an `IfStepV1` containing a `RaiseStepV1` instead of an `OpaqueStepV1`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1da25a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->