### PR TITLE
Consume authenticated source actual pairs

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -124,6 +124,8 @@ class ConstructedCallActualV1:
         )
         if observed != self.testimony.semantic_value_cid:
             raise ValueError("constructed actual does not match its source testimony")
+        if self.node.fragment.seal().cid != self.testimony.source_fragment_cid:
+            raise ValueError("constructed actual has a foreign source occurrence")
 
 
 @dataclass(frozen=True)
@@ -738,10 +740,11 @@ def construct_manager_behavior(
         return frame_result
     frame, _target = frame_result
     try:
-        values = frame.bind_actuals(
+        bound_actuals = frame.bind_actuals(
             tuple(item.value for item in actuals),
             tuple((name, item.value) for name, item in keyword_actuals),
         )
+        values = bound_actuals.actuals
         declaration_body = frame.body
         frame = frame.bind_node_actuals(
             tuple(item.node for item in actuals),
@@ -756,8 +759,17 @@ def construct_manager_behavior(
             id(item.node): item.testimony
             for item in (*actuals, *(item for _, item in keyword_actuals))
         }
+        bound_by_coordinate = {
+            pair.coordinate.cid: pair for pair in bound_actuals.pairs
+        }
         authenticated_entries = []
-        for entry, value in zip(frame.runtime_entries, values, strict=True):
+        for entry in frame.runtime_entries:
+            pair = bound_by_coordinate.get(entry.coordinate.cid)
+            if pair is None or pair.coordinate != entry.coordinate:
+                raise SourceCallBindingGap(
+                    "runtime entry has a foreign formal coordinate"
+                )
+            value = pair.actual
             testimony = supplied.get(id(entry.state))
             if testimony is None:
                 testimony = ConstructedValueTestimonyV1.mint(

--- a/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
@@ -122,6 +122,24 @@ def _opaque_gap(root: Path, *, factory_source: str, support_source: str):
     return raised.value
 
 
+def test_constructed_call_actual_rejects_foreign_source_occurrence(tmp_path):
+    left_path = tmp_path / "left.py"
+    right_path = tmp_path / "right.py"
+    left_path.write_text("consume(23)\n", encoding="utf-8")
+    right_path.write_text("consume(0x17)\n", encoding="utf-8")
+    left = SourceFile.from_path(left_path)
+    right = SourceFile.from_path(right_path)
+    left_literal = next(item for item in left.nodes() if isinstance(item, Constant))
+    right_literal = next(item for item in right.nodes() if isinstance(item, Constant))
+    value = TermValue(23)
+    foreign_testimony = ConstructedValueTestimonyV1.mint(
+        right_literal.fragment, _term_content_cid(value.to_term(owner="test"))
+    )
+
+    with pytest.raises(ValueError, match="foreign source occurrence"):
+        ConstructedCallActualV1(left_literal, value, foreign_testimony)
+
+
 _CROSS_MODULE_CLASS_FACTORY = (
     "from arbitrary.support import ScopedSlot\n"
     "\n"


### PR DESCRIPTION
R_manager_bound_actual_iteration: 1 -> 0 (Delta -1).\n\nOrdinary authenticated cross-module class construction now consumes SourceCallFrame.bind_actuals typed coordinate/value pairs. Constructed actual testimony rejects a foreign source occurrence.\n\nFocused receipt: bin/bpytest test_external_call_target_construction.py::{test_cross_module_class_call_target_reduces_to_constructed_receiver,test_constructed_call_actual_rejects_foreign_source_occurrence} -q --tb=short => 2 passed in 0.67s.\n\nFloors: no carrier/ExitSet/Floor changes; no name mapper; removed the legacy runtime_entries/values zip.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate authenticated source actual pairs by formal coordinate in `construct_manager_behavior`
> - `ConstructedCallActualV1.__post_init__` now validates that the node's fragment seal CID matches the testimony's `source_fragment_cid`, raising `ValueError('constructed actual has a foreign source occurrence')` if they differ.
> - `construct_manager_behavior` replaces positional zipping of runtime entries with actuals by a coordinate-keyed lookup, raising `SourceCallBindingGap('runtime entry has a foreign formal coordinate')` when no matching coordinate is found.
> - A new test in [test_external_call_target_construction.py](https://github.com/TSavo/sugar/pull/6827/files#diff-4569d90d54480b0f5db43f6dbaafd3ca3ac277150cc9e217e4c1dd346de3e08b) covers the foreign-source-occurrence rejection path.
> - Behavioral Change: positional mismatches that previously silently paired the wrong value now raise a binding gap error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6c314f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->