### PR TITLE
Project authenticated bound actual values explicitly

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -639,12 +639,16 @@ class ObjectValue(FloorValue):
                 )
             target_name = f"{self.class_name}.{name}"
             arg_values = (self, *arguments)
+            bound_source_actuals = None
             selected_frame = required_frame or method.source_call_frame
             if selected_frame is not None:
                 from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
                 try:
-                    arg_values = selected_frame.bind_actuals(arg_values, keywords, ctx)
+                    bound_source_actuals = selected_frame.bind_actuals(
+                        arg_values, keywords, ctx
+                    )
+                    arg_values = bound_source_actuals.actuals
                 except SourceCallBindingGap as exc:
                     return self._floor_gap(
                         owner=owner,
@@ -676,6 +680,7 @@ class ObjectValue(FloorValue):
                 body=method.body,
                 source_call_frame_cid=method.source_call_frame_cid,
                 formal_coordinate_cids=method.formal_coordinate_cids,
+                bound_source_actuals=bound_source_actuals,
             )
             if not any(
                 isinstance(value, (SymbolicValue, CallSiteValue))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/computed_call_sugar.py
@@ -152,7 +152,7 @@ class ComputedCallSugar(ConstructedTermSugar):
                     fix="construct a typed source frame or keep the call loud",
                 )
             try:
-                positional = frame.bind_actuals(positional, kw_values, ctx)
+                bound_source_actuals = frame.bind_actuals(positional, kw_values, ctx)
             except SourceCallBindingGap as exc:
                 raise SugarNotWritten(
                     blame=self.site,
@@ -164,7 +164,7 @@ class ComputedCallSugar(ConstructedTermSugar):
             return Complete(
                 CallSiteValue(
                     target_name="py.call",
-                    arg_values=positional,
+                    arg_values=bound_source_actuals.actuals,
                     parameters=frame.parameters,
                     term=term,
                     body=frame.body,
@@ -173,6 +173,7 @@ class ComputedCallSugar(ConstructedTermSugar):
                     formal_coordinate_cids=tuple(
                         item.cid for item in frame.formal_coordinates
                     ),
+                    bound_source_actuals=bound_source_actuals,
                 )
             )
         return Complete(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
@@ -317,11 +317,12 @@ class SpreadCallSugar(Sugar):
             source_body = owner.source_visible_constructor_frame().body
         return CallSiteValue(
             target_name=self.callee_name or "python:call",
-            arg_values=bound,
+            arg_values=bound.actuals,
             parameters=frame.parameters,
             term=term,
             body=source_body,
             site=self.site,
             source_call_frame_cid=frame.frame_cid,
             formal_coordinate_cids=tuple(item.cid for item in frame.formal_coordinates),
+            bound_source_actuals=bound,
         )


### PR DESCRIPTION
Fix-forward for #6768: three production call handoffs still passed BoundSourceCallActualsV1 where CallSiteValue requires a value tuple. Computed calls, spread calls, and source methods now pass bound.actuals explicitly while retaining the full authenticated receipt in bound_source_actuals. Sequence compatibility remains deleted.\n\nMeasured focused source-return matrix: base 34 passed / 6 failed; head 37 passed / 3 failed. Delta=-3 wrapper-leak failures. The surviving three are the independently owned nested-carrier reds, including the shadowed-coordinate lying arm, and remain loud.\n\nDoctrine twins remain green: explicit .actuals and authenticated-coordinate equality truthful arms; foreign-coordinate and Sequence/tuple masquerade lying arms. Focused doctrine receipt: 44 passed in 1.18s.\n\nNo test-only drift, carrier/ExitSet, spelling/vendor dispatch, reconstruction, or compatibility methods.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include bound source actuals explicitly in authenticated `CallSiteValue` construction
> Updates three call-site desugaring paths to store the result of `bind_actuals` in a named variable (`bound_source_actuals`) and pass it as a dedicated field to `CallSiteValue`, while deriving `arg_values` from `bound_source_actuals.actuals`. This affects [`object_value.py`](https://github.com/TSavo/sugar/pull/6774/files#diff-915d55e3a0e35db85dc48bceffe52001584a598ab89e134e598a042edea35a7b), [`computed_call_sugar.py`](https://github.com/TSavo/sugar/pull/6774/files#diff-a3d120c7639aa3b0ba91d8111b7382ea76711750f38865a71ec2bfbfe42b1750), and [`spread_sugar.py`](https://github.com/TSavo/sugar/pull/6774/files#diff-462f912508b271ce479f5b6c3757a9e656e009ab945f3b9c632e8cb7bdfc4945). Behavioral Change: `CallSiteValue` instances now carry `bound_source_actuals` as a separate field in addition to `arg_values`, changing the shape of the produced value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95188a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->