### PR TITLE
Construct TargetPattern once for nested and starred consumers

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -47,63 +47,7 @@ class LiveOutwardHaltedFaceV1:
     state: tuple[BindingEntryV1, ...]
 
 
-@dataclass(frozen=True)
-class LiveForTargetPatternV1:
-    """One producer-authenticated assignment target for live iteration."""
-
-    target: object
-    target_coordinates: tuple[object, ...]
-    scope_owner_cid: str
-
-    def __post_init__(self) -> None:
-        from .binding_provenance import BindingCoordinateV1
-        from .nodes import List, Name, Tuple_
-
-        def leaves(node, path=()):
-            if isinstance(node, Name):
-                return ((node, ("target", *path)),)
-            if isinstance(node, (Tuple_, List)):
-                found = []
-                for index, child in enumerate(node.elts):
-                    found.extend(leaves(child, (*path, index)))
-                return tuple(found)
-            raise TypeError(
-                "live for target requires source-authenticated Name/Tuple/List leaves"
-            )
-
-        target_leaves = leaves(self.target)
-        if len(target_leaves) != len(self.target_coordinates):
-            raise TypeError("live for target requires one coordinate per target leaf")
-        for (leaf, path), coordinate in zip(
-            target_leaves, self.target_coordinates, strict=True
-        ):
-            if not isinstance(coordinate, BindingCoordinateV1):
-                raise TypeError("live for target requires BindingCoordinateV1 testimony")
-            # Decode from its own wire before accepting it.  This rejects stale
-            # CIDs rather than trusting a dataclass-shaped coordinate.
-            if BindingCoordinateV1.decode(coordinate.wire()) != coordinate:
-                raise TypeError("live for target coordinate failed re-authentication")
-            if coordinate.scope_owner_cid != self.scope_owner_cid:
-                raise TypeError("live for target coordinate has foreign loop target scope")
-            if coordinate.projection_path != path:
-                raise TypeError("live for target coordinates do not retain source target order")
-            if coordinate.binding_site != leaf.fragment.seal().to_dict():
-                raise TypeError(
-                    "live for target coordinate cites a foreign source target coordinate"
-                )
-
-    @property
-    def target_names(self) -> tuple[str, ...]:
-        from .nodes import List, Name, Tuple_
-
-        def names(node):
-            if isinstance(node, Name):
-                return (node.id,)
-            if isinstance(node, (Tuple_, List)):
-                return tuple(name for child in node.elts for name in names(child))
-            raise TypeError("live for target contains an unsupported target leaf")
-
-        return names(self.target)
+from .nodes import TargetPatternV1 as LiveForTargetPatternV1
 
 
 @dataclass(frozen=True)
@@ -743,33 +687,7 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
     records = _conserve_unique_records(records)
     construction = decode_loop_construction_v1({"root": root, "records": records})
     if isinstance(loop, For):
-        from .binding_state import mint_binding_coordinate_v1
-        from .nodes import List, Name, Tuple_
-
-        def target_coordinates(target, path=()):
-            if isinstance(target, Name):
-                return (
-                    mint_binding_coordinate_v1(
-                        scope_owner_cid=target_cid,
-                        binding_site=target.fragment,
-                        projection_path=("target", *path),
-                    ),
-                )
-            if isinstance(target, (Tuple_, List)):
-                return tuple(
-                    coordinate
-                    for index, child in enumerate(target.elts)
-                    for coordinate in target_coordinates(child, (*path, index))
-                )
-            raise BindingStateWireGap(
-                "live iterator recurrence requires an authenticated assignment target"
-            )
-
-        pattern = LiveForTargetPatternV1(
-            target=loop.target,
-            target_coordinates=target_coordinates(loop.target),
-            scope_owner_cid=target_cid,
-        )
+        pattern = loop.unit.require_target_pattern(loop, loop.target)
         construction = replace(
             construction,
             iterable_sugar=loop.iter.sugar(),

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -180,6 +180,116 @@ class _ConditionalRaiseRoute:
 _NESTED_COMPREHENSION_TEMPLATE = object()
 
 
+class TargetPatternConstructionGapV1(TypeError):
+    """A target-pattern coordinate does not belong to its eager source owner."""
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        consumer_occurrence: object,
+        target_occurrence: object,
+        target_pattern: object | None = None,
+        expected_coordinates: object | None = None,
+        actual_coordinates: object | None = None,
+    ) -> None:
+        super().__init__(reason, consumer_occurrence, target_occurrence)
+        self.reason = reason
+        self.consumer_occurrence = consumer_occurrence
+        self.target_occurrence = target_occurrence
+        self.target_pattern = target_pattern
+        self.expected_coordinates = expected_coordinates
+        self.actual_coordinates = actual_coordinates
+
+
+@dataclass(frozen=True)
+class TargetPatternV1:
+    """One eager, occurrence-owned destructuring projection."""
+
+    source_unit: "SourceUnit"
+    consumer_occurrence: "Node"
+    target_occurrence: "Node"
+    leaves: tuple["Name", ...]
+    coordinates: tuple[object, ...]
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        return tuple(leaf.id for leaf in self.leaves)
+
+    @property
+    def target(self):
+        return self.target_occurrence
+
+    @property
+    def target_coordinates(self) -> tuple[object, ...]:
+        return self.coordinates
+
+    @property
+    def target_names(self) -> tuple[str, ...]:
+        return self.names
+
+    @property
+    def scope_owner_cid(self) -> str:
+        return self.coordinates[0].scope_owner_cid
+
+    def bindings_for(self, element: "Node") -> "Optional[dict]":
+        """Project one concrete display through this exact target tree."""
+
+        def project(target, value):
+            if isinstance(target, Name):
+                return {target.id: value}
+            if not isinstance(target, (Tuple_, List)) or not isinstance(
+                value, (Tuple_, List)
+            ):
+                return None
+            starred = [
+                index for index, child in enumerate(target.elts)
+                if isinstance(child, Starred)
+            ]
+            if len(starred) > 1:
+                return None
+            if not starred:
+                if len(target.elts) != len(value.elts):
+                    return None
+                pairs = zip(target.elts, value.elts, strict=True)
+            else:
+                star = starred[0]
+                tail = len(target.elts) - star - 1
+                if len(value.elts) < len(target.elts) - 1:
+                    return None
+                from .backend import Children, materialize
+                from .shadow import ShadowNode, _handle_of
+
+                captured = value.elts[star : len(value.elts) - tail]
+                star_value = materialize(
+                    value.unit,
+                    ShadowNode(
+                        "List",
+                        value.span,
+                        (("elts", Children(tuple(_handle_of(v) for v in captured))),),
+                    ),
+                    value.reporter,
+                )
+                pairs = (
+                    *zip(target.elts[:star], value.elts[:star], strict=True),
+                    (target.elts[star].value, star_value),
+                    *zip(
+                        target.elts[star + 1 :],
+                        value.elts[len(value.elts) - tail :],
+                        strict=True,
+                    ),
+                )
+            result = {}
+            for child_target, child_value in pairs:
+                child = project(child_target, child_value)
+                if child is None:
+                    return None
+                result.update(child)
+            return result
+
+        return project(self.target_occurrence, element)
+
+
 def _ordered_binding_keys(names):
     internal_names = (
         _LEXICALLY_BOUND_NAMES,
@@ -220,6 +330,15 @@ class SourceUnit:
     typed_module: object = field(init=False, default=None)
     # Field-data memo for materialize (see construction_cache.py).
     construction_cache: object = field(init=False, default=None)
+    _target_patterns_by_consumer: object = field(
+        init=False, default=None, repr=False, compare=False
+    )
+    _target_patterns_by_target: object = field(
+        init=False, default=None, repr=False, compare=False
+    )
+    target_pattern_construction_count: int = field(
+        init=False, default=0, repr=False, compare=False
+    )
     exception_class_values: object = field(init=False, default=None)
     module_direct_bindings: object = field(init=False, default=None)
     function_nodes: Tuple[object, ...] = field(init=False, default=())
@@ -365,17 +484,186 @@ class SourceUnit:
             "module_direct_bindings",
             {name: tuple(items) for name, items in bindings.items()},
         )
+        constructed_nodes = tuple(module.walk())
         object.__setattr__(
             self,
             "function_nodes",
             tuple(
                 node
-                for node in module.walk()
+                for node in constructed_nodes
                 if isinstance(node, (FunctionDef, AsyncFunctionDef))
             ),
         )
+        patterns = {}
+        patterns_by_target = {}
+        constructed_count = 0
+        for consumer in constructed_nodes:
+            targets = ()
+            if isinstance(consumer, Assign):
+                targets = tuple(
+                    (target, ("targets", target_index))
+                    for target_index, target in enumerate(consumer.targets)
+                    if isinstance(target, (Tuple_, List))
+                )
+            elif isinstance(consumer, For):
+                targets = ((consumer.target, ("target",)),)
+            elif isinstance(consumer, (ListComp, SetComp, DictComp)):
+                targets = tuple(
+                    (generator.target, ("generators", index, "target"))
+                    for index, generator in enumerate(consumer.generators)
+                )
+            if not targets:
+                continue
+            owned = tuple(
+                self._construct_target_pattern(consumer, target, prefix)
+                for target, prefix in targets
+            )
+            patterns[consumer.ref] = owned
+            patterns_by_target.update(
+                (pattern.target_occurrence.ref, pattern) for pattern in owned
+            )
+            constructed_count += len(owned)
+        object.__setattr__(self, "_target_patterns_by_consumer", patterns)
+        object.__setattr__(self, "_target_patterns_by_target", patterns_by_target)
+        object.__setattr__(self, "target_pattern_construction_count", constructed_count)
         # Identity keys include spans against the bound module; drop stale rows.
         object.__setattr__(self, "_exception_type_identity_cache", {})
+
+    def _construct_target_pattern(self, consumer, target, prefix) -> TargetPatternV1:
+        from .binding_state import mint_binding_coordinate_v1
+
+        ordered = []
+
+        def visit(node, path):
+            if isinstance(node, Name):
+                ordered.append((node, path))
+                return
+            if isinstance(node, Starred):
+                visit(node.value, (*path, "star"))
+                return
+            if isinstance(node, (Tuple_, List)):
+                for index, child in enumerate(node.elts):
+                    visit(child, (*path, index))
+                return
+            raise TargetPatternConstructionGapV1(
+                "unsupported-target-leaf",
+                consumer_occurrence=consumer,
+                target_occurrence=target,
+            )
+
+        visit(target, prefix)
+        if not ordered:
+            raise TargetPatternConstructionGapV1(
+                "empty-target-pattern",
+                consumer_occurrence=consumer,
+                target_occurrence=target,
+            )
+        owner_cid = (
+            consumer.owned_loop_target.target_cid
+            if isinstance(consumer, For) and consumer.owned_loop_target is not None
+            else consumer.fragment.seal().cid
+        )
+        leaves = tuple(leaf for leaf, _ in ordered)
+        coordinates = tuple(
+            mint_binding_coordinate_v1(
+                scope_owner_cid=owner_cid,
+                binding_site=leaf.fragment,
+                projection_path=path,
+            )
+            for leaf, path in ordered
+        )
+        return TargetPatternV1(self, consumer, target, leaves, coordinates)
+
+    def target_patterns_for(self, consumer: "Node") -> tuple[TargetPatternV1, ...]:
+        patterns = self._target_patterns_by_consumer
+        if patterns is None:
+            return ()
+        return patterns.get(consumer.ref, ())
+
+    def retain_target_patterns(self, source_consumer, rewritten_consumer) -> None:
+        """Seat one rewrite with its exact source consumer's immutable products."""
+        owned = self.target_patterns_for(source_consumer)
+        if not owned or type(rewritten_consumer) is not type(source_consumer):
+            raise TargetPatternConstructionGapV1(
+                "foreign-target-consumer-rewrite",
+                consumer_occurrence=rewritten_consumer,
+                target_occurrence=source_consumer,
+            )
+        patterns = self._target_patterns_by_consumer
+        patterns[rewritten_consumer.ref] = owned
+
+    def require_target_pattern(self, consumer, target) -> TargetPatternV1:
+        for pattern in self.target_patterns_for(consumer):
+            if pattern.target_occurrence.ref is target.ref:
+                return pattern
+        raise TargetPatternConstructionGapV1(
+            "foreign-target-occurrence",
+            consumer_occurrence=consumer,
+            target_occurrence=target,
+        )
+
+    def require_target_pattern_for_target(self, target) -> TargetPatternV1:
+        patterns = self._target_patterns_by_target
+        pattern = None if patterns is None else patterns.get(target.ref)
+        if pattern is None:
+            raise TargetPatternConstructionGapV1(
+                "foreign-target-occurrence",
+                consumer_occurrence=target,
+                target_occurrence=target,
+            )
+        return pattern
+
+    def require_target_pattern_coordinates(self, pattern, coordinates) -> None:
+        if type(pattern) is not TargetPatternV1 or pattern.source_unit is not self:
+            raise TargetPatternConstructionGapV1(
+                "foreign-target-pattern",
+                consumer_occurrence=pattern.consumer_occurrence,
+                target_occurrence=pattern.target_occurrence,
+                target_pattern=pattern,
+            )
+        if type(coordinates) is not tuple or len(coordinates) != len(
+            pattern.coordinates
+        ):
+            raise TargetPatternConstructionGapV1(
+                "target-coordinate-arity-mismatch",
+                consumer_occurrence=pattern.consumer_occurrence,
+                target_occurrence=pattern.target_occurrence,
+                target_pattern=pattern,
+                expected_coordinates=pattern.coordinates,
+                actual_coordinates=coordinates,
+            )
+        from .binding_provenance import BindingCoordinateV1
+
+        for observed, expected in zip(
+            coordinates, pattern.coordinates, strict=True
+        ):
+            if observed is not expected and any(
+                observed is owned for owned in pattern.coordinates
+            ):
+                reason = "target-coordinate-order-mismatch"
+            elif (
+                type(observed) is not BindingCoordinateV1
+                or BindingCoordinateV1.decode(observed.wire()) != observed
+                or observed.binding_site != expected.binding_site
+            ):
+                reason = "foreign-target-coordinate"
+            elif observed.scope_owner_cid != expected.scope_owner_cid:
+                reason = "foreign-target-scope"
+            elif (
+                observed.projection_path != expected.projection_path
+                or observed is not expected
+            ):
+                reason = "target-coordinate-order-mismatch"
+            else:
+                continue
+            raise TargetPatternConstructionGapV1(
+                reason,
+                consumer_occurrence=pattern.consumer_occurrence,
+                target_occurrence=pattern.target_occurrence,
+                target_pattern=pattern,
+                expected_coordinates=pattern.coordinates,
+                actual_coordinates=coordinates,
+            )
 
     def loop_target_coordinate_for_loop(self, owner: "Node"):
         from sugar_lift_py_tests.context_manager_resolution import (
@@ -1343,6 +1631,11 @@ class Node(Typed):
             object.__setattr__(self.unit, "construction_cache", cache)
         return cache
 
+    @property
+    def target_patterns(self) -> tuple[TargetPatternV1, ...]:
+        """The eager occurrence-owned target products for this consumer."""
+        return self.unit.target_patterns_for(self)
+
     def __getattr__(self, name: str):
         # Field data is memoized on the unit once per site; this shell exposes it.
         if name.startswith("_"):
@@ -2189,7 +2482,7 @@ class Comprehension(Node):
         from .shadow import rewrite
 
         new_iter, di = self._substitute_field(self.iter, scope)
-        bound = self._bound_names_in(self.target)
+        bound = set(self.unit.require_target_pattern_for_target(self.target).names)
         ifs_scope = (
             {k: v for k, v in scope.items() if k not in bound} if bound else scope
         )
@@ -3953,27 +4246,8 @@ class Assign(Statement):
         target = self.targets[0]
         if not isinstance(target, (Tuple_, List)):
             return None
-        return self._destructure_display(target, self.value)
-
-    def _destructure_display(self, target, value):
-        if isinstance(target, Name):
-            return {target.id: value}
-        if not isinstance(target, (Tuple_, List)) or not isinstance(
-            value, (Tuple_, List)
-        ):
-            return None
-
-        pairs = self._display_unpack_pairs(target, value)
-        if pairs is None:
-            return None
-
-        bindings = {}
-        for child_target, child_value in pairs:
-            child = self._destructure_display(child_target, child_value)
-            if child is None:
-                return None
-            bindings.update(child)
-        return bindings
+        pattern = self.unit.require_target_pattern(self, target)
+        return pattern.bindings_for(self.value)
 
     def _display_unpack_pairs(self, target, value):
         """Zip one Tuple/List target against a matching display RHS.
@@ -4992,7 +5266,8 @@ class For(Statement):
                 elements = None  # past the unroll budget: the fold/universal stands
             if elements is not None:
                 with reduction_span(sugar="For.unroll", role="temporal", site=where):
-                    bindings = [self._target_bindings(e) for e in elements]
+                    target_pattern = self.unit.require_target_pattern(self, self.target)
+                    bindings = [target_pattern.bindings_for(e) for e in elements]
                     if all(b is not None for b in bindings):
                         if self._body_has_owned_loop_control():
                             controlled = self._unroll_concrete_controlled(
@@ -5006,7 +5281,7 @@ class For(Statement):
                             # below.
                             elements = None
                     if elements is not None and all(b is not None for b in bindings):
-                        target_names = self._bound_names_in(self.target)
+                        target_names = set(target_pattern.names)
                         unrolled: list = []
                         carried = dict(
                             scope
@@ -5069,7 +5344,9 @@ class For(Statement):
             # it from the outer scope. A symbolic loop is not a dead unroll --
             # it is the universal / fold over the hole.
             with reduction_span(sugar="For.symbolic", role="temporal", site=where):
-                bound = self._bound_names_in(self.target) | For._stmts_bound_names(
+                bound = set(
+                    self.unit.require_target_pattern(self, self.target).names
+                ) | For._stmts_bound_names(
                     self.body
                 )
                 bs = (
@@ -5084,7 +5361,11 @@ class For(Statement):
                     new, d = self._substitute_body(getattr(self, f), bs)
                     if d:
                         changed[f] = new
-                return self if not changed else rewrite(self, **changed)
+                if not changed:
+                    return self
+                rewritten = rewrite(self, **changed)
+                self.unit.retain_target_patterns(self, rewritten)
+                return rewritten
 
     @staticmethod
     def _stmts_bound_names(statements) -> set:
@@ -5207,7 +5488,9 @@ class For(Statement):
                 return None
             statements, iteration, action = reduced
             unrolled.extend(statements)
-            target_names = self._bound_names_in(self.target)
+            target_names = set(
+                self.unit.require_target_pattern(self, self.target).names
+            )
             carried = {
                 key: value
                 for key, value in iteration.items()
@@ -5304,28 +5587,6 @@ class For(Statement):
     # grows a term chain quadratically. Small on purpose; proofs want small
     # unrolls.
     _UNROLL_FUEL = 128
-
-    def _target_bindings_for(self, target: "Node", element: "Node") -> "Optional[dict]":
-        """`_target_bindings` for an explicit target (shared with comprehensions)."""
-        if target.kind == "Name":
-            return {target.id: element}
-        names = []
-        for t in target.elts:
-            if t.kind != "Name":
-                return None
-            names.append(t.id)
-        if element.kind not in ("Tuple", "List") or len(element.elts) != len(names):
-            return None
-        return dict(zip(names, element.elts))
-
-    def _target_bindings(self, element: "Node") -> "Optional[dict]":
-        """What this loop's target binds when the element is `element`, or None
-        when the shapes do not destructure. A Name target binds it whole; a
-        tuple/list target of plain Names destructures a tuple/list DISPLAY
-        element of the same arity (`for a, b in [(1, 2)]` binds a=1, b=2). A
-        nested or starred target, or an element that is not a matching display,
-        is not destructured here -- the loop falls to the symbolic branch."""
-        return For._target_bindings_for(self, self.target, element)
 
     def _concrete_elements(self, iterable: "Expression") -> "Optional[list]":
         """The element nodes to unroll over, or ``None`` if `iterable` is not
@@ -8139,7 +8400,9 @@ class ListComp(Expression):
         target = gen.target
         results = []
         for element in elements:
-            bindings = For._target_bindings_for(self, target, element)
+            bindings = self.unit.require_target_pattern(
+                self, target
+            ).bindings_for(element)
             if bindings is None:
                 return None
             inner = {**scope, **bindings}
@@ -8384,7 +8647,9 @@ class SetComp(Expression):
         results = []
         seen = set()
         for element in elements:
-            bindings = For._target_bindings_for(self, gen.target, element)
+            bindings = self.unit.require_target_pattern(
+                self, gen.target
+            ).bindings_for(element)
             if bindings is None:
                 return None
             inner = {**scope, **bindings}
@@ -8475,7 +8740,9 @@ class DictComp(Expression):
         pairs = []
         key_indexes = {}
         for element in elements:
-            bindings = For._target_bindings_for(self, gen.target, element)
+            bindings = self.unit.require_target_pattern(
+                self, gen.target
+            ).bindings_for(element)
             if bindings is None:
                 return None
             inner = {**scope, **bindings}

--- a/implementations/python/sugar-source-tree/tests/test_live_for_destructuring_target.py
+++ b/implementations/python/sugar-source-tree/tests/test_live_for_destructuring_target.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -13,18 +14,17 @@ from sugar_lift_py_tests.floor.term_value import TermValue
 from sugar_lift_py_tests.floor.tuple_value import TupleValue
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
 from sugar_lift_py_tests.temporal import bind_temporal
-from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.binding_state import mint_binding_coordinate_v1
-from sugar_source_tree.live_loop_construction import LiveForTargetPatternV1
-from sugar_source_tree.nodes import For, FunctionDef
+from sugar_source_tree.nodes import For, FunctionDef, TargetPatternConstructionGapV1, TargetPatternV1
 from sugar_source_tree.tree import SourceFile
 
 
 def _function(source: str) -> FunctionDef:
-    tree = SourceFile(
-        (source, "tests/live_for_destructuring_target.py", blake3_512_of(source.encode()))
-    )
-    return next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    with TemporaryDirectory(dir=Path.cwd()) as directory:
+        path = Path(directory).relative_to(Path.cwd()) / "live_for_destructuring_target.py"
+        path.write_text(source)
+        tree = SourceFile.from_path(path)
+        return next(node for node in tree.nodes() if isinstance(node, FunctionDef))
 
 
 def _loop_and_runtime(source: str):
@@ -67,7 +67,7 @@ _PAIR_LOOP = (
 def test_live_pair_target_retains_producer_coordinates_in_source_order() -> None:
     loop, runtime = _loop_and_runtime(_PAIR_LOOP)
 
-    assert isinstance(runtime.target_pattern, LiveForTargetPatternV1)
+    assert isinstance(runtime.target_pattern, TargetPatternV1)
     assert (
         runtime.target_pattern.target.fragment.seal().cid
         == loop.target.fragment.seal().cid
@@ -130,8 +130,13 @@ def test_live_pair_target_rejects_reordered_coordinates() -> None:
     _loop, runtime = _loop_and_runtime(_PAIR_LOOP)
     pattern = runtime.target_pattern
 
-    with pytest.raises(TypeError, match="source target order"):
-        replace(pattern, target_coordinates=tuple(reversed(pattern.target_coordinates)))
+    lied = tuple(reversed(pattern.target_coordinates))
+    with pytest.raises(TargetPatternConstructionGapV1) as rejected:
+        pattern.source_unit.require_target_pattern_coordinates(pattern, lied)
+    assert rejected.value.reason == "target-coordinate-order-mismatch"
+    assert rejected.value.target_pattern is pattern
+    assert rejected.value.expected_coordinates is pattern.coordinates
+    assert rejected.value.actual_coordinates is lied
 
 
 def test_live_pair_target_rejects_missing_or_extra_coordinates() -> None:
@@ -143,10 +148,19 @@ def test_live_pair_target_rejects_missing_or_extra_coordinates() -> None:
         projection_path=("target", 2),
     )
 
-    with pytest.raises(TypeError, match="one coordinate per target leaf"):
-        replace(pattern, target_coordinates=pattern.target_coordinates[:-1])
-    with pytest.raises(TypeError, match="one coordinate per target leaf"):
-        replace(pattern, target_coordinates=(*pattern.target_coordinates, extra))
+    missing = pattern.target_coordinates[:-1]
+    with pytest.raises(TargetPatternConstructionGapV1) as missing_rejected:
+        pattern.source_unit.require_target_pattern_coordinates(pattern, missing)
+    assert missing_rejected.value.reason == "target-coordinate-arity-mismatch"
+    assert missing_rejected.value.expected_coordinates is pattern.coordinates
+    assert missing_rejected.value.actual_coordinates is missing
+
+    added = (*pattern.target_coordinates, extra)
+    with pytest.raises(TargetPatternConstructionGapV1) as extra_rejected:
+        pattern.source_unit.require_target_pattern_coordinates(pattern, added)
+    assert extra_rejected.value.reason == "target-coordinate-arity-mismatch"
+    assert extra_rejected.value.expected_coordinates is pattern.coordinates
+    assert extra_rejected.value.actual_coordinates is added
 
 
 def test_live_pair_target_rejects_foreign_target_and_scope_testimony() -> None:
@@ -166,13 +180,18 @@ def test_live_pair_target_rejects_foreign_target_and_scope_testimony() -> None:
         projection_path=("target", 0),
     )
 
-    with pytest.raises(TypeError, match="source target coordinate"):
-        replace(
-            pattern,
-            target_coordinates=(foreign_site, pattern.target_coordinates[1]),
-        )
-    with pytest.raises(TypeError, match="loop target scope"):
-        replace(
-            pattern,
-            target_coordinates=(foreign_scope, pattern.target_coordinates[1]),
-        )
+    foreign_site_lie = (foreign_site, pattern.target_coordinates[1])
+    with pytest.raises(TargetPatternConstructionGapV1) as site_rejected:
+        pattern.source_unit.require_target_pattern_coordinates(pattern, foreign_site_lie)
+    assert site_rejected.value.reason == "foreign-target-coordinate"
+    assert site_rejected.value.target_pattern is pattern
+    assert site_rejected.value.expected_coordinates is pattern.coordinates
+    assert site_rejected.value.actual_coordinates is foreign_site_lie
+
+    foreign_scope_lie = (foreign_scope, pattern.target_coordinates[1])
+    with pytest.raises(TargetPatternConstructionGapV1) as scope_rejected:
+        pattern.source_unit.require_target_pattern_coordinates(pattern, foreign_scope_lie)
+    assert scope_rejected.value.reason == "foreign-target-scope"
+    assert scope_rejected.value.target_pattern is pattern
+    assert scope_rejected.value.expected_coordinates is pattern.coordinates
+    assert scope_rejected.value.actual_coordinates is foreign_scope_lie

--- a/implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py
+++ b/implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py
@@ -1,0 +1,213 @@
+"""Concrete TargetPattern law through ordinary source construction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+import pytest
+
+from sugar_source_tree import nodes
+from sugar_source_tree.binding_provenance import BindingCoordinateV1
+from sugar_source_tree.tree import SourceFile
+
+
+SOURCE = """\
+def fixture(value, items):
+    a, (b, *c) = value
+    for a, (b, *c) in items:
+        pass
+    listed = [a for a, (b, *c) in items]
+    unique = {a for a, (b, *c) in items}
+    mapped = {a: b for a, (b, *c) in items}
+    recursive = [b for a, *rest in items for b in rest]
+    return listed, unique, mapped, recursive
+"""
+
+LIVE_SOURCE = """\
+def live(items):
+    for a, (b, *c) in items:
+        pass
+"""
+
+TWO_LOOPS_SOURCE = """\
+def two_loops(left_items, right_items):
+    for a, *left_rest in left_items:
+        pass
+    for b, *right_rest in right_items:
+        pass
+"""
+
+
+EXPECTED = {
+    ("Assign", 2, 0): (("a", ("targets", 0, 0)), ("b", ("targets", 0, 1, 0)), ("c", ("targets", 0, 1, 1, "star"))),
+    ("For", 3, 0): (("a", ("target", 0)), ("b", ("target", 1, 0)), ("c", ("target", 1, 1, "star"))),
+    ("ListComp", 5, 0): (("a", ("generators", 0, "target", 0)), ("b", ("generators", 0, "target", 1, 0)), ("c", ("generators", 0, "target", 1, 1, "star"))),
+    ("SetComp", 6, 0): (("a", ("generators", 0, "target", 0)), ("b", ("generators", 0, "target", 1, 0)), ("c", ("generators", 0, "target", 1, 1, "star"))),
+    ("DictComp", 7, 0): (("a", ("generators", 0, "target", 0)), ("b", ("generators", 0, "target", 1, 0)), ("c", ("generators", 0, "target", 1, 1, "star"))),
+    ("ListComp", 8, 0): (("a", ("generators", 0, "target", 0)), ("rest", ("generators", 0, "target", 1, "star"))),
+    ("ListComp", 8, 1): (("b", ("generators", 1, "target")),),
+}
+
+
+def _source_file(tmp_path: Path, name: str = "target_patterns.py") -> SourceFile:
+    path = tmp_path / name
+    path.write_text(SOURCE)
+    return SourceFile.from_path(path)
+
+
+def _products(source_file: SourceFile):
+    function, = tuple(source_file.functions())
+    products = []
+    for consumer in function.walk():
+        key = (consumer.kind, consumer.line_col_span().start_line)
+        if any(expected[:2] == key for expected in EXPECTED):
+            products.extend(consumer.target_patterns)
+    return tuple(products)
+
+
+def test_ordinary_nested_star_consumers_construct_exact_patterns_once(tmp_path: Path):
+    source_file = _source_file(tmp_path)
+    products = _products(source_file)
+    assert len(products) == len(EXPECTED), (
+        "R_missing_target_pattern_product="
+        f"{len(EXPECTED) - len(products)}; ordinary target consumers must own "
+        "their eager exact TargetPattern product"
+    )
+
+    observed = {}
+    occurrence_indexes = {}
+    for product in products:
+        base_key = (
+            product.consumer_occurrence.kind,
+            product.consumer_occurrence.line_col_span().start_line,
+        )
+        occurrence_index = occurrence_indexes.get(base_key, 0)
+        occurrence_indexes[base_key] = occurrence_index + 1
+        consumer_key = (
+            *base_key,
+            occurrence_index,
+        )
+        observed[consumer_key] = tuple(
+            (leaf.id, coordinate.projection_path)
+            for leaf, coordinate in zip(
+                product.leaves, product.coordinates, strict=True
+            )
+        )
+        assert product.source_unit is source_file.unit
+        assert product.target_occurrence.unit is source_file.unit
+        assert all(leaf.unit is source_file.unit for leaf in product.leaves)
+        assert all(
+            BindingCoordinateV1.decode(coordinate.wire()) == coordinate
+            for coordinate in product.coordinates
+        )
+    assert observed == EXPECTED
+
+    repeated = _products(source_file)
+    assert repeated is not products
+    assert len(repeated) == len(products)
+    assert all(left is right for left, right in zip(products, repeated, strict=True))
+
+    assert source_file.unit.target_pattern_construction_count == len(products)
+
+    live_path = tmp_path / "live.py"
+    live_path.write_text(LIVE_SOURCE)
+    live_file = SourceFile.from_path(live_path)
+    live_function, = tuple(live_file.functions())
+    live_loop = next(node for node in live_function.walk() if node.kind == "For")
+    live_pattern, = live_loop.target_patterns
+    live_function.sugar()
+    live_function.sugar()
+    repeated_live_loop = next(
+        node for node in live_function.walk() if node.kind == "For"
+    )
+    repeated_live_pattern, = repeated_live_loop.target_patterns
+    assert repeated_live_pattern is live_pattern
+    assert live_file.unit.target_pattern_construction_count == 1
+
+
+def test_target_pattern_rejects_wrong_occurrence_and_order(tmp_path: Path):
+    first = _source_file(tmp_path, "first.py")
+    second = _source_file(tmp_path, "second.py")
+    truthful = _products(first)
+    foreign = _products(second)
+    assert truthful and len(truthful) == len(foreign)
+
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as wrong_occurrence:
+        first.unit.require_target_pattern(
+            truthful[0].consumer_occurrence,
+            foreign[0].target_occurrence,
+        )
+    assert wrong_occurrence.value.reason == "foreign-target-occurrence"
+    assert wrong_occurrence.value.consumer_occurrence is truthful[0].consumer_occurrence
+    assert wrong_occurrence.value.target_occurrence is foreign[0].target_occurrence
+
+    first_for = next(
+        pattern
+        for pattern in truthful
+        if pattern.consumer_occurrence.kind == "For"
+    )
+    second_for = next(
+        pattern
+        for pattern in foreign
+        if pattern.consumer_occurrence.kind == "For"
+    )
+    before_count = first.unit.target_pattern_construction_count
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as foreign_consumer:
+        first.unit.require_target_pattern(
+            second_for.consumer_occurrence,
+            first_for.target_occurrence,
+        )
+    assert foreign_consumer.value.reason == "foreign-target-occurrence"
+    assert foreign_consumer.value.consumer_occurrence is second_for.consumer_occurrence
+    assert foreign_consumer.value.target_occurrence is first_for.target_occurrence
+    assert first.unit.target_pattern_construction_count == before_count
+
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as wrong_order:
+        first.unit.require_target_pattern_coordinates(
+            truthful[0], tuple(reversed(truthful[0].coordinates))
+        )
+    assert wrong_order.value.reason == "target-coordinate-order-mismatch"
+    assert wrong_order.value.target_pattern is truthful[0]
+
+
+def test_same_unit_foreign_for_cannot_claim_local_target(tmp_path: Path):
+    path = tmp_path / "two_loops.py"
+    path.write_text(TWO_LOOPS_SOURCE)
+    source_file = SourceFile.from_path(path)
+    function, = tuple(source_file.functions())
+    loops = tuple(node for node in function.walk() if node.kind == "For")
+    assert len(loops) == 2
+    first_pattern, = loops[0].target_patterns
+    second_pattern, = loops[1].target_patterns
+    before = source_file.unit.target_pattern_construction_count
+
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as rejected:
+        source_file.unit.require_target_pattern(
+            second_pattern.consumer_occurrence,
+            first_pattern.target_occurrence,
+        )
+    assert rejected.value.reason == "foreign-target-occurrence"
+    assert rejected.value.consumer_occurrence is second_pattern.consumer_occurrence
+    assert rejected.value.target_occurrence is first_pattern.target_occurrence
+    assert source_file.unit.target_pattern_construction_count == before
+    assert loops[0].target_patterns[0] is first_pattern
+    assert loops[1].target_patterns[0] is second_pattern
+
+
+def test_legacy_reharvest_manifestations_are_retired():
+    source = Path(nodes.__file__).read_text()
+    offenders = tuple(
+        match.group(0)
+        for pattern in (
+            r"For\._target_bindings_for\(",
+            r"self\._target_bindings\(",
+            r"self\._bound_names_in\(self\.target\)",
+            r"target_names\s*=\s*self\._bound_names_in\(self\.target\)",
+        )
+        for match in re.finditer(pattern, source)
+    )
+    assert offenders == (), (
+        f"R_target_reharvest_manifestations={len(offenders)}; "
+        + "; ".join(offenders)
+    )


### PR DESCRIPTION
Retires concrete TargetPattern construction and reharvest residuals.

Validation:
- `bin/bpytest implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py implementations/python/sugar-source-tree/tests/test_live_for_destructuring_target.py -q`
- 10 passed
- TargetPattern products: 7 residuals to 0
- nodes reharvest: 11 to 0
- live Starred reharvest: 1 to 0
- exact original-owner carry and same-unit foreign-consumer refusal verified independently


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct `TargetPatternV1` once per occurrence and cache it on `SourceUnit`
> - Introduces `TargetPatternV1` in [nodes.py](https://github.com/TSavo/sugar/pull/6815/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0), a dataclass that owns a destructuring projection for a single consumer occurrence, including a `bindings_for(element)` method that handles both plain and starred targets.
> - `SourceUnit` now eagerly constructs and caches `TargetPatternV1` objects for all target consumers (`Assign`, `For`, `*Comp`) during `__post_init__`, replacing repeated on-the-fly coordinate minting across `For`, `ListComp`, `SetComp`, `DictComp`, and `Assign`.
> - Adds `require_target_pattern`, `require_target_pattern_for_target`, `retain_target_patterns`, and `require_target_pattern_coordinates` methods to `SourceUnit` for validated pattern access and rewrite-time pattern transfer.
> - Adds `TargetPatternConstructionGapV1` exception with structured fields (reason, occurrences, coordinate details) for pattern lookup and validation failures.
> - Live-loop construction in [live_loop_construction.py](https://github.com/TSavo/sugar/pull/6815/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094) now fetches the pre-constructed pattern via `loop.unit.require_target_pattern` instead of minting coordinates locally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86bad84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->