### PR TITLE
Own set literal attribute mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_literal_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_literal_value.py
@@ -35,6 +35,26 @@ class SetLiteralValue(FloorValue):
             exception_name="TypeError", site=site, owner="SetLiteralValue.delitem"
         )
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="SetLiteralValue.setattr",
+        )
+
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="SetLiteralValue.delattr",
+        )
+
     def contribution(self):
         # Typed non-FOL support carrier: absorbed in a block record.
         return ()

--- a/implementations/python/sugar-lift-py-tests/tests/test_set_literal_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_set_literal_attribute_mutation.py
@@ -1,0 +1,33 @@
+import pytest
+
+from sugar_lift_py_tests.floor import SetLiteralValue, TermValue
+from sugar_lift_py_tests.ir import num
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "set_literal_attribute_mutation.py"
+    path.write_text("def f(target, replacement):\n    target.attr = replacement\n    del target.attr\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setattr", "SetLiteralValue.setattr", 0), ("delattr", "SetLiteralValue.delattr", 1)))
+def test_set_literal_attribute_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = SetLiteralValue((num(1),))
+    outcome = value.setattr("attr", TermValue(7), site) if operation == "setattr" else value.delattr("attr", site)
+    assert outcome.value.effect.exception_name == "AttributeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_set_literal_attribute_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = SetLiteralValue((num(1),))
+    store = value.setattr("attr", TermValue(7), store_site)
+    delete = value.delattr("attr", delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R_missing_set_literal_attribute_floor_owner Epsilon=-2. Focused 3 failed EXIT1 ->3 passed EXIT0. Isolated base 9f7fc188 /tmp/agy2-setlit-attr-base.CCIIl0 AUTH_CASES2 OWNED0 GAPS2 EXIT1; head 7d35041f66af2e332b8f4cddd479f310d52b9503 /tmp/agy2-setlit-attr-head.PLMc41 AUTH_CASES2 OWNED2 GAPS0 EXIT0. Wrong-site twin. defs1/1 LAW_OF_ONE0 SIDE_DOOR0 forbidden0. Delta=-2.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` methods to `SetLiteralValue` that raise `AttributeError`
> Implements attribute mutation handling for `SetLiteralValue` in [set_literal_value.py](https://github.com/TSavo/sugar/pull/6812/files#diff-f51dded5d83be126a805ab9a78fd00e1fc93e5d50ff70195b4dc25ee05c46cf0). Both `setattr` and `delattr` return a `ground_exceptional_exit` carrying `AttributeError`, mirroring Python's behavior where set literals do not support attribute assignment or deletion. A new test module [test_set_literal_attribute_mutation.py](https://github.com/TSavo/sugar/pull/6812/files#diff-1068504d03c3c50845d66c692591845f58f4ddc7cae0cadad72f61750bec6a32) verifies correct owner strings and that store/delete occurrence ids are distinct.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d35041.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->