### PR TITLE
Close loop projected binding product construction

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -124,6 +124,8 @@ class LoopProjectedBinding:
 
     target_cid: str
     completed_faces: tuple[LoopProjectedCompletedFace, ...]
+    projection: object | None = None
+    constructed_term_product: object | None = None
 
     def __post_init__(self) -> None:
         _require_runtime_cid(self.target_cid, "targetCid")
@@ -131,6 +133,29 @@ class LoopProjectedBinding:
             raise BindingStateWireGap("loop projected binding requires completed faces")
         if any(face.target_cid != self.target_cid for face in self.completed_faces):
             raise BindingStateWireGap("loop projected binding target mismatch")
+        if (self.projection is None) != (self.constructed_term_product is None):
+            raise BindingStateWireGap(
+                "loop projected binding requires one closed projection product"
+            )
+        if self.constructed_term_product is not None:
+            from sugar_source_tree.loop_recurrence import (
+                LoopProjectedBindingProductSugar,
+            )
+
+            if not isinstance(
+                self.constructed_term_product, LoopProjectedBindingProductSugar
+            ):
+                raise BindingStateWireGap(
+                    "loop projected binding received a foreign constructed product"
+                )
+            if self.constructed_term_product.projection is not self.projection:
+                raise BindingStateWireGap(
+                    "loop projected binding product lost exact projection identity"
+                )
+            if self.constructed_term_product.target_cid != self.target_cid:
+                raise BindingStateWireGap(
+                    "loop projected binding product has a foreign loop occurrence"
+                )
 
 
 BindingState: TypeAlias = (

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -207,45 +207,6 @@ def _sealed_state(snapshot: tuple[BindingEntryV1, ...]):
     return raw, testified
 
 
-def construct_live_binding_product_sugar(
-    *, name: str, entry: BindingEntryV1, expected_coordinate, site
-):
-    """Project one authenticated binding product into term-sugar currency.
-
-    The runtime entry is already the product of ``_sealed_state``.  This door
-    re-authenticates its coordinate and exact live/sealed pairing before using
-    the shared binding-projection owner; a loop consumer never reconstructs a
-    projection from lexical names or from whichever state happens to arrive.
-    """
-    from .binding_provenance import BindingCoordinateV1
-    from .nodes import _construct_binding_projection
-    from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import (
-        GuardedBindingReadSugar,
-    )
-    from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
-
-    if not isinstance(entry, BindingEntryV1) or not isinstance(
-        expected_coordinate, BindingCoordinateV1
-    ):
-        raise BindingStateWireGap(
-            "live binding product requires an authenticated binding entry coordinate"
-        )
-    BindingCoordinateV1.decode(entry.coordinate.wire())
-    BindingCoordinateV1.decode(expected_coordinate.wire())
-    if entry.coordinate != expected_coordinate:
-        raise BindingStateWireGap(
-            "live binding product received a foreign binding coordinate"
-        )
-    if entry.sealed_state != _seal_runtime_state(entry.state):
-        raise BindingStateWireGap(
-            "live state disagrees with its authenticated sealed binding product"
-        )
-    projection = _construct_binding_projection(entry.state)
-    if isinstance(projection, ConstructedTermSugar):
-        return projection
-    return GuardedBindingReadSugar(name=name, state=projection, site=site)
-
-
 def _combine(outer, inner):
     return inner if outer is None else and_([outer, inner])
 
@@ -816,15 +777,10 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
                 pattern,
                 carried_names,
                 tuple(
-                    construct_live_binding_product_sugar(
-                        name=name,
-                        entry=runtime_entry,
-                        expected_coordinate=source_entry.coordinate,
-                        site=loop.fragment,
-                    )
-                    for name, source_entry, runtime_entry in zip(
-                        carried_names, pre_entries, pre_runtime, strict=True
-                    )
+                    entry.state.constructed_term_product
+                    if isinstance(entry.state, LoopProjectedBinding)
+                    else entry.state.sugar()
+                    for entry in pre_runtime
                 ),
                 tuple(loop.body),
                 tuple(loop.orelse),
@@ -838,6 +794,8 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
             binding_coordinate=entry.coordinate,
             runtime_states=runtime_states,
             live_guards=live_guards,
+            read_name=name,
+            read_site=loop.fragment,
         )
         bindings[name] = replace(entry, state=projected, sealed_state=None)
     return LiveLoopProjectionV1(
@@ -856,6 +814,5 @@ __all__ = [
     "LiveForTargetPatternV1",
     "LiveLoopProjectionV1",
     "LiveOutwardHaltedFaceV1",
-    "construct_live_binding_product_sugar",
     "construct_live_loop_recurrence",
 ]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
+
+from sugar_lift_python_source.canonical import cid_of_json
 
 from sugar_lift_py_tests.loop_construction import (
     LoopConstructionV1,
     decode_loop_construction_v1,
 )
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
 from .binding_provenance import BindingCoordinateV1
 from .binding_state import (
@@ -17,6 +21,99 @@ from .binding_state import (
     LoopProjectedCompletedFace,
 )
 
+_PRODUCT_MINT_AUTHORITY = cid_of_json(
+    {"owner": "sugar_source_tree.loop_recurrence.project_loop_post_binding"}
+)
+
+
+@dataclass(frozen=True)
+class LoopProjectedBindingProductSugar(ConstructedTermSugar):
+    """Closed term product minted with one authenticated loop projection."""
+
+    name: str
+    projection: object
+    site: object
+    binding_coordinate: BindingCoordinateV1
+    target_cid: str
+    name_identity_cid: str
+    occurrence_cid: str
+    _mint_authority: object
+
+    def __post_init__(self) -> None:
+        from sugar_lift_py_tests.sugar.binding_projection import LoopGuardedProjection
+
+        if self._mint_authority is not _PRODUCT_MINT_AUTHORITY:
+            raise BindingStateWireGap(
+                "loop binding product must come from its authenticated projection mint"
+            )
+        if not isinstance(self.projection, LoopGuardedProjection):
+            raise BindingStateWireGap(
+                "loop binding product requires the producer's exact projection"
+            )
+        if self.projection.target_cid != self.target_cid:
+            raise BindingStateWireGap("loop binding product has a foreign loop occurrence")
+        if cid_of_json(self.binding_coordinate.preimage) != self.binding_coordinate.cid:
+            raise BindingStateWireGap("loop binding product has a foreign coordinate")
+        expected_name = cid_of_json(
+            {
+                "bindingCoordinateCid": self.binding_coordinate.cid,
+                "name": self.name,
+            }
+        )
+        if self.name_identity_cid != expected_name:
+            raise BindingStateWireGap("loop binding product has a foreign binding name")
+        expected_occurrence = cid_of_json(self.site.seal().to_dict())
+        if self.occurrence_cid != expected_occurrence:
+            raise BindingStateWireGap("loop binding product has a foreign read occurrence")
+        if (
+            self.binding_coordinate.binding_site["source_cid"]
+            != self.site.seal().source_cid
+        ):
+            raise BindingStateWireGap("loop binding product crosses source frames")
+
+    @classmethod
+    def _mint(
+        cls,
+        *,
+        name: str,
+        projection: object,
+        site: object,
+        binding_coordinate: BindingCoordinateV1,
+        target_cid: str,
+    ) -> "LoopProjectedBindingProductSugar":
+        return cls(
+            name,
+            projection,
+            site,
+            binding_coordinate,
+            target_cid,
+            cid_of_json(
+                {"bindingCoordinateCid": binding_coordinate.cid, "name": name}
+            ),
+            cid_of_json(site.seal().to_dict()),
+            _PRODUCT_MINT_AUTHORITY,
+        )
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import read_binding
+
+        return read_binding(
+            self.projection, read_name=self.name, read_site=self.site, ctx=ctx
+        ).collapse()
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.sugar.guarded_binding_read_sugar import (
+            GuardedBindingReadSugar,
+        )
+
+        return GuardedBindingReadSugar(
+            name=self.name, state=self.projection, site=self.site
+        ).to_term(owner=owner)
+
 
 def project_loop_post_binding(
     *,
@@ -24,6 +121,8 @@ def project_loop_post_binding(
     binding_coordinate: BindingCoordinateV1,
     runtime_states: Mapping[str, tuple[BindingEntryV1, ...]],
     live_guards: Mapping[str, object] | None = None,
+    read_name: str | None = None,
+    read_site: object | None = None,
 ) -> LoopProjectedBinding:
     """Project one coordinate through every exact completed loop face.
 
@@ -108,7 +207,21 @@ def project_loop_post_binding(
             f"retained {len(projected_faces)}. A partition missing a face is "
             "an outcome nobody accounted for; do not project it as complete"
         )
-    return LoopProjectedBinding(target_cid, tuple(projected_faces))
+    faces = tuple(projected_faces)
+    if read_name is None or read_site is None:
+        return LoopProjectedBinding(target_cid, faces)
+    from .nodes import _construct_binding_projection
+
+    provisional = LoopProjectedBinding(target_cid, faces)
+    projection = _construct_binding_projection(provisional)
+    product = LoopProjectedBindingProductSugar._mint(
+        name=read_name,
+        projection=projection,
+        site=read_site,
+        binding_coordinate=binding_coordinate,
+        target_cid=target_cid,
+    )
+    return LoopProjectedBinding(target_cid, faces, projection, product)
 
 
-__all__ = ["project_loop_post_binding"]
+__all__ = ["LoopProjectedBindingProductSugar", "project_loop_post_binding"]

--- a/implementations/python/sugar-source-tree/tests/test_loop_projected_binding_product.py
+++ b/implementations/python/sugar-source-tree/tests/test_loop_projected_binding_product.py
@@ -1,128 +1,78 @@
-"""Canonical constructed product for authenticated loop post-bindings."""
+"""LAW_OF_ONE for authenticated loop projected binding products."""
 
 from __future__ import annotations
 
 from dataclasses import replace
+from pathlib import Path
+import tempfile
 
 import pytest
 
-from sugar_lift_python_source.canonical import cid_of_json
-from sugar_lift_py_tests.ir import atomic, not_, str_const
-from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
-from sugar_source_tree.binding_state import (
-    BindingEntryV1,
-    BindingStateWireGap,
-    LoopProjectedBinding,
-    LoopProjectedCompletedFace,
-    RuntimeBindingEntryFactoryV1,
-)
-from sugar_source_tree import live_loop_construction as live_loop
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.binding_state import BindingStateWireGap
+from sugar_source_tree.loop_recurrence import LoopProjectedBindingProductSugar
 from sugar_source_tree.tree import SourceFile
 
 
-def _assignment(source: str):
-    function = next(SourceFile((source, "tests/loop_product.py", cid_of_json(source))).functions())
-    assignment = next(node for node in function.walk() if node.kind == "Assign")
-    return function, assignment
+def _function(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    return next(SourceFile(path_source(path)).functions())
 
 
-def _projected_entry():
-    function, first = _assignment("def f():\n    value = 1\n")
-    _other_function, second = _assignment("def g():\n    value = 2\n")
-    factory = RuntimeBindingEntryFactoryV1(
-        cid_of_json({"scope": function.fragment.seal().to_dict()})
-    )
-    entry = factory.mint_entry(
-        binding_site=first.targets[0].fragment,
-        projection_path=("targets", 0),
-        state=first.value,
-    )
-    target_cid = cid_of_json({"loop": function.fragment.seal().cid})
-    guard = atomic("loop.product.guard", (str_const(target_cid),))
-    projected = LoopProjectedBinding(
-        target_cid,
-        (
-            LoopProjectedCompletedFace(
-                target_cid,
-                "BreakExit",
-                live_loop._formula_cid(guard),
-                first.value,
-                guard,
-                2,
-            ),
-            LoopProjectedCompletedFace(
-                target_cid,
-                "NormalExhaustion",
-                live_loop._formula_cid(not_(guard)),
-                second.value,
-                not_(guard),
-                2,
-            ),
-        ),
-    )
-    return first, replace(
-        entry,
-        state=projected,
-        sealed_state=live_loop._seal_runtime_state(projected),
-    )
+def _product(*, function_name: str = "arbitrary", carried_name: str = "carried"):
+    constructed = _function(
+        f"""
+def {function_name}(items):
+    {carried_name} = 0
+    for first in items:
+        {carried_name} = first
+    for second in items:
+        {carried_name} = second
+    return {carried_name}
+"""
+    ).sugar()
+    product = constructed.statements[2].construction.loop_runtime.initial_value_sugars[0]
+    assert isinstance(product, LoopProjectedBindingProductSugar)
+    return product
 
 
-def _construct_product(**kwargs):
-    producer = getattr(live_loop, "construct_live_binding_product_sugar", None)
-    assert producer is not None, (
-        "live loop binding products require one authenticated ConstructedTermSugar "
-        "projection owner"
-    )
-    return producer(**kwargs)
+def test_real_source_loop_reuses_the_exact_producer_owned_product() -> None:
+    product = _product()
 
-
-def test_authenticated_loop_projection_constructs_one_term_product() -> None:
-    assignment, entry = _projected_entry()
-
-    product = _construct_product(
-        name="value",
-        entry=entry,
-        expected_coordinate=entry.coordinate,
-        site=assignment.fragment,
-    )
-
-    assert isinstance(product, ConstructedTermSugar)
+    assert product.projection.target_cid == product.target_cid
+    assert product.name == "carried"
     assert product.to_term(owner="test").name == "python:guarded-binding-read"
 
 
-def test_foreign_binding_coordinate_cannot_select_the_product() -> None:
-    assignment, entry = _projected_entry()
-    _foreign_function, foreign = _assignment("def h():\n    other = 3\n")
-    foreign_coordinate = RuntimeBindingEntryFactoryV1(
-        cid_of_json({"scope": foreign.fragment.seal().to_dict()})
-    ).mint_entry(
-        binding_site=foreign.targets[0].fragment,
-        projection_path=("targets", 0),
-        state=foreign.value,
-    ).coordinate
+@pytest.mark.parametrize(
+    ("change", "message"),
+    (
+        (lambda product, foreign: {"projection": foreign.projection}, "foreign loop occurrence"),
+        (lambda product, foreign: {"name": "same_spelling"}, "foreign binding name"),
+        (lambda product, foreign: {"binding_coordinate": foreign.binding_coordinate}, "foreign binding name"),
+        (lambda product, foreign: {"site": foreign.site}, "foreign read occurrence"),
+        (lambda product, foreign: {"occurrence_cid": foreign.occurrence_cid}, "foreign read occurrence"),
+        (lambda product, foreign: {"target_cid": foreign.target_cid}, "foreign loop occurrence"),
+        (lambda product, foreign: {"_mint_authority": foreign.target_cid}, "authenticated projection mint"),
+    ),
+)
+def test_product_substitution_twins_refuse(change, message: str) -> None:
+    product = _product()
+    foreign = _product(function_name="foreign", carried_name="carried")
 
-    with pytest.raises(BindingStateWireGap, match="foreign binding coordinate"):
-        _construct_product(
-            name="value",
-            entry=entry,
-            expected_coordinate=foreign_coordinate,
-            site=assignment.fragment,
-        )
+    with pytest.raises(BindingStateWireGap, match=message):
+        replace(product, **change(product, foreign))
 
 
-def test_live_state_cannot_disagree_with_its_authenticated_sealed_product() -> None:
-    assignment, entry = _projected_entry()
-    _foreign_function, foreign = _assignment("def h():\n    value = 9\n")
-    face = entry.state.completed_faces[0]
-    lying_state = replace(
-        entry.state,
-        completed_faces=(replace(face, state=foreign.value), *entry.state.completed_faces[1:]),
-    )
+def test_side_door_zero_is_structural() -> None:
+    source = Path(__file__).parents[1] / "src/sugar_source_tree/live_loop_construction.py"
+    text = source.read_text()
 
-    with pytest.raises(BindingStateWireGap, match="sealed binding product"):
-        _construct_product(
-            name="value",
-            entry=replace(entry, state=lying_state),
-            expected_coordinate=entry.coordinate,
-            site=assignment.fragment,
-        )
+    assert "construct_live_binding_product_sugar" not in text
+    assert "expected_coordinate" not in text
+    assert "BindingCoordinateV1.decode(entry.coordinate.wire())" not in text
+    assert "_construct_binding_projection" not in text
+    assert "GuardedBindingReadSugar" not in text
+    assert "carried_names, pre_entries, pre_runtime" not in text


### PR DESCRIPTION
Fix-forward for #6786 / LAW_OF_ONE.

- deletes the public live-loop binding-product construction door and export
- mints the closed projected term product with the authenticated loop projection
- consumes the stored product without coordinate/name/site rebinding
- adds exact product substitution twins and a structural SIDE_DOOR_ZERO instrument

R(SIDE_DOOR production)=7 -> 0; Delta=-7; Epsilon=0.

Focused: bin/bpytest implementations/python/sugar-source-tree/tests/test_loop_projected_binding_product.py implementations/python/sugar-source-tree/tests/test_live_loop_post_projection.py -q (17 passed).
Loop family telemetry: 31 passed/1 failed; surviving failure is the explicitly stale multi-face expectation in test_guarded_loop_recurrence.py:253.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close the loop projected binding product construction for For-loop recurrence
> - Introduces `LoopProjectedBindingProductSugar` in [`loop_recurrence.py`](https://github.com/TSavo/sugar/pull/6795/files#diff-afe55c723729e17a85608133e5f131be4afde1ab9414bb2eedbd2f61a3de4b4a), a new authenticated `ConstructedTermSugar` subclass that enforces provenance (mint authority, projection identity, target CID, binding coordinate, and site consistency) at instantiation.
> - Extends `project_loop_post_binding` to accept an optional read name and site; when supplied, it mints a `LoopProjectedBindingProductSugar` and returns a `LoopProjectedBinding` carrying both the projection and the pre-minted product.
> - Updates `LoopProjectedBinding` in [`binding_state.py`](https://github.com/TSavo/sugar/pull/6795/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40) with optional `projection` and `constructed_term_product` fields, validated together via `__post_init__`.
> - Refactors `construct_live_loop_recurrence` in [`live_loop_construction.py`](https://github.com/TSavo/sugar/pull/6795/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094) to consume the pre-minted product from `LoopProjectedBinding.constructed_term_product` when available, removing the now-deleted `construct_live_binding_product_sugar` helper.
> - Behavioral Change: `construct_live_binding_product_sugar` is removed and no longer importable; callers must migrate to the new product minting path via `project_loop_post_binding`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 422731f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->