### PR TITLE
Authenticate while recurrence test state

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
@@ -621,7 +621,11 @@ def decode_loop_construction_v1(graph: Any) -> LoopConstructionV1:
         record(operation.raw["binderTransformCid"], "loop-binder-transform")
         record(operation.raw["iteratorTestimonyCid"], "loop-iterator-testimony")
     else:
-        record(operation.raw["testTransformCid"], "loop-test-transform")
+        initial_test = record(
+            operation.raw["testTransformCid"], "loop-test-transform"
+        )
+        if initial_test.raw["inputStateCid"] != pre_state.state_cid:
+            raise LoopWireError("initial test input state mismatch")
 
     completed = []
     completed_by_cid = {}
@@ -644,7 +648,12 @@ def decode_loop_construction_v1(graph: Any) -> LoopConstructionV1:
         input_face = completed_by_cid.get(latch.raw["inputCompletedFaceCid"])
         if input_face is None or input_face.completion_kind != "BodyFallthrough":
             raise LoopWireError("latch input must be BodyFallthrough")
-        record(latch.raw["successorTransformCid"])
+        successor = record(latch.raw["successorTransformCid"])
+        if latch.raw["operationKind"] == "WhileTest":
+            if successor.kind != "loop-test-transform":
+                raise LoopWireError("while latch successor must be loop-test-transform")
+            if successor.raw["inputStateCid"] != latch.raw["inputStateCid"]:
+                raise LoopWireError("recurrence test input state mismatch")
 
     for cid in root["continueLatchObligationCids"]:
         latch = record(cid, "loop-continue-latch-obligation")

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -426,31 +426,37 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
         successor_cid = binder["binderTransformCid"]
         records.extend((binder, iterator, operation))
     else:
-        test_transform = _record(
-            {
-                "kind": "loop-test-transform",
-                "schemaVersion": "1",
-                "targetCid": target_cid,
-                "inputStateCid": pre_state["stateCid"],
-                "testValueConstructionCid": loop.test.fragment.seal().cid,
-                "trueGuardFormulaCid": _formula_cid(true_guard),
-                "falseGuardFormulaCid": _formula_cid(exhaustion_guard),
-                "haltedFaceCids": [],
-            },
-            "testTransformCid",
-        )
+        def while_test_transform(input_state_cid):
+            return _record(
+                {
+                    "kind": "loop-test-transform",
+                    "schemaVersion": "1",
+                    "targetCid": target_cid,
+                    "inputStateCid": input_state_cid,
+                    "testValueConstructionCid": loop.test.fragment.seal().cid,
+                    "trueGuardFormulaCid": _formula_cid(true_guard),
+                    "falseGuardFormulaCid": _formula_cid(exhaustion_guard),
+                    "haltedFaceCids": [],
+                },
+                "testTransformCid",
+            )
+
+        initial_test_transform = while_test_transform(pre_state["stateCid"])
+        recurrence_test_transform = while_test_transform(body_face["stateCid"])
         operation = _record(
             {
                 "kind": "while-operation",
                 "schemaVersion": "1",
                 "targetCid": target_cid,
                 "nativeLoopTermCid": cid_of_json({"native": "python:while"}),
-                "testTransformCid": test_transform["testTransformCid"],
+                "testTransformCid": initial_test_transform["testTransformCid"],
             },
             "operationCid",
         )
-        successor_cid = test_transform["testTransformCid"]
-        records.extend((test_transform, operation))
+        successor_cid = recurrence_test_transform["testTransformCid"]
+        records.extend(
+            (initial_test_transform, recurrence_test_transform, operation)
+        )
 
     body = _record(
         {

--- a/implementations/python/sugar-source-tree/tests/test_while_temporal_recurrence.py
+++ b/implementations/python/sugar-source-tree/tests/test_while_temporal_recurrence.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 
+import pytest
+
+from sugar_lift_py_tests.loop_construction import (
+    LoopWireError,
+    decode_loop_construction_v1,
+    seal_loop_record,
+)
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.nodes import While
 from sugar_source_tree.tree import SourceFile
@@ -37,15 +45,89 @@ def test_body_state_is_the_next_condition_input_not_the_stale_initial_state(
         if type(statement).__name__ == "LoopRecurrenceSugar"
     )
     graph = loop.construction.wire_graph()
-    test_transform = _record(graph, "loop-test-transform")
+    test_transforms = tuple(
+        record for record in graph["records"] if record["kind"] == "loop-test-transform"
+    )
+    operation = graph["root"]["operation"]
     latch = _record(graph, "loop-latch-obligation")
+    initial = next(
+        transform
+        for transform in test_transforms
+        if transform["testTransformCid"] == operation["testTransformCid"]
+    )
+    recurrence = next(
+        transform
+        for transform in test_transforms
+        if transform["testTransformCid"] == latch["successorTransformCid"]
+    )
 
-    assert test_transform["testValueConstructionCid"] == (
+    assert len(test_transforms) == 2
+    assert initial["testValueConstructionCid"] == (
         while_node.test.fragment.seal().cid
     )
-    assert latch["successorTransformCid"] == test_transform["testTransformCid"]
+    assert recurrence["testValueConstructionCid"] == initial["testValueConstructionCid"]
+    assert initial["inputStateCid"] == graph["root"]["preStateCid"]
     assert latch["inputStateCid"] != graph["root"]["preStateCid"]
-    assert test_transform["inputStateCid"] == latch["inputStateCid"], (
+    assert recurrence["inputStateCid"] == latch["inputStateCid"], (
         "the reached next condition must consume the body-completed state; "
         "reusing preStateCid is the stale-initial-state lying twin"
     )
+
+
+def test_swapping_only_recurrence_test_back_to_pre_state_is_refused(tmp_path: Path):
+    """Lying coordinate twin: a sealed stale-state transform is still invalid."""
+    function = _function(
+        tmp_path,
+        "def renamed(bound):\n"
+        "    value = 0\n"
+        "    while value < bound:\n"
+        "        value = value + 1\n"
+        "    return value\n",
+    )
+    loop = next(
+        statement
+        for statement in function.sugar().statements
+        if type(statement).__name__ == "LoopRecurrenceSugar"
+    )
+    graph = loop.construction.wire_graph()
+    tampered = deepcopy(graph)
+    latch = _record(tampered, "loop-latch-obligation")
+    recurrence = next(
+        record
+        for record in tampered["records"]
+        if record.get("testTransformCid") == latch["successorTransformCid"]
+    )
+
+    old_transform_cid = recurrence["testTransformCid"]
+    transform_preimage = {
+        key: value for key, value in recurrence.items() if key != "testTransformCid"
+    }
+    transform_preimage["inputStateCid"] = tampered["root"]["preStateCid"]
+    replacement = seal_loop_record(transform_preimage, "testTransformCid")
+    recurrence.clear()
+    recurrence.update(replacement)
+
+    old_latch_cid = latch["latchObligationCid"]
+    latch_preimage = {
+        key: value for key, value in latch.items() if key != "latchObligationCid"
+    }
+    latch_preimage["successorTransformCid"] = replacement["testTransformCid"]
+    replacement_latch = seal_loop_record(latch_preimage, "latchObligationCid")
+    latch.clear()
+    latch.update(replacement_latch)
+    tampered["root"]["latchObligationCids"] = [
+        replacement_latch["latchObligationCid"]
+        if cid == old_latch_cid
+        else cid
+        for cid in tampered["root"]["latchObligationCids"]
+    ]
+    assert old_transform_cid != replacement["testTransformCid"]
+    root_preimage = {
+        key: value
+        for key, value in tampered["root"].items()
+        if key != "loopConstructionCid"
+    }
+    tampered["root"] = seal_loop_record(root_preimage, "loopConstructionCid")
+
+    with pytest.raises(LoopWireError, match="duplicate loop graph CID"):
+        decode_loop_construction_v1(tampered)


### PR DESCRIPTION
Producer-only repair for the merged #6742 temporal recurrence instrument.

R / delta:
- R_while_reentry_state: 1 -> 0, Delta=-1
- focused loop construction floor: 25 passed

Law:
- the initial while-test transform consumes root.preStateCid
- a distinct recurrence while-test transform consumes the authenticated BodyFallthrough state
- while-operation points only to the initial transform
- body and continue latches point to the recurrence transform
- decoder authenticates initial/pre and recurrence/latch state relationships

Truthful/lying twins:
- truthful graph proves two distinct transforms over the exact test occurrence
- resealing only the recurrence transform with preStateCid collapses to the initial transform CID and is refused as a duplicate authenticated record

Floors: producer wire graph only; no carrier or ExitSet changes, no reconstruction, spelling dispatch, or silent gaps.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate recurrence test state in while-loop wire graphs
> - While-loop graphs now produce two `loop-test-transform` records: one consuming the pre-state (initial test) and one consuming the body-completed state (recurrence test). The while-operation references the initial test; the latch successor references the recurrence test.
> - `decode_loop_construction_v1` in [loop_construction.py](https://github.com/TSavo/sugar/pull/6763/files#diff-82ae08e844ec0a3ad333125f7e4a0609af140be5e2413837fe63ad5a63de3bbc) now validates that the initial test's `inputStateCid` matches `pre_state.state_cid`, and that each `WhileTest` latch's successor is a `loop-test-transform` whose `inputStateCid` matches the latch's `inputStateCid`.
> - A new test asserts that substituting the recurrence test transform with one that points back to the pre-state CID is rejected with a `LoopWireError`.
> - Behavioral Change: graphs that previously passed decoding may now be rejected if their test transforms reference incorrect input state CIDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25568aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->