### PR TITLE
Support authenticated live for destructuring targets

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
@@ -251,14 +251,36 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
             raise TypeError("NextOperation must produce NextResult or a named exception")
 
         next_result = outcome.value
-        iteration_ctx = bind_temporal(
-            ctx,
-            runtime.target_name,
-            next_result.value,
-            owner="LoopRecurrenceSugar",
-            blame=str(self.site),
+        projected = self._project_iteration_target(
+            runtime.target_pattern, next_result.value, ctx
         )
-        body = reduce_block_to_exitset(runtime.body_sugars, iteration_ctx)
+        if isinstance(projected, Incomplete):
+            # Assignment has not begun: the positional-unpack Floor owns the
+            # halt and the exact context entering this iteration is its state.
+            return ExitSet.halted(projected.effect, state=ctx)
+        if not isinstance(projected, Complete):
+            return projected
+        target_bindings = projected.value
+        iteration_ctx = ctx
+        for name, coordinate_cid, value in target_bindings:
+            iteration_ctx = bind_temporal(
+                iteration_ctx,
+                name,
+                value,
+                owner="LoopRecurrenceSugar",
+                blame=str(self.site),
+            )
+            iteration_ctx = bind_temporal(
+                iteration_ctx,
+                coordinate_cid,
+                value,
+                owner="LoopRecurrenceSugar.target-coordinate",
+                blame=str(self.site),
+            )
+        body = reduce_block_to_exitset(
+            tuple(statement.sugar() for statement in runtime.body_statements),
+            iteration_ctx,
+        )
         if not isinstance(body, ExitSet):
             return body
         if len(body.exits) != 1:
@@ -272,8 +294,7 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
             ):
                 state = self._require_loop_control_state(
                     face.state,
-                    target_name=runtime.target_name,
-                    target_value=next_result.value,
+                    target_bindings=target_bindings,
                 )
                 if effect.action == "continue":
                     return self._advance_iterator(
@@ -300,8 +321,60 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
             entries=combined,
         )
 
+    def _project_iteration_target(self, pattern, value, ctx):
+        """Project every target leaf through the Floor-owned unpack door."""
+        from sugar_lift_py_tests.operations.positional_unpack_operation import (
+            PositionalUnpackOperation,
+            UnpackMemberRoster,
+        )
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+        from sugar_source_tree.nodes import List, Name, Tuple_
+
+        coordinates = {
+            coordinate.projection_path: coordinate
+            for coordinate in pattern.target_coordinates
+        }
+
+        def project(target, current, path=()):
+            if isinstance(target, Name):
+                coordinate = coordinates[("target", *path)]
+                return Complete(((target.id, coordinate.cid, current),))
+            if not isinstance(target, (Tuple_, List)):
+                raise TypeError("live for target contains an unsupported target leaf")
+            operation = PositionalUnpackOperation(
+                fixed_prefix=len(target.elts),
+                fixed_suffix=0,
+                has_star=False,
+                owner="LoopRecurrenceSugar.target",
+                blame=target.fragment,
+            )
+            unpacked = operation.submit(current, ctx)
+            if isinstance(unpacked, Incomplete):
+                return unpacked
+            if not isinstance(unpacked, Complete) or not isinstance(
+                unpacked.value, UnpackMemberRoster
+            ):
+                raise TypeError("positional target unpack omitted its authenticated roster")
+            if (
+                unpacked.value.occurrence is not target.fragment
+                or unpacked.value.demand_cid != operation.demand_cid()
+                or len(unpacked.value.members) != len(target.elts)
+            ):
+                raise TypeError("positional target unpack returned cross-wired testimony")
+            bindings = []
+            for index, (child, member) in enumerate(
+                zip(target.elts, unpacked.value.members, strict=True)
+            ):
+                child_result = project(child, member, (*path, index))
+                if not isinstance(child_result, Complete):
+                    return child_result
+                bindings.extend(child_result.value)
+            return Complete(tuple(bindings))
+
+        return project(pattern.target, value)
+
     @staticmethod
-    def _require_loop_control_state(state, *, target_name, target_value):
+    def _require_loop_control_state(state, *, target_bindings):
         """Authenticate the producer's exact current reduction context.
 
         A loop-control halt carries the context it received at its source
@@ -313,8 +386,12 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
 
         if not isinstance(state, ReduceContext):
             raise TypeError("loop control omitted its exact ReduceContext state")
-        if state.temporal.value_if_bound(target_name) is not target_value:
-            raise TypeError("loop control state lacks exact iteration target identity")
+        for target_name, coordinate_cid, target_value in target_bindings:
+            if (
+                state.temporal.value_if_bound(target_name) is not target_value
+                or state.temporal.value_if_bound(coordinate_cid) is not target_value
+            ):
+                raise TypeError("loop control state lacks exact iteration target identity")
         return state
 
     def _finish_iterator(self, runtime, ctx, *, entries):
@@ -323,9 +400,11 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
         )
         from sugar_lift_py_tests.outcome import Completed, ExitSet
 
-        if not runtime.else_sugars:
+        if not runtime.else_statements:
             return self._publish_runtime_bindings(runtime, ctx, entries=entries)
-        otherwise = reduce_block_to_exitset(runtime.else_sugars, ctx)
+        otherwise = reduce_block_to_exitset(
+            tuple(statement.sugar() for statement in runtime.else_statements), ctx
+        )
         if not isinstance(otherwise, ExitSet) or len(otherwise.exits) != 1:
             return otherwise
         face = otherwise.exits[0]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -48,14 +48,73 @@ class LiveOutwardHaltedFaceV1:
 
 
 @dataclass(frozen=True)
+class LiveForTargetPatternV1:
+    """One producer-authenticated assignment target for live iteration."""
+
+    target: object
+    target_coordinates: tuple[object, ...]
+    scope_owner_cid: str
+
+    def __post_init__(self) -> None:
+        from .binding_provenance import BindingCoordinateV1
+        from .nodes import List, Name, Tuple_
+
+        def leaves(node, path=()):
+            if isinstance(node, Name):
+                return ((node, ("target", *path)),)
+            if isinstance(node, (Tuple_, List)):
+                found = []
+                for index, child in enumerate(node.elts):
+                    found.extend(leaves(child, (*path, index)))
+                return tuple(found)
+            raise TypeError(
+                "live for target requires source-authenticated Name/Tuple/List leaves"
+            )
+
+        target_leaves = leaves(self.target)
+        if len(target_leaves) != len(self.target_coordinates):
+            raise TypeError("live for target requires one coordinate per target leaf")
+        for (leaf, path), coordinate in zip(
+            target_leaves, self.target_coordinates, strict=True
+        ):
+            if not isinstance(coordinate, BindingCoordinateV1):
+                raise TypeError("live for target requires BindingCoordinateV1 testimony")
+            # Decode from its own wire before accepting it.  This rejects stale
+            # CIDs rather than trusting a dataclass-shaped coordinate.
+            if BindingCoordinateV1.decode(coordinate.wire()) != coordinate:
+                raise TypeError("live for target coordinate failed re-authentication")
+            if coordinate.scope_owner_cid != self.scope_owner_cid:
+                raise TypeError("live for target coordinate has foreign loop target scope")
+            if coordinate.projection_path != path:
+                raise TypeError("live for target coordinates do not retain source target order")
+            if coordinate.binding_site != leaf.fragment.seal().to_dict():
+                raise TypeError(
+                    "live for target coordinate cites a foreign source target coordinate"
+                )
+
+    @property
+    def target_names(self) -> tuple[str, ...]:
+        from .nodes import List, Name, Tuple_
+
+        def names(node):
+            if isinstance(node, Name):
+                return (node.id,)
+            if isinstance(node, (Tuple_, List)):
+                return tuple(name for child in node.elts for name in names(child))
+            raise TypeError("live for target contains an unsupported target leaf")
+
+        return names(self.target)
+
+
+@dataclass(frozen=True)
 class LiveForRuntimeV1:
     """Unsealed execution handles paired with the sealed for construction."""
 
-    target_name: str
+    target_pattern: LiveForTargetPatternV1
     carried_names: tuple[str, ...]
     initial_value_sugars: tuple[object, ...]
-    body_sugars: tuple[object, ...]
-    else_sugars: tuple[object, ...]
+    body_statements: tuple[object, ...]
+    else_statements: tuple[object, ...]
 
 
 def _formula_cid(formula) -> str:
@@ -684,19 +743,42 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
     records = _conserve_unique_records(records)
     construction = decode_loop_construction_v1({"root": root, "records": records})
     if isinstance(loop, For):
-        if loop.target.kind != "Name":
+        from .binding_state import mint_binding_coordinate_v1
+        from .nodes import List, Name, Tuple_
+
+        def target_coordinates(target, path=()):
+            if isinstance(target, Name):
+                return (
+                    mint_binding_coordinate_v1(
+                        scope_owner_cid=target_cid,
+                        binding_site=target.fragment,
+                        projection_path=("target", *path),
+                    ),
+                )
+            if isinstance(target, (Tuple_, List)):
+                return tuple(
+                    coordinate
+                    for index, child in enumerate(target.elts)
+                    for coordinate in target_coordinates(child, (*path, index))
+                )
             raise BindingStateWireGap(
-                "live iterator recurrence requires an authenticated name target"
+                "live iterator recurrence requires an authenticated assignment target"
             )
+
+        pattern = LiveForTargetPatternV1(
+            target=loop.target,
+            target_coordinates=target_coordinates(loop.target),
+            scope_owner_cid=target_cid,
+        )
         construction = replace(
             construction,
             iterable_sugar=loop.iter.sugar(),
             loop_runtime=LiveForRuntimeV1(
-                loop.target.id,
+                pattern,
                 carried_names,
                 tuple(entry.state.sugar() for entry in pre_runtime),
-                tuple(statement.sugar() for statement in loop.body),
-                tuple(statement.sugar() for statement in loop.orelse),
+                tuple(loop.body),
+                tuple(loop.orelse),
             ),
         )
 
@@ -721,6 +803,8 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
 
 
 __all__ = [
+    "LiveForRuntimeV1",
+    "LiveForTargetPatternV1",
     "LiveLoopProjectionV1",
     "LiveOutwardHaltedFaceV1",
     "construct_live_loop_recurrence",

--- a/implementations/python/sugar-source-tree/tests/test_for_iterator_recurrence_integration.py
+++ b/implementations/python/sugar-source-tree/tests/test_for_iterator_recurrence_integration.py
@@ -96,6 +96,13 @@ def test_loop_control_state_accepts_only_the_exact_iteration_binding_identity() 
         owner="loop-control-exact",
         blame="loop-control-exact",
     )
+    exact = bind_temporal(
+        exact,
+        "blake3-512:" + "a" * 128,
+        value,
+        owner="loop-control-coordinate",
+        blame="loop-control-coordinate",
+    )
     foreign = bind_temporal(
         ambient,
         "item",
@@ -107,20 +114,17 @@ def test_loop_control_state_accepts_only_the_exact_iteration_binding_identity() 
     assert (
         LoopRecurrenceSugar._require_loop_control_state(
             exact,
-            target_name="item",
-            target_value=value,
+            target_bindings=(("item", "blake3-512:" + "a" * 128, value),),
         )
         is exact
     )
     with pytest.raises(TypeError, match="exact iteration target identity"):
         LoopRecurrenceSugar._require_loop_control_state(
             ambient,
-            target_name="item",
-            target_value=value,
+            target_bindings=(("item", "blake3-512:" + "a" * 128, value),),
         )
     with pytest.raises(TypeError, match="exact iteration target identity"):
         LoopRecurrenceSugar._require_loop_control_state(
             foreign,
-            target_name="item",
-            target_value=value,
+            target_bindings=(("item", "blake3-512:" + "a" * 128, value),),
         )

--- a/implementations/python/sugar-source-tree/tests/test_live_for_destructuring_target.py
+++ b/implementations/python/sugar-source-tree/tests/test_live_for_destructuring_target.py
@@ -1,0 +1,178 @@
+"""Authenticated live ``for`` destructuring target recurrence law."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.context.reduce_context import ReduceContext
+from sugar_lift_py_tests.floor.iterator_value import TupleIteratorValue
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.floor.tuple_value import TupleValue
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
+from sugar_lift_py_tests.temporal import bind_temporal
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.binding_state import mint_binding_coordinate_v1
+from sugar_source_tree.live_loop_construction import LiveForTargetPatternV1
+from sugar_source_tree.nodes import For, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str) -> FunctionDef:
+    tree = SourceFile(
+        (source, "tests/live_for_destructuring_target.py", blake3_512_of(source.encode()))
+    )
+    return next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+
+
+def _loop_and_runtime(source: str):
+    function = _function(source)
+    loop_node = next(node for node in function.body if isinstance(node, For))
+    loop_sugar = next(
+        statement
+        for statement in function.sugar().statements
+        if type(statement).__name__ == "LoopRecurrenceSugar"
+    )
+    return loop_node, loop_sugar.construction.loop_runtime
+
+
+def _loop_sugar(source: str):
+    return next(
+        statement
+        for statement in _function(source).sugar().statements
+        if type(statement).__name__ == "LoopRecurrenceSugar"
+    )
+
+
+def _completed_post(outcome):
+    if isinstance(outcome, Complete):
+        return outcome.value.post()
+    assert isinstance(outcome, ExitSet), outcome
+    completed = [face for face in outcome.exits if isinstance(face, Completed)]
+    assert len(completed) == 1, completed
+    return completed[0].value.post()
+
+
+_PAIR_LOOP = (
+    "def helper(items):\n"
+    "    result = 0\n"
+    "    for left, right in items:\n"
+    "        result = left\n"
+    "    return result\n"
+)
+
+
+def test_live_pair_target_retains_producer_coordinates_in_source_order() -> None:
+    loop, runtime = _loop_and_runtime(_PAIR_LOOP)
+
+    assert isinstance(runtime.target_pattern, LiveForTargetPatternV1)
+    assert (
+        runtime.target_pattern.target.fragment.seal().cid
+        == loop.target.fragment.seal().cid
+    )
+    assert runtime.target_pattern.target_names == ("left", "right")
+    assert tuple(
+        coordinate.projection_path
+        for coordinate in runtime.target_pattern.target_coordinates
+    ) == (("target", 0), ("target", 1))
+    assert all(
+        coordinate.scope_owner_cid == loop.owned_loop_target.target_cid
+        for coordinate in runtime.target_pattern.target_coordinates
+    )
+
+
+def test_live_pair_target_unpacks_by_floor_order_and_threads_each_iteration() -> None:
+    source = (
+        "def helper():\n"
+        "    result = 0\n"
+        "    for left, right in [(1, 2), (3, 4)]:\n"
+        "        result = left\n"
+        "    return result\n"
+    )
+
+    post = _completed_post(_function(source).sugar().desugar())
+
+    assert post.args[1].value == 3
+
+
+def test_live_pair_target_arity_halt_retains_exact_pre_assignment_state() -> None:
+    recurrence = _loop_sugar(_PAIR_LOOP)
+    result = TermValue(7)
+    ctx = bind_temporal(
+        ReduceContext.root(owner="live-pair-arity"),
+        "result",
+        result,
+        owner="live-pair-arity",
+        blame=str(recurrence.site),
+    )
+
+    outcome = recurrence._advance_iterator(
+        TupleIteratorValue((TupleValue((TermValue(1),)),)),
+        recurrence.construction.loop_runtime,
+        ctx,
+        entries=(),
+    )
+
+    assert isinstance(outcome, ExitSet)
+    halted = [face for face in outcome.exits if isinstance(face, Halted)]
+    assert len(halted) == 1
+    assert isinstance(halted[0].effect, RaiseEffect)
+    assert halted[0].effect.exception_name == "ValueError"
+    assert halted[0].state is ctx
+    assert halted[0].state.temporal.value_if_bound("result") is result
+    assert halted[0].state.temporal.value_if_bound("left") is None
+    assert halted[0].state.temporal.value_if_bound("right") is None
+
+
+def test_live_pair_target_rejects_reordered_coordinates() -> None:
+    _loop, runtime = _loop_and_runtime(_PAIR_LOOP)
+    pattern = runtime.target_pattern
+
+    with pytest.raises(TypeError, match="source target order"):
+        replace(pattern, target_coordinates=tuple(reversed(pattern.target_coordinates)))
+
+
+def test_live_pair_target_rejects_missing_or_extra_coordinates() -> None:
+    loop, runtime = _loop_and_runtime(_PAIR_LOOP)
+    pattern = runtime.target_pattern
+    extra = mint_binding_coordinate_v1(
+        scope_owner_cid=loop.owned_loop_target.target_cid,
+        binding_site=loop.target.elts[0].fragment,
+        projection_path=("target", 2),
+    )
+
+    with pytest.raises(TypeError, match="one coordinate per target leaf"):
+        replace(pattern, target_coordinates=pattern.target_coordinates[:-1])
+    with pytest.raises(TypeError, match="one coordinate per target leaf"):
+        replace(pattern, target_coordinates=(*pattern.target_coordinates, extra))
+
+
+def test_live_pair_target_rejects_foreign_target_and_scope_testimony() -> None:
+    loop, runtime = _loop_and_runtime(_PAIR_LOOP)
+    pattern = runtime.target_pattern
+    foreign_loop, _foreign_runtime = _loop_and_runtime(
+        _PAIR_LOOP.replace("left, right", "other_left, other_right")
+    )
+    foreign_site = mint_binding_coordinate_v1(
+        scope_owner_cid=loop.owned_loop_target.target_cid,
+        binding_site=foreign_loop.target.elts[0].fragment,
+        projection_path=("target", 0),
+    )
+    foreign_scope = mint_binding_coordinate_v1(
+        scope_owner_cid=foreign_loop.owned_loop_target.target_cid,
+        binding_site=loop.target.elts[0].fragment,
+        projection_path=("target", 0),
+    )
+
+    with pytest.raises(TypeError, match="source target coordinate"):
+        replace(
+            pattern,
+            target_coordinates=(foreign_site, pattern.target_coordinates[1]),
+        )
+    with pytest.raises(TypeError, match="loop target scope"):
+        replace(
+            pattern,
+            target_coordinates=(foreign_scope, pattern.target_coordinates[1]),
+        )


### PR DESCRIPTION
## What changed
- retain a producer-authenticated source target pattern and one BindingCoordinateV1 per target leaf
- project tuple/list targets through Floor-owned positional unpack before temporal binding
- preserve exact pre-assignment context on unpack halt and defer body sugar construction until recurrence execution
- reject reordered, missing, extra, foreign-target, and foreign-scope testimony

## Instrument
- R_non_Name recurrence manifestations: 3 -> 0 (Delta=-3, Epsilon=0 on the owning denominator)
- the real option_context construction advances beyond the non-Name recurrence seam; the surviving dynamic-export resolution red is separately owned

## Tests
- bin/bpytest implementations/python/sugar-source-tree/tests/test_live_for_destructuring_target.py implementations/python/sugar-source-tree/tests/test_for_iterator_recurrence_integration.py -q
- 10 passed in 1.06s

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support destructuring assignment targets in authenticated live `for` loops
> - Adds `LiveForTargetPatternV1` to carry producer-authenticated `BindingCoordinateV1` coordinates for each leaf of a destructuring target (Name, Tuple, List), validated at construction time against source order and scope owner.
> - Replaces the single `target_name: str` in `LiveForRuntimeV1` with `target_pattern: LiveForTargetPatternV1`, and switches body/else fields from pre-sugared tuples to raw statement nodes.
> - `LoopRecurrenceSugar._advance_iterator` now calls a new `_project_iteration_target` helper that uses a Floor-owned `PositionalUnpackOperation` to unpack and bind each target leaf along with its coordinate CID; returns a halted `ExitSet` if unpacking is incomplete.
> - Loop control validation in `_require_loop_control_state` is updated to check that both the target name and its coordinate CID are bound to the exact same value object.
> - Behavioral Change: loops with multi-target destructuring now halt before any assignment when unpacking is incomplete, rather than binding a single name directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5db91a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->