### PR TITLE
Dispatch authenticated exception type attribute mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/authenticated_exception_type_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/authenticated_exception_type_value.py
@@ -25,6 +25,12 @@ class AuthenticatedExceptionTypeValue(FloorValue):
     def delitem(self, index, site):
         return self.value.delitem(index, site)
 
+    def setattr(self, name, value, site):
+        return self.value.setattr(name, value, site)
+
+    def delattr(self, name, site):
+        return self.value.delattr(name, site)
+
     def exception_type_identity(self) -> Term:
         return self.identity
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_authenticated_exception_type_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_authenticated_exception_type_attribute_mutation.py
@@ -1,0 +1,35 @@
+import pytest
+
+from sugar_lift_py_tests.floor import BlockValue, BuiltinExceptionClassValue, TermValue
+from sugar_lift_py_tests.floor.authenticated_exception_type_value import AuthenticatedExceptionTypeValue
+from sugar_lift_py_tests.ir import str_const
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "authenticated_exception_type_attribute_mutation.py"
+    path.write_text("def mutate_exception_type(exc_type):\n    exc_type.attr = 7\n    del exc_type.attr\n")
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+def _value():
+    carried = BuiltinExceptionClassValue("ValueError", (), BlockValue(()))
+    return AuthenticatedExceptionTypeValue(carried, str_const("exception-type"))
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setattr", "BuiltinExceptionClassValue.setattr", 0), ("delattr", "BuiltinExceptionClassValue.delattr", 1)))
+def test_authenticated_exception_type_attribute_mutations_dispatch_to_exact_carried_owner(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path); site = sites[site_index]; value = _value()
+    outcome = value.setattr("attr", TermValue(7), site) if operation == "setattr" else value.delattr("attr", site)
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_authenticated_exception_type_attribute_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path); value = _value()
+    store = value.setattr("attr", TermValue(7), store_site); delete = value.delattr("attr", delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
## Instrument

Ordinary authenticated builtin exception-type receiver with distinct attribute-store/delete sites and wrong-site twin. The typed wrapper delegates directly to its authenticated carried Floor.

## Exact receipt
- base `7ea4b10f22ce5db1dcd6e5bb6b9d07407663ef02`: `AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1`
- head `861008dc436c2442bddaae883610313d5d38584b`: `AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0`
- carried owners unchanged: `BuiltinExceptionClassValue.setattr/delattr`
- focused `3 passed in 4.16s`, exit 0
- exact dispatch defs `SETATTR=1 DELATTR=1`
- scope: 2 files, 41 insertions, 0 deletions
- `LAW_OF_ONE=0 SIDE_DOOR=0`; forbidden and underlying-owner drift 0; diff-check exit 0

`R_authenticated_exception_type_attribute_mutation 2 -> 0`; Delta `-2`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dispatch `setattr` and `delattr` on `AuthenticatedExceptionTypeValue` to carried value
> Adds `setattr` and `delattr` methods to `AuthenticatedExceptionTypeValue` that delegate to the corresponding methods on the wrapped `FloorValue`. Tests verify that the produced effects carry the correct exception name, producer node owner, and occurrence ID, and that site associations are not cross-assigned between the two operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 861008d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->