### PR TITLE
Require explicit bound actual projection

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field, replace
 from sugar_lift_python_source.canonical import cid_of_json
 from sugar_source_tree.binding_provenance import BindingCoordinateV1
@@ -98,7 +97,7 @@ class BoundFormalActualV1:
 
 
 @dataclass(frozen=True, eq=False)
-class BoundSourceCallActualsV1(Sequence):
+class BoundSourceCallActualsV1:
     """One binder result with its authenticated coordinate testimony."""
 
     actuals: tuple
@@ -114,15 +113,6 @@ class BoundSourceCallActualsV1(Sequence):
             raise SourceCallBindingGap("bound actual coordinate arity mismatch")
         _reauthenticate_binding_coordinates(self.formal_coordinates)
         _reauthenticate_native_coordinates(self.native_formal_coordinates)
-
-    def __len__(self) -> int:
-        return len(self.actuals)
-
-    def __getitem__(self, index):
-        return self.actuals[index]
-
-    def __iter__(self) -> Iterator:
-        return iter(self.actuals)
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, BoundSourceCallActualsV1):

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
@@ -192,8 +192,8 @@ def test_production_positional_bind_actuals_floor_reaches_guard_by_identity() ->
     true_arg = TrueBoolLiteralSugar(site=call.args[0].fragment)
     # Production binder: bind_actuals then CallSiteSugar.allocate path.
     bound_floors = frame.bind_actuals((true_arg,), ())
-    assert bound_floors[0] is true_arg
-    assert isinstance(bound_floors[0], FloorValue)
+    assert bound_floors.actuals[0] is true_arg
+    assert isinstance(bound_floors.actuals[0], FloorValue)
 
     caller = FactoryBuildContext(filename="prod.py", catalog=SugarCatalog())
     sugar = CallSiteSugar(
@@ -234,8 +234,8 @@ def test_production_keyword_and_default_bind_actuals_floor_by_identity() -> None
     enabled_floor = TrueBoolLiteralSugar(site="kw:enabled")
     # Keyword for enabled; flag takes default via bind_actuals.
     bound = frame.bind_actuals((), (("enabled", enabled_floor),))
-    assert bound[0] is enabled_floor
-    assert isinstance(bound[1], FloorValue)  # default True
+    assert bound.actuals[0] is enabled_floor
+    assert isinstance(bound.actuals[1], FloorValue)  # default True
 
     sugar = CallSiteSugar(
         target_name="option_context",
@@ -257,7 +257,7 @@ def test_production_keyword_and_default_bind_actuals_floor_by_identity() -> None
     }
     assert by_cid[frame.formal_coordinates[0].cid] is enabled_floor
     # Default formal is the exact object bind_actuals returned.
-    assert by_cid[frame.formal_coordinates[1].cid] is bound[1]
+    assert by_cid[frame.formal_coordinates[1].cid] is bound.actuals[1]
     assert machine._guard_evaluation_context().temporal.value_if_bound(
         frame.formal_coordinates[0].cid
     ) is enabled_floor

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py
@@ -214,7 +214,7 @@ def test_bind_actuals_packs_star_without_self_name_shift() -> None:
         TupleValue((TermValue(1), TermValue(2), TermValue(3))),
     )
     # Two bound slots only — pack is values, not shifted by self/name.
-    assert len(bound) == 2
+    assert len(bound.actuals) == 2
 
 
 def test_bind_actuals_packs_kw_without_self_name_shift() -> None:
@@ -239,7 +239,7 @@ def test_bind_actuals_packs_kw_without_self_name_shift() -> None:
             )
         ),
     )
-    assert len(bound) == 2
+    assert len(bound.actuals) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import replace
 
 import pytest
@@ -35,7 +36,7 @@ def test_binder_returns_ordered_typed_coordinate_testimony() -> None:
     bound = frame.bind_actuals((left,), ())
 
     assert isinstance(bound, BoundSourceCallActualsV1)
-    assert bound[0] is left
+    assert bound.actuals[0] is left
     assert bound.formal_coordinates == frame.formal_coordinates
     assert bound.native_formal_coordinates == frame.native_operation_formal_coordinates
     assert tuple(pair.actual for pair in bound.pairs) == bound.actuals
@@ -65,6 +66,22 @@ def test_bound_actuals_equality_requires_authenticated_coordinate_testimony() ->
     assert truthful != lying
     assert truthful != values
     assert values != truthful
+
+
+def test_bound_actuals_requires_explicit_value_projection() -> None:
+    """Authenticated testimony cannot masquerade as an unlabelled sequence."""
+    frame = _frame()
+    values = (TermValue(1), TermValue(2))
+    bound = BoundSourceCallActualsV1(
+        values,
+        frame.formal_coordinates,
+        frame.native_operation_formal_coordinates,
+    )
+
+    assert bound.actuals == values
+    assert not isinstance(bound, Sequence)
+    with pytest.raises(TypeError):
+        tuple(bound)
 
 
 @pytest.mark.parametrize("variant", ("missing", "duplicate", "reordered", "foreign"))


### PR DESCRIPTION
Removes the remaining tuple/Sequence compatibility surface from BoundSourceCallActualsV1. Authenticated binder testimony can no longer be indexed, iterated, unpacked, or length-checked as an unlabelled value tuple; consumers must explicitly select .actuals. Coordinate-bearing equality and binder behavior are unchanged.\n\nTruthful/lying tooth: explicit .actuals projection preserves the values; Sequence identity and tuple(bound) masquerade are refused.\n\nFocused receipt: bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py => 44 passed in 1.16s.\n\nR_sequence_compatibility_side_door: 1 -> 0; Delta=-1. No binder semantics, carrier/ExitSet, spelling/vendor, reconstruction, or other lane changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `Sequence` protocol from `BoundSourceCallActualsV1` to require explicit `.actuals` projection
> - `BoundSourceCallActualsV1` no longer subclasses `collections.abc.Sequence` and drops `__len__`, `__getitem__`, and `__iter__`, so callers must access values via the `.actuals` tuple attribute.
> - Tests are updated throughout to use `bound.actuals[n]` and `len(bound.actuals)` in place of direct indexing and `len(bound)`.
> - A new test in [`test_source_call_frame_coordinate_testimony.py`](https://github.com/TSavo/sugar/pull/6768/files#diff-b7122e53d9b7aac7a6e0ff00dd86655e0a7cab9ab7f2e6072be3f768f4e95cca) asserts the class is not a `Sequence` and that `tuple(bound)` raises `TypeError`.
> - Behavioral Change: any code iterating or indexing a `BoundSourceCallActualsV1` instance directly will now raise `TypeError` at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09f2be0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->