### PR TITLE
Own builtin exception class attribute mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_exception_class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_exception_class_value.py
@@ -36,6 +36,26 @@ class BuiltinExceptionClassValue(ClassValue):
             owner="BuiltinExceptionClassValue.delitem",
         )
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="BuiltinExceptionClassValue.setattr",
+        )
+
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="BuiltinExceptionClassValue.delattr",
+        )
+
     def exception_type_identity(self) -> Term:
         """Same coordinate ``SourceUnit.exception_type_identity`` publishes for builtins."""
         from sugar_lift_py_tests.ir import ctor, str_const

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_exception_class_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_exception_class_attribute_mutation.py
@@ -1,0 +1,50 @@
+import pytest
+
+from sugar_lift_py_tests.floor import (
+    BlockValue,
+    BuiltinExceptionClassValue,
+    TermValue,
+)
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "builtin_exception_class_attribute_mutation.py"
+    path.write_text("def f(cls, value):\n    cls.attr = value\n    del cls.attr\n")
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setattr", "BuiltinExceptionClassValue.setattr", 0),
+        ("delattr", "BuiltinExceptionClassValue.delattr", 1),
+    ),
+)
+def test_builtin_exception_class_attribute_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = BuiltinExceptionClassValue("ValueError", (), BlockValue(()))
+    outcome = (
+        value.setattr("attr", TermValue(7), site)
+        if operation == "setattr"
+        else value.delattr("attr", site)
+    )
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_builtin_exception_class_attribute_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = BuiltinExceptionClassValue("ValueError", (), BlockValue(()))
+    store = value.setattr("attr", TermValue(7), store_site)
+    delete = value.delattr("attr", delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R axis: R_missing_builtin_exception_class_attribute_floor_owner

Predicted Epsilon R: -2.

Focused honest instrument: base collected 3 and failed 3 with independent setattr/delattr Floor panics plus wrong-site twin; head collected 3 and passed 3.

Isolated byte-identical authentication:
- base 5dfc4f3f66b491cd22c5ff025dd844d915ff58de at /tmp/agy2-builtin-exc-attr-base.6HhcvT: AUTH_CASES=2 OWNED=0 GAPS=2 PROBE_EXIT=1
- head 7dd70a389b3d0819b1e673b85f0e257418d1b810 at /tmp/agy2-builtin-exc-attr-head.hfUXXV: AUTH_CASES=2 OWNED=2 GAPS=0 PROBE_EXIT=0
- observed Delta R: -2

Floors: SETATTR_DEFS=1 DELATTR_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 FORBIDDEN_CARRIER_EXITSET_OUTCOME_DRIFT=0. No spelling/vendor dispatch.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` handlers to `BuiltinExceptionClassValue` to raise TypeError
> Adds `setattr` and `delattr` methods to [`BuiltinExceptionClassValue`](https://github.com/TSavo/sugar/pull/6805/files#diff-f83131cc905cfa91db96f12eab4342acec82b8f1ed514c870d6963e7b057a4d1) so that attribute assignment and deletion on builtin exception classes produce a `TypeError` exceptional exit with the appropriate owner identifier and site-based occurrence ID. Tests in [`test_builtin_exception_class_attribute_mutation.py`](https://github.com/TSavo/sugar/pull/6805/files#diff-d7c97256ba118c29976fc9303475ec1ddb257c6d99612d5d7cc935ce580a11f0) verify the owner string and occurrence tracking for both operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7dd70a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->