### PR TITLE
Construct authenticated generator for steps

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -186,6 +186,7 @@ class ForStepV1:
     iterable: ConstructedTermSugar
     target_coordinates: tuple
     body_steps: tuple
+    module_cid: str
     fragment_cid: str
 
     def __post_init__(self) -> None:
@@ -204,10 +205,12 @@ class ForStepV1:
             coordinate_cids.append(coordinate.cid)
         if len(coordinate_cids) != len(set(coordinate_cids)):
             raise TypeError("ForStepV1 target coordinates must be distinct")
-        if not isinstance(self.fragment_cid, str) or not self.fragment_cid.startswith(
-            "blake3-512:"
+        for field_name, value in (
+            ("module_cid", self.module_cid),
+            ("fragment_cid", self.fragment_cid),
         ):
-            raise TypeError("ForStepV1.fragment_cid must be authenticated")
+            if not isinstance(value, str) or not value.startswith("blake3-512:"):
+                raise TypeError(f"ForStepV1.{field_name} must be authenticated")
 
 
 @dataclass(frozen=True)
@@ -429,6 +432,7 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
     if isinstance(step, ForStepV1):
         return {
             "kind": "for",
+            "moduleCid": step.module_cid,
             "fragmentCid": step.fragment_cid,
             "iterable": _generator_value_testimony(step.iterable, owner=owner),
             "targetCoordinateCids": [

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -168,10 +168,46 @@ class FinallyStepV1:
     """
 
     statements: tuple[ConstructedTermSugar, ...]
+    cleanup_steps: tuple = ()
 
     def __post_init__(self) -> None:
         for statement in self.statements:
             _require_constructed_term(statement, owner="FinallyStepV1.statements")
+
+
+@dataclass(frozen=True)
+class ForStepV1:
+    """Authenticated source construction for one generator ``for`` step.
+
+    Transition remains a separate loud gap until the generator machine owns
+    iterator advancement and authenticated StopIteration routing.
+    """
+
+    iterable: ConstructedTermSugar
+    target_coordinates: tuple
+    body_steps: tuple
+    fragment_cid: str
+
+    def __post_init__(self) -> None:
+        _require_constructed_term(self.iterable, owner="ForStepV1.iterable")
+        if not self.target_coordinates:
+            raise TypeError("ForStepV1 requires authenticated target coordinates")
+        from sugar_source_tree.binding_provenance import BindingCoordinateV1
+
+        coordinate_cids = []
+        for coordinate in self.target_coordinates:
+            if not isinstance(coordinate, BindingCoordinateV1):
+                raise TypeError(
+                    "ForStepV1 target coordinates must be authenticated "
+                    "BindingCoordinateV1 values"
+                )
+            coordinate_cids.append(coordinate.cid)
+        if len(coordinate_cids) != len(set(coordinate_cids)):
+            raise TypeError("ForStepV1 target coordinates must be distinct")
+        if not isinstance(self.fragment_cid, str) or not self.fragment_cid.startswith(
+            "blake3-512:"
+        ):
+            raise TypeError("ForStepV1.fragment_cid must be authenticated")
 
 
 @dataclass(frozen=True)
@@ -267,6 +303,7 @@ GeneratorStepV1 = (
     | InertStepV1
     | AssignStepV1
     | FinallyStepV1
+    | ForStepV1
     | RaiseStepV1
     | TermStepV1
     | IfStepV1
@@ -383,6 +420,22 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
             "statements": [
                 _generator_value_testimony(item, owner=owner)
                 for item in step.statements
+            ],
+            "cleanupSteps": [
+                _generator_step_testimony(item, owner=owner)
+                for item in step.cleanup_steps
+            ],
+        }
+    if isinstance(step, ForStepV1):
+        return {
+            "kind": "for",
+            "fragmentCid": step.fragment_cid,
+            "iterable": _generator_value_testimony(step.iterable, owner=owner),
+            "targetCoordinateCids": [
+                coordinate.cid for coordinate in step.target_coordinates
+            ],
+            "bodySteps": [
+                _generator_step_testimony(item, owner=owner) for item in step.body_steps
             ],
         }
     if isinstance(step, RaiseStepV1):
@@ -723,6 +776,12 @@ class GeneratorConstructionV1:
                 return after
             return after._transition(requested)
         if isinstance(step, FinallyStepV1):
+            if step.cleanup_steps:
+                return self._gap(
+                    requested,
+                    "FinallyStepV1 structured cleanup steps require generator "
+                    "cleanup transition composition",
+                )
             cleanup = self._reduce_finally(step)
             from sugar_lift_py_tests.outcome import Completed, Halted
 
@@ -732,6 +791,12 @@ class GeneratorConstructionV1:
             return machine._transition(requested)
         if isinstance(step, IfStepV1):
             return self._transition_branch(step, requested)
+        if isinstance(step, ForStepV1):
+            return self._gap(
+                requested,
+                "ForStepV1 requires iter_with/next_with transition and "
+                "authenticated StopIteration routing",
+            )
         if isinstance(step, ReturnStepV1):
             value = self._reduce_value(step.value, requested)
             if isinstance(value, GeneratorTransitionGapV1):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2663,6 +2663,7 @@ class FunctionDef(Statement):
                         iterable=iterable,
                         target_coordinates=target_coordinates,
                         body_steps=body_steps,
+                        module_cid=generator_for_module_cid(statement),
                         fragment_cid=statement.fragment.seal().cid,
                     )
                 )
@@ -2720,16 +2721,9 @@ class FunctionDef(Statement):
 
         def generator_for_target_coordinates(statement):
             """Mint one authenticated coordinate per lexical target leaf."""
-            from sugar_lift_python_source.canonical import cid_of_json
             from .binding_state import mint_binding_coordinate_v1
 
-            scope_owner_cid = cid_of_json(
-                {
-                    "kind": "generator-for-binding-scope",
-                    "schemaVersion": "1",
-                    "source": statement.fragment.seal().to_dict(),
-                }
-            )
+            scope_owner_cid = generator_for_module_cid(statement)
 
             def collect(target, path):
                 if isinstance(target, Name):
@@ -2751,6 +2745,19 @@ class FunctionDef(Statement):
                 return None
 
             return collect(statement.target, ())
+
+        def generator_for_module_cid(statement):
+            """Authenticate module identity separately from content/span CID."""
+            from sugar_lift_python_source.canonical import cid_of_json
+
+            return cid_of_json(
+                {
+                    "kind": "generator-for-module",
+                    "schemaVersion": "1",
+                    "filename": statement.unit.filename,
+                    "sourceCid": statement.unit.source_cid,
+                }
+            )
 
         def compose_finally(body_steps, cleanup_step):
             """Seat cleanup before every terminal face and on fall-through."""

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2529,6 +2529,7 @@ class FunctionDef(Statement):
         from sugar_lift_py_tests.generator_construction import (
             AssignStepV1,
             FinallyStepV1,
+            ForStepV1,
             IfStepV1,
             InertStepV1,
             OpaqueStepV1,
@@ -2644,6 +2645,28 @@ class FunctionDef(Statement):
                     )
                 )
             if (
+                isinstance(statement, For)
+                and not statement.orelse
+                and not self._owns_yield((statement,))
+            ):
+                body_steps = branch_steps(statement.body)
+                target_coordinates = generator_for_target_coordinates(statement)
+                iterable = statement.iter.sugar()
+                if (
+                    body_steps is None
+                    or target_coordinates is None
+                    or not isinstance(iterable, ConstructedTermSugar)
+                ):
+                    return absent_step
+                return _GeneratorNamedStepV1(
+                    ForStepV1(
+                        iterable=iterable,
+                        target_coordinates=target_coordinates,
+                        body_steps=body_steps,
+                        fragment_cid=statement.fragment.seal().cid,
+                    )
+                )
+            if (
                 isinstance(statement, Try)
                 and not statement.handlers
                 and not statement.orelse
@@ -2661,6 +2684,14 @@ class FunctionDef(Statement):
                     cleanup_step = FinallyStepV1(cleanup.terms)
                     return _GeneratorTryFinallyStepsV1(
                         compose_finally(body_steps, cleanup_step)
+                    )
+                cleanup_steps = branch_steps(statement.finalbody)
+                if body_steps is not None and cleanup_steps is not None:
+                    return _GeneratorTryFinallyStepsV1(
+                        compose_finally(
+                            body_steps,
+                            FinallyStepV1((), cleanup_steps=cleanup_steps),
+                        )
                     )
                 if body_steps is None and self._owns_yield(statement.body):
                     return _GeneratorTryFinallyExpansionV1(statement, cleanup)
@@ -2686,6 +2717,40 @@ class FunctionDef(Statement):
                     continue
                 return None
             return tuple(collected)
+
+        def generator_for_target_coordinates(statement):
+            """Mint one authenticated coordinate per lexical target leaf."""
+            from sugar_lift_python_source.canonical import cid_of_json
+            from .binding_state import mint_binding_coordinate_v1
+
+            scope_owner_cid = cid_of_json(
+                {
+                    "kind": "generator-for-binding-scope",
+                    "schemaVersion": "1",
+                    "source": statement.fragment.seal().to_dict(),
+                }
+            )
+
+            def collect(target, path):
+                if isinstance(target, Name):
+                    return (
+                        mint_binding_coordinate_v1(
+                            scope_owner_cid=scope_owner_cid,
+                            binding_site=target.fragment,
+                            projection_path=("target", *path),
+                        ),
+                    )
+                if isinstance(target, (Tuple_, List)):
+                    coordinates = []
+                    for index, child in enumerate(target.elts):
+                        nested = collect(child, (*path, index))
+                        if nested is None:
+                            return None
+                        coordinates.extend(nested)
+                    return tuple(coordinates) if coordinates else None
+                return None
+
+            return collect(statement.target, ())
 
         def compose_finally(body_steps, cleanup_step):
             """Seat cleanup before every terminal face and on fall-through."""
@@ -2726,6 +2791,10 @@ class FunctionDef(Statement):
             for item in finalbody:
                 if isinstance(item, Pass):
                     continue
+                if isinstance(item, For):
+                    # A structured cleanup step is not a term. Let the typed
+                    # step path below own it without probing ``For.sugar``.
+                    return absent_cleanup
                 if isinstance(item, Expr) and not self._owns_yield((item,)):
                     value_sugar = item.value.sugar()
                     if isinstance(value_sugar, ConstructedTermSugar):

--- a/implementations/python/sugar-source-tree/tests/test_generator_for_step_v1_instrument.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_for_step_v1_instrument.py
@@ -17,6 +17,8 @@ these tests.
 
 from __future__ import annotations
 
+import pytest
+
 from sugar_lift_py_tests import generator_construction as generator_api
 from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_python_source.canonical import blake3_512_of
@@ -183,3 +185,40 @@ def test_for_step_transition_contract_is_explicit_and_owner_complete() -> None:
         "preserve body halts, accept only authenticated StopIteration, and route "
         "fall-through/return/halt through paired finally cleanup"
     )
+
+
+def test_for_step_transition_remains_the_exact_named_consumer_gap() -> None:
+    """Producer green is not a fabricated generator-loop completion claim."""
+    step = _for_steps(_OPTION_PAIR_MANAGER)[0]
+    machine = generator_api.GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:renamed-pair-scope",
+        frame_coordinate="frame:renamed-pair-scope",
+        binding_state=(),
+        steps=(step,),
+    )
+
+    gap = machine.resume()
+
+    assert isinstance(gap, generator_api.GeneratorTransitionGapV1)
+    assert gap.owner == "GeneratorConstructionV1.transition"
+    assert gap.requested == "resume"
+    assert gap.observed == (
+        "ForStepV1 requires iter_with/next_with transition and authenticated "
+        "StopIteration routing"
+    )
+
+
+def test_for_step_rejects_cid_shaped_foreign_target_coordinates() -> None:
+    """A CID-looking object is not producer-authenticated binding testimony."""
+    step = _for_steps(_OPTION_PAIR_MANAGER)[0]
+
+    class ForeignCoordinate:
+        cid = step.target_coordinates[0].cid
+
+    with pytest.raises(TypeError, match="authenticated BindingCoordinateV1"):
+        generator_api.ForStepV1(
+            iterable=step.iterable,
+            target_coordinates=(ForeignCoordinate(),),
+            body_steps=step.body_steps,
+            fragment_cid=step.fragment_cid,
+        )

--- a/implementations/python/sugar-source-tree/tests/test_generator_for_step_v1_instrument.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_for_step_v1_instrument.py
@@ -49,9 +49,11 @@ _RENAMED_TWIN = (
 )
 
 
-def _function(source: str) -> FunctionDef:
+def _function(
+    source: str, filename: str = "generator_for_step_v1.py"
+) -> FunctionDef:
     tree = SourceFile(
-        (source, "generator_for_step_v1.py", blake3_512_of(source.encode("utf-8")))
+        (source, filename, blake3_512_of(source.encode("utf-8")))
     )
     return next(node for node in tree.nodes() if isinstance(node, FunctionDef))
 
@@ -168,6 +170,33 @@ def test_cleanup_iterable_and_target_coordinates_are_not_reconstructed() -> None
     assert before.fragment_cid != cleanup.fragment_cid
 
 
+def test_for_steps_seat_exact_module_and_target_site_identity() -> None:
+    """Truthful/lying module twin: every coordinate names its lexical memento."""
+    function = _function(_OPTION_PAIR_MANAGER)
+    loops = tuple(node for node in function.walk() if node.kind == "For")
+    steps = _for_steps(_OPTION_PAIR_MANAGER)
+
+    assert function.unit.filename == "generator_for_step_v1.py"
+    assert function.unit.source_cid == blake3_512_of(_OPTION_PAIR_MANAGER.encode())
+    assert len(loops) == len(steps) == 2
+    for loop, step in zip(loops, steps, strict=True):
+        assert step.fragment_cid == loop.fragment.seal().cid
+        assert step.iterable.site.seal().to_dict() == loop.iter.fragment.seal().to_dict()
+        target_sites = tuple(item.fragment.seal().to_dict() for item in loop.target.elts)
+        assert tuple(coordinate.binding_site for coordinate in step.target_coordinates) == (
+            target_sites
+        )
+
+    foreign_module = _function(_OPTION_PAIR_MANAGER, "foreign_scope.py")
+    foreign_steps = foreign_module._source_visible_generator_steps_from(
+        foreign_module.body
+    )
+    foreign_for = next(step for step in foreign_steps if isinstance(step, _for_step_type()))
+    assert foreign_for.fragment_cid == steps[0].fragment_cid
+    assert foreign_for.module_cid != steps[0].module_cid
+    assert _target_coordinate_cids(foreign_for) != _target_coordinate_cids(steps[0])
+
+
 def test_for_step_transition_contract_is_explicit_and_owner_complete() -> None:
     """The step itself names every state/exit obligation; consumers do not infer it."""
     for_step_type = _for_step_type()
@@ -177,6 +206,7 @@ def test_for_step_transition_contract_is_explicit_and_owner_complete() -> None:
         "iterable",
         "target_coordinates",
         "body_steps",
+        "module_cid",
         "fragment_cid",
     }
     assert required <= set(fields), (
@@ -220,5 +250,6 @@ def test_for_step_rejects_cid_shaped_foreign_target_coordinates() -> None:
             iterable=step.iterable,
             target_coordinates=(ForeignCoordinate(),),
             body_steps=step.body_steps,
+            module_cid=step.module_cid,
             fragment_cid=step.fragment_cid,
         )

--- a/implementations/python/sugar-source-tree/tests/test_generator_step_if_finally_producer.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_step_if_finally_producer.py
@@ -566,8 +566,9 @@ def test_unsupported_x_yield_in_branch_keeps_whole_if_opaque() -> None:
     assert steps[0].carries_suspension is True
 
 
-def test_unnameable_finally_keeps_try_opaque_with_suspension() -> None:
-    # for-loop cleanup is not a ConstructedTermSugar term path → opaque Try
+def test_structured_for_cleanup_stays_owned_by_finally() -> None:
+    from sugar_lift_py_tests.generator_construction import FinallyStepV1, ForStepV1
+
     steps = _steps(
         "def manager():\n"
         "    try:\n"
@@ -576,10 +577,9 @@ def test_unnameable_finally_keeps_try_opaque_with_suspension() -> None:
         "        for x in items:\n"
         "            pass\n"
     )
-    assert any(
-        isinstance(s, OpaqueStepV1) and s.observed == "Try" and s.carries_suspension
-        for s in steps
-    )
+    cleanup = next(s for s in steps if isinstance(s, FinallyStepV1))
+    assert len(cleanup.cleanup_steps) == 1
+    assert isinstance(cleanup.cleanup_steps[0], ForStepV1)
 
 
 def test_cleanup_construction_invariant_failure_stays_loud() -> None:
@@ -592,17 +592,18 @@ def test_cleanup_construction_invariant_failure_stays_loud() -> None:
         "            pass\n"
     )
     cleanup_for = next(node for node in function.walk() if node.kind == "For")
-    original = type(cleanup_for).sugar
+    iterable_type = type(cleanup_for.iter)
+    original = iterable_type.sugar
 
     def invariant_failure(self):
         raise RuntimeError("cleanup constructor invariant")
 
-    type(cleanup_for).sugar = invariant_failure
+    iterable_type.sugar = invariant_failure
     try:
         with pytest.raises(RuntimeError, match="cleanup constructor invariant"):
             _steps_of(function)
     finally:
-        type(cleanup_for).sugar = original
+        iterable_type.sugar = original
 
 
 def test_cleanup_call_is_term_step_when_bare_expr_before_yield() -> None:


### PR DESCRIPTION
Producer-only partial capability for the merged #6748 instrument.

R / epsilon:
- merged ForStepV1 structural instrument: 4 failing tests -> 0
- re-export/value-use focused axes: 64/64 remain green
- predicted epsilon: producer-owned missing ForStepV1 construction -4 focused reds

Construction law:
- source-visible generator `for` retains its constructed iterable, one authenticated BindingCoordinateV1 per target leaf, exact content-addressed module identity (`filename + sourceCid`), ordered body steps, and the loop occurrence CID
- target coordinates are scoped by that authenticated module identity; identical source text at a foreign module path cannot share seats
- cleanup loops remain nested under FinallyStepV1
- renamed programs use the same structural producer; CID-shaped foreign target coordinates are rejected
- suspension-owning loops and `for ... else` remain opaque/loud

Honest remaining gap:
`GeneratorConstructionV1.transition`: ForStepV1 still refuses with the exact missing iter_with/next_with + authenticated StopIteration consumer law. This PR does not claim generator-loop execution completion.

Focused receipt (battleaxe, CPython 3.12.13, pandas 3.0.3): 99 passed, 2 unrelated deprecation warnings.

Floors: no scanning, spelling/vendor arms, reconstruction, fabricated coordinates, silent gaps, carrier, or ExitSet changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add authenticated `ForStepV1` generator step and structured finally cleanup steps
> - Introduces `ForStepV1`, a new authenticated step type for simple `for` loops in generator pipelines, with CID-bound module/fragment identity and validated `BindingCoordinateV1` target coordinates.
> - Extends `FinallyStepV1` with a `cleanup_steps` field, allowing try/finally cleanup to be represented as structured steps rather than opaque `Try` nodes when the finalbody is nameable.
> - Updates `_source_visible_generator_steps_from` in [nodes.py](https://github.com/TSavo/sugar/pull/6753/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to emit `ForStepV1` for simple for-loops and structured `FinallyStepV1` cleanup steps.
> - `GeneratorConstructionV1.transition` returns a named `GeneratorTransitionGapV1` instead of executing when it encounters a `ForStepV1` or a `FinallyStepV1` with non-empty `cleanup_steps`.
> - Testimony serialization is extended to include `ForStepV1` and `FinallyStepV1.cleanupSteps`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e18979.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->