### PR TITLE
Require coordinate testimony in bound actual equality

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -131,8 +131,6 @@ class BoundSourceCallActualsV1(Sequence):
                 and self.formal_coordinates == other.formal_coordinates
                 and self.native_formal_coordinates == other.native_formal_coordinates
             )
-        if isinstance(other, tuple):
-            return self.actuals == other
         return NotImplemented
 
     @property

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py
@@ -209,7 +209,7 @@ def test_bind_actuals_packs_star_without_self_name_shift() -> None:
         (ListValue((TermValue(0),)), TermValue(1), TermValue(2), TermValue(3)),
         (),
     )
-    assert bound == (
+    assert bound.actuals == (
         ListValue((TermValue(0),)),
         TupleValue((TermValue(1), TermValue(2), TermValue(3))),
     )
@@ -230,7 +230,7 @@ def test_bind_actuals_packs_kw_without_self_name_shift() -> None:
         (ListValue((TermValue(0),)),),
         (("a", TermValue(1)), ("b", TermValue(2))),
     )
-    assert bound == (
+    assert bound.actuals == (
         ListValue((TermValue(0),)),
         DictValue(
             (

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
@@ -46,6 +46,27 @@ def test_binder_returns_ordered_typed_coordinate_testimony() -> None:
     )
 
 
+def test_bound_actuals_equality_requires_authenticated_coordinate_testimony() -> None:
+    """Equal values cannot erase their source-coordinate authority."""
+    frame = _frame()
+    foreign = _frame(name="other", filename="foreign_equality.py")
+    values = (TermValue(1), TermValue(2))
+    truthful = BoundSourceCallActualsV1(
+        values,
+        frame.formal_coordinates,
+        frame.native_operation_formal_coordinates,
+    )
+    lying = BoundSourceCallActualsV1(
+        values,
+        foreign.formal_coordinates,
+        foreign.native_operation_formal_coordinates,
+    )
+
+    assert truthful != lying
+    assert truthful != values
+    assert values != truthful
+
+
 @pytest.mark.parametrize("variant", ("missing", "duplicate", "reordered", "foreign"))
 def test_binder_refuses_corrupt_formal_coordinate_roster(variant: str) -> None:
     frame = _frame()


### PR DESCRIPTION
Closes the tuple-compatible equality side door on BoundSourceCallActualsV1. Equal actual values compare equal only when authenticated formal and native-coordinate testimony also agrees; raw tuples cannot masquerade as a bound result. Migrates the two stale variadic assertions to inspect .actuals explicitly. No binder behavior change.\n\nInstrument: test_bound_actuals_equality_requires_authenticated_coordinate_testimony failed before and passes after.\n\nFocused receipt: bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py => 27 passed in 0.99s.\n\nR(tuple-compatible authenticated equality side doors): 1 -> 0; Delta=-1. Floors: no spelling/vendor dispatch, reconstruction, carrier/ExitSet, or binder behavior changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require coordinate testimony in `BoundSourceCallActualsV1` equality checks
> - `BoundSourceCallActualsV1.__eq__` now requires the other object to also be a `BoundSourceCallActualsV1` with matching `formal_coordinates` and `native_formal_coordinates`, not just equal actuals.
> - Removes the special-case branch that allowed equality comparisons against raw tuples; all non-`BoundSourceCallActualsV1` comparisons now return `NotImplemented`.
> - Affected tests in [test_setattr_named_variadic_binding.py](https://github.com/TSavo/sugar/pull/6765/files#diff-99b4f8c62f136b148902c329f870f7e0f1350e03231f1511250ee1cc7c9542fe) are updated to compare `.actuals` directly instead of comparing the wrapper instance to a tuple.
> - Behavioral Change: code that previously relied on `bound == (val1, val2)` tuple equality will now evaluate as not equal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0486dca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->