### PR TITLE
Delete None exit disposition side door

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
@@ -176,7 +176,7 @@ def _resource_verdict(disposition: object, effect: object) -> str:
     )
     from sugar_lift_py_tests.floor.call_site_value import ExitSuppressionContract
 
-    if disposition is None or isinstance(disposition, RuntimeSelected):
+    if isinstance(disposition, RuntimeSelected):
         return "open"
 
     if isinstance(disposition, (NeverSuppresses, NeverSuppressesDispositionV1)):

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -28,6 +28,8 @@ from sugar_lift_py_tests.floor.inv_value import InvValue
 from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
 from sugar_lift_py_tests.ir import atomic, make_var, not_
 from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.outcome import exit_disposition as exit_disposition_module
+from sugar_lift_py_tests.outcome.exit_disposition import exit_disposition_effect
 from sugar_lift_py_tests.outcome.exit_set import Completed, Halted, true_guard
 from sugar_lift_py_tests.outcome.resource_bindings import ExitFaceBinding
 from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
@@ -173,6 +175,80 @@ def _resource(
         exit_definition=exit_definition,
         site=None,
     )
+
+
+def test_runtime_selected_authenticates_completed_face_without_mutation():
+    value = object()
+    incoming = Completed(true_guard(), value)
+
+    assert exit_disposition_effect(RuntimeSelected(), incoming) is None
+    assert incoming.value is value
+
+
+def test_runtime_selected_authenticates_halted_face_preserving_identity():
+    effect = RaiseEffect(exception_name="ValueError", occurrence="law.py:1:0")
+    state = object()
+    incoming = Halted(true_guard(), effect, state)
+
+    assert exit_disposition_effect(RuntimeSelected(), incoming) is effect
+    assert incoming.effect is effect
+    assert incoming.state is state
+
+
+def test_none_disposition_refuses_completed_face_without_mutation():
+    value = object()
+    incoming = Completed(true_guard(), value)
+
+    with pytest.raises(TypeError) as raised:
+        exit_disposition_effect(None, incoming)
+
+    assert str(raised.value) == (
+        "exit disposition must be NeverSuppresses, ExitSuppressionContract, "
+        "RuntimeSelected, Suppresses, or EffectBoundaryDisposition; got NoneType"
+    )
+    assert incoming.value is value
+
+
+def test_none_disposition_refuses_halted_face_without_mutation():
+    effect = RaiseEffect(exception_name="ValueError", occurrence="law.py:2:0")
+    state = object()
+    incoming = Halted(true_guard(), effect, state)
+
+    with pytest.raises(TypeError) as raised:
+        exit_disposition_effect(None, incoming)
+
+    assert str(raised.value) == (
+        "exit disposition must be NeverSuppresses, ExitSuppressionContract, "
+        "RuntimeSelected, Suppresses, or EffectBoundaryDisposition; got NoneType"
+    )
+    assert incoming.effect is effect
+    assert incoming.state is state
+
+
+def test_none_disposition_compatibility_paths_are_structurally_absent():
+    module_tree = ast.parse(inspect.getsource(exit_disposition_module))
+
+    none_arms = [
+        node
+        for node in ast.walk(module_tree)
+        if isinstance(node, ast.Compare)
+        and isinstance(node.left, ast.Name)
+        and node.left.id == "disposition"
+        and any(isinstance(op, ast.Is) for op in node.ops)
+        and any(
+            isinstance(comparator, ast.Constant) and comparator.value is None
+            for comparator in node.comparators
+        )
+    ]
+    production_mappers = [
+        node
+        for node in ast.walk(module_tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "RuntimeSelected"
+    ]
+    assert none_arms == []
+    assert production_mappers == []
 
 
 def test_manager_expression_evaluated_exactly_once():


### PR DESCRIPTION
Law: SIDE_DOOR_ZERO / LAW_OF_ONE

Deletes the `None` compatibility arm from `exit_disposition_effect`; `RuntimeSelected` remains the sole typed open owner.

Instrument:
- D_NoneDisposition=4 direct faces
- RuntimeSelected + Completed preserves value identity
- RuntimeSelected + authentic Halted preserves effect/state identity
- None + Completed refuses with exact TypeError and no mutation
- None + same Halted refuses with exact TypeError and no mutation
- production-only structural tooth forbids the None arm and RuntimeSelected construction/mapping

Red receipt: 5 selected; 2 passed, 3 failed (two semantic refusals plus structural tooth).
Green receipt: 5 passed, 30 deselected.

Measured: semantic failing teeth 2 -> 0; production R_NoneArm 1 -> 0, Delta=-1. No helper policy change, wrapper, deprecation, mapper, or default conversion.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `None` disposition side door from `_resource_verdict`
> - `_resource_verdict` in [exit_disposition.py](https://github.com/TSavo/sugar/pull/6792/files#diff-76129a966576d0bf8e6154295bc1ae8dc5b58eb63e5dd6e3f562a97d826dfc6c) previously treated `None` as equivalent to `RuntimeSelected`, returning `'open'`. The condition now only matches `RuntimeSelected` explicitly.
> - Adds tests covering `RuntimeSelected` behavior for both `Completed` and `Halted` exits, and asserting that `None` raises `TypeError` for both exit types.
> - An AST-based test asserts that no `is None` disposition comparisons exist anywhere in the production module.
> - Behavioral Change: Callers passing `None` as disposition to `exit_disposition_effect` now get a `TypeError` instead of an `'open'` verdict.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ebf787.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->