### PR TITLE
Project authenticated loop binding products

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -207,6 +207,45 @@ def _sealed_state(snapshot: tuple[BindingEntryV1, ...]):
     return raw, testified
 
 
+def construct_live_binding_product_sugar(
+    *, name: str, entry: BindingEntryV1, expected_coordinate, site
+):
+    """Project one authenticated binding product into term-sugar currency.
+
+    The runtime entry is already the product of ``_sealed_state``.  This door
+    re-authenticates its coordinate and exact live/sealed pairing before using
+    the shared binding-projection owner; a loop consumer never reconstructs a
+    projection from lexical names or from whichever state happens to arrive.
+    """
+    from .binding_provenance import BindingCoordinateV1
+    from .nodes import _construct_binding_projection
+    from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import (
+        GuardedBindingReadSugar,
+    )
+    from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+
+    if not isinstance(entry, BindingEntryV1) or not isinstance(
+        expected_coordinate, BindingCoordinateV1
+    ):
+        raise BindingStateWireGap(
+            "live binding product requires an authenticated binding entry coordinate"
+        )
+    BindingCoordinateV1.decode(entry.coordinate.wire())
+    BindingCoordinateV1.decode(expected_coordinate.wire())
+    if entry.coordinate != expected_coordinate:
+        raise BindingStateWireGap(
+            "live binding product received a foreign binding coordinate"
+        )
+    if entry.sealed_state != _seal_runtime_state(entry.state):
+        raise BindingStateWireGap(
+            "live state disagrees with its authenticated sealed binding product"
+        )
+    projection = _construct_binding_projection(entry.state)
+    if isinstance(projection, ConstructedTermSugar):
+        return projection
+    return GuardedBindingReadSugar(name=name, state=projection, site=site)
+
+
 def _combine(outer, inner):
     return inner if outer is None else and_([outer, inner])
 
@@ -776,7 +815,17 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
             loop_runtime=LiveForRuntimeV1(
                 pattern,
                 carried_names,
-                tuple(entry.state.sugar() for entry in pre_runtime),
+                tuple(
+                    construct_live_binding_product_sugar(
+                        name=name,
+                        entry=runtime_entry,
+                        expected_coordinate=source_entry.coordinate,
+                        site=loop.fragment,
+                    )
+                    for name, source_entry, runtime_entry in zip(
+                        carried_names, pre_entries, pre_runtime, strict=True
+                    )
+                ),
                 tuple(loop.body),
                 tuple(loop.orelse),
             ),
@@ -807,5 +856,6 @@ __all__ = [
     "LiveForTargetPatternV1",
     "LiveLoopProjectionV1",
     "LiveOutwardHaltedFaceV1",
+    "construct_live_binding_product_sugar",
     "construct_live_loop_recurrence",
 ]

--- a/implementations/python/sugar-source-tree/tests/test_loop_projected_binding_product.py
+++ b/implementations/python/sugar-source-tree/tests/test_loop_projected_binding_product.py
@@ -1,0 +1,128 @@
+"""Canonical constructed product for authenticated loop post-bindings."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_py_tests.ir import atomic, not_, str_const
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+from sugar_source_tree.binding_state import (
+    BindingEntryV1,
+    BindingStateWireGap,
+    LoopProjectedBinding,
+    LoopProjectedCompletedFace,
+    RuntimeBindingEntryFactoryV1,
+)
+from sugar_source_tree import live_loop_construction as live_loop
+from sugar_source_tree.tree import SourceFile
+
+
+def _assignment(source: str):
+    function = next(SourceFile((source, "tests/loop_product.py", cid_of_json(source))).functions())
+    assignment = next(node for node in function.walk() if node.kind == "Assign")
+    return function, assignment
+
+
+def _projected_entry():
+    function, first = _assignment("def f():\n    value = 1\n")
+    _other_function, second = _assignment("def g():\n    value = 2\n")
+    factory = RuntimeBindingEntryFactoryV1(
+        cid_of_json({"scope": function.fragment.seal().to_dict()})
+    )
+    entry = factory.mint_entry(
+        binding_site=first.targets[0].fragment,
+        projection_path=("targets", 0),
+        state=first.value,
+    )
+    target_cid = cid_of_json({"loop": function.fragment.seal().cid})
+    guard = atomic("loop.product.guard", (str_const(target_cid),))
+    projected = LoopProjectedBinding(
+        target_cid,
+        (
+            LoopProjectedCompletedFace(
+                target_cid,
+                "BreakExit",
+                live_loop._formula_cid(guard),
+                first.value,
+                guard,
+                2,
+            ),
+            LoopProjectedCompletedFace(
+                target_cid,
+                "NormalExhaustion",
+                live_loop._formula_cid(not_(guard)),
+                second.value,
+                not_(guard),
+                2,
+            ),
+        ),
+    )
+    return first, replace(
+        entry,
+        state=projected,
+        sealed_state=live_loop._seal_runtime_state(projected),
+    )
+
+
+def _construct_product(**kwargs):
+    producer = getattr(live_loop, "construct_live_binding_product_sugar", None)
+    assert producer is not None, (
+        "live loop binding products require one authenticated ConstructedTermSugar "
+        "projection owner"
+    )
+    return producer(**kwargs)
+
+
+def test_authenticated_loop_projection_constructs_one_term_product() -> None:
+    assignment, entry = _projected_entry()
+
+    product = _construct_product(
+        name="value",
+        entry=entry,
+        expected_coordinate=entry.coordinate,
+        site=assignment.fragment,
+    )
+
+    assert isinstance(product, ConstructedTermSugar)
+    assert product.to_term(owner="test").name == "python:guarded-binding-read"
+
+
+def test_foreign_binding_coordinate_cannot_select_the_product() -> None:
+    assignment, entry = _projected_entry()
+    _foreign_function, foreign = _assignment("def h():\n    other = 3\n")
+    foreign_coordinate = RuntimeBindingEntryFactoryV1(
+        cid_of_json({"scope": foreign.fragment.seal().to_dict()})
+    ).mint_entry(
+        binding_site=foreign.targets[0].fragment,
+        projection_path=("targets", 0),
+        state=foreign.value,
+    ).coordinate
+
+    with pytest.raises(BindingStateWireGap, match="foreign binding coordinate"):
+        _construct_product(
+            name="value",
+            entry=entry,
+            expected_coordinate=foreign_coordinate,
+            site=assignment.fragment,
+        )
+
+
+def test_live_state_cannot_disagree_with_its_authenticated_sealed_product() -> None:
+    assignment, entry = _projected_entry()
+    _foreign_function, foreign = _assignment("def h():\n    value = 9\n")
+    face = entry.state.completed_faces[0]
+    lying_state = replace(
+        entry.state,
+        completed_faces=(replace(face, state=foreign.value), *entry.state.completed_faces[1:]),
+    )
+
+    with pytest.raises(BindingStateWireGap, match="sealed binding product"):
+        _construct_product(
+            name="value",
+            entry=replace(entry, state=lying_state),
+            expected_coordinate=entry.coordinate,
+            site=assignment.fragment,
+        )


### PR DESCRIPTION
## What changed
- add one producer-owned conversion from authenticated BindingEntryV1 products to ConstructedTermSugar
- re-authenticate the binding coordinate and exact live/sealed state pairing before projection
- delegate all guarded and loop-face construction to the existing binding projection owner
- use that product for live-loop carried initial values instead of calling .sugar() on LoopProjectedBinding

## Instrument
- R_LoopProjectedBinding.sugar: 2 -> 0
- Delta=-2; Epsilon=0
- truthful product plus foreign-coordinate and wrong-state twins remain loud

## Tests
- bin/bpytest implementations/python/sugar-source-tree/tests/test_loop_projected_binding_product.py implementations/python/sugar-lift-py-tests/tests/test_loop_post_state_sealing_partition.py implementations/python/sugar-source-tree/tests/test_live_loop_post_projection.py -q
- 26 passed in 0.85s

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate loop binding products in `construct_live_loop_recurrence`
> - Adds `construct_live_binding_product_sugar` in [`live_loop_construction.py`](https://github.com/TSavo/sugar/pull/6786/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094), which validates a `BindingEntryV1` against an expected `BindingCoordinateV1` and checks that `sealed_state` matches the live state before projecting.
> - In the For-loop branch of `construct_live_loop_recurrence`, carried binding sugars are now built via this authenticated utility instead of calling `entry.state.sugar()` directly.
> - Returns a `ConstructedTermSugar` if the projection is already constructed, otherwise wraps it in a `GuardedBindingReadSugar`.
> - Adds tests covering the happy path, coordinate mismatch, and sealed-state disagreement in [`test_loop_projected_binding_product.py`](https://github.com/TSavo/sugar/pull/6786/files#diff-e96ae571b7702b31ac258775c65a1da9fcf249f2bdbe73295fab61ca9a77bfb1).
> - Risk: `construct_live_loop_recurrence` now raises `BindingStateWireGap` if the runtime entry's coordinate does not match the pre-entry coordinate or if `sealed_state` disagrees with the live state, where it previously succeeded silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7aaf9f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->