### PR TITLE
Own predicate subscript mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
@@ -75,6 +75,16 @@ class PredicateValue(FloorValue):
             )
         )
 
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="TypeError", site=site, owner="PredicateValue.setitem")
+
+    def delitem(self, index, site):
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="TypeError", site=site, owner="PredicateValue.delitem")
+
     def guarded(self, formula):
         """A carried boolean rides under a guard unchanged.
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_predicate_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_predicate_subscript_mutation.py
@@ -1,0 +1,30 @@
+from sugar_lift_py_tests.floor import PredicateValue, TermValue
+from sugar_lift_py_tests.ir import atomic
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "predicate_subscript_mutation.py"
+    path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+def _outcomes(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = PredicateValue(atomic("p", []))
+    return ((value.setitem(TermValue(0), TermValue(7), store_site), "PredicateValue.setitem", store_site), (value.delitem(TermValue(0), delete_site), "PredicateValue.delitem", delete_site))
+
+
+def test_predicate_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        assert outcome.value.effect.producer_node_owner == owner
+        assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_predicate_mutations_reject_wrong_site(tmp_path):
+    store, _, store_site = _outcomes(tmp_path)[0]
+    delete, _, delete_site = _outcomes(tmp_path)[1]
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
PredicateValue setitem/delitem exact TypeErrors with real store/delete occurrences and wrong-site twin. Base 7a158910: AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1. Head dd8ed890f: AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0. Focused 2 passed. R 2->0. SETITEM_DEFS=1 DELITEM_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 carrier/ExitSet/outcome drift=0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` TypeError mutation error handling to `PredicateValue`
> - Adds `PredicateValue.setitem` and `PredicateValue.delitem` methods in [`predicate_value.py`](https://github.com/TSavo/sugar/pull/6794/files#diff-bf8558da2ec15a7df0fe4f46839b48dc644e7fb1b99384bb19cf43111745583c) that return a `ground_exceptional_exit` result typed as `TypeError`, mirroring how other unsupported operations are handled.
> - Adds tests in [`test_predicate_subscript_mutation.py`](https://github.com/TSavo/sugar/pull/6794/files#diff-d65db77c9e868f5d139c5e9c2e9fa0fd02345bd2271de708389a375d1f6f57f2) verifying that the owner label and occurrence ID match the exact call site for both methods, and that sites are not interchangeable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd8ed89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->