### PR TITLE
Instrument nested lexical call discrimination

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
@@ -665,20 +665,105 @@ def test_lambda_inside_nested_function_composes_with_source_return_projection() 
     ) == TermValue(6)
 
 
-@pytest.mark.parametrize(
-    "source",
-    [
-        "def outer():\n    def inner(value):\n        return value + 1\n    return inner(3)\n\nouter()\n",
-        "def inner(value):\n    return value + 10\n\ndef outer():\n    def inner(value):\n        return value + 1\n    return inner(3)\n\nouter()\n",
-        "def outer():\n    def inner(value):\n        return value + 1\n    return inner(3)\n\ndef other():\n    return inner(4)\n\nother()\n",
-    ],
-)
-def test_nested_lookup_lies_cannot_authorize_by_name_or_span(source: str) -> None:
-    tree, _, _ = _tree(source, bind=frozenset({"outer", "inner", "other"}))
-    nested_calls = [
+def _nested_definition_and_call(source: str):
+    tree, context, _ = _tree(
+        source, bind=frozenset({"outer", "inner", "other", "foreign"})
+    )
+    nested = [
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == "inner"
+    ]
+    calls = [
         node
         for node in tree.nodes()
         if isinstance(node, Call) and getattr(node.func, "id", None) == "inner"
     ]
-    assert nested_calls
-    assert all(node.unit.source_function_definition_for_call(node) is None for node in nested_calls)
+    return tree, context, nested, calls
+
+
+def test_nested_call_after_definition_resolves_exact_lexical_definition() -> None:
+    _, _, definitions, calls = _nested_definition_and_call(
+        "def outer():\n"
+        "    def inner(value):\n"
+        "        return value + 1\n"
+        "    return inner(3)\n"
+    )
+    assert len(definitions) == len(calls) == 1
+    assert calls[0].unit.source_function_definition_for_call(calls[0]) is definitions[0]
+
+
+def test_nested_definition_shadows_same_name_module_definition() -> None:
+    _, _, definitions, calls = _nested_definition_and_call(
+        "def inner(value):\n"
+        "    return value + 10\n\n"
+        "def outer():\n"
+        "    def inner(value):\n"
+        "        return value + 1\n"
+        "    return inner(3)\n"
+    )
+    assert len(definitions) == 2 and len(calls) == 1
+    nested = max(definitions, key=lambda node: node.line_col_span().start_line)
+    assert calls[0].unit.source_function_definition_for_call(calls[0]) is nested
+
+
+def test_nested_definition_is_not_visible_outside_its_lexical_function() -> None:
+    _, _, _, calls = _nested_definition_and_call(
+        "def outer():\n"
+        "    def inner(value):\n"
+        "        return value + 1\n"
+        "    return inner(3)\n\n"
+        "def other():\n"
+        "    return inner(4)\n"
+    )
+    outside = max(calls, key=lambda node: node.line_col_span().start_line)
+    assert outside.unit.source_function_definition_for_call(outside) is None
+
+
+def test_nested_definition_after_call_does_not_authorize_earlier_call() -> None:
+    _, _, _, calls = _nested_definition_and_call(
+        "def outer():\n"
+        "    result = inner(3)\n"
+        "    def inner(value):\n"
+        "        return value + 1\n"
+        "    return result\n"
+    )
+    assert len(calls) == 1
+    assert calls[0].unit.source_function_definition_for_call(calls[0]) is None
+
+
+@pytest.mark.parametrize("foreign_owner", ("module", "wrong-scope"))
+def test_foreign_same_signature_nested_frame_refuses_loudly(
+    foreign_owner: str,
+) -> None:
+    source = (
+        "def inner(value):\n"
+        "    return value + 10\n\n"
+        "def foreign():\n"
+        "    def inner(value):\n"
+        "        return value + 20\n"
+        "    return inner(1)\n\n"
+        "def outer():\n"
+        "    def inner(value):\n"
+        "        return value + 1\n"
+        "    return inner(3)\n\n"
+        "outer()\n"
+    )
+    tree, context, definitions, calls = _nested_definition_and_call(source)
+    outer_call = max(calls, key=lambda node: node.line_col_span().start_line)
+    module_definition = min(definitions, key=lambda node: node.line_col_span().start_line)
+    wrong_scope_definition = sorted(
+        definitions, key=lambda node: node.line_col_span().start_line
+    )[1]
+    foreign_definition = (
+        module_definition if foreign_owner == "module" else wrong_scope_definition
+    )
+    context.source_call_frames[_coordinate(outer_call)] = (
+        foreign_definition.source_visible_call_frame()
+    )
+    public_call = _calls_named(tree, "outer")[0]
+
+    with pytest.raises((AssertionError, ConstructionPanic, SugarNotWritten)):
+        public_call.sugar().desugar(None).value._dig_floor_or_none(
+            None, owner=f"foreign-nested-{foreign_owner}"
+        )


### PR DESCRIPTION
Tests-only red instrument replacing the blanket nested-call-is-None expectation with exact lexical laws.\n\nNew lane: 6 collected, 2 passed, 4 failed. R_nested_lexical_discrimination=4: valid after-definition resolution, nested shadow over same-name module definition, and two foreign same-signature/wrong-scope receipt refusals. Out-of-scope and definition-after-call teeth pass.\n\nFull focused receipt: bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py => 38 collected, 31 passed, 7 failed in 1.85s. The other 3 reds are the pre-existing nested carrier residual.\n\nProduction delta zero. No name/span authority, production edits, reconstruction, spelling/vendor arms, carrier, or ExitSet changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for nested lexical call discrimination in `source_function_definition_for_call`
> Replaces a single generic negative test with a suite of specific tests covering lexical scoping rules for nested function definitions.
>
> - Asserts that a call to a nested function resolves to the exact lexical definition when the definition precedes the call
> - Asserts that a nested definition shadows a same-named module-level definition inside its enclosing function
> - Asserts that nested definitions are not visible outside their enclosing function
> - Asserts that a definition appearing after a call does not retroactively authorize that earlier call
> - Asserts that using a foreign nested call frame during desugaring raises `AssertionError`, `ConstructionPanic`, or `SugarNotWritten`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ae954d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->