### PR TITLE
Own tuple literal attribute mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_literal_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_literal_value.py
@@ -26,6 +26,26 @@ class TupleLiteralValue(FloorValue):
             exception_name="TypeError", site=site, owner="TupleLiteralValue.delitem"
         )
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="TupleLiteralValue.setattr",
+        )
+
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="TupleLiteralValue.delattr",
+        )
+
     def __post_init__(self) -> None:
         if not all(isinstance(item, FloorValue) for item in self.items):
             raise TypeError("TupleLiteralValue items must be floor values")

--- a/implementations/python/sugar-lift-py-tests/tests/test_tuple_literal_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_tuple_literal_attribute_mutation.py
@@ -1,0 +1,28 @@
+import pytest
+
+from sugar_lift_py_tests.floor import TermValue, TupleLiteralValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "tuple_literal_attribute_mutation.py"
+    path.write_text("def f(target, replacement):\n    target.attr = replacement\n    del target.attr\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setattr", "TupleLiteralValue.setattr", 0), ("delattr", "TupleLiteralValue.delattr", 1)))
+def test_tuple_literal_attribute_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path); site = sites[site_index]; value = TupleLiteralValue((TermValue(1),))
+    outcome = value.setattr("attr", TermValue(7), site) if operation == "setattr" else value.delattr("attr", site)
+    assert outcome.value.effect.exception_name == "AttributeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_tuple_literal_attribute_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path); value = TupleLiteralValue((TermValue(1),))
+    store = value.setattr("attr", TermValue(7), store_site); delete = value.delattr("attr", delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R_missing_tuple_literal_attribute_floor_owner Epsilon=-2. Rebased exact base 5612330db74e7baf927533f7ac40de4a1f260ea1. Fresh focused base3 failed EXIT1 head3 passed EXIT0. Isolated base /tmp/agy2-tuplelit-attr-base.klIGWG AUTH_CASES2 OWNED0 GAPS2 EXIT1; head 7a8539033fd94dfafd337985d150959281e583cf /tmp/agy2-tuplelit-attr-head.RmDWEK AUTH_CASES2 OWNED2 GAPS0 EXIT0. wrong-site twin, defs1/1 LAW_OF_ONE0 SIDE_DOOR0 forbidden0. Delta=-2.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` methods to `TupleLiteralValue` that raise `AttributeError`
> Adds `setattr` and `delattr` methods to [`TupleLiteralValue`](https://github.com/TSavo/sugar/pull/6816/files#diff-63ea2d23cbf965606afaa5d8ee7fff336edf95cb2c126ee3146a7c7120c17548) that each return a `ground_exceptional_exit` with `exception_name='AttributeError'`, matching Python's runtime behavior for tuple attribute mutation. Adds tests in [`test_tuple_literal_attribute_mutation.py`](https://github.com/TSavo/sugar/pull/6816/files#diff-17af750a477f1bff94b7cb1404b223ad43cbb5a68f739b1e33ba3f4205068a49) verifying the correct owner string and occurrence id for both store and delete attribute sites.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a85390.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->