### PR TITLE
Propagate bound testimony through nested source returns

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -132,6 +132,7 @@ class CallSiteValue(FloorValue):
     bound_native_source_actuals: object | None = dataclass_field(
         default=None, compare=False
     )
+    bound_source_actuals: object | None = dataclass_field(default=None, compare=False)
 
     def denotes_value(self) -> bool:
         """A call result denotes a Python runtime value."""
@@ -1135,6 +1136,16 @@ class CallSiteValue(FloorValue):
             outcome = _reduce_callsite_body(body, reduce_ctx, blame=self.target_name)
         finally:
             _ACTIVE_DIG_DEMAND.reset(token)
+        from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+        if isinstance(outcome, NativeOperationExitCarrierV1):
+            source_actuals = self.bound_source_actuals or self.bound_native_source_actuals
+            if source_actuals is not None:
+                outcome = outcome.discharge(
+                    {
+                        pair.coordinate.coordinate_cid: pair.actual
+                        for pair in source_actuals.pairs
+                    }
+                )
         # ConstructionPanic is BaseException and process-terminal: dig must not convert
         # it into opacity/None (python-sole-construction; #5238).
         if isinstance(outcome, Incomplete):
@@ -1303,7 +1314,7 @@ class CallSiteValue(FloorValue):
             return Complete(self)
         from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
         if isinstance(outcome, NativeOperationExitCarrierV1):
-            source_actuals = self.bound_native_source_actuals
+            source_actuals = self.bound_source_actuals or self.bound_native_source_actuals
             actuals = (
                 None
                 if source_actuals is None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -221,6 +221,7 @@ class CallSiteSugar(ConstructedTermSugar):
         source_body = None
         source_frame_cid = None
         native_operation_actuals = None
+        bound_source_actuals = None
         if self.source_call_frame is not None:
             from sugar_lift_py_tests.source_call_frame import SourceVisibleCallFrameV1
             from sugar_source_tree.panic import SugarNotWritten
@@ -348,6 +349,7 @@ class CallSiteSugar(ConstructedTermSugar):
                 if native_operation_actuals is None
                 else native_operation_actuals.source_actuals
             ),
+            bound_source_actuals=bound_source_actuals,
         )
         if native_operation_actuals is not None:
             pending = self.source_call_frame.pending_native_operation.discharge(


### PR DESCRIPTION
Consumes BoundSourceCallActualsV1 at the generic source-return producer and dig path. Nested truthful red remains explicit pending further frame propagation; no second bind or coordinate reconstruction.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate bound source actuals through nested source returns in `CallSiteValue`
> - Adds a `bound_source_actuals` field to `CallSiteValue` (default `None`) to carry source-bound actuals alongside native-bound actuals.
> - `project_operation_receiver` and `project_producer_outcome` now discharge `NativeOperationExitCarrierV1` using `bound_source_actuals` when present, falling back to `bound_native_source_actuals`.
> - `CallSiteSugar.desugar` initializes and passes `bound_source_actuals` into the `CallSiteValue` constructor so it is available downstream.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2513fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->