### PR TITLE
Own encoded string attribute mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/encoded_string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/encoded_string_value.py
@@ -41,5 +41,25 @@ class EncodedStringValue(FloorValue):
             owner="EncodedStringValue.delitem",
         )
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="EncodedStringValue.setattr",
+        )
+
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="EncodedStringValue.delattr",
+        )
+
     def binary_operator_with(self, operation, ctx):
         return operation.binary_encoded_string(self, ctx)

--- a/implementations/python/sugar-lift-py-tests/tests/test_encoded_string_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_encoded_string_attribute_mutation.py
@@ -1,0 +1,46 @@
+import pytest
+
+from sugar_lift_py_tests.floor import EncodedStringValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "encoded_string_attribute_mutation.py"
+    path.write_text("def f(value, replacement):\n    value.attr = replacement\n    del value.attr\n")
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setattr", "EncodedStringValue.setattr", 0),
+        ("delattr", "EncodedStringValue.delattr", 1),
+    ),
+)
+def test_encoded_string_attribute_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = EncodedStringValue((), ())
+    outcome = (
+        value.setattr("attr", TermValue(7), site)
+        if operation == "setattr"
+        else value.delattr("attr", site)
+    )
+    assert outcome.value.effect.exception_name == "AttributeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_encoded_string_attribute_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = EncodedStringValue((), ())
+    store = value.setattr("attr", TermValue(7), store_site)
+    delete = value.delattr("attr", delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R axis: R_missing_encoded_string_attribute_floor_owner

Predicted Epsilon R: -2.

Focused honest instrument: base collected 3 and failed 3 with independent setattr/delattr Floor panics plus wrong-site twin; head collected 3 and passed 3.

Isolated byte-identical authentication:
- base 7c571df4189c58d661cc189ffddb61f94a2878b9 at /tmp/agy2-encoded-string-attr-base.v2hZrW: AUTH_CASES=2 OWNED=0 GAPS=2 PROBE_EXIT=1
- head f7a0bf73cd5c6e75e74f65cc3da12ff5e8817bb8 at /tmp/agy2-encoded-string-attr-head.7rm806: AUTH_CASES=2 OWNED=2 GAPS=0 PROBE_EXIT=0
- observed Delta R: -2

Floors: SETATTR_DEFS=1 DELATTR_DEFS=1 LAW_OF_ONE_VIOLATIONS=0 SIDE_DOOR_OCCURRENCES=0 FORBIDDEN_DRIFT=0. No spelling/vendor dispatch, reconstruction, carrier/ExitSet/outcome, Halted, TargetPattern, FBC, or codex-4/7/8 lane edits.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` mutation handling to `EncodedStringValue`
> Adds `setattr` and `delattr` methods to `EncodedStringValue` that return a `ground_exceptional_exit` with `exception_name` set to `"AttributeError"` and the provided site as the occurrence context, matching Python's behavior for immutable string attributes.
>
> Tests verify that each method tags the effect with the correct owner (`EncodedStringValue.setattr` or `EncodedStringValue.delattr`) and that site occurrence IDs are not interchangeable between the two operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7a0bf7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->