### PR TITLE
Own object method attribute mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_method_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_method_value.py
@@ -50,3 +50,23 @@ class ObjectMethodValue(FloorValue):
             site=site,
             owner="ObjectMethodValue.delitem",
         )
+
+    def setattr(self, name, value, site):
+        del name, value
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="ObjectMethodValue.setattr",
+        )
+
+    def delattr(self, name, site):
+        del name
+        from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="ObjectMethodValue.delattr",
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_object_method_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_method_attribute_mutation.py
@@ -1,0 +1,37 @@
+import pytest
+
+from sugar_lift_py_tests.floor import ObjectMethodValue, TermValue
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "object_method_attribute_mutation.py"
+    path.write_text(
+        "def mutate_method(method):\n"
+        "    method.attr = 7\n"
+        "    del method.attr\n"
+    )
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+def _value(site):
+    return ObjectMethodValue("method", ("self",), TrueBoolLiteralSugar(site=site))
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setattr", "ObjectMethodValue.setattr", 0), ("delattr", "ObjectMethodValue.delattr", 1)))
+def test_object_method_attribute_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path); site = sites[site_index]; value = _value(site)
+    outcome = value.setattr("attr", TermValue(7), site) if operation == "setattr" else value.delattr("attr", site)
+    assert outcome.value.effect.exception_name == "AttributeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_object_method_attribute_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path); value = _value(store_site)
+    store = value.setattr("attr", TermValue(7), store_site); delete = value.delattr("attr", delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
## Instrument

Ordinary bound-method receiver with independent `method.attr = 7` and `del method.attr` sites plus wrong-site twin.

## Receipt
- base `8bbc3cc861167d47e43720873089ca212a572ebd`: `AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1`
- head `397b0ab6c05555549d6981d02915a7c1f4ab7cac`: `AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0`
- focused `3 passed in 2.95s`, exit 0
- `SETATTR_DEFS=1 DELATTR_DEFS=1`
- `LAW_OF_ONE=0 SIDE_DOOR=0`
- carrier/ExitSet/outcome/Halted/TargetPattern/FBC drift 0; diff-check exit 0

`R_missing_object_method_attribute_floor_owner 2 -> 0`; Delta `-2`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setattr` and `delattr` methods to `ObjectMethodValue` that raise `AttributeError`
> Adds `setattr` and `delattr` methods to `ObjectMethodValue` in [object_method_value.py](https://github.com/TSavo/sugar/pull/6828/files#diff-a0b76bdbb48a03580882933c66ef9ceb7f2d8c964afc160f47bae161404eb82f). Both methods return a `ground_exceptional_exit` carrying an `AttributeError`, rejecting attribute mutation on method objects. Tests in [test_object_method_attribute_mutation.py](https://github.com/TSavo/sugar/pull/6828/files#diff-581206c024358543577f072b0f3c8b481d64552148c3c03057a1dd49178fc582) verify that the returned exceptional exit carries the correct owner and site occurrence ID for each operation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 397b0ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->