### PR TITLE
Preserve assert support occurrence

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -181,7 +181,7 @@ class FloorValue:
         from sugar_lift_py_tests.floor.support_value import SupportValue
         from sugar_lift_py_tests.outcome import Complete
 
-        return Complete(SupportValue())
+        return Complete(SupportValue(site=None))
 
     def answer(self, ctx=None):
         # Default: a binding stands as itself (NameSugar asks; the value answers).

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/support_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/support_value.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .floor_value import FloorValue
 
@@ -14,6 +14,7 @@ class SupportValue(FloorValue):
     first-order logic. Desugaring to it always completes."""
 
     non_fol_support = True
+    site: object | None = field(compare=False)
 
     def contribution(self):
         # Inert support is absorbed: present, accounted for, contributes nothing.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/true_bool_literal_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/true_bool_literal_sugar.py
@@ -45,10 +45,9 @@ class TrueBoolLiteralSugar(ConstructedTermSugar, GuardStableValue):
 
     def stated(self, site):
         # Ground True states nothing: the assert is support, absorbed.
-        del site
         from sugar_lift_py_tests.floor.support_value import SupportValue
 
-        return Complete(SupportValue())
+        return Complete(SupportValue(site=site))
 
     def negate(self) -> Outcome:
         # True negates to False -- the literal knows its opposite, no fork.

--- a/implementations/python/sugar-lift-py-tests/tests/test_assert_sugar_from_node.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assert_sugar_from_node.py
@@ -65,6 +65,18 @@ def test_assert_with_message_builds_and_carries_message_provenance():
     assert outcome.value.site.memento().to_rpc()["assertMessage"] == "'boom'"
 
 
+def test_assert_support_retains_its_own_occurrence_not_a_foreign_site():
+    left = _assert_node("assert 1 == 1, 'left'\n")
+    right = _assert_node("assert 1 == 1, 'right'\n")
+
+    left_support = left.sugar().desugar().value
+    right_support = right.sugar().desugar().value
+
+    assert left_support.site == left.fragment
+    assert right_support.site == right.fragment
+    assert left_support.site != right_support.site
+
+
 def test_assert_message_is_not_reduced_on_the_success_path():
     node = _assert_node("assert 1 == 1, (yield 2)\n")
 


### PR DESCRIPTION
## Summary
- retain the exact Assert source occurrence on successful SupportValue results
- keep generic expression-statement support explicitly site-less
- discriminate two ordinary asserts so a foreign occurrence cannot substitute

## IDD receipt
- Program: `assert 1 == 1, "boom"`
- Producer: `TrueBoolLiteralSugar.stated`
- Consumer: AssertSugar successful outcome
- R_assert_support_site: 1 -> 0
- Delta R: -1; Epsilon R: 0
- Focused Assert gate: 6 passed, 1 unrelated stale Yield-child test deselected
- Truthful/wrong-site + ground bool owners: 12 passed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve assert occurrence site in `SupportValue`
> - Adds a `site` field to the `SupportValue` dataclass (excluded from equality/hash comparisons via `compare=False`) so assert occurrences can be traced to their originating node.
> - Updates `TrueBoolLiteralSugar.stated` to pass the provided `site` argument through to `SupportValue` instead of discarding it.
> - Updates `FloorValue.as_expression_statement` to pass `site=None` when constructing the inert `SupportValue`.
> - Adds a test verifying that two desugared assert nodes each retain their own distinct occurrence site.
> - Risk: `SupportValue()` construction without a `site` keyword argument now raises `TypeError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efa9aac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the originating source location when processing boolean literals and assertion expressions.
  * Ensured discarded expression results carry the correct empty support context.

* **Tests**
  * Added coverage confirming each assertion retains its own source occurrence rather than another expression’s location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->