### PR TITLE
Promote guarded loop reads to constructed terms

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
@@ -11,7 +11,7 @@ from sugar_lift_py_tests.sugar.binding_projection import (
     LoopGuardedProjection,
     UnboundProjection,
 )
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
 
 
 def _guarded_projection_faces(state: GuardedProjection):
@@ -116,8 +116,82 @@ def read_binding(state, *, read_name: str, read_site, ctx) -> ExitSet:
     )
 
 
+def _projection_term(state, *, owner: str):
+    """Canonical testimony for one producer-authenticated binding projection."""
+    from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
+    from sugar_lift_py_tests.ir import ctor, formula_to_value, num, str_const
+
+    if isinstance(state, ConstructedTermSugar):
+        return state.to_term(owner=owner)
+    if isinstance(state, UnboundProjection):
+        cause = state.cause.seal()
+        return ctor(
+            "python:unbound-binding-projection",
+            (
+                str_const(state.name),
+                str_const(cause.source_cid),
+                num(cause.start),
+                num(cause.end),
+                str_const(cause.cid),
+            ),
+            symbol_kind="coordinate",
+        )
+    if isinstance(state, GuardedProjection):
+        return ctor(
+            "python:guarded-binding-projection",
+            (
+                str_const(state.slot.slot_id),
+                _projection_term(state.when_true, owner=owner),
+                _projection_term(state.when_false, owner=owner),
+            ),
+            symbol_kind="coordinate",
+        )
+    if isinstance(state, LoopGuardedProjection):
+        if (
+            not isinstance(state.target_cid, str)
+            or not state.target_cid.startswith("blake3-512:")
+        ):
+            raise TypeError(
+                "loop guarded binding projection requires authenticated target CID"
+            )
+        faces = []
+        for face in state.completed_faces:
+            if face.guard_formula is None:
+                raise TypeError(
+                    "loop guarded binding projection requires exact guard testimony"
+                )
+            if not isinstance(face.exit_partition_arity, int):
+                raise TypeError(
+                    "loop guarded binding projection requires exit-family arity"
+                )
+            guard_cid = blake3_512_of(
+                encode_jcs(formula_to_value(face.guard_formula)).encode("utf-8")
+            )
+            faces.append(
+                ctor(
+                    "python:loop-guarded-binding-face",
+                    (
+                        str_const(face.completion_kind),
+                        str_const(guard_cid),
+                        num(face.exit_partition_arity),
+                        _projection_term(face.state, owner=owner),
+                    ),
+                    symbol_kind="coordinate",
+                )
+            )
+        return ctor(
+            "python:loop-guarded-binding-projection",
+            (str_const(state.target_cid), *faces),
+            symbol_kind="coordinate",
+        )
+    raise TypeError(
+        "guarded binding read requires constructed projection testimony, got "
+        f"{type(state).__name__}"
+    )
+
+
 @dataclass(frozen=True)
-class GuardedBindingReadSugar(Sugar):
+class GuardedBindingReadSugar(ConstructedTermSugar):
     name: str
     state: object
     site: object = dataclass_field(compare=False)
@@ -130,3 +204,16 @@ class GuardedBindingReadSugar(Sugar):
         return read_binding(
             self.state, read_name=self.name, read_site=self.site, ctx=ctx
         ).collapse()
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:guarded-binding-read",
+            (
+                self.occurrence_term(owner=owner),
+                str_const(self.name),
+                _projection_term(self.state, owner=owner),
+            ),
+            symbol_kind="coordinate",
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_exit_partition_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_exit_partition_carrier.py
@@ -43,6 +43,7 @@ family is refused, so the end-to-end green cannot be bought by a fallback.
 from __future__ import annotations
 
 from pathlib import Path
+from dataclasses import dataclass
 
 import pytest
 
@@ -58,6 +59,9 @@ from sugar_lift_py_tests.sugar.binding_projection import (
 )
 from sugar_lift_py_tests.sugar.delete_name_sugar import delete_binding
 from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import _loop_exit_faces
+from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import GuardedBindingReadSugar
+from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
 # The shape of `pandas/core/methods/selectn.py:224`: a name carried across a
 # `for` loop that can `break`, then READ after the loop. The read is where the
@@ -74,6 +78,27 @@ def compute(columns, seed, sink):
 """
 
 _CID = "blake3-512:" + "ab" * 32
+
+
+@dataclass(frozen=True)
+class _SealedSite:
+    source_cid: str
+    start: int
+    end: int
+    cid: str
+
+
+@dataclass(frozen=True)
+class _TermSite:
+    coordinate: str
+
+    def seal(self):
+        return _SealedSite(
+            source_cid="blake3-512:" + "11" * 32,
+            start=1,
+            end=2,
+            cid=self.coordinate,
+        )
 
 
 def _face(kind: str, arity: int | None, *, guard: object = None):
@@ -114,6 +139,78 @@ def test_the_loop_exit_family_reaches_the_arms(tmp_path):
     measured rows are back.
     """
     _desugar_all(_write(tmp_path, FIXTURE))
+
+
+def test_guarded_loop_read_is_a_constructed_term_with_exact_coordinates():
+    """Truthful producer: the read carries its occurrence and loop testimony."""
+    from sugar_lift_py_tests.ir import _term_content_cid, atomic
+
+    read_site = _TermSite("blake3-512:" + "22" * 32)
+    value_site = _TermSite("blake3-512:" + "33" * 32)
+    projection = LoopGuardedProjection(
+        (
+            LoopGuardedCompletedFace(
+                "BreakExit", atomic("break_guard", []), IntLiteralSugar(1, value_site), 2
+            ),
+            LoopGuardedCompletedFace(
+                "NormalExhaustion",
+                atomic("exhausted_guard", []),
+                IntLiteralSugar(2, value_site),
+                2,
+            ),
+        ),
+        _CID,
+    )
+    read = GuardedBindingReadSugar("value", projection, read_site)
+
+    assert isinstance(read, ConstructedTermSugar)
+    authentic_cid = _term_content_cid(read.to_term(owner="guarded-loop-read-test"))
+
+    foreign_target = GuardedBindingReadSugar(
+        "value",
+        LoopGuardedProjection(
+            projection.completed_faces,
+            "blake3-512:" + "cd" * 32,
+        ),
+        read_site,
+    )
+    foreign_occurrence = GuardedBindingReadSugar(
+        "value",
+        projection,
+        _TermSite("blake3-512:" + "44" * 32),
+    )
+
+    assert _term_content_cid(
+        foreign_target.to_term(owner="guarded-loop-read-foreign-target")
+    ) != authentic_cid
+    assert _term_content_cid(
+        foreign_occurrence.to_term(owner="guarded-loop-read-foreign-occurrence")
+    ) != authentic_cid
+
+    missing_target = GuardedBindingReadSugar(
+        "value",
+        LoopGuardedProjection(projection.completed_faces, None),
+        read_site,
+    )
+    missing_arity_faces = tuple(
+        LoopGuardedCompletedFace(
+            face.completion_kind,
+            face.guard_formula,
+            face.state,
+            None,
+        )
+        for face in projection.completed_faces
+    )
+    missing_arity = GuardedBindingReadSugar(
+        "value",
+        LoopGuardedProjection(missing_arity_faces, _CID),
+        read_site,
+    )
+
+    with pytest.raises(TypeError, match="authenticated target CID"):
+        missing_target.to_term(owner="guarded-loop-read-missing-target")
+    with pytest.raises(TypeError, match="exit-family arity"):
+        missing_arity.to_term(owner="guarded-loop-read-missing-arity")
 
 
 def test_the_carrier_is_the_loop_projection_read(tmp_path):


### PR DESCRIPTION
## Capability

Promotes `GuardedBindingReadSugar` through the general `ConstructedTermSugar` producer door. Canonical testimony recursively retains the exact read occurrence, guarded/loop coordinates, ordered completion faces, guard formula CIDs, declared arity, and constructed leaf terms. Missing target or arity refuses loudly; foreign target/read occurrences produce distinct construction terms.

No consumer, carrier, ExitSet, reducer, name recognition, LoopProjectedBinding, or stale-expectation changes.

## IDD receipt

- `R(guarded-read-CTS): 3 -> 0`; `Delta=-3`; `Epsilon=0`.
- `bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_loop_exit_partition_carrier.py -q -k guarded_loop_read_is_a_constructed_term_with_exact_coordinates` — 1 passed, 15 deselected.
- `bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_guarded_binding_partition_carrier.py implementations/python/sugar-lift-py-tests/tests/test_delete_name_binding.py -q` — 25 passed.
- The three former CTS rows advance to the accepted reattributed carrier red: `outcome_to_exitset ... observed=undischarged native operation demand`; `R(carrier discharge)=3` remains loud and out of scope.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Promote `GuardedBindingReadSugar` to a `ConstructedTermSugar` with canonical loop-guarded projection terms
> - Changes `GuardedBindingReadSugar` base class from `Sugar` to `ConstructedTermSugar` and adds a `to_term(owner)` method that emits a `python:guarded-binding-read` coordinate term containing the occurrence, read name, and projection testimony.
> - Adds `_projection_term`, a helper that dispatches over projection types (`UnboundProjection`, `GuardedProjection`, `LoopGuardedProjection`) and computes Blake3-512 CIDs from canonical JSON-encoded guard formulas for loop-guarded projections.
> - Risk: `to_term(owner)` raises `TypeError` when a `LoopGuardedProjection` is missing an authenticated target CID, exact guard testimony, or exit-family arity — these were previously unchecked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1d7b29.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->