### PR TITLE
Own set attribute mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py
@@ -25,6 +25,24 @@ class SetValue(FloorValue):
 
         return getattr_coordinate(self, name, owner="SetValue.attribute")
 
+    def setattr(self, name, value, site):
+        """Sets have no instance ``__dict__``; store is AttributeError."""
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="SetValue.setattr"
+        )
+
+    def delattr(self, name, site):
+        """Sets have no instance ``__dict__``; delete is AttributeError."""
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="SetValue.delattr"
+        )
+
     def denotes_value(self) -> bool:
         """This floor value denotes a ``set``."""
         return True

--- a/implementations/python/sugar-lift-py-tests/tests/test_set_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_set_attribute_mutation.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+from sugar_lift_py_tests.floor import SetValue, TermValue
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.sugar.delete_effect_sugar import AttributeDeleteEffectSugar
+from sugar_lift_py_tests.sugar.store_effect_sugar import AttributeStoreEffectSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "set_attribute_mutation.py"
+    path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@dataclass(frozen=True)
+class _Value(Sugar):
+    value: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+
+def _outcomes(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    receiver = SetValue((TermValue(1),))
+    store = AttributeStoreEffectSugar(_Value(receiver), _Value(TermValue(7)), "attr", store_site).desugar()
+    delete = AttributeDeleteEffectSugar(_Value(receiver), "attr", delete_site).desugar()
+    return ((store, "SetValue.setattr", store_site), (delete, "SetValue.delattr", delete_site))
+
+
+def test_set_attribute_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        assert isinstance(outcome, Incomplete)
+        assert outcome.effect.exception_name == "AttributeError"
+        assert outcome.effect.producer_node_owner == owner
+        assert outcome.effect.occurrence_id == str(site)
+
+
+def test_set_attribute_mutations_cannot_fabricate_completion(tmp_path):
+    for outcome, _, _ in _outcomes(tmp_path):
+        assert not isinstance(outcome, Complete)


### PR DESCRIPTION
Floor-owned `SetValue.setattr`/`delattr` AttributeErrors with exact authentic assign/delete occurrences and no-completion twins.

Base `ebdb858de047a1a6eda5b9e6cc077691784f96b5`: `AUTH_CASES=2 OWNED=0 GAPS=2 PROBE_EXIT=1`. Head `9b9aec31536398033ce387a8ddccf89ed604ef6a`: `AUTH_CASES=2 OWNED=2 GAPS=0 PROBE_EXIT=0`. Focused `2 passed`, exit 0. `R 2->0`, Delta=-2. `SETATTR_PRODUCTION_DEFS=1`, `DELATTR_PRODUCTION_DEFS=1`, `LAW_OF_ONE_VIOLATIONS=0`, `SIDE_DOOR_OCCURRENCES=0`, carrier/ExitSet/outcome drift=0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` error handling to `SetValue` to raise `AttributeError`
> Adds `setattr` and `delattr` methods to `SetValue` in [set_value.py](https://github.com/TSavo/sugar/pull/6787/files#diff-b0c9e960d3d4b7db93191cc5b7756b6af96e114df7d3a37ecb672ac519858cb3) that return a `ground_exceptional_exit` with `AttributeError` instead of allowing attribute mutation or deletion. Tests in [test_set_attribute_mutation.py](https://github.com/TSavo/sugar/pull/6787/files#diff-77efc638a1abde6669469b0c780fdf3722088768204b51edc215f607cd768953) verify that these operations produce `Incomplete` outcomes with the correct owner and site, and cannot yield `Complete` outcomes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b9aec3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->