### PR TITLE
Own builtin exception class subscript mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_exception_class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_exception_class_value.py
@@ -16,6 +16,26 @@ class BuiltinExceptionClassValue(ClassValue):
     constructor semantics by leaf-name coincidence.
     """
 
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="BuiltinExceptionClassValue.setitem",
+        )
+
+    def delitem(self, index, site):
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="BuiltinExceptionClassValue.delitem",
+        )
+
     def exception_type_identity(self) -> Term:
         """Same coordinate ``SourceUnit.exception_type_identity`` publishes for builtins."""
         from sugar_lift_py_tests.ir import ctor, str_const

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_exception_class_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_exception_class_subscript_mutation.py
@@ -1,0 +1,48 @@
+import pytest
+
+from sugar_lift_py_tests.floor import (
+    BlockValue,
+    BuiltinExceptionClassValue,
+    TermValue,
+)
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "builtin_exception_class_subscript_mutation.py"
+    path.write_text("def f(cls, value):\n    cls[0] = value\n    del cls[0]\n")
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (("setitem", "BuiltinExceptionClassValue.setitem", 0),
+     ("delitem", "BuiltinExceptionClassValue.delitem", 1)),
+)
+def test_builtin_exception_class_subscript_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = BuiltinExceptionClassValue("ValueError", (), BlockValue(()))
+    outcome = (
+        value.setitem(TermValue(0), TermValue(7), site)
+        if operation == "setitem"
+        else value.delitem(TermValue(0), site)
+    )
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_builtin_exception_class_subscript_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = BuiltinExceptionClassValue("ValueError", (), BlockValue(()))
+    store = value.setitem(TermValue(0), TermValue(7), store_site)
+    delete = value.delitem(TermValue(0), delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R axis: R_missing_builtin_exception_class_subscript_floor_owner

Predicted Epsilon R: -2.

Focused honest instrument: base collected 3 and failed 3 with independent setitem/delitem Floor panics plus wrong-site twin; head collected 3 and passed 3.

Isolated byte-identical authentication:
- base a5aaf3aa31272ca0a096dc6bac90b01babbea76f at /tmp/agy2-builtin-exc-sub-base.FQVVAV: AUTH_CASES=2 OWNED=0 GAPS=2 PROBE_EXIT=1
- head 4dc36fa9f9971bde4a92d490344d000a982cb573 at /tmp/agy2-builtin-exc-sub-head.cT9aie: AUTH_CASES=2 OWNED=2 GAPS=0 PROBE_EXIT=0
- observed Delta R: -2

Floors: SETITEM_DEFS=1 DELITEM_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 FORBIDDEN_CARRIER_EXITSET_OUTCOME_DRIFT=0. No spelling/vendor dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscript assignment and deletion on built-in exception class values now consistently raise `TypeError`.
  * Error details correctly identify the operation and source location.

* **Tests**
  * Added coverage for subscript assignment and deletion behavior.
  * Verified that errors are associated with the correct operation and location, including mismatched locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` to `BuiltinExceptionClassValue` to raise TypeError on subscript mutation
> Adds `setitem` and `delitem` methods to `BuiltinExceptionClassValue` in [builtin_exception_class_value.py](https://github.com/TSavo/sugar/pull/6804/files#diff-f83131cc905cfa91db96f12eab4342acec82b8f1ed514c870d6963e7b057a4d1). Both methods ignore their arguments and return a `TypeError` exceptional exit tagged with the call site, matching Python's behavior when attempting to subscript-assign or subscript-delete a built-in exception class. Tests in [test_builtin_exception_class_subscript_mutation.py](https://github.com/TSavo/sugar/pull/6804/files#diff-81ef2e74b47a5d41bf4f11d8ae11d4b453f2c68af0b27029f838dc697e293109) verify that the owner and occurrence ID are correct and that distinct sites produce distinct occurrence IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4dc36fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->