### PR TITLE
Use closed native testimony map for nested carrier discharge

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -1138,14 +1138,9 @@ class CallSiteValue(FloorValue):
             _ACTIVE_DIG_DEMAND.reset(token)
         from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
         if isinstance(outcome, NativeOperationExitCarrierV1):
-            source_actuals = self.bound_source_actuals or self.bound_native_source_actuals
-            if source_actuals is not None:
-                outcome = outcome.discharge(
-                    {
-                        pair.coordinate.coordinate_cid: pair.actual
-                        for pair in source_actuals.pairs
-                    }
-                )
+            actuals = self.bound_native_actuals_by_coordinate
+            if actuals is not None:
+                outcome = outcome.discharge(actuals)
         # ConstructionPanic is BaseException and process-terminal: dig must not convert
         # it into opacity/None (python-sole-construction; #5238).
         if isinstance(outcome, Incomplete):
@@ -1314,15 +1309,7 @@ class CallSiteValue(FloorValue):
             return Complete(self)
         from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
         if isinstance(outcome, NativeOperationExitCarrierV1):
-            source_actuals = self.bound_source_actuals or self.bound_native_source_actuals
-            actuals = (
-                None
-                if source_actuals is None
-                else {
-                    pair.coordinate.coordinate_cid: pair.actual
-                    for pair in source_actuals.pairs
-                }
-            )
+            actuals = self.bound_native_actuals_by_coordinate
             if actuals is None:
                 return outcome
             outcome = outcome.discharge(actuals)


### PR DESCRIPTION
Fixes the invalid BindingCoordinateV1.coordinate_cid access by consuming only the binder-owned native formal-coordinate map. Missing testimony remains pending; no zip or second bind.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `bound_native_actuals_by_coordinate` directly for nested carrier discharge in `CallSiteValue`
> When handling `NativeOperationExitCarrierV1` during callsite reduction in [`call_site_value.py`](https://github.com/TSavo/sugar/pull/6761/files#diff-8c40ae10c3e0722cf284a5e0bb43d2d29524ce10b6eb590893ccfcab4785689a), discharge actuals are now taken from `self.bound_native_actuals_by_coordinate` instead of being derived from `bound_source_actuals` or `bound_native_source_actuals`. Both affected code paths are updated: the first skips discharge when the mapping is `None`, and the second returns the outcome unchanged instead of falling back to source-derived actuals.
>
> - Behavioral Change: source-derived actuals are no longer consulted during discharge, which can change whether and how the carrier is discharged when `bound_native_actuals_by_coordinate` is `None`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 163ea14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->