### PR TITLE
Own encoded string subscript mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/encoded_string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/encoded_string_value.py
@@ -21,5 +21,25 @@ class EncodedStringValue(FloorValue):
     table: tuple[int, ...]
     indices: tuple[Term, ...]
 
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="EncodedStringValue.setitem",
+        )
+
+    def delitem(self, index, site):
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="EncodedStringValue.delitem",
+        )
+
     def binary_operator_with(self, operation, ctx):
         return operation.binary_encoded_string(self, ctx)

--- a/implementations/python/sugar-lift-py-tests/tests/test_encoded_string_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_encoded_string_subscript_mutation.py
@@ -1,0 +1,46 @@
+import pytest
+
+from sugar_lift_py_tests.floor import EncodedStringValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "encoded_string_subscript_mutation.py"
+    path.write_text("def f(value, replacement):\n    value[0] = replacement\n    del value[0]\n")
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setitem", "EncodedStringValue.setitem", 0),
+        ("delitem", "EncodedStringValue.delitem", 1),
+    ),
+)
+def test_encoded_string_subscript_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = EncodedStringValue((), ())
+    outcome = (
+        value.setitem(TermValue(0), TermValue(7), site)
+        if operation == "setitem"
+        else value.delitem(TermValue(0), site)
+    )
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_encoded_string_subscript_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = EncodedStringValue((), ())
+    store = value.setitem(TermValue(0), TermValue(7), store_site)
+    delete = value.delitem(TermValue(0), delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R axis: R_missing_encoded_string_subscript_floor_owner

Predicted Epsilon R: -2.

Focused honest instrument: base collected 3 and failed 3 with independent setitem/delitem Floor panics plus wrong-site twin; head collected 3 and passed 3.

Isolated byte-identical authentication:
- base 3330a52749076ef7faddbee2f118d90f2ba56bf2 at /tmp/agy2-encoded-string-sub-base.3zlEzN: AUTH_CASES=2 OWNED=0 GAPS=2 PROBE_EXIT=1
- head 90f5cd71cc8f7f1e9341d31bc40a9519f85841b5 at /tmp/agy2-encoded-string-sub-head.X0CQn9: AUTH_CASES=2 OWNED=2 GAPS=0 PROBE_EXIT=0
- observed Delta R: -2

Floors: SETITEM_DEFS=1 DELITEM_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 FORBIDDEN_CARRIER_EXITSET_OUTCOME_DRIFT=0. No spelling/vendor dispatch or reconstruction.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` methods to `EncodedStringValue` that raise `TypeError`
> Implements subscript mutation handling for `EncodedStringValue` by adding `setitem` and `delitem` methods in [encoded_string_value.py](https://github.com/TSavo/sugar/pull/6806/files#diff-cbb3a51f96d08ffbd4ac9ba25d123a78dee7bf1918b6523b0f7be2414335ad22). Both methods always return a `ground_exceptional_exit` with `TypeError`, binding the occurrence to the provided site. Tests in [test_encoded_string_subscript_mutation.py](https://github.com/TSavo/sugar/pull/6806/files#diff-7559577c357a62049de1023762f808c86a7ca778e0f17c65398b91c4d16073c0) verify that the owner and occurrence ID are correct and that occurrence IDs are tied to their respective sites.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90f5cd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->