### PR TITLE
Route source If through authenticated slot substitution

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_if_branch_result_slot.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_if_branch_result_slot.py
@@ -142,15 +142,13 @@ def _two_source_ifs() -> tuple[If, If]:
     return branches
 
 
-def test_absent_branch_result_slot_panics_at_the_exact_if_occurrence() -> None:
+def test_raw_source_if_routes_through_its_exact_slot_at_the_if_occurrence() -> None:
     branch, _ = _two_source_ifs()
 
-    with pytest.raises(BackendDefect) as raised:
-        branch.sugar()
+    sugar = branch.sugar()
 
-    message = str(raised.value)
-    assert "If without a stored branch-result slot" in message
-    assert "if-branch-result-slot.py:1:0" in message
+    assert sugar.branch_slot == branch_result_slot(branch.test)
+    assert sugar.site.seal().cid == branch.fragment.seal().cid
 
 
 def test_truthful_stored_slot_constructs_but_slot_swap_panics_at_its_occurrence() -> None:
@@ -171,13 +169,13 @@ def test_truthful_stored_slot_constructs_but_slot_swap_panics_at_its_occurrence(
 def test_duplicated_branch_result_slot_panics_at_the_exact_if_occurrence() -> None:
     branch, _ = _two_source_ifs()
     slot = branch_result_slot(branch.test)
-    duplicated = branch._rewrite_with_slot({}, slot)._rewrite_with_slot({}, slot)
+    rewritten = branch._rewrite_with_slot({}, slot)
 
     with pytest.raises(BackendDefect) as raised:
-        duplicated.sugar()
+        rewritten._rewrite_with_slot({}, slot)
 
     message = str(raised.value)
-    assert "branch-result slot" in message
+    assert "second branch-result slot" in message
     assert "if-branch-result-slot.py:1:0" in message
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_if_construct_sugar_slot_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_if_construct_sugar_slot_producer.py
@@ -41,17 +41,61 @@ def _two_ifs() -> tuple[If, If]:
     return branches
 
 
-def test_raw_source_if_names_the_exact_missing_slot_producer() -> None:
+def test_raw_source_if_routes_through_one_condition_owned_slot() -> None:
     branch, _ = _two_ifs()
 
-    with pytest.raises(BackendDefect) as raised:
-        branch.sugar()
+    sugar = branch.sugar()
+    outcome = sugar.desugar(None)
 
-    message = str(raised.value)
-    assert "If._construct_sugar" in message
-    assert "If without a stored branch-result slot" in message
-    assert "consume the slot minted once by If.substitute" in message
-    assert "if-construct-slot.py:1:0" in message
+    slot = branch_result_slot(branch.test)
+    assert sugar.branch_slot == slot
+    assert isinstance(outcome, Complete)
+    authentications = tuple(
+        entry
+        for entry in outcome.value.unconditional_entries
+        if isinstance(entry, BranchResultAuthentication)
+    )
+    assert len(authentications) == 1
+    assert authentications[0].slot == slot
+
+
+def test_renamed_raw_source_if_uses_its_exact_condition_slot() -> None:
+    branch = next(
+        node
+        for node in _tree(
+            "if renamed is sentinel:\n"
+            "    assert renamed is sentinel\n"
+            "else:\n"
+            "    assert renamed is not sentinel\n"
+        ).nodes()
+        if isinstance(node, If)
+    )
+
+    sugar = branch.sugar()
+    outcome = sugar.desugar(None)
+
+    slot = branch_result_slot(branch.test)
+    assert sugar.branch_slot == slot
+    assert isinstance(outcome, Complete)
+    assert outcome.value.guard == branch_result_guard(slot, sugar.site)
+
+
+def test_repeated_raw_source_if_construction_does_not_mint_a_second_slot() -> None:
+    branch, _ = _two_ifs()
+
+    first = branch.sugar()
+    second = branch.sugar()
+    outcome = second.desugar(None)
+
+    assert second is first
+    assert isinstance(outcome, Complete)
+    authentications = tuple(
+        entry
+        for entry in outcome.value.unconditional_entries
+        if isinstance(entry, BranchResultAuthentication)
+    )
+    assert len(authentications) == 1
+    assert authentications[0].slot == branch_result_slot(branch.test)
 
 
 def test_condition_owned_slot_constructs_one_authenticated_guard() -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5594,6 +5594,18 @@ class If(Statement):
         from .backend import Leaf, materialize
         from .shadow import ShadowNode, rewrite
 
+        try:
+            self.branch_result_slot_id
+        except AttributeError:
+            pass
+        else:
+            backend_defect(
+                blame=self.fragment,
+                owner="If._rewrite_with_slot",
+                observed="If attempted to mint a second branch-result slot",
+                requested="the one slot authenticated for this exact If.test",
+                fix="route the source If through ordinary substitution exactly once",
+            )
         rewritten = rewrite(self, **changed)
         if authenticated_slot is None:
             authenticated_slot = branch_result_slot(rewritten.test)
@@ -5671,13 +5683,10 @@ class If(Statement):
         try:
             slot = BranchResultSlot(self.branch_result_slot_id)
         except AttributeError:
-            backend_defect(
-                blame=self.fragment,
-                owner="If._construct_sugar",
-                observed="If without a stored branch-result slot",
-                requested="consume the slot minted once by If.substitute",
-                fix="route every If through substitution before Sugar construction",
-            )
+            substituted = self.substitute({})
+            if isinstance(substituted, _Splice):
+                substituted = substituted.statements[0]
+            return substituted.sugar()
         try:
             authenticated_slot = BranchResultSlot(
                 self.authenticated_branch_result_slot_id


### PR DESCRIPTION
## Producer repair

A raw source `If` that has not yet stored its branch-result slot now routes through its ordinary `If.substitute({})` construction before building `IfSugar`. That substitution mints the slot for the exact `self.test`; already-authenticated nodes continue through the existing equality check. `_rewrite_with_slot` now panics at the If occurrence if asked to mint a second slot.

No nearby-slot fallback, CID fabrication, pandas/name dispatch, scan, IfSugar change, carrier/ExitSet change, or contextlib overlap.

## Evidence

- Red: `test_if_construct_sugar_slot_producer.py` — 3 failed at `BACKEND DEFECT [If._construct_sugar]: If without a stored branch-result slot`, 6 passed
- Green: same focused file — 9 passed
- If slot matrix excluding the separately banked IfExp axis — 25 passed, 1 deselected
- Full two-file run truthfully remains red only on `test_symbolic_ternary_result_uses_its_authenticated_branch_slot`, an IfExp law unchanged by this PR

Authenticated downstream target: R(If._construct_sugar missing stored slot)=2 -> 0 at pandas `_config/config.py:66`; ForStep remains zero.

The superseded local #6750 snapshot is preserved recoverably in `stash@{0}` and is not part of this PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route source `If` through authenticated slot substitution in `If.sugar`
> - `If.sugar` previously raised a `backend_defect` when no stored branch-result slot was present. It now calls `self.substitute({})`, unwraps a `_Splice` if returned, and delegates to the resulting node's `sugar()` to construct and return `IfSugar`.
> - `If._rewrite_with_slot` now raises a `backend_defect` if a `branch_result_slot_id` is already set, preventing a second slot from being minted.
> - Tests in [`test_if_branch_result_slot.py`](https://github.com/TSavo/sugar/pull/6772/files#diff-8082a1f14323374d0403bd91768678a1bbd222d9e3b8b4ceb8059f7549a923df) and [`test_if_construct_sugar_slot_producer.py`](https://github.com/TSavo/sugar/pull/6772/files#diff-e7fc71aee3c31d7a24ffb291b543b584b713d9150bf2b9bf0c838f9fe6a1b0b2) are updated to assert successful slot routing and authentication instead of expecting exceptions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f1f6e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->