### PR TITLE
Own term and tuple attribute delete errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -671,6 +671,15 @@ class TermValue(FloorValue):
             exception_name="AttributeError", site=site, owner="TermValue.setattr"
         )
 
+    def delattr(self, name, site):
+        """``del (1).x`` raises AttributeError — delete, not read."""
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="TermValue.delattr"
+        )
+
     def subscript(self, index, site):
         """Numbers are never subscriptable: exact ground TypeError."""
         del index

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -390,3 +390,12 @@ class TupleValue(FloorValue):
         return ground_exceptional_exit(
             exception_name="AttributeError", site=site, owner="TupleValue.setattr"
         )
+
+    def delattr(self, name, site):
+        """Tuples have no ``__dict__``; attribute delete is AttributeError."""
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="TupleValue.delattr"
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_term_tuple_attribute_delete.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_term_tuple_attribute_delete.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.floor import TermValue, TupleValue
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.sugar.delete_effect_sugar import AttributeDeleteEffectSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _site(tmp_path):
+    path = tmp_path / "term_tuple_attr_delete.py"
+    path.write_text("def f(obj):\n    del obj.attr\n")
+    return next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body[0].fragment
+
+
+@dataclass(frozen=True)
+class _Receiver(Sugar):
+    value: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+
+@pytest.mark.parametrize(
+    ("receiver", "owner"),
+    ((TermValue(1), "TermValue.delattr"), (TupleValue(()), "TupleValue.delattr")),
+)
+def test_term_tuple_attribute_delete_has_exact_owner_occurrence(tmp_path, receiver, owner):
+    site = _site(tmp_path)
+    outcome = AttributeDeleteEffectSugar(_Receiver(receiver), "attr", site).desugar()
+    assert isinstance(outcome, Incomplete)
+    assert outcome.effect.exception_name == "AttributeError"
+    assert outcome.effect.producer_node_owner == owner
+    assert outcome.effect.occurrence_id == str(site)
+
+
+@pytest.mark.parametrize("receiver", (TermValue(1), TupleValue(())))
+def test_term_tuple_attribute_delete_cannot_fabricate_completion(tmp_path, receiver):
+    outcome = AttributeDeleteEffectSugar(_Receiver(receiver), "attr", _site(tmp_path)).desugar()
+    assert not isinstance(outcome, Complete)


### PR DESCRIPTION
## Instrument

Floor-owned attribute-delete errors for `TermValue.delattr` and `TupleValue.delattr`, with truthful exact-owner/occurrence and lying no-fabricated-completion twins.

## Authenticated isolated receipt

The byte-identical invocation used real occurrence `<SourceFragment 'agy2-term-tuple-delattr-specimen.py' [16, 28) node=Delete>`. Each run pinned cwd/PYTHONPATH exclusively to its checkout and printed `sys.executable` plus `term_value.py`, `tuple_value.py`, `delete_effect_sugar.py`, and `ground_exit.py` module paths rooted there.\n\n- live base `5dd9b6e7a0976c43b4ebf5bac674bea4049d659c`: `AUTH_CASES=2 OWNED=0 GAPS=2`, `PROBE_EXIT=1`\n- head `4fe60348c3055b3641117e64c8efee2236efc704`: `AUTH_CASES=2 OWNED=2 GAPS=0`, `PROBE_EXIT=0`\n\n`R_missing_term_tuple_attribute_delete_floor_owner: 2 -> 0`; `Delta=-2`.\n\nFocused: `4 passed in 5.22s`; `REBASED_FOCUSED_EXIT=0`.\n\nFloors: `SIDE_DOOR_OCCURRENCES=0`; forbidden carrier/ExitSet/outcome drift `0`; exact three-file scope.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `delattr` error handling for `TermValue` and `TupleValue`
> Attribute deletion on `TermValue` and `TupleValue` instances now returns a ground `AttributeError` rather than producing an unhandled path. Both `delattr` implementations discard the attribute name and return a `ground_exceptional_exit` with the appropriate owner string (`TermValue.delattr` or `TupleValue.delattr`). Tests in [test_term_tuple_attribute_delete.py](https://github.com/TSavo/sugar/pull/6780/files#diff-46a5740cd45fe073586f08d657f6d7ebb60f410da4da313192b0000fbca13a7e) assert the correct `Incomplete` outcome, producer owner, and absence of any `Complete` result.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fe6034.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->