### PR TITLE
Own set literal subscript mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_literal_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_literal_value.py
@@ -19,6 +19,22 @@ class SetLiteralValue(FloorValue):
 
     items: tuple[Term, ...]
 
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="SetLiteralValue.setitem"
+        )
+
+    def delitem(self, index, site):
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="SetLiteralValue.delitem"
+        )
+
     def contribution(self):
         # Typed non-FOL support carrier: absorbed in a block record.
         return ()

--- a/implementations/python/sugar-lift-py-tests/tests/test_set_literal_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_set_literal_subscript_mutation.py
@@ -1,0 +1,33 @@
+import pytest
+
+from sugar_lift_py_tests.floor import SetLiteralValue, TermValue
+from sugar_lift_py_tests.ir import num
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "set_literal_subscript_mutation.py"
+    path.write_text("def f(target, replacement):\n    target[0] = replacement\n    del target[0]\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "SetLiteralValue.setitem", 0), ("delitem", "SetLiteralValue.delitem", 1)))
+def test_set_literal_subscript_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = SetLiteralValue((num(1),))
+    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_set_literal_subscript_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = SetLiteralValue((num(1),))
+    store = value.setitem(TermValue(0), TermValue(7), store_site)
+    delete = value.delitem(TermValue(0), delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R axis R_missing_set_literal_subscript_floor_owner; Epsilon=-2. Initial collection error excluded. Counted focused base 3 failed EXIT1, head 3 passed EXIT0, independent real sites and wrong-site twin. Isolated base f61815f7 /tmp/agy2-setlit-sub-base.cmneVk AUTH_CASES2 OWNED0 GAPS2 EXIT1; head 97facd0e4242a0bb17f62a9b3d5db9279874f597 /tmp/agy2-setlit-sub-head.SSUma8 AUTH_CASES2 OWNED2 GAPS0 EXIT0. Delta=-2. defs1/1 LAW_OF_ONE0 SIDE_DOOR0 forbidden0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SetLiteralValue.setitem` and `SetLiteralValue.delitem` mutation methods
> - Adds `setitem` and `delitem` methods to `SetLiteralValue` in [set_literal_value.py](https://github.com/TSavo/sugar/pull/6811/files#diff-f51dded5d83be126a805ab9a78fd00e1fc93e5d50ff70195b4dc25ee05c46cf0), both returning a `TypeError` exceptional exit since sets do not support subscript mutation.
> - Adds tests in [test_set_literal_subscript_mutation.py](https://github.com/TSavo/sugar/pull/6811/files#diff-4b4485988ae5b3ece6242971760ac0f2c24592fbb42875ddaf454023583a4d03) verifying that each method produces the correct `exception_name`, `producer_node_owner`, and `occurrence_id` tied to the call site, and that store and delete produce distinct occurrence ids when given different sites.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97facd0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->