### PR TITLE
Dispatch authenticated exception type subscript mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/authenticated_exception_type_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/authenticated_exception_type_value.py
@@ -19,6 +19,12 @@ class AuthenticatedExceptionTypeValue(FloorValue):
     def to_term(self, *, owner: str):
         return self.value.to_term(owner=owner)
 
+    def setitem(self, index, value, site):
+        return self.value.setitem(index, value, site)
+
+    def delitem(self, index, site):
+        return self.value.delitem(index, site)
+
     def exception_type_identity(self) -> Term:
         return self.identity
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_authenticated_exception_type_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_authenticated_exception_type_subscript_mutation.py
@@ -1,0 +1,41 @@
+import pytest
+
+from sugar_lift_py_tests.floor import ExceptionClassValue, TermValue
+from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
+    AuthenticatedExceptionTypeValue,
+)
+from sugar_lift_py_tests.ir import str_const
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "authenticated_exception_type_subscript_mutation.py"
+    path.write_text(
+        "def mutate_exception_type(exc_type):\n"
+        "    exc_type[0] = 7\n"
+        "    del exc_type[0]\n"
+    )
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+def _value():
+    carried = ExceptionClassValue("module.CustomError")
+    return AuthenticatedExceptionTypeValue(carried, str_const("exception-type"))
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "ExceptionClassValue.setitem", 0), ("delitem", "ExceptionClassValue.delitem", 1)))
+def test_authenticated_exception_type_subscript_mutations_dispatch_to_exact_carried_owner(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path); site = sites[site_index]; value = _value()
+    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_authenticated_exception_type_subscript_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path); value = _value()
+    store = value.setitem(TermValue(0), TermValue(7), store_site); delete = value.delitem(TermValue(0), delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
## Instrument

Ordinary authenticated exception-type receiver with independent Assign/Delete sites and wrong-site twin. The typed wrapper delegates to its carried Floor; no second owner is fabricated.

## Exact receipt
- exact base `6d755322e17c35af0951e1d4c2384791fb7d3ae5`: `AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1`
- head `4de2ad2674d5a6e95f01abb8e91d928e3b9e5cac`: `AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0`
- carried owners unchanged: `ExceptionClassValue.setitem`, `ExceptionClassValue.delitem`
- focused `3 passed in 2.61s`, exit 0
- dispatch definitions `SETITEM=1 DELITEM=1`
- exact scope: 2 files, 47 insertions, 0 deletions
- `LAW_OF_ONE=0 SIDE_DOOR=0`, forbidden drift 0, underlying owner file drift 0, diff-check exit 0

`R_missing_authenticated_exception_type_subscript_dispatch 2 -> 0`; Delta `-2`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `setitem` and `delitem` methods to `AuthenticatedExceptionTypeValue` for subscript mutations
> Adds `setitem` and `delitem` instance methods to `AuthenticatedExceptionTypeValue` that delegate directly to the carried `FloorValue`. Tests verify that both methods forward to the correct `ExceptionClassValue` owner and that occurrence IDs are tied to the exact operation site.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4de2ad2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->