### PR TITLE
Authenticate Lambda as a constructed term

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/lambda_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/lambda_sugar.py
@@ -5,18 +5,35 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
 
 
 @dataclass(frozen=True)
-class LambdaSugar(Sugar):
+class LambdaSugar(ConstructedTermSugar):
     """Plain positional formals plus one already-constructed body expression."""
 
     formals: tuple[str, ...]
     body: Sugar
     source_call_frame: object
+    formal_coordinate_cids: tuple[str, ...]
+    body_fragment_cid: str
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        frame = self.source_call_frame
+        if tuple(frame.parameters) != self.formals:
+            raise TypeError("LambdaSugar formals require their authenticated source frame")
+        if tuple(coordinate.cid for coordinate in frame.formal_coordinates) != (
+            self.formal_coordinate_cids
+        ):
+            raise TypeError(
+                "LambdaSugar formal coordinates require producer-authenticated testimony"
+            )
+        if frame.definition_fragment_cid != self.site.seal().cid:
+            raise TypeError("LambdaSugar source frame requires its exact lambda occurrence")
+        if self.body.site.seal().cid != self.body_fragment_cid:
+            raise TypeError("LambdaSugar body requires its exact source body testimony")
 
     @classmethod
     def witnesses(cls):
@@ -43,4 +60,41 @@ class LambdaSugar(Sugar):
                 construction_identity=construction_identity,
                 source_call_frame=self.source_call_frame,
             )
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, num, str_const
+
+        body_occurrence = self.body.site.seal()
+
+        return ctor(
+            "python:lambda-construction",
+            (
+                self.occurrence_term(owner=owner),
+                ctor(
+                    "python:lambda-formals",
+                    tuple(
+                        ctor(
+                            "python:lambda-formal",
+                            (str_const(name), str_const(coordinate_cid)),
+                            symbol_kind="coordinate",
+                        )
+                        for name, coordinate_cid in zip(
+                            self.formals, self.formal_coordinate_cids, strict=True
+                        )
+                    ),
+                ),
+                ctor(
+                    "python:lambda-body",
+                    (
+                        str_const(body_occurrence.source_cid),
+                        num(body_occurrence.start),
+                        num(body_occurrence.end),
+                        str_const(self.body_fragment_cid),
+                    ),
+                    symbol_kind="coordinate",
+                ),
+                str_const(self.source_call_frame.frame_cid),
+            ),
+            symbol_kind="coordinate",
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
@@ -20,6 +20,8 @@ laws below go green and direct-value twins stay isomorphic.
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import (
@@ -49,6 +51,7 @@ from sugar_source_tree.nodes import (
     Call,
     Compare,
     FunctionDef,
+    Lambda,
     Subscript,
 )
 from sugar_source_tree.panic import SugarNotWritten
@@ -534,6 +537,40 @@ def test_authenticated_lambda_return_flows_into_binop() -> None:
     )
 
     assert value == TermValue(6)
+
+
+def test_renamed_keyword_lambda_return_flows_into_binop() -> None:
+    tree, _, _ = _tree(
+        "def consume():\n"
+        "    return (lambda renamed: renamed + 1)(renamed=2) + 3\n\n"
+        "consume()\n",
+        bind=frozenset({"consume"}),
+    )
+    call = _calls_named(tree, "consume")[0]
+    value = call.sugar().desugar(None).value._dig_floor_or_none(
+        None, owner="renamed-keyword-lambda-return"
+    )
+
+    assert value == TermValue(6)
+
+
+def test_lambda_rejects_foreign_body_and_formal_coordinate_testimony() -> None:
+    tree, _, _ = _tree(
+        "def consume():\n"
+        "    left = lambda value: value + 1\n"
+        "    right = lambda renamed: renamed + 2\n"
+        "    return left(2) + right(2)\n",
+        bind=frozenset({"consume"}),
+    )
+    lambdas = tuple(node for node in tree.nodes() if isinstance(node, Lambda))
+    assert len(lambdas) == 2
+    left, right = tuple(node.substitute({}).sugar() for node in lambdas)
+
+    with pytest.raises(TypeError, match="exact source body testimony"):
+        replace(left, body=right.body)
+
+    with pytest.raises(TypeError, match="producer-authenticated testimony"):
+        replace(left, formal_coordinate_cids=right.formal_coordinate_cids)
 
 
 def test_unauthenticated_lambda_callee_stays_loud() -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -7879,10 +7879,15 @@ class Lambda(Expression):
 
         from sugar_lift_py_tests.sugar.lambda_sugar import LambdaSugar
 
+        frame = self.source_visible_call_frame()
         return LambdaSugar(
             formals=tuple(param.name for param in self.params),
             body=self.body.sugar(),
-            source_call_frame=self.source_visible_call_frame(),
+            source_call_frame=frame,
+            formal_coordinate_cids=tuple(
+                coordinate.cid for coordinate in frame.formal_coordinates
+            ),
+            body_fragment_cid=self.body.fragment.seal().cid,
             site=self.fragment,
         )
 

--- a/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_lambda_sugar.py
@@ -33,7 +33,7 @@ def _post_term(source: str):
 
 def test_lambda_identity_truthful_and_lying_terms_discriminate():
     truthful = _post_term("def A(v):\n    return (lambda x: x)(v)\n")
-    lying = _post_term("def A(v):\n    return (lambda x: x)(v + 1)\n")
+    lying = _post_term("def A(v, other):\n    return (lambda x: x)(other)\n")
 
     assert truthful.name == "py.call"
     assert truthful.args[0].name == "python:lambda"


### PR DESCRIPTION
Promotes `LambdaSugar` through the canonical `ConstructedTermSugar` door so computed source-return callers receive authenticated lambda construction testimony.

The producer now binds the exact lambda occurrence to its source call frame, formal-coordinate CIDs, and body occurrence CID. The canonical term carries those coordinates without spelling dispatch, fabricated CIDs, or a consumer exception. Truthful positional/renamed-keyword callers and foreign-body/formal-coordinate lying twins pin both arms.

Focused receipt on current main:
- `bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py -q -k "authenticated_lambda_return_flows_into_binop or renamed_keyword_lambda_return_flows_into_binop or lambda_rejects_foreign_body_and_formal_coordinate_testimony or lambda_inside_nested_function_composes_with_source_return_projection"` — 4 passed, 28 deselected
- `bin/bpytest implementations/python/sugar-source-tree/tests/test_lambda_sugar.py -q` — 26 passed
- `bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py -q` — 47 passed

The unrelated local loop-construction changes were excluded from this commit.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate LambdaSugar as a constructed term with formal and body CID verification
> - `LambdaSugar` now extends `ConstructedTermSugar` and validates formals, formal coordinate CIDs, body fragment CID, and source frame on construction, raising `TypeError` on any mismatch.
> - `Lambda._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/6758/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) passes `formal_coordinate_cids` and `body_fragment_cid` when building `LambdaSugar`.
> - `LambdaSugar.to_term()` returns a `'python:lambda-construction'` coordinate term including occurrence, authenticated formals, body coordinates, and the frame CID.
> - Tests verify that substituting a foreign body or formal coordinate CIDs raises `TypeError` with the expected messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 468a4a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->