### PR TITLE
Authenticate starred opaque-call construction

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/starred_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/starred_sugar.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
 
 
 @dataclass(frozen=True)
-class StarredSugar(Sugar):
+class StarredSugar(ConstructedTermSugar):
     """A starred expression node owned for construction totality.
 
     Parents (Call / List / Tuple / Set) already project ``python:starred``
@@ -18,8 +21,11 @@ class StarredSugar(Sugar):
     wrap so the node is never an unowned gap; unpack targets stay Assign's job.
     """
 
-    value: Sugar
+    value: ConstructedTermSugar
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        require_constructed_term_sugar(self.value, owner="StarredSugar.value")
 
     @classmethod
     def witnesses(cls):
@@ -27,6 +33,18 @@ class StarredSugar(Sugar):
             sugar_name=cls.__name__,
             floor_name="starred coordinate",
             reason="starred elements are projected by their display/call parent",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:starred-construction",
+            (
+                self.occurrence_term(owner=owner),
+                self.value.to_term(owner=owner),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py
+++ b/implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py
@@ -16,6 +16,8 @@ perturbed.
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import (
@@ -36,6 +38,7 @@ from sugar_lift_py_tests.sugar.binding_coordinate_ref_sugar import (
     BindingCoordinateRefSugar,
 )
 from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+from sugar_lift_py_tests.sugar.starred_sugar import StarredSugar
 from sugar_lift_py_tests.temporal import TemporalContext
 from sugar_source_tree.nodes import Call, FunctionDef
 from sugar_source_tree.panic import SugarNotWritten
@@ -129,6 +132,13 @@ def test_opaque_source_call_obligation_precedes_spread_selection() -> None:
     opaque = opaque_call.sugar()
 
     assert isinstance(opaque, CallSiteSugar)
+    assert isinstance(opaque.args[0], StarredSugar)
+    opaque.args[0].to_term(owner="authenticated opaque spread")
+    with pytest.raises(
+        TypeError,
+        match="requires an authenticated source occurrence for StarredSugar",
+    ):
+        replace(opaque.args[0], site=object()).to_term(owner="foreign spread")
     assert opaque.contract_resolution_gap == "opaque-call-target:func"
     with pytest.raises(SugarNotWritten) as raised:
         opaque.desugar()


### PR DESCRIPTION
## Capability

Promotes `StarredSugar` through the existing authenticated `ConstructedTermSugar` door so an opaque source call with `*args` reaches its named resolution boundary. The starred term binds the exact source occurrence and its already-constructed operand; forged occurrence testimony refuses.

## Instrument

Program: `func(*[1], **{})\nordinary(2)\n`

R_starred_constructed_term: 1 -> 0. The opaque call reaches `opaque-call-target:func`; the ordinary twin remains gap-free.

## Focused receipts

- `bin/bpytest implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py::test_opaque_source_call_obligation_precedes_spread_selection -q` — 1 passed
- `bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_small_family_batch.py -q` — 11 passed

## Floors

No Carrier, ExitSet, Halted, Floor, reducer, boundary, projector, or vendor-spelling changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate starred opaque-call construction in `StarredSugar`
> - Changes `StarredSugar` base class to `ConstructedTermSugar` and adds a `__post_init__` validator that calls `require_constructed_term_sugar` on `value`, raising if the value is not a constructed-term sugar.
> - Adds `StarredSugar.to_term` which emits a `python:starred-construction` coordinate term using `occurrence_term` and the child's `to_term`.
> - Extends `test_opaque_source_call_obligation_precedes_spread_selection` to verify that `to_term` raises `TypeError` when called with a foreign (unauthenticated) site owner.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5fa7326.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->