### PR TITLE
Preserve loop-control pre-exit state identity

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_control_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_control_sugar.py
@@ -19,7 +19,7 @@ class LoopControlSugar(Sugar):
         return ()
 
     def desugar(self, ctx: object = None):
-        del ctx
         return ExitSet.halted(
-            LoopControlEffect(self.action, self.target_cid, self.occurrence_cid)
+            LoopControlEffect(self.action, self.target_cid, self.occurrence_cid),
+            state=ctx,
         )

--- a/implementations/python/sugar-source-tree/tests/test_loop_control_pre_exit_state.py
+++ b/implementations/python/sugar-source-tree/tests/test_loop_control_pre_exit_state.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.effect import LoopControlEffect
+from sugar_lift_py_tests.outcome import Halted
+from sugar_source_tree.tree import SourceFile
+
+
+SOURCE = (
+    "def helper(values):\n"
+    "    for value in values:\n"
+    "        if value:\n"
+    "            continue\n"
+    "        break\n"
+)
+
+
+def _controls():
+    function = next(
+        SourceFile(
+            (
+                SOURCE,
+                "tests/loop_control_pre_exit_state.py",
+                blake3_512_of(SOURCE.encode()),
+            )
+        ).functions()
+    )
+    return tuple(
+        node for node in function.walk() if node.kind in {"Break", "Continue"}
+    )
+
+
+@pytest.mark.parametrize("action", ("break", "continue"))
+def test_loop_control_preserves_exact_authenticated_pre_exit_state(action: str) -> None:
+    node = next(node for node in _controls() if node.kind.lower() == action)
+    pre_exit_state = object()
+    foreign_state = object()
+
+    exit_ = node.sugar().desugar(pre_exit_state).exits[0]
+
+    assert isinstance(exit_, Halted)
+    assert isinstance(exit_.effect, LoopControlEffect)
+    assert exit_.effect.action == action
+    assert exit_.effect.occurrence_cid == node.fragment.seal().cid
+    assert exit_.state is pre_exit_state
+    assert exit_.state is not foreign_state
+
+
+@pytest.mark.parametrize("action", ("break", "continue"))
+def test_loop_control_absent_and_foreign_state_twins_do_not_authenticate(
+    action: str,
+) -> None:
+    node = next(node for node in _controls() if node.kind.lower() == action)
+    truthful_state = object()
+    foreign_state = object()
+
+    absent = node.sugar().desugar().exits[0]
+    foreign = node.sugar().desugar(foreign_state).exits[0]
+
+    assert absent.effect.occurrence_cid == node.fragment.seal().cid
+    assert absent.state is not truthful_state
+    assert foreign.effect.occurrence_cid == node.fragment.seal().cid
+    assert foreign.state is foreign_state
+    assert foreign.state is not truthful_state


### PR DESCRIPTION
## Producer repair

`LoopControlSugar.desugar(ctx)` now carries the exact received context into its owned `ExitSet.halted` face. Break and continue retain their authenticated occurrence CIDs and preserve state by object identity; absent and foreign-state twins discriminate. No recurrence consumer, carrier, ExitSet algebra, or reducer changed.

## Focused receipts

- `bin/bpytest implementations/python/sugar-source-tree/tests/test_loop_control_pre_exit_state.py -q` — red 4 failed (`state=None`), green 4 passed
- `bin/bpytest implementations/python/sugar-source-tree/tests/test_loop_control_construction.py implementations/python/sugar-source-tree/tests/test_loop_control_pre_exit_state.py -q` — 17 passed
- `bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_loop_construction_acceptance_fixture.py implementations/python/sugar-lift-py-tests/tests/test_loop_construction_wire.py -q` — 23 passed

## Honest downstream red / owner handoff

The open #6750 integration advances past `loop control omitted its exact pre-exit state`, receives the preserved `ReduceContext`, then its recurrence consumer raises `AttributeError: ReduceContext object has no attribute entries` at `loop_recurrence_sugar.py:277`. That consumer is explicitly out of this PR scope and remains unchanged.

Unrelated #6750 worktree changes were excluded from this commit.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve loop-control pre-exit state identity in `LoopControlSugar.desugar`
> - Passes the caller-provided `ctx` as `state=ctx` to `ExitSet.halted` in [`loop_control_sugar.py`](https://github.com/TSavo/sugar/pull/6764/files#diff-f359f8cbc5d452bc7af109f8cad1a388d5f82f165e7d8906923c509175a6d1e1), so the resulting `Halted` exit carries the exact state object through.
> - Adds tests in [`test_loop_control_pre_exit_state.py`](https://github.com/TSavo/sugar/pull/6764/files#diff-3e23a82797cc8e57d73a74d52c94e6f64ae3010448c25fe0dbf4b40421060e5e) verifying that `exit.state` is the same object as the provided `pre_exit_state` for both `break` and `continue`, and that absent or foreign states are handled without conflation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a72a3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->