### PR TITLE
Authenticate imported exception attribute occurrences

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1025,6 +1025,21 @@ class SourceUnit:
         """
         from sugar_lift_py_tests.ir import ctor, str_const
 
+        # Spans are meaningful only inside the SourceUnit that minted them.
+        # A same-shaped Attribute from another module can occupy the identical
+        # line/column coordinate; never let it index this unit's reaching-import
+        # table and borrow exception authority from an unrelated occurrence.
+        if node.unit is not self:
+            from sugar_source_tree.panic import BackendDefect
+
+            raise BackendDefect(
+                blame=node.fragment,
+                owner="SourceUnit.imported_exception_type_identity",
+                observed="foreign imported-exception Attribute occurrence",
+                requested="an Attribute occurrence owned by this SourceUnit",
+                fix="ask the SourceUnit that constructed the occurrence for its identity",
+            )
+
         link = node
         attributes = []
         while isinstance(link, Attribute):

--- a/implementations/python/sugar-source-tree/tests/test_imported_exception_attribute_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_imported_exception_attribute_construction.py
@@ -200,6 +200,53 @@ def test_module_name_arrow_exception_identity_is_import_coordinate(tmp_path):
     )
 
 
+def test_imported_exception_identity_rejects_a_foreign_attribute_occurrence(tmp_path):
+    """A same-span Attribute from another module cannot borrow this import floor."""
+    truthful_path = tmp_path / "truthful.py"
+    truthful_path.write_text(
+        "import pyarrow as errors\n"
+        "def f():\n"
+        "    raise errors.ArrowInvalid\n",
+        encoding="utf-8",
+    )
+    foreign_path = tmp_path / "foreign.py"
+    foreign_path.write_text(
+        "import pandas as errors\n"
+        "def f():\n"
+        "    raise errors.ArrowInvalid\n",
+        encoding="utf-8",
+    )
+    truthful = SourceFile(path_source(str(truthful_path)))
+    foreign = SourceFile(path_source(str(foreign_path)))
+    truthful_occurrence = _attribute(truthful, "ArrowInvalid")
+    foreign_occurrence = _attribute(foreign, "ArrowInvalid")
+
+    assert truthful.unit.imported_exception_type_identity(
+        truthful_occurrence
+    ) == ctor(
+        "python:exception_type_identity",
+        [str_const("import"), str_const("pyarrow.ArrowInvalid")],
+    )
+    raised = next(node for node in truthful.nodes() if node.kind == "Raise")
+    raised_value = raised.sugar().desugar().effect.raised_value
+    assert isinstance(raised_value, AuthenticatedExceptionTypeValue)
+    assert isinstance(raised_value.value, ExceptionClassValue)
+    assert raised_value.value.qualified_name == "pyarrow.ArrowInvalid"
+    assert foreign.unit.imported_exception_type_identity(foreign_occurrence) == ctor(
+        "python:exception_type_identity",
+        [str_const("import"), str_const("pandas.ArrowInvalid")],
+    )
+    from sugar_source_tree.panic import BackendDefect
+
+    with pytest.raises(BackendDefect) as wrong_occurrence:
+        truthful.unit.imported_exception_type_identity(foreign_occurrence)
+    assert (
+        wrong_occurrence.value.owner
+        == "SourceUnit.imported_exception_type_identity"
+    )
+    assert wrong_occurrence.value.blame.node is foreign_occurrence
+
+
 def test_import_bound_exception_desugars_to_authenticated_type(tmp_path):
     """Truthful twin: manager arg is AuthenticatedExceptionTypeValue, not Attribute."""
     boundary = _boundary(


### PR DESCRIPTION
## What changed

- Require imported-exception Attribute occurrences to belong to the SourceUnit whose reaching-import table authenticates them.
- Raise a typed BackendDefect for a foreign-module/wrong-occurrence query.
- Add an ordinary import/raise program proving the truthful pyarrow floor value, the foreign pandas identity, and the cross-unit refusal.

## Root cause

Imported exception identity lookup used line/column span as its lookup key without first authenticating the owning SourceUnit. A same-shaped foreign module occurrence at the same span could borrow the truthful module's import-bound exception identity.

## Delta-epsilon

- R_imported_exception_floor: 1 -> 0
- Floors preserved: no spelling/vendor authority; unresolved same-unit imports remain absent/loud; no fixture or auditor changes.

## Focused receipt

```text
/usr/local/opt/python@3.14/bin/python3.14
Python 3.14.4
12 passed in 1.42s
```

Draft only: hold merge until shared gates are green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject foreign `Attribute` occurrences in `SourceUnit.imported_exception_type_identity`
> Adds an ownership guard to `SourceUnit.imported_exception_type_identity` in [nodes.py](https://github.com/TSavo/sugar/pull/6849/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) that raises `BackendDefect` when the provided `Attribute` occurrence belongs to a different `SourceUnit`. A new test in [test_imported_exception_attribute_construction.py](https://github.com/TSavo/sugar/pull/6849/files#diff-261c29ba7dbbed9dcc457d4aff2cd270046b2198f8237c341736b0473e4041ed) verifies that each module resolves its own identity correctly and that passing a foreign occurrence raises the expected error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ac95c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->