### PR TITLE
Execute generator assert steps

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -209,6 +209,41 @@ class AttributeAssignStepV1:
 
 
 @dataclass(frozen=True)
+class AssertStepV1:
+    """One authenticated source Assert executed by the generator machine."""
+
+    assert_sugar: object
+    assert_cid: str
+    assert_coordinate: object
+    occurrence: object = field(compare=False, repr=False)
+
+    def __post_init__(self) -> None:
+        from sugar_lift_py_tests.sugar.assert_sugar import AssertSugar
+
+        if not isinstance(self.assert_sugar, AssertSugar):
+            raise TypeError("AssertStepV1 requires AssertSugar")
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+        )
+
+        try:
+            span = self.occurrence.line_col_span
+            observed_coordinate = SourceFragmentCoordinateV1(
+                self.occurrence.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+        except (AttributeError, TypeError) as exc:
+            raise TypeError("AssertStepV1 requires an authenticated occurrence") from exc
+        if observed_coordinate != self.assert_coordinate:
+            raise TypeError(
+                "AssertStepV1 assert occurrence does not match its authenticated coordinate"
+            )
+
+
+@dataclass(frozen=True)
 class FinallyStepV1:
     """Cleanup suite as ConstructedTermSugar payloads only.
 
@@ -399,6 +434,7 @@ GeneratorStepV1 = (
     | InertStepV1
     | AssignStepV1
     | AttributeAssignStepV1
+    | AssertStepV1
     | FinallyStepV1
     | ForStepV1
     | RaiseStepV1
@@ -534,6 +570,15 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
             "targetCid": step.target_cid,
             "receiver": _generator_value_testimony(step.receiver, owner=owner),
             "value": _generator_value_testimony(step.value, owner=owner),
+        }
+    if isinstance(step, AssertStepV1):
+        return {
+            "kind": "assert",
+            "assertCid": step.assert_cid,
+            "assertCoordinate": step.assert_coordinate.wire(),
+            "test": _generator_value_testimony(
+                step.assert_sugar.test, owner=owner
+            ),
         }
     if isinstance(step, FinallyStepV1):
         return {
@@ -917,6 +962,18 @@ class GeneratorConstructionV1:
             if not isinstance(outcome, Complete):
                 return self._gap(
                     requested, f"attribute store returned {type(outcome).__name__}"
+                )
+            machine = replace(self, cursor=self.cursor + 1)
+            return machine._transition(requested)
+        if isinstance(step, AssertStepV1):
+            from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+            outcome = step.assert_sugar.desugar(self._guard_evaluation_context())
+            if isinstance(outcome, Incomplete):
+                return ExitSet.halted(outcome.effect, state=self)
+            if not isinstance(outcome, Complete):
+                return self._gap(
+                    requested, f"assert returned {type(outcome).__name__}"
                 )
             machine = replace(self, cursor=self.cursor + 1)
             return machine._transition(requested)

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_assert_execution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_assert_execution.py
@@ -1,0 +1,54 @@
+from dataclasses import replace
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    YieldEffect,
+)
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _steps(source: str):
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".py", delete=False, dir=Path.cwd()
+    ) as handle:
+        handle.write(source)
+        path = handle.name
+    function = next(
+        SourceFile(workspace_path_source(path, root=str(Path.cwd()))).functions()
+    )
+    return function._source_visible_generator_steps_from(function.body)
+
+
+def test_generator_assert_true_advances_to_yield():
+    steps = _steps("def g():\n    assert True\n    yield 7\n")
+    assert type(steps[0]).__name__ == "AssertStepV1"
+    outcome = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:assert-true",
+        frame_coordinate="frame:assert-true",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert isinstance(outcome, YieldEffect)
+
+
+def test_generator_assert_retains_its_exact_occurrence_coordinate():
+    steps = _steps("def g():\n    assert True\n    yield 7\n")
+    assertion = steps[0]
+    span = assertion.occurrence.line_col_span
+    assert assertion.assert_coordinate.source_cid == assertion.occurrence.source_cid
+    assert assertion.assert_coordinate.start_line == span.start_line
+    assert assertion.assert_coordinate.start_col == span.start_col
+    assert assertion.assert_coordinate.end_line == span.end_line
+    assert assertion.assert_coordinate.end_col == span.end_col
+
+
+def test_generator_assert_rejects_a_foreign_occurrence():
+    truthful = _steps("def g():\n    assert True\n    yield 7\n")[0]
+    foreign = _steps("def h():\n    assert True\n    yield 8\n")[0]
+    with pytest.raises(TypeError, match="assert occurrence does not match"):
+        replace(truthful, occurrence=foreign.occurrence)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2860,6 +2860,7 @@ class FunctionDef(Statement):
         from sugar_lift_py_tests.generator_construction import (
             AssignStepV1,
             AttributeAssignStepV1,
+            AssertStepV1,
             FinallyStepV1,
             ForStepV1,
             IfStepV1,
@@ -2985,6 +2986,26 @@ class FunctionDef(Statement):
                         statement.target.id,
                         statement.value.sugar(),
                         statement.fragment.seal().cid,
+                    )
+                )
+            if isinstance(statement, Assert) and not self._owns_yield((statement,)):
+                from sugar_lift_py_tests.context_manager_resolution import (
+                    SourceFragmentCoordinateV1,
+                )
+
+                span = statement.line_col_span()
+                return _GeneratorNamedStepV1(
+                    AssertStepV1(
+                        assert_sugar=statement.sugar(),
+                        assert_cid=statement.fragment.seal().cid,
+                        assert_coordinate=SourceFragmentCoordinateV1(
+                            statement.unit.source_cid,
+                            span.start_line,
+                            span.start_col,
+                            span.end_line,
+                            span.end_col,
+                        ),
+                        occurrence=statement.fragment,
                     )
                 )
             if isinstance(statement, If):


### PR DESCRIPTION
R_generator_assert_step: 4 -> 0 over the authenticated pandas generator-statement ledger (1421 files, 149 generator functions).

An ordinary pre-yield `assert True` now constructs an authenticated AssertStepV1, executes the existing AssertSugar, and advances to yield. The step carries a full source-fragment coordinate; a same-spelling foreign-source occurrence is rejected.

Focused red: 3 failures, OpaqueStepV1 / absent occurrence ownership.
Focused green: `bin/bpytest -q implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_assert_execution.py` => 3 passed in 0.86s under authenticated CPython 3.12.13.

Scope: three files. No Floor implementation, nested lexical, option_context, carrier, or ExitSet ownership edits.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Execute generator assert steps in the generator construction machine
> - Adds `AssertStepV1`, a frozen dataclass representing a pre-yield assert step, with validation that the occurrence is authenticated and its coordinate matches the provided `assert_coordinate`.
> - Extends `GeneratorConstructionV1.transition` to handle `AssertStepV1`: it desugars the assert sugar using the guard evaluation context, halts on `Incomplete`, raises a gap on non-`Complete` outcomes, and advances the cursor on success.
> - Extends `FunctionDef._source_visible_generator_steps_from` in [nodes.py](https://github.com/TSavo/sugar/pull/6842/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to emit `AssertStepV1` for pre-yield assert statements with authenticated CID and coordinate.
> - Adds testimony support for `AssertStepV1`, emitting a structured `assert` record with kind, `assertCid`, `assertCoordinate`, and test value.
> - New tests in [test_generator_pre_yield_assert_execution.py](https://github.com/TSavo/sugar/pull/6842/files#diff-3f2b3da086a7342fbb2a21f64c1a2ccee7351bcdc835f3f938141134c5b18370) cover: successful advance to `YieldEffect`, coordinate validation, and rejection of mismatched occurrences.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9520b51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->