### PR TITLE
Execute generator import steps

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -280,6 +280,42 @@ class ImportFromStepV1:
 
 
 @dataclass(frozen=True)
+class ImportStepV1:
+    """Authenticated source import statement with inert meaning."""
+
+    import_sugar: object
+    coordinate: object
+    occurrence: object = field(compare=False, repr=False)
+
+    def __post_init__(self) -> None:
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+        )
+        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+        if not isinstance(self.import_sugar, InertSugar):
+            raise TypeError("ImportStepV1 requires InertSugar")
+        try:
+            span = self.occurrence.line_col_span
+            observed = SourceFragmentCoordinateV1(
+                self.occurrence.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+        except (AttributeError, TypeError) as exc:
+            raise TypeError(
+                "ImportStepV1 requires an authenticated import occurrence"
+            ) from exc
+        if observed != self.coordinate:
+            raise TypeError(
+                "ImportStepV1 import occurrence does not match its "
+                "authenticated coordinate"
+            )
+
+
+@dataclass(frozen=True)
 class FinallyStepV1:
     """Cleanup suite as ConstructedTermSugar payloads only.
 
@@ -472,6 +508,7 @@ GeneratorStepV1 = (
     | AttributeAssignStepV1
     | AssertStepV1
     | ImportFromStepV1
+    | ImportStepV1
     | FinallyStepV1
     | ForStepV1
     | RaiseStepV1
@@ -620,6 +657,11 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
     if isinstance(step, ImportFromStepV1):
         return {
             "kind": "import-from",
+            "coordinate": step.coordinate.wire(),
+        }
+    if isinstance(step, ImportStepV1):
+        return {
+            "kind": "import",
             "coordinate": step.coordinate.wire(),
         }
     if isinstance(step, FinallyStepV1):
@@ -1026,6 +1068,16 @@ class GeneratorConstructionV1:
             if not isinstance(outcome, Complete):
                 return self._gap(
                     requested, f"import-from returned {type(outcome).__name__}"
+                )
+            machine = replace(self, cursor=self.cursor + 1)
+            return machine._transition(requested)
+        if isinstance(step, ImportStepV1):
+            from sugar_lift_py_tests.outcome import Complete
+
+            outcome = step.import_sugar.desugar(self._guard_evaluation_context())
+            if not isinstance(outcome, Complete):
+                return self._gap(
+                    requested, f"import returned {type(outcome).__name__}"
                 )
             machine = replace(self, cursor=self.cursor + 1)
             return machine._transition(requested)

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_import_execution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_import_execution.py
@@ -1,0 +1,57 @@
+from dataclasses import replace
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    YieldEffect,
+)
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _steps(source: str):
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".py", delete=False, dir=Path.cwd()
+    ) as handle:
+        handle.write(source)
+        path = handle.name
+    function = next(
+        SourceFile(workspace_path_source(path, root=str(Path.cwd()))).functions()
+    )
+    return function._source_visible_generator_steps_from(function.body)
+
+
+def test_generator_import_advances_to_yield():
+    steps = _steps("def g():\n    import math\n    yield 7\n")
+    assert type(steps[0]).__name__ == "ImportStepV1"
+    outcome = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:import",
+        frame_coordinate="frame:import",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert isinstance(outcome, YieldEffect)
+
+
+def test_generator_import_retains_exact_occurrence():
+    step = _steps("def g():\n    import math\n    yield 7\n")[0]
+    span = step.occurrence.line_col_span
+    assert step.coordinate.source_cid == step.occurrence.source_cid
+    assert (step.coordinate.start_line, step.coordinate.start_col) == (
+        span.start_line,
+        span.start_col,
+    )
+    assert (step.coordinate.end_line, step.coordinate.end_col) == (
+        span.end_line,
+        span.end_col,
+    )
+
+
+def test_generator_import_rejects_foreign_occurrence():
+    truthful = _steps("def g():\n    import math\n    yield 7\n")[0]
+    foreign = _steps("def h():\n    import math\n    yield 8\n")[0]
+    with pytest.raises(TypeError, match="import occurrence does not match"):
+        replace(truthful, occurrence=foreign.occurrence)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2862,6 +2862,7 @@ class FunctionDef(Statement):
             AttributeAssignStepV1,
             AssertStepV1,
             ImportFromStepV1,
+            ImportStepV1,
             FinallyStepV1,
             ForStepV1,
             IfStepV1,
@@ -2996,6 +2997,25 @@ class FunctionDef(Statement):
             if isinstance(statement, ImportFrom) and not self._owns_yield((statement,)):
                 from sugar_lift_py_tests.context_manager_resolution import (
                     SourceFragmentCoordinateV1,
+                )
+            if isinstance(statement, Import) and not self._owns_yield((statement,)):
+                from sugar_lift_py_tests.context_manager_resolution import (
+                    SourceFragmentCoordinateV1,
+                )
+
+                span = statement.line_col_span()
+                return _GeneratorNamedStepV1(
+                    ImportStepV1(
+                        import_sugar=statement.sugar(),
+                        coordinate=SourceFragmentCoordinateV1(
+                            statement.unit.source_cid,
+                            span.start_line,
+                            span.start_col,
+                            span.end_line,
+                            span.end_col,
+                        ),
+                        occurrence=statement.fragment,
+                    )
                 )
 
                 span = statement.line_col_span()


### PR DESCRIPTION
R_generator_import_step: 2 -> 0 from the existing authenticated ledger. No recensus was run while shared gates remain active.

Ordinary pre-yield `import math` constructs an authenticated ImportStepV1 and executes the existing InertSugar before advancing. Full source coordinate is retained; same-spelling foreign-source occurrence is rejected. No module/name resolution or lexical ownership is added.

Focused red: 3 failures (OpaqueStepV1 / missing occurrence). Focused green: `bin/bpytest -q implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_import_execution.py` => 3 passed in 0.61s on authenticated CPython 3.12.13.

No Floor, nested lexical, option_context, carrier, or ExitSet ownership edits.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Execute plain `import` statements as generator steps pre-yield
> - Adds `ImportStepV1`, a new dataclass in [`generator_construction.py`](https://github.com/TSavo/sugar/pull/6845/files#diff-35db5b3e2bf70dbb9aa1b5a6d30899e84d402ab203905605799dbd5855b1f072) representing a plain `import` statement step, mirroring the existing `ImportFromStepV1`.
> - Extends `GeneratorConstructionV1.transition` to desugar and advance past `ImportStepV1` on a `Complete` outcome, or produce a transition gap for other outcomes.
> - Extends [`nodes.FunctionDef._source_visible_generator_steps_from`](https://github.com/TSavo/sugar/pull/6845/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to emit `ImportStepV1` for plain `import` statements encountered before the first yield.
> - Adds tests in [`test_generator_pre_yield_import_execution.py`](https://github.com/TSavo/sugar/pull/6845/files#diff-0495af2f3ea62ef6e78726b9dd51bbc16f6a38cad15326598fd6d23af5b18fc7) covering step production, cursor advancement, coordinate matching, and tampered-occurrence errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3e4d7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->