### PR TITLE
Resolve authenticated nested function calls lexically

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -491,6 +491,23 @@ class SourceUnit:
                 containing.append(candidate)
         if containing:
             owner = max(containing, key=lambda item: item.line_col_span().start_line)
+            nested = tuple(
+                member
+                for member in owner.body
+                if isinstance(member, (FunctionDef, AsyncFunctionDef))
+                and member.name == call.func.id
+                and member.unit.source_cid == call.unit.source_cid
+            )
+            if len(nested) == 1:
+                definition = nested[0]
+                definition_span = definition.line_col_span()
+                if (
+                    definition_span.start_line <= span.start_line
+                    and span.start_line <= owner.line_col_span().end_line
+                    and (definition_span.start_line, definition_span.start_col)
+                    < (span.start_line, span.start_col)
+                ):
+                    return definition
             table = self.function_symtable(owner.name, owner.line_col_span().start_line)
             try:
                 symbol = table.lookup(call.func.id)


### PR DESCRIPTION
Adds exact lexical nested FunctionDef resolution using source identity and declaration/call loci. Existing enrollment/binder/CallSiteValue doors unchanged; residual nested carrier remains explicit.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve authenticated nested function calls lexically in `SourceUnit`
> When resolving a function call target inside a function body, the resolver in [nodes.py](https://github.com/TSavo/sugar/pull/6767/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now first scans the owning function's body for a nested `FunctionDef` or `AsyncFunctionDef` whose name and source CID match the call. If exactly one such definition exists and appears before the call within the owner's span, it is returned immediately without consulting the symbol table. This fixes cases where authenticated nested function definitions were not correctly resolved lexically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6064d58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->