### PR TITLE
Dispatch named expression subscript mutations

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/named_expression_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/named_expression_value.py
@@ -127,6 +127,12 @@ class NamedExpressionValue(FloorValue):
     def subscript(self, index, site):
         return self.presented_value.subscript(index, site).and_then(self._carry)
 
+    def setitem(self, index, value, site):
+        return self.presented_value.setitem(index, value, site).and_then(self._carry)
+
+    def delitem(self, index, site):
+        return self.presented_value.delitem(index, site).and_then(self._carry)
+
     def attribute(self, name, site):
         return self.presented_value.attribute(name, site).and_then(self._carry)
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_named_expression_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_named_expression_subscript_mutation.py
@@ -1,0 +1,36 @@
+import pytest
+
+from sugar_lift_py_tests.floor import NamedExpressionValue, NoneValue, TermValue
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path):
+    path = tmp_path / "named_expression_subscript_mutation.py"
+    path.write_text(
+        "def mutate(value):\n"
+        "    (bound := None)[0] = value\n"
+        "    del (bound := None)[0]\n"
+    )
+    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    return body[0].fragment, body[1].fragment
+
+
+def _value():
+    return NamedExpressionValue("bound", NoneValue())
+
+
+@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "NoneValue.setitem", 0), ("delitem", "NoneValue.delitem", 1)))
+def test_named_expression_subscript_mutations_dispatch_to_exact_presented_owner(tmp_path, operation, owner, site_index):
+    sites = _sites(tmp_path); site = sites[site_index]; value = _value()
+    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+    assert outcome.value.effect.exception_name == "TypeError"
+    assert outcome.value.effect.producer_node_owner == owner
+    assert outcome.value.effect.occurrence_id == str(site)
+
+
+def test_named_expression_subscript_mutations_reject_wrong_site(tmp_path):
+    store_site, delete_site = _sites(tmp_path); value = _value()
+    store = value.setitem(TermValue(0), TermValue(7), store_site); delete = value.delitem(TermValue(0), delete_site)
+    assert store.value.effect.occurrence_id != str(delete_site)
+    assert delete.value.effect.occurrence_id != str(store_site)


### PR DESCRIPTION
## Instrument

Authentic walrus receivers `(bound := None)[0] = value` and `del (bound := None)[0]` provide independent Assign/Delete occurrences plus a wrong-site twin. Typed dispatch uses `presented_value` and the existing carry rule.

## Receipt
- base `db2f086486a8883eb12c289778a3b6a9d41ecd5a`: `AUTH_CASES=2 OWNED=0 GAPS=2 EXIT=1`
- head `8a3284d0641777fa0e9ffe03cc6fb24b127d9500`: `AUTH_CASES=2 OWNED=2 GAPS=0 EXIT=0`
- carried owners unchanged: `NoneValue.setitem/delitem`
- focused `3 passed in 1.97s`, exit 0
- dispatch defs `SETITEM=1 DELITEM=1`
- `LAW_OF_ONE=0 SIDE_DOOR=0`; forbidden and underlying-owner drift 0; diff-check exit 0

`R_named_expression_subscript_mutation 2 -> 0`; Delta `-2`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dispatch subscript mutations in `NamedExpressionValue` to its presented value
> Adds `setitem` and `delitem` methods to `NamedExpressionValue` in [named_expression_value.py](https://github.com/TSavo/sugar/pull/6832/files#diff-99bcc111f9525fdf703347507f9fe12a152810e455aa1fe8ed13b6ec10768938). Both methods delegate to the corresponding method on `presented_value`, then thread the result through `_carry` via `and_then`. Tests in [test_named_expression_subscript_mutation.py](https://github.com/TSavo/sugar/pull/6832/files#diff-2ccce315918d5cac7075ef8801be74ee4a01a0d6018ec8dead188166d9204eab) verify that errors originate from the presented owner and that site identity is preserved across both operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a3284d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved named-expression subscript mutations so item assignment and deletion preserve their associated binding context.
  * Corrected mutation error reporting to identify the affected value and exact operation location.

* **Tests**
  * Added coverage for assignment and deletion behavior, including validation of operation-site metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->