### PR TITLE
Authenticate exception type call construction

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/authenticated_exception_type_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/authenticated_exception_type_sugar.py
@@ -2,16 +2,24 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field as dataclass_field
 
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
 
 
 @dataclass(frozen=True)
-class AuthenticatedExceptionTypeSugar(Sugar):
-    value: Sugar
+class AuthenticatedExceptionTypeSugar(ConstructedTermSugar):
+    value: ConstructedTermSugar
     identity: object
     mro: tuple | None = None
     site: object = dataclass_field(compare=False, default=None)
     class_value: object | None = dataclass_field(compare=False, default=None)
+
+    def __post_init__(self) -> None:
+        require_constructed_term_sugar(
+            self.value, owner="AuthenticatedExceptionTypeSugar.value"
+        )
 
     @classmethod
     def witnesses(cls):
@@ -22,6 +30,19 @@ class AuthenticatedExceptionTypeSugar(Sugar):
             owner_sugar="AuthenticatedExceptionTypeSugar",
             truthful="def f(x):\n    return x\n",
             lying="def f(x):\n    return 0\n",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:authenticated-exception-type-construction",
+            (
+                self.occurrence_term(owner=owner),
+                self.identity,
+                self.value.to_term(owner=owner),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx=None):


### PR DESCRIPTION
## Capability

Promotes `AuthenticatedExceptionTypeSugar` through the canonical `ConstructedTermSugar` door. Import-authenticated exception operands now retain their exact source occurrence, exception identity, and constructed source operand when a context-manager call consumes them.

## Instrument

Program: `import pyarrow as pa; def f(): with expect(pa.ArrowInvalid): raise ValueError("x")`

R_authenticated_exception_constructed_term: 1 -> 0. Existing module-qualified, renamed-import, nested-export, and reassigned-import discrimination twins remain active.

## Receipt

- `bin/bpytest implementations/python/sugar-source-tree/tests/test_imported_exception_attribute_construction.py -q` — 11 passed

## Floors

No Carrier, ExitSet, Halted, Floor, reducer, boundary, projector, vendor spelling, or spread-selection changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate exception type call construction in `AuthenticatedExceptionTypeSugar`
> - Changes `AuthenticatedExceptionTypeSugar` base class from `Sugar` to `ConstructedTermSugar` and updates the `value` field type to match.
> - Adds `__post_init__` validation that calls `require_constructed_term_sugar` on `value`, erroring if `value` is not a `ConstructedTermSugar`.
> - Adds `to_term` method that builds a coordinate `ctor` term named `python:authenticated-exception-type-construction` from the occurrence term, identity, and `value.to_term`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 134fd51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->