### PR TITLE
Own immutable slice store TypeErrors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
@@ -62,6 +62,15 @@ class BytesValue(FloorValue):
 
         return Complete(tuple(TermValue(byte) for byte in self.value))
 
+    def setitem(self, index, value, site):
+        """Bytes are immutable: every subscript store is exact TypeError."""
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="BytesValue.setitem"
+        )
+
     def to_term(self, *, owner: str):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -301,6 +301,15 @@ class StringValue(GuardStableValue):
             )
         return self.undecided_subscript(index, site, owner="StringValue.subscript")
 
+    def setitem(self, index, value, site):
+        """Strings are immutable: every subscript store is exact TypeError."""
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="StringValue.setitem"
+        )
+
     def add(self, other, site):
         # A string's addition IS concatenation: two strings fold to their join.
         # Anything else falls to the honest addition-floor gap.

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py
@@ -4,7 +4,15 @@ from dataclasses import dataclass
 
 import pytest
 
-from sugar_lift_py_tests.floor import ListValue, SymbolicValue, TermValue, TupleValue
+from sugar_lift_py_tests.floor import (
+    BytesValue,
+    ListValue,
+    SliceValue,
+    StringValue,
+    SymbolicValue,
+    TermValue,
+    TupleValue,
+)
 from sugar_lift_py_tests.ir import make_var
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.store_effect_sugar import SubscriptStoreEffectSugar
@@ -72,6 +80,81 @@ def test_readable_immutable_receiver_raises_on_store(tmp_path):
     assert "TypeError" in repr(outcome.effect.exception_type_coordinate)
     assert "ValueError" not in repr(outcome.effect.exception_type_coordinate)
     assert outcome.effect.producer_node_owner == "TupleValue.setitem"
+
+
+@pytest.mark.parametrize(
+    ("receiver", "owner"),
+    (
+        (StringValue("abc"), "StringValue.setitem"),
+        (BytesValue(b"abc"), "BytesValue.setitem"),
+    ),
+)
+def test_immutable_slice_store_has_exact_typeerror_occurrence(
+    tmp_path, receiver, owner
+):
+    site = _site(tmp_path)
+    outcome = _store(
+        receiver,
+        SliceValue(TermValue(1), TermValue(2), None),
+        ListValue((TermValue(9),)),
+        [],
+        site,
+    ).desugar()
+
+    assert type(outcome).__name__ == "Incomplete"
+    assert outcome.effect.exception_name == "TypeError"
+    assert outcome.effect.producer_node_owner == owner
+    assert outcome.effect.occurrence_id == str(site)
+
+
+@pytest.mark.parametrize(
+    ("receiver", "fabricated"),
+    (
+        (StringValue("abc"), StringValue("a9c")),
+        (BytesValue(b"abc"), BytesValue(b"a9c")),
+    ),
+)
+def test_immutable_slice_store_cannot_fabricate_mutated_receiver(
+    tmp_path, receiver, fabricated
+):
+    site = _site(tmp_path)
+    outcome = _store(
+        receiver,
+        SliceValue(TermValue(1), TermValue(2), None),
+        ListValue((TermValue(9),)),
+        [],
+        site,
+    ).desugar()
+
+    assert outcome != Complete(fabricated)
+    assert outcome.effect.producer_node_owner != "TupleValue.setitem"
+
+
+@pytest.mark.parametrize(
+    "receiver", (StringValue("abc"), BytesValue(b"abc"))
+)
+def test_immutable_slice_store_halt_preserves_exact_prior_state(tmp_path, receiver):
+    from sugar_lift_py_tests.floor.block_value import BlockValue
+    from sugar_lift_py_tests.outcome import Halted
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        reduce_block_to_exitset,
+    )
+
+    prior = _ObservedSugar(
+        "prior", BlockValue((TermValue(99),), can_fall_through=True), []
+    )
+    store = _store(
+        receiver,
+        SliceValue(TermValue(1), TermValue(2), None),
+        ListValue((TermValue(9),)),
+        [],
+        _site(tmp_path),
+    )
+
+    outcome = reduce_block_to_exitset((prior, store), None)
+    halted = [exit_ for exit_ in outcome.exits if isinstance(exit_, Halted)]
+    assert len(halted) == 1
+    assert halted[0].state.entries == (TermValue(99),)
 
 
 def test_undecided_store_never_claims_a_completed_face(tmp_path):


### PR DESCRIPTION
## Summary

Close the concrete immutable slice-store pair through Floor-owned dispatch. StringValue and BytesValue now answer subscript stores with exact ground TypeError exits owned by their receiver floors. Production twins prove the original occurrence, reject fabricated mutated receivers and the TupleValue owner, and retain the exact pre-store block state.

## Delta-epsilon

- R_immutable_slice_store_missing_floor_owner: 2 -> 0 (Delta R = -2, Epsilon R = -2)
- R_nested_formal_slice_bound_transport: 1 unchanged (carrier-forbidden lane)
- R_set_iteration_order_authentication: 1 unchanged
- spelling/vendor dispatch: 0
- carrier/ExitSet/outcome edits: 0

## Validation

PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src python3 -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py

12 passed in 3.80s.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Own TypeError on subscript store for immutable `BytesValue` and `StringValue`
> Adds `setitem` methods to [`BytesValue`](https://github.com/TSavo/sugar/pull/6754/files#diff-7a88547a9abe7f0b9c6abca596b360b1b8597a1bde0a83596437b46ca87a3a91) and [`StringValue`](https://github.com/TSavo/sugar/pull/6754/files#diff-7f7cef79e8741c9f5ef0a7a75ab1e3f73d2cf58f59cc5d53870d530f4ffcbda5) that return a `TypeError` exceptional exit when a subscript store is attempted. Previously, these immutable types did not handle this operation themselves.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b441b74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->