### PR TITLE
Execute generator while steps

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -316,6 +316,42 @@ class ImportStepV1:
 
 
 @dataclass(frozen=True)
+class WhileStepV1:
+    """Authenticated generator while with a nameable body and no else."""
+
+    guard: ConstructedTermSugar
+    body_steps: tuple
+    fragment_cid: str
+    coordinate: object
+    occurrence: object = field(compare=False, repr=False)
+
+    def __post_init__(self) -> None:
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+        )
+
+        _require_constructed_term(self.guard, owner="WhileStepV1.guard")
+        try:
+            span = self.occurrence.line_col_span
+            observed = SourceFragmentCoordinateV1(
+                self.occurrence.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+        except (AttributeError, TypeError) as exc:
+            raise TypeError(
+                "WhileStepV1 requires an authenticated while occurrence"
+            ) from exc
+        if observed != self.coordinate:
+            raise TypeError(
+                "WhileStepV1 while occurrence does not match its "
+                "authenticated coordinate"
+            )
+
+
+@dataclass(frozen=True)
 class FinallyStepV1:
     """Cleanup suite as ConstructedTermSugar payloads only.
 
@@ -509,6 +545,7 @@ GeneratorStepV1 = (
     | AssertStepV1
     | ImportFromStepV1
     | ImportStepV1
+    | WhileStepV1
     | FinallyStepV1
     | ForStepV1
     | RaiseStepV1
@@ -663,6 +700,17 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
         return {
             "kind": "import",
             "coordinate": step.coordinate.wire(),
+        }
+    if isinstance(step, WhileStepV1):
+        return {
+            "kind": "while",
+            "fragmentCid": step.fragment_cid,
+            "coordinate": step.coordinate.wire(),
+            "guard": _generator_value_testimony(step.guard, owner=owner),
+            "bodySteps": [
+                _generator_step_testimony(item, owner=owner)
+                for item in step.body_steps
+            ],
         }
     if isinstance(step, FinallyStepV1):
         return {
@@ -1081,6 +1129,21 @@ class GeneratorConstructionV1:
                 )
             machine = replace(self, cursor=self.cursor + 1)
             return machine._transition(requested)
+        if isinstance(step, WhileStepV1):
+            from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+            guard_outcome = self._guard_truth(step.guard)
+            if isinstance(guard_outcome, Incomplete):
+                return ExitSet.halted(guard_outcome.effect, state=self)
+            if not isinstance(guard_outcome, Complete):
+                return self._gap(requested, "While guard is not ground")
+            decided = self._decide_guard(guard_outcome.value)
+            if decided is False:
+                machine = replace(self, cursor=self.cursor + 1)
+                return machine._transition(requested)
+            if decided is True:
+                return self._spliced((*step.body_steps, step))._transition(requested)
+            return self._gap(requested, "While guard is not ground")
         if isinstance(step, RaiseStepV1):
             from sugar_lift_py_tests.outcome import Incomplete
 

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_while_execution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_while_execution.py
@@ -1,0 +1,57 @@
+from dataclasses import replace
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from sugar_lift_py_tests.generator_construction import (
+    GeneratorConstructionV1,
+    YieldEffect,
+)
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _steps(source: str):
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".py", delete=False, dir=Path.cwd()
+    ) as handle:
+        handle.write(source)
+        path = handle.name
+    function = next(
+        SourceFile(workspace_path_source(path, root=str(Path.cwd()))).functions()
+    )
+    return function._source_visible_generator_steps_from(function.body)
+
+
+def test_generator_false_while_advances_to_yield():
+    steps = _steps("def g():\n    while False:\n        pass\n    yield 7\n")
+    assert type(steps[0]).__name__ == "WhileStepV1"
+    outcome = GeneratorConstructionV1.allocate(
+        allocation_coordinate="enter:while",
+        frame_coordinate="frame:while",
+        binding_state=(),
+        steps=steps,
+    ).resume()
+    assert isinstance(outcome, YieldEffect)
+
+
+def test_generator_while_retains_exact_occurrence():
+    step = _steps("def g():\n    while False:\n        pass\n    yield 7\n")[0]
+    span = step.occurrence.line_col_span
+    assert step.coordinate.source_cid == step.occurrence.source_cid
+    assert (step.coordinate.start_line, step.coordinate.start_col) == (
+        span.start_line,
+        span.start_col,
+    )
+    assert (step.coordinate.end_line, step.coordinate.end_col) == (
+        span.end_line,
+        span.end_col,
+    )
+
+
+def test_generator_while_rejects_foreign_occurrence():
+    truthful = _steps("def g():\n    while False:\n        pass\n    yield 7\n")[0]
+    foreign = _steps("def h():\n    while False:\n        pass\n    yield 8\n")[0]
+    with pytest.raises(TypeError, match="while occurrence does not match"):
+        replace(truthful, occurrence=foreign.occurrence)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2863,6 +2863,7 @@ class FunctionDef(Statement):
             AssertStepV1,
             ImportFromStepV1,
             ImportStepV1,
+            WhileStepV1,
             FinallyStepV1,
             ForStepV1,
             IfStepV1,
@@ -3001,6 +3002,31 @@ class FunctionDef(Statement):
             if isinstance(statement, Import) and not self._owns_yield((statement,)):
                 from sugar_lift_py_tests.context_manager_resolution import (
                     SourceFragmentCoordinateV1,
+                )
+            if isinstance(statement, While) and not statement.orelse:
+                from sugar_lift_py_tests.context_manager_resolution import (
+                    SourceFragmentCoordinateV1,
+                )
+
+                body_steps = branch_steps(statement.body)
+                guard = statement.test.sugar()
+                if body_steps is None or not isinstance(guard, ConstructedTermSugar):
+                    return absent_step
+                span = statement.line_col_span()
+                return _GeneratorNamedStepV1(
+                    WhileStepV1(
+                        guard=guard,
+                        body_steps=body_steps,
+                        fragment_cid=statement.fragment.seal().cid,
+                        coordinate=SourceFragmentCoordinateV1(
+                            statement.unit.source_cid,
+                            span.start_line,
+                            span.start_col,
+                            span.end_line,
+                            span.end_col,
+                        ),
+                        occurrence=statement.fragment,
+                    )
                 )
 
                 span = statement.line_col_span()


### PR DESCRIPTION
R_generator_while_step: 3 -> 0 for authenticated step construction from the existing ledger; no recensus while shared gates remain active.

A no-else generator `while` with a fully nameable body now constructs WhileStepV1. Ground false advances; ground true splices the body and the same authenticated step for re-evaluation. Symbolic guard truth stays a loud transition gap. Full source coordinate is retained and a foreign-source occurrence is rejected.

Focused red: 3 failures (OpaqueStepV1 / missing occurrence). Focused green: `bin/bpytest -q implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_while_execution.py` => 3 passed in 0.81s on authenticated CPython 3.12.13.

No lexical, option_context, TargetPattern, Floor, carrier, or ExitSet ownership edits.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Execute generator while steps in `GeneratorConstructionV1`
> - Adds a `WhileStepV1` dataclass to represent authenticated while-loop steps in a generator, with validation that the occurrence's coordinates match the provided `SourceFragmentCoordinateV1`.
> - Extends `GeneratorStepV1` and `_generator_step_testimony` to support `WhileStepV1`, enabling serialization of while steps alongside other step kinds.
> - Implements execution semantics in `GeneratorConstructionV1.transition`: an incomplete guard halts the generator, a false guard advances to the next step, and a true guard splices the body steps followed by the while step back onto the instruction stream to loop.
> - Adds `WhileStepV1` construction in `FunctionDef._source_visible_generator_steps_from` for while-loops without an `else` clause.
> - Behavioral Change: generators containing while loops will now execute loop semantics rather than skipping or erroring; unresolved guards suspend the generator at that step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e317d82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->