### PR TITLE
Authenticate source call frame definition sites

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -163,11 +163,37 @@ class SourceVisibleCallFrameV1:
     runtime_entries: tuple[BindingEntryV1, ...] = field(
         default=(), compare=False, repr=False
     )
+    formal_declaration_sites: tuple[dict, ...] = field(
+        default=(), compare=False, repr=False
+    )
+    formal_projection_paths: tuple[tuple[str | int, ...], ...] = field(
+        default=(), compare=False, repr=False
+    )
     generator_steps: tuple | None = field(default=None, compare=False, repr=False)
     generator_step_fragment_cids: tuple[str, ...] = ()
     frame_cid: str = field(init=False)
 
     def __post_init__(self) -> None:
+        # The frame retains the producer-owned declaration roster once.  A
+        # FunctionDef frame's rows come from its params; a ClassDef constructor
+        # frame's rows are the initializer params already selected by the class
+        # producer (with the receiver omitted).  Consumers never rediscover the
+        # initializer or construct a second frame.
+        if not self.formal_declaration_sites:
+            object.__setattr__(
+                self,
+                "formal_declaration_sites",
+                tuple(coordinate.binding_site for coordinate in self.formal_coordinates),
+            )
+        if not self.formal_projection_paths:
+            object.__setattr__(
+                self,
+                "formal_projection_paths",
+                tuple(
+                    coordinate.projection_path
+                    for coordinate in self.formal_coordinates
+                ),
+            )
         preimage = {
             "kind": "source-visible-call-frame",
             "schemaVersion": "1",
@@ -176,6 +202,10 @@ class SourceVisibleCallFrameV1:
             "definitionFragmentCid": self.definition_fragment_cid,
             "parameters": list(self.parameters),
             "formalCoordinates": [item.wire() for item in self.formal_coordinates],
+            "formalDeclarationSites": list(self.formal_declaration_sites),
+            "formalProjectionPaths": [
+                list(path) for path in self.formal_projection_paths
+            ],
             "parameterKinds": list(self.parameter_kinds),
             "defaultFragmentCids": list(self.default_fragment_cids),
             "generatorStepFragmentCids": list(self.generator_step_fragment_cids),
@@ -287,9 +317,11 @@ class SourceVisibleCallFrameV1:
         cids = tuple(coordinate.cid for coordinate in coordinates)
         if len(set(cids)) != len(cids):
             raise SourceCallBindingGap("formal coordinate roster contains a duplicate")
-        if any(
-            coordinate.projection_path != ("formal", index)
-            for index, coordinate in enumerate(coordinates)
+        if len(self.formal_projection_paths) != len(coordinates) or any(
+            coordinate.projection_path != expected
+            for coordinate, expected in zip(
+                coordinates, self.formal_projection_paths, strict=True
+            )
         ):
             raise SourceCallBindingGap("formal coordinate roster is reordered")
         if any(
@@ -299,11 +331,11 @@ class SourceVisibleCallFrameV1:
             raise SourceCallBindingGap(
                 "formal coordinate roster has a foreign scope owner"
             )
-        owner_parameters = tuple(self.owner.params)
-        if len(owner_parameters) != len(coordinates) or any(
-            coordinate.binding_site != parameter.fragment.seal().to_dict()
-            for coordinate, parameter in zip(
-                coordinates, owner_parameters, strict=True
+        declaration_sites = self.formal_declaration_sites
+        if len(declaration_sites) != len(coordinates) or any(
+            coordinate.binding_site != declaration_site
+            for coordinate, declaration_site in zip(
+                coordinates, declaration_sites, strict=True
             )
         ):
             raise SourceCallBindingGap(
@@ -313,6 +345,7 @@ class SourceVisibleCallFrameV1:
         native = self.native_operation_formal_coordinates
         if not native:
             return
+        owner_parameters = tuple(self.owner.params)
         _reauthenticate_native_coordinates(native)
         native_cids = tuple(coordinate.coordinate_cid for coordinate in native)
         expected_kinds = {

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -151,6 +151,8 @@ class SourceVisibleCallFrameV1:
     definition_fragment_cid: str
     parameters: tuple[str, ...]
     formal_coordinates: tuple[BindingCoordinateV1, ...]
+    formal_declaration_sites: tuple[dict, ...]
+    formal_projection_paths: tuple[tuple[str | int, ...], ...]
     parameter_kinds: tuple[str, ...]
     default_sugars: tuple[object | None, ...] = field(compare=False)
     default_nodes: tuple[object | None, ...] = field(compare=False)
@@ -163,37 +165,11 @@ class SourceVisibleCallFrameV1:
     runtime_entries: tuple[BindingEntryV1, ...] = field(
         default=(), compare=False, repr=False
     )
-    formal_declaration_sites: tuple[dict, ...] = field(
-        default=(), compare=False, repr=False
-    )
-    formal_projection_paths: tuple[tuple[str | int, ...], ...] = field(
-        default=(), compare=False, repr=False
-    )
     generator_steps: tuple | None = field(default=None, compare=False, repr=False)
     generator_step_fragment_cids: tuple[str, ...] = ()
     frame_cid: str = field(init=False)
 
     def __post_init__(self) -> None:
-        # The frame retains the producer-owned declaration roster once.  A
-        # FunctionDef frame's rows come from its params; a ClassDef constructor
-        # frame's rows are the initializer params already selected by the class
-        # producer (with the receiver omitted).  Consumers never rediscover the
-        # initializer or construct a second frame.
-        if not self.formal_declaration_sites:
-            object.__setattr__(
-                self,
-                "formal_declaration_sites",
-                tuple(coordinate.binding_site for coordinate in self.formal_coordinates),
-            )
-        if not self.formal_projection_paths:
-            object.__setattr__(
-                self,
-                "formal_projection_paths",
-                tuple(
-                    coordinate.projection_path
-                    for coordinate in self.formal_coordinates
-                ),
-            )
         preimage = {
             "kind": "source-visible-call-frame",
             "schemaVersion": "1",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -269,6 +269,17 @@ class SourceVisibleCallFrameV1:
         )
 
     def _validate_formal_coordinate_rosters(self) -> None:
+        owner = self.owner
+        owner_fragment = getattr(owner, "fragment", None)
+        if owner_fragment is None or self.definition_site != _source_coordinate(owner):
+            raise SourceCallBindingGap(
+                "source call frame has a foreign definition site"
+            )
+        if owner_fragment.seal().cid != self.definition_fragment_cid:
+            raise SourceCallBindingGap(
+                "source call frame has a foreign definition fragment"
+            )
+
         coordinates = self.formal_coordinates
         if len(coordinates) != len(self.parameters):
             raise SourceCallBindingGap("formal coordinate roster is missing an entry")

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2774,6 +2774,12 @@ class FunctionDef(Statement):
             definition_fragment_cid=self.fragment.seal().cid,
             parameters=parameters,
             formal_coordinates=coordinates,
+            formal_declaration_sites=tuple(
+                param.fragment.seal().to_dict() for param in self.params
+            ),
+            formal_projection_paths=tuple(
+                ("formal", index) for index, _ in enumerate(self.params)
+            ),
             parameter_kinds=tuple(param.param_kind for param in self.params),
             default_sugars=tuple(
                 param.default.sugar() if param.default is not None else None
@@ -3787,6 +3793,8 @@ class ClassDef(Statement):
                 definition_fragment_cid=owner_cid,
                 parameters=("args",),
                 formal_coordinates=(args_coordinate,),
+                formal_declaration_sites=(self.fragment.seal().to_dict(),),
+                formal_projection_paths=(("inherited-exception-args", 0),),
                 parameter_kinds=("vararg",),
                 default_sugars=(None,),
                 default_nodes=(None,),
@@ -3810,6 +3818,12 @@ class ClassDef(Statement):
             definition_fragment_cid=owner_cid,
             parameters=tuple(param.name for param in params),
             formal_coordinates=coordinates,
+            formal_declaration_sites=tuple(
+                param.fragment.seal().to_dict() for param in params
+            ),
+            formal_projection_paths=tuple(
+                ("formal", index) for index, _ in enumerate(params)
+            ),
             parameter_kinds=tuple(param.param_kind for param in params),
             default_sugars=tuple(
                 param.default.sugar() if param.default is not None else None
@@ -8174,6 +8188,12 @@ class Lambda(Expression):
             definition_fragment_cid=owner_cid,
             parameters=tuple(param.name for param in self.params),
             formal_coordinates=coordinates,
+            formal_declaration_sites=tuple(
+                param.fragment.seal().to_dict() for param in self.params
+            ),
+            formal_projection_paths=tuple(
+                ("formal", index) for index, _ in enumerate(self.params)
+            ),
             parameter_kinds=tuple(param.param_kind for param in self.params),
             default_sugars=tuple(
                 param.default.sugar() if param.default is not None else None

--- a/implementations/python/sugar-source-tree/tests/test_source_call_frame_definition_site.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_call_frame_definition_site.py
@@ -55,6 +55,33 @@ def test_class_constructor_binds_its_initializer_parameter_roster(tmp_path) -> N
     )
 
 
+def test_class_constructor_rejects_same_arity_foreign_initializer_roster(
+    tmp_path,
+) -> None:
+    path = tmp_path / "foreign_initializer.py"
+    path.write_text(
+        "class Left:\n"
+        "    def __init__(self, value):\n"
+        "        self.value = value\n\n"
+        "class Right:\n"
+        "    def __init__(self, value):\n"
+        "        self.value = value\n",
+        encoding="utf-8",
+    )
+    source = SourceFile.from_path(path)
+    classes = {
+        node.name: node for node in source.nodes() if isinstance(node, ClassDef)
+    }
+    left = classes["Left"].source_visible_constructor_frame()
+    right = classes["Right"].source_visible_constructor_frame()
+    wrong_roster = replace(
+        left, formal_declaration_sites=right.formal_declaration_sites
+    )
+
+    with pytest.raises(SourceCallBindingGap, match="foreign declaration site"):
+        wrong_roster.bind_actuals((TermValue(11),), ())
+
+
 def test_inherited_exception_constructor_retains_vararg_roster(tmp_path) -> None:
     path = tmp_path / "exception_frame.py"
     path.write_text("class Raised(Exception):\n    pass\n", encoding="utf-8")

--- a/implementations/python/sugar-source-tree/tests/test_source_call_frame_definition_site.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_call_frame_definition_site.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+from sugar_source_tree.tree import SourceFile
+
+
+def test_source_call_frame_rejects_same_source_foreign_definition_site(tmp_path) -> None:
+    path = tmp_path / "two_frames.py"
+    path.write_text(
+        "def left(value):\n"
+        "    return value\n"
+        "\n"
+        "def right(value):\n"
+        "    return value\n",
+        encoding="utf-8",
+    )
+    functions = {function.name: function for function in SourceFile.from_path(path).functions()}
+    left = functions["left"].source_visible_call_frame()
+    right = functions["right"].source_visible_call_frame()
+    actual = TermValue(7)
+
+    truthful = left.bind_actuals((actual,), ())
+    assert truthful.actuals == (actual,)
+
+    wrong_site = replace(left, definition_site=right.definition_site)
+    with pytest.raises(SourceCallBindingGap, match="definition site"):
+        wrong_site.bind_actuals((actual,), ())

--- a/implementations/python/sugar-source-tree/tests/test_source_call_frame_definition_site.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_call_frame_definition_site.py
@@ -4,8 +4,9 @@ from dataclasses import replace
 
 import pytest
 
-from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.floor import TermValue, TupleValue
 from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+from sugar_source_tree.nodes import ClassDef
 from sugar_source_tree.tree import SourceFile
 
 
@@ -30,3 +31,40 @@ def test_source_call_frame_rejects_same_source_foreign_definition_site(tmp_path)
     wrong_site = replace(left, definition_site=right.definition_site)
     with pytest.raises(SourceCallBindingGap, match="definition site"):
         wrong_site.bind_actuals((actual,), ())
+
+
+def test_class_constructor_binds_its_initializer_parameter_roster(tmp_path) -> None:
+    path = tmp_path / "class_frame.py"
+    path.write_text(
+        "class Box:\n"
+        "    def __init__(self, value):\n"
+        "        self.value = value\n",
+        encoding="utf-8",
+    )
+    source = SourceFile.from_path(path)
+    class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+    frame = class_node.source_visible_constructor_frame()
+    actual = TermValue(11)
+
+    bound = frame.bind_actuals((actual,), ())
+
+    assert frame.parameters == ("value",)
+    assert bound.actuals == (actual,)
+    assert frame.formal_declaration_sites == tuple(
+        coordinate.binding_site for coordinate in frame.formal_coordinates
+    )
+
+
+def test_inherited_exception_constructor_retains_vararg_roster(tmp_path) -> None:
+    path = tmp_path / "exception_frame.py"
+    path.write_text("class Raised(Exception):\n    pass\n", encoding="utf-8")
+    source = SourceFile.from_path(path)
+    class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+    frame = class_node.source_visible_constructor_frame()
+    left = TermValue(1)
+    right = TermValue(2)
+
+    bound = frame.bind_actuals((left, right), ())
+
+    assert frame.parameters == ("args",)
+    assert bound.actuals == (TupleValue((left, right)),)

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -182,6 +182,19 @@ def test_repeated_initializer_uses_the_last_class_binding() -> None:
     context.source_call_frames[_coordinate(call)] = (
         class_node.source_visible_constructor_frame()
     )
+    initializers = tuple(
+        item
+        for item in class_node.body
+        if isinstance(item, FunctionDef) and item.name == "__init__"
+    )
+    frame = context.source_call_frames[_coordinate(call)]
+
+    assert frame.formal_declaration_sites == (
+        initializers[-1].params[1].fragment.seal().to_dict(),
+    )
+    assert frame.formal_declaration_sites != (
+        initializers[0].params[1].fragment.seal().to_dict(),
+    )
 
     receiver = (
         call.sugar()


### PR DESCRIPTION
## Instrument

Ordinary `SourceFile.from_path` with two same-source functions showed `SourceVisibleCallFrameV1.bind_actuals` accepted the left frame after substituting the right function definition locus.

- R_source_frame_wrong_site: 1 -> 0
- Delta: -1
- Epsilon: 0

## Change

Bind the frame definition site and fragment CID to its exact producer-owned source definition before validating/binding formal coordinates.

## Tests

`bin/bpytest implementations/python/sugar-source-tree/tests/test_source_call_frame_definition_site.py implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py -q --tb=short`

18 passed.

Floors: no carrier, ExitSet, nodes.py/backend.py/tree.py, FBC, Halted, or Floor changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate source call frame definition sites in `SourceVisibleCallFrameV1`
> - Adds `formal_declaration_sites` and `formal_projection_paths` fields to `SourceVisibleCallFrameV1`, including them in the preimage used to compute `frame_cid`.
> - `bind_actuals` now rejects frames whose owner does not match the frame's recorded definition site or fragment, raising `SourceCallBindingGap` for mismatches.
> - `FunctionDef`, `ClassDef`, and `Lambda` node types populate the new fields when constructing call frames.
> - New tests in [`test_source_call_frame_definition_site.py`](https://github.com/TSavo/sugar/pull/6821/files#diff-86449d923a15ab98eaf694b750d0bbecc35e393d0cf61de89b2ae89064b7beca) cover rejection of foreign definition sites and correct roster binding.
> - Behavioral Change: `frame_cid` values change for all existing frames due to the new fields being included in the preimage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 566b389.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->