### PR TITLE
Reject foreign mutable globals on source frames

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -204,6 +204,11 @@ class SourceVisibleCallFrameV1:
     frame_cid: str = field(init=False)
 
     def __post_init__(self) -> None:
+        if any(
+            binding.source_cid != self.source_identity_cid
+            for binding in self.mutable_global_bindings
+        ):
+            raise SourceCallBindingGap("foreign mutable-global source")
         preimage = {
             "kind": "source-visible-call-frame",
             "schemaVersion": "1",

--- a/implementations/python/sugar-lift-python-source/tests/test_mutable_global_frame_source_identity.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_mutable_global_frame_source_identity.py
@@ -1,0 +1,56 @@
+from dataclasses import replace
+
+import pytest
+
+from sugar_lift_py_tests.source_call_frame import (
+    MutableGlobalBindingV1,
+    SourceCallBindingGap,
+)
+from sugar_lift_python_source.value_pins import scan_module_value_pins
+from sugar_source_tree import SourceFile
+
+
+def _source(tmp_path, name, *, key="OPTIONS"):
+    path = tmp_path / name
+    path.write_text(f"{key} = {{}}\n\ndef selected():\n    return {key}\n")
+    return SourceFile.from_path(path)
+
+
+def _binding(source_file):
+    pin, = scan_module_value_pins(source_file.root).mutable_global_pins
+    return MutableGlobalBindingV1(
+        source_cid=pin.source_cid,
+        binding_occurrence=pin.binding_occurrence,
+        name=pin.name,
+        kind=pin.kind,
+        term=pin.term,
+        line=pin.line,
+        col=pin.col,
+    )
+
+
+def test_source_frame_accepts_its_exact_mutable_global_binding(tmp_path):
+    source_file = _source(tmp_path, "truth.py")
+    function, = source_file.functions()
+    binding = _binding(source_file)
+
+    frame = replace(
+        function.source_visible_call_frame(),
+        mutable_global_bindings=(binding,),
+    )
+
+    assert frame.mutable_global_bindings == (binding,)
+    assert frame.mutable_global_bindings[0] is binding
+
+
+def test_source_frame_refuses_foreign_mutable_global_before_frame_cid(tmp_path):
+    local = _source(tmp_path, "local.py")
+    foreign = _source(tmp_path, "foreign.py", key="FOREIGN_OPTIONS")
+    function, = local.functions()
+    foreign_binding = _binding(foreign)
+
+    with pytest.raises(SourceCallBindingGap, match="foreign mutable-global source"):
+        replace(
+            function.source_visible_call_frame(),
+            mutable_global_bindings=(foreign_binding,),
+        )


### PR DESCRIPTION
R_foreign_frame: 1 -> 0

SourceVisibleCallFrameV1 now rejects a MutableGlobalBindingV1 whose source CID differs from the frame source before computing the frame CID. Includes truthful identity and content-different foreign-source twins.

Test: `BCARGO_REMOTE_ROOT=/home/tsavo/remote/sugar-bcargo-codex1-foreign-frame-green2 bin/bpytest implementations/python/sugar-lift-python-source/tests/test_mutable_global_frame_source_identity.py` (2 passed).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject foreign mutable globals in `SourceVisibleCallFrameV1.__post_init__`
> Adds a validation guard in `SourceVisibleCallFrameV1.__post_init__` that raises `SourceCallBindingGap` with the message `'foreign mutable-global source'` if any binding in `mutable_global_bindings` has a `source_cid` that does not match the frame's `source_identity_cid`. Tests covering both the accepted (same-source) and rejected (foreign-source) cases are added in [`test_mutable_global_frame_source_identity.py`](https://github.com/TSavo/sugar/pull/6850/files#diff-b01f150c8773f0e41f988c6ea10951efcdaae0d1b5b9fbdd39c1e681ecc880eb).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0932bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->