### PR TITLE
Own dict attribute mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
@@ -127,6 +127,24 @@ class DictValue(FloorValue):
 
         return getattr_coordinate(self, name, owner="DictValue.attribute")
 
+    def setattr(self, name, value, site):
+        """Dicts have no instance ``__dict__``; store is AttributeError."""
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="DictValue.setattr"
+        )
+
+    def delattr(self, name, site):
+        """Dicts have no instance ``__dict__``; delete is AttributeError."""
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="DictValue.delattr"
+        )
+
     def to_term(self, *, owner: str):
         # Project as python:dict of entry pairs (layout-preserving coordinate).
         from sugar_lift_py_tests.ir import ctor

--- a/implementations/python/sugar-lift-py-tests/tests/test_dict_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dict_attribute_mutation.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+
+from sugar_lift_py_tests.floor import DictValue, TermValue
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.sugar.delete_effect_sugar import AttributeDeleteEffectSugar
+from sugar_lift_py_tests.sugar.store_effect_sugar import AttributeStoreEffectSugar
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "dict_attribute_mutation.py"
+    path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@dataclass(frozen=True)
+class _Value(Sugar):
+    value: object
+
+    @classmethod
+    def witnesses(cls): return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+
+def _outcomes(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    receiver = DictValue(())
+    store = AttributeStoreEffectSugar(_Value(receiver), _Value(TermValue(7)), "attr", store_site).desugar()
+    delete = AttributeDeleteEffectSugar(_Value(receiver), "attr", delete_site).desugar()
+    return ((store, "DictValue.setattr", store_site), (delete, "DictValue.delattr", delete_site))
+
+
+def test_dict_attribute_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        assert isinstance(outcome, Incomplete)
+        assert outcome.effect.exception_name == "AttributeError"
+        assert outcome.effect.producer_node_owner == owner
+        assert outcome.effect.occurrence_id == str(site)
+
+
+def test_dict_attribute_mutations_cannot_fabricate_completion(tmp_path):
+    for outcome, _, _ in _outcomes(tmp_path):
+        assert not isinstance(outcome, Complete)


### PR DESCRIPTION
Floor-owned `DictValue.setattr`/`delattr` AttributeErrors with authentic assign/delete occurrences and no-completion twins. Base `8080e06f078cecf4311789063c268d8c38224de1`: `AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1`; head `91e0b2c22cc87a5e920739fc6cd0ca0967e96533`: `AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0`. Focused `2 passed`. R 2->0, Delta=-2. SETATTR_DEFS=1 DELATTR_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 carrier/ExitSet/outcome drift=0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `AttributeError` outcomes for attribute mutation on `DictValue`
> Adds `setattr` and `delattr` methods to `DictValue` that return a `ground_exceptional_exit` with `AttributeError` instead of allowing attribute assignment or deletion to succeed silently. Tests verify that both operations produce `Incomplete` outcomes with the correct `producer_node_owner` and `occurrence_id`, and that neither can fabricate a `Complete` outcome.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91e0b2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->