### PR TITLE
Restrict Assign pattern transport to RHS rewrites

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4399,7 +4399,7 @@ class Assign(Statement):
         if not changes:
             return self
         rewritten = rewrite(self, **changes)
-        if self.unit.target_patterns_for(self):
+        if "targets" not in changes and self.unit.target_patterns_for(self):
             self.unit.retain_target_patterns(self, rewritten)
         return rewritten
 

--- a/implementations/python/sugar-source-tree/tests/test_assign_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_targets.py
@@ -14,6 +14,7 @@ import pytest
 from sugar_lift_py_tests.effect import AttributeStoreRuntimeEffect
 from sugar_lift_py_tests.outcome import Incomplete
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree import nodes
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
@@ -212,6 +213,35 @@ def test_non_display_rhs_constructs_and_retains_its_arity_obligation():
     assert halted.state.entries == ()
     assert halted.state.fall_through == ()
     assert halted.state.transforms == ()
+
+
+def test_target_rewrite_does_not_carry_the_original_assign_pattern(monkeypatch):
+    function = _fn(
+        "def A(left, right):\n"
+        "    a, b = left\n"
+        "    c, d = right\n"
+    )
+    assignments = tuple(node for node in function.walk() if node.kind == "Assign")
+    original, foreign = assignments
+    original_pattern, = original.target_patterns
+    before = function.unit.target_pattern_construction_count
+
+    monkeypatch.setattr(
+        nodes,
+        "_substituted_unpack_store_leaves",
+        lambda statement, target, scope: foreign.targets[0],
+    )
+    rewritten = original.substitute({"left": foreign.value})
+
+    assert rewritten.targets[0].ref is foreign.targets[0].ref
+    assert rewritten.target_patterns == ()
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as refused:
+        function.unit.require_target_pattern(rewritten, rewritten.targets[0])
+    assert refused.value.reason == "foreign-target-occurrence"
+    assert refused.value.consumer_occurrence is rewritten
+    assert refused.value.target_occurrence is rewritten.targets[0]
+    assert original.target_patterns[0] is original_pattern
+    assert function.unit.target_pattern_construction_count == before
 
 
 def test_display_rhs_arity_mismatch_is_still_a_refusal_not_an_effect():


### PR DESCRIPTION
## Fix-forward

- Restrict Assign TargetPattern transport to RHS-only rewrites.
- Leave target-changing rewrites unseated so exact target ownership refuses loudly.
- Preserve the merged dynamic-unpack R1 -> 0 capability.

## Root cause

#6843 transferred the original product after every Assign rewrite. When the rewrite changed `targets`, the carried product still named the old target occurrence.

## Checks

- `bin/bpytest implementations/python/sugar-source-tree/tests/test_assign_targets.py implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py -q --tb=short` — 24 passed

## Delta

- `R_assign_pattern_bad_transport`: 1 -> 0
- Prior `R_assign_target_pattern`: remains 0


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict `Assign.substitute` target pattern retention to rewrites that leave targets unchanged
> Previously, `unit.retain_target_patterns` was called whenever target patterns existed for an `Assign` node, even if the rewrite changed its targets tuple. Now, retention is skipped when targets are modified, preventing rewritten `Assign` nodes from carrying stale target patterns. A new test in [test_assign_targets.py](https://github.com/TSavo/sugar/pull/6846/files#diff-91153c1ff8e699049c64744bb1af84de90ecb151910a727b2cab71174096e3cd) asserts that substituting an `Assign` with changed targets raises `TargetPatternConstructionGapV1` with reason `foreign-target-occurrence` when a target pattern is required.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc9d7cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->