### PR TITLE
Own exception value subscript mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/exception_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/exception_value.py
@@ -15,6 +15,22 @@ class ExceptionValue(FloorValue):
     arguments: tuple[FloorValue, ...]
     site: object = dataclass_field(compare=False)
 
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="ExceptionValue.setitem"
+        )
+
+    def delitem(self, index, site):
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="ExceptionValue.delitem"
+        )
+
     def argument_terms(self) -> tuple[Term, ...]:
 
         return tuple(

--- a/implementations/python/sugar-lift-py-tests/tests/test_exception_value_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exception_value_subscript_mutation.py
@@ -1,0 +1,28 @@
+import pytest
+
+from sugar_lift_py_tests.floor import ExceptionValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "exception_value_subscript_mutation.py"
+    path.write_text("def f(exc, replacement):\n    exc[0] = replacement\n    del exc[0]\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "ExceptionValue.setitem", 0), ("delitem", "ExceptionValue.delitem", 1)))
+def test_exception_value_subscript_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path); site = sites[site_index]; value = ExceptionValue("ValueError", (), site)
+    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_exception_value_subscript_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path); value = ExceptionValue("ValueError", (), store_site)
+    store = value.setitem(TermValue(0), TermValue(7), store_site); delete = value.delitem(TermValue(0), delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
R_missing_exception_value_subscript_floor_owner Epsilon=-2. Focused3 failed->3 passed. Isolated base3462fc1c /tmp/agy2-exc-sub-base.kqJGHm AUTH_CASES2 OWNED0 GAPS2 EXIT1; head6adeccf4 /tmp/agy2-exc-sub-head.3bMIeB AUTH_CASES2 OWNED2 GAPS0 EXIT0. wrong twin defs1/1 LAW_OF_ONE0 SIDE_DOOR0 forbidden0 Delta=-2.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` subscript mutation handling to `ExceptionValue`
> Adds two methods to the `ExceptionValue` class in [exception_value.py](https://github.com/TSavo/sugar/pull/6820/files#diff-bd2eef6fba7abd86243aae8c2a3d63e29bf5266488db141e87787cb8f713a97b): `setitem` and `delitem`. Both methods raise a `TypeError` exceptional exit via `ground_exceptional_exit`, ignoring the mutation arguments and tagging `producer_node_owner` as `"ExceptionValue.setitem"` or `"ExceptionValue.delitem"` respectively. New tests in [test_exception_value_subscript_mutation.py](https://github.com/TSavo/sugar/pull/6820/files#diff-7833ea75d75ac5790fb3e4875815725c4f1f09954fa63b1fcf7ddc18b71ec898) verify the correct exception name, owner tag, and that differing sites produce different `occurrence_id` values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6adeccf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->