### PR TITLE
Own builtin attribute delete errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -47,6 +47,15 @@ class ListValue(FloorValue):
             exception_name="AttributeError", site=site, owner="ListValue.setattr"
         )
 
+    def delattr(self, name, site):
+        """Lists have no instance ``__dict__``; delete is AttributeError."""
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="ListValue.delattr"
+        )
+
     def to_term(self, *, owner: str):
         # Project elements into FOL — assert equality / dig return faces.
         from sugar_lift_py_tests.ir import ctor

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
@@ -83,6 +83,17 @@ class NoneValue(FloorValue):
             owner="NoneValue.setattr",
         )
 
+    def delattr(self, name, site):
+        """``del None.name`` is always AttributeError — delete, not read."""
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="NoneValue.delattr",
+        )
+
     def subscript(self, index, site):
         """Construct Python's exact ground ``None[...]`` exceptional exit."""
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_attribute_delete.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_attribute_delete.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.floor import ListValue, NoneValue
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.sugar.delete_effect_sugar import AttributeDeleteEffectSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _site(tmp_path):
+    path = tmp_path / "builtin_attr_delete.py"
+    path.write_text("def f(obj):\n    del obj.attr\n")
+    return next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body[0].fragment
+
+
+@dataclass(frozen=True)
+class _Receiver(Sugar):
+    value: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+
+@pytest.mark.parametrize(
+    ("receiver", "owner"),
+    ((ListValue(()), "ListValue.delattr"), (NoneValue(), "NoneValue.delattr")),
+)
+def test_builtin_without_instance_dict_delete_has_exact_owner_occurrence(tmp_path, receiver, owner):
+    site = _site(tmp_path)
+    outcome = AttributeDeleteEffectSugar(_Receiver(receiver), "attr", site).desugar()
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect.exception_name == "AttributeError"
+    assert outcome.effect.producer_node_owner == owner
+    assert outcome.effect.occurrence_id == str(site)
+
+
+@pytest.mark.parametrize("receiver", (ListValue(()), NoneValue()))
+def test_builtin_without_instance_dict_delete_cannot_fabricate_completion(tmp_path, receiver):
+    outcome = AttributeDeleteEffectSugar(_Receiver(receiver), "attr", _site(tmp_path)).desugar()
+    assert not isinstance(outcome, Complete)


### PR DESCRIPTION
## Instrument

Floor-owned attribute-delete errors for `ListValue.delattr` and `NoneValue.delattr`, with truthful exact-owner/occurrence and lying no-fabricated-completion twins.

## Authenticated isolated receipt

One byte-identical invocation used the real occurrence `<SourceFragment 'agy2-builtin-delattr-specimen.py' [16, 28) node=Delete>`. Each invocation pinned cwd and PYTHONPATH exclusively to its isolated checkout and printed `sys.executable` plus `list_value.py`, `none_value.py`, `delete_effect_sugar.py`, and `ground_exit.py` module `__file__` paths rooted there.\n\n- live base `1361c8ebf275c42a74ed132fa762e223b9df5070`: `AUTH_CASES=2 OWNED=0 GAPS=2`, literal `PROBE_EXIT=1`\n- head `86c47e89109b96ff848cca12be5da6583de41884`: `AUTH_CASES=2 OWNED=2 GAPS=0`, literal `PROBE_EXIT=0`\n\nMeasured `R_missing_builtin_attribute_delete_floor_owner: 2 -> 0`; `Delta=-2`.\n\n## Focused receipt\n\n`4 passed in 6.13s`; literal `REBASED_FOCUSED_EXIT=0`.\n\n## Floors\n\nForbidden carrier/ExitSet/outcome drift: `0`. Exact three-file scope; no spelling/vendor dispatch arms.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `delattr` error handling to `ListValue` and `NoneValue` builtin types
> Adds a `delattr` method to `ListValue` and `NoneValue` that returns a ground exceptional exit with `AttributeError` rather than falling through to undefined behavior. Adds a test module verifying that delete on these types yields an `Incomplete` with the correct exception name, owner, and occurrence id, and cannot produce a `Complete` outcome.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86c47e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->