### PR TITLE
Own bv32 attribute mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bv32_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bv32_value.py
@@ -27,6 +27,22 @@ class Bv32Value(FloorValue):
             exception_name="TypeError", site=site, owner="Bv32Value.delitem"
         )
 
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="Bv32Value.setattr"
+        )
+
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="Bv32Value.delattr"
+        )
+
     def to_term(self, *, owner: str):
         del owner
         return self.term

--- a/implementations/python/sugar-lift-py-tests/tests/test_bv32_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bv32_attribute_mutation.py
@@ -1,0 +1,29 @@
+import pytest
+
+from sugar_lift_py_tests.floor import Bv32Value, TermValue
+from sugar_lift_py_tests.ir import num
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "bv32_attribute_mutation.py"
+    path.write_text("def f(target, replacement):\n    target.attr = replacement\n    del target.attr\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setattr", "Bv32Value.setattr", 0), ("delattr", "Bv32Value.delattr", 1)))
+def test_bv32_attribute_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path); site = sites[site_index]; value = Bv32Value(num(1))
+    outcome = value.setattr("attr", TermValue(7), site) if operation == "setattr" else value.delattr("attr", site)
+    assert outcome.value.effect.exception_name == "AttributeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_bv32_attribute_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path); value = Bv32Value(num(1))
+    store = value.setattr("attr", TermValue(7), store_site); delete = value.delattr("attr", delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R_missing_bv32_attribute_floor_owner Epsilon=-2. Focused3 failed->3 passed. Isolated base db928181 /tmp/agy2-bv32-attr-base.GdTaDs AUTH_CASES2 OWNED0 GAPS2 EXIT1; head8e6cec8f /tmp/agy2-bv32-attr-head.H47cZe AUTH_CASES2 OWNED2 GAPS0 EXIT0. wrong twin defs1/1 LAW_OF_ONE0 SIDE_DOOR0 forbidden0 Delta=-2.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` methods to `Bv32Value` that raise `AttributeError`
> Implements `Bv32Value.setattr` and `Bv32Value.delattr` in [bv32_value.py](https://github.com/TSavo/sugar/pull/6819/files#diff-cbb93aece1e7f7c1f41117f21f2c6bcad2e04d31a2501777de5562b2286fc86c), both returning a `ground_exceptional_exit` with `exception_name='AttributeError'` and the correct `owner` and `occurrence_id` derived from the call site. Adds tests in [test_bv32_attribute_mutation.py](https://github.com/TSavo/sugar/pull/6819/files#diff-899c31c0512a6cda8f74588ee00c9113f32d44649d28932fa879deeb4f91f308) that verify the exact owner string and occurrence_id for each operation, and assert that sites from different operations do not match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e6cec8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->