### PR TITLE
Execute generator attribute assignment steps

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -180,6 +180,35 @@ class AssignStepV1:
 
 
 @dataclass(frozen=True)
+class AttributeAssignStepV1:
+    """Authenticated generator assignment to one source Attribute target."""
+
+    receiver: ConstructedTermSugar
+    attr: str
+    value: ConstructedTermSugar
+    fragment_cid: str
+    target_cid: str
+    occurrence: object = field(compare=False, repr=False)
+
+    def __post_init__(self) -> None:
+        _require_constructed_term(
+            self.receiver, owner="AttributeAssignStepV1.receiver"
+        )
+        _require_constructed_term(self.value, owner="AttributeAssignStepV1.value")
+        try:
+            observed_target_cid = self.occurrence.seal().cid
+        except (AttributeError, TypeError) as exc:
+            raise TypeError(
+                "AttributeAssignStepV1 requires an authenticated target occurrence"
+            ) from exc
+        if observed_target_cid != self.target_cid:
+            raise TypeError(
+                "AttributeAssignStepV1 target occurrence does not match its "
+                "authenticated target CID"
+            )
+
+
+@dataclass(frozen=True)
 class FinallyStepV1:
     """Cleanup suite as ConstructedTermSugar payloads only.
 
@@ -369,6 +398,7 @@ GeneratorStepV1 = (
     | OpaqueStepV1
     | InertStepV1
     | AssignStepV1
+    | AttributeAssignStepV1
     | FinallyStepV1
     | ForStepV1
     | RaiseStepV1
@@ -494,6 +524,15 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
             "kind": "assign",
             "name": step.name,
             "fragmentCid": step.fragment_cid,
+            "value": _generator_value_testimony(step.value, owner=owner),
+        }
+    if isinstance(step, AttributeAssignStepV1):
+        return {
+            "kind": "attribute-assign",
+            "attr": step.attr,
+            "fragmentCid": step.fragment_cid,
+            "targetCid": step.target_cid,
+            "receiver": _generator_value_testimony(step.receiver, owner=owner),
             "value": _generator_value_testimony(step.value, owner=owner),
         }
     if isinstance(step, FinallyStepV1):
@@ -860,6 +899,26 @@ class GeneratorConstructionV1:
                 cursor=self.cursor + 1,
                 binding_state=(*self.binding_state, binding),
             )
+            return machine._transition(requested)
+        if isinstance(step, AttributeAssignStepV1):
+            from sugar_lift_py_tests.outcome import Complete, Incomplete
+            from sugar_lift_py_tests.sugar.store_effect_sugar import (
+                AttributeStoreEffectSugar,
+            )
+
+            outcome = AttributeStoreEffectSugar(
+                receiver=step.receiver,
+                value=step.value,
+                attr=step.attr,
+                site=step.occurrence,
+            ).desugar(self._guard_evaluation_context())
+            if isinstance(outcome, Incomplete):
+                return ExitSet.halted(outcome.effect, state=self)
+            if not isinstance(outcome, Complete):
+                return self._gap(
+                    requested, f"attribute store returned {type(outcome).__name__}"
+                )
+            machine = replace(self, cursor=self.cursor + 1)
             return machine._transition(requested)
         if isinstance(step, RaiseStepV1):
             from sugar_lift_py_tests.outcome import Incomplete

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_assign_execution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_assign_execution.py
@@ -7,27 +7,103 @@ content-stable testimony.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field, replace
+from pathlib import Path
 import tempfile
+
+import pytest
 
 from sugar_lift_py_tests.floor import NoneValue, TermValue
 from sugar_lift_py_tests.generator_construction import (
     AssignStepV1,
+    AttributeAssignStepV1,
     GeneratorAssignBindingV1,
     GeneratorConstructionV1,
     YieldEffect,
     YieldStepV1,
 )
+from sugar_lift_py_tests.outcome import Complete, Halted
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_python_source.canonical import cid_of_json
-from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.tree import SourceFile
 
 
 def _steps(source: str):
-    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".py", delete=False, dir=Path.cwd()
+    ) as handle:
         handle.write(source)
         path = handle.name
-    function = next(SourceFile(path_source(path)).functions())
+    function = next(
+        SourceFile(workspace_path_source(path, root=str(Path.cwd()))).functions()
+    )
     return function._source_visible_generator_steps_from(function.body)
+
+
+@dataclass(frozen=True)
+class _CountingValue(ConstructedTermSugar):
+    value: object
+    label: str
+    events: list[str] = field(compare=False, repr=False)
+    site: object = field(compare=False, repr=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        self.events.append(self.label)
+        return Complete(self.value)
+
+    def to_term(self, *, owner: str):
+        return self.value.to_term(owner=owner)
+
+
+def test_generator_attribute_assign_executes_once_at_exact_target_occurrence():
+    steps = _steps(
+        "def g(holder):\n"
+        "    holder.hidden = True\n"
+        "    yield holder\n"
+    )
+    assign = steps[0]
+    assert isinstance(assign, AttributeAssignStepV1)
+    assert assign.attr == "hidden"
+    assert assign.occurrence.seal().cid == assign.target_cid
+
+    events: list[str] = []
+    instrumented = replace(
+        assign,
+        value=_CountingValue(NoneValue(), "rhs", events, assign.value.site),
+        receiver=_CountingValue(NoneValue(), "target", events, assign.receiver.site),
+    )
+    outcome = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:attribute-assign",
+        frame_coordinate="frame:attribute-assign",
+        binding_state=(),
+        steps=(instrumented,),
+    ).resume()
+    assert events == ["rhs", "target"]
+    assert len(outcome.exits) == 1
+    assert isinstance(outcome.exits[0], Halted)
+
+
+def test_generator_attribute_assign_rejects_foreign_target_occurrence():
+    truthful = _steps(
+        "def g(holder):\n"
+        "    holder.hidden = True\n"
+        "    yield holder\n"
+    )[0]
+    foreign = _steps(
+        "def h(other):\n"
+        "    other.hidden = True\n"
+        "    yield other\n"
+    )[0]
+    assert isinstance(truthful, AttributeAssignStepV1)
+    assert isinstance(foreign, AttributeAssignStepV1)
+    with pytest.raises(TypeError, match="target occurrence does not match"):
+        replace(truthful, occurrence=foreign.occurrence)
 
 
 def test_config_setter_pre_yield_assign_executes_before_yield():

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2859,6 +2859,7 @@ class FunctionDef(Statement):
             return None
         from sugar_lift_py_tests.generator_construction import (
             AssignStepV1,
+            AttributeAssignStepV1,
             FinallyStepV1,
             ForStepV1,
             IfStepV1,
@@ -2954,6 +2955,23 @@ class FunctionDef(Statement):
                         statement.targets[0].id,
                         statement.value.sugar(),
                         statement.fragment.seal().cid,
+                    )
+                )
+            if (
+                isinstance(statement, Assign)
+                and not self._owns_yield((statement,))
+                and len(statement.targets) == 1
+                and isinstance(statement.targets[0], Attribute)
+            ):
+                target = statement.targets[0]
+                return _GeneratorNamedStepV1(
+                    AttributeAssignStepV1(
+                        receiver=target.value.sugar(),
+                        attr=target.attr,
+                        value=statement.value.sugar(),
+                        fragment_cid=statement.fragment.seal().cid,
+                        target_cid=target.fragment.seal().cid,
+                        occurrence=target.fragment,
                     )
                 )
             if (


### PR DESCRIPTION
R_generator_attribute_assign: 1 -> 0 (predicted/observed focused semantic drain).

Ordinary source `holder.hidden = True` now constructs an authenticated AttributeAssignStepV1. Execution evaluates RHS then target exactly once and dispatches through the existing AttributeStoreEffectSugar. The step retains the exact target occurrence and rejects a foreign-site twin.

Focused receipt: `bin/bpytest -q implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_assign_execution.py` => 7 passed in 1.31s under authenticated CPython 3.12.13.

Scope: three files; no Floor implementation edits and no mutation Floor campaign.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Execute generator attribute assignment steps in the generator machine
> - Adds `AttributeAssignStepV1`, a frozen dataclass representing an authenticated pre-yield attribute assignment step, with validation that the occurrence's `seal().cid` matches `target_cid`.
> - Extends `GeneratorConstructionV1.transition` to execute `AttributeAssignStepV1` by constructing an `AttributeStoreEffectSugar`, desugaring it, and either halting with the effect or advancing the cursor on completion.
> - Extends `FunctionDef._source_visible_generator_steps_from` in [nodes.py](https://github.com/TSavo/sugar/pull/6840/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to emit `AttributeAssignStepV1` for simple pre-yield attribute assignments instead of falling through unhandled.
> - Adds serialization support for `AttributeAssignStepV1` in `_generator_step_testimony`, emitting `kind: 'attribute-assign'` with authenticated fragment and target CIDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdcb3dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->