### PR TITLE
Implement general generator ForStepV1 recurrence

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -188,6 +188,7 @@ class ForStepV1:
     body_steps: tuple
     module_cid: str
     fragment_cid: str
+    occurrence: object = field(compare=False, repr=False)
 
     def __post_init__(self) -> None:
         _require_constructed_term(self.iterable, owner="ForStepV1.iterable")
@@ -205,6 +206,30 @@ class ForStepV1:
             coordinate_cids.append(coordinate.cid)
         if len(coordinate_cids) != len(set(coordinate_cids)):
             raise TypeError("ForStepV1 target coordinates must be distinct")
+        if any(
+            coordinate.scope_owner_cid != self.module_cid
+            for coordinate in self.target_coordinates
+        ):
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="ForStepV1.__post_init__",
+                blame=self.occurrence,
+                observed="target coordinate outside authenticated module",
+                requested="all target coordinates owned by ForStepV1.module_cid",
+                fix="retain the producer-minted module coordinate without substitution",
+            )
+        occurrence_cid = self.occurrence.seal().cid
+        if occurrence_cid != self.fragment_cid:
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="ForStepV1.__post_init__",
+                blame=self.occurrence,
+                observed="For occurrence and fragment CID disagree",
+                requested="the producer-authenticated For source occurrence",
+                fix="retain the occurrence paired with its own fragment CID",
+            )
         for field_name, value in (
             ("module_cid", self.module_cid),
             ("fragment_cid", self.fragment_cid),
@@ -239,6 +264,16 @@ class TermStepV1:
 
     def __post_init__(self) -> None:
         _require_constructed_term(self.term, owner="TermStepV1.term")
+
+
+@dataclass(frozen=True)
+class _ForIteratorStepV1:
+    iterator: object = field(compare=False, repr=False)
+    target_coordinates: tuple
+    body_steps: tuple
+    module_cid: str
+    fragment_cid: str
+    occurrence: object = field(compare=False, repr=False)
 
 
 @dataclass(frozen=True)
@@ -309,6 +344,7 @@ GeneratorStepV1 = (
     | ForStepV1
     | RaiseStepV1
     | TermStepV1
+    | _ForIteratorStepV1
     | IfStepV1
     | NestedManagerStepV1
     | NestedManagerExitStepV1
@@ -330,6 +366,13 @@ def _generator_value_testimony(value: object, *, owner: str) -> dict:
             "kind": "assign-binding",
             "name": value.name,
             "fragmentCid": value.fragment_cid,
+            "value": _generator_value_testimony(value.value, owner=owner),
+        }
+    if isinstance(value, GeneratorLoopBindingV1):
+        return {
+            "kind": "loop-binding",
+            "coordinateCid": value.coordinate.cid,
+            "demandCid": value.demand_cid,
             "value": _generator_value_testimony(value.value, owner=owner),
         }
     if isinstance(value, NestedEnteredBindingV1):
@@ -454,6 +497,16 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
             "fragmentCid": step.fragment_cid,
             "term": _generator_value_testimony(step.term, owner=owner),
         }
+    if isinstance(step, _ForIteratorStepV1):
+        return {
+            "kind": "for-iterator",
+            "moduleCid": step.module_cid,
+            "fragmentCid": step.fragment_cid,
+            "targetCoordinateCids": [c.cid for c in step.target_coordinates],
+            "bodySteps": [
+                _generator_step_testimony(item, owner=owner) for item in step.body_steps
+            ],
+        }
     if isinstance(step, IfStepV1):
         return {
             "kind": "if",
@@ -502,6 +555,14 @@ class GeneratorAssignBindingV1:
     name: str
     value: object
     fragment_cid: str
+
+
+@dataclass(frozen=True)
+class GeneratorLoopBindingV1:
+    coordinate: object
+    value: object = field(compare=False, repr=False)
+    occurrence: object = field(compare=False, repr=False)
+    demand_cid: str
 
 
 @dataclass(frozen=True)
@@ -767,11 +828,19 @@ class GeneratorConstructionV1:
                 return ExitSet.halted(outcome.effect, state=self)
             return self._gap(requested, f"raise did not halt ({type(outcome).__name__})")
         if isinstance(step, TermStepV1):
-            value = self._reduce_value(step.term, requested)
-            if isinstance(value, GeneratorTransitionGapV1):
-                return value
+            outcome = step.term.desugar(self._guard_evaluation_context())
+            from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+            if isinstance(outcome, Incomplete):
+                return ExitSet.halted(outcome.effect, state=self)
+            if not isinstance(outcome, Complete):
+                return self._gap(requested, type(outcome).__name__)
             machine = replace(self, cursor=self.cursor + 1)
             return machine._transition(requested)
+        if isinstance(step, ForStepV1):
+            return self._transition_for(step, requested)
+        if isinstance(step, _ForIteratorStepV1):
+            return self._transition_for_iterator(step, requested)
         if isinstance(step, NestedManagerStepV1):
             return self._transition_nested_manager(step, requested)
         if isinstance(step, NestedManagerExitStepV1):
@@ -791,7 +860,19 @@ class GeneratorConstructionV1:
 
             if any(isinstance(exit_, Halted) for exit_ in cleanup.exits):
                 return cleanup
-            machine = replace(self, cursor=self.cursor + 1)
+            completed = tuple(
+                exit_ for exit_ in cleanup.exits if isinstance(exit_, Completed)
+            )
+            binding_state = self.binding_state
+            if len(completed) == 1 and isinstance(
+                completed[0].value, GeneratorTerminationV1
+            ):
+                binding_state = completed[0].value.binding_state
+            machine = replace(
+                self,
+                cursor=self.cursor + 1,
+                binding_state=binding_state,
+            )
             return machine._transition(requested)
         if isinstance(step, IfStepV1):
             return self._transition_branch(step, requested)
@@ -816,6 +897,94 @@ class GeneratorConstructionV1:
             suspended_resume_coordinate=resume_coordinate,
         )
         return YieldEffect(value, resume_coordinate, machine)
+
+    def _transition_for(self, step: ForStepV1, requested: str):
+        from sugar_lift_py_tests.operations import IteratorOperation
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+        iterable = step.iterable.desugar(self._guard_evaluation_context())
+        if isinstance(iterable, Incomplete):
+            return ExitSet.halted(iterable.effect, state=self)
+        if not isinstance(iterable, Complete):
+            return self._gap(requested, type(iterable).__name__)
+        iterator = IteratorOperation(
+            owner="GeneratorConstructionV1.ForStepV1.iter",
+            blame=step.occurrence,
+        ).submit(iterable.value, self._guard_evaluation_context())
+        if isinstance(iterator, Incomplete):
+            return ExitSet.halted(iterator.effect, state=self)
+        if not isinstance(iterator, Complete):
+            return self._gap(requested, type(iterator).__name__)
+        runtime = _ForIteratorStepV1(
+            iterator.value,
+            step.target_coordinates,
+            step.body_steps,
+            step.module_cid,
+            step.fragment_cid,
+            step.occurrence,
+        )
+        machine = replace(self, steps=(*self.steps[: self.cursor], runtime, *self.steps[self.cursor + 1 :]))
+        return machine._transition(requested)
+
+    def _transition_for_iterator(self, step: _ForIteratorStepV1, requested: str):
+        from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+        from sugar_lift_py_tests.floor.ground_exit import ground_raise_effect
+        from sugar_lift_py_tests.floor.iterator_value import NextResult
+        from sugar_lift_py_tests.operations import NextOperation
+        from sugar_lift_py_tests.operations.positional_unpack_operation import (
+            PositionalUnpackOperation,
+            UnpackMemberRoster,
+        )
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+        outcome = NextOperation(
+            owner="GeneratorConstructionV1.ForStepV1.next",
+            blame=step.occurrence,
+        ).submit(step.iterator, self._guard_evaluation_context())
+        if isinstance(outcome, Incomplete):
+            effect = outcome.effect
+            stop_identity = ground_raise_effect(
+                exception_name="StopIteration",
+                site=step.occurrence,
+                owner="GeneratorConstructionV1.ForStepV1.next",
+            ).exception_type_coordinate
+            if (
+                isinstance(effect, RaiseEffect)
+                and effect.exception_type_coordinate == stop_identity
+                and effect.occurrence == str(step.occurrence)
+            ):
+                machine = replace(self, cursor=self.cursor + 1)
+                return machine._transition(requested)
+            return ExitSet.halted(effect, state=self)
+        if not isinstance(outcome, Complete) or not isinstance(outcome.value, NextResult):
+            return self._gap(requested, f"next_with returned {type(outcome).__name__}")
+
+        unpack = PositionalUnpackOperation(
+            fixed_prefix=len(step.target_coordinates),
+            fixed_suffix=0,
+            has_star=False,
+            owner="GeneratorConstructionV1.ForStepV1.target",
+            blame=step.occurrence,
+        ).submit(outcome.value.value, self._guard_evaluation_context())
+        if isinstance(unpack, Incomplete):
+            return ExitSet.halted(unpack.effect, state=self)
+        if not isinstance(unpack, Complete) or not isinstance(unpack.value, UnpackMemberRoster):
+            return self._gap(requested, f"target unpack returned {type(unpack).__name__}")
+        bindings = tuple(
+            GeneratorLoopBindingV1(coordinate, member, unpack.value.occurrence, unpack.value.demand_cid)
+            for coordinate, member in zip(
+                step.target_coordinates, unpack.value.members, strict=True
+            )
+        )
+        recurrence = replace(step, iterator=outcome.value.advanced)
+        steps = (
+            *self.steps[: self.cursor],
+            *step.body_steps,
+            recurrence,
+            *self.steps[self.cursor + 1 :],
+        )
+        machine = replace(self, steps=steps, binding_state=(*self.binding_state, *bindings))
+        return machine._transition(requested)
 
     def _transition_nested_manager(self, step: NestedManagerStepV1, requested: str):
         """Enter nested protocol, bind entered state, splice body + exit step."""
@@ -1005,6 +1174,8 @@ class GeneratorConstructionV1:
         for item in self.binding_state:
             if isinstance(item, GeneratorAssignBindingV1) and item.value is not None:
                 temporal = temporal.bind_value(item.name, item.value)
+            if isinstance(item, GeneratorLoopBindingV1):
+                temporal = temporal.bind_value(item.coordinate.cid, item.value)
 
         if base is None:
             return _BinderOnlyReduceCtx(temporal)
@@ -1102,12 +1273,32 @@ class GeneratorConstructionV1:
             return outcome.value
         return self._gap(requested, type(outcome).__name__)
 
-    @staticmethod
-    def _reduce_finally(step: FinallyStepV1) -> ExitSet:
+    def _reduce_finally(self, step: FinallyStepV1) -> ExitSet:
         from sugar_lift_py_tests.sugar.function_universe_sugar import (
             reduce_block_to_exitset,
         )
 
+        if step.cleanup_steps:
+            cleanup_machine = replace(
+                self,
+                steps=(*step.cleanup_steps, ReturnStepV1()),
+                cursor=0,
+                suspended_resume_coordinate=None,
+            )
+            result = cleanup_machine._transition("finally cleanup")
+            if isinstance(result, GeneratorTerminationV1):
+                return ExitSet.completed(result)
+            if isinstance(result, ExitSet):
+                return result
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="GeneratorConstructionV1._reduce_finally",
+                blame=step,
+                observed=f"cleanup transitioned to {type(result).__name__}",
+                requested="completed or halted cleanup",
+                fix="keep suspension and unresolved steps out of a finally cleanup suite",
+            )
         return reduce_block_to_exitset(step.statements)
 
     @staticmethod

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2665,6 +2665,7 @@ class FunctionDef(Statement):
                         body_steps=body_steps,
                         module_cid=generator_for_module_cid(statement),
                         fragment_cid=statement.fragment.seal().cid,
+                        occurrence=statement.fragment,
                     )
                 )
             if (


### PR DESCRIPTION
## Law

Closes the merged #6748 red instrument after the exact #6745 producer/finally dependency landed.

- retains the iterable as `ConstructedTermSugar` and source-authenticated target coordinates
- advances only through `iter_with` / `next_with` and exact builtin `StopIteration` identity
- executes ordered `TermStepV1` bodies while threading the advanced iterator and per-iteration bindings
- preserves non-exhaustion and body halts
- keeps general cleanup loops inside `FinallyStepV1` and runs them on normal, close, and throw edges
- contains no pandas/name/vendor admission arm

## Instrument

`R_ForStepV1: 7 red -> 0` for the merged #6748 instrument, expanded with body-halt, foreign-StopIteration, and close/throw cleanup twins.

Focused receipt:

```
uv run --project implementations/python pytest -q implementations/python/sugar-source-tree/tests/test_generator_for_step_v1_instrument.py implementations/python/sugar-source-tree/tests/test_generator_step_if_finally_producer.py
39 passed in 2.30s
```

`git diff --check`: clean. Ruff was not available in the configured environment, so no lint result is claimed.

## Floors

No pandas arm. No carrier or ExitSet owner files changed. No spelling dispatch, iterable reconstruction, or fabricated exhaustion identity.

Dependency: #6745 (merged as `df7bb25e2`).

Do not merge from this worker.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `ForStepV1` recurrence in the generator state machine
> - Adds runtime for-loop execution to `GeneratorConstructionV1` via a new `_ForIteratorStepV1` internal step type that holds iterator state across iterations.
> - `_transition_for` desugars the iterable and obtains an iterator; `_transition_for_iterator` calls `NextOperation` each iteration, detects `StopIteration`, and unpacks yielded values into target coordinates.
> - Introduces `GeneratorLoopBindingV1` to record loop variable bindings in `binding_state`, making them visible to guard evaluation via their coordinate CIDs.
> - `ForStepV1.__post_init__` now validates target coordinate ownership and occurrence/fragment CID consistency, calling `construction_panic_gap` on mismatch.
> - `FunctionDef.source_visible_call_frame` now passes `occurrence=statement.fragment` when constructing `ForStepV1` to enable downstream panic routing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac257af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->