### PR TITLE
Own complex attribute mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
@@ -133,6 +133,16 @@ class ComplexValue(FloorValue):
             return constructed
         return super().multiply(other, site)
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="ComplexValue.setattr")
+
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="ComplexValue.delattr")
+
     def setitem(self, index, value, site):
         """Complex numbers reject subscript store with exact TypeError."""
         del index, value

--- a/implementations/python/sugar-lift-py-tests/tests/test_complex_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_complex_attribute_mutation.py
@@ -1,0 +1,35 @@
+from sugar_lift_py_tests.floor import ComplexValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "complex_attribute_mutation.py"
+    path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+def _outcomes(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = ComplexValue(1.0, 2.0)
+    return (
+        (value.setattr("attr", TermValue(7), store_site), "ComplexValue.setattr", store_site),
+        (value.delattr("attr", delete_site), "ComplexValue.delattr", delete_site),
+    )
+
+
+def test_complex_attribute_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        assert outcome.value.effect.exception_name == "AttributeError"
+        assert outcome.value.effect.producer_node_owner == owner
+        assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_complex_attribute_mutations_reject_completion_and_wrong_site(tmp_path):
+    outcomes = _outcomes(tmp_path)
+    store, _, store_site = outcomes[0]
+    delete, _, delete_site = outcomes[1]
+    assert store_site != delete_site
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
ComplexValue setattr/delattr exact AttributeErrors with distinct authentic assign/delete occurrences and wrong-site twin. Base 094d50fe: AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1. Head 798c0f7fb: AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0. Focused 2 passed. R 2->0. SETATTR_DEFS=1 DELATTR_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 carrier/ExitSet/outcome drift=0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` handlers to `ComplexValue` that raise `AttributeError`
> Implements `setattr` and `delattr` on `ComplexValue` in [complex_value.py](https://github.com/TSavo/sugar/pull/6793/files#diff-01562e043933cb4edfaa880980b83b15c5fe5d7bcd92380b3fa0d3ed2b88de9d), both of which always return a `ground_exceptional_exit` with `exception_name='AttributeError'` and the caller-provided site as the occurrence ID.
>
> Adds [test_complex_attribute_mutation.py](https://github.com/TSavo/sugar/pull/6793/files#diff-50a6c17bed85a10b94e2d33728b36d7da8145030edbc185c73de14a3c8f0ee06) to assert that the raised exceptions carry the correct `producer_node_owner` and `occurrence_id`, and that store and delete sites produce distinct occurrence IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 798c0f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->