### PR TITLE
Integrate retained synchronous iterators through for recurrence

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
@@ -428,6 +428,7 @@ class LoopConstructionV1:
     loop_construction_cid: str
     _graph: dict[str, Any]
     iterable_sugar: object | None = field(default=None, compare=False, repr=False)
+    loop_runtime: object | None = field(default=None, compare=False, repr=False)
 
     def wire_graph(self) -> dict[str, Any]:
         return deepcopy(self._graph)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
@@ -5,11 +5,11 @@ from dataclasses import dataclass, field
 from sugar_lift_py_tests.floor import SymbolicValue
 from sugar_lift_py_tests.ir import atomic, ctor, not_, or_, str_const
 from sugar_lift_py_tests.outcome import Complete
-from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
 
 @dataclass(frozen=True)
-class LoopBindingRefSugar(Sugar):
+class LoopBindingRefSugar(ConstructedTermSugar):
     target_cid: str
     binding_coordinate_cid: str
     completion_kind: str
@@ -19,21 +19,25 @@ class LoopBindingRefSugar(Sugar):
     def witnesses(cls):
         return ()
 
-    def desugar(self, ctx=None):
-        del ctx
-        return Complete(
-            SymbolicValue(
-                ctor(
-                    "python:loop.post_binding",
-                    [
-                        str_const(self.target_cid),
-                        str_const(self.binding_coordinate_cid),
-                        str_const(self.completion_kind),
-                    ],
-                    symbol_kind="coordinate",
-                )
-            )
+    def to_term(self, *, owner: str):
+        del owner
+        return ctor(
+            "python:loop.post_binding",
+            [
+                str_const(self.target_cid),
+                str_const(self.binding_coordinate_cid),
+                str_const(self.completion_kind),
+            ],
+            symbol_kind="coordinate",
         )
+
+    def desugar(self, ctx=None):
+        temporal = getattr(ctx, "temporal", None) if ctx is not None else None
+        if temporal is not None:
+            bound = temporal.value_if_bound(self.binding_coordinate_cid)
+            if bound is not None:
+                return Complete(bound)
+        return Complete(SymbolicValue(self.to_term(owner="LoopBindingRefSugar")))
 
 
 @dataclass(frozen=True)
@@ -109,6 +113,41 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
         )
 
     def _desugar_with_iterable(self, iterable, ctx):
+        runtime = self.construction.loop_runtime
+        from sugar_lift_py_tests.floor import SymbolicValue
+
+        if (
+            iterable is not None
+            and runtime is not None
+            and not isinstance(iterable, SymbolicValue)
+        ):
+            from sugar_lift_py_tests.operations.iterator_operation import (
+                IteratorOperation,
+            )
+            from sugar_lift_py_tests.temporal import bind_temporal
+
+            runtime_ctx = ctx
+            for name, sugar in zip(
+                runtime.carried_names, runtime.initial_value_sugars, strict=True
+            ):
+                initial = sugar.desugar(runtime_ctx)
+                if not isinstance(initial, Complete):
+                    return initial
+                runtime_ctx = bind_temporal(
+                    runtime_ctx,
+                    name,
+                    initial.value,
+                    owner="LoopRecurrenceSugar",
+                    blame=str(self.site),
+                )
+            return IteratorOperation(
+                owner="LoopRecurrenceSugar", blame=self.site
+            ).submit(iterable, runtime_ctx).and_then(
+                lambda iterator: self._advance_iterator(
+                    iterator, runtime, runtime_ctx, entries=()
+                )
+            )
+
         from sugar_lift_py_tests.floor import InvValue
         from sugar_lift_py_tests.floor.block_value import BlockValue
 
@@ -187,3 +226,131 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
                             )
                         )
         return ExitSet(tuple(exits)).normalize()
+
+    def _advance_iterator(self, iterator, runtime, ctx, *, entries):
+        from sugar_lift_py_tests.effect.loop_control_effect import LoopControlEffect
+        from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.floor.iterator_value import NextResult
+        from sugar_lift_py_tests.operations.next_operation import NextOperation
+        from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
+        from sugar_lift_py_tests.temporal import bind_temporal
+
+        outcome = NextOperation(owner="LoopRecurrenceSugar", blame=self.site).submit(
+            iterator, ctx
+        )
+        if isinstance(outcome, Incomplete):
+            effect = outcome.effect
+            if isinstance(effect, RaiseEffect) and effect.exception_name == "StopIteration":
+                return self._finish_iterator(runtime, ctx, entries=entries)
+            return outcome
+        if not isinstance(outcome, Complete) or not isinstance(outcome.value, NextResult):
+            raise TypeError("NextOperation must produce NextResult or a named exception")
+
+        next_result = outcome.value
+        iteration_ctx = bind_temporal(
+            ctx,
+            runtime.target_name,
+            next_result.value,
+            owner="LoopRecurrenceSugar",
+            blame=str(self.site),
+        )
+        body = reduce_block_to_exitset(runtime.body_sugars, iteration_ctx)
+        if not isinstance(body, ExitSet):
+            return body
+        if len(body.exits) != 1:
+            return body
+        face = body.exits[0]
+        if isinstance(face, Halted):
+            effect = face.effect
+            if (
+                isinstance(effect, LoopControlEffect)
+                and effect.target_cid == self.target_cid
+            ):
+                state = face.state
+                if state is None:
+                    raise TypeError("loop control omitted its exact pre-exit state")
+                combined = (*entries, *state.entries)
+                if effect.action == "continue":
+                    return self._advance_iterator(
+                        next_result.advanced,
+                        runtime,
+                        state.context,
+                        entries=combined,
+                    )
+                if effect.action == "break":
+                    return self._publish_runtime_bindings(
+                        runtime, state.context, entries=combined
+                    )
+            return body
+        if not isinstance(face, Completed):
+            return body
+        state = face.value
+        combined = (*entries, *state.entries)
+        if not state.can_fall_through:
+            return Complete(BlockValue(combined, can_fall_through=False))
+        return self._advance_iterator(
+            next_result.advanced,
+            runtime,
+            state.context,
+            entries=combined,
+        )
+
+    def _finish_iterator(self, runtime, ctx, *, entries):
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
+        from sugar_lift_py_tests.outcome import Completed, ExitSet
+
+        if not runtime.else_sugars:
+            return self._publish_runtime_bindings(runtime, ctx, entries=entries)
+        otherwise = reduce_block_to_exitset(runtime.else_sugars, ctx)
+        if not isinstance(otherwise, ExitSet) or len(otherwise.exits) != 1:
+            return otherwise
+        face = otherwise.exits[0]
+        if not isinstance(face, Completed):
+            return otherwise
+        state = face.value
+        return self._publish_runtime_bindings(
+            runtime,
+            state.context,
+            entries=(*entries, *state.entries),
+            fall_through=state.fall_through,
+            can_fall_through=state.can_fall_through,
+        )
+
+    def _publish_runtime_bindings(
+        self,
+        runtime,
+        ctx,
+        *,
+        entries,
+        fall_through=(),
+        can_fall_through=True,
+    ):
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind
+        from sugar_lift_py_tests.outcome import Complete
+
+        temporal = getattr(ctx, "temporal", None)
+        if temporal is None:
+            raise TypeError("loop recurrence omitted its temporal context")
+        projected = []
+        for name, coordinate_cid in zip(
+            runtime.carried_names, self.binding_coordinate_cids, strict=True
+        ):
+            value = temporal.value_if_bound(name)
+            if value is None:
+                raise TypeError("loop recurrence omitted a carried binding")
+            projected.append(ScopeRebind(name, value))
+            projected.append(ScopeRebind(coordinate_cid, value))
+        return Complete(
+            BlockValue(
+                (*entries, *projected),
+                fall_through=fall_through,
+                can_fall_through=can_fall_through,
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
@@ -270,20 +270,21 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
                 isinstance(effect, LoopControlEffect)
                 and effect.target_cid == self.target_cid
             ):
-                state = face.state
-                if state is None:
-                    raise TypeError("loop control omitted its exact pre-exit state")
-                combined = (*entries, *state.entries)
+                state = self._require_loop_control_state(
+                    face.state,
+                    target_name=runtime.target_name,
+                    target_value=next_result.value,
+                )
                 if effect.action == "continue":
                     return self._advance_iterator(
                         next_result.advanced,
                         runtime,
-                        state.context,
-                        entries=combined,
+                        state,
+                        entries=entries,
                     )
                 if effect.action == "break":
                     return self._publish_runtime_bindings(
-                        runtime, state.context, entries=combined
+                        runtime, state, entries=entries
                     )
             return body
         if not isinstance(face, Completed):
@@ -298,6 +299,23 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
             state.context,
             entries=combined,
         )
+
+    @staticmethod
+    def _require_loop_control_state(state, *, target_name, target_value):
+        """Authenticate the producer's exact current reduction context.
+
+        A loop-control halt carries the context it received at its source
+        occurrence.  The current target Floor was bound into that context by
+        this recurrence, so object identity authenticates the context without
+        rebuilding a reduced block or accepting an ambient/foreign scope.
+        """
+        from sugar_lift_py_tests.context.reduce_context import ReduceContext
+
+        if not isinstance(state, ReduceContext):
+            raise TypeError("loop control omitted its exact ReduceContext state")
+        if state.temporal.value_if_bound(target_name) is not target_value:
+            raise TypeError("loop control state lacks exact iteration target identity")
+        return state
 
     def _finish_iterator(self, runtime, ctx, *, entries):
         from sugar_lift_py_tests.sugar.function_universe_sugar import (

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -47,6 +47,17 @@ class LiveOutwardHaltedFaceV1:
     state: tuple[BindingEntryV1, ...]
 
 
+@dataclass(frozen=True)
+class LiveForRuntimeV1:
+    """Unsealed execution handles paired with the sealed for construction."""
+
+    target_name: str
+    carried_names: tuple[str, ...]
+    initial_value_sugars: tuple[object, ...]
+    body_sugars: tuple[object, ...]
+    else_sugars: tuple[object, ...]
+
+
 def _formula_cid(formula) -> str:
     # Encode the Value tree once and hash those bytes. Do not decode the
     # canonical JCS string back through JSON merely to re-encode for the CID.
@@ -673,7 +684,21 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
     records = _conserve_unique_records(records)
     construction = decode_loop_construction_v1({"root": root, "records": records})
     if isinstance(loop, For):
-        construction = replace(construction, iterable_sugar=loop.iter.sugar())
+        if loop.target.kind != "Name":
+            raise BindingStateWireGap(
+                "live iterator recurrence requires an authenticated name target"
+            )
+        construction = replace(
+            construction,
+            iterable_sugar=loop.iter.sugar(),
+            loop_runtime=LiveForRuntimeV1(
+                loop.target.id,
+                carried_names,
+                tuple(entry.state.sugar() for entry in pre_runtime),
+                tuple(statement.sugar() for statement in loop.body),
+                tuple(statement.sugar() for statement in loop.orelse),
+            ),
+        )
 
     bindings = {}
     for name, entry in zip(carried_names, pre_entries, strict=True):

--- a/implementations/python/sugar-source-tree/tests/test_for_iterator_recurrence_integration.py
+++ b/implementations/python/sugar-source-tree/tests/test_for_iterator_recurrence_integration.py
@@ -1,0 +1,64 @@
+"""Real ``for`` recurrence consumes the retained synchronous iterator Floor."""
+
+from __future__ import annotations
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    return next(
+        SourceFile(
+            (
+                source,
+                "tests/for_iterator_recurrence_integration.py",
+                blake3_512_of(source.encode()),
+            )
+        ).functions()
+    )
+
+
+def _completed_post(outcome):
+    if isinstance(outcome, Complete):
+        return outcome.value.post()
+    assert isinstance(outcome, ExitSet), outcome
+    completed = [face for face in outcome.exits if isinstance(face, Completed)]
+    assert len(completed) == 1, completed
+    return completed[0].value.post()
+
+
+def test_retained_list_iterates_to_named_exhaustion_then_runs_else() -> None:
+    values = tuple(range(1, 130))
+    display = ", ".join(str(value) for value in values)
+    source = (
+        "def helper():\n"
+        "    total = 0\n"
+        f"    for item in [{display}]:\n"
+        "        total += item\n"
+        "    else:\n"
+        "        total += 1000\n"
+        "    return total\n"
+    )
+
+    outcome = _function(source).sugar().desugar()
+
+    post = _completed_post(outcome)
+    assert post.args[1].value == sum(values) + 1000
+
+
+def test_break_bypasses_later_next_calls_and_loop_else() -> None:
+    values = ", ".join(str(value) for value in range(129))
+    source = (
+        "def helper():\n"
+        "    total = 0\n"
+        f"    for item in [{values}]:\n"
+        "        total += item\n"
+        "        break\n"
+        "    else:\n"
+        "        total += 1000\n"
+        "    return total\n"
+    )
+
+    post = _completed_post(_function(source).sugar().desugar())
+    assert post.args[1].value == 0

--- a/implementations/python/sugar-source-tree/tests/test_for_iterator_recurrence_integration.py
+++ b/implementations/python/sugar-source-tree/tests/test_for_iterator_recurrence_integration.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
+from sugar_lift_py_tests.context.reduce_context import ReduceContext
+from sugar_lift_py_tests.floor.term_value import TermValue
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet
+from sugar_lift_py_tests.sugar.loop_recurrence_sugar import LoopRecurrenceSugar
+from sugar_lift_py_tests.temporal import bind_temporal
 from sugar_source_tree.tree import SourceFile
 
 
@@ -62,3 +68,59 @@ def test_break_bypasses_later_next_calls_and_loop_else() -> None:
 
     post = _completed_post(_function(source).sugar().desugar())
     assert post.args[1].value == 0
+
+
+def test_continue_preserves_current_state_before_the_next_iteration() -> None:
+    source = (
+        "def helper():\n"
+        "    total = 0\n"
+        "    for item in [1, 2, 3]:\n"
+        "        total = total + item\n"
+        "        continue\n"
+        "    else:\n"
+        "        total = total + 10\n"
+        "    return total\n"
+    )
+
+    post = _completed_post(_function(source).sugar().desugar())
+    assert post.args[1].value == 16
+
+
+def test_loop_control_state_accepts_only_the_exact_iteration_binding_identity() -> None:
+    value = TermValue(7)
+    ambient = ReduceContext.root(owner="loop-control-ambient")
+    exact = bind_temporal(
+        ambient,
+        "item",
+        value,
+        owner="loop-control-exact",
+        blame="loop-control-exact",
+    )
+    foreign = bind_temporal(
+        ambient,
+        "item",
+        TermValue(7),
+        owner="loop-control-foreign",
+        blame="loop-control-foreign",
+    )
+
+    assert (
+        LoopRecurrenceSugar._require_loop_control_state(
+            exact,
+            target_name="item",
+            target_value=value,
+        )
+        is exact
+    )
+    with pytest.raises(TypeError, match="exact iteration target identity"):
+        LoopRecurrenceSugar._require_loop_control_state(
+            ambient,
+            target_name="item",
+            target_value=value,
+        )
+    with pytest.raises(TypeError, match="exact iteration target identity"):
+        LoopRecurrenceSugar._require_loop_control_state(
+            foreign,
+            target_name="item",
+            target_value=value,
+        )


### PR DESCRIPTION
## Capability
- retain runtime body/else handles beside the sealed LoopConstructionV1
- invoke IteratorOperation once and advance exact finite iterators through NextOperation
- publish carried values under authenticated loop binding coordinates
- accept named StopIteration as natural exhaustion and run loop else

## Instrument / current R
- `test_retained_list_iterates_to_named_exhaustion_then_runs_else`: green
- `test_break_bypasses_later_next_calls_and_loop_else`: honorably red
- R = {natural_exhaustion: 0, break_pre_exit_state: 1}
- Delta R = {natural_exhaustion: -1, break_pre_exit_state: 0}
- Epsilon R = {natural_exhaustion: -1, break_pre_exit_state: 0 until producer repair}

## Exact producer blocker
`function_universe_sugar.py::_halt_state(state: _ReducedBlock, exit_) -> object` returns `None` for the stateless LoopControl halt after a completed body prefix. The consumer refuses rather than substituting ambient context. Contract required: preserve the reducer-issued exact prefix state on a stateless control halt. Carrier and ExitSet are untouched.

## Receipts
- loop recurrence term family: 9 passed
- integration instrument: 1 passed, 1 failed with `TypeError: loop control omitted its exact pre-exit state`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Execute retained synchronous iterators concretely during `for` loop desugaring
> - Adds `loop_runtime` field to `LoopConstructionV1` and populates it with a `LiveForRuntimeV1` instance in [`construct_live_loop_recurrence`](https://github.com/TSavo/sugar/pull/6750/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094), carrying the target name, carried names, and body/else sugars.
> - When a concrete iterable and `loop_runtime` are available, `LoopRecurrenceSugar._desugar_with_iterable` now runs the loop body step-by-step via a new `_advance_iterator` helper instead of falling back to symbolic evaluation.
> - `_advance_iterator` handles `continue`/`break` effects, accumulates `BlockValue` entries, and delegates to `_finish_iterator` on exhaustion, which executes the `else` block if present.
> - `_publish_runtime_bindings` projects final carried-variable values into `ScopeRebind` entries in the returned `Complete(BlockValue)`.
> - `LoopBindingRefSugar` now returns the concrete bound value from the temporal context when available, rather than a symbolic coordinate term.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa9142b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->