### PR TITLE
Own Ellipsis subscript mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ellipsis_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ellipsis_value.py
@@ -60,6 +60,24 @@ class EllipsisValue(FloorValue):
             return Complete(TrueBoolLiteralSugar(site=site))
         return super().is_identical(other, site)
 
+    def setitem(self, index, value, site):
+        """Ellipsis rejects subscript store with exact TypeError."""
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="EllipsisValue.setitem"
+        )
+
+    def delitem(self, index, site):
+        """Ellipsis rejects subscript delete with exact TypeError."""
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="EllipsisValue.delitem"
+        )
+
     def to_term(self, *, owner: str):
         del owner
         from sugar_lift_py_tests.ir import ctor

--- a/implementations/python/sugar-lift-py-tests/tests/test_ellipsis_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_ellipsis_subscript_mutation.py
@@ -1,0 +1,26 @@
+from sugar_lift_py_tests.floor import EllipsisValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _outcomes(tmp_path):
+    path = tmp_path / "ellipsis_subscript_mutation.py"
+    path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    s, d = body[0].fragment, body[1].fragment
+    value = EllipsisValue()
+    return ((value.setitem(TermValue(0), TermValue(7), s), "EllipsisValue.setitem", s), (value.delitem(TermValue(0), d), "EllipsisValue.delitem", d))
+
+
+def test_ellipsis_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        assert outcome.value.effect.exception_name == "TypeError"
+        assert outcome.value.effect.producer_node_owner == owner
+        assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_ellipsis_mutations_reject_wrong_site(tmp_path):
+    store, _, store_site = _outcomes(tmp_path)[0]
+    delete, _, delete_site = _outcomes(tmp_path)[1]
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
EllipsisValue setitem/delitem exact TypeErrors with authentic occurrences and wrong-site twin. Base d7486763: AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1. Head 37bafdd61: AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0. Focused 2 passed. R 2->0. SETITEM_DEFS=1 DELITEM_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 carrier/ExitSet/outcome drift=0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` methods to `EllipsisValue` to own subscript mutation errors
> Adds `EllipsisValue.setitem` and `EllipsisValue.delitem` methods in [ellipsis_value.py](https://github.com/TSavo/sugar/pull/6802/files#diff-55b36f733df9f20d1fdd8038599b1e8f00d18dda31d09dde6abde6f7d4d40116) that return a `ground_exceptional_exit` with `TypeError`, setting the `producer_node_owner` to the respective method name and `occurrence_id` from the provided site. New tests in [test_ellipsis_subscript_mutation.py](https://github.com/TSavo/sugar/pull/6802/files#diff-96e25eb8daaf63a0ccbf76364cf105614bc66efa6239b25affe3d6a9baf2108f) verify that the correct owner string and occurrence site are recorded for each operation, and that store and delete sites are not interchangeable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37bafdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->