### PR TITLE
Authenticate real literal construction testimony

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/real_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/real_literal_sugar.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.floor import TermValue
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
 @dataclass(frozen=True)
-class RealLiteralSugar(Sugar):
+class RealLiteralSugar(ConstructedTermSugar):
     """A float literal. Like IntLiteralSugar, it stands as a TermValue -- but a
     float carries the Real sort (int -> Int, float -> Real; there is no Number
     sort). A leaf: no child sugars."""
@@ -30,3 +30,12 @@ class RealLiteralSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx
         return Complete(TermValue(self.value))
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, real_lit
+
+        return ctor(
+            "python:real-literal-construction",
+            (self.occurrence_term(owner=owner), real_lit(repr(self.value))),
+            symbol_kind="coordinate",
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_real_literal_constructed_term.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_real_literal_constructed_term.py
@@ -1,0 +1,75 @@
+"""Real literals carry exact, source-authenticated construction testimony."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.no_call_body_attribution import _exceptional_exit_effects
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
+from sugar_lift_py_tests.sugar.real_literal_sugar import RealLiteralSugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
+from sugar_lift_py_tests.sugar.unary_op_sugar import UnaryOpSugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Constant, UnaryOp
+from sugar_source_tree.tree import SourceFile
+
+
+def _unary(source: str, name: str) -> UnaryOp:
+    tree = SourceFile((source, name, blake3_512_of(source.encode())))
+    return next(node for node in tree.nodes() if isinstance(node, UnaryOp))
+
+
+def test_real_literal_admits_truthful_renamed_and_contextual_unary_sources() -> None:
+    direct = _unary("~3.5\n", "direct.py")
+    renamed = _unary("def renamed():\n    return ~3.5\n", "renamed.py")
+
+    for node in (direct, renamed):
+        literal = node.operand.sugar()
+        assert isinstance(literal, RealLiteralSugar)
+        assert isinstance(literal, ConstructedTermSugar)
+        outcome = node.sugar().desugar(None)
+        effects = _exceptional_exit_effects(outcome)
+        assert len(effects) == 1
+        assert effects[0].exception_name == "TypeError"
+
+
+def test_real_literal_term_seals_value_sort_and_exact_occurrence() -> None:
+    first = _unary("~3.5\n", "first.py").operand.sugar()
+    second = _unary("\n~3.5\n", "second.py").operand.sugar()
+    integer_node = next(
+        node
+        for node in SourceFile(
+            ("~3\n", "integer.py", blake3_512_of(b"~3\n"))
+        ).nodes()
+        if isinstance(node, Constant)
+    )
+    integer = integer_node.sugar()
+
+    first_term = first.to_term(owner="real-first")
+    assert first_term.args[1].sort == PrimitiveSort("Real")
+    assert first_term != second.to_term(owner="real-second")
+    assert first_term != integer.to_term(owner="integer-sort-twin")
+
+
+@dataclass(frozen=True)
+class _PrivateOperand(Sugar):
+    site: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(TermValue(3.5))
+
+
+def test_private_operand_cannot_claim_real_literal_construction() -> None:
+    node = _unary("~3.5\n", "private.py")
+    with pytest.raises(TypeError, match="requires ConstructedTermSugar"):
+        UnaryOpSugar("Invert", _PrivateOperand(node.operand.fragment), node.fragment)


### PR DESCRIPTION
R axis: UnaryOp real-literal ConstructedTermSugar admission 1 -> 0 (predicted epsilon -1).

Production program: `~3.5`; UnaryOp consumes a RealLiteralSugar constructed from the exact source occurrence and literal value. The real literal now provides a canonical real-sorted construction term sealed to that occurrence.

Discrimination: renamed/contextual truthful source programs publish the authenticated TypeError; private Sugar cannot enter the closed boundary; changed occurrence and integer-sort testimony produce different terms.

Focused authenticated receipt: `bin/bpytest -q tests/test_real_literal_constructed_term.py tests/test_first_auth_exit_vertical_slices.py::test_producer_emits_authenticated_exceptional_exit[UnaryOp] tests/test_constructed_term_sugar.py -k "real_literal or UnaryOp or constructed_term_nested_children_are_closed_at_construction"` => 32 passed, 19 deselected in 1.91s under CPython 3.12.13.

Floors preserved: no pytest.raises/name arm, no manager-resolution change, no generic CTS fallback. The separate pytest.raises dynamic-export R=18 remains loud and excluded.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate real literal construction testimony via `ConstructedTermSugar` and `to_term`
> - Changes `RealLiteralSugar` to inherit from `ConstructedTermSugar` instead of `Sugar`, making it a valid constructed term and granting access to `occurrence_term`.
> - Adds a `to_term(owner: str)` method that emits a constructed term using the `python:real-literal-construction` coordinate symbol, capturing the source occurrence and the `real_lit` value.
> - Adds tests verifying that real literal terms carry `PrimitiveSort('Real')`, differ across distinct source occurrences and from integer counterparts, and that non-`ConstructedTermSugar` operands are rejected with a `TypeError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bfab2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->