### PR TITLE
Normalize reducer context for guarded returns

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -236,6 +236,10 @@ def reduce_block_to_exitset(
     statements: tuple, ctx: object = None
 ) -> ExitSet[_ReducedBlock]:
     """Reduce a suite to guarded exits before the linear compatibility view."""
+    if ctx is None:
+        from sugar_lift_py_tests.context import ReduceContext
+
+        ctx = ReduceContext.root(owner="reduce_block_to_exitset")
     exits = ExitSet.completed(
         _ReducedBlock(entries=(), can_fall_through=True, fall_through=(), context=ctx)
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_return_reducer_context.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_return_reducer_context.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sugar_lift_py_tests.context import ReduceContext
+from sugar_lift_py_tests.floor import FloorValue, GuardedFaces
+from sugar_lift_py_tests.ir import atomic, not_
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+
+@dataclass(frozen=True)
+class _OccurrenceStateValue(FloorValue):
+    occurrence: object
+    state: object
+
+
+class _CaptureContext(Sugar):
+    def __init__(self, seen: list[object]):
+        self.seen = seen
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        self.seen.append(ctx)
+        return Complete(TrueBoolLiteralSugar(site="capture"))
+
+
+class _GuardedBindingStatement(Sugar):
+    def __init__(self, guard, value):
+        self.guard = guard
+        self.value = value
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        return Complete(
+            GuardedFaces(
+                self.guard,
+                (),
+                then_exits=False,
+                else_exits=False,
+                guarded_bindings=((self.guard, "result", self.value),),
+            )
+        )
+
+
+def test_explicit_reduction_context_reaches_first_statement_unchanged() -> None:
+    explicit = ReduceContext.root(owner="explicit-context-twin")
+    seen: list[object] = []
+
+    reduce_block_to_exitset((_CaptureContext(seen),), explicit)
+
+    assert seen == [explicit]
+    assert seen[0] is explicit
+
+
+def test_none_entry_is_normalized_before_first_statement() -> None:
+    seen: list[object] = []
+
+    reduce_block_to_exitset((_CaptureContext(seen),), None)
+
+    assert len(seen) == 1
+    assert isinstance(seen[0], ReduceContext)
+
+
+def test_guarded_truthful_face_extends_normalized_scope_with_exact_value() -> None:
+    guard = atomic("guarded.return.truth", [])
+    occurrence = object()
+    state = object()
+    value = _OccurrenceStateValue(occurrence, state)
+    seen: list[object] = []
+
+    reduce_block_to_exitset(
+        (_GuardedBindingStatement(guard, value), _CaptureContext(seen)), None
+    )
+
+    assert len(seen) == 1
+    active = seen[0].temporal.activate_guard(guard)
+    retained = active.value_if_bound("result")
+    assert retained is value
+    assert retained.occurrence is occurrence
+    assert retained.state is state
+
+
+def test_guarded_lying_face_does_not_activate_truthful_scope() -> None:
+    guard = atomic("guarded.return.truth", [])
+    value = _OccurrenceStateValue(object(), object())
+    seen: list[object] = []
+
+    reduce_block_to_exitset(
+        (_GuardedBindingStatement(guard, value), _CaptureContext(seen)), None
+    )
+
+    lying = seen[0].temporal.activate_guard(not_(guard))
+    assert lying.value_if_bound("result") is None


### PR DESCRIPTION
## What changed

- Normalize `ctx=None` once at `reduce_block_to_exitset` entry using the real `ReduceContext.root` constructor.
- Preserve explicit contexts unchanged.
- Add truthful/lying guarded-scope teeth that retain exact value occurrence/state identity.

## Root cause

The reducer passed `None` into `GuardedFaces.extend_scope`, even though that typed floor correctly requires a real temporal reduction context. The fix belongs at the reducer entry, not in a consumer-side `GuardedFaces` workaround.

## Validation

`PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src python3 -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_guarded_return_reducer_context.py`

Result: 4 passed.

Broader pre-existing reds in native-operation and authenticated-exception lanes were observed but are outside this PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize reducer context for guarded returns in `reduce_block_to_exitset`
> - When `reduce_block_to_exitset` is called with `ctx=None`, it now initializes a `ReduceContext.root(owner="reduce_block_to_exitset")` before processing any statements, so all statement reductions receive a non-`None` context.
> - Adds tests verifying that an explicit context passes through unchanged, that `None` is normalized before the first statement, and that guarded binding scopes expose or withhold bound values correctly depending on which guard face is activated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dff3052.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->