### PR TITLE
Own None subscript mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
@@ -103,6 +103,24 @@ class NoneValue(FloorValue):
             exception_name="TypeError", site=site, owner="ground_type_error"
         )
 
+    def setitem(self, index, value, site):
+        """``None[index] = value`` is an exact ground TypeError."""
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="NoneValue.setitem"
+        )
+
+    def delitem(self, index, site):
+        """``del None[index]`` is an exact ground TypeError."""
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="NoneValue.delitem"
+        )
+
     def less_than(self, other, site):
         # None orders against nothing: any ground comparison is authenticated
         # TypeError. Symbolic falls to super() emit.

--- a/implementations/python/sugar-lift-py-tests/tests/test_none_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_none_subscript_mutation.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.floor import NoneValue, TermValue
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.sugar.delete_effect_sugar import SubscriptDeleteEffectSugar
+from sugar_lift_py_tests.sugar.store_effect_sugar import SubscriptStoreEffectSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "none_subscript_mutation.py"
+    path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@dataclass(frozen=True)
+class _Value(Sugar):
+    value: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+
+def _outcomes(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    store = SubscriptStoreEffectSugar(_Value(NoneValue()), _Value(TermValue(0)), _Value(TermValue(7)), store_site).desugar()
+    delete = SubscriptDeleteEffectSugar(_Value(NoneValue()), _Value(TermValue(0)), delete_site).desugar()
+    return ((store, "NoneValue.setitem", store_site), (delete, "NoneValue.delitem", delete_site))
+
+
+def test_none_subscript_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        assert isinstance(outcome, Incomplete)
+        assert outcome.effect.exception_name == "TypeError"
+        assert outcome.effect.producer_node_owner == owner
+        assert outcome.effect.occurrence_id == str(site)
+
+
+def test_none_subscript_mutations_cannot_fabricate_completion(tmp_path):
+    for outcome, _, _ in _outcomes(tmp_path):
+        assert not isinstance(outcome, Complete)


### PR DESCRIPTION
## Instrument

Floor-owned `NoneValue.setitem` and `NoneValue.delitem` TypeErrors with truthful exact-owner/two-occurrence and lying no-fabricated-completion twins.

## Authenticated isolated receipt

The byte-identical invocation used two real source occurrences: store `<SourceFragment 'agy2-none-subscript-mutation-specimen.py' [23, 37) node=Assign>` and delete `<SourceFragment 'agy2-none-subscript-mutation-specimen.py' [42, 52) node=Delete>`. Each run pinned cwd/PYTHONPATH exclusively to its checkout and printed executable plus `none_value.py`, store/delete sugar, and ground-exit module paths rooted there.\n\n- base `e42766ef6160c24e80809c16ed3ad4fab7f56c8a`: `AUTH_CASES=2 OWNED=0 GAPS=2`, `PROBE_EXIT=1`\n- head `14c541b02f0538fda06e11f623f47e83195b388d`: `AUTH_CASES=2 OWNED=2 GAPS=0`, `PROBE_EXIT=0`\n\n`R_missing_none_subscript_mutation_floor_owner: 2 -> 0`; `Delta=-2`. Focused: `2 passed in 4.36s`, `GREEN_EXIT=0`.\n\nFloors: `SIDE_DOOR_OCCURRENCES=0`; forbidden carrier/ExitSet/outcome drift `0`; exact two-file scope.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` error handling to `NoneValue` for subscript mutations
> Subscript store (`None[i] = v`) and delete (`del None[i]`) operations on `NoneValue` previously had no defined behavior. `NoneValue.setitem` and `NoneValue.delitem` methods are added to [none_value.py](https://github.com/TSavo/sugar/pull/6781/files#diff-d7f92aa15d34339330d1f1f0ea95b7c46596f65fcc90a7ec442f972226710140), each returning a `ground_exceptional_exit` with `exception_name='TypeError'` and the call site as the occurrence ID. Tests in [test_none_subscript_mutation.py](https://github.com/TSavo/sugar/pull/6781/files#diff-b696331d48838539b496fe10447b74877d2c419be3ae9eb49fb8de097ebaa973) verify that outcomes are `Incomplete` with the correct owner and that no `Complete` outcome can be fabricated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14c541b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->