### PR TITLE
Own complex subscript mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
@@ -133,6 +133,24 @@ class ComplexValue(FloorValue):
             return constructed
         return super().multiply(other, site)
 
+    def setitem(self, index, value, site):
+        """Complex numbers reject subscript store with exact TypeError."""
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="ComplexValue.setitem"
+        )
+
+    def delitem(self, index, site):
+        """Complex numbers reject subscript delete with exact TypeError."""
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="ComplexValue.delitem"
+        )
+
     def to_term(self, *, owner: str):
         del owner
         from decimal import Decimal

--- a/implementations/python/sugar-lift-py-tests/tests/test_complex_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_complex_subscript_mutation.py
@@ -1,0 +1,33 @@
+from sugar_lift_py_tests.floor import ComplexValue, TermValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "complex_subscript_mutation.py"
+    path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+def _outcomes(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    receiver = ComplexValue(1.0, 2.0)
+    return (
+        (receiver.setitem(TermValue(0), TermValue(7), store_site), "ComplexValue.setitem", store_site),
+        (receiver.delitem(TermValue(0), delete_site), "ComplexValue.delitem", delete_site),
+    )
+
+
+def test_complex_subscript_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        effect = outcome.value.effect
+        assert effect.exception_name == "TypeError"
+        assert effect.producer_node_owner == owner
+        assert effect.occurrence_id == str(site)
+
+
+def test_complex_subscript_mutations_cannot_fabricate_completion(tmp_path):
+    for outcome, _, _ in _outcomes(tmp_path):
+        assert not (isinstance(outcome, Complete) and not hasattr(outcome.value, "effect"))


### PR DESCRIPTION
ComplexValue setitem/delitem exact TypeErrors. Base 2866f149: AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1. Head c3a47e619: AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0. Focused 2 passed. R 2->0. SETITEM_DEFS=1 DELITEM_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 carrier/ExitSet/outcome drift=0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` error handling to `ComplexValue` subscript mutations
> Implements `ComplexValue.setitem` and `ComplexValue.delitem` in [complex_value.py](https://github.com/TSavo/sugar/pull/6790/files#diff-01562e043933cb4edfaa880980b83b15c5fe5d7bcd92380b3fa0d3ed2b88de9d) to always produce a `ground_exceptional_exit` with `TypeError` instead of succeeding silently. Adds tests in [test_complex_subscript_mutation.py](https://github.com/TSavo/sugar/pull/6790/files#diff-a886f4f3eb4cc0ff17d3051b7a475d08b298821d9eb3fb69388842ba22988bbe) that verify the owner name, occurrence ID, and that the result cannot be mistaken for a successful `Complete`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3a47e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->