### PR TITLE
Pin ordinary generator term and assign steps

### DIFF
--- a/implementations/python/sugar-source-tree/tests/test_generator_context_manager_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_context_manager_construction.py
@@ -169,27 +169,31 @@ def test_docstring_is_stepped_and_is_never_the_blocker():
     )
 
 
-def test_inert_step_does_not_swallow_a_call_expression():
-    """LYING TWIN. An `Expr` that is not a `Constant` still owes execution.
-
-    `record()` is spelled like the docstring -- a bare expression statement --
-    and is exactly what a spelling-based admission would step past. It owes a
-    call, so it stays opaque and loud. If this node goes green the inert row
-    has been widened past what it can prove.
-    """
+def test_term_step_executes_a_call_expression_before_yield():
+    """A constructed call is an explicit TermStep, never an inert Expr."""
     sugar = _with_sugar("    record()\n    yield 7")
 
-    with pytest.raises(SugarNotWritten, match="opaque generator transition: Expr"):
-        sugar.desugar()
+    outcome = sugar.desugar()
+    assert isinstance(outcome, Complete)
+    assert outcome.value.statements[0].formula == eq(
+        ctor("enter_result_value", [str_const(sugar.enter_slot_id)]), num(7)
+    )
 
 
-def test_inert_step_does_not_swallow_a_binding():
-    """LYING TWIN. A binding is real work and must remain the named blocker.
-
-    This is the pandas `__tracebackhide__ = True` shape, and it is what the
-    machine must report once the docstring ahead of it is stepped.
-    """
+def test_assign_step_executes_a_name_binding_before_yield():
+    """A simple name binding is an explicit AssignStep, never inert work."""
     sugar = _with_sugar("    '''Doc.'''\n    hidden = True\n    yield 7")
+
+    outcome = sugar.desugar()
+    assert isinstance(outcome, Complete)
+    assert outcome.value.statements[0].formula == eq(
+        ctor("enter_result_value", [str_const(sugar.enter_slot_id)]), num(7)
+    )
+
+
+def test_assign_step_refuses_an_unowned_attribute_binding():
+    """Discrimination: only the producer-owned simple-name assignment advances."""
+    sugar = _with_sugar("    holder.hidden = True\n    yield 7")
 
     with pytest.raises(SugarNotWritten, match="opaque generator transition: Assign"):
         sugar.desugar()


### PR DESCRIPTION
## Instrument repair

Updates stale generator context-manager twins to pin the already-constructed `TermStepV1` and simple-name `AssignStepV1` capabilities. A source-visible call and a name binding execute before the first yield; an attribute assignment remains the exact opaque discrimination arm.

## Receipt

`bin/bpytest implementations/python/sugar-source-tree/tests/test_generator_context_manager_construction.py -q` — 11 passed.

## Scope

Tests only. No Carrier, ExitSet, Halted, Floor, import-floor membrane, or spread-selection changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin ordinary generator term and assign steps to succeed on desugar
> Updates tests in [test_generator_context_manager_construction.py](https://github.com/TSavo/sugar/pull/6837/files#diff-94e55387dc77922abd716e297c564377f0ce63e91fa8966cbf7a8c9c13e83402) to reflect that call expressions and simple name bindings before a yield are now recognized as explicit `TermStep` and `AssignStep` respectively, rather than opaque transitions that raise `SugarNotWritten`.
>
> - `test_term_step_executes_a_call_expression_before_yield`: now asserts `desugar()` returns a `Complete` outcome with the first statement equating `enter_result_value` to `7`, instead of expecting a `SugarNotWritten` exception.
> - `test_assign_step_executes_a_name_binding_before_yield`: same change — simple name bindings now succeed on `desugar()`.
> - `test_assign_step_refuses_an_unowned_attribute_binding`: new test asserting that attribute assignments (not producer-owned) still raise `SugarNotWritten` matching `'opaque generator transition: Assign'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 562484e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->