### PR TITLE
Retain Assign target patterns across rewrites

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4332,7 +4332,10 @@ class Assign(Statement):
                 changes["targets"] = (new_target,)
         if not changes:
             return self
-        return rewrite(self, **changes)
+        rewritten = rewrite(self, **changes)
+        if self.unit.target_patterns_for(self):
+            self.unit.retain_target_patterns(self, rewritten)
+        return rewritten
 
     def _destructured_binding(self):
         # Destructure only an already-constructed Tuple/List display.  This is


### PR DESCRIPTION
## What changed

- Preserve the eager producer-owned TargetPattern row when Assign rewrites its RHS.
- Keep foreign consumer/target combinations loudly rejected.

## Root cause

`Assign.substitute` created a new exact consumer occurrence but, unlike the corresponding For rewrite seam, did not transfer the original producer-owned target-pattern testimony.

## Measured result

- `R_assign_target_pattern`: 1 -> 0
- `Delta R`: -1
- `Epsilon R`: 0

## Checks

- `bin/bpytest implementations/python/sugar-source-tree/tests/test_assign_targets.py implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py -q --tb=short` — 23 passed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retain target patterns on rewritten `Assign` nodes during substitution
> When `Assign.substitute` rewrites a node, it now calls `unit.retain_target_patterns(self, rewritten)` to carry forward any target pattern associations from the original node to the rewritten one. Previously, the rewritten node was returned directly, losing those associations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5b983c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->