### PR TITLE
Own Ellipsis attribute mutation errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ellipsis_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ellipsis_value.py
@@ -60,6 +60,16 @@ class EllipsisValue(FloorValue):
             return Complete(TrueBoolLiteralSugar(site=site))
         return super().is_identical(other, site)
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="EllipsisValue.setattr")
+
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="EllipsisValue.delattr")
+
     def setitem(self, index, value, site):
         """Ellipsis rejects subscript store with exact TypeError."""
         del index, value

--- a/implementations/python/sugar-lift-py-tests/tests/test_ellipsis_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_ellipsis_attribute_mutation.py
@@ -1,0 +1,26 @@
+from sugar_lift_py_tests.floor import EllipsisValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _outcomes(tmp_path):
+    path = tmp_path / "ellipsis_attribute_mutation.py"
+    path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    s, d = body[0].fragment, body[1].fragment
+    value = EllipsisValue()
+    return ((value.setattr("attr", TermValue(7), s), "EllipsisValue.setattr", s), (value.delattr("attr", d), "EllipsisValue.delattr", d))
+
+
+def test_ellipsis_attribute_mutations_have_exact_owner_occurrences(tmp_path):
+    for outcome, owner, site in _outcomes(tmp_path):
+        assert outcome.value.effect.exception_name == "AttributeError"
+        assert outcome.value.effect.producer_node_owner == owner
+        assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_ellipsis_attribute_mutations_reject_wrong_site(tmp_path):
+    store, _, store_site = _outcomes(tmp_path)[0]
+    delete, _, delete_site = _outcomes(tmp_path)[1]
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R axis: R_missing_ellipsis_attribute_floor_owner

Predicted Epsilon R: -2.

Focused instrument: 2 red on base, 2 green on head. Authentic store/delete SourceFragment occurrences plus wrong-site substitution twin.

Isolated byte-identical authentication:
- base 4c9c05a308064906ef75fcadab5daa5a9f2448e5 at /tmp/agy2-ellipsis-attr-base.D03yGK: AUTH_CASES=2 OWNED=0 GAPS=2 PROBE_EXIT=1
- head 885a73dedc3bfc7745f0959157c8e334da6b5c27 at /tmp/agy2-ellipsis-attr-head.hrcxj9: AUTH_CASES=2 OWNED=2 GAPS=0 PROBE_EXIT=0
- observed Delta R: -2

Floors: SETATTR_DEFS=1 DELATTR_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 FORBIDDEN_CARRIER_EXITSET_OUTCOME_DRIFT=0. No spelling/vendor dispatch.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` to `EllipsisValue` to raise `AttributeError`
> Implements `setattr` and `delattr` methods on `EllipsisValue` that return a `ground_exceptional_exit` with `AttributeError`, matching Python's behavior when mutating attributes on the `Ellipsis` singleton. Adds tests verifying that each method records the correct `producer_node_owner` and that `occurrence_id` is site-specific and not shared between store and delete operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 885a73d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->