### PR TITLE
Advance authenticated module alias receipts

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1942,6 +1942,16 @@ def _seat_import_value_use_receipts(
             # import-use coordinate unseated; any consumer that needs it stays
             # typed-loud at its ordinary resolution door.
             continue
+        binding_target = receipt.import_binding.value["target"]
+        if (
+            binding_target["exportedPath"] == []
+            and receipt.use.get("exportedMemberPath") == []
+        ):
+            # A module-alias value is authenticated import testimony, but it
+            # is not a callable definition to seat on this SourceUnit.  Its
+            # attributed member carries its own later receipt and exact use
+            # coordinate; only that member may become a source call frame.
+            continue
         imported = resolve_import_binding(
             receipt, graph=dependency_graph, session=session
         )


### PR DESCRIPTION
R_module_alias_value_seating: 1 -> 0 (Delta -1).\n\nAn authenticated module-alias value receipt has no callable definition to seat. The producer now advances only when both the binding exported path and use member path are empty; the attributed member receipt retains its exact coordinate and seats normally.\n\nReceipts: focused truthful/forged-head/foreign-unit arms 3 passed; source-call-preconstruction + import-value-use-frame-seating suites 25 passed in 0.91s.\n\nFloors: malformed, foreign-source, foreign-use-site, and unresolved member receipts remain loud. No nodes/backend/tree, carrier, ExitSet, FBC, or Floor changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip resolving and seating module-alias import-use receipts in `_seat_import_value_use_receipts`
> When a receipt has an empty `exportedPath` on its target and an empty `exportedMemberPath` on its use, it represents a module-alias import that should not be resolved or seated on the `SourceUnit`. A guard in [manager_construction.py](https://github.com/TSavo/sugar/pull/6830/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) now detects this case and issues an early `continue`, deferring to the attributed-member receipts instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3517b71.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->