### PR TITLE
Implement authenticated generator ForStepV1 recurrence

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -168,6 +168,7 @@ class FinallyStepV1:
     """
 
     statements: tuple[ConstructedTermSugar, ...]
+    cleanup_steps: tuple = ()
 
     def __post_init__(self) -> None:
         for statement in self.statements:
@@ -200,6 +201,35 @@ class TermStepV1:
 
     def __post_init__(self) -> None:
         _require_constructed_term(self.term, owner="TermStepV1.term")
+
+
+@dataclass(frozen=True)
+class ForStepV1:
+    """One source ``for`` recurrence owned by the generator producer."""
+
+    iterable: ConstructedTermSugar
+    target_coordinates: tuple
+    body_steps: tuple
+    fragment_cid: str
+    site: object = field(compare=False, repr=False)
+
+    def __post_init__(self) -> None:
+        _require_constructed_term(self.iterable, owner="ForStepV1.iterable")
+        if not self.target_coordinates:
+            raise TypeError("ForStepV1 requires authenticated target coordinates")
+        for coordinate in self.target_coordinates:
+            cid = getattr(coordinate, "cid", None)
+            if not isinstance(cid, str) or not cid.startswith("blake3-512:"):
+                raise TypeError("ForStepV1 target coordinate must be authenticated")
+
+
+@dataclass(frozen=True)
+class _ForIteratorStepV1:
+    iterator: object = field(compare=False, repr=False)
+    target_coordinates: tuple
+    body_steps: tuple
+    fragment_cid: str
+    site: object = field(compare=False, repr=False)
 
 
 @dataclass(frozen=True)
@@ -269,6 +299,8 @@ GeneratorStepV1 = (
     | FinallyStepV1
     | RaiseStepV1
     | TermStepV1
+    | ForStepV1
+    | _ForIteratorStepV1
     | IfStepV1
     | NestedManagerStepV1
     | NestedManagerExitStepV1
@@ -290,6 +322,13 @@ def _generator_value_testimony(value: object, *, owner: str) -> dict:
             "kind": "assign-binding",
             "name": value.name,
             "fragmentCid": value.fragment_cid,
+            "value": _generator_value_testimony(value.value, owner=owner),
+        }
+    if isinstance(value, GeneratorLoopBindingV1):
+        return {
+            "kind": "loop-binding",
+            "coordinateCid": value.coordinate.cid,
+            "demandCid": value.demand_cid,
             "value": _generator_value_testimony(value.value, owner=owner),
         }
     if isinstance(value, NestedEnteredBindingV1):
@@ -384,6 +423,10 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
                 _generator_value_testimony(item, owner=owner)
                 for item in step.statements
             ],
+            "cleanupSteps": [
+                _generator_step_testimony(item, owner=owner)
+                for item in step.cleanup_steps
+            ],
         }
     if isinstance(step, RaiseStepV1):
         return {
@@ -396,6 +439,25 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
             "kind": "term",
             "fragmentCid": step.fragment_cid,
             "term": _generator_value_testimony(step.term, owner=owner),
+        }
+    if isinstance(step, ForStepV1):
+        return {
+            "kind": "for",
+            "fragmentCid": step.fragment_cid,
+            "iterable": _generator_value_testimony(step.iterable, owner=owner),
+            "targetCoordinateCids": [c.cid for c in step.target_coordinates],
+            "bodySteps": [
+                _generator_step_testimony(item, owner=owner) for item in step.body_steps
+            ],
+        }
+    if isinstance(step, _ForIteratorStepV1):
+        return {
+            "kind": "for-iterator",
+            "fragmentCid": step.fragment_cid,
+            "targetCoordinateCids": [c.cid for c in step.target_coordinates],
+            "bodySteps": [
+                _generator_step_testimony(item, owner=owner) for item in step.body_steps
+            ],
         }
     if isinstance(step, IfStepV1):
         return {
@@ -445,6 +507,14 @@ class GeneratorAssignBindingV1:
     name: str
     value: object
     fragment_cid: str
+
+
+@dataclass(frozen=True)
+class GeneratorLoopBindingV1:
+    coordinate: object
+    value: object = field(compare=False, repr=False)
+    occurrence: object = field(compare=False, repr=False)
+    demand_cid: str
 
 
 @dataclass(frozen=True)
@@ -710,11 +780,19 @@ class GeneratorConstructionV1:
                 return ExitSet.halted(outcome.effect, state=self)
             return self._gap(requested, f"raise did not halt ({type(outcome).__name__})")
         if isinstance(step, TermStepV1):
-            value = self._reduce_value(step.term, requested)
-            if isinstance(value, GeneratorTransitionGapV1):
-                return value
+            outcome = step.term.desugar(self._guard_evaluation_context())
+            from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+            if isinstance(outcome, Incomplete):
+                return ExitSet.halted(outcome.effect, state=self)
+            if not isinstance(outcome, Complete):
+                return self._gap(requested, type(outcome).__name__)
             machine = replace(self, cursor=self.cursor + 1)
             return machine._transition(requested)
+        if isinstance(step, ForStepV1):
+            return self._transition_for(step, requested)
+        if isinstance(step, _ForIteratorStepV1):
+            return self._transition_for_iterator(step, requested)
         if isinstance(step, NestedManagerStepV1):
             return self._transition_nested_manager(step, requested)
         if isinstance(step, NestedManagerExitStepV1):
@@ -728,7 +806,19 @@ class GeneratorConstructionV1:
 
             if any(isinstance(exit_, Halted) for exit_ in cleanup.exits):
                 return cleanup
-            machine = replace(self, cursor=self.cursor + 1)
+            completed = tuple(
+                exit_ for exit_ in cleanup.exits if isinstance(exit_, Completed)
+            )
+            binding_state = self.binding_state
+            if len(completed) == 1 and isinstance(
+                completed[0].value, GeneratorTerminationV1
+            ):
+                binding_state = completed[0].value.binding_state
+            machine = replace(
+                self,
+                cursor=self.cursor + 1,
+                binding_state=binding_state,
+            )
             return machine._transition(requested)
         if isinstance(step, IfStepV1):
             return self._transition_branch(step, requested)
@@ -747,6 +837,92 @@ class GeneratorConstructionV1:
             suspended_resume_coordinate=resume_coordinate,
         )
         return YieldEffect(value, resume_coordinate, machine)
+
+    def _transition_for(self, step: ForStepV1, requested: str):
+        from sugar_lift_py_tests.operations import IteratorOperation
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+        iterable = step.iterable.desugar(self._guard_evaluation_context())
+        if isinstance(iterable, Incomplete):
+            return ExitSet.halted(iterable.effect, state=self)
+        if not isinstance(iterable, Complete):
+            return self._gap(requested, type(iterable).__name__)
+        iterator = IteratorOperation(
+            owner="GeneratorConstructionV1.ForStepV1.iter",
+            blame=step.site,
+        ).submit(iterable.value, self._guard_evaluation_context())
+        if isinstance(iterator, Incomplete):
+            return ExitSet.halted(iterator.effect, state=self)
+        if not isinstance(iterator, Complete):
+            return self._gap(requested, type(iterator).__name__)
+        runtime = _ForIteratorStepV1(
+            iterator.value,
+            step.target_coordinates,
+            step.body_steps,
+            step.fragment_cid,
+            step.site,
+        )
+        machine = replace(self, steps=(*self.steps[: self.cursor], runtime, *self.steps[self.cursor + 1 :]))
+        return machine._transition(requested)
+
+    def _transition_for_iterator(self, step: _ForIteratorStepV1, requested: str):
+        from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+        from sugar_lift_py_tests.floor.ground_exit import ground_raise_effect
+        from sugar_lift_py_tests.floor.iterator_value import NextResult
+        from sugar_lift_py_tests.operations import NextOperation
+        from sugar_lift_py_tests.operations.positional_unpack_operation import (
+            PositionalUnpackOperation,
+            UnpackMemberRoster,
+        )
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+        outcome = NextOperation(
+            owner="GeneratorConstructionV1.ForStepV1.next",
+            blame=step.site,
+        ).submit(step.iterator, self._guard_evaluation_context())
+        if isinstance(outcome, Incomplete):
+            effect = outcome.effect
+            stop_identity = ground_raise_effect(
+                exception_name="StopIteration",
+                site=step.site,
+                owner="GeneratorConstructionV1.ForStepV1.next",
+            ).exception_type_coordinate
+            if (
+                isinstance(effect, RaiseEffect)
+                and effect.exception_type_coordinate == stop_identity
+            ):
+                machine = replace(self, cursor=self.cursor + 1)
+                return machine._transition(requested)
+            return ExitSet.halted(effect, state=self)
+        if not isinstance(outcome, Complete) or not isinstance(outcome.value, NextResult):
+            return self._gap(requested, f"next_with returned {type(outcome).__name__}")
+
+        unpack = PositionalUnpackOperation(
+            fixed_prefix=len(step.target_coordinates),
+            fixed_suffix=0,
+            has_star=False,
+            owner="GeneratorConstructionV1.ForStepV1.target",
+            blame=step.site,
+        ).submit(outcome.value.value, self._guard_evaluation_context())
+        if isinstance(unpack, Incomplete):
+            return ExitSet.halted(unpack.effect, state=self)
+        if not isinstance(unpack, Complete) or not isinstance(unpack.value, UnpackMemberRoster):
+            return self._gap(requested, f"target unpack returned {type(unpack).__name__}")
+        bindings = tuple(
+            GeneratorLoopBindingV1(coordinate, member, unpack.value.occurrence, unpack.value.demand_cid)
+            for coordinate, member in zip(
+                step.target_coordinates, unpack.value.members, strict=True
+            )
+        )
+        recurrence = replace(step, iterator=outcome.value.advanced)
+        steps = (
+            *self.steps[: self.cursor],
+            *step.body_steps,
+            recurrence,
+            *self.steps[self.cursor + 1 :],
+        )
+        machine = replace(self, steps=steps, binding_state=(*self.binding_state, *bindings))
+        return machine._transition(requested)
 
     def _transition_nested_manager(self, step: NestedManagerStepV1, requested: str):
         """Enter nested protocol, bind entered state, splice body + exit step."""
@@ -936,6 +1112,8 @@ class GeneratorConstructionV1:
         for item in self.binding_state:
             if isinstance(item, GeneratorAssignBindingV1) and item.value is not None:
                 temporal = temporal.bind_value(item.name, item.value)
+            if isinstance(item, GeneratorLoopBindingV1):
+                temporal = temporal.bind_value(item.coordinate.cid, item.value)
 
         if base is None:
             return _BinderOnlyReduceCtx(temporal)
@@ -1033,12 +1211,32 @@ class GeneratorConstructionV1:
             return outcome.value
         return self._gap(requested, type(outcome).__name__)
 
-    @staticmethod
-    def _reduce_finally(step: FinallyStepV1) -> ExitSet:
+    def _reduce_finally(self, step: FinallyStepV1) -> ExitSet:
         from sugar_lift_py_tests.sugar.function_universe_sugar import (
             reduce_block_to_exitset,
         )
 
+        if step.cleanup_steps:
+            cleanup_machine = replace(
+                self,
+                steps=(*step.cleanup_steps, ReturnStepV1()),
+                cursor=0,
+                suspended_resume_coordinate=None,
+            )
+            result = cleanup_machine._transition("finally cleanup")
+            if isinstance(result, GeneratorTerminationV1):
+                return ExitSet.completed(result)
+            if isinstance(result, ExitSet):
+                return result
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="GeneratorConstructionV1._reduce_finally",
+                blame=step,
+                observed=f"cleanup transitioned to {type(result).__name__}",
+                requested="completed or halted cleanup",
+                fix="keep suspension and unresolved steps out of a finally cleanup suite",
+            )
         return reduce_block_to_exitset(step.statements)
 
     @staticmethod

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2529,6 +2529,7 @@ class FunctionDef(Statement):
         from sugar_lift_py_tests.generator_construction import (
             AssignStepV1,
             FinallyStepV1,
+            ForStepV1,
             IfStepV1,
             InertStepV1,
             OpaqueStepV1,
@@ -2643,6 +2644,25 @@ class FunctionDef(Statement):
                         statement.fragment.seal().cid,
                     )
                 )
+            if isinstance(statement, For) and not statement.orelse:
+                body = branch_steps(statement.body)
+                coordinates = for_target_coordinates(statement)
+                iterable = statement.iter.sugar()
+                if (
+                    body is None
+                    or coordinates is None
+                    or not isinstance(iterable, ConstructedTermSugar)
+                ):
+                    return None
+                return _GeneratorNamedStepV1(
+                    ForStepV1(
+                        iterable=iterable,
+                        target_coordinates=coordinates,
+                        body_steps=body,
+                        fragment_cid=statement.fragment.seal().cid,
+                        site=statement.fragment,
+                    )
+                )
             if (
                 isinstance(statement, Try)
                 and not statement.handlers
@@ -2662,10 +2682,44 @@ class FunctionDef(Statement):
                     return _GeneratorTryFinallyStepsV1(
                         compose_finally(body_steps, cleanup_step)
                     )
+                cleanup_steps = branch_steps(statement.finalbody)
+                if body_steps is not None and cleanup_steps is not None:
+                    cleanup_step = FinallyStepV1((), cleanup_steps=cleanup_steps)
+                    return _GeneratorTryFinallyStepsV1(
+                        compose_finally(body_steps, cleanup_step)
+                    )
                 if body_steps is None and self._owns_yield(statement.body):
                     return _GeneratorTryFinallyExpansionV1(statement, cleanup)
                 return absent_step
             return absent_step
+
+        def for_target_coordinates(statement):
+            from sugar_source_tree.binding_state import mint_binding_coordinate_v1
+
+            leaves = []
+
+            def collect(target, path):
+                if isinstance(target, Name):
+                    leaves.append((target, path))
+                    return True
+                if not isinstance(target, (Tuple_, List)) or not target.elts:
+                    return False
+                return all(
+                    collect(child, (*path, index))
+                    for index, child in enumerate(target.elts)
+                )
+
+            if not collect(statement.target, ("for-target",)):
+                return None
+            owner_cid = statement.fragment.seal().cid
+            return tuple(
+                mint_binding_coordinate_v1(
+                    scope_owner_cid=owner_cid,
+                    binding_site=leaf.fragment,
+                    projection_path=path,
+                )
+                for leaf, path in leaves
+            )
 
         def branch_steps(body):
             """Steps for one branch/suite, or None if any shape is unnameable.

--- a/implementations/python/sugar-source-tree/tests/test_generator_for_step_v1_instrument.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_for_step_v1_instrument.py
@@ -17,10 +17,25 @@ these tests.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
+import pytest
+
 from sugar_lift_py_tests import generator_construction as generator_api
+from sugar_lift_py_tests.context.reduce_context import ReduceContext
+from sugar_lift_py_tests.floor.floor_value import FloorValue
+from sugar_lift_py_tests.floor.iterator_value import (
+    ListIteratorValue,
+    NextResult,
+)
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.floor.tuple_value import TupleValue
+from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted, Incomplete
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_python_source.canonical import blake3_512_of
-from sugar_source_tree.nodes import FunctionDef
+from sugar_source_tree.binding_state import mint_binding_coordinate_v1
+from sugar_source_tree.nodes import For, FunctionDef
 from sugar_source_tree.tree import SourceFile
 
 
@@ -109,6 +124,30 @@ def _for_steps(source: str):
     return tuple(found)
 
 
+def _for_steps_with_parents(source: str):
+    for_step_type = _for_step_type()
+    found = []
+
+    def visit(step, parent) -> None:
+        if isinstance(step, for_step_type):
+            found.append((step, parent))
+        for field_name in (
+            "body_steps",
+            "then_steps",
+            "else_steps",
+            "cleanup_steps",
+            "statements",
+        ):
+            children = getattr(step, field_name, ())
+            if isinstance(children, tuple):
+                for child in children:
+                    visit(child, step)
+
+    for root in _steps(source):
+        visit(root, None)
+    return tuple(found)
+
+
 def _target_coordinate_cids(step) -> tuple[str, ...]:
     coordinates = getattr(step, "target_coordinates", None)
     assert coordinates is not None, (
@@ -166,6 +205,20 @@ def test_cleanup_iterable_and_target_coordinates_are_not_reconstructed() -> None
     assert before.fragment_cid != cleanup.fragment_cid
 
 
+def test_cleanup_for_step_remains_owned_by_finally_not_flattened() -> None:
+    """Lying-edge twin: lexical cleanup cannot become ordinary fall-through."""
+    finally_step_type = getattr(generator_api, "FinallyStepV1", None)
+    assert finally_step_type is not None
+    pairs = _for_steps_with_parents(_OPTION_PAIR_MANAGER)
+
+    assert len(pairs) == 2
+    assert pairs[0][1] is None, "the pre-yield loop is ordinary generator flow"
+    assert isinstance(pairs[1][1], finally_step_type), (
+        "the undo loop must remain a child of FinallyStepV1 so return, halt, "
+        "throw, close, and fall-through all route through it"
+    )
+
+
 def test_for_step_transition_contract_is_explicit_and_owner_complete() -> None:
     """The step itself names every state/exit obligation; consumers do not infer it."""
     for_step_type = _for_step_type()
@@ -176,6 +229,7 @@ def test_for_step_transition_contract_is_explicit_and_owner_complete() -> None:
         "target_coordinates",
         "body_steps",
         "fragment_cid",
+        "site",
     }
     assert required <= set(fields), (
         "ForStepV1 must own iterable, target coordinates, ordered body, and "
@@ -183,3 +237,346 @@ def test_for_step_transition_contract_is_explicit_and_owner_complete() -> None:
         "preserve body halts, accept only authenticated StopIteration, and route "
         "fall-through/return/halt through paired finally cleanup"
     )
+
+
+@dataclass(frozen=True)
+class _ValueSugar(ConstructedTermSugar):
+    value: FloorValue
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+    def to_term(self, *, owner: str):
+        return self.value.to_term(owner=owner)
+
+
+@dataclass(frozen=True)
+class _TracingIterable(FloorValue):
+    elements: tuple[FloorValue, ...]
+    events: list = field(compare=False, repr=False)
+
+    def iter_with(self, operation, ctx):
+        del operation, ctx
+        self.events.append("iter_with")
+        return Complete(_TracingIterator(self.elements, self.events))
+
+
+@dataclass(frozen=True)
+class _TracingIterator(FloorValue):
+    elements: tuple[FloorValue, ...]
+    events: list = field(compare=False, repr=False)
+
+    def next_with(self, operation, ctx):
+        self.events.append("next_with")
+        if not self.elements:
+            # Production authentication door: source occurrence + builtin
+            # StopIteration coordinate. The test never fabricates the effect.
+            return ListIteratorValue((), index=0).next_with(operation, ctx)
+        return Complete(
+            NextResult(
+                self.elements[0],
+                _TracingIterator(self.elements[1:], self.events),
+            )
+        )
+
+
+@dataclass(frozen=True)
+class _NextHaltIterable(FloorValue):
+    effect: object
+    events: list = field(compare=False, repr=False)
+
+    def iter_with(self, operation, ctx):
+        del operation, ctx
+        self.events.append("iter_with")
+        return Complete(_NextHaltIterator(self.effect, self.events))
+
+
+@dataclass(frozen=True)
+class _NextHaltIterator(FloorValue):
+    effect: object
+    events: list = field(compare=False, repr=False)
+
+    def next_with(self, operation, ctx):
+        del operation, ctx
+        self.events.append("next_with")
+        return Incomplete(self.effect)
+
+
+@dataclass(frozen=True)
+class _ObserveTargetBindings(ConstructedTermSugar):
+    coordinate_cids: tuple[str, ...]
+    events: list = field(compare=False, repr=False)
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        values = tuple(ctx.temporal.value_for(cid) for cid in self.coordinate_cids)
+        self.events.append(("body", values))
+        return Complete(TermValue(0))
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:test-observe-for-bindings",
+            tuple(str_const(cid) for cid in self.coordinate_cids),
+            symbol_kind="coordinate",
+        )
+
+
+@dataclass(frozen=True)
+class _HaltBody(ConstructedTermSugar):
+    effect: object
+    events: list = field(compare=False, repr=False)
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        self.events.append("body_halt")
+        return Incomplete(self.effect)
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import str_const
+
+        del owner
+        return str_const("test:for-body-halt")
+
+
+def _runtime_for_step(events: list):
+    for_step_type = _for_step_type()
+    term_step_type = _term_step_type()
+    function = _function(
+        "def renamed(ops):\n"
+        "    for left, right in ops:\n"
+        "        apply_pair(left, right)\n"
+        "    yield None\n"
+    )
+    source_for = next(node for node in function.body if isinstance(node, For))
+    coordinates = tuple(
+        mint_binding_coordinate_v1(
+            scope_owner_cid=source_for.fragment.seal().cid,
+            binding_site=leaf.fragment,
+            projection_path=("for-target", index),
+        )
+        for index, leaf in enumerate(source_for.target.elts)
+    )
+    iterable = _TracingIterable(
+        (
+            TupleValue((TermValue(1), TermValue(2))),
+            TupleValue((TermValue(3), TermValue(4))),
+        ),
+        events,
+    )
+    body_term = _ObserveTargetBindings(
+        tuple(coordinate.cid for coordinate in coordinates),
+        events,
+        source_for.body[0].fragment,
+    )
+    step = for_step_type(
+        iterable=_ValueSugar(iterable, source_for.iter.fragment),
+        target_coordinates=coordinates,
+        body_steps=(
+            term_step_type(body_term, source_for.body[0].fragment.seal().cid),
+        ),
+        fragment_cid=source_for.fragment.seal().cid,
+        site=source_for.fragment,
+    )
+    return generator_api.GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:renamed",
+        frame_coordinate="frame:renamed",
+        binding_state=(),
+        steps=(step, generator_api.ReturnStepV1()),
+        reduction_context=ReduceContext.root(owner="ForStepV1-test"),
+    )
+
+
+def test_for_step_uses_iter_next_and_threads_each_advanced_binding_state() -> None:
+    """Truthful transition: two items, ordered bodies, then exact exhaustion."""
+    events = []
+    outcome = _runtime_for_step(events).resume()
+
+    assert isinstance(outcome, generator_api.GeneratorTerminationV1)
+    assert events == [
+        "iter_with",
+        "next_with",
+        ("body", (TermValue(1), TermValue(2))),
+        "next_with",
+        ("body", (TermValue(3), TermValue(4))),
+        "next_with",
+    ]
+
+
+def test_same_target_spelling_cannot_resolve_at_foreign_coordinates() -> None:
+    """Lying-coordinate twin: target names never authorize body reads."""
+    machine = _runtime_for_step([])
+    step = machine.steps[0]
+    coordinates = tuple(step.target_coordinates)
+    forged = tuple(
+        mint_binding_coordinate_v1(
+            scope_owner_cid=coordinate.scope_owner_cid,
+            binding_site=_function("def other():\n    yield None\n").fragment,
+            projection_path=coordinate.projection_path,
+        )
+        for coordinate in coordinates
+    )
+    observed = _ObserveTargetBindings(
+        tuple(coordinate.cid for coordinate in forged),
+        [],
+        step.site,
+    )
+    wrong_body = _term_step_type()(
+        observed,
+        step.body_steps[0].fragment_cid,
+    )
+    wrong = type(step)(
+        iterable=step.iterable,
+        target_coordinates=coordinates,
+        body_steps=(wrong_body,),
+        fragment_cid=step.fragment_cid,
+        site=step.site,
+    )
+    machine = type(machine).allocate(
+        allocation_coordinate="call:wrong-coordinate",
+        frame_coordinate="frame:wrong-coordinate",
+        binding_state=(),
+        steps=(wrong, generator_api.ReturnStepV1()),
+        reduction_context=ReduceContext.root(owner="ForStepV1-wrong-coordinate"),
+    )
+
+    with pytest.raises(ConstructionPanic):
+        machine.resume()
+
+
+def test_body_halt_is_preserved_and_does_not_advance_the_iterator() -> None:
+    """A body effect exits this iteration; recurrence cannot swallow it."""
+    from sugar_lift_py_tests.floor.ground_exit import ground_raise_effect
+
+    events = []
+    machine = _runtime_for_step(events)
+    step = machine.steps[0]
+    effect = ground_raise_effect(
+        exception_name="ValueError",
+        site=step.site,
+        owner="ForStepV1-body-halt-test",
+    )
+    halted_body = _HaltBody(effect, events, step.site)
+    halted_step = type(step)(
+        iterable=step.iterable,
+        target_coordinates=step.target_coordinates,
+        body_steps=(
+            _term_step_type()(halted_body, step.body_steps[0].fragment_cid),
+        ),
+        fragment_cid=step.fragment_cid,
+        site=step.site,
+    )
+    machine = type(machine).allocate(
+        allocation_coordinate="call:body-halt",
+        frame_coordinate="frame:body-halt",
+        binding_state=(),
+        steps=(halted_step, generator_api.ReturnStepV1()),
+        reduction_context=ReduceContext.root(owner="ForStepV1-body-halt"),
+    )
+
+    outcome = machine.resume()
+
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    assert isinstance(outcome.exits[0], Halted)
+    assert outcome.exits[0].effect is effect
+    assert events == ["iter_with", "next_with", "body_halt"]
+
+
+def test_stopiteration_spelling_with_foreign_identity_does_not_exhaust() -> None:
+    """Lying twin: the exception label cannot replace its type coordinate."""
+    from dataclasses import replace
+
+    from sugar_lift_py_tests.floor.ground_exit import ground_raise_effect
+
+    events = []
+    machine = _runtime_for_step(events)
+    step = machine.steps[0]
+    value_error = ground_raise_effect(
+        exception_name="ValueError",
+        site=step.site,
+        owner="ForStepV1-foreign-stop-test",
+    )
+    foreign_stop = replace(value_error, exception_name="StopIteration")
+    wrong = replace(
+        step,
+        iterable=_ValueSugar(
+            _NextHaltIterable(foreign_stop, events),
+            step.site,
+        ),
+    )
+    machine = replace(machine, steps=(wrong, generator_api.ReturnStepV1()))
+
+    outcome = machine.resume()
+
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 1
+    assert isinstance(outcome.exits[0], Halted)
+    assert outcome.exits[0].effect is foreign_stop
+    assert events == ["iter_with", "next_with"]
+
+
+def _suspended_with_for_cleanup(events: list):
+    loop = _runtime_for_step(events).steps[0]
+    machine = generator_api.GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:finally-for",
+        frame_coordinate="frame:finally-for",
+        binding_state=(),
+        steps=(
+            generator_api.YieldStepV1(None),
+            generator_api.FinallyStepV1((), cleanup_steps=(loop,)),
+            generator_api.ReturnStepV1(),
+        ),
+        reduction_context=ReduceContext.root(owner="ForStepV1-finally-test"),
+    )
+    yielded = machine.resume()
+    assert isinstance(yielded, generator_api.YieldEffect)
+    return yielded.machine, loop.site
+
+
+@pytest.mark.parametrize("outgoing", ["close", "throw"])
+def test_for_cleanup_runs_on_each_outgoing_edge(outgoing: str) -> None:
+    """The structured finally retains its loop on normal and halted exits."""
+    from sugar_lift_py_tests.floor.ground_exit import ground_raise_effect
+
+    events = []
+    suspended, site = _suspended_with_for_cleanup(events)
+    if outgoing == "close":
+        result = suspended.close()
+    else:
+        effect = ground_raise_effect(
+            exception_name="ValueError",
+            site=site,
+            owner="ForStepV1-finally-throw-test",
+        )
+        result = suspended.throw(effect)
+        assert any(
+            isinstance(exit_, Halted) and exit_.effect is effect
+            for exit_ in result.exits
+        )
+
+    assert isinstance(result, ExitSet)
+    assert events == [
+        "iter_with",
+        "next_with",
+        ("body", (TermValue(1), TermValue(2))),
+        "next_with",
+        ("body", (TermValue(3), TermValue(4))),
+        "next_with",
+    ]

--- a/implementations/python/sugar-source-tree/tests/test_generator_step_if_finally_producer.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_step_if_finally_producer.py
@@ -23,6 +23,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
 from sugar_lift_py_tests.floor.predicate_value import PredicateValue
 from sugar_lift_py_tests.generator_construction import (
     FinallyStepV1,
+    ForStepV1,
     GeneratorConstructionV1,
     GeneratorTransitionGapV1,
     IfStepV1,
@@ -566,8 +567,7 @@ def test_unsupported_x_yield_in_branch_keeps_whole_if_opaque() -> None:
     assert steps[0].carries_suspension is True
 
 
-def test_unnameable_finally_keeps_try_opaque_with_suspension() -> None:
-    # for-loop cleanup is not a ConstructedTermSugar term path → opaque Try
+def test_general_for_finally_stays_owned_by_cleanup() -> None:
     steps = _steps(
         "def manager():\n"
         "    try:\n"
@@ -576,10 +576,9 @@ def test_unnameable_finally_keeps_try_opaque_with_suspension() -> None:
         "        for x in items:\n"
         "            pass\n"
     )
-    assert any(
-        isinstance(s, OpaqueStepV1) and s.observed == "Try" and s.carries_suspension
-        for s in steps
-    )
+    cleanup = next(s for s in steps if isinstance(s, FinallyStepV1))
+    assert len(cleanup.cleanup_steps) == 1
+    assert isinstance(cleanup.cleanup_steps[0], ForStepV1)
 
 
 def test_cleanup_construction_invariant_failure_stays_loud() -> None:
@@ -633,9 +632,7 @@ def test_twin_branch_swap_changes_then_else_payloads() -> None:
     assert a.else_steps != b.else_steps
 
 
-def test_twin_missing_branch_occurrence_is_opaque_when_unnameable() -> None:
-    # raise without constructing if would be RaiseStep; missing nameable
-    # shape inside branch with for stays opaque If.
+def test_general_for_inside_branch_remains_an_ordered_branch_step() -> None:
     steps = _steps(
         "def m(c):\n"
         "    if c:\n"
@@ -643,8 +640,9 @@ def test_twin_missing_branch_occurrence_is_opaque_when_unnameable() -> None:
         "            yield x\n"
         "    yield 0\n"
     )
-    assert isinstance(steps[0], OpaqueStepV1)
-    assert steps[0].carries_suspension is True
+    assert isinstance(steps[0], IfStepV1)
+    assert len(steps[0].then_steps) == 1
+    assert isinstance(steps[0].then_steps[0], ForStepV1)
 
 
 def test_twin_cleanup_deletion_removes_finally_step() -> None:


### PR DESCRIPTION
## Capability

Adds producer-authenticated `ForStepV1` construction and live generator transition through Floor-owned `iter_with`, `next_with`, and positional unpack. The iterable is reduced once, the retained iterator advances across ordered body steps, target values bind by authenticated coordinate identity, non-matching exceptional exits remain halted, and only the authenticated StopIteration identity licenses exhaustion. Typed `FinallyStepV1.cleanup_steps` keeps loop cleanup structured across normal and halted exits with cleanup halt supersession.

No carrier, ExitSet, pandas/name recognition, or reconstruction paths were changed.

## IDD receipt

- R before: `generator_for_step_construction=4/4 red`
- Delta R: `-4`; focused producer/transition matrix is `39 passed`
- Epsilon R: `0` for the ForStep construction/transition axes pinned here
- Floors: renamed twin, foreign target coordinate, foreign StopIteration identity, body halt/no-later-next, retained iterator threading, and structured finally cleanup all pass

## Tests

- `bin/bpytest implementations/python/sugar-source-tree/tests/test_generator_for_step_v1_instrument.py implementations/python/sugar-source-tree/tests/test_generator_step_if_finally_producer.py -q` — 39 passed
- `bin/bpytest implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py -q` — red upstream of ForStep: authenticated option_context publication reaches `If._construct_sugar` at `pandas/_config/config.py:66:0`, then fails with `If without a stored branch-result slot`; provider receiver count remains 0. The broader file also exposes binder/ClassDef `params` reds. These signals are preserved, not suppressed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement authenticated `ForStepV1` recurrence in generator construction
> - Adds `ForStepV1`, a new generator step type representing `for` loops with authenticated target coordinates (blake3-512 prefixed) and body steps, produced from `for` statements in [`nodes.py`](https://github.com/TSavo/sugar/pull/6756/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0).
> - Introduces `_ForIteratorStepV1` as an internal runtime step carrying iterator state between transitions, and `GeneratorLoopBindingV1` to record per-iteration target bindings in `binding_state`.
> - Extends `GeneratorConstructionV1._transition` with `_transition_for` (desugars iterable, obtains authenticated iterator) and `_transition_for_iterator` (drives per-iteration binding, body execution, and StopIteration detection).
> - Updates `FinallyStepV1` to carry structured `cleanup_steps` so that for-loops inside `finally` blocks are preserved as typed steps rather than opaque terms.
> - `TermStepV1` handling is refactored to use `term.desugar` outcomes directly instead of `_reduce_value`, removing implicit yielding on completion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07ee940.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->