### PR TITLE
Own immutable attribute store errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
@@ -80,6 +80,14 @@ class BytesValue(FloorValue):
             exception_name="TypeError", site=site, owner="BytesValue.delitem"
         )
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="BytesValue.setattr"
+        )
+
     def to_term(self, *, owner: str):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -319,6 +319,14 @@ class StringValue(GuardStableValue):
             exception_name="TypeError", site=site, owner="StringValue.delitem"
         )
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="StringValue.setattr"
+        )
+
     def add(self, other, site):
         # A string's addition IS concatenation: two strings fold to their join.
         # Anything else falls to the honest addition-floor gap.

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
@@ -41,6 +41,7 @@ from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCar
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.effect import AttributeStoreRuntimeEffect
 from sugar_lift_py_tests.floor import (
+    BytesValue,
     FloorValue,
     ListValue,
     NoneValue,
@@ -215,6 +216,29 @@ def test_readable_immutable_receiver_raises_on_store(tmp_path):
     assert isinstance(outcome, Incomplete)
     assert outcome.effect.exception_name == "AttributeError"
     assert outcome.effect.producer_node_owner == "TupleValue.setattr"
+
+
+@pytest.mark.parametrize(
+    ("receiver", "owner"),
+    ((StringValue("abc"), "StringValue.setattr"), (BytesValue(b"abc"), "BytesValue.setattr")),
+)
+def test_immutable_scalar_attribute_store_has_exact_owner_occurrence(
+    tmp_path, receiver, owner
+):
+    site = _site(tmp_path)
+    outcome = _store(receiver, TermValue(7), [], site).desugar()
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect.exception_name == "AttributeError"
+    assert outcome.effect.producer_node_owner == owner
+    assert outcome.effect.occurrence_id == str(site)
+
+
+@pytest.mark.parametrize("receiver", (StringValue("abc"), BytesValue(b"abc")))
+def test_immutable_scalar_attribute_store_cannot_fabricate_completion(
+    tmp_path, receiver
+):
+    outcome = _store(receiver, TermValue(7), [], _site(tmp_path)).desugar()
+    assert not isinstance(outcome, Complete)
 
 
 def test_none_setattr_is_attribute_error_on_store_path(tmp_path):


### PR DESCRIPTION
## Instrument

Immutable attribute-store Floor ownership for `StringValue` and `BytesValue`, with truthful exact-owner/occurrence and no-fabricated-completion twins.

## Authenticated isolated receipt

Byte-identical probe invocation used a real `SourceFragment` minted from the same `def f(obj, value): obj.attr = value` specimen/locus, with cwd and PYTHONPATH rooted exclusively in each isolated checkout; the invocation printed `sys.executable` and the imported `string_value.py`, `bytes_value.py`, and `store_effect_sugar.py` module paths.

- base `98d4d57bb6dbc8001574eaf3248bd8f3a09e410a`: `PROBE_EXIT=1`, `AUTH_CASES=4 OWNED=0 GAPS=2`
- pre-rebase head `5b3515bff24d0b625afe255caf3b5ffe183cfb7f`: `PROBE_EXIT=0`, `AUTH_CASES=4 OWNED=4 GAPS=0`
- rebased published head: `62b1ee1ba9850dcdb53b392905b9339c5a57959a`

Measured `R_immutable_attribute_store_missing_floor_owner: 2 -> 0`; `Delta=-2`.

## Floors

- exact three-file scope
- carrier/ExitSet/outcome drift: `0`
- no spelling or vendor dispatch arms

## Focused post-rebase receipt

`4 passed, 17 deselected in 5.25s`; literal `EXIT=0`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Own immutable attribute store errors in `BytesValue` and `StringValue`
> Adds `setattr` methods to `BytesValue` and `StringValue` that return an `AttributeError` via `ground_exceptional_exit`, with the owner set to the respective class's `setattr`. New tests verify that the error has the correct `producer_node_owner` and `occurrence_id`, and that no `Complete` outcome is produced.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62b1ee1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->