### PR TITLE
Own tuple iterator subscript mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
@@ -70,6 +70,16 @@ class TupleIteratorValue(FloorValue):
     def denotes_value(self) -> bool:
         return True
 
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="TypeError", site=site, owner="TupleIteratorValue.setitem")
+
+    def delitem(self, index, site):
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="TypeError", site=site, owner="TupleIteratorValue.delitem")
+
     def next_with(self, operation, ctx):
         del ctx
         from sugar_lift_py_tests.outcome import Complete

--- a/implementations/python/sugar-lift-py-tests/tests/test_tuple_iterator_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_tuple_iterator_subscript_mutation.py
@@ -1,0 +1,26 @@
+from sugar_lift_py_tests.floor import TermValue, TupleIteratorValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _outcomes(tmp_path):
+    path = tmp_path / "tuple_iterator_subscript_mutation.py"
+    path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    store_site, delete_site = body[0].fragment, body[1].fragment
+    value = TupleIteratorValue((TermValue(1),))
+    return ((value.setitem(TermValue(0), TermValue(7), store_site), "TupleIteratorValue.setitem", store_site), (value.delitem(TermValue(0), delete_site), "TupleIteratorValue.delitem", delete_site))
+
+
+def test_tuple_iterator_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        assert outcome.value.effect.exception_name == "TypeError"
+        assert outcome.value.effect.producer_node_owner == owner
+        assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_tuple_iterator_mutations_reject_wrong_site(tmp_path):
+    store, _, store_site = _outcomes(tmp_path)[0]
+    delete, _, delete_site = _outcomes(tmp_path)[1]
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
TupleIteratorValue setitem/delitem exact TypeErrors with authentic occurrences and wrong-site twin. Base 81339600: AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1. Head 7f92c0939: AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0. Focused 2 passed. R 2->0. SETITEM_DEFS=1 DELITEM_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 carrier/ExitSet/outcome drift=0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` TypeError handling to `TupleIteratorValue`
> Adds `setitem` and `delitem` methods to `TupleIteratorValue` in [iterator_value.py](https://github.com/TSavo/sugar/pull/6799/files#diff-763a56c63f3bea747334ec7177f103d162d0fbb9cafa36746cd0b1bb8cfe2c83) that return a `ground_exceptional_exit` with `TypeError`, matching Python's behavior of rejecting subscript mutation on tuple iterators. Adds tests in [test_tuple_iterator_subscript_mutation.py](https://github.com/TSavo/sugar/pull/6799/files#diff-dd8b488028272a8e7a8ffcaa73e1f249912b83e5c72782c711777fb3b932937e) verifying that each method produces a TypeError effect with the correct owner string and site-specific occurrence ID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f92c09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->