### PR TITLE
Own bv32 subscript mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bv32_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bv32_value.py
@@ -11,6 +11,22 @@ from .floor_value import FloorValue
 class Bv32Value(FloorValue):
     term: Term
 
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="Bv32Value.setitem"
+        )
+
+    def delitem(self, index, site):
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="Bv32Value.delitem"
+        )
+
     def to_term(self, *, owner: str):
         del owner
         return self.term

--- a/implementations/python/sugar-lift-py-tests/tests/test_bv32_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bv32_subscript_mutation.py
@@ -1,0 +1,29 @@
+import pytest
+
+from sugar_lift_py_tests.floor import Bv32Value, TermValue
+from sugar_lift_py_tests.ir import num
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "bv32_subscript_mutation.py"
+    path.write_text("def f(target, replacement):\n    target[0] = replacement\n    del target[0]\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "Bv32Value.setitem", 0), ("delitem", "Bv32Value.delitem", 1)))
+def test_bv32_subscript_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path); site = sites[site_index]; value = Bv32Value(num(1))
+    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_bv32_subscript_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path); value = Bv32Value(num(1))
+    store = value.setitem(TermValue(0), TermValue(7), store_site); delete = value.delitem(TermValue(0), delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R_missing_bv32_subscript_floor_owner Epsilon=-2. Focused3 failed EXIT1->3 passed EXIT0. Isolated based2346298 /tmp/agy2-bv32-sub-base.lQzg88 AUTH_CASES2 OWNED0 GAPS2 EXIT1; headd08dda2b /tmp/agy2-bv32-sub-head.rk31uL AUTH_CASES2 OWNED2 GAPS0 EXIT0. wrong twin defs1/1 LAW_OF_ONE0 SIDE_DOOR0 forbidden0 Delta=-2.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Bv32Value.setitem` and `Bv32Value.delitem` subscript mutation methods
> Adds `setitem` and `delitem` methods to `Bv32Value` in [bv32_value.py](https://github.com/TSavo/sugar/pull/6818/files#diff-cbb93aece1e7f7c1f41117f21f2c6bcad2e04d31a2501777de5562b2286fc86c), both returning a `ground_exceptional_exit` with a `TypeError` effect tagged with the method name as owner and the caller-provided site as `occurrence_id`. New tests in [test_bv32_subscript_mutation.py](https://github.com/TSavo/sugar/pull/6818/files#diff-e55b70a2435b8b214dc55e985a0ab6b224659c5c9b2331b1084307c2eedcfa40) verify correct owner/occurrence_id and that store and delete sites produce distinct occurrence IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d08dda2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->