### PR TITLE
Authenticate bytes literal call construction

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bytes_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bytes_literal_sugar.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.floor.bytes_value import BytesValue
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
 @dataclass(frozen=True)
-class BytesLiteralSugar(Sugar):
+class BytesLiteralSugar(ConstructedTermSugar):
     """A `bytes` literal (`b"..."`). A leaf: it holds its value and no child
     sugars, and it desugars to the BytesValue floor -- which stands as the
     vendor-canonical ``python:bytes(<hex String const>)`` term already
@@ -32,3 +32,15 @@ class BytesLiteralSugar(Sugar):
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx  # the bytes stand as a floor value
         return Complete(BytesValue(self.value))
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:bytes-literal-construction",
+            (
+                self.occurrence_term(owner=owner),
+                BytesValue(self.value).to_term(owner=owner),
+            ),
+            symbol_kind="coordinate",
+        )

--- a/implementations/python/sugar-source-tree/tests/test_constant_kinds.py
+++ b/implementations/python/sugar-source-tree/tests/test_constant_kinds.py
@@ -8,9 +8,14 @@ whitelist and fold table, so it lifts too -- this is not a new vocabulary
 decision, it mirrors vocabulary already agreed elsewhere in the kit.
 """
 
+from dataclasses import replace
 import tempfile
 
+import pytest
+
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.sugar.bytes_literal_sugar import BytesLiteralSugar
+from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
 from sugar_source_tree.tree import SourceFile
 
 
@@ -37,6 +42,29 @@ def test_bytes_literal_discriminates_on_content():
     ab = _return_value('def A():\n    return b"ab"\n')
     ac = _return_value('def A():\n    return b"ac"\n')
     assert ab != ac
+
+
+def test_bytes_literal_is_an_authenticated_call_operand():
+    function = _fn('def A():\n    return sink(b"ab")\n')
+    call = next(node for node in function.walk() if node.kind == "Call")
+
+    constructed = call.sugar()
+
+    assert isinstance(constructed, CallSiteSugar)
+    assert isinstance(constructed.args[0], BytesLiteralSugar)
+    constructed.args[0].to_term(owner="bytes call operand")
+    with pytest.raises(
+        TypeError,
+        match="requires an authenticated source occurrence for BytesLiteralSugar",
+    ):
+        replace(constructed.args[0], site=object()).to_term(owner="foreign bytes")
+
+    integer_call = next(
+        node
+        for node in _fn("def A():\n    return sink(1)\n").walk()
+        if node.kind == "Call"
+    )
+    assert isinstance(integer_call.sugar(), CallSiteSugar)
 
 
 def test_ellipsis_literal_lifts_to_canonical_py_ellipsis_term():


### PR DESCRIPTION
## Capability

Promotes `BytesLiteralSugar` through the canonical `ConstructedTermSugar` door. `sink(b"ab")` now carries the exact bytes occurrence and the existing canonical `python:bytes` value into call construction.

## Instrument

The truthful bytes-call arm and existing integer-call arm construct; replacing the bytes occurrence with an unauthenticated object refuses.

R_bytes_constructed_term: 1 -> 0.

## Receipt

`bin/bpytest implementations/python/sugar-source-tree/tests/test_constant_kinds.py -q` — 6 passed.

## Floors

No Attribute assignment, import-floor, spread-selection, Carrier, ExitSet, Halted, or Floor changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate bytes literal call construction in `BytesLiteralSugar`
> - Changes `BytesLiteralSugar` base class from `Sugar` to `ConstructedTermSugar` and adds a `to_term` method that produces a coordinate term named `python:bytes-literal-construction`.
> - Adds tests asserting that a bytes literal argument to a call sugars to `CallSiteSugar` with a `BytesLiteralSugar` argument, that `to_term` succeeds when authenticated, and that a foreign site raises `TypeError`.
> - Risk: `to_term` raises if the instance lacks an authenticated source occurrence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ec96fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->