### PR TITLE
Remove unsound nested body name scan

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -491,23 +491,6 @@ class SourceUnit:
                 containing.append(candidate)
         if containing:
             owner = max(containing, key=lambda item: item.line_col_span().start_line)
-            nested = tuple(
-                member
-                for member in owner.body
-                if isinstance(member, (FunctionDef, AsyncFunctionDef))
-                and member.name == call.func.id
-                and member.unit.source_cid == call.unit.source_cid
-            )
-            if len(nested) == 1:
-                definition = nested[0]
-                definition_span = definition.line_col_span()
-                if (
-                    definition_span.start_line <= span.start_line
-                    and span.start_line <= owner.line_col_span().end_line
-                    and (definition_span.start_line, definition_span.start_col)
-                    < (span.start_line, span.start_col)
-                ):
-                    return definition
             table = self.function_symtable(owner.name, owner.line_col_span().start_line)
             try:
                 symbol = table.lookup(call.func.id)


### PR DESCRIPTION
Removal-only fix-forward: deletes all owner.body FunctionDef/name inference lines. Nested R remains 3 loud; scalar unchanged. Authenticated lexical testimony is deferred to a separate follow-on.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unsound nested body name scan from `SourceUnit` symbol lookup
> The `SourceUnit` method previously scanned the owning function's body to find a matching nested function definition before consulting the symbol table. This shortcut was unsound and is now removed; the method goes directly to symbol table lookup within the owning function's scope.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4f65b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->