### PR TITLE
Add dict attribute wrong-site twin

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_dict_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dict_attribute_mutation.py
@@ -47,3 +47,15 @@ def test_dict_attribute_mutations_have_exact_owner_occurrences(tmp_path):
 def test_dict_attribute_mutations_cannot_fabricate_completion(tmp_path):
     for outcome, _, _ in _outcomes(tmp_path):
         assert not isinstance(outcome, Complete)
+
+
+def test_dict_attribute_mutations_reject_wrong_site_substitution(tmp_path):
+    outcomes = _outcomes(tmp_path)
+    store_outcome, _, store_site = outcomes[0]
+    delete_outcome, _, delete_site = outcomes[1]
+
+    assert store_site != delete_site
+    assert store_outcome.effect.occurrence_id == str(store_site)
+    assert store_outcome.effect.occurrence_id != str(delete_site)
+    assert delete_outcome.effect.occurrence_id == str(delete_site)
+    assert delete_outcome.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
Test-only fix-forward for #6788. Adds the missing wrong-site substitution twin: store/delete fragments are distinct, and each produced occurrence must equal its own authentic site and differ from the adjacent site. Focused: 3 passed, exit 0. Production files changed=0; SIDE_DOOR_OCCURRENCES=0; carrier/ExitSet/outcome drift=0. This supplies the occurrence-closure evidence that #6788 itself did not contain.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add wrong-site substitution rejection test for dict attribute mutations
> Adds a pytest test in [test_dict_attribute_mutation.py](https://github.com/TSavo/sugar/pull/6791/files#diff-744ea09d068961452b9c85d51b0738ff2c3498ae11ca76cc80a1c13992b57a17) that verifies `occurrence_id` on store and delete outcomes matches their respective sites and does not cross-substitute between operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19f46b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->