### PR TITLE
Carry formal coordinate testimony from SourceCallFrame binder

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field, replace
 from sugar_lift_python_source.canonical import cid_of_json
 from sugar_source_tree.binding_provenance import BindingCoordinateV1
@@ -9,12 +10,143 @@ from sugar_source_tree.binding_state import BindingEntryV1
 from .context_manager_resolution import SourceFragmentCoordinateV1
 
 
+def _reauthenticate_binding_coordinates(coordinates: tuple) -> None:
+    from sugar_source_tree.binding_provenance import BindingProvenanceGap
+
+    seen = set()
+    for coordinate in coordinates:
+        if type(coordinate) is not BindingCoordinateV1:
+            raise SourceCallBindingGap(
+                "formal coordinate roster contains a foreign coordinate type"
+            )
+        if cid_of_json(coordinate.preimage) != coordinate.cid:
+            raise SourceCallBindingGap("formal coordinate roster contains a stale CID")
+        try:
+            decoded = BindingCoordinateV1.decode(coordinate.wire())
+        except BindingProvenanceGap as exc:
+            raise SourceCallBindingGap(
+                "formal coordinate roster failed wire authentication"
+            ) from exc
+        if decoded != coordinate or coordinate.cid in seen:
+            raise SourceCallBindingGap(
+                "formal coordinate roster contains duplicate or foreign testimony"
+            )
+        seen.add(coordinate.cid)
+
+
+def _reauthenticate_native_coordinates(coordinates: tuple) -> None:
+    from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+
+    seen = set()
+    for coordinate in coordinates:
+        if type(coordinate) is not FormalParameterCoordinateV1:
+            raise SourceCallBindingGap(
+                "native formal coordinate roster contains a foreign coordinate type"
+            )
+        try:
+            authenticated = FormalParameterCoordinateV1(
+                coordinate.owner_source_identity_cid,
+                coordinate.owner_definition_locus,
+                coordinate.declaration_locus,
+                coordinate.ordinal,
+                coordinate.parameter_kind,
+                coordinate.declared_name,
+                coordinate.sort,
+                coordinate.coordinate_cid,
+                coordinate.kind,
+                coordinate.schema_version,
+            )
+        except ValueError as exc:
+            raise SourceCallBindingGap(
+                "native formal coordinate roster failed authentication"
+            ) from exc
+        if authenticated != coordinate or coordinate.coordinate_cid in seen:
+            raise SourceCallBindingGap(
+                "native formal coordinate roster contains duplicate testimony"
+            )
+        seen.add(coordinate.coordinate_cid)
+
+
+def _source_coordinate(node) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
 @dataclass(frozen=True)
 class BoundNativeOperationActualsV1:
     """The one Python binder's ordered result, indexed by formal coordinate."""
 
     actuals: tuple
     by_formal_coordinate: dict[str, object]
+
+
+@dataclass(frozen=True)
+class BoundFormalActualV1:
+    coordinate: BindingCoordinateV1
+    actual: object
+
+
+@dataclass(frozen=True, eq=False)
+class BoundSourceCallActualsV1(Sequence):
+    """One binder result with its authenticated coordinate testimony."""
+
+    actuals: tuple
+    formal_coordinates: tuple[BindingCoordinateV1, ...]
+    native_formal_coordinates: tuple = ()
+
+    def __post_init__(self) -> None:
+        actual_count = len(self.actuals)
+        if len(self.formal_coordinates) != actual_count or (
+            self.native_formal_coordinates
+            and len(self.native_formal_coordinates) != actual_count
+        ):
+            raise SourceCallBindingGap("bound actual coordinate arity mismatch")
+        _reauthenticate_binding_coordinates(self.formal_coordinates)
+        _reauthenticate_native_coordinates(self.native_formal_coordinates)
+
+    def __len__(self) -> int:
+        return len(self.actuals)
+
+    def __getitem__(self, index):
+        return self.actuals[index]
+
+    def __iter__(self) -> Iterator:
+        return iter(self.actuals)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, BoundSourceCallActualsV1):
+            return (
+                self.actuals == other.actuals
+                and self.formal_coordinates == other.formal_coordinates
+                and self.native_formal_coordinates == other.native_formal_coordinates
+            )
+        if isinstance(other, tuple):
+            return self.actuals == other
+        return NotImplemented
+
+    @property
+    def pairs(self) -> tuple[BoundFormalActualV1, ...]:
+        return tuple(
+            BoundFormalActualV1(coordinate, actual)
+            for coordinate, actual in zip(
+                self.formal_coordinates, self.actuals, strict=True
+            )
+        )
+
+    @property
+    def by_native_formal_coordinate(self) -> dict[str, object]:
+        return {
+            coordinate.coordinate_cid: actual
+            for coordinate, actual in zip(
+                self.native_formal_coordinates, self.actuals, strict=True
+            )
+        }
 
 
 @dataclass(frozen=True)
@@ -57,7 +189,9 @@ class SourceVisibleCallFrameV1:
         }
         object.__setattr__(self, "frame_cid", cid_of_json(preimage))
 
-    def bind_actuals(self, positional: tuple, keywords: tuple, ctx=None) -> tuple:
+    def bind_actuals(
+        self, positional: tuple, keywords: tuple, ctx=None
+    ) -> BoundSourceCallActualsV1:
         """Bind positional/keyword FloorValues onto this frame's formals.
 
         ``keywords`` is ``(name, value)`` pairs in source order. A name of
@@ -68,6 +202,8 @@ class SourceVisibleCallFrameV1:
         loud rather than inventing keys.
         """
         from sugar_lift_py_tests.floor import DictValue, StringValue, TupleValue
+
+        self._validate_formal_coordinate_rosters()
 
         remaining = list(positional)
         named: dict = {}
@@ -133,7 +269,94 @@ class SourceVisibleCallFrameV1:
             bound.append(value)
         if remaining or named:
             raise SourceCallBindingGap("unconsumed call actual")
-        return tuple(bound)
+        return BoundSourceCallActualsV1(
+            tuple(bound),
+            self.formal_coordinates,
+            self.native_operation_formal_coordinates,
+        )
+
+    def _validate_formal_coordinate_rosters(self) -> None:
+        coordinates = self.formal_coordinates
+        if len(coordinates) != len(self.parameters):
+            raise SourceCallBindingGap("formal coordinate roster is missing an entry")
+        _reauthenticate_binding_coordinates(coordinates)
+        cids = tuple(coordinate.cid for coordinate in coordinates)
+        if len(set(cids)) != len(cids):
+            raise SourceCallBindingGap("formal coordinate roster contains a duplicate")
+        if any(
+            coordinate.projection_path != ("formal", index)
+            for index, coordinate in enumerate(coordinates)
+        ):
+            raise SourceCallBindingGap("formal coordinate roster is reordered")
+        if any(
+            coordinate.scope_owner_cid != self.definition_fragment_cid
+            for coordinate in coordinates
+        ):
+            raise SourceCallBindingGap(
+                "formal coordinate roster has a foreign scope owner"
+            )
+        owner_parameters = tuple(self.owner.params)
+        if len(owner_parameters) != len(coordinates) or any(
+            coordinate.binding_site != parameter.fragment.seal().to_dict()
+            for coordinate, parameter in zip(
+                coordinates, owner_parameters, strict=True
+            )
+        ):
+            raise SourceCallBindingGap(
+                "formal coordinate roster has a foreign declaration site"
+            )
+
+        native = self.native_operation_formal_coordinates
+        if not native:
+            return
+        _reauthenticate_native_coordinates(native)
+        native_cids = tuple(coordinate.coordinate_cid for coordinate in native)
+        expected_kinds = {
+            "positional_only": "positional-only",
+            "positional_or_keyword": "positional-or-keyword",
+            "vararg": "variadic-positional",
+            "keyword_only": "keyword-only",
+            "kwarg": "variadic-keyword",
+        }
+        from sugar_lift_py_tests.ir import PrimitiveSort
+
+        if (
+            len(native) != len(self.parameters)
+            or len(set(native_cids)) != len(native_cids)
+            or any(
+                coordinate.owner_source_identity_cid != self.source_identity_cid
+                or coordinate.owner_definition_locus != self.definition_site
+                or coordinate.declaration_locus
+                != _source_coordinate(owner_parameters[index])
+                or coordinate.parameter_kind
+                != expected_kinds[self.parameter_kinds[index]]
+                or coordinate.sort != PrimitiveSort("Value")
+                or coordinate.ordinal != index
+                or coordinate.declared_name != self.parameters[index]
+                for index, coordinate in enumerate(native)
+            )
+        ):
+            raise SourceCallBindingGap("native formal coordinate roster is cross-wired")
+        pending = self.pending_native_operation
+        if pending is None:
+            raise SourceCallBindingGap(
+                "native formal coordinate roster omitted its pending demand"
+            )
+        by_cid = {coordinate.coordinate_cid: coordinate for coordinate in native}
+        demanded = pending.demand.operand_coordinate_cids
+        for coordinate_cid, stored in zip(
+            demanded, pending.coordinates, strict=True
+        ):
+            if coordinate_cid is None:
+                if stored is not None:
+                    raise SourceCallBindingGap(
+                        "pending carrier demand coordinate testimony is cross-wired"
+                    )
+                continue
+            if coordinate_cid not in by_cid or stored != by_cid[coordinate_cid]:
+                raise SourceCallBindingGap(
+                    "pending carrier demand coordinate testimony is cross-wired"
+                )
 
     def bind_native_operation_actuals(
         self, positional: tuple, keywords: tuple, ctx=None
@@ -141,15 +364,8 @@ class SourceVisibleCallFrameV1:
         """Bind once, then key that exact result by formal coordinates."""
         bound = self.bind_actuals(positional, keywords, ctx)
         return BoundNativeOperationActualsV1(
-            actuals=bound,
-            by_formal_coordinate={
-                coordinate.coordinate_cid: actual
-                for coordinate, actual in zip(
-                    self.native_operation_formal_coordinates,
-                    bound,
-                    strict=True,
-                )
-            },
+            actuals=bound.actuals,
+            by_formal_coordinate=bound.by_native_formal_coordinate,
         )
 
     def with_native_operation_projection(self, formal_coordinates, pending):

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.source_call_frame import (
+    BoundSourceCallActualsV1,
+    SourceCallBindingGap,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _frame(*, name: str = "helper", filename: str = "bound_coordinates.py"):
+    source = f"def {name}(left, right=2):\n    return left + right\n"
+    tree = SourceFile(
+        (source, filename, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    return function.source_visible_call_frame().with_native_operation_projection(
+        function.formal_coordinates(), function.sugar().desugar(None)
+    )
+
+
+def test_binder_returns_ordered_typed_coordinate_testimony() -> None:
+    frame = _frame()
+    left = TermValue(1)
+    bound = frame.bind_actuals((left,), ())
+
+    assert isinstance(bound, BoundSourceCallActualsV1)
+    assert bound[0] is left
+    assert bound.formal_coordinates == frame.formal_coordinates
+    assert bound.native_formal_coordinates == frame.native_operation_formal_coordinates
+    assert tuple(pair.actual for pair in bound.pairs) == bound.actuals
+    assert tuple(pair.coordinate for pair in bound.pairs) == frame.formal_coordinates
+    assert tuple(bound.by_native_formal_coordinate) == tuple(
+        coordinate.coordinate_cid
+        for coordinate in frame.native_operation_formal_coordinates
+    )
+
+
+@pytest.mark.parametrize("variant", ("missing", "duplicate", "reordered", "foreign"))
+def test_binder_refuses_corrupt_formal_coordinate_roster(variant: str) -> None:
+    frame = _frame()
+    coordinates = frame.formal_coordinates
+    if variant == "missing":
+        corrupt = coordinates[:-1]
+    elif variant == "duplicate":
+        corrupt = (coordinates[0], coordinates[0])
+    elif variant == "reordered":
+        corrupt = tuple(reversed(coordinates))
+    else:
+        corrupt = (replace(coordinates[0], scope_owner_cid="blake3-512:" + "00" * 64), coordinates[1])
+
+    with pytest.raises(SourceCallBindingGap, match="formal coordinate roster"):
+        replace(frame, formal_coordinates=corrupt).bind_actuals(
+            (TermValue(1), TermValue(2)), ()
+        )
+
+
+def test_binder_refuses_cross_wired_native_formal_roster() -> None:
+    frame = _frame()
+    with pytest.raises(SourceCallBindingGap, match="native formal coordinate roster"):
+        replace(
+            frame,
+            native_operation_formal_coordinates=tuple(
+                reversed(frame.native_operation_formal_coordinates)
+            ),
+        ).bind_actuals((TermValue(1), TermValue(2)), ())
+
+
+def test_binder_refuses_wholly_foreign_binding_roster() -> None:
+    frame = _frame()
+    foreign = _frame(name="other", filename="foreign_bindings.py")
+
+    with pytest.raises(SourceCallBindingGap, match="scope owner"):
+        replace(frame, formal_coordinates=foreign.formal_coordinates).bind_actuals(
+            (TermValue(1), TermValue(2)), ()
+        )
+
+
+def test_binder_refuses_stale_binding_coordinate_cid() -> None:
+    frame = _frame()
+    stale = replace(frame.formal_coordinates[0], cid="blake3-512:" + "00" * 64)
+
+    with pytest.raises(SourceCallBindingGap, match="CID"):
+        replace(frame, formal_coordinates=(stale, frame.formal_coordinates[1])).bind_actuals(
+            (TermValue(1), TermValue(2)), ()
+        )
+
+
+def test_binder_refuses_same_signature_foreign_native_roster() -> None:
+    frame = _frame()
+    foreign = _frame(name="other", filename="foreign_native.py")
+
+    with pytest.raises(SourceCallBindingGap, match="native formal coordinate roster"):
+        replace(
+            frame,
+            native_operation_formal_coordinates=foreign.native_operation_formal_coordinates,
+        ).bind_actuals((TermValue(1), TermValue(2)), ())
+
+
+def test_binder_refuses_foreign_pending_carrier_demand() -> None:
+    frame = _frame()
+    foreign = _frame(name="other", filename="foreign_pending.py")
+
+    with pytest.raises(SourceCallBindingGap, match="pending carrier demand"):
+        replace(
+            frame, pending_native_operation=foreign.pending_native_operation
+        ).bind_actuals((TermValue(1), TermValue(2)), ())
+
+
+def test_binder_refuses_wrong_native_parameter_kind() -> None:
+    frame = _frame()
+    original = frame.native_operation_formal_coordinates[0]
+    wrong = FormalParameterCoordinateV1.mint(
+        owner_source_identity_cid=original.owner_source_identity_cid,
+        owner_definition_locus=original.owner_definition_locus,
+        declaration_locus=original.declaration_locus,
+        ordinal=original.ordinal,
+        parameter_kind="keyword-only",
+        declared_name=original.declared_name,
+        sort=PrimitiveSort("Value"),
+    )
+
+    with pytest.raises(SourceCallBindingGap, match="native formal coordinate roster"):
+        replace(
+            frame,
+            native_operation_formal_coordinates=(
+                wrong,
+                frame.native_operation_formal_coordinates[1],
+            ),
+        ).bind_actuals((TermValue(1), TermValue(2)), ())
+
+
+@pytest.mark.parametrize("coordinate_kind", ("formal", "native"))
+@pytest.mark.parametrize("delta", (-1, 1))
+def test_bound_result_rejects_missing_or_extra_coordinate(
+    coordinate_kind: str, delta: int
+) -> None:
+    frame = _frame()
+    actuals = (TermValue(1), TermValue(2))
+    formal = frame.formal_coordinates
+    native = frame.native_operation_formal_coordinates
+    roster = formal if coordinate_kind == "formal" else native
+    corrupt = roster[:-1] if delta < 0 else (*roster, roster[-1])
+
+    with pytest.raises(SourceCallBindingGap, match="bound actual coordinate arity"):
+        BoundSourceCallActualsV1(
+            actuals,
+            corrupt if coordinate_kind == "formal" else formal,
+            corrupt if coordinate_kind == "native" else native,
+        )


### PR DESCRIPTION
## Capability
- return one immutable sequence-compatible binder result carrying ordered binding coordinates
- expose native formal-coordinate actual mapping without a second zip
- panic loudly on missing, duplicate, reordered, foreign, or cross-wired rosters

## Instruments
- 6 focused coordinate testimony and lying-twin tests
- existing generator and native-operation binder teeth: 24 passed

R: untyped binder coordinate pairing -> 0 for SourceCallFrame.bind_actuals
Epsilon R: -1 binder reconstruction seam
Floors: ExitSet, carriers, CallSiteValue, nodes.py untouched

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Carry formal coordinate testimony from `SourceVisibleCallFrameV1.bind_actuals`
> - `bind_actuals` now validates formal and native coordinate rosters via a new `_validate_formal_coordinate_rosters` method before binding, and returns `BoundSourceCallActualsV1` instead of a plain tuple.
> - `BoundSourceCallActualsV1` is a new `Sequence` dataclass that carries authenticated binding and native formal coordinates, exposes structured `pairs`, and a `by_native_formal_coordinate` mapping keyed by coordinate CID.
> - Two new utilities, `_reauthenticate_binding_coordinates` and `_reauthenticate_native_coordinates`, verify CID integrity, wire authentication, type exactness, and absence of duplicates, raising `SourceCallBindingGap` on any failure.
> - New tests in [`test_source_call_frame_coordinate_testimony.py`](https://github.com/TSavo/sugar/pull/6746/files#diff-b7122e53d9b7aac7a6e0ff00dd86655e0a7cab9ab7f2e6072be3f768f4e95cca) cover the happy path and eight categories of corrupted or cross-wired coordinate inputs.
> - Risk: callers of `bind_actuals` that expect a plain tuple will break; `SourceCallBindingGap` is now raised for roster mismatches that previously passed silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1a799e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->