### PR TITLE
Own tuple iterator attribute mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
@@ -80,6 +80,16 @@ class TupleIteratorValue(FloorValue):
     def denotes_value(self) -> bool:
         return True
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="TupleIteratorValue.setattr")
+
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="TupleIteratorValue.delattr")
+
     def setitem(self, index, value, site):
         del index, value
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit

--- a/implementations/python/sugar-lift-py-tests/tests/test_tuple_iterator_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_tuple_iterator_attribute_mutation.py
@@ -1,0 +1,26 @@
+from sugar_lift_py_tests.floor import TermValue, TupleIteratorValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _outcomes(tmp_path):
+    path = tmp_path / "tuple_iterator_attribute_mutation.py"
+    path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    store_site, delete_site = body[0].fragment, body[1].fragment
+    value = TupleIteratorValue((TermValue(1),))
+    return ((value.setattr("attr", TermValue(7), store_site), "TupleIteratorValue.setattr", store_site), (value.delattr("attr", delete_site), "TupleIteratorValue.delattr", delete_site))
+
+
+def test_tuple_iterator_attribute_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        assert outcome.value.effect.exception_name == "AttributeError"
+        assert outcome.value.effect.producer_node_owner == owner
+        assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_tuple_iterator_attribute_mutations_reject_wrong_site(tmp_path):
+    store, _, store_site = _outcomes(tmp_path)[0]
+    delete, _, delete_site = _outcomes(tmp_path)[1]
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
TupleIteratorValue setattr/delattr exact AttributeErrors with authentic occurrences and wrong-site twin. Base c80ab330: AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1. Head 97b12804d: AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0. Focused 2 passed. R 2->0. SETATTR_DEFS=1 DELATTR_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 carrier/ExitSet/outcome drift=0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` error handling to `TupleIteratorValue`
> Adds `setattr` and `delattr` methods to `TupleIteratorValue` that return `AttributeError` exceptional exits, matching Python's runtime behavior for tuple iterator attribute mutation. Each method tags the exit with its own owner string and the provided source site. Tests verify that the exception name, owner, and site are all correctly associated for each operation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97b1280.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->