### PR TITLE
Own predicate attribute mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
@@ -75,6 +75,16 @@ class PredicateValue(FloorValue):
             )
         )
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="PredicateValue.setattr")
+
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="PredicateValue.delattr")
+
     def setitem(self, index, value, site):
         del index, value
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit

--- a/implementations/python/sugar-lift-py-tests/tests/test_predicate_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_predicate_attribute_mutation.py
@@ -1,0 +1,31 @@
+from sugar_lift_py_tests.floor import PredicateValue, TermValue
+from sugar_lift_py_tests.ir import atomic
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "predicate_attribute_mutation.py"
+    path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+def _outcomes(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = PredicateValue(atomic("p", []))
+    return ((value.setattr("attr", TermValue(7), store_site), "PredicateValue.setattr", store_site), (value.delattr("attr", delete_site), "PredicateValue.delattr", delete_site))
+
+
+def test_predicate_attribute_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        assert outcome.value.effect.exception_name == "AttributeError"
+        assert outcome.value.effect.producer_node_owner == owner
+        assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_predicate_attribute_mutations_reject_wrong_site(tmp_path):
+    store, _, store_site = _outcomes(tmp_path)[0]
+    delete, _, delete_site = _outcomes(tmp_path)[1]
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
PredicateValue setattr/delattr exact AttributeErrors with authentic assign/delete occurrences and wrong-site twin. Base c486479c: AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1. Head 9455c4500: AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0. Focused 2 passed. R 2->0. SETATTR_DEFS=1 DELATTR_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 carrier/ExitSet/outcome drift=0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` methods to `PredicateValue` that return `AttributeError` exceptional exits
> Implements `PredicateValue.__setattr__` and `PredicateValue.__delattr__` in [predicate_value.py](https://github.com/TSavo/sugar/pull/6796/files#diff-bf8558da2ec15a7df0fe4f46839b48dc644e7fb1b99384bb19cf43111745583c) to signal that predicate attributes are immutable. Both methods return a `ground_exceptional_exit` with `exception_name='AttributeError'` and the provided occurrence site. Tests in [test_predicate_attribute_mutation.py](https://github.com/TSavo/sugar/pull/6796/files#diff-1efb2b9869d98da8a3bee678b65a9de0852c5ef0496947b1368fe64195d951c2) verify the correct `producer_node_owner`, exception name, and site association for both operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9455c45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->