### PR TITLE
fix: authenticate If branch-result slot

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5337,7 +5337,7 @@ class If(Statement):
         new_orelse, d, else_net = self._substitute_body_tracked(self.orelse, scope)
         if d:
             changed["orelse"] = new_orelse
-        node = self._rewrite_with_slot(changed, slot)
+        node = self._rewrite_with_slot(changed, slot, authenticated_slot=slot)
 
         names = set(then_net) | set(else_net)
         phis = []
@@ -5362,18 +5362,27 @@ class If(Statement):
             return node
         return _Splice((node, *phis), availability)
 
-    def _rewrite_with_slot(self, changed, slot):
+    def _rewrite_with_slot(self, changed, slot, *, authenticated_slot=None):
         from .backend import Leaf, materialize
         from .shadow import ShadowNode, rewrite
 
         rewritten = rewrite(self, **changed)
+        if authenticated_slot is None:
+            authenticated_slot = branch_result_slot(rewritten.test)
         desc = rewritten.ref.describe()
         return materialize(
             self.unit,
             ShadowNode(
                 desc.kind,
                 desc.raw_span or self.span,
-                (*desc.slots, ("branch_result_slot_id", Leaf(slot.slot_id))),
+                (
+                    *desc.slots,
+                    ("branch_result_slot_id", Leaf(slot.slot_id)),
+                    (
+                        "authenticated_branch_result_slot_id",
+                        Leaf(authenticated_slot.slot_id),
+                    ),
+                ),
             ),
             self.reporter,
         )
@@ -5440,6 +5449,26 @@ class If(Statement):
                 observed="If without a stored branch-result slot",
                 requested="consume the slot minted once by If.substitute",
                 fix="route every If through substitution before Sugar construction",
+            )
+        try:
+            authenticated_slot = BranchResultSlot(
+                self.authenticated_branch_result_slot_id
+            )
+        except AttributeError:
+            backend_defect(
+                blame=self.fragment,
+                owner="If._construct_sugar",
+                observed="If without condition-owned branch-result authentication",
+                requested="the slot identity authenticated once by If.substitute",
+                fix="carry the authenticated slot through If._rewrite_with_slot",
+            )
+        if slot != authenticated_slot:
+            backend_defect(
+                blame=self.fragment,
+                owner="If._construct_sugar",
+                observed="If stored a branch-result slot from a different condition",
+                requested="the branch-result slot authenticated for this exact If.test",
+                fix="carry branch_result_slot(If.test) through If.substitute unchanged",
             )
         where = f"{self.unit.filename}"
         try:


### PR DESCRIPTION
## Fix-forward

`If.substitute` now carries the condition-owned branch-result slot as explicit authentication testimony through `_rewrite_with_slot`. `If._construct_sugar` accepts the stored slot only when it matches that carried identity and panics at the exact If occurrence otherwise.

This preserves the existing mint-once law: construction compares producer-carried identities and does not re-mint, parse, reconstruct, or infer a slot. No carrier, ExitSet, reducer, generator-step, boundary, or projector files changed.

## Tests

- `../../../bin/bpytest tests/test_if_construct_sugar_slot_producer.py -q` — **7 passed in 0.70s**
- `../../../bin/bpytest tests/test_branch_result_slot.py::test_unchanged_if_mints_and_stores_its_branch_slot_once -q` — **1 passed in 0.63s**

A broad `sugar-source-tree` run also reported pre-existing repository reds: **525 passed, 295 failed, 5 skipped**. They were not suppressed or modified.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate branch-result slot identity in `If` node rewriting
> - `If._rewrite_with_slot` now stores an `authenticated_branch_result_slot_id` (derived from the condition via `branch_result_slot`) alongside the existing `branch_result_slot_id` in the materialized `ShadowNode`.
> - `If.substitute` passes the pre-computed slot explicitly as `authenticated_slot` so rewrites triggered by substitution preserve the original slot identity.
> - `If._construct_sugar` validates that `authenticated_branch_result_slot_id` is present and matches `branch_result_slot_id`, reporting a `backend_defect` for each violation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e17735.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conditional branch handling during substitutions and sugar construction.
  * Added validation to prevent condition results from being associated with an incorrect or missing branch slot.
  * Reports a backend defect when conditional slot information is invalid, helping prevent inconsistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->