### PR TITLE
Execute generator import-from steps

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -244,6 +244,42 @@ class AssertStepV1:
 
 
 @dataclass(frozen=True)
+class ImportFromStepV1:
+    """Authenticated source import-from statement with inert meaning."""
+
+    import_sugar: object
+    coordinate: object
+    occurrence: object = field(compare=False, repr=False)
+
+    def __post_init__(self) -> None:
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+        )
+        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+        if not isinstance(self.import_sugar, InertSugar):
+            raise TypeError("ImportFromStepV1 requires InertSugar")
+        try:
+            span = self.occurrence.line_col_span
+            observed = SourceFragmentCoordinateV1(
+                self.occurrence.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+        except (AttributeError, TypeError) as exc:
+            raise TypeError(
+                "ImportFromStepV1 requires an authenticated import occurrence"
+            ) from exc
+        if observed != self.coordinate:
+            raise TypeError(
+                "ImportFromStepV1 import occurrence does not match its "
+                "authenticated coordinate"
+            )
+
+
+@dataclass(frozen=True)
 class FinallyStepV1:
     """Cleanup suite as ConstructedTermSugar payloads only.
 
@@ -435,6 +471,7 @@ GeneratorStepV1 = (
     | AssignStepV1
     | AttributeAssignStepV1
     | AssertStepV1
+    | ImportFromStepV1
     | FinallyStepV1
     | ForStepV1
     | RaiseStepV1
@@ -579,6 +616,11 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
             "test": _generator_value_testimony(
                 step.assert_sugar.test, owner=owner
             ),
+        }
+    if isinstance(step, ImportFromStepV1):
+        return {
+            "kind": "import-from",
+            "coordinate": step.coordinate.wire(),
         }
     if isinstance(step, FinallyStepV1):
         return {
@@ -974,6 +1016,16 @@ class GeneratorConstructionV1:
             if not isinstance(outcome, Complete):
                 return self._gap(
                     requested, f"assert returned {type(outcome).__name__}"
+                )
+            machine = replace(self, cursor=self.cursor + 1)
+            return machine._transition(requested)
+        if isinstance(step, ImportFromStepV1):
+            from sugar_lift_py_tests.outcome import Complete
+
+            outcome = step.import_sugar.desugar(self._guard_evaluation_context())
+            if not isinstance(outcome, Complete):
+                return self._gap(
+                    requested, f"import-from returned {type(outcome).__name__}"
                 )
             machine = replace(self, cursor=self.cursor + 1)
             return machine._transition(requested)

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_importfrom_execution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_importfrom_execution.py
@@ -1,0 +1,57 @@
+from dataclasses import replace
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    YieldEffect,
+)
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _steps(source: str):
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".py", delete=False, dir=Path.cwd()
+    ) as handle:
+        handle.write(source)
+        path = handle.name
+    function = next(
+        SourceFile(workspace_path_source(path, root=str(Path.cwd()))).functions()
+    )
+    return function._source_visible_generator_steps_from(function.body)
+
+
+def test_generator_importfrom_advances_to_yield():
+    steps = _steps("def g():\n    from math import sqrt\n    yield 7\n")
+    assert type(steps[0]).__name__ == "ImportFromStepV1"
+    outcome = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:importfrom",
+        frame_coordinate="frame:importfrom",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert isinstance(outcome, YieldEffect)
+
+
+def test_generator_importfrom_retains_exact_occurrence():
+    step = _steps("def g():\n    from math import sqrt\n    yield 7\n")[0]
+    span = step.occurrence.line_col_span
+    assert step.coordinate.source_cid == step.occurrence.source_cid
+    assert (step.coordinate.start_line, step.coordinate.start_col) == (
+        span.start_line,
+        span.start_col,
+    )
+    assert (step.coordinate.end_line, step.coordinate.end_col) == (
+        span.end_line,
+        span.end_col,
+    )
+
+
+def test_generator_importfrom_rejects_foreign_occurrence():
+    truthful = _steps("def g():\n    from math import sqrt\n    yield 7\n")[0]
+    foreign = _steps("def h():\n    from math import sqrt\n    yield 8\n")[0]
+    with pytest.raises(TypeError, match="import occurrence does not match"):
+        replace(truthful, occurrence=foreign.occurrence)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2861,6 +2861,7 @@ class FunctionDef(Statement):
             AssignStepV1,
             AttributeAssignStepV1,
             AssertStepV1,
+            ImportFromStepV1,
             FinallyStepV1,
             ForStepV1,
             IfStepV1,
@@ -2991,6 +2992,25 @@ class FunctionDef(Statement):
             if isinstance(statement, Assert) and not self._owns_yield((statement,)):
                 from sugar_lift_py_tests.context_manager_resolution import (
                     SourceFragmentCoordinateV1,
+                )
+            if isinstance(statement, ImportFrom) and not self._owns_yield((statement,)):
+                from sugar_lift_py_tests.context_manager_resolution import (
+                    SourceFragmentCoordinateV1,
+                )
+
+                span = statement.line_col_span()
+                return _GeneratorNamedStepV1(
+                    ImportFromStepV1(
+                        import_sugar=statement.sugar(),
+                        coordinate=SourceFragmentCoordinateV1(
+                            statement.unit.source_cid,
+                            span.start_line,
+                            span.start_col,
+                            span.end_line,
+                            span.end_col,
+                        ),
+                        occurrence=statement.fragment,
+                    )
                 )
 
                 span = statement.line_col_span()


### PR DESCRIPTION
R_generator_importfrom_step: 7 -> 0 from the existing authenticated ledger; no post-gate recensus was run because nested/option owners remain active.

Ordinary pre-yield `from math import sqrt` now constructs an authenticated ImportFromStepV1 and executes the existing InertSugar before advancing. Full source coordinate is retained and a same-spelling foreign-source occurrence is rejected. No module/name resolution or lexical ownership is added.

Focused red: 3 failures (OpaqueStepV1 / missing occurrence). Focused green: `bin/bpytest -q implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_importfrom_execution.py` => 3 passed in 0.66s on authenticated CPython 3.12.13.

No Floor, nested lexical, option_context, carrier, or ExitSet ownership edits.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Execute generator import-from steps in the generator construction machine
> - Adds `ImportFromStepV1`, a frozen dataclass representing a pre-yield `from ... import ...` statement, and includes it in the `GeneratorStepV1` union type.
> - `GeneratorConstructionV1.transition` now handles `ImportFromStepV1` by desugaring the inert import sugar and advancing the cursor; non-`Complete` outcomes produce a transition gap.
> - `FunctionDef._source_visible_generator_steps_from` now emits an `ImportFromStepV1` for `ImportFrom` statements that appear before any yield, rather than skipping them.
> - Content-addressing via `_generator_step_testimony` returns `{'kind': 'import-from', 'coordinate': ...}` for the new step type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 251c896.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->