### PR TITLE
Execute source-visible yield-from delegation

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -75,6 +75,27 @@ class YieldStepV1:
 
 
 @dataclass(frozen=True)
+class YieldFromStepV1:
+    """Authenticated delegated-iteration suspension.
+
+    The iterable remains constructed testimony until transition.  The source
+    occurrence authenticates both iterator acquisition and exhaustion; neither
+    operation is inferred from the iterable's spelling.
+    """
+
+    iterable: ConstructedTermSugar
+    occurrence: object = field(compare=False, repr=False)
+    occurrence_cid: str
+
+    def __post_init__(self) -> None:
+        _require_constructed_term(self.iterable, owner="YieldFromStepV1.iterable")
+        if self.occurrence.seal().cid != self.occurrence_cid:
+            raise TypeError(
+                "YieldFromStepV1 occurrence must match its authenticated CID"
+            )
+
+
+@dataclass(frozen=True)
 class ReturnStepV1:
     value: ConstructedTermSugar | None = None
 
@@ -277,6 +298,13 @@ class _ForIteratorStepV1:
 
 
 @dataclass(frozen=True)
+class _YieldFromIteratorStepV1:
+    iterator: object = field(compare=False, repr=False)
+    occurrence: object = field(compare=False, repr=False)
+    occurrence_cid: str
+
+
+@dataclass(frozen=True)
 class IfStepV1:
     """A branch inside a generator body, with each side's own step sequence.
 
@@ -336,6 +364,7 @@ class NestedManagerExitStepV1:
 
 GeneratorStepV1 = (
     YieldStepV1
+    | YieldFromStepV1
     | ReturnStepV1
     | OpaqueStepV1
     | InertStepV1
@@ -345,6 +374,7 @@ GeneratorStepV1 = (
     | RaiseStepV1
     | TermStepV1
     | _ForIteratorStepV1
+    | _YieldFromIteratorStepV1
     | IfStepV1
     | NestedManagerStepV1
     | NestedManagerExitStepV1
@@ -440,6 +470,12 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
             "kind": "yield",
             "value": _generator_value_testimony(step.value, owner=owner),
         }
+    if isinstance(step, YieldFromStepV1):
+        return {
+            "kind": "yield-from",
+            "occurrenceCid": step.occurrence_cid,
+            "iterable": _generator_value_testimony(step.iterable, owner=owner),
+        }
     if isinstance(step, ReturnStepV1):
         return {
             "kind": "return",
@@ -506,6 +542,11 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
             "bodySteps": [
                 _generator_step_testimony(item, owner=owner) for item in step.body_steps
             ],
+        }
+    if isinstance(step, _YieldFromIteratorStepV1):
+        return {
+            "kind": "yield-from-iterator",
+            "occurrenceCid": step.occurrence_cid,
         }
     if isinstance(step, IfStepV1):
         return {
@@ -841,6 +882,10 @@ class GeneratorConstructionV1:
             return self._transition_for(step, requested)
         if isinstance(step, _ForIteratorStepV1):
             return self._transition_for_iterator(step, requested)
+        if isinstance(step, YieldFromStepV1):
+            return self._transition_yield_from(step, requested)
+        if isinstance(step, _YieldFromIteratorStepV1):
+            return self._transition_yield_from_iterator(step, requested)
         if isinstance(step, NestedManagerStepV1):
             return self._transition_nested_manager(step, requested)
         if isinstance(step, NestedManagerExitStepV1):
@@ -925,6 +970,82 @@ class GeneratorConstructionV1:
         )
         machine = replace(self, steps=(*self.steps[: self.cursor], runtime, *self.steps[self.cursor + 1 :]))
         return machine._transition(requested)
+
+    def _transition_yield_from(self, step: YieldFromStepV1, requested: str):
+        from sugar_lift_py_tests.operations import IteratorOperation
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+        iterable = step.iterable.desugar(self._guard_evaluation_context())
+        if isinstance(iterable, Incomplete):
+            return ExitSet.halted(iterable.effect, state=self)
+        if not isinstance(iterable, Complete):
+            return self._gap(requested, type(iterable).__name__)
+        iterator = IteratorOperation(
+            owner="GeneratorConstructionV1.YieldFromStepV1.iter",
+            blame=step.occurrence,
+        ).submit(iterable.value, self._guard_evaluation_context())
+        if isinstance(iterator, Incomplete):
+            return ExitSet.halted(iterator.effect, state=self)
+        if not isinstance(iterator, Complete):
+            return self._gap(requested, type(iterator).__name__)
+        runtime = _YieldFromIteratorStepV1(
+            iterator.value, step.occurrence, step.occurrence_cid
+        )
+        machine = replace(
+            self,
+            steps=(
+                *self.steps[: self.cursor],
+                runtime,
+                *self.steps[self.cursor + 1 :],
+            ),
+        )
+        return machine._transition(requested)
+
+    def _transition_yield_from_iterator(
+        self, step: _YieldFromIteratorStepV1, requested: str
+    ):
+        from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+        from sugar_lift_py_tests.floor.ground_exit import ground_raise_effect
+        from sugar_lift_py_tests.floor.iterator_value import NextResult
+        from sugar_lift_py_tests.operations import NextOperation
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+        outcome = NextOperation(
+            owner="GeneratorConstructionV1.YieldFromStepV1.next",
+            blame=step.occurrence,
+        ).submit(step.iterator, self._guard_evaluation_context())
+        if isinstance(outcome, Incomplete):
+            effect = outcome.effect
+            stop_identity = ground_raise_effect(
+                exception_name="StopIteration",
+                site=step.occurrence,
+                owner="GeneratorConstructionV1.YieldFromStepV1.next",
+            ).exception_type_coordinate
+            if (
+                isinstance(effect, RaiseEffect)
+                and effect.exception_type_coordinate == stop_identity
+                and effect.occurrence == str(step.occurrence)
+            ):
+                machine = replace(self, cursor=self.cursor + 1)
+                return machine._transition(requested)
+            return ExitSet.halted(effect, state=self)
+        if not isinstance(outcome, Complete) or not isinstance(
+            outcome.value, NextResult
+        ):
+            return self._gap(requested, f"next_with returned {type(outcome).__name__}")
+
+        runtime = replace(step, iterator=outcome.value.advanced)
+        machine = replace(
+            self,
+            steps=(
+                *self.steps[: self.cursor],
+                runtime,
+                *self.steps[self.cursor + 1 :],
+            ),
+        )
+        resume_coordinate = f"{self.instance_coordinate}:resume:{self.cursor + 1}"
+        machine = replace(machine, suspended_resume_coordinate=resume_coordinate)
+        return YieldEffect(outcome.value.value, resume_coordinate, machine)
 
     def _transition_for_iterator(self, step: _ForIteratorStepV1, requested: str):
         from sugar_lift_py_tests.effect.raise_effect import RaiseEffect

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2835,6 +2835,7 @@ class FunctionDef(Statement):
             RaiseStepV1,
             ReturnStepV1,
             TermStepV1,
+            YieldFromStepV1,
             YieldStepV1,
         )
         from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
@@ -2859,6 +2860,15 @@ class FunctionDef(Statement):
                 value = statement.value.value
                 return _GeneratorNamedStepV1(
                     YieldStepV1(None if value is None else value.sugar())
+                )
+            if isinstance(statement, Expr) and isinstance(statement.value, YieldFrom):
+                occurrence = statement.value.fragment
+                return _GeneratorNamedStepV1(
+                    YieldFromStepV1(
+                        statement.value.value.sugar(),
+                        occurrence,
+                        occurrence.seal().cid,
+                    )
                 )
             if isinstance(statement, Return):
                 return _GeneratorNamedStepV1(

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -290,14 +290,12 @@ def test_yield_from_only_function_allocates_a_generator_not_an_eager_call() -> N
     assert not isinstance(outcome.value, CallSiteValue)
 
 
-def test_yield_from_delegation_stays_a_typed_gap_and_is_never_invented() -> None:
-    """LYING FACE: recognizing the boundary must not fabricate delegated iteration.
+def test_yield_from_tuple_delegates_each_value_then_returns_to_the_generator() -> None:
+    """A constructed ``yield from`` delegates in order, then resumes its tail.
 
-    Owning the boundary is exactly what the recognition fix buys; it does NOT
-    buy `yield from`'s delegation protocol. Resuming names
-    `GeneratorConstructionV1.transition` as the owner that still owes it, so
-    the debt is loud and attributed rather than silently discharged as a
-    yielded value or a termination.
+    The direct-``yield`` test above is the discrimination arm: both suspension
+    kinds reach the same generator consumer, while only this one must retain a
+    delegated iterator across resumes.
     """
     context = TreeConstructionContextV1.for_source_call_construction()
     source = _source_file(
@@ -312,13 +310,15 @@ def test_yield_from_delegation_stays_a_typed_gap_and_is_never_invented() -> None
     context.source_call_frames[_coordinate(call)] = function.source_visible_call_frame()
 
     machine = call.sugar().desugar().value
-    transition = machine.resume()
-
-    assert isinstance(transition, GeneratorTransitionGapV1)
-    assert transition.owner == "GeneratorConstructionV1.transition"
-    assert transition.requested == "resume"
-    assert not isinstance(transition, YieldEffect)
-    assert not isinstance(transition, GeneratorTerminationV1)
+    first = machine.resume()
+    assert isinstance(first, YieldEffect)
+    assert first.value == TermValue(1)
+    second = first.machine.resume()
+    assert isinstance(second, YieldEffect)
+    assert second.value == TermValue(2)
+    terminated = second.machine.resume()
+    assert isinstance(terminated, GeneratorTerminationV1)
+    assert terminated.return_value == TermValue(9)
 
 
 def test_census_door_refuses_both_yield_constructors_with_no_call_site() -> None:


### PR DESCRIPTION
## Capability

Constructs `YieldFromStepV1` from the source boundary and resumes delegated iteration through the existing authenticated iterator/next operations. Matching authenticated `StopIteration` returns control to the generator tail; direct `yield` remains the discrimination arm.

R_yield_from: 1 -> 0 (Delta -1). No Floor, Halted, ConstructedModule, Carrier, or ExitSet implementation changes.

## Receipts

- `bin/bpytest` exact post-rebase direct/yield-from matrix: 3 passed in 0.86s.
- owning source file + generator construction file: 12 passed, 7 baseline failures; all seven are the sacred stale `_ConstInt` fixture refusal `YieldStepV1.value requires ConstructedTermSugar`.
- sugar-source-tree package telemetry: 609 passed, 294 failed, 5 skipped (broad baseline; no chase).
- sugar-lift-py-tests complete package telemetry launched separately; final receipt pending and will be reported without gating this capability.
- `git diff --check`: pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement source-visible `yield from` delegation in generator state machines
> - Adds `YieldFromStepV1` as a new immutable step type in [generator_construction.py](https://github.com/TSavo/sugar/pull/6834/files#diff-35db5b3e2bf70dbb9aa1b5a6d30899e84d402ab203905605799dbd5855b1f072), representing a source-level `yield from` with CID-authenticated occurrence validation.
> - Adds `_YieldFromIteratorStepV1` as a runtime step carrying the live delegated iterator during execution.
> - Implements `_transition_yield_from` and `_transition_yield_from_iterator` on `GeneratorConstructionV1` to resolve the iterable, drive the delegated iterator, propagate yielded values with resume coordinates, and advance past the `yield from` on `StopIteration`.
> - Updates [nodes.py](https://github.com/TSavo/sugar/pull/6834/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to import `YieldFromStepV1` alongside existing step types.
> - The existing test for `yield from` is rewritten to assert actual value delegation (`1`, `2`) and termination with return value `9`, replacing the previous typed-gap assertion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2a786b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->