### PR TITLE
Own dict literal attribute mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_literal_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_literal_value.py
@@ -34,6 +34,26 @@ class DictLiteralValue(FloorValue):
 
     entries: tuple[tuple[Term, Term], ...]
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="DictLiteralValue.setattr",
+        )
+
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="DictLiteralValue.delattr",
+        )
+
     def contribution(self):
         # Typed non-FOL support carrier: absorbed in a block record.
         return ()

--- a/implementations/python/sugar-lift-py-tests/tests/test_dict_literal_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dict_literal_attribute_mutation.py
@@ -1,0 +1,28 @@
+import pytest
+
+from sugar_lift_py_tests.floor import DictLiteralValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "dict_literal_attribute_mutation.py"
+    path.write_text("def f(target, replacement):\n    target.attr = replacement\n    del target.attr\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setattr", "DictLiteralValue.setattr", 0), ("delattr", "DictLiteralValue.delattr", 1)))
+def test_dict_literal_attribute_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path); site = sites[site_index]; value = DictLiteralValue(())
+    outcome = value.setattr("attr", TermValue(7), site) if operation == "setattr" else value.delattr("attr", site)
+    assert outcome.value.effect.exception_name == "AttributeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_dict_literal_attribute_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path); value = DictLiteralValue(())
+    store = value.setattr("attr", TermValue(7), store_site); delete = value.delattr("attr", delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R_missing_dict_literal_attribute_floor_owner Epsilon=-2. Focused3 failed EXIT1->3 passed EXIT0. Isolated base14fae94b /tmp/agy2-dictlit-attr-base.7uRbmo AUTH_CASES2 OWNED0 GAPS2 EXIT1; head9e300446 /tmp/agy2-dictlit-attr-head.24Wpu9 AUTH_CASES2 OWNED2 GAPS0 EXIT0. wrong twin defs1/1 LAW_OF_ONE0 SIDE_DOOR0 forbidden0 Delta=-2.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` methods to `DictLiteralValue` that return `AttributeError`
> Implements `setattr` and `delattr` on `DictLiteralValue` in [dict_literal_value.py](https://github.com/TSavo/sugar/pull/6817/files#diff-85df17658459bd009003e412c793be2424153b6df675c3abee5a6bef98111cf8), each returning a `ground_exceptional_exit` with `exception_name='AttributeError'` and site-specific `occurrence_id`. Tests in [test_dict_literal_attribute_mutation.py](https://github.com/TSavo/sugar/pull/6817/files#diff-239c3ace33cbf9d5351e1da70088cd80d486dbd7b2e50c5aa57b7729f6de1b02) verify the correct owner name and that each method's occurrence ID is tied to its specific site.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e30044.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->