### PR TITLE
Own class subscript mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
@@ -173,6 +173,22 @@ class ClassValue(FloorValue):
         # Recognition-era subscription tables are gone; emit the coordinate.
         return self.py_subscript_coordinate(index, site)
 
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="ClassValue.setitem"
+        )
+
+    def delitem(self, index, site):
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="ClassValue.delitem"
+        )
+
     def contribution(self):
         # Splice body entries (methods, assigns) into the enclosing record.
         return self.record.contribution()

--- a/implementations/python/sugar-lift-py-tests/tests/test_class_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_class_subscript_mutation.py
@@ -1,0 +1,50 @@
+import pytest
+
+from sugar_lift_py_tests.floor import BlockValue, ClassValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "class_subscript_mutation.py"
+    path.write_text(
+        "def mutate_class(C):\n"
+        "    C[0] = 7\n"
+        "    del C[0]\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
+    return body[0].fragment, body[1].fragment
+
+
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setitem", "ClassValue.setitem", 0),
+        ("delitem", "ClassValue.delitem", 1),
+    ),
+)
+def test_class_subscript_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = ClassValue("C", (), BlockValue(()))
+    outcome = (
+        value.setitem(TermValue(0), TermValue(7), site)
+        if operation == "setitem"
+        else value.delitem(TermValue(0), site)
+    )
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_class_subscript_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = ClassValue("C", (), BlockValue(()))
+    store = value.setitem(TermValue(0), TermValue(7), store_site)
+    delete = value.delitem(TermValue(0), delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
## Instrument

Ordinary class-valued receiver with independent `C[0] = 7` and `del C[0]` source sites plus a wrong-site twin.

## Exact receipt

- exact base: `c3b9309f20d6ce052d6b58fea8d25fe16a7a7a69`
- head: `179cd0518d9fada1997d2ed770438b429e4f26db`
- isolated identical probe: base `AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1`; head `AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0`
- focused: `3 passed in 4.16s`, exit 0
- `SETITEM_DEFS=1`, `DELITEM_DEFS=1`
- `LAW_OF_ONE_VIOLATIONS=0`, `SIDE_DOOR_OCCURRENCES=0`
- carrier/ExitSet/outcome/Halted/TargetPattern/FBC path drift: 0
- `git diff --check`: exit 0

Named residual: `R_missing_class_subscript_floor_owner 2 -> 0`; observed Delta `-2`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` subscript mutation handling to `ClassValue`
> Adds `setitem` and `delitem` methods to `ClassValue` that each return a `TypeError` exceptional exit tagged with the provided site and a specific `producer_node_owner` string (`ClassValue.setitem` or `ClassValue.delitem`). Tests verify that the `occurrence_id` on the exceptional exit matches the exact site passed to each operation and does not cross-match between the two.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 179cd05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->