### PR TITLE
Own immutable attribute delete errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
@@ -88,6 +88,14 @@ class BytesValue(FloorValue):
             exception_name="AttributeError", site=site, owner="BytesValue.setattr"
         )
 
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="BytesValue.delattr"
+        )
+
     def to_term(self, *, owner: str):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -327,6 +327,14 @@ class StringValue(GuardStableValue):
             exception_name="AttributeError", site=site, owner="StringValue.setattr"
         )
 
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="StringValue.delattr"
+        )
+
     def add(self, other, site):
         # A string's addition IS concatenation: two strings fold to their join.
         # Anything else falls to the honest addition-floor gap.

--- a/implementations/python/sugar-lift-py-tests/tests/test_immutable_attribute_delete.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_immutable_attribute_delete.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.floor import BytesValue, StringValue
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.sugar.delete_effect_sugar import AttributeDeleteEffectSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _site(tmp_path):
+    path = tmp_path / "attr_delete.py"
+    path.write_text("def f(obj):\n    del obj.attr\n")
+    function = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions())
+    return function.body[0].fragment
+
+
+@dataclass(frozen=True)
+class _Receiver(Sugar):
+    value: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+
+@pytest.mark.parametrize(
+    ("receiver", "owner"),
+    ((StringValue("abc"), "StringValue.delattr"), (BytesValue(b"abc"), "BytesValue.delattr")),
+)
+def test_immutable_scalar_attribute_delete_has_exact_owner_occurrence(tmp_path, receiver, owner):
+    site = _site(tmp_path)
+    outcome = AttributeDeleteEffectSugar(_Receiver(receiver), "attr", site).desugar()
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect.exception_name == "AttributeError"
+    assert outcome.effect.producer_node_owner == owner
+    assert outcome.effect.occurrence_id == str(site)
+
+
+@pytest.mark.parametrize("receiver", (StringValue("abc"), BytesValue(b"abc")))
+def test_immutable_scalar_attribute_delete_cannot_fabricate_completion(tmp_path, receiver):
+    outcome = AttributeDeleteEffectSugar(_Receiver(receiver), "attr", _site(tmp_path)).desugar()
+    assert not isinstance(outcome, Complete)


### PR DESCRIPTION
## Instrument

Floor-owned immutable attribute-delete errors for `StringValue.delattr` and `BytesValue.delattr`, with truthful exact-owner/occurrence and lying no-fabricated-completion twins.

## Authenticated isolated receipt

The byte-identical probe used a real `SourceFragment` from `def f(obj): del obj.attr` at `<SourceFragment 'agy2-delattr-specimen.py' [16, 28) node=Delete>`. Both invocations pinned cwd and PYTHONPATH exclusively to their isolated checkout and printed `sys.executable` plus `string_value.py`, `bytes_value.py`, `delete_effect_sugar.py`, and `ground_exit.py` module `__file__` paths rooted there.\n\n- live base `44f7a2f597f1b0c31e9706e2a20fc57f83941c7f`: `AUTH_CASES=2 OWNED=0 GAPS=2`, literal `PROBE_EXIT=1`\n- head `bab2e473a5cc069c06c9917216a25f9077393a3b`: `AUTH_CASES=2 OWNED=2 GAPS=0`, literal `PROBE_EXIT=0`\n\nMeasured `R_immutable_attribute_delete_missing_floor_owner: 2 -> 0`; `Delta=-2`.\n\n## Focused receipt\n\n`4 passed in 5.65s`; literal `REBASED_FOCUSED_EXIT=0`.\n\n## Floors\n\nForbidden carrier/ExitSet/outcome drift: `0`. Exact three-file scope; no spelling/vendor dispatch arms.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `delattr` error handling to `BytesValue` and `StringValue` immutable types
> - Adds a `delattr(name, site)` method to [`BytesValue`](https://github.com/TSavo/sugar/pull/6773/files#diff-7a88547a9abe7f0b9c6abca596b360b1b8597a1bde0a83596437b46ca87a3a91) and [`StringValue`](https://github.com/TSavo/sugar/pull/6773/files#diff-7f7cef79e8741c9f5ef0a7a75ab1e3f73d2cf58f59cc5d53870d530f4ffcbda5) that always returns a `ground_exceptional_exit` with `AttributeError`, ignoring the attribute name.
> - Adds tests in [`test_immutable_attribute_delete.py`](https://github.com/TSavo/sugar/pull/6773/files#diff-a321472b9dc8bde6aca5dff445c5fac12722782f36d51ed09c4c9db5304e1188) verifying the correct `owner`, `occurrence_id`, and that no `Complete` outcome can be produced.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bab2e47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->