### PR TITLE
Delete leaf call-edge reconstruction side door

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/leaf_assertions.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/leaf_assertions.py
@@ -52,7 +52,7 @@ from sugar_source_tree.nodes import (
 )
 from sugar_source_tree.tree import SourceFile
 
-from .canonical import blake3_512_of
+from .canonical import blake3_512_of, cid_of_json
 
 Json = dict[str, Any]
 
@@ -75,6 +75,154 @@ class HarvestResult:
 
 class _Unsupported(Exception):
     pass
+
+
+class _LeafCallTestimonyMismatch(TypeError):
+    pass
+
+
+def _construction_refused(kind: str) -> TypeError:
+    return TypeError(f"{kind} is producer-minted only")
+
+
+@dataclass(frozen=True, init=False)
+class _CallOccurrence:
+    target_symbol: str
+    source_cid: str
+    source_path: str
+    line: int
+    column: int
+    _call: Call = field(repr=False, compare=False)
+    _seal: tuple[object, ...] = field(repr=False, compare=False)
+
+    def __init__(self, *args, **kwargs) -> None:
+        del args, kwargs
+        raise _construction_refused("_CallOccurrence")
+
+    @classmethod
+    def _mint(cls, call: Call) -> _CallOccurrence:
+        if not isinstance(call.func, Name):
+            raise _Unsupported("call callee is not a bare identifier")
+        span = call.line_col_span()
+        self = object.__new__(cls)
+        values = (
+            call.func.id,
+            call.unit.source_cid,
+            call.unit.filename,
+            span.start_line,
+            span.start_col,
+        )
+        for name, value in zip(
+            ("target_symbol", "source_cid", "source_path", "line", "column"),
+            values,
+            strict=True,
+        ):
+            object.__setattr__(self, name, value)
+        object.__setattr__(self, "_call", call)
+        object.__setattr__(self, "_seal", (call, *values))
+        return self
+
+    def edge(self, *, source_contract: FunctionDef) -> Json:
+        span = self._call.line_col_span()
+        observed = (
+            self._call,
+            self.target_symbol,
+            self.source_cid,
+            self.source_path,
+            self.line,
+            self.column,
+        )
+        if observed != self._seal:
+            raise _LeafCallTestimonyMismatch(
+                "leaf call testimony does not match its authenticated Call occurrence"
+            )
+        if (
+            not isinstance(self._call.func, Name)
+            or self._call.func.id != self.target_symbol
+            or self._call.unit.source_cid != self.source_cid
+            or self._call.unit.filename != self.source_path
+            or span.start_line != self.line
+            or span.start_col != self.column
+        ):
+            raise _LeafCallTestimonyMismatch(
+                "leaf call testimony does not match its authenticated Call occurrence"
+            )
+        contract_span = source_contract.span
+        if (
+            source_contract.unit is not self._call.unit
+            or contract_span.start > self._call.span.start
+            or self._call.span.end > contract_span.end
+        ):
+            raise _LeafCallTestimonyMismatch(
+                "leaf call testimony does not belong to the authenticated FunctionDef"
+            )
+        return {
+            "kind": "call-edge",
+            "sourceContract": source_contract.name,
+            "targetSymbol": self.target_symbol,
+            "callSiteLocus": {
+                "file": self.source_path,
+                "line": self.line,
+                "column": self.column,
+            },
+        }
+
+
+@dataclass(frozen=True, init=False)
+class _TranslatedTerm:
+    term: Json
+    calls: tuple[_CallOccurrence, ...]
+    _preimage: Expression = field(repr=False, compare=False)
+    _term_cid: str = field(repr=False, compare=False)
+    _seal: tuple[object, ...] = field(repr=False, compare=False)
+
+    def __init__(self, *args, **kwargs) -> None:
+        del args, kwargs
+        raise _construction_refused("_TranslatedTerm")
+
+    @classmethod
+    def _mint(
+        cls,
+        *,
+        term: Json,
+        calls: tuple[_CallOccurrence, ...],
+        preimage: Expression,
+    ) -> _TranslatedTerm:
+        if any(call._call.unit is not preimage.unit for call in calls):
+            raise _LeafCallTestimonyMismatch(
+                "leaf call roster contains foreign-source testimony"
+            )
+        self = object.__new__(cls)
+        term_cid = cid_of_json(term)
+        object.__setattr__(self, "term", term)
+        object.__setattr__(self, "calls", calls)
+        object.__setattr__(self, "_preimage", preimage)
+        object.__setattr__(self, "_term_cid", term_cid)
+        object.__setattr__(
+            self,
+            "_seal",
+            (preimage, preimage.unit.source_cid, term_cid, tuple(call._seal for call in calls)),
+        )
+        return self
+
+    def project(self) -> tuple[Json, tuple[_CallOccurrence, ...]]:
+        observed = (
+            self._preimage,
+            self._preimage.unit.source_cid,
+            cid_of_json(self.term),
+            tuple(call._seal for call in self.calls),
+        )
+        if observed != self._seal:
+            raise _LeafCallTestimonyMismatch(
+                "translated term/call roster does not match its authenticated preimage"
+            )
+        return self.term, self.calls
+
+
+@dataclass(frozen=True)
+class _LiftedAssertion:
+    atom: Json
+    call_edges: tuple[Json, ...]
 
 
 def harvest_source(source: str, source_path: str) -> HarvestResult:
@@ -106,10 +254,9 @@ def harvest_source(source: str, source_path: str) -> HarvestResult:
             if not isinstance(stmt, Assert):
                 continue
             try:
-                atoms.append(_lift_assert(stmt))
-                result.call_edges.extend(
-                    _call_edges(stmt, source_path, source_contract=node.name)
-                )
+                lifted = _lift_assert(stmt, source_contract=node)
+                atoms.append(lifted.atom)
+                result.call_edges.extend(lifted.call_edges)
             except _Unsupported as exc:
                 result.diagnostics.append(
                     {
@@ -134,35 +281,9 @@ def harvest_source(source: str, source_path: str) -> HarvestResult:
     return result
 
 
-def _call_edges(stmt: Assert, source_path: str, *, source_contract: str) -> list[Json]:
-    """Project the call coordinates already admitted by ``_lift_assert``.
-
-    This runs only after the assertion translated successfully, so an edge can
-    never claim a callsite whose consumer formula the harvester omitted.
-    ``targetSymbol`` deliberately uses the ctor's bare name: it is the exact
-    EUF coordinate stamped as ``bridgeSourceSymbol`` by ``verify_dialect``.
-    """
-    edges: list[Json] = []
-    for node in stmt.test.walk():
-        if not isinstance(node, Call) or not isinstance(node.func, Name):
-            continue
-        span = node.line_col_span()
-        edges.append(
-            {
-                "kind": "call-edge",
-                "sourceContract": source_contract,
-                "targetSymbol": node.func.id,
-                "callSiteLocus": {
-                    "file": source_path,
-                    "line": span.start_line,
-                    "column": span.start_col,
-                },
-            }
-        )
-    return edges
-
-
-def _lift_assert(stmt: Assert) -> Json:
+def _lift_assert(
+    stmt: Assert, *, source_contract: FunctionDef
+) -> _LiftedAssertion:
     test = stmt.test
     if not isinstance(test, Compare):
         raise _Unsupported("assert is not a comparison")
@@ -170,44 +291,60 @@ def _lift_assert(stmt: Assert) -> Json:
         raise _Unsupported("only single-comparison asserts are harvested")
     lhs = _translate_term(test.left)
     rhs = _translate_term(test.comparators[0])
+    lhs_term, lhs_calls = lhs.project()
+    rhs_term, rhs_calls = rhs.project()
 
     if test.ops[0].kind in ("Is", "IsNot"):
-        if _is_none_ctor(lhs) == _is_none_ctor(rhs):
+        if _is_none_ctor(lhs_term) == _is_none_ctor(rhs_term):
             raise _Unsupported("identity comparison is only supported against None")
         op = "=" if test.ops[0].kind == "Is" else "≠"
-        return _comparison_with_none_guard(op, lhs, rhs)
+        atom = _comparison_with_none_guard(op, lhs_term, rhs_term)
+    else:
+        op = _CMP.get(test.ops[0].kind)
+        if op is None:
+            raise _Unsupported(f"comparison op {test.ops[0].kind} not in whitelist")
+        atom = _comparison(op, lhs_term, rhs_term)
 
-    op = _CMP.get(test.ops[0].kind)
-    if op is None:
-        raise _Unsupported(f"comparison op {test.ops[0].kind} not in whitelist")
-    return _comparison(op, lhs, rhs)
+    calls = lhs_calls + rhs_calls
+    return _LiftedAssertion(
+        atom=atom,
+        call_edges=tuple(
+            occurrence.edge(source_contract=source_contract) for occurrence in calls
+        ),
+    )
 
 
-def _translate_term(node: Expression) -> Json:
+def _translate_term(node: Expression) -> _TranslatedTerm:
     if isinstance(node, Name):
-        return {"kind": "var", "name": node.id}
+        return _TranslatedTerm._mint(
+            term={"kind": "var", "name": node.id}, calls=(), preimage=node
+        )
     if isinstance(node, Constant):
         value = node.value
         if isinstance(value, bool):
-            return {
+            return _TranslatedTerm._mint(term={
                 "kind": "const",
                 "value": value,
                 "sort": {"kind": "primitive", "name": "Bool"},
-            }
+            }, calls=(), preimage=node)
         if isinstance(value, int):
-            return {
+            return _TranslatedTerm._mint(term={
                 "kind": "const",
                 "value": value,
                 "sort": {"kind": "primitive", "name": "Int"},
-            }
+            }, calls=(), preimage=node)
         if isinstance(value, str):
-            return {
+            return _TranslatedTerm._mint(term={
                 "kind": "const",
                 "value": value,
                 "sort": {"kind": "primitive", "name": "String"},
-            }
+            }, calls=(), preimage=node)
         if value is None:
-            return {"kind": "ctor", "name": "None", "args": []}
+            return _TranslatedTerm._mint(
+                term={"kind": "ctor", "name": "None", "args": []},
+                calls=(),
+                preimage=node,
+            )
         raise _Unsupported(f"unsupported constant {type(value).__name__}")
     if isinstance(node, UnaryOp) and node.op.kind == "USub":
         operand = node.operand
@@ -216,11 +353,11 @@ def _translate_term(node: Expression) -> Json:
             and isinstance(operand.value, int)
             and not isinstance(operand.value, bool)
         ):
-            return {
+            return _TranslatedTerm._mint(term={
                 "kind": "const",
                 "value": -operand.value,
                 "sort": {"kind": "primitive", "name": "Int"},
-            }
+            }, calls=(), preimage=node)
         raise _Unsupported("unary minus only on int literals")
     if isinstance(node, Call):
         # Single-arg bare call f(arg) -> ctor("f", [<arg>]); the ctor name is
@@ -230,7 +367,14 @@ def _translate_term(node: Expression) -> Json:
         if node.keywords:
             raise _Unsupported("call has keyword arguments")
         args = [_translate_term(arg) for arg in node.args]
-        return {"kind": "ctor", "name": node.func.id, "args": args}
+        projected_args = [arg.project() for arg in args]
+        occurrence = _CallOccurrence._mint(node)
+        return _TranslatedTerm._mint(
+            term={"kind": "ctor", "name": node.func.id, "args": [arg.term for arg in args]},
+            calls=(occurrence,)
+            + tuple(call for _, calls in projected_args for call in calls),
+            preimage=node,
+        )
     raise _Unsupported(f"operand {type(node).__name__} not supported")
 
 

--- a/implementations/python/sugar-lift-python-source/tests/test_verify_dialect.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_verify_dialect.py
@@ -640,8 +640,210 @@ def test_leaf_harvester_uses_typed_source_tree_for_renamed_call():
         "def test_arbitrary():\n" "    assert renamed_operation(3) == 7\n",
         "renamed_fixture.py",
     )
-    assert [edge["targetSymbol"] for edge in result.call_edges] == ["renamed_operation"]
+    assert result.call_edges == [
+        {
+            "kind": "call-edge",
+            "sourceContract": "test_arbitrary",
+            "targetSymbol": "renamed_operation",
+            "callSiteLocus": {
+                "file": "renamed_fixture.py",
+                "line": 2,
+                "column": 11,
+            },
+        }
+    ]
     assert result.diagnostics == []
+
+
+def test_leaf_call_edge_same_locus_different_call_does_not_cross_wire():
+    first = harvest_source(
+        "def test_one():\n    assert first_call(3) == 7\n", "same.py"
+    )
+    second = harvest_source(
+        "def test_one():\n    assert second_call(3) == 7\n", "same.py"
+    )
+
+    assert first.call_edges[0]["callSiteLocus"] == second.call_edges[0]["callSiteLocus"]
+    assert first.call_edges[0]["targetSymbol"] == "first_call"
+    assert second.call_edges[0]["targetSymbol"] == "second_call"
+
+
+def test_leaf_call_edge_same_spelling_keeps_distinct_occurrences():
+    result = harvest_source(
+        "def test_two():\n"
+        "    assert repeated(1) == 1\n"
+        "    assert repeated(2) == 2\n",
+        "two.py",
+    )
+
+    assert [edge["targetSymbol"] for edge in result.call_edges] == [
+        "repeated",
+        "repeated",
+    ]
+    assert [edge["callSiteLocus"]["line"] for edge in result.call_edges] == [2, 3]
+
+
+def test_leaf_call_edges_follow_nested_producer_order():
+    result = harvest_source(
+        "def test_nested():\n    assert outer(inner(3)) == 7\n", "nested.py"
+    )
+
+    assert [edge["targetSymbol"] for edge in result.call_edges] == ["outer", "inner"]
+    assert [edge["callSiteLocus"]["column"] for edge in result.call_edges] == [11, 17]
+
+
+def test_unsupported_leaf_call_emits_no_edge():
+    result = harvest_source(
+        "def test_unsupported():\n    assert obj.method(3) == 7\n", "unsupported.py"
+    )
+
+    assert result.ir == []
+    assert result.call_edges == []
+    assert result.diagnostics == [
+        {
+            "kind": "leaf-assertion-skipped",
+            "message": "call callee is not a bare identifier",
+            "path": "unsupported.py",
+            "line": 2,
+        }
+    ]
+
+
+def test_leaf_call_edge_consumer_projects_producer_owned_testimony(monkeypatch):
+    import sugar_lift_python_source.leaf_assertions as leaf_assertions
+    from sugar_source_tree.nodes import Call
+
+    original = leaf_assertions._translate_term
+
+    def cross_wired_translate(node):
+        translated = original(node)
+        if not isinstance(node, Call):
+            return translated
+        object.__setattr__(translated.calls[0], "target_symbol", "foreign-symbol")
+        return translated
+
+    monkeypatch.setattr(leaf_assertions, "_translate_term", cross_wired_translate)
+
+    with pytest.raises(leaf_assertions._LeafCallTestimonyMismatch) as raised:
+        leaf_assertions.harvest_source(
+            "def test_foreign():\n    assert source_spelling(3) == 7\n", "source.py"
+        )
+    assert str(raised.value) == (
+        "leaf call testimony does not match its authenticated Call occurrence"
+    )
+
+
+def test_leaf_call_testimony_constructors_and_replace_refuse():
+    from dataclasses import replace
+    import sugar_lift_python_source.leaf_assertions as leaf_assertions
+
+    with pytest.raises(TypeError, match="^_CallOccurrence is producer-minted only$"):
+        leaf_assertions._CallOccurrence()
+    with pytest.raises(TypeError, match="^_TranslatedTerm is producer-minted only$"):
+        leaf_assertions._TranslatedTerm()
+
+    source = "def test_one():\n    assert kept(1) == 1\n"
+    source_file = leaf_assertions.SourceFile(
+        (source, "kept.py", leaf_assertions.blake3_512_of(source.encode("utf-8")))
+    )
+    call = next(node for node in source_file.nodes() if isinstance(node, leaf_assertions.Call))
+    translated = leaf_assertions._translate_term(call)
+    with pytest.raises(TypeError, match="^_TranslatedTerm is producer-minted only$"):
+        replace(translated, calls=())
+
+
+def test_leaf_call_testimony_refuses_foreign_frame_and_roster_cross_wires():
+    import sugar_lift_python_source.leaf_assertions as leaf_assertions
+
+    def translated_in(path, callee):
+        source = f"def test_one():\n    assert {callee}(1) == 1\n"
+        source_file = leaf_assertions.SourceFile(
+            (source, path, leaf_assertions.blake3_512_of(source.encode("utf-8")))
+        )
+        contract = next(
+            node
+            for node in source_file.root.body
+            if isinstance(node, leaf_assertions.FunctionDef)
+        )
+        call = next(
+            node for node in source_file.nodes() if isinstance(node, leaf_assertions.Call)
+        )
+        return leaf_assertions._translate_term(call), contract
+
+    first, first_contract = translated_in("first.py", "same")
+    second, second_contract = translated_in("second.py", "same")
+
+    with pytest.raises(leaf_assertions._LeafCallTestimonyMismatch) as foreign:
+        first.calls[0].edge(source_contract=second_contract)
+    assert str(foreign.value) == (
+        "leaf call testimony does not belong to the authenticated FunctionDef"
+    )
+
+    object.__setattr__(first, "calls", second.calls)
+    with pytest.raises(leaf_assertions._LeafCallTestimonyMismatch) as roster:
+        first.project()
+    assert str(roster.value) == (
+        "translated term/call roster does not match its authenticated preimage"
+    )
+
+    second.term["name"] = "mutated-alias"
+    with pytest.raises(leaf_assertions._LeafCallTestimonyMismatch) as alias:
+        second.project()
+    assert str(alias.value) == (
+        "translated term/call roster does not match its authenticated preimage"
+    )
+
+    assert first_contract.unit is not second_contract.unit
+
+
+def test_leaf_call_edge_reconstruction_side_door_is_structurally_absent():
+    import inspect
+    import sugar_lift_python_source.leaf_assertions as leaf_assertions
+
+    tree = ast.parse(inspect.getsource(leaf_assertions))
+    functions = {
+        node.name: node for node in tree.body if isinstance(node, ast.FunctionDef)
+    }
+    assert [
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_call_edges"
+    ] == []
+    assert {"term", "calls"}.issubset(
+        leaf_assertions._TranslatedTerm.__dataclass_fields__
+    )
+    assert sum(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_translate_term"
+        for node in ast.walk(functions["_lift_assert"])
+    ) == 2
+    assert [
+        function.name
+        for function in functions.values()
+        if function.name != "_translate_term"
+        and any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "walk"
+            for node in ast.walk(function)
+        )
+    ] == []
+    assert [
+        function.name
+        for function in functions.values()
+        if function.name != "_translate_term"
+        and any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "isinstance"
+            and any(
+                isinstance(arg, ast.Name) and arg.id in {"Call", "Name"}
+                for arg in node.args[1:]
+            )
+            for node in ast.walk(function)
+        )
+    ] == []
 
 
 def test_leaf_harvester_lifts_is_none_with_substrate_guard():


### PR DESCRIPTION
Law: SIDE_DOOR_ZERO / LAW_OF_ONE

Deletes `_call_edges` and its second source-tree walk. `_translate_term` is now the sole construction event for both the translated term and its authenticated call occurrence roster. Occurrences are producer-minted, init-disabled, source-CID/path/span sealed, and projected only under their exact FunctionDef frame.

Authentic denominator: `test_verify_dialect.py` exercises genuine `SourceFile` construction. Twins cover exact truthful locus, same spelling/different occurrence, same locus/different call, nested producer order, unsupported call with zero edges, and exact refusals for direct construction, dataclass replacement, mutable alias, foreign frame, roster cross-wire, and target tampering.

Focused receipt after rebase to main 813396008: 9 passed, 42 deselected.

R_leaf_call_edge_side_door: 1 -> 0; Delta=-1. Floors: no second walk, no name/span reconstruction, no wrapper or compatibility path.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Delete `_call_edges` side door and gate call-edge emission on authenticated occurrence verification
> - Removes the standalone `_call_edges` AST walk in [leaf_assertions.py](https://github.com/TSavo/sugar/pull/6798/files#diff-f60af2e7bc0c97b4ac9790763c82c8889ecb714ea333435199b06b33d7fa6701) and replaces it with verified call-edge emission via new `_CallOccurrence` and `_TranslatedTerm` dataclasses.
> - `_CallOccurrence` seals a snapshot of each Call site (symbol, source CID, path, line, column) and only emits a call-edge if the current state matches the seal and the call belongs to the provided `FunctionDef`.
> - `_TranslatedTerm` carries an authenticated roster of `_CallOccurrence` instances and raises `_LeafCallTestimonyMismatch` on projection if any testimony has been mutated or cross-sourced.
> - `_lift_assert` now returns a `_LiftedAssertion` bundling the assertion atom and verified call-edges, which `harvest_source` consumes directly.
> - Risk: cross-source or mutated testimony that previously passed silently now raises `_LeafCallTestimonyMismatch`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73a2abe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->