### PR TITLE
Ground literal-true while recurrence guards

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -302,8 +302,12 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
         exhaustion_guard = atomic("python.loop.exhausted", [str_const(target_cid)])
         operation_kind = "ForNext"
     else:
-        test_guard = branch_result_guard(
-            branch_result_slot(loop.test), loop.test.fragment
+        test_guard = (
+            and_([])
+            if loop._ground_truth(loop.test) is True
+            else branch_result_guard(
+                branch_result_slot(loop.test), loop.test.fragment
+            )
         )
         exhaustion_guard = not_(test_guard)
         true_guard = test_guard

--- a/implementations/python/sugar-source-tree/tests/test_while_return_else_source_visible.py
+++ b/implementations/python/sugar-source-tree/tests/test_while_return_else_source_visible.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from sugar_lift_py_tests.floor import BlockValue, ReturnValue
+from sugar_lift_py_tests.outcome import Complete, ExitSet
+from sugar_source_tree.tree import SourceFile
+
+
+def _outcome(tmp_path, source: str):
+    path = tmp_path / "while_return_else.py"
+    path.write_text(source, encoding="utf-8")
+    function = next(SourceFile.from_path(path).functions())
+    return function.sugar().desugar()
+
+
+def test_unconditional_while_return_has_no_fabricated_else_face(tmp_path) -> None:
+    outcome = _outcome(
+        tmp_path,
+        "def choose():\n"
+        "    while True:\n"
+        "        return 7\n"
+        "    else:\n"
+        "        return 9\n",
+    )
+
+    assert isinstance(outcome, Complete), outcome
+    assert isinstance(outcome.value.record, BlockValue)
+    returns = tuple(
+        entry
+        for entry in outcome.value.record.statements
+        if isinstance(entry, ReturnValue)
+    )
+    assert len(returns) == 1
+    assert returns[0].value.value == 7
+
+
+def test_symbolic_while_retains_distinct_return_and_else_faces(tmp_path) -> None:
+    outcome = _outcome(
+        tmp_path,
+        "def choose(condition):\n"
+        "    while condition:\n"
+        "        return 7\n"
+        "    else:\n"
+        "        return 9\n",
+    )
+
+    assert isinstance(outcome, ExitSet), outcome
+    assert len(outcome.exits) == 2


### PR DESCRIPTION
## What changed

- Ground authenticated literal-true `while` test guards at live recurrence construction.
- Preserve symbolic tests as complementary return/exhaustion alternatives.
- Add ordinary `SourceFile.from_path` truthful and discrimination coverage.

## Why

The live loop producer reconstructed every while condition as a symbolic branch-result guard. For `while True`, that made the unconditional return non-total and fabricated an else completion.

## Measured result

- `R_while_return_else`: 2 -> 0
- `Delta R`: -2
- `Epsilon R`: 0

## Checks

- `bin/bpytest implementations/python/sugar-source-tree/tests/test_while_return_else_source_visible.py -q --tb=short` — 2 passed
- Full sugar-source-tree suite launched as post-shot telemetry.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ground literal-true `while` loop guards to eliminate NormalExhaustion path
> - In `construct_live_loop_recurrence`, the While-branch now checks `loop._ground_truth(loop.test)` before computing `test_guard`: when the condition is always true, `test_guard` is set to `and([])` (logically true) instead of a branch-result guard.
> - As a result, `exhaustion_guard` becomes logically false and the `NormalExhaustion` exit is removed from the completed specs for unconditional `while True` loops.
> - New tests in [`test_while_return_else_source_visible.py`](https://github.com/TSavo/sugar/pull/6841/files#diff-aa264081627c1b3d34158e5e77f3456d7737e5538f7b1b105b5ddd6941354a88) verify that `while True` with a return has no else exit, while a symbolic condition retains both return and else exits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9e0b45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->