### PR TITLE
Own list iterator attribute mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
@@ -39,6 +39,16 @@ class ListIteratorValue(FloorValue):
     def denotes_value(self) -> bool:
         return True
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="ListIteratorValue.setattr")
+
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="ListIteratorValue.delattr")
+
     def setitem(self, index, value, site):
         del index, value
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit

--- a/implementations/python/sugar-lift-py-tests/tests/test_list_iterator_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_list_iterator_attribute_mutation.py
@@ -1,0 +1,26 @@
+from sugar_lift_py_tests.floor import ListIteratorValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _outcomes(tmp_path):
+    path = tmp_path / "list_iterator_attribute_mutation.py"
+    path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    store_site, delete_site = body[0].fragment, body[1].fragment
+    value = ListIteratorValue((TermValue(1),))
+    return ((value.setattr("attr", TermValue(7), store_site), "ListIteratorValue.setattr", store_site), (value.delattr("attr", delete_site), "ListIteratorValue.delattr", delete_site))
+
+
+def test_list_iterator_attribute_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        assert outcome.value.effect.exception_name == "AttributeError"
+        assert outcome.value.effect.producer_node_owner == owner
+        assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_list_iterator_attribute_mutations_reject_wrong_site(tmp_path):
+    store, _, store_site = _outcomes(tmp_path)[0]
+    delete, _, delete_site = _outcomes(tmp_path)[1]
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
ListIteratorValue setattr/delattr exact AttributeErrors with authentic occurrences and wrong-site twin. Base 73d5d879: AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1. Head e3ea5d580: AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0. Focused 2 passed. R 2->0. SETATTR_DEFS=1 DELATTR_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 carrier/ExitSet/outcome drift=0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` to `ListIteratorValue` to raise `AttributeError`
> Adds `setattr` and `delattr` methods to `ListIteratorValue` in [iterator_value.py](https://github.com/TSavo/sugar/pull/6800/files#diff-763a56c63f3bea747334ec7177f103d162d0fbb9cafa36746cd0b1bb8cfe2c83), both returning a `ground_exceptional_exit` with `exception_name="AttributeError"` and the provided site. Tests in [test_list_iterator_attribute_mutation.py](https://github.com/TSavo/sugar/pull/6800/files#diff-3b03ce1cafc7ae195ec5694607025471aa8d0189c7431667d086a3cbb8d28676) verify that the correct owner string and site-specific `occurrence_id` are produced for each operation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3ea5d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * List iterators now consistently reject unsupported attribute assignment and deletion with an `AttributeError`.
  * Attribute mutation errors now report the correct operation and source location.

* **Tests**
  * Added coverage for list-iterator attribute mutation failures and precise error metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->