### PR TITLE
Own slice value subscript mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/slice_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/slice_value.py
@@ -11,6 +11,22 @@ class SliceValue(FloorValue):
     upper: FloorValue | None
     step: FloorValue | None
 
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="SliceValue.setitem"
+        )
+
+    def delitem(self, index, site):
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="SliceValue.delitem"
+        )
+
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.ir import ctor
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_slice_value_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_slice_value_subscript_mutation.py
@@ -1,0 +1,32 @@
+import pytest
+
+from sugar_lift_py_tests.floor import SliceValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "slice_value_subscript_mutation.py"
+    path.write_text("def f(value, replacement):\n    value[0] = replacement\n    del value[0]\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "SliceValue.setitem", 0), ("delitem", "SliceValue.delitem", 1)))
+def test_slice_value_subscript_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = SliceValue(None, None, None)
+    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_slice_value_subscript_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = SliceValue(None, None, None)
+    store = value.setitem(TermValue(0), TermValue(7), store_site)
+    delete = value.delitem(TermValue(0), delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R axis: R_missing_slice_value_subscript_floor_owner; Epsilon=-2.

Focused: base 3 failed EXIT=1, head 3 passed EXIT=0; independent real store/delete occurrences plus wrong-site twin.

Isolated auth:
- base ee631b0b9f58baec9c300c3474e3693e9b739d14 /tmp/agy2-slice-sub-base.7opjxD: AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1
- head ce411f735aa807eac164ccc5c836722d51b21246 /tmp/agy2-slice-sub-head.h3Nhnk: AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0
Delta=-2. SETITEM_DEFS=1 DELITEM_DEFS=1 LAW_OF_ONE=0 SIDE_DOOR=0 forbidden drift=0. Excluded lanes untouched.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` methods to `SliceValue` that raise `TypeError`
> Implements subscript mutation handling for `SliceValue` by adding `setitem` and `delitem` methods in [slice_value.py](https://github.com/TSavo/sugar/pull/6809/files#diff-69d3ace047e9662a97007a850903e8fb933879e2a7d1f1e3e640573cb7568b7f). Both methods ignore their arguments and return a `ground_exceptional_exit` representing a `TypeError`, matching Python's behavior for slice objects. A new test module verifies that the correct `producer_node_owner` and `occurrence_id` are produced for each operation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce411f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->