### PR TITLE
Carry authenticated binder testimony through native producer

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -129,6 +129,9 @@ class CallSiteValue(FloorValue):
     bound_native_actuals_by_coordinate: dict[str, FloorValue] | None = dataclass_field(
         default=None, compare=False
     )
+    bound_native_source_actuals: object | None = dataclass_field(
+        default=None, compare=False
+    )
 
     def denotes_value(self) -> bool:
         """A call result denotes a Python runtime value."""
@@ -1300,7 +1303,15 @@ class CallSiteValue(FloorValue):
             return Complete(self)
         from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
         if isinstance(outcome, NativeOperationExitCarrierV1):
-            actuals = self.bound_native_actuals_by_coordinate
+            source_actuals = self.bound_native_source_actuals
+            actuals = (
+                None
+                if source_actuals is None
+                else {
+                    pair.coordinate.coordinate_cid: pair.actual
+                    for pair in source_actuals.pairs
+                }
+            )
             if actuals is None:
                 return outcome
             outcome = outcome.discharge(actuals)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -84,6 +84,11 @@ class BoundNativeOperationActualsV1:
 
     actuals: tuple
     by_formal_coordinate: dict[str, object]
+    source_actuals: BoundSourceCallActualsV1
+
+    def __post_init__(self) -> None:
+        if self.source_actuals.actuals != self.actuals:
+            raise SourceCallBindingGap("native actual testimony values diverge")
 
 
 @dataclass(frozen=True)
@@ -366,6 +371,7 @@ class SourceVisibleCallFrameV1:
         return BoundNativeOperationActualsV1(
             actuals=bound.actuals,
             by_formal_coordinate=bound.by_native_formal_coordinate,
+            source_actuals=bound,
         )
 
     def with_native_operation_projection(self, formal_coordinates, pending):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -343,6 +343,11 @@ class CallSiteSugar(ConstructedTermSugar):
                 if native_operation_actuals is None
                 else native_operation_actuals.by_formal_coordinate
             ),
+            bound_native_source_actuals=(
+                None
+                if native_operation_actuals is None
+                else native_operation_actuals.source_actuals
+            ),
         )
         if native_operation_actuals is not None:
             pending = self.source_call_frame.pending_native_operation.discharge(


### PR DESCRIPTION
First binder-testimony cut: BoundNativeOperationActualsV1 carries the exact BoundSourceCallActualsV1 minted by the sole bind_actuals invocation. Focused binder tests pass; nested propagation remains a follow-on.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Carry authenticated binder testimony through native producer for discharge keyed by source coordinate CIDs
> - Adds a `bound_native_source_actuals` field to `CallSiteValue` and propagates it from `BoundNativeOperationActualsV1` through `CallSiteSugar.producer_outcome`.
> - `BoundNativeOperationActualsV1` now stores `source_actuals` and validates on construction that native actuals match source-actuals testimony, raising `SourceCallBindingGap` on divergence.
> - `CallSiteValue.project_operation_receiver` now builds the discharge dict from source actual pairs keyed by `coordinate_cid` instead of `bound_native_actuals_by_coordinate`; if no source actuals are present, the carrier is returned undischarged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c53e8a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->