### PR TITLE
Own slice value attribute mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/slice_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/slice_value.py
@@ -27,6 +27,22 @@ class SliceValue(FloorValue):
             exception_name="TypeError", site=site, owner="SliceValue.delitem"
         )
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="SliceValue.setattr"
+        )
+
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="SliceValue.delattr"
+        )
+
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.ir import ctor
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_slice_value_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_slice_value_attribute_mutation.py
@@ -1,0 +1,43 @@
+import pytest
+
+from sugar_lift_py_tests.floor import SliceValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "slice_value_attribute_mutation.py"
+    path.write_text("def f(value, replacement):\n    value.attr = replacement\n    del value.attr\n")
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (("setattr", "SliceValue.setattr", 0), ("delattr", "SliceValue.delattr", 1)),
+)
+def test_slice_value_attribute_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = SliceValue(None, None, None)
+    outcome = (
+        value.setattr("attr", TermValue(7), site)
+        if operation == "setattr"
+        else value.delattr("attr", site)
+    )
+    assert outcome.value.effect.exception_name == "AttributeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_slice_value_attribute_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = SliceValue(None, None, None)
+    store = value.setattr("attr", TermValue(7), store_site)
+    delete = value.delattr("attr", delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R axis: R_missing_slice_value_attribute_floor_owner; Epsilon=-2.
Focused base 3 failed EXIT1, head 3 passed EXIT0; real independent attribute sites plus wrong-site twin.
Isolated base 48b488ff at /tmp/agy2-slice-attr-base.T6MTJU AUTH_CASES=2 OWNED=0 GAPS=2 EXIT1; head 902297d392ad36d6627b3e1acc5ea6c5307074a1 at /tmp/agy2-slice-attr-head.56ohNp AUTH_CASES=2 OWNED=2 GAPS=0 EXIT0. Delta=-2. SETATTR_DEFS=1 DELATTR_DEFS=1 LAW_OF_ONE=0 SIDE_DOOR=0 forbidden drift=0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` methods to `SliceValue` that raise `AttributeError`
> Adds `SliceValue.setattr` and `SliceValue.delattr` methods in [slice_value.py](https://github.com/TSavo/sugar/pull/6810/files#diff-69d3ace047e9662a97007a850903e8fb933879e2a7d1f1e3e640573cb7568b7f), each returning a `ground_exceptional_exit` with `exception_name='AttributeError'` and the provided site, ignoring the name/value arguments. Tests in [test_slice_value_attribute_mutation.py](https://github.com/TSavo/sugar/pull/6810/files#diff-0c2ea7529a4ac82c0feca1c54ad2f33c631c21da0384263df115d6f132a4aa5f) verify that the resulting exceptional exits carry the correct owner string and `occurrence_id` matching the call site, and that distinct sites produce distinct `occurrence_id` values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 902297d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->