### PR TITLE
Carry authenticated dependency graphs into manager frames

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -947,6 +947,7 @@ def resolve_source_visible_frame(
     resolved: ResolvedPythonObjectV1,
     *,
     graph: DependencyArtifactGraph,
+    dependency_graphs: dict[str, DependencyArtifactGraph] | None = None,
     session: SourceResolutionSession | None = None,
 ) -> tuple[object, Node] | ManagerConstructionGapV1:
     """Resolve one authenticated definition into the ordinary source frame.
@@ -981,6 +982,12 @@ def resolve_source_visible_frame(
     definition = resolved.definition
     cache_key = (
         graph.distribution_artifact_cid,
+        tuple(
+            sorted(
+                (name, dependency.distribution_artifact_cid)
+                for name, dependency in (dependency_graphs or {}).items()
+            )
+        ),
         resolved.source_cid,
         definition.name,
         definition.kind,
@@ -1003,7 +1010,11 @@ def resolve_source_visible_frame(
     session.frame_active.add(cache_key)
     try:
         result = _resolve_source_visible_frame_uncached(
-            resolved, graph=graph, module=module, session=session
+            resolved,
+            graph=graph,
+            module=module,
+            dependency_graphs=dependency_graphs,
+            session=session,
         )
     finally:
         session.frame_active.discard(cache_key)
@@ -1022,6 +1033,7 @@ def _resolve_source_visible_frame_uncached(
     *,
     graph: DependencyArtifactGraph,
     module,
+    dependency_graphs: dict[str, DependencyArtifactGraph] | None,
     session: SourceResolutionSession,
 ) -> tuple[object, Node, object] | ManagerConstructionGapV1:
     # frame_projection: dual-mode factories may nest With only on non-CM
@@ -1033,9 +1045,8 @@ def _resolve_source_visible_frame_uncached(
         (module.source, module.source_seat, module.source_cid),
         construction_context=context,
     )
-    dependency_graphs: dict[str, DependencyArtifactGraph] = {
-        resolved.module_name.split(".", 1)[0]: graph
-    }
+    dependency_graphs = dict(dependency_graphs or {})
+    dependency_graphs[resolved.module_name.split(".", 1)[0]] = graph
     # Seat final-checked import value-use receipts into THIS frame's SourceUnit
     # before any construction.  Identity operands (e.g. ``pd.array``) bind via
     # authenticated definition coordinates on this unit — never cross-unit spans.
@@ -1210,7 +1221,10 @@ def _resolve_source_visible_frame_uncached(
 
         try:
             projected = resolve_source_visible_frame(
-                imported, graph=dependency_graph, session=session
+                imported,
+                graph=dependency_graph,
+                dependency_graphs=dependency_graphs,
+                session=session,
             )
         except SugarNotWritten as exc:
             # Imported callee body is incomplete: park the obligation, do not
@@ -1912,10 +1926,10 @@ def _seat_import_value_use_receipts(
         # pre-authenticated graphs carried by this publication.
         dependency_graph = dependency_graphs.get(top_level)
         if dependency_graph is None:
-            raise ImportValueUseSeatingGap(
-                "dependency-graph-unavailable",
-                f"no pre-authenticated graph for {dependency_module!r}",
-            )
+            # An absent graph carries no source authority.  Leave the exact
+            # import-use coordinate unseated; any consumer that needs it stays
+            # typed-loud at its ordinary resolution door.
+            continue
         imported = resolve_import_binding(
             receipt, graph=dependency_graph, session=session
         )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1291,7 +1291,10 @@ def populate_source_derived_resource_refs(
         )
 
         frame_result = resolve_source_visible_frame(
-            resolved, graph=graph, session=session
+            resolved,
+            graph=graph,
+            dependency_graphs=graphs,
+            session=session,
         )
         if not isinstance(frame_result, ManagerConstructionGapV1):
             frame, generator_target = frame_result
@@ -1316,6 +1319,7 @@ def populate_source_derived_resource_refs(
                     receipt=receipt,
                     session=session,
                     graph=graph,
+                    dependency_graphs=graphs,
                     distribution_index=distribution_index,
                     resolved_cid=resolved.cid,
                 )
@@ -1642,6 +1646,7 @@ def _publish_generator_backed_resource_contract(
     receipt,
     session,
     graph=None,
+    dependency_graphs=None,
     distribution_index=None,
     resolved_cid: str,
 ) -> None:
@@ -1674,6 +1679,7 @@ def _publish_generator_backed_resource_contract(
         generator_target,
         session=session,
         graph=graph,
+        dependency_graphs=dependency_graphs,
         distribution_index=distribution_index,
     )
     if coords is None:
@@ -2300,7 +2306,12 @@ def _mint_yield_face(statement) -> GeneratorYieldFaceV1:
 
 
 def _protocol_coords_from_generator_decorators(
-    generator_target, *, session, graph=None, distribution_index=None
+    generator_target,
+    *,
+    session,
+    graph=None,
+    dependency_graphs=None,
+    distribution_index=None,
 ):
     """Construct enter/exit definition sites from generator decorator testimony."""
     from sugar_source_tree.nodes import FunctionDef
@@ -2316,6 +2327,7 @@ def _protocol_coords_from_generator_decorators(
             decorator,
             session=session,
             graph=graph,
+            dependency_graphs=dependency_graphs,
             distribution_index=distribution_index,
         )
         if decorator_fn is None:
@@ -2335,15 +2347,18 @@ def _protocol_coords_from_generator_decorators(
 
 
 def _construct_decorator_function(
-    decorator, *, session, graph=None, distribution_index=None
+    decorator,
+    *,
+    session,
+    graph=None,
+    dependency_graphs=None,
+    distribution_index=None,
 ):
     """Resolve and construct the decorator callable from typed import testimony."""
     from sugar_source_tree.nodes import FunctionDef, Name
 
     from .dependency_artifact import (
-        DependencyArtifactAuthenticationError,
         ResolvedPythonObjectV1,
-        authenticate_dependency_top_level,
         resolve_authenticated_module_export,
     )
     from .manager_construction import (
@@ -2364,14 +2379,9 @@ def _construct_decorator_function(
     if graph is not None:
         graphs.append(graph)
     top_level = module_name.split(".", 1)[0]
-    try:
-        graphs.append(
-            authenticate_dependency_top_level(
-                top_level, distribution_index=distribution_index
-            )
-        )
-    except DependencyArtifactAuthenticationError:
-        pass
+    authenticated_dependency = (dependency_graphs or {}).get(top_level)
+    if authenticated_dependency is not None and authenticated_dependency not in graphs:
+        graphs.append(authenticated_dependency)
     resolved = None
     resolved_graph = None
     for candidate in graphs:
@@ -2391,7 +2401,10 @@ def _construct_decorator_function(
     if resolved is None or resolved_graph is None:
         return None
     frame_result = resolve_source_visible_frame(
-        resolved, graph=resolved_graph, session=session
+        resolved,
+        graph=resolved_graph,
+        dependency_graphs=dependency_graphs,
+        session=session,
     )
     if isinstance(frame_result, ManagerConstructionGapV1):
         return None

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -133,7 +133,7 @@ def _distribution(root: Path, source: str, *, exported: str = "make_guard"):
     return importlib.metadata.Distribution.at(metadata)
 
 
-def _tree(root: Path, consumer: str, *, dist):
+def _tree(root: Path, consumer: str, *, dist, artifact_graph_cache=None):
     path = root / "consumer.py"
     path.write_text(consumer, encoding="utf-8")
     context = TreeConstructionContextV1.for_source_call_construction()
@@ -146,8 +146,18 @@ def _tree(root: Path, consumer: str, *, dist):
         root=root,
         path=path,
         distribution_index={"arbitrary": dist},
+        artifact_graph_cache=artifact_graph_cache,
     )
     return tree, context, path
+
+
+def _contextmanager_dependency_graphs():
+    """Authenticated stdlib roster consumed by the decorator frame projection."""
+    from sugar_lift_python_source.dependency_artifact import (
+        authenticate_dependency_top_level,
+    )
+
+    return {"contextlib": authenticate_dependency_top_level("contextlib")}
 
 
 def _with_chain(sugar):
@@ -324,6 +334,9 @@ def test_real_option_context_coordinates_drive_every_resource_lifecycle_face():
     assert sys.executable == "/usr/local/bin/python"
     assert platform.python_version() == "3.12.13"
     assert pandas.__file__ == "/usr/local/lib/python3.12/site-packages/pandas/__init__.py"
+    print(f"sys.executable={sys.executable}")
+    print(f"sys.version={sys.version}")
+    print(f"pandas.__file__={pandas.__file__}")
 
     corpus = authenticated_pandas_corpus()
     root = corpus.root.parent
@@ -346,6 +359,9 @@ def test_real_option_context_coordinates_drive_every_resource_lifecycle_face():
     assert len(receivers) == 1, (
         "authenticated pandas option_context use at line 25 must publish exactly "
         "one provider receiver before With construction; publication stopped "
+        "at the current producer contract: pandas/_config/config.py:66:0 "
+        "If._construct_sugar must consume the branch-result slot minted once by "
+        "If.substitute; "
         "upstream, derived refs="
         f"{tuple(type(ref).__name__ for ref in context.source_derived_contract_refs.values())}"
     )
@@ -501,6 +517,7 @@ def test_renamed_source_generator_resources_use_the_same_closed_factory_arm(
         f"with {manager_name}(7) as entered:\n"
         "    observed = entered\n",
         dist=dist,
+        artifact_graph_cache=_contextmanager_dependency_graphs(),
     )
     with_node = next(node for node in tree.nodes() if node.kind == "With")
     receiver = next(iter(context.source_manager_provider_calls))
@@ -565,6 +582,7 @@ def test_renamed_pre_yield_branch_and_cleanup_spellings_share_one_resource_path(
         f"with {manager_name}(7) as entered:\n"
         "    observed = entered\n",
         dist=dist,
+        artifact_graph_cache=_contextmanager_dependency_graphs(),
     )
     with_node = next(node for node in tree.nodes() if node.kind == "With")
     receiver = next(iter(context.source_manager_provider_calls))
@@ -592,6 +610,61 @@ def test_renamed_pre_yield_branch_and_cleanup_spellings_share_one_resource_path(
     ]
     assert resource.enter.native_definition_coordinate == resource.enter_definition
     assert resource.exit.native_definition_coordinate == resource.exit_definition
+
+
+@pytest.mark.parametrize("graph_kind", ("missing", "foreign"))
+def test_renamed_generator_requires_its_authenticated_decorator_graph(
+    tmp_path: Path, graph_kind: str
+):
+    """Missing or cross-wired graph testimony never publishes a resource ref."""
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+    )
+    from sugar_lift_py_tests.sugar.generator_with_sugar import GeneratorWithSugar
+    from sugar_lift_python_source.dependency_artifact import DependencyArtifactGraph
+    from sugar_lift_python_source.manager_construction import (
+        ImportValueUseSeatingGap,
+    )
+
+    manager_name = "structural_scope"
+    implementation = (
+        "from contextlib import contextmanager\n\n"
+        "@contextmanager\n"
+        f"def {manager_name}(value):\n"
+        "    yield value\n"
+    )
+    dist = _distribution(tmp_path, implementation, exported=manager_name)
+    graphs = {}
+    if graph_kind == "foreign":
+        graphs["contextlib"] = DependencyArtifactGraph.authenticate(dist)
+        with pytest.raises(
+            ImportValueUseSeatingGap, match="resolution-artifact-module-absent"
+        ):
+            _tree(
+                tmp_path,
+                f"from arbitrary import {manager_name}\n"
+                f"with {manager_name}(7) as entered:\n"
+                "    observed = entered\n",
+                dist=dist,
+                artifact_graph_cache=graphs,
+            )
+        return
+    tree, context, _ = _tree(
+        tmp_path,
+        f"from arbitrary import {manager_name}\n"
+        f"with {manager_name}(7) as entered:\n"
+        "    observed = entered\n",
+        dist=dist,
+        artifact_graph_cache=graphs,
+    )
+
+    assert len(context.source_derived_contract_refs) == 1
+    assert all(
+        isinstance(reference, ContextManagerResolutionGapV1)
+        for reference in context.source_derived_contract_refs.values()
+    )
+    resource = next(node for node in tree.nodes() if node.kind == "With").sugar()
+    assert isinstance(resource, GeneratorWithSugar)
 
 
 def test_unauthenticated_generator_manager_stays_on_generator_path(tmp_path: Path):


### PR DESCRIPTION
R: renamed generator manager dependency-graph-unavailable residuals 2 -> 0.

Projects the caller-owned authenticated artifact graph roster through source frame and decorator resolution, and includes graph CIDs in the session cache identity. Missing graph stays a typed publication gap; cross-wired graph refuses. Removes ambient decorator graph authentication.

Focused receipt (authenticated CPython 3.12.13):
`PYTHON312=/usr/local/opt/python@3.12/bin/python3.12 ../../../bin/bpytest -q ...renamed factory arm ...renamed pre-yield arm ...authenticated decorator graph twins`

6 passed in 5.10s.

The real pandas vertical remains independently red at the codex-4-owned `If._construct_sugar` branch-result-slot producer boundary.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Carry authenticated dependency graphs into manager frame resolution
> - `resolve_source_visible_frame` and related functions in [manager_construction.py](https://github.com/TSavo/sugar/pull/6771/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) now accept a `dependency_graphs` mapping, which is incorporated into the memoization cache key so different graph sets produce distinct cache entries.
> - [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/6771/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) threads the authenticated graphs through frame projection and decorator resolution, replacing on-demand `authenticate_dependency_top_level` calls in `_construct_decorator_function`.
> - When a dependency graph for an imported top-level module is absent from the supplied mapping, import-use seating is skipped rather than raising `ImportValueUseSeatingGap('dependency-graph-unavailable')`; the coordinate stays unseated.
> - Tests in [test_returned_resource_with_construction.py](https://github.com/TSavo/sugar/pull/6771/files#diff-516e8891dc248d2149005b9dfa3dfc5e559fe9652a9f705bca9ebd9c97741685) are updated to supply a `contextlib` dependency graph so `contextmanager` decorators resolve correctly, and a new parametrized test verifies behavior when the graph is missing or cross-wired.
> - Behavioral Change: external decorators (e.g. `contextlib.contextmanager`) will no longer resolve to source and will not publish protocol coordinates unless the caller supplies the matching authenticated graph.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be49bdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->