### PR TITLE
Use canonical encoded string occurrence fixture

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_encoded_string_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_encoded_string_attribute_mutation.py
@@ -1,16 +1,15 @@
 import pytest
 
 from sugar_lift_py_tests.floor import EncodedStringValue, TermValue
-from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_lift_py_tests.ir import ctor, str_const
 from sugar_source_tree.tree import SourceFile
 
 
-def _sites(tmp_path):
+def _sites(tmp_path, monkeypatch):
     path = tmp_path / "encoded_string_attribute_mutation.py"
     path.write_text("def f(value, replacement):\n    value.attr = replacement\n    del value.attr\n")
-    body = next(
-        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
-    ).body
+    monkeypatch.chdir(tmp_path)
+    body = next(SourceFile.from_path(path.name).functions()).body
     return body[0].fragment, body[1].fragment
 
 
@@ -22,9 +21,9 @@ def _sites(tmp_path):
     ),
 )
 def test_encoded_string_attribute_mutations_have_exact_owner_occurrences(
-    tmp_path, operation, owner, site_index
+    tmp_path, monkeypatch, operation, owner, site_index
 ):
-    sites = _sites(tmp_path)
+    sites = _sites(tmp_path, monkeypatch)
     site = sites[site_index]
     value = EncodedStringValue((), ())
     outcome = (
@@ -35,10 +34,17 @@ def test_encoded_string_attribute_mutations_have_exact_owner_occurrences(
     assert outcome.value.effect.exception_name == "AttributeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)
+    identity = lambda name: ctor(
+        "python:exception_type_identity", [str_const("builtins"), str_const(name)]
+    )
+    assert outcome.value.effect.exception_type_coordinate == identity("AttributeError")
+    assert outcome.value.effect.exception_type_mro == tuple(
+        identity(name) for name in ("AttributeError", "Exception", "BaseException")
+    )
 
 
-def test_encoded_string_attribute_mutations_reject_wrong_site(tmp_path):
-    store_site, delete_site = _sites(tmp_path)
+def test_encoded_string_attribute_mutations_reject_wrong_site(tmp_path, monkeypatch):
+    store_site, delete_site = _sites(tmp_path, monkeypatch)
     value = EncodedStringValue((), ())
     store = value.setattr("attr", TermValue(7), store_site)
     delete = value.delattr("attr", delete_site)


### PR DESCRIPTION
Tests-only #6807 fix-forward. Production files changed: 0.

Canonical fixture: sole SourceFile.from_path door, independent attribute store/delete sites, wrong-site twin, exact AttributeError coordinate and MRO.

Same-job receipt, /usr/local/opt/python@3.14/bin/python3.14, Python 3.14.4:
- immutable pre-#6807 base 7c571df4189c58d661cc189ffddb61f94a2878b9 at /tmp/agy2-encoded-attr-fix-base.MOf1wR with byte-identical fixed test: 3 failed, EXIT=1; exact EncodedStringValue.setattr and .delattr method-gap reds plus wrong-site test blocked by the same missing owner
- fixed head b8c9cd0b751a4a0ba10d00f6a8ee549f7475ffd6: 3 passed, EXIT=0; both exact coordinate/MRO outcomes and wrong-site twin green

Semantic R 2->0 remains banked in #6807. SIDE_DOOR_OCCURRENCES=0, forbidden drift=0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use canonical encoded string occurrence fixture in attribute mutation tests
> Updates [test_encoded_string_attribute_mutation.py](https://github.com/TSavo/sugar/pull/6808/files#diff-159dc09c9f1ef84b7c5c4bcf3f9bcdbd61311f8ed52a0d6ffef8342728678605) to use a canonical fixture pattern for encoded string occurrences.
>
> - Replaces `workspace_path_source` with `SourceFile.from_path` combined with `monkeypatch.chdir` to resolve source files by relative name during tests.
> - Adds assertions in `test_encoded_string_attribute_mutations_have_exact_owner_occurrences` verifying the effect's exception type coordinate and MRO match `builtins.AttributeError`, `Exception`, and `BaseException`.
> - Constructs exception type identities using `ctor`/`str_const` helpers imported from `sugar_lift_py_tests.ir`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8c9cd0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Python test setup to create and load source files in temporary directories.
  * Expanded validation for encoded string attribute mutations to verify exception type details, including the exception class and method resolution order.
  * Updated related rejection tests to use the revised test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->