### PR TITLE
Own exception class subscript mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/exception_class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/exception_class_value.py
@@ -11,6 +11,26 @@ class ExceptionClassValue(FloorValue):
 
     qualified_name: str
 
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="ExceptionClassValue.setitem",
+        )
+
+    def delitem(self, index, site):
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="ExceptionClassValue.delitem",
+        )
+
     @property
     def name(self) -> str:
         return self.qualified_name

--- a/implementations/python/sugar-lift-py-tests/tests/test_exception_class_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exception_class_subscript_mutation.py
@@ -1,0 +1,28 @@
+import pytest
+
+from sugar_lift_py_tests.floor import ExceptionClassValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "exception_class_subscript_mutation.py"
+    path.write_text("def f(exc_type, replacement):\n    exc_type[0] = replacement\n    del exc_type[0]\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "ExceptionClassValue.setitem", 0), ("delitem", "ExceptionClassValue.delitem", 1)))
+def test_exception_class_subscript_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path); site = sites[site_index]; value = ExceptionClassValue("module.CustomError")
+    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_exception_class_subscript_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path); value = ExceptionClassValue("module.CustomError")
+    store = value.setitem(TermValue(0), TermValue(7), store_site); delete = value.delitem(TermValue(0), delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
## Instrument

Ordinary source-defined exception class program with independent `exc_type[0] = replacement` and `del exc_type[0]` sites plus a wrong-site twin.

## Exact receipt

- exact base: `24fd4bad3749dbda97cc079f0766b347feca35e8`
- head: `3111c3ab43cd5837d6eeeadd3e8110edb50db0f7`
- isolated identical probe: base `AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1`; head `AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0`
- focused: `3 passed in 2.67s`, exit 0
- `SETITEM_DEFS=1`, `DELITEM_DEFS=1`
- `LAW_OF_ONE_VIOLATIONS=0`, `SIDE_DOOR_OCCURRENCES=0`
- carrier/ExitSet/outcome/Halted/TargetPattern/FBC path drift: 0
- `git diff --check`: exit 0

Named residual: `R_missing_exception_class_subscript_floor_owner 2 -> 0`; observed Delta `-2`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` methods to `ExceptionClassValue` that raise `TypeError`
> Implements subscript mutation handling for `ExceptionClassValue` by adding `setitem` and `delitem` methods in [exception_class_value.py](https://github.com/TSavo/sugar/pull/6822/files#diff-cc22f8b161894328c7f3bb110b176acc89c29bf1a7a2de0e267cbdd83600a282). Both methods return a `ground_exceptional_exit` with `exception_name` set to `"TypeError"`, annotated with the provided site and their respective owner strings. A new test file verifies that each method produces a `TypeError` exit with the correct `producer_node_owner` and site-specific `occurrence_id`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3111c3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->