### PR TITLE
Own numeric subscript mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -691,6 +691,24 @@ class TermValue(FloorValue):
             owner="TermValue.subscript",
         )
 
+    def setitem(self, index, value, site):
+        """Numeric values reject subscript store with exact TypeError."""
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="TermValue.setitem"
+        )
+
+    def delitem(self, index, site):
+        """Numeric values reject subscript delete with exact TypeError."""
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="TermValue.delitem"
+        )
+
     def to_term(self, *, owner: str):
         del owner
         if type(self.value) is float:

--- a/implementations/python/sugar-lift-py-tests/tests/test_term_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_term_subscript_mutation.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+
+from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.sugar.delete_effect_sugar import SubscriptDeleteEffectSugar
+from sugar_lift_py_tests.sugar.store_effect_sugar import SubscriptStoreEffectSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "term_subscript_mutation.py"
+    path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@dataclass(frozen=True)
+class _Value(Sugar):
+    value: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+
+def _outcomes(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    store = SubscriptStoreEffectSugar(_Value(TermValue(1)), _Value(TermValue(0)), _Value(TermValue(7)), store_site).desugar()
+    delete = SubscriptDeleteEffectSugar(_Value(TermValue(1)), _Value(TermValue(0)), delete_site).desugar()
+    return ((store, "TermValue.setitem", store_site), (delete, "TermValue.delitem", delete_site))
+
+
+def test_term_subscript_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        assert isinstance(outcome, Incomplete)
+        assert outcome.effect.exception_name == "TypeError"
+        assert outcome.effect.producer_node_owner == owner
+        assert outcome.effect.occurrence_id == str(site)
+
+
+def test_term_subscript_mutations_cannot_fabricate_completion(tmp_path):
+    for outcome, _, _ in _outcomes(tmp_path):
+        assert not isinstance(outcome, Complete)


### PR DESCRIPTION
## Instrument

Floor-owned `TermValue.setitem` and `TermValue.delitem` TypeErrors with truthful exact-owner/two-occurrence and lying no-fabricated-completion twins.

## Authenticated isolated receipt

The byte-identical invocation used real store `<SourceFragment 'agy2-term-subscript-mutation-specimen.py' [23, 37) node=Assign>` and delete `<SourceFragment 'agy2-term-subscript-mutation-specimen.py' [42, 52) node=Delete>` occurrences. Each run pinned cwd/PYTHONPATH exclusively to its checkout and printed executable plus `term_value.py`, store/delete sugar, and ground-exit module paths rooted there.\n\n- base `c19194a07ccb7c6c413a32e0c1d5d47958963f41`: `AUTH_CASES=2 OWNED=0 GAPS=2`, `PROBE_EXIT=1`\n- head `bd03e38a22145211243278afcf4ab9417404ba0a`: `AUTH_CASES=2 OWNED=2 GAPS=0`, `PROBE_EXIT=0`\n\n`R_missing_numeric_subscript_mutation_floor_owner: 2 -> 0`; `Delta=-2`. Focused: `2 passed in 2.88s`, `GREEN_EXIT=0`.\n\nFloors: `SETITEM_PRODUCTION_DEFS=1`, `DELITEM_PRODUCTION_DEFS=1`, `LAW_OF_ONE_VIOLATIONS=0`, `SIDE_DOOR_OCCURRENCES=0`, forbidden carrier/ExitSet/outcome drift `0`; exact two-file scope.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `TypeError` exits for subscript mutation on numeric `TermValue`
> - Adds `setitem` and `delitem` methods to `TermValue` in [term_value.py](https://github.com/TSavo/sugar/pull/6783/files#diff-e121752ef29c0271aaddd03d641288ad242e0daed95686a07feb339efc29a9ea) that return a `ground_exceptional_exit` with `TypeError` instead of performing the operation.
> - Adds tests in [test_term_subscript_mutation.py](https://github.com/TSavo/sugar/pull/6783/files#diff-0eb9b9b202a565af21cbc3f63e7dd6f86c6d9ae5ba9003984f5a10bbe01ad5a2) verifying that subscript store and delete on numeric `TermValue` produce `Incomplete` outcomes with the correct owner and occurrence ID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd03e38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->