### PR TITLE
Own immutable slice delete TypeErrors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
@@ -71,6 +71,15 @@ class BytesValue(FloorValue):
             exception_name="TypeError", site=site, owner="BytesValue.setitem"
         )
 
+    def delitem(self, index, site):
+        """Bytes are immutable: every subscript delete is exact TypeError."""
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="BytesValue.delitem"
+        )
+
     def to_term(self, *, owner: str):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -310,6 +310,15 @@ class StringValue(GuardStableValue):
             exception_name="TypeError", site=site, owner="StringValue.setitem"
         )
 
+    def delitem(self, index, site):
+        """Strings are immutable: every subscript delete is exact TypeError."""
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="StringValue.delitem"
+        )
+
     def add(self, other, site):
         # A string's addition IS concatenation: two strings fold to their join.
         # Anything else falls to the honest addition-floor gap.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -373,6 +373,15 @@ class TupleValue(FloorValue):
             exception_name="TypeError", site=site, owner="TupleValue.setitem"
         )
 
+    def delitem(self, index, site):
+        """Tuples are immutable: every subscript delete is exact TypeError."""
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="TupleValue.delitem"
+        )
+
     def setattr(self, name, value, site):
         """Tuples have no ``__dict__``; attribute store is AttributeError."""
         del name, value

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py
@@ -51,13 +51,16 @@ from sugar_lift_py_tests.caller_parameter_contract import (
 )
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import (
+    BytesValue,
     DictValue,
     ListValue,
     ObjectField,
     ObjectMethodValue,
     ObjectValue,
+    SliceValue,
     StringValue,
     TermValue,
+    TupleValue,
 )
 from sugar_lift_py_tests.floor.block_value import BlockValue
 from sugar_lift_py_tests.floor.return_value import ReturnValue
@@ -649,6 +652,58 @@ def _floor_site():
     """Genuine fragment locus for Floor delitem (not a string blame)."""
     function, _ = _delitem_helper()
     return function.body[0].fragment
+
+
+@dataclass(frozen=True)
+class _FloorSugar(Sugar):
+    value: object
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+@pytest.mark.parametrize(
+    ("receiver", "owner"),
+    (
+        (StringValue("abc"), "StringValue.delitem"),
+        (BytesValue(b"abc"), "BytesValue.delitem"),
+        (TupleValue((TermValue(1),)), "TupleValue.delitem"),
+    ),
+)
+def test_immutable_slice_delete_has_exact_typeerror_occurrence(receiver, owner):
+    site = _floor_site()
+    outcome = SubscriptDeleteEffectSugar(
+        _FloorSugar(receiver),
+        _FloorSugar(SliceValue(TermValue(0), TermValue(1), None)),
+        site,
+    ).desugar(None)
+    assert type(outcome).__name__ == "Incomplete"
+    assert outcome.effect.exception_name == "TypeError"
+    assert outcome.effect.producer_node_owner == owner
+    assert outcome.effect.occurrence_id == str(site)
+
+
+@pytest.mark.parametrize(
+    "receiver",
+    (
+        StringValue("abc"),
+        BytesValue(b"abc"),
+        TupleValue((TermValue(1),)),
+    ),
+)
+def test_immutable_slice_delete_cannot_fabricate_mutated_receiver(receiver):
+    site = _floor_site()
+    outcome = SubscriptDeleteEffectSugar(
+        _FloorSugar(receiver),
+        _FloorSugar(SliceValue(TermValue(0), TermValue(1), None)),
+        site,
+    ).desugar(None)
+    assert not isinstance(outcome, Complete)
 
 
 def test_floor_list_delitem_completes_with_element_gone() -> None:


### PR DESCRIPTION
## Summary

Close the immutable slice-delete Floor owner family. StringValue, BytesValue, and TupleValue now produce exact ground TypeError exits with owner-specific producer identity and the original occurrence. Truthful/lying production twins reject fabricated completion.

## Authenticated red/green

Byte-identical probe SHA-256: 86c6342402164c2880b245270ab5262f37cea6c4289b1273279b49ebfabc4efd.

- Base 6dfd313e26378f76511165b81a5d804863bb8a27, cwd and every imported module rooted in /tmp/agy2-delete-auth-base.FQpPVY: collected 6, 6 failed, exit 1.
- Head a654bb1c0b9d8d6d12fd879375728a9711142c2b, cwd and every imported module rooted in /tmp/agy2-delete-auth-head.96uIAM: collected 6, 6 passed, exit 0.
- Rebased head 53df6a4b549539b6c5e778a006deca43144f24db: 6 passed, 27 deselected in 4.83s, exit 0.

## Delta-epsilon

- R_immutable_slice_delete_missing_floor_owner: 3 -> 0; Delta R = -3; Epsilon R = -3.
- carrier/ExitSet/outcome edits: 0.
- spelling/vendor/species probes: 0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `delitem` TypeError handling to immutable slice types `BytesValue`, `StringValue`, and `TupleValue`
> - Adds `delitem` methods to `BytesValue`, `StringValue`, and `TupleValue` that return a `ground_exceptional_exit` with `exception_name='TypeError'`, matching Python's runtime behavior for deletion on immutable sequences.
> - Adds parametrized tests verifying that slice deletion on these types produces an `Incomplete` outcome with a `TypeError` (correct owner and `occurrence_id`) and never produces a `Complete` outcome.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53df6a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->