### PR TITLE
Authenticate source IfExp branch-result slots

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -38,6 +38,7 @@ class IfExpSugar(ConstructedTermSugar):
     body: ConstructedTermSugar  # the then-value
     orelse: ConstructedTermSugar  # the else-value
     site: object = dataclass_field(compare=False, default=None)
+    branch_slot: object = None
 
     def __post_init__(self) -> None:
         require_constructed_term_sugar(self.test, owner="IfExpSugar.test")
@@ -86,7 +87,15 @@ class IfExpSugar(ConstructedTermSugar):
         # `.truth`: a predicate test (`5 if a == b else 6`) stands as its formula,
         # a bare value (`5 if c else 6`) emits `py.truthy(c)`. A ground-bool test
         # folds to a literal with no formula and is not lifted yet -- LOUD.
-        formula = predicate_formula(cond_value, self.site)
+        observed_formula = predicate_formula(cond_value, self.site)
+        formula = observed_formula
+        if self.branch_slot is not None:
+            from sugar_lift_py_tests.floor.branch_result_coordinate import (
+                branch_result_guard,
+            )
+
+            if observed_formula not in (false_guard(), true_guard()):
+                formula = branch_result_guard(self.branch_slot, self.site)
         # Ground conditions select one arm before the peer reduces — same law
         # IfSugar owns for statement form. Dual-mode RaisesExc phis
         # (`(T,) if not isinstance(x, tuple) else x`) must collapse to the live

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -8001,6 +8001,7 @@ class IfExp(Expression):
             body=self.body.sugar(),
             orelse=self.orelse.sugar(),
             site=self.fragment,
+            branch_slot=branch_result_slot(self.test),
         )
 
 


### PR DESCRIPTION
## Residual

Source `IfExp` constructed its guarded value directly from the condition formula, even though branch-result slots are the authenticated identity for control results.

## Repair

- `IfExp._construct_sugar` passes `branch_result_slot(self.test)`
- `IfExpSugar` uses that exact slot guard for symbolic conditions
- direct sugar constructors without a source slot retain their existing formula behavior
- ground short-circuit, condition halt, selected-arm halt, and peer skipping remain unchanged

No If statement, BoolOp, carrier, ExitSet, reducer, or consumer changes.

## Receipt

- formerly red symbolic ternary node: 1 passed
- full `test_if_branch_result_slot.py`: 17 passed
- `test_constructed_term_sugar.py`: 47 passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate source IfExp branch-result slots using branch-result guard
> - Adds a `branch_slot` field to `IfExpSugar` (derived from the test node via `branch_result_slot`) so the join can use a branch-result guard instead of a predicate formula for non-ground conditions.
> - In `IfExpSugar._join`, when `branch_slot` is set and the observed formula is not a literal true/false guard, the formula is replaced with `branch_result_guard(self.branch_slot, self.site)`; ground true/false conditions still short-circuit to the corresponding arm.
> - Behavioral Change: IfExp joins for non-ground tests now authenticate against the branch-result coordinate rather than the predicate formula directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 642f0cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->