### PR TITLE
Own object method subscript mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_method_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_method_value.py
@@ -30,3 +30,23 @@ class ObjectMethodValue(FloorValue):
 
         if not isinstance(self.body, (SugarBody, Sugar)):
             raise TypeError("ObjectMethodValue body must be constructor-built")
+
+    def setitem(self, index, value, site):
+        del index, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="ObjectMethodValue.setitem",
+        )
+
+    def delitem(self, index, site):
+        del index
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="TypeError",
+            site=site,
+            owner="ObjectMethodValue.delitem",
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_object_method_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_method_subscript_mutation.py
@@ -1,0 +1,55 @@
+import pytest
+
+from sugar_lift_py_tests.floor import ObjectMethodValue, TermValue
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "object_method_subscript_mutation.py"
+    path.write_text(
+        "def mutate_method(method):\n"
+        "    method[0] = 7\n"
+        "    del method[0]\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
+    return body[0].fragment, body[1].fragment
+
+
+def _value(site):
+    return ObjectMethodValue("method", ("self",), TrueBoolLiteralSugar(site=site))
+
+
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setitem", "ObjectMethodValue.setitem", 0),
+        ("delitem", "ObjectMethodValue.delitem", 1),
+    ),
+)
+def test_object_method_subscript_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = _value(site)
+    outcome = (
+        value.setitem(TermValue(0), TermValue(7), site)
+        if operation == "setitem"
+        else value.delitem(TermValue(0), site)
+    )
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_object_method_subscript_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path)
+    value = _value(store_site)
+    store = value.setitem(TermValue(0), TermValue(7), store_site)
+    delete = value.delitem(TermValue(0), delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
## Instrument

Ordinary source method receiver with independent `method[0] = 7` and `del method[0]` sites plus a wrong-site twin.

## Exact receipt

- exact base: `42c48eeae1db8e045bfc2956d8255a936ea95e08`
- head: `aa2e7e316dcea07dcf51c9ff66dd7231c7fb5977`
- isolated identical probe: base `AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1`; head `AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0`
- focused: `3 passed in 3.09s`, exit 0
- `SETITEM_DEFS=1`, `DELITEM_DEFS=1`
- `LAW_OF_ONE_VIOLATIONS=0`, `SIDE_DOOR_OCCURRENCES=0`
- carrier/ExitSet/outcome/Halted/TargetPattern/FBC drift: 0
- `git diff --check`: exit 0

Named residual `R_missing_object_method_subscript_floor_owner 2 -> 0`; Delta `-2`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` mutation handlers to `ObjectMethodValue`
> Adds `setitem` and `delitem` methods to [`ObjectMethodValue`](https://github.com/TSavo/sugar/pull/6825/files#diff-a0b76bdbb48a03580882933c66ef9ceb7f2d8c964afc160f47bae161404eb82f), both of which raise a `TypeError` via `ground_exceptional_exit` with distinct owner strings. A new test module ([test_object_method_subscript_mutation.py](https://github.com/TSavo/sugar/pull/6825/files#diff-74cf6fc64ff760c7b1e27145dad70926645f40b96c60fa4bac190ff2f9ba57e3)) verifies that each method produces the correct owner string, occurrence ID matching the provided site, and that store and delete sites produce distinct occurrence IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa2e7e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->