### PR TITLE
Project finite slice RHS through Floor owners

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
@@ -54,6 +54,14 @@ class BytesValue(FloorValue):
             )
         return super().equals(other, site)
 
+    def slice_assign_iterable_with(self, operation, ctx):
+        """Project the bytes object's authenticated integer members."""
+        del operation, ctx
+        from sugar_lift_py_tests.floor.term_value import TermValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(tuple(TermValue(byte) for byte in self.value))
+
     def to_term(self, *, owner: str):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
@@ -43,6 +43,13 @@ class DictValue(FloorValue):
 
         return Complete(TermValue(len(self.entries)))
 
+    def slice_assign_iterable_with(self, operation, ctx):
+        """Project insertion-ordered authenticated keys for slice assignment."""
+        del operation, ctx
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(tuple(key for key, _value in self.entries))
+
     def contains(self, item, site):
         # A guarded needle is not one needle: distribute into its faces and
         # rejoin under the same guard before this receiver's own law runs.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -75,6 +75,25 @@ class SetValue(FloorValue):
 
         return Complete(TermValue(len(self.elements)))
 
+    def slice_assign_iterable_with(self, operation, ctx):
+        """Keep runtime set iteration order loud; construction order is not it."""
+        del ctx
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="SetValue.slice_assign_iterable_with",
+            blame=operation.blame,
+            observed=(
+                "constructed SetValue members carry construction order, not "
+                "authenticated Python set iteration order"
+            ),
+            requested="finite RHS members in authenticated runtime iteration order",
+            fix=(
+                "carry producer-owned set iteration-order testimony into SetValue, "
+                "then project exactly that order through this Floor door"
+            ),
+        )
+
     def contains(self, item, site):
         # A guarded needle is not one needle: distribute into its faces and
         # rejoin under the same guard before this receiver's own law runs.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -138,6 +138,13 @@ class StringValue(GuardStableValue):
 
         return Complete(TermValue(len(self.value)))
 
+    def slice_assign_iterable_with(self, operation, ctx):
+        """Project the string's authenticated characters for slice assignment."""
+        del operation, ctx
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(tuple(StringValue(character) for character in self.value))
+
     def attribute(self, name, site):
         # Bound methods and fields on a constructed string (``"{:.2f}".format``,
         # ``"%.5f".__mod__``, …) stay the py.getattr coordinate — same EUF

--- a/implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_store_formal_caller.py
@@ -23,7 +23,16 @@ import pytest
 
 from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
-from sugar_lift_py_tests.floor import ListValue, SliceValue, TermValue, TupleValue
+from sugar_lift_py_tests.floor import (
+    BytesValue,
+    DictValue,
+    ListValue,
+    SetValue,
+    SliceValue,
+    StringValue,
+    TermValue,
+    TupleValue,
+)
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet
 from sugar_lift_py_tests.sugar.slice_sugar import SliceSugar
 from sugar_lift_py_tests.sugar.store_effect_sugar import SubscriptStoreEffectSugar
@@ -284,6 +293,98 @@ def test_tuple_rhs_is_accepted_for_slice_store() -> None:
         site,
     )
     assert out.value == ListValue((TermValue(8), TermValue(8), TermValue(2)))
+
+
+def test_string_rhs_projects_authenticated_characters() -> None:
+    site = _site()
+    out = ListValue((TermValue(0),)).setitem(
+        SliceValue(None, None, None), StringValue("ab"), site
+    )
+    assert out == Complete(ListValue((StringValue("a"), StringValue("b"))))
+
+
+def test_string_rhs_is_not_one_unsplit_string_or_typeerror() -> None:
+    site = _site()
+    out = ListValue((TermValue(0),)).setitem(
+        SliceValue(None, None, None), StringValue("ab"), site
+    )
+    assert out != Complete(ListValue((StringValue("ab"),)))
+    from sugar_lift_py_tests.floor import RaiseValue
+
+    assert not (isinstance(out, Complete) and isinstance(out.value, RaiseValue))
+
+
+def test_bytes_rhs_projects_authenticated_integer_bytes() -> None:
+    site = _site()
+    out = ListValue((TermValue(0),)).setitem(
+        SliceValue(None, None, None), BytesValue(b"AB"), site
+    )
+    assert out == Complete(ListValue((TermValue(65), TermValue(66))))
+
+
+def test_bytes_rhs_is_not_bytes_singletons_or_typeerror() -> None:
+    site = _site()
+    out = ListValue((TermValue(0),)).setitem(
+        SliceValue(None, None, None), BytesValue(b"AB"), site
+    )
+    assert out != Complete(ListValue((BytesValue(b"A"), BytesValue(b"B"))))
+    from sugar_lift_py_tests.floor import RaiseValue
+
+    assert not (isinstance(out, Complete) and isinstance(out.value, RaiseValue))
+
+
+def test_dict_rhs_projects_authenticated_insertion_order_keys() -> None:
+    site = _site()
+    rhs = DictValue(
+        ((StringValue("a"), TermValue(1)), (StringValue("b"), TermValue(2)))
+    )
+    out = ListValue((TermValue(0),)).setitem(
+        SliceValue(None, None, None), rhs, site
+    )
+    assert out == Complete(ListValue((StringValue("a"), StringValue("b"))))
+
+
+def test_dict_rhs_is_not_values_or_typeerror() -> None:
+    site = _site()
+    rhs = DictValue(
+        ((StringValue("a"), TermValue(1)), (StringValue("b"), TermValue(2)))
+    )
+    out = ListValue((TermValue(0),)).setitem(
+        SliceValue(None, None, None), rhs, site
+    )
+    assert out != Complete(ListValue((TermValue(1), TermValue(2))))
+    from sugar_lift_py_tests.floor import RaiseValue
+
+    assert not (isinstance(out, Complete) and isinstance(out.value, RaiseValue))
+
+
+def test_set_rhs_keeps_unowned_runtime_iteration_order_loud() -> None:
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    site = _site()
+    with pytest.raises(ConstructionPanic) as raised:
+        ListValue((TermValue(0),)).setitem(
+            SliceValue(None, None, None),
+            SetValue(
+                (StringValue("constructed-first"), StringValue("constructed-second"))
+            ),
+            site,
+        )
+    assert raised.value.info.owner == "SetValue.slice_assign_iterable_with"
+    assert "iteration order" in raised.value.info.observed
+    assert "producer-owned" in raised.value.info.fix
+
+
+def test_set_rhs_does_not_fabricate_construction_order_or_typeerror() -> None:
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    site = _site()
+    constructed = (StringValue("constructed-first"), StringValue("constructed-second"))
+    with pytest.raises(ConstructionPanic):
+        fabricated = ListValue((TermValue(0),)).setitem(
+            SliceValue(None, None, None), SetValue(constructed), site
+        )
+        assert fabricated == Complete(ListValue(constructed))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Drain the post-#6734 false-TypeError slice-assignment RHS family through Floor-owned dispatch. StringValue projects authenticated characters, BytesValue projects authenticated integer bytes, and DictValue projects insertion-ordered keys. SetValue refuses to reconstruct runtime iteration order from construction order and raises a named ConstructionPanic with the producer-owned testimony retirement path.

## Delta-epsilon

- R_false_typeerror: 4 -> 0 (Delta R = -4, Epsilon R = -4)
- R_set_iteration_order_authentication: 0 -> 1 reattributed loud residual
- R_nested_formal_slice_bound_transport: 1 unchanged
- getattr/spelling/vendor dispatch: 0
- carrier/ExitSet/outcome edits: 0

## Validation

PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src python3 -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_store_formal_caller.py

34 passed in 6.55s.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Project finite slice RHS through Floor owners for bytes, dict, set, and string values
> - `BytesValue.slice_assign_iterable_with` yields a tuple of integer `TermValue` elements, one per byte, when used as the RHS of a slice assignment.
> - `StringValue.slice_assign_iterable_with` yields a tuple of per-character `StringValue` elements.
> - `DictValue.slice_assign_iterable_with` yields a tuple of keys in authenticated insertion order.
> - `SetValue.slice_assign_iterable_with` raises a `ConstructionPanic` rather than fabricating an iteration order, since sets have no authenticated runtime order.
> - Nine new tests in [test_slice_subscript_store_formal_caller.py](https://github.com/TSavo/sugar/pull/6751/files#diff-9933bc74655b2a5d9b9195791cba877d40eda441ff1d1b7828be60bb24668ae2) cover correct projection and explicitly reject incorrect projections (e.g. unsplit string, byte singletons, dict values, fabricated set order).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db3d00d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->