### PR TITLE
Own class definition subscript mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -45,6 +45,26 @@ class ClassDefinitionValue(GuardStableValue):
             symbol_kind="coordinate",
         )
 
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="ClassDefinitionValue.setitem",
+        )
+
+    def delitem(self, index, site):
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="ClassDefinitionValue.delitem",
+        )
+
     def construct_receiver_state_from_block(self, block, receiver_coordinate_cid):
         from sugar_lift_py_tests.floor import (
             GuardedReceiverFieldStoreValue,

--- a/implementations/python/sugar-lift-py-tests/tests/test_class_definition_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_class_definition_subscript_mutation.py
@@ -1,0 +1,54 @@
+import pytest
+
+from sugar_lift_py_tests.floor import ClassDefinitionValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "class_definition_subscript_mutation.py"
+    path.write_text(
+        "def mutate_class(C):\n"
+        "    C[0] = 7\n"
+        "    del C[0]\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
+    return body[0].fragment, body[1].fragment
+
+
+def _value():
+    return ClassDefinitionValue("C", "class-cid", (), None)
+
+
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setitem", "ClassDefinitionValue.setitem", 0),
+        ("delitem", "ClassDefinitionValue.delitem", 1),
+    ),
+)
+def test_class_definition_subscript_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = _value()
+    outcome = (
+        value.setitem(TermValue(0), TermValue(7), site)
+        if operation == "setitem"
+        else value.delitem(TermValue(0), site)
+    )
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_class_definition_subscript_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = _value()
+    store = value.setitem(TermValue(0), TermValue(7), store_site)
+    delete = value.delitem(TermValue(0), delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
## Instrument

Ordinary class-valued receiver with independent `C[0] = 7` and `del C[0]` source sites plus a wrong-site twin, exercised through the source-constructed `ClassDefinitionValue` floor.

## Exact receipt

- exact base: `4e3d5f15c56d6021503f7f7ea3ea5268103c93fc`
- head: `92426a5f8923ef1120a9aaf1ef7b8d8bc2a99ffb`
- isolated identical probe: base `AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1`; head `AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0`
- focused: `3 passed in 4.65s`, exit 0
- `SETITEM_DEFS=1`, `DELITEM_DEFS=1`
- `LAW_OF_ONE_VIOLATIONS=0`, `SIDE_DOOR_OCCURRENCES=0`
- carrier/ExitSet/outcome/Halted/TargetPattern/FBC path drift: 0
- `git diff --check`: exit 0

Named residual: `R_missing_class_definition_subscript_floor_owner 2 -> 0`; observed Delta `-2`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` methods to `ClassDefinitionValue` that raise TypeError
> - Adds `ClassDefinitionValue.setitem` and `ClassDefinitionValue.delitem` in [class_definition_value.py](https://github.com/TSavo/sugar/pull/6824/files#diff-e98bab463d1ea052d9ed8fa03d55c22ed6f572af21beeb2a3d00de10ba42e757), each returning a `ground_exceptional_exit` with `exception_name='TypeError'` and the provided site as `occurrence_id`.
> - Adds tests in [test_class_definition_subscript_mutation.py](https://github.com/TSavo/sugar/pull/6824/files#diff-b13b57be99428206689a2c803e1e7635db24ae714cc194c1586d4ac105a8a97d) verifying correct `producer_node_owner`, `occurrence_id`, and that distinct sites produce distinct `occurrence_id`s.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92426a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->