### PR TITLE
Instrument lexical consumer side-door retirement

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -1,5 +1,31 @@
 from __future__ import annotations
 
+from pathlib import Path
+import re
+
+
+def test_lexical_consumer_side_doors_are_retired_to_closed_lookup_rows() -> None:
+    """Red instrument for the queued NestedFunctionLookupV1 migration."""
+    root = Path(__file__).parents[1]
+    targets = (
+        root / "src/sugar_lift_python_source/source_call_preconstruction.py",
+        root / "src/sugar_lift_python_source/manager_construction.py",
+    )
+    forbidden = re.compile(
+        r"(first[-_ ]match|name[_ ]map|coordinate[_ ]reconstruction|span[_ ]scan|\.walk\()",
+        re.IGNORECASE,
+    )
+    offenders = []
+    for path in targets:
+        for line_no, line in enumerate(path.read_text().splitlines(), 1):
+            if forbidden.search(line):
+                offenders.append(f"{path}:{line_no}: {line.strip()}")
+    assert not offenders, (
+        "R_lexical consumer side doors remains nonempty; replace each offender "
+        "with authenticated NestedFunctionLookupV1 rows keyed by source CID, "
+        "definition/call loci, and lexical scope.\n" + "\n".join(offenders)
+    )
+
 import csv
 from dataclasses import replace
 import importlib.metadata


### PR DESCRIPTION
Tests-only honest red instrument. Enumerates live source/manager preconstruction scan/name/span/coordinate side doors and states replacement: closed NestedFunctionLookupV1 rows. Production untouched.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test enforcing retirement of lexical consumer side-doors in source construction files
> Adds a test in [test_source_call_preconstruction.py](https://github.com/TSavo/sugar/pull/6789/files#diff-af9ccbdeb2416e91eee428d9c20850ad53f523ceda2c2ad34a1ac68d88204e8c) that scans `source_call_preconstruction.py` and `manager_construction.py` for forbidden patterns associated with lexical consumer side-doors (e.g. `first_match`, `name_map`, `span_scan`, `.walk(`). The test fails with a detailed violation report if any matching lines are found, enforcing that these access patterns are not used in the targeted modules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5164a8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->