### PR TITLE
Instrument nested lookup lying twins

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
@@ -663,3 +663,22 @@ def test_lambda_inside_nested_function_composes_with_source_return_projection() 
     assert call.sugar().desugar(None).value._dig_floor_or_none(
         None, owner="nested-lambda-return"
     ) == TermValue(6)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def outer():\n    def inner(value):\n        return value + 1\n    return inner(3)\n\nouter()\n",
+        "def inner(value):\n    return value + 10\n\ndef outer():\n    def inner(value):\n        return value + 1\n    return inner(3)\n\nouter()\n",
+        "def outer():\n    def inner(value):\n        return value + 1\n    return inner(3)\n\ndef other():\n    return inner(4)\n\nother()\n",
+    ],
+)
+def test_nested_lookup_lies_cannot_authorize_by_name_or_span(source: str) -> None:
+    tree, _, _ = _tree(source, bind=frozenset({"outer", "inner", "other"}))
+    nested_calls = [
+        node
+        for node in tree.nodes()
+        if isinstance(node, Call) and getattr(node.func, "id", None) == "inner"
+    ]
+    assert nested_calls
+    assert all(node.unit.source_function_definition_for_call(node) is None for node in nested_calls)


### PR DESCRIPTION
Tests-only regression teeth: nested FunctionDef lookup cannot authorize by spelling/body membership/span. Shadowed same-name, foreign same-signature, and wrong lexical scope remain loud. Replacement lookup deferred.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests asserting nested lookup lying twins cannot be resolved by `source_function_definition_for_call`
> Adds a parametrized pytest test in [test_source_return_operation_generalization.py](https://github.com/TSavo/sugar/pull/6770/files#diff-69bf6af7fd5dd5059861d26a5049e910aeebfe513d041f0a7065d9990495f794) covering three name-shadowing and scope scenarios. Each variant builds a tree from a Python source snippet, collects `Call` nodes targeting a function named `inner`, and asserts that `unit.source_function_definition_for_call` returns `None` for all of them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d68ceec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->