### PR TITLE
Own tuple literal subscript mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_literal_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_literal_value.py
@@ -10,6 +10,22 @@ from .floor_value import FloorValue
 class TupleLiteralValue(FloorValue):
     items: tuple[FloorValue, ...]
 
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="TupleLiteralValue.setitem"
+        )
+
+    def delitem(self, index, site):
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="TupleLiteralValue.delitem"
+        )
+
     def __post_init__(self) -> None:
         if not all(isinstance(item, FloorValue) for item in self.items):
             raise TypeError("TupleLiteralValue items must be floor values")

--- a/implementations/python/sugar-lift-py-tests/tests/test_tuple_literal_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_tuple_literal_subscript_mutation.py
@@ -1,0 +1,28 @@
+import pytest
+
+from sugar_lift_py_tests.floor import TermValue, TupleLiteralValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "tuple_literal_subscript_mutation.py"
+    path.write_text("def f(target, replacement):\n    target[0] = replacement\n    del target[0]\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "TupleLiteralValue.setitem", 0), ("delitem", "TupleLiteralValue.delitem", 1)))
+def test_tuple_literal_subscript_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path); site = sites[site_index]; value = TupleLiteralValue((TermValue(1),))
+    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_tuple_literal_subscript_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path); value = TupleLiteralValue((TermValue(1),))
+    store = value.setitem(TermValue(0), TermValue(7), store_site); delete = value.delitem(TermValue(0), delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R_missing_tuple_literal_subscript_floor_owner Epsilon=-2. Focused3 failed EXIT1->3 passed EXIT0. Isolated base dd247e36 /tmp/agy2-tuplelit-sub-base.qVCUbJ AUTH_CASES2 OWNED0 GAPS2 EXIT1; head 1e4ca22ca01a957956a15e56b77038a73d29acec /tmp/agy2-tuplelit-sub-head.X1fMES AUTH_CASES2 OWNED2 GAPS0 EXIT0. wrong-site twin. defs1/1 LAW_OF_ONE0 SIDE_DOOR0 forbidden0. Delta=-2.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` to `TupleLiteralValue` to raise TypeError on subscript mutation
> Tuples are immutable, so `TupleLiteralValue` should signal a `TypeError` when subscript assignment or deletion is attempted. Both methods ignore their index/value arguments and return a `ground_exceptional_exit` tagged with `owner` and the provided site. Tests in [`test_tuple_literal_subscript_mutation.py`](https://github.com/TSavo/sugar/pull/6814/files#diff-fee066c02af469b02457cadc90cd4df14f87bdf6f8664be74d766c6607147dc1) verify correct exception names, owner strings, and that store/delete sites are not interchangeable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e4ca22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->