### PR TITLE
Own set subscript mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -43,6 +43,24 @@ class SetValue(FloorValue):
             owner="SetValue.subscript",
         )
 
+    def setitem(self, index, value, site):
+        """Sets reject subscript store with exact TypeError."""
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="SetValue.setitem"
+        )
+
+    def delitem(self, index, site):
+        """Sets reject subscript delete with exact TypeError."""
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="SetValue.delitem"
+        )
+
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.ir import ctor
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_set_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_set_subscript_mutation.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+from sugar_lift_py_tests.floor import SetValue, TermValue
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.sugar.delete_effect_sugar import SubscriptDeleteEffectSugar
+from sugar_lift_py_tests.sugar.store_effect_sugar import SubscriptStoreEffectSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "set_subscript_mutation.py"
+    path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@dataclass(frozen=True)
+class _Value(Sugar):
+    value: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+
+def _outcomes(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    receiver = SetValue((TermValue(1),))
+    store = SubscriptStoreEffectSugar(_Value(receiver), _Value(TermValue(0)), _Value(TermValue(7)), store_site).desugar()
+    delete = SubscriptDeleteEffectSugar(_Value(receiver), _Value(TermValue(0)), delete_site).desugar()
+    return ((store, "SetValue.setitem", store_site), (delete, "SetValue.delitem", delete_site))
+
+
+def test_set_subscript_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        assert isinstance(outcome, Incomplete)
+        assert outcome.effect.exception_name == "TypeError"
+        assert outcome.effect.producer_node_owner == owner
+        assert outcome.effect.occurrence_id == str(site)
+
+
+def test_set_subscript_mutations_cannot_fabricate_completion(tmp_path):
+    for outcome, _, _ in _outcomes(tmp_path):
+        assert not isinstance(outcome, Complete)


### PR DESCRIPTION
## Instrument

Floor-owned `SetValue.setitem` and `SetValue.delitem` TypeErrors with truthful exact-owner/two-occurrence and lying no-fabricated-completion twins.

## Authenticated isolated receipt

Byte-identical runs used real store `<SourceFragment 'agy2-set-subscript-mutation-specimen.py' [23, 37) node=Assign>` and delete `<SourceFragment 'agy2-set-subscript-mutation-specimen.py' [42, 52) node=Delete>` occurrences, with cwd/PYTHONPATH and printed module paths rooted exclusively in each checkout.\n\n- base `62cf3ea14ca5020133e8838589e3214b7c9b605f`: `AUTH_CASES=2 OWNED=0 GAPS=2`, `PROBE_EXIT=1`\n- head `d48140dc3f41ab1598bb58122346c67595888111`: `AUTH_CASES=2 OWNED=2 GAPS=0`, `PROBE_EXIT=0`\n\n`R_missing_set_subscript_mutation_floor_owner: 2 -> 0`; `Delta=-2`. Focused: `2 passed in 3.11s`, `GREEN_EXIT=0`.\n\nFloors: `SETITEM_PRODUCTION_DEFS=1`, `DELITEM_PRODUCTION_DEFS=1`, `LAW_OF_ONE_VIOLATIONS=0`, `SIDE_DOOR_OCCURRENCES=0`, forbidden carrier/ExitSet/outcome drift `0`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TypeError responses for subscript store and delete on `SetValue`
> - Adds `SetValue.setitem` and `SetValue.delitem` methods in [`set_value.py`](https://github.com/TSavo/sugar/pull/6785/files#diff-b0c9e960d3d4b7db93191cc5b7756b6af96e114df7d3a37ecb672ac519858cb3) that return a `ground_exceptional_exit` with `exception_name='TypeError'` instead of allowing subscript mutation on sets.
> - Adds tests in [`test_set_subscript_mutation.py`](https://github.com/TSavo/sugar/pull/6785/files#diff-d79826bc6d17ccb7468a5de3494829831b98a085ead4e7106a3ff5667dfc5ed3) verifying that subscript store/delete produce `Incomplete` outcomes with the correct `producer_node_owner` and cannot produce `Complete` outcomes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d48140d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->