### PR TITLE
Project guarded generator manager entry outcomes

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -10,6 +10,7 @@ from .branch_result_coordinate import (
 )
 from .bound_var import BoundVar
 from .module_bound_var import ModuleBoundVar
+from .mutable_global_value import MutableGlobalValue
 from .named_expression_value import NamedExpressionValue
 from .native_callable_value import NativeCallableValue
 from .builder_state import BuilderState
@@ -96,6 +97,7 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     BranchResultAuthentication,
     BranchResultCoordinate,
     BoundVar,
+    MutableGlobalValue,
     NamedExpressionValue,
     NativeCallableValue,
     BuilderState,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guarded_value.py
@@ -67,6 +67,10 @@ class GuardedValue(FloorValue):
         """Resolve both binding arms when a joined name is read."""
         return self._map("answer", ctx)
 
+    def length(self, site):
+        """Distribute ``len`` through the existing guarded outcome algebra."""
+        return self._map("length", site)
+
     def _map(self, method: str, *args):
         from sugar_lift_py_tests.ir import not_
         from sugar_lift_py_tests.outcome import Complete, Incomplete

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mutable_global_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mutable_global_value.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sugar_source_tree.fragment import SourceMemento
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class MutableGlobalValue(FloorValue):
+    """A mutable module binding authenticated at its defining target."""
+
+    name: str
+    kind: str
+    pin_source_cid: str
+    binding_memento: SourceMemento
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.binding_memento, SourceMemento):
+            raise TypeError("MutableGlobalValue binding_memento must be SourceMemento")
+        if self.binding_memento.source_cid != self.pin_source_cid:
+            raise ValueError(
+                "MutableGlobalValue requires its exact binding SourceMemento/source CID"
+            )
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, num, str_const
+
+        return ctor(
+            "python:mutable_global_pin",
+            [
+                str_const(self.name),
+                str_const(self.kind),
+                str_const(self.binding_memento.file),
+                str_const(self.binding_memento.source_cid),
+                str_const(self.binding_memento.cid),
+                num(self.binding_memento.start),
+                num(self.binding_memento.end),
+            ],
+        )
+
+    def subscript(self, index, site):
+        if self.kind != "dict":
+            return self.undecided_subscript(
+                index, site, owner="MutableGlobalValue.subscript"
+            )
+        if getattr(site, "source_cid", None) != self.pin_source_cid:
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                blame=site,
+                owner="MutableGlobalValue.subscript",
+                observed="foreign source for mutable-global lookup occurrence",
+                requested="an authenticated lookup site from the pin's SourceUnit",
+                fix="carry the binding-owned pin into same-source module temporal state",
+            )
+
+        from sugar_lift_py_tests.floor.ground_exit import ground_raise_effect
+        from sugar_lift_py_tests.ir import atomic
+        from sugar_lift_py_tests.outcome import ExitSet
+        from sugar_lift_py_tests.outcome.exit_set import (
+            Completed,
+            Halted,
+            complement_guard,
+            partition,
+        )
+
+        raises = atomic(
+            "python.mutable_dict_lookup_raises_key_error",
+            [self.to_term(owner="mutable global lookup"), index.to_term(owner="mutable global lookup")],
+        )
+        halted_face, completed_face = partition(
+            ("mutable-global-dict-subscript", _occurrence_key(site))
+        )
+        completed = self.py_subscript_coordinate(index, site).value
+        effect = ground_raise_effect(
+            exception_name="KeyError",
+            site=site,
+            owner="MutableGlobalValue.subscript",
+        )
+        return ExitSet(
+            (
+                Halted(raises, effect, faces=frozenset({halted_face})),
+                Completed(
+                    complement_guard(raises),
+                    completed,
+                    frozenset({completed_face}),
+                ),
+            )
+        ).normalize()
+
+
+def _occurrence_key(site: object) -> tuple[object, object, object, object]:
+    fragment = getattr(site, "fragment", site)
+    span = getattr(fragment, "span", None)
+    return (
+        getattr(fragment, "filename", None),
+        getattr(fragment, "source_cid", None),
+        getattr(span, "start", None),
+        getattr(span, "end", None),
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -1491,63 +1491,55 @@ class GeneratorConstructionV1:
 
         from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, partition
 
-        from sugar_lift_py_tests.outcome import Complete, Halted, Incomplete
+        from sugar_lift_py_tests.outcome import Complete, Incomplete
+
+        def _transition_truth(truth):
+            decided = self._decide_guard(truth)
+            if decided is True:
+                return self._spliced(step.then_steps)._transition(requested)
+            if decided is False:
+                return self._spliced(step.else_steps)._transition(requested)
+
+            guard_formula = self._guard_formula(truth)
+            if guard_formula is None:
+                return self._gap(requested, "If carrying a suspension")
+
+            then_face, else_face = partition(
+                ("generator.branch", self.instance_coordinate, step.fragment_cid)
+            )
+            from sugar_lift_py_tests.ir import not_
+
+            return ExitSet(
+                (
+                    Completed(
+                        guard_formula,
+                        self._spliced(step.then_steps),
+                        frozenset({then_face}),
+                        (),
+                    ),
+                    Completed(
+                        not_(guard_formula),
+                        self._spliced(step.else_steps),
+                        frozenset({else_face}),
+                        (),
+                    ),
+                )
+            ).factor_completed()
 
         guard_outcome = self._guard_truth(step.guard)
         if isinstance(guard_outcome, ExitSet):
-            if guard_outcome.exits and all(
-                isinstance(face, Halted) for face in guard_outcome.exits
-            ):
-                return ExitSet(
-                    tuple(
-                        Halted(
-                            face.guard,
-                            face.effect,
-                            self,
-                            face.faces,
-                            face.pending_contracts,
-                        )
-                        for face in guard_outcome.exits
-                    )
-                )
-            return self._gap(requested, "If guard has mixed completed/halted faces")
+            def _transition_completed(truth):
+                transitioned = _transition_truth(truth)
+                if isinstance(transitioned, ExitSet):
+                    return transitioned
+                return ExitSet.completed(transitioned)
+
+            return guard_outcome.sequence(_transition_completed)
         if isinstance(guard_outcome, Incomplete):
             return ExitSet.halted(guard_outcome.effect, state=self)
         if not isinstance(guard_outcome, Complete):
             return self._gap(requested, "If carrying a suspension")
-
-        truth = guard_outcome.value
-        decided = self._decide_guard(truth)
-        if decided is True:
-            return self._spliced(step.then_steps)._transition(requested)
-        if decided is False:
-            return self._spliced(step.else_steps)._transition(requested)
-
-        guard_formula = self._guard_formula(truth)
-        if guard_formula is None:
-            return self._gap(requested, "If carrying a suspension")
-
-        then_face, else_face = partition(
-            ("generator.branch", self.instance_coordinate, step.fragment_cid)
-        )
-        from sugar_lift_py_tests.ir import not_
-
-        return ExitSet(
-            (
-                Completed(
-                    guard_formula,
-                    self._spliced(step.then_steps),
-                    frozenset({then_face}),
-                    (),
-                ),
-                Completed(
-                    not_(guard_formula),
-                    self._spliced(step.else_steps),
-                    frozenset({else_face}),
-                    (),
-                ),
-            )
-        ).factor_completed()
+        return _transition_truth(guard_outcome.value)
 
     def _spliced(self, branch_steps: tuple) -> "GeneratorConstructionV1":
         """This machine with the branch's steps in place of the `If`."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -738,10 +738,21 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
             ],
         }
     if isinstance(step, RaiseStepV1):
+        from sugar_lift_py_tests.sugar.raise_sugar import RaiseSugar
+
+        if not isinstance(step.raise_sugar, RaiseSugar):
+            raise TypeError(
+                f"{owner} requires RaiseSugar for RaiseStepV1, got "
+                f"{type(step.raise_sugar).__name__}"
+            )
         return {
             "kind": "raise",
             "fragmentCid": step.fragment_cid,
-            "raiseSugar": _generator_value_testimony(step.raise_sugar, owner=owner),
+            "exception": _generator_value_testimony(
+                step.raise_sugar.exception, owner=owner
+            ),
+            "cause": _generator_value_testimony(step.raise_sugar.cause, owner=owner),
+            "inFlightSlot": step.raise_sugar.in_flight_slot,
         }
     if isinstance(step, TermStepV1):
         return {

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -34,6 +34,7 @@ class FormalFloorBindingV1:
 
     coordinate_cid: str
     floor_value: object = field(compare=False, repr=False)
+    coordinate: object | None = field(default=None, compare=False, repr=False)
 
     def __post_init__(self) -> None:
         if (
@@ -51,6 +52,19 @@ class FormalFloorBindingV1:
                 "FormalFloorBindingV1.floor_value must be a FloorValue, "
                 f"got {type(self.floor_value).__name__}"
             )
+        if self.coordinate is not None:
+            from sugar_source_tree.binding_provenance import BindingCoordinateV1
+
+            if (
+                type(self.coordinate) is not BindingCoordinateV1
+                or self.coordinate.cid != self.coordinate_cid
+                or cid_of_json(self.coordinate.preimage) != self.coordinate.cid
+                or BindingCoordinateV1.decode(self.coordinate.wire())
+                != self.coordinate
+            ):
+                raise FormalFloorBindingGap(
+                    "projected formal floor binding has foreign coordinate testimony"
+                )
 
 
 @dataclass(frozen=True)
@@ -920,7 +934,20 @@ class GeneratorConstructionV1:
             for entry in binding_state
             if isinstance(entry, BindingEntryV1)
         )
-        floor_cids = tuple(item.coordinate_cid for item in formal_floor_bindings)
+        root_floor_bindings = tuple(
+            item for item in formal_floor_bindings if item.coordinate is None
+        )
+        projected_floor_bindings = tuple(
+            item for item in formal_floor_bindings if item.coordinate is not None
+        )
+        projected_cids = tuple(
+            item.coordinate_cid for item in projected_floor_bindings
+        )
+        if len(projected_cids) != len(set(projected_cids)):
+            raise FormalFloorBindingGap(
+                "projected formal floor bindings must not duplicate a coordinate"
+            )
+        floor_cids = tuple(item.coordinate_cid for item in root_floor_bindings)
         if len(floor_cids) != len(set(floor_cids)):
             raise FormalFloorBindingGap(
                 "formal floor bindings must not duplicate a formal coordinate"
@@ -931,6 +958,37 @@ class GeneratorConstructionV1:
                 f"formal roster; floors={sorted(floor_cids)!r} "
                 f"sealed={sorted(sealed_formal_cids)!r}"
             )
+        sealed_coordinates = tuple(
+            entry.coordinate
+            for entry in binding_state
+            if isinstance(entry, BindingEntryV1)
+        )
+        for binding in projected_floor_bindings:
+            coordinate = binding.coordinate
+            parents = tuple(
+                root
+                for root in sealed_coordinates
+                if coordinate.scope_owner_cid == root.scope_owner_cid
+                and coordinate.binding_site == root.binding_site
+                and coordinate.projection_path[: len(root.projection_path)]
+                == root.projection_path
+            )
+            suffix = (
+                coordinate.projection_path[len(parents[0].projection_path) :]
+                if len(parents) == 1
+                else ()
+            )
+            if (
+                len(parents) != 1
+                or len(suffix) != 2
+                or suffix[0] != "variadic"
+                or not isinstance(suffix[1], int)
+                or isinstance(suffix[1], bool)
+                or coordinate != parents[0].project(*suffix)
+            ):
+                raise FormalFloorBindingGap(
+                    "projected formal floor coordinate is foreign to sealed formal roster"
+                )
         if reduction_context is not None and not callable(
             getattr(reduction_context, "with_temporal", None)
         ):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -636,9 +636,11 @@ class _Pass:
         if node.func.kind == "Name":
             local_name = node.func.id
             exported_path: tuple[str, ...] = ()
-        elif node.func.kind == "Attribute" and node.func.value.kind == "Name":
-            local_name = node.func.value.id
-            exported_path = (node.func.attr,)
+        elif node.func.kind == "Attribute":
+            path = self._attribute_export_path(node.func)
+            if path is None:
+                return
+            local_name, exported_path = path
         else:
             return
         reaching = state.get(local_name, frozenset({_UNBOUND}))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -5,8 +5,38 @@ from sugar_lift_python_source.canonical import cid_of_json
 from sugar_source_tree.binding_provenance import BindingCoordinateV1
 from sugar_source_tree.binding_provenance import BoundBindingStateV1
 from sugar_source_tree.binding_state import BindingEntryV1
+from sugar_source_tree.fragment import SourceMemento
 
 from .context_manager_resolution import SourceFragmentCoordinateV1
+
+
+@dataclass(frozen=True)
+class MutableGlobalBindingV1:
+    source_cid: str
+    binding_occurrence: SourceMemento
+    name: str
+    kind: str
+    term: object = field(compare=False)
+    line: int
+    col: int
+    cid: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.binding_occurrence.source_cid != self.source_cid:
+            raise ValueError("mutable global binding occurrence/source CID mismatch")
+        if not self.name or self.kind not in {"dict", "list", "set"}:
+            raise ValueError("mutable global binding requires a closed mutable kind")
+        object.__setattr__(self, "cid", cid_of_json({
+            "kind": "mutable-global-binding",
+            "schemaVersion": "1",
+            "sourceCid": self.source_cid,
+            "bindingOccurrence": self.binding_occurrence.to_dict(),
+            "name": self.name,
+            "mutableKind": self.kind,
+            "term": self.term,
+            "line": self.line,
+            "col": self.col,
+        }))
 
 
 def _reauthenticate_binding_coordinates(coordinates: tuple) -> None:
@@ -212,6 +242,10 @@ class SourceVisibleCallFrameV1:
     )
     generator_steps: tuple | None = field(default=None, compare=False, repr=False)
     generator_step_fragment_cids: tuple[str, ...] = ()
+    mutable_global_bindings: tuple[MutableGlobalBindingV1, ...] = field(
+        default=(), compare=False
+    )
+    declaration_frame_cid: str | None = field(default=None, compare=False)
     frame_cid: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -230,8 +264,15 @@ class SourceVisibleCallFrameV1:
             "parameterKinds": list(self.parameter_kinds),
             "defaultFragmentCids": list(self.default_fragment_cids),
             "generatorStepFragmentCids": list(self.generator_step_fragment_cids),
+            "mutableGlobalBindingCids": [
+                item.cid for item in self.mutable_global_bindings
+            ],
         }
+        if self.declaration_frame_cid is not None:
+            preimage["declarationFrameCid"] = self.declaration_frame_cid
         object.__setattr__(self, "frame_cid", cid_of_json(preimage))
+        if self.declaration_frame_cid is None:
+            object.__setattr__(self, "declaration_frame_cid", self.frame_cid)
 
     def bind_actuals(
         self, positional: tuple, keywords: tuple, ctx=None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -133,6 +133,7 @@ class BoundSourceCallActualsV1:
     actuals: tuple
     formal_coordinates: tuple[BindingCoordinateV1, ...]
     native_formal_coordinates: tuple = ()
+    projected_pairs: tuple[BoundFormalActualV1, ...] = ()
 
     def __post_init__(self) -> None:
         actual_count = len(self.actuals)
@@ -143,6 +144,39 @@ class BoundSourceCallActualsV1:
             raise SourceCallBindingGap("bound actual coordinate arity mismatch")
         _reauthenticate_binding_coordinates(self.formal_coordinates)
         _reauthenticate_native_coordinates(self.native_formal_coordinates)
+        _reauthenticate_binding_coordinates(
+            tuple(pair.coordinate for pair in self.projected_pairs)
+        )
+        from sugar_lift_py_tests.floor import TupleValue
+
+        roots = tuple(zip(self.formal_coordinates, self.actuals, strict=True))
+        for pair in self.projected_pairs:
+            matching = tuple(
+                (root, actual)
+                for root, actual in roots
+                if pair.coordinate.scope_owner_cid == root.scope_owner_cid
+                and pair.coordinate.binding_site == root.binding_site
+                and pair.coordinate.projection_path[: len(root.projection_path)]
+                == root.projection_path
+            )
+            suffix = pair.coordinate.projection_path[
+                len(matching[0][0].projection_path) :
+            ] if len(matching) == 1 else ()
+            if (
+                len(matching) != 1
+                or len(suffix) != 2
+                or suffix[0] != "variadic"
+                or not isinstance(suffix[1], int)
+                or isinstance(suffix[1], bool)
+                or type(matching[0][1]) is not TupleValue
+                or suffix[1] < 0
+                or suffix[1] >= len(matching[0][1].elements)
+                or pair.actual is not matching[0][1].elements[suffix[1]]
+                or pair.coordinate != matching[0][0].project(*suffix)
+            ):
+                raise SourceCallBindingGap(
+                    "projected formal coordinate is foreign or cross-wired"
+                )
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, BoundSourceCallActualsV1):
@@ -150,6 +184,7 @@ class BoundSourceCallActualsV1:
                 self.actuals == other.actuals
                 and self.formal_coordinates == other.formal_coordinates
                 and self.native_formal_coordinates == other.native_formal_coordinates
+                and self.projected_pairs == other.projected_pairs
             )
         return NotImplemented
 
@@ -318,6 +353,7 @@ class SourceVisibleCallFrameV1:
                 raise SourceCallBindingGap("duplicate keyword actual")
             named[key] = value
         bound = []
+        projected_pairs = []
         for index, (name, kind, default) in enumerate(
             zip(
                 self.parameters,
@@ -327,7 +363,13 @@ class SourceVisibleCallFrameV1:
             )
         ):
             if kind == "vararg":
-                bound.append(TupleValue(tuple(remaining)))
+                values = tuple(remaining)
+                root = self.formal_coordinates[index]
+                projected_pairs.extend(
+                    BoundFormalActualV1(root.project("variadic", ordinal), actual)
+                    for ordinal, actual in enumerate(values)
+                )
+                bound.append(TupleValue(values))
                 remaining.clear()
                 continue
             if kind == "kwarg":
@@ -365,6 +407,7 @@ class SourceVisibleCallFrameV1:
             tuple(bound),
             self.formal_coordinates,
             self.native_operation_formal_coordinates,
+            tuple(projected_pairs),
         )
 
     def _validate_formal_coordinate_rosters(self) -> None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -249,6 +249,13 @@ class SourceVisibleCallFrameV1:
     frame_cid: str = field(init=False)
 
     def __post_init__(self) -> None:
+        if any(
+            binding.source_cid != self.source_identity_cid
+            for binding in self.mutable_global_bindings
+        ):
+            raise SourceCallBindingGap(
+                "mutable global binding source does not match source frame identity"
+            )
         preimage = {
             "kind": "source-visible-call-frame",
             "schemaVersion": "1",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -328,6 +328,7 @@ class CallSiteSugar(ConstructedTermSugar):
                     requested="a closed SourceCallFrameV1 variant",
                     fix="construct a typed source frame or keep the call loud",
                 )
+            ctx = _with_frame_mutable_globals(ctx, self.source_call_frame)
             from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
             try:
@@ -551,3 +552,29 @@ class CallSiteSugar(ConstructedTermSugar):
                 term, reference.contract_cid, reference.member_cid, callsite
             )
         )
+
+
+def _with_frame_mutable_globals(ctx, frame):
+    bindings = frame.mutable_global_bindings
+    if not bindings:
+        return ctx
+    from dataclasses import replace
+
+    from sugar_lift_py_tests.context import ReduceContext
+    from sugar_lift_py_tests.floor.mutable_global_value import MutableGlobalValue
+    from sugar_lift_py_tests.temporal import TemporalContext
+
+    if ctx is None:
+        ctx = ReduceContext.root(owner="CallSiteSugar mutable module globals")
+    module_temporal = ctx.module_temporal or TemporalContext.empty()
+    temporal = ctx.temporal
+    for binding in bindings:
+        value = MutableGlobalValue(
+            name=binding.name,
+            kind=binding.kind,
+            pin_source_cid=binding.source_cid,
+            binding_memento=binding.binding_occurrence,
+        )
+        module_temporal = module_temporal.bind_value(binding.name, value)
+        temporal = temporal.bind_value(binding.name, value)
+    return replace(ctx, temporal=temporal, module_temporal=module_temporal)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -328,7 +328,7 @@ class CallSiteSugar(ConstructedTermSugar):
                     requested="a closed SourceCallFrameV1 variant",
                     fix="construct a typed source frame or keep the call loud",
                 )
-            ctx = _with_frame_mutable_globals(ctx, self.source_call_frame)
+            ctx = _with_frame_mutable_globals(ctx, source_call_frame)
             from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
             try:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -92,9 +92,29 @@ class CallSiteSugar(ConstructedTermSugar):
             )
         definition_authority = []
         if self.exception_type_coordinate is not None:
-            definition_authority.append(
-                str_const(self.exception_type_coordinate.cid)
-            )
+            coordinate_cid = getattr(self.exception_type_coordinate, "cid", None)
+            if coordinate_cid is not None:
+                definition_authority.append(str_const(coordinate_cid))
+            else:
+                from sugar_lift_py_tests.ir import (
+                    _ConstBool,
+                    _ConstInt,
+                    _ConstReal,
+                    _ConstStr,
+                    _Ctor,
+                    _Lambda,
+                    _Var,
+                )
+
+                if not isinstance(
+                    self.exception_type_coordinate,
+                    (_Ctor, _ConstInt, _ConstStr, _ConstBool, _ConstReal, _Var, _Lambda),
+                ):
+                    raise TypeError(
+                        f"{owner} requires authenticated exception definition "
+                        "coordinate or term"
+                    )
+                definition_authority.append(self.exception_type_coordinate)
         definition_authority.extend(
             str_const(cid) for cid in self.formal_coordinate_cids
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -407,6 +407,13 @@ class CallSiteSugar(ConstructedTermSugar):
                         positional,
                         strict=True,
                     )
+                ) + tuple(
+                    FormalFloorBindingV1(
+                        pair.coordinate.cid,
+                        pair.actual,
+                        coordinate=pair.coordinate,
+                    )
+                    for pair in bound_source_actuals.projected_pairs
                 )
                 return Complete(
                     GeneratorConstructionV1.allocate(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -370,7 +370,10 @@ class CallSiteSugar(ConstructedTermSugar):
                 # BindingCoordinateRefs match this frame's formal coordinates,
                 # not the caller's inlined formal nodes.
                 declaration_frame = owner.source_visible_call_frame()
-                if declaration_frame.frame_cid != source_call_frame.frame_cid:
+                if (
+                    declaration_frame.frame_cid
+                    != source_call_frame.declaration_frame_cid
+                ):
                     from sugar_source_tree.panic import BackendDefect
 
                     raise BackendDefect(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
@@ -72,12 +72,9 @@ class SubscriptSugar(ConstructedTermSugar):
         # sole re-attachment door and is itself loud when the joined outcome has
         # nowhere to carry the demand: nothing here drops an obligation quietly.
         #
-        # Operand reduction may also publish a dual-edge ExitSet (undecided
-        # Compare/BinOp dispatch: Halted raise face + Completed solver face).
-        # Sequence those partitions so Halted faces bypass the subscript step;
-        # an undecided completed face that cannot honestly subscript contributes
-        # no face rather than aborting the partition with SugarNotWritten and
-        # erasing the sibling halt.
+        # Operand reduction may also publish a dual-edge ExitSet. Sequence its
+        # completed faces through the receiver floor; a typed refusal remains a
+        # refusal and must never be converted into an empty outcome.
         from dataclasses import replace
 
         from sugar_lift_py_tests.caller_parameter_contract import merge_demands
@@ -85,8 +82,7 @@ class SubscriptSugar(ConstructedTermSugar):
             pending_demand,
             rewrap_pending,
         )
-        from sugar_lift_py_tests.outcome import ExitSet, outcome_to_exitset, true_guard
-        from sugar_source_tree.panic import SugarNotWritten
+        from sugar_lift_py_tests.outcome import outcome_to_exitset, true_guard
 
         # A subscript expression has no guard of its own, so both obligations
         # hoist unconditionally.
@@ -106,14 +102,6 @@ class SubscriptSugar(ConstructedTermSugar):
             plain.append(value_outcome)
         receiver_outcome, index_outcome = plain
 
-        def _subscript_face(receiver, index):
-            try:
-                return outcome_to_exitset(self._subscript(receiver, index, ctx))
-            except SugarNotWritten:
-                # Completion path cannot decide the lookup. Sibling halt faces
-                # from the index/receiver partition already survive sequence.
-                return ExitSet(())
-
         from sugar_lift_py_tests.outcome import ExitSet as _ExitSet
 
         receiver_partitioned = isinstance(receiver_outcome, _ExitSet)
@@ -121,28 +109,11 @@ class SubscriptSugar(ConstructedTermSugar):
         if receiver_partitioned or index_partitioned:
             subscripted = outcome_to_exitset(receiver_outcome).and_then(
                 lambda receiver: outcome_to_exitset(index_outcome).and_then(
-                    lambda index: _subscript_face(receiver, index)
+                    lambda index: outcome_to_exitset(
+                        self._subscript(receiver, index, ctx)
+                    )
                 )
             )
-            if isinstance(subscripted, _ExitSet) and not subscripted.exits:
-                # Every completed face refused and no halt survived: surface the
-                # undecided lookup as the named refusal (not an empty partition).
-                raise SugarNotWritten(
-                    owner="SubscriptSugar",
-                    observed=(
-                        "undecided subscript after partitioned operand faces "
-                        "refused without a surviving halt"
-                    ),
-                    requested=(
-                        "authenticated exceptional exit or named undecided "
-                        "refusal at the receiver floor"
-                    ),
-                    fix=(
-                        "preserve a Halted face from the index/receiver "
-                        "partition, or name the undecided lookup on the "
-                        "receiver floor"
-                    ),
-                )
         else:
             # Single-outcome path: undecided lookups raise SugarNotWritten
             # from the receiver floor (named refusal), exact exits Complete.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_source_resource_sugar.py
@@ -67,7 +67,10 @@ class WithSourceResourceSugar(Sugar):
             manager_facts = ManagerBinding(
                 self.manager_slot_id, manager_face.value
             ).to_facts(site=self.site)
-            enter_es = outcome_to_exitset(self.protocol.enter_resource_outcome(ctx))
+            enter_outcome = self.protocol.enter_resource_outcome_for(
+                manager_face.value, ctx
+            )
+            enter_es = outcome_to_exitset(enter_outcome)
             for enter_face in enter_es.exits:
                 guard = _and(manager_face.guard, enter_face.guard)
                 if isinstance(enter_face, Halted):

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
@@ -6,7 +6,7 @@ from types import MappingProxyType
 import pytest
 
 from sugar_lift_py_tests.call_contract_resolution import ResolvedCallContractRefV1
-from sugar_lift_py_tests.ir import PrimitiveSort, str_const
+from sugar_lift_py_tests.ir import PrimitiveSort, ctor, str_const
 from sugar_lift_py_tests.generator_construction import YieldStepV1
 from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
 from sugar_lift_py_tests.sugar.binop_sugar import BinOpSugar
@@ -242,6 +242,23 @@ def test_changed_resolved_contract_authority_changes_call_term():
     assert _call(contract=_contract("a")).to_term(
         owner="first-contract"
     ) != _call(contract=_contract("b")).to_term(owner="second-contract")
+
+
+def test_exception_definition_term_is_canonical_call_authority():
+    first = replace(
+        _call(),
+        exception_type_coordinate=ctor(
+            "python:exception_type_identity", (str_const("first"),)
+        ),
+    )
+    second = replace(
+        first,
+        exception_type_coordinate=ctor(
+            "python:exception_type_identity", (str_const("second"),)
+        ),
+    )
+
+    assert first.to_term(owner="first") != second.to_term(owner="second")
 
 
 @pytest.mark.parametrize(

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
@@ -154,6 +154,22 @@ def test_pre_yield_if_with_raise_is_raise_step_inside_if() -> None:
     assert isinstance(steps[1], YieldStepV1)
 
 
+def test_raise_step_has_canonical_generator_construction_testimony() -> None:
+    steps = _steps(
+        "def g(c):\n"
+        "    if c:\n"
+        "        raise ValueError('boom')\n"
+        "    yield 1\n"
+    )
+
+    preimage = _machine(steps).construction_term_preimage()
+
+    raise_row = preimage["steps"][0]["thenSteps"][0]
+    assert raise_row["kind"] == "raise"
+    assert raise_row["exception"]["kind"] == "term-cid"
+    assert raise_row["cause"] == {"kind": "null"}
+
+
 # -- the three transition arms -----------------------------------------------
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
@@ -52,7 +52,9 @@ from sugar_lift_py_tests.generator_construction import (
     YieldEffect,
     YieldStepV1,
 )
-from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.ir import atomic
+from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
 from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
 from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
 from sugar_lift_py_tests.sugar.name_sugar import NameSugar
@@ -199,6 +201,43 @@ def test_an_undecided_guard_partitions_into_two_faces() -> None:
     outcome = _machine(_steps("def g(c):\n    if c:\n        yield 1\n")).resume()
 
     assert isinstance(outcome, ExitSet)
+
+
+def test_a_partitioned_guard_preserves_halts_and_transitions_completed_faces(
+    monkeypatch,
+) -> None:
+    """Guard evaluation exits are paths, not a reason to discard the branch."""
+    halted_guard = atomic("test.guard.halted", [])
+    completed_guard = atomic("test.guard.completed", [])
+    effect = RaiseEffect(exception_name="GuardError", occurrence="guard:site")
+    halted = Halted(halted_guard, effect, state="guard-state")
+    guard_outcome = ExitSet(
+        (
+            halted,
+            Completed(completed_guard, TrueBoolLiteralSugar(site="guard:true")),
+        )
+    )
+    monkeypatch.setattr(
+        GeneratorConstructionV1,
+        "_guard_truth",
+        lambda self, guard: guard_outcome,
+    )
+    step = IfStepV1(
+        TrueBoolLiteralSugar(site="guard"),
+        (YieldStepV1(IntLiteralSugar(1, site="yield:1")),),
+        (),
+        "frag",
+    )
+
+    outcome = _machine((step, ReturnStepV1())).resume()
+
+    assert isinstance(outcome, ExitSet)
+    halted_faces = [face for face in outcome.exits if isinstance(face, Halted)]
+    completed_faces = [face for face in outcome.exits if isinstance(face, Completed)]
+    assert halted_faces == [halted]
+    assert len(completed_faces) == 1
+    assert completed_faces[0].guard == completed_guard
+    assert isinstance(completed_faces[0].value, YieldEffect)
 
 
 # -- the arm count: factoring holds, so sequencing does not multiply ---------

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_value_length.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_value_length.py
@@ -1,0 +1,96 @@
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor import FloorValue, GuardedValue, TermValue, TupleValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import and_, atomic, not_
+from sugar_lift_py_tests.outcome import Complete, ExitSet
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted, true_guard
+
+
+GUARD = atomic("choose_length_arm", ())
+
+
+@dataclass(frozen=True)
+class _Demand:
+    demand_cid: str
+
+
+@dataclass(frozen=True)
+class _DemandEntry:
+    demands: tuple[_Demand, ...]
+
+
+def test_guarded_length_distributes_to_both_truthful_arms():
+    value = GuardedValue(
+        GUARD,
+        TupleValue((TermValue(1), TermValue(2))),
+        TupleValue((TermValue(3),)),
+    )
+
+    outcome = value.length("length-site")
+
+    assert outcome == Complete(GuardedValue(GUARD, TermValue(2), TermValue(1)))
+
+
+def test_guarded_length_preserves_halt_guards_and_pending_contracts():
+    completed_guard = atomic("length_completed", ())
+    halted_guard = atomic("length_halted", ())
+    pending = _DemandEntry((_Demand("length-demand"),))
+
+    class PartitionedLength(FloorValue):
+        def length(self, site):
+            del site
+            return ExitSet(
+                (
+                    Completed(
+                        completed_guard,
+                        TermValue(4),
+                        pending_contracts=(pending,),
+                    ),
+                    Halted(
+                        halted_guard,
+                        RaiseEffect(exception_name="TypeError", blame="length-site"),
+                        state="pre-length-state",
+                        pending_contracts=(pending,),
+                    ),
+                )
+            )
+
+    outcome = GuardedValue(
+        GUARD,
+        PartitionedLength(),
+        TupleValue((TermValue(9),)),
+    ).length("length-site")
+
+    assert isinstance(outcome, ExitSet)
+    halted = next(face for face in outcome.exits if isinstance(face, Halted))
+    assert halted.guard == and_((GUARD, halted_guard))
+    assert halted.state == "pre-length-state"
+    assert halted.pending_contracts == (pending,)
+    completed = tuple(face for face in outcome.exits if isinstance(face, Completed))
+    assert any(
+        face.guard == and_((GUARD, completed_guard))
+        and face.pending_contracts == (pending,)
+        for face in completed
+    )
+    assert any(
+        face.guard == and_((not_(GUARD), true_guard()))
+        and face.value == TermValue(1)
+        for face in completed
+    )
+
+
+def test_guarded_length_keeps_an_arm_without_length_loud():
+    class NoLength(FloorValue):
+        pass
+
+    value = GuardedValue(GUARD, TupleValue(()), NoLength())
+
+    with pytest.raises(ConstructionPanic) as raised:
+        value.length("lying-length-site")
+
+    assert raised.value.info.owner == "length"
+    assert raised.value.info.observed == "NoLength"

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_use_source_cid_pairing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_use_source_cid_pairing.py
@@ -69,3 +69,42 @@ def test_honest_path_source_triple_mints_receipts(tmp_path: Path) -> None:
         assert receipt.source_cid == source_cid
         assert blake3_512_of(receipt.source.encode("utf-8")) == receipt.source_cid
     del locus
+
+
+def test_multisegment_import_call_keeps_exact_call_demand_and_site(tmp_path: Path):
+    path = tmp_path / "consumer.py"
+    path.write_text("import os\nvalue = os.path.dirname('x')\n", encoding="utf-8")
+    source, _, source_cid = path_source(str(path))
+
+    receipts, outcomes = authenticated_import_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+
+    assert outcomes == {(2, 8, 2, 28): "authenticated-import-use"}
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt.target_symbol == "python:os.path.dirname"
+    assert receipt.demand["kind"] == "call-contract-demand"
+    assert receipt.use["useSite"] == {
+        "sourceCid": source_cid,
+        "startLine": 2,
+        "startCol": 8,
+        "endLine": 2,
+        "endCol": 28,
+    }
+
+
+def test_shadowed_multisegment_head_cannot_mint_call_demand(tmp_path: Path):
+    path = tmp_path / "consumer.py"
+    path.write_text(
+        "import os\ndef use(os):\n    return os.path.dirname('x')\n",
+        encoding="utf-8",
+    )
+    source, _, source_cid = path_source(str(path))
+
+    receipts, outcomes = authenticated_import_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+
+    assert not receipts
+    assert tuple(outcomes.values()) == ("shadowed-non-import",)

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
@@ -73,7 +73,7 @@ def test_non_imported_name_gets_no_value_use_receipt(tmp_path: Path) -> None:
         tmp_path, path, source, source_cid, module_identities={}
     )
     assert receipts == []
-    assert outcomes == {}
+    assert set(outcomes.values()) == {"shadowed-non-import"}
 
 
 def test_tampered_source_cid_refuses_value_use_receipts(tmp_path: Path) -> None:
@@ -348,6 +348,37 @@ def test_call_relabeled_as_value_use_refused_with_real_authority(
             module_identities={},
             _authority=ib._IMPORT_AUTHORITY,
         )
+
+
+def test_call_receipt_carries_exact_multi_segment_export_path(tmp_path: Path) -> None:
+    path = tmp_path / "multi_hop_call.py"
+    source, source_cid = _write(path, "import os\nos.path.dirname('a/b')\n")
+
+    receipts, outcomes = authenticated_import_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+
+    assert set(outcomes.values()) == {"authenticated-import-use"}
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt.demand["kind"] == "call-contract-demand"
+    assert receipt.target_symbol == "python:os.path.dirname"
+    assert receipt.use["useSite"] == receipt.demand["useSite"]
+
+
+def test_shadowed_multi_segment_call_head_has_no_import_receipt(tmp_path: Path) -> None:
+    path = tmp_path / "shadowed_multi_hop_call.py"
+    source, source_cid = _write(
+        path,
+        "import os\ndef use(os):\n    return os.path.dirname('a/b')\n",
+    )
+
+    receipts, outcomes = authenticated_import_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+
+    assert receipts == []
+    assert outcomes == {}
 
 
 def test_forged_binding_head_with_real_authority_refused(tmp_path: Path) -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_mutable_global_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_mutable_global_value.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.floor import CallSiteValue, MutableGlobalValue, StringValue
+from sugar_lift_py_tests.ir import _Ctor
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+from sugar_source_tree.nodes import Name, Subscript
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _sites(tmp_path, source: str, filename: str):
+    path = tmp_path / filename
+    path.write_text(source)
+    tree = SourceFile.from_path(filename)
+    binding = next(
+        node.fragment
+        for node in tree.nodes()
+        if isinstance(node, Name) and node.fragment.text == "OPTIONS"
+    )
+    lookup = next(node for node in tree.nodes() if isinstance(node, Subscript)).fragment
+    return binding, lookup
+
+
+def test_mutable_dict_global_lookup_preserves_complementary_value_and_keyerror_faces(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    binding, site = _sites(
+        tmp_path,
+        "OPTIONS = {}\nvalue = OPTIONS[key]\n", "mutable_global_truth.py"
+    )
+    value = MutableGlobalValue(
+        "OPTIONS", "dict", binding.source_cid, binding.seal()
+    )
+    term = value.to_term(owner="test")
+
+    exits = value.subscript(StringValue("display.max_rows"), site)
+
+    assert isinstance(term, _Ctor)
+    assert binding.source_cid in repr(term)
+    assert binding.seal().cid in repr(term)
+    assert len(exits.exits) == 2
+    halted = next(exit for exit in exits.exits if isinstance(exit, Halted))
+    completed = next(exit for exit in exits.exits if isinstance(exit, Completed))
+    assert halted.effect.exception_name == "KeyError"
+    assert halted.effect.occurrence == str(site)
+    assert halted.effect.exception_type_coordinate is not None
+    assert halted.effect.exception_type_mro is not None
+    assert isinstance(completed.value, CallSiteValue)
+    assert completed.value.target_name == "py.subscript"
+    assert completed.value.site is site
+    assert completed.guard.operands == (halted.guard,)
+    assert halted.faces and completed.faces
+    assert next(iter(halted.faces)).partition == next(iter(completed.faces)).partition
+
+
+def test_mutable_dict_global_lookup_refuses_foreign_source_coordinate(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    binding, truthful = _sites(
+        tmp_path,
+        "OPTIONS = {}\nvalue = OPTIONS[key]\n", "mutable_global_truth.py"
+    )
+    _foreign_binding, foreign = _sites(
+        tmp_path,
+        "OPTIONS = {}\nvalue = OPTIONS[other_key]\n", "mutable_global_foreign.py"
+    )
+    value = MutableGlobalValue(
+        "OPTIONS", "dict", binding.source_cid, binding.seal()
+    )
+
+    assert truthful is not binding
+    assert len(value.subscript(StringValue("display.max_rows"), truthful).exits) == 2
+
+    with pytest.raises(SugarNotWritten) as raised:
+        value.subscript(StringValue("display.max_rows"), foreign)
+
+    assert raised.value.owner == "MutableGlobalValue.subscript"
+    assert "foreign source" in raised.value.observed

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
@@ -11,6 +11,7 @@ from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
 from sugar_lift_py_tests.ir import PrimitiveSort
 from sugar_lift_py_tests.source_call_frame import (
     BoundSourceCallActualsV1,
+    MutableGlobalBindingV1,
     SourceCallBindingGap,
 )
 from sugar_lift_python_source.canonical import blake3_512_of
@@ -122,6 +123,24 @@ def test_binder_refuses_wholly_foreign_binding_roster() -> None:
         replace(frame, formal_coordinates=foreign.formal_coordinates).bind_actuals(
             (TermValue(1), TermValue(2)), ()
         )
+
+
+def test_frame_refuses_mutable_global_binding_from_foreign_source() -> None:
+    frame = _frame()
+    foreign = _frame(name="other", filename="foreign_mutable_global.py")
+    occurrence = foreign.owner.fragment.seal()
+    binding = MutableGlobalBindingV1(
+        source_cid=foreign.source_identity_cid,
+        binding_occurrence=occurrence,
+        name="REGISTRY",
+        kind="dict",
+        term={"kind": "test-mutable-global-term"},
+        line=foreign.owner.lineno,
+        col=foreign.owner.col_offset,
+    )
+
+    with pytest.raises(SourceCallBindingGap, match="mutable global binding source"):
+        replace(frame, mutable_global_bindings=(binding,))
 
 
 def test_binder_refuses_stale_binding_coordinate_cid() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
-from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.floor import TermValue, TupleValue
 from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
 from sugar_lift_py_tests.ir import PrimitiveSort
 from sugar_lift_py_tests.source_call_frame import (
@@ -29,6 +29,53 @@ def _frame(*, name: str = "helper", filename: str = "bound_coordinates.py"):
     return function.source_visible_call_frame().with_native_operation_projection(
         function.formal_coordinates(), function.sugar().desugar(None)
     )
+
+
+def _vararg_frame(*, filename: str = "bound_vararg_coordinates.py"):
+    source = "def helper(*values):\n    return values[0]\n"
+    tree = SourceFile(
+        (source, filename, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
+    return function.source_visible_call_frame()
+
+
+def test_vararg_binder_retains_authenticated_child_coordinate_actuals() -> None:
+    frame = _vararg_frame()
+    first = TermValue(1)
+    second = TermValue(2)
+
+    bound = frame.bind_actuals((first, second), ())
+
+    assert bound.actuals == (TupleValue((first, second)),)
+    assert tuple(pair.coordinate for pair in bound.projected_pairs) == (
+        frame.formal_coordinates[0].project("variadic", 0),
+        frame.formal_coordinates[0].project("variadic", 1),
+    )
+    assert tuple(pair.actual for pair in bound.projected_pairs) == (first, second)
+
+
+@pytest.mark.parametrize("variant", ("wrong-child", "foreign-root"))
+def test_vararg_binder_refuses_cross_wired_child_projection(variant: str) -> None:
+    frame = _vararg_frame()
+    foreign = _vararg_frame(filename="foreign_vararg_coordinates.py")
+    first = TermValue(1)
+    truthful = frame.bind_actuals((first,), ())
+    child = truthful.projected_pairs[0]
+    coordinate = (
+        frame.formal_coordinates[0].project("variadic", 1)
+        if variant == "wrong-child"
+        else foreign.formal_coordinates[0].project("variadic", 0)
+    )
+
+    with pytest.raises(SourceCallBindingGap, match="projected formal coordinate"):
+        BoundSourceCallActualsV1(
+            truthful.actuals,
+            truthful.formal_coordinates,
+            truthful.native_formal_coordinates,
+            (replace(child, coordinate=coordinate),),
+        )
 
 
 def test_binder_returns_ordered_typed_coordinate_testimony() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_refusal_preservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_refusal_preservation.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor import DictValue, FloorValue, StringValue, TermValue
+from sugar_lift_py_tests.ir import atomic, ctor
+from sugar_lift_py_tests.outcome import Complete, ExitSet
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted, complement_guard
+from sugar_lift_py_tests.sugar.subscript_sugar import SubscriptSugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+from sugar_source_tree.nodes import Subscript
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+@dataclass(frozen=True)
+class _ValueSugar(ConstructedTermSugar):
+    outcome: object
+    site: object
+
+    @classmethod
+    def witnesses(cls):
+        raise NotImplementedError
+
+    def desugar(self, ctx=None):
+        del ctx
+        return self.outcome
+
+    def to_term(self, *, owner: str):
+        del owner
+        return ctor("test:value-sugar", [])
+
+
+@dataclass(frozen=True)
+class _RefusingValue(FloorValue):
+    refusal: SugarNotWritten
+
+    def subscript(self, index, site):
+        del index, site
+        raise self.refusal
+
+
+def _site(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    path = tmp_path / "subscript_refusal.py"
+    path.write_text("result = receiver[key]\n")
+    tree = SourceFile.from_path(path.name)
+    return next(node.fragment for node in tree.nodes() if isinstance(node, Subscript))
+
+
+def test_partitioned_subscript_preserves_original_typed_refusal(tmp_path, monkeypatch):
+    site = _site(tmp_path, monkeypatch)
+    refusal = SugarNotWritten(
+        blame=site,
+        owner="RefusingValue.subscript",
+        observed="authenticated undecided lookup",
+        requested="producer testimony",
+        fix="retain this typed refusal",
+    )
+    guard = atomic("test.receiver.completed", [])
+    receiver = ExitSet(
+        (
+            Halted(
+                complement_guard(guard),
+                RaiseEffect(exception_name="RuntimeError", occurrence=str(site)),
+            ),
+            Completed(guard, _RefusingValue(refusal)),
+        )
+    )
+    sugar = SubscriptSugar(
+        _ValueSugar(receiver, site),
+        _ValueSugar(Complete(StringValue("key")), site),
+        site,
+    )
+
+    with pytest.raises(SugarNotWritten) as raised:
+        sugar.desugar()
+
+    assert raised.value is refusal
+
+
+def test_partitioned_subscript_truth_keeps_value_and_halt_faces(tmp_path, monkeypatch):
+    site = _site(tmp_path, monkeypatch)
+    guard = atomic("test.receiver.completed", [])
+    receiver = ExitSet(
+        (
+            Halted(
+                complement_guard(guard),
+                RaiseEffect(exception_name="RuntimeError", occurrence=str(site)),
+            ),
+            Completed(
+                guard,
+                DictValue(((StringValue("key"), TermValue(7)),)),
+            ),
+        )
+    )
+    sugar = SubscriptSugar(
+        _ValueSugar(receiver, site),
+        _ValueSugar(Complete(StringValue("key")), site),
+        site,
+    )
+
+    exits = sugar.desugar()
+
+    assert len(exits.exits) == 2
+    assert any(isinstance(exit, Halted) for exit in exits.exits)
+    completed = next(exit for exit in exits.exits if isinstance(exit, Completed))
+    assert completed.value == TermValue(7)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1065,16 +1065,6 @@ def _resolve_source_visible_frame_uncached(
     )
     dependency_graphs = dict(dependency_graphs or {})
     dependency_graphs[resolved.module_name.split(".", 1)[0]] = graph
-    # Seat final-checked import value-use receipts into THIS frame's SourceUnit
-    # before any construction.  Identity operands (e.g. ``pd.array``) bind via
-    # authenticated definition coordinates on this unit — never cross-unit spans.
-    _seat_import_value_use_receipts(
-        source_file=source_file,
-        module=module,
-        session=session,
-        context=context,
-        dependency_graphs=dependency_graphs,
-    )
     definitions = tuple(
         item
         for item in source_file.root.body
@@ -1106,6 +1096,18 @@ def _resolve_source_visible_frame_uncached(
         return ManagerConstructionGapV1(
             "definition-missing", resolved.cid, "resolved definition coordinate"
         )
+    # Seat final-checked import value-use receipts owned by THIS resolved
+    # definition before constructing its frame. Identity operands bind via
+    # authenticated coordinates on this unit; unrelated sibling definitions
+    # never acquire authority merely by sharing the module source.
+    _seat_import_value_use_receipts(
+        source_file=source_file,
+        module=module,
+        target=target,
+        session=session,
+        context=context,
+        dependency_graphs=dependency_graphs,
+    )
     # Nested method export: project its ordinary frame without requiring the
     # enclosing class to be the export target. Leading ``self`` is the bound
     # instance for ``name = Class()`` callables and is not supplied by the
@@ -1859,11 +1861,12 @@ def _seat_import_value_use_receipts(
     *,
     source_file,
     module,
+    target: Node,
     session: SourceResolutionSession,
     context: TreeConstructionContextV1,
     dependency_graphs: dict[str, DependencyArtifactGraph],
 ) -> None:
-    """Seat authenticated value-use receipts on this frame unit only.
+    """Seat authenticated value-use receipts owned by this exact frame target.
 
     Receipts are minted once via ``authenticated_import_value_use_receipts``
     (source-CID authenticated; dual-door / mismatch raises).  Resolution uses
@@ -1904,6 +1907,18 @@ def _seat_import_value_use_receipts(
         module.source_cid,
         module_identities={},
     )
+    owned_spans = [target.line_col_span()]
+    owned_spans.extend(
+        decorator.line_col_span()
+        for decorator in getattr(target, "decorators", ())
+    )
+    owned_ranges = tuple(
+        (
+            (span.start_line, span.start_col),
+            (span.end_line, span.end_col),
+        )
+        for span in owned_spans
+    )
     for receipt in receipts:
         if receipt.source_cid != module.source_cid:
             raise ImportValueUseSeatingGap(
@@ -1929,6 +1944,12 @@ def _seat_import_value_use_receipts(
             site["endLine"],
             site["endCol"],
         )
+        use_start = (site["startLine"], site["startCol"])
+        use_end = (site["endLine"], site["endCol"])
+        if not any(
+            start <= use_start and use_end <= end for start, end in owned_ranges
+        ):
+            continue
         identity = receipt.import_binding.value["target"]["moduleIdentity"]
         if identity["kind"] == "authenticated-python-module":
             dependency_module = identity["moduleName"]
@@ -1962,6 +1983,13 @@ def _seat_import_value_use_receipts(
             receipt, graph=dependency_graph, session=session
         )
         if not isinstance(imported, ResolvedPythonObjectV1):
+            if imported.kind in {"dynamic-export", "static-export-absent"}:
+                # Honest open-world value exports carry no definition
+                # coordinate to seat. Leave the exact use unresolved so its
+                # ordinary consumer remains typed-loud if execution reaches
+                # it; unrelated construction must not turn that absence into
+                # module-wide refusal.
+                continue
             raise ImportValueUseSeatingGap(
                 f"resolution-{imported.kind}",
                 "authenticated value-use receipt did not resolve",

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1063,6 +1063,27 @@ def _resolve_source_visible_frame_uncached(
         (module.source, module.source_seat, module.source_cid),
         construction_context=context,
     )
+    from sugar_lift_python_source.value_pins import scan_module_value_pins
+    from sugar_lift_py_tests.source_call_frame import MutableGlobalBindingV1
+
+    pin_scan = scan_module_value_pins(
+        source_file.root, source=module.source, source_path=module.source_seat
+    )
+    mutable_global_bindings = tuple(
+        MutableGlobalBindingV1(
+            source_cid=pin.source_cid,
+            binding_occurrence=pin.binding_occurrence,
+            name=pin.name,
+            kind=pin.kind,
+            term=pin.term,
+            line=pin.line,
+            col=pin.col,
+        )
+        for pin in pin_scan.mutable_global_pins
+    )
+
+    def with_mutable_globals(frame):
+        return replace(frame, mutable_global_bindings=mutable_global_bindings)
     dependency_graphs = dict(dependency_graphs or {})
     dependency_graphs[resolved.module_name.split(".", 1)[0]] = graph
     definitions = tuple(
@@ -1117,7 +1138,7 @@ def _resolve_source_visible_frame_uncached(
         and target not in definitions
         and resolved.definition.name == "__call__"
     ):
-        frame = target.source_visible_call_frame()
+        frame = with_mutable_globals(target.source_visible_call_frame())
         if frame.parameters and frame.parameters[0] == "self":
             frame = replace(
                 frame,
@@ -1447,7 +1468,9 @@ def _resolve_source_visible_frame_uncached(
                     nested = external_frames.get(call.func.id)
                 if nested is not None:
                     _install_source_call_frame(context, call, nested)
-            frames[function.name] = function.source_visible_call_frame()
+            frames[function.name] = with_mutable_globals(
+                function.source_visible_call_frame()
+            )
             pending.remove(function)
             progressed = True
         if not progressed:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -550,13 +550,7 @@ def enter_bound_generator_resource_outcome(
 ):
     """Resume the exact authenticated generator construction at manager enter."""
     del ctx
-    from sugar_lift_py_tests.generator_construction import (
-        GeneratorConstructionV1,
-        GeneratorTerminationV1,
-        GeneratorTransitionGapV1,
-        YieldEffect,
-    )
-    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.generator_construction import GeneratorConstructionV1
     from sugar_source_tree.panic import SugarNotWritten
 
     if type(machine) is not GeneratorConstructionV1:
@@ -579,6 +573,59 @@ def enter_bound_generator_resource_outcome(
             fix="pass the manager call's authenticated generator construction",
         )
     result = machine.resume()
+    return _project_generator_enter_result(protocol, machine, result)
+
+
+def _project_generator_enter_result(protocol, entry_machine, result):
+    """Project every completed generator-enter arm; halted arms bypass intact."""
+    from sugar_lift_py_tests.floor import GuardedValue
+    from sugar_lift_py_tests.generator_construction import (
+        GeneratorConstructionV1,
+        GeneratorTerminationV1,
+        GeneratorTransitionGapV1,
+        YieldEffect,
+    )
+    from sugar_lift_py_tests.ir import not_
+    from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete
+    from sugar_lift_py_tests.outcome.exit_set import Completed
+    from sugar_source_tree.panic import SugarNotWritten
+
+    if isinstance(result, ExitSet):
+        return result.and_then(
+            lambda value: _project_generator_enter_result(
+                protocol, entry_machine, value
+            )
+        )
+    if isinstance(result, GuardedValue):
+        guarded_arms = ExitSet(
+            (
+                Completed(result.guard, result.when_true),
+                Completed(not_(result.guard), result.when_false),
+            )
+        )
+
+        def _project_guarded_arm(arm):
+            if type(arm) is GeneratorConstructionV1:
+                if arm.frame_coordinate != protocol.generator_frame_cid:
+                    raise SugarNotWritten(
+                        blame=protocol.exit_face_id,
+                        owner="GeneratorBackedManagerProtocolV1.enter_resource_outcome",
+                        observed=(
+                            "foreign frame coordinate "
+                            f"{arm.frame_coordinate} in guarded generator arm"
+                        ),
+                        requested=(
+                            "exact guarded GeneratorConstructionV1 arm for frame "
+                            f"{protocol.generator_frame_cid}"
+                        ),
+                        fix="retain the branch machine produced by this generator frame",
+                    )
+                return _project_generator_enter_result(
+                    protocol, entry_machine, arm.resume()
+                )
+            return _project_generator_enter_result(protocol, entry_machine, arm)
+
+        return guarded_arms.and_then(_project_guarded_arm)
     if isinstance(result, YieldEffect):
         enter_value = _floor_enter_value(result.value)
         # Per-protocol enter ordinal distinguishes successive enters that
@@ -605,8 +652,6 @@ def enter_bound_generator_resource_outcome(
         )
         return Complete(entered)
     # Nested enter can surface Incomplete (inner raise before yield).
-    from sugar_lift_py_tests.outcome import Incomplete
-
     if isinstance(result, Incomplete):
         return result
     if isinstance(result, GeneratorTerminationV1):
@@ -616,7 +661,7 @@ def enter_bound_generator_resource_outcome(
         from sugar_lift_py_tests.outcome import Incomplete
 
         refusal = observed_entry_refusal()
-        blame = str(machine.instance_coordinate)
+        blame = str(entry_machine.instance_coordinate)
         return Incomplete(
             RaiseEffect(
                 exception_name=refusal.exception_name,

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -99,16 +99,18 @@ class ConstructedManagerProtocolV1:
 
     def enter_resource_outcome(self, ctx: object = None):
         """Run enter once and carry each face's exact receiver into resource exit."""
-
-        def run_enter(receiver):
-            enter = _call_protocol_method(
-                receiver, "__enter__", (), self.exit_face_id, ctx
-            ).reduce_source_outcome(ctx)
-            return _resource_enter_transitions(receiver, enter, blame=self.exit_face_id)
-
         if isinstance(self.receiver_state, ObjectValue):
-            return run_enter(self.receiver_state)
-        return _completed_receiver_exits(self.receiver_state).sequence(run_enter)
+            return self.enter_resource_outcome_for(self.receiver_state, ctx)
+        return _completed_receiver_exits(self.receiver_state).sequence(
+            lambda receiver: self.enter_resource_outcome_for(receiver, ctx)
+        )
+
+    def enter_resource_outcome_for(self, receiver, ctx: object = None):
+        """Run enter on the exact receiver value produced by the manager face."""
+        enter = _call_protocol_method(
+            receiver, "__enter__", (), self.exit_face_id, ctx
+        ).reduce_source_outcome(ctx)
+        return _resource_enter_transitions(receiver, enter, blame=self.exit_face_id)
 
     def exit_outcome_for(self, entered: EnteredManagerStateValue, ctx: object = None):
         if not isinstance(entered, EnteredManagerStateValue):
@@ -502,6 +504,10 @@ class GeneratorBackedManagerProtocolV1:
         """Enter the authenticated generator lifecycle; return yield + machine."""
         return enter_generator_resource_outcome(self, ctx=ctx)
 
+    def enter_resource_outcome_for(self, machine, ctx: object = None):
+        """Enter the exact generator construction returned by the manager call."""
+        return enter_bound_generator_resource_outcome(self, machine, ctx=ctx)
+
     def exit_outcome_for(self, entered, ctx: object = None):
         """Resume/throw the exact entered machine once; expose suppression."""
         return exit_generator_resource_outcome_for(self, entered, ctx=ctx)
@@ -514,14 +520,9 @@ def enter_generator_resource_outcome(protocol, *, ctx: object = None):
     that duck-type the same fields. Returns ``Complete(EnteredGeneratorManagerStateV1)``
     on yield; typed-loud refusal when the machine cannot enter.
     """
-    del ctx
     from sugar_lift_py_tests.generator_construction import (
         GeneratorConstructionV1,
-        GeneratorTerminationV1,
-        GeneratorTransitionGapV1,
-        YieldEffect,
     )
-    from sugar_lift_py_tests.outcome import Complete
     from sugar_source_tree.panic import SugarNotWritten
 
     frame = protocol.generator_frame
@@ -541,6 +542,42 @@ def enter_generator_resource_outcome(protocol, *, ctx: object = None):
         binding_state=bindings,
         steps=steps,
     )
+    return enter_bound_generator_resource_outcome(protocol, machine, ctx=ctx)
+
+
+def enter_bound_generator_resource_outcome(
+    protocol, machine, *, ctx: object = None
+):
+    """Resume the exact authenticated generator construction at manager enter."""
+    del ctx
+    from sugar_lift_py_tests.generator_construction import (
+        GeneratorConstructionV1,
+        GeneratorTerminationV1,
+        GeneratorTransitionGapV1,
+        YieldEffect,
+    )
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_source_tree.panic import SugarNotWritten
+
+    if type(machine) is not GeneratorConstructionV1:
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.enter_resource_outcome_for",
+            observed=f"foreign construction type {type(machine).__name__}",
+            requested="exact GeneratorConstructionV1 from the manager call",
+            fix="pass the manager call's authenticated generator construction",
+        )
+    if machine.frame_coordinate != protocol.generator_frame_cid:
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.enter_resource_outcome_for",
+            observed=f"foreign frame coordinate {machine.frame_coordinate}",
+            requested=(
+                "exact generator construction frame coordinate "
+                f"{protocol.generator_frame_cid}"
+            ),
+            fix="pass the manager call's authenticated generator construction",
+        )
     result = machine.resume()
     if isinstance(result, YieldEffect):
         enter_value = _floor_enter_value(result.value)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -2382,6 +2382,20 @@ def _construct_decorator_function(
     authenticated_dependency = (dependency_graphs or {}).get(top_level)
     if authenticated_dependency is not None and authenticated_dependency not in graphs:
         graphs.append(authenticated_dependency)
+    if not any(module_name in candidate.modules for candidate in graphs):
+        from .dependency_artifact import (
+            DependencyArtifactAuthenticationError,
+            authenticate_dependency_top_level,
+        )
+
+        try:
+            authenticated_dependency = authenticate_dependency_top_level(
+                top_level, distribution_index=distribution_index
+            )
+        except DependencyArtifactAuthenticationError:
+            return None
+        if authenticated_dependency not in graphs:
+            graphs.append(authenticated_dependency)
     resolved = None
     resolved_graph = None
     for candidate in graphs:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -2358,7 +2358,9 @@ def _construct_decorator_function(
     from sugar_source_tree.nodes import FunctionDef, Name
 
     from .dependency_artifact import (
+        DependencyArtifactAuthenticationError,
         ResolvedPythonObjectV1,
+        authenticate_dependency_top_level,
         resolve_authenticated_module_export,
     )
     from .manager_construction import (
@@ -2380,6 +2382,16 @@ def _construct_decorator_function(
         graphs.append(graph)
     top_level = module_name.split(".", 1)[0]
     authenticated_dependency = (dependency_graphs or {}).get(top_level)
+    if authenticated_dependency is None:
+        try:
+            authenticated_dependency = authenticate_dependency_top_level(
+                top_level, distribution_index=distribution_index
+            )
+        except DependencyArtifactAuthenticationError:
+            authenticated_dependency = None
+        else:
+            if dependency_graphs is not None:
+                dependency_graphs[top_level] = authenticated_dependency
     if authenticated_dependency is not None and authenticated_dependency not in graphs:
         graphs.append(authenticated_dependency)
     if not any(module_name in candidate.modules for candidate in graphs):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
@@ -108,6 +108,8 @@ class ValuePin:
 
 @dataclass(frozen=True)
 class MutableGlobalPin:
+    source_cid: str
+    binding_occurrence: "SourceMemento"
     name: str
     kind: str
     term: Json
@@ -150,6 +152,7 @@ class _Candidate:
     line: int
     confession: str | None
     col: int = 0
+    binding_occurrence: "SourceMemento | None" = None
 
 
 def scan_module_value_pins(
@@ -189,8 +192,12 @@ def scan_module_value_pins(
             scan.boundaries.append(_pin_boundary(candidate, exc.reason))
             mutable_kind = _direct_mutable_kind(candidate.value)
             if mutable_kind is not None:
+                if candidate.binding_occurrence is None:
+                    raise AssertionError("mutable global candidate lost binding occurrence")
                 scan.mutable_global_pins.append(
                     MutableGlobalPin(
+                        source_cid=tree.unit.source_cid,
+                        binding_occurrence=candidate.binding_occurrence,
                         name=candidate.name,
                         kind=mutable_kind,
                         term=mutable_global_pin_term(candidate.name, mutable_kind),
@@ -486,6 +493,7 @@ def _collect_candidates(tree: typed.Module) -> dict[str, _Candidate]:
             line=stmt.lineno,
             confession=confession,
             col=name_node.col_offset,
+            binding_occurrence=name_node.fragment.seal(),
         )
     # A duplicated candidate name surfaces through the binding-event scan
     # (two assignment events), so the first occurrence remains the candidate

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
@@ -21,6 +21,7 @@ from types import SimpleNamespace
 import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.context import ReduceContext
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 from sugar_lift_py_tests.floor import BlockValue, ReturnValue, StringValue, TermValue
 from sugar_lift_py_tests.generator_construction import (
@@ -88,6 +89,39 @@ def test_enter_resource_outcome_yields_value_with_exact_machine_state():
     assert entered.machine.suspended_resume_coordinate is not None
     assert entered.protocol_construction_cid == protocol.protocol_construction_cid
     assert entered.entry_cid.startswith("blake3-512:")
+
+
+def test_enter_bound_generator_construction_preserves_exact_machine_testimony():
+    protocol = _protocol()
+    reduction_context = ReduceContext.root(owner="already-bound-generator")
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:already-bound-generator",
+        frame_coordinate=protocol.generator_frame_cid,
+        binding_state=(),
+        steps=protocol.generator_frame.generator_steps,
+        reduction_context=reduction_context,
+    )
+
+    outcome = protocol.enter_resource_outcome_for(machine)
+
+    assert isinstance(outcome, Complete)
+    entered = outcome.value
+    assert entered.machine.instance_coordinate == machine.instance_coordinate
+    assert entered.machine.allocation_coordinate == machine.allocation_coordinate
+    assert entered.machine.reduction_context is reduction_context
+
+
+def test_enter_bound_generator_construction_refuses_foreign_frame():
+    protocol = _protocol()
+    foreign = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:foreign-generator",
+        frame_coordinate=cid_of_json({"frame": "foreign-generator"}),
+        binding_state=(),
+        steps=protocol.generator_frame.generator_steps,
+    )
+
+    with pytest.raises(SugarNotWritten, match="frame coordinate"):
+        protocol.enter_resource_outcome_for(foreign)
 
 
 def test_exit_outcome_for_resumes_exact_entered_machine_once():

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
@@ -23,15 +23,24 @@ import pytest
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.context import ReduceContext
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
-from sugar_lift_py_tests.floor import BlockValue, ReturnValue, StringValue, TermValue
+from sugar_lift_py_tests.floor import (
+    BlockValue,
+    GuardedValue,
+    ReturnValue,
+    StringValue,
+    TermValue,
+)
 from sugar_lift_py_tests.generator_construction import (
     GeneratorConstructionV1,
     InertStepV1,
     OpaqueStepV1,
     ReturnStepV1,
+    YieldEffect,
     YieldStepV1,
 )
-from sugar_lift_py_tests.outcome import Complete, Incomplete, outcome_to_exitset
+from sugar_lift_py_tests.ir import atomic, not_
+from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete, outcome_to_exitset
+from sugar_lift_py_tests.outcome.exit_set import Completed, Halted, partition
 from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
 from sugar_lift_py_tests.sugar.none_literal_sugar import NoneLiteralSugar
 from sugar_lift_py_tests.sugar.string_literal_sugar import StringLiteralSugar
@@ -109,6 +118,162 @@ def test_enter_bound_generator_construction_preserves_exact_machine_testimony():
     assert entered.machine.instance_coordinate == machine.instance_coordinate
     assert entered.machine.allocation_coordinate == machine.allocation_coordinate
     assert entered.machine.reduction_context is reduction_context
+
+
+def test_enter_bound_generator_maps_yield_and_preserves_mixed_halt(monkeypatch):
+    protocol = _protocol()
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:mixed-enter",
+        frame_coordinate=protocol.generator_frame_cid,
+        binding_state=(),
+        steps=protocol.generator_frame.generator_steps,
+    )
+    yielded = machine.resume()
+    assert isinstance(yielded, YieldEffect)
+    completed_guard = atomic("mixed_enter_completed", ())
+    halted_guard = atomic("mixed_enter_halted", ())
+    completed_face, halted_face = partition(("mixed-enter", "lifecycle"))
+    pending = SimpleNamespace(demands=())
+    effect = RaiseEffect(exception_name="ValueError", blame="before-enter")
+    mixed = ExitSet(
+        (
+            Completed(
+                completed_guard,
+                yielded,
+                frozenset({completed_face}),
+                (pending,),
+            ),
+            Halted(
+                halted_guard,
+                effect,
+                machine,
+                frozenset({halted_face}),
+                (pending,),
+            ),
+        )
+    )
+    monkeypatch.setattr(GeneratorConstructionV1, "resume", lambda self: mixed)
+
+    outcome = protocol.enter_resource_outcome_for(machine)
+
+    assert isinstance(outcome, ExitSet)
+    halted = next(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
+    assert halted.guard == halted_guard
+    assert halted.effect is effect
+    assert halted.state is machine
+    assert halted.faces == frozenset({halted_face})
+    assert halted.pending_contracts == (pending,)
+    completed = next(
+        exit_ for exit_ in outcome.exits if isinstance(exit_, Completed)
+    )
+    assert completed.guard == completed_guard
+    assert isinstance(completed.value, EnteredGeneratorManagerStateV1)
+    assert completed.value.machine is yielded.machine
+    assert completed.faces == frozenset({completed_face})
+    assert completed.pending_contracts == (pending,)
+
+
+def test_enter_bound_generator_resumes_guarded_machine_arms(monkeypatch):
+    protocol = _protocol()
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:guarded-enter",
+        frame_coordinate=protocol.generator_frame_cid,
+        binding_state=(),
+        steps=protocol.generator_frame.generator_steps,
+    )
+    left_machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:guarded-enter-left",
+        frame_coordinate=protocol.generator_frame_cid,
+        binding_state=(),
+        steps=protocol.generator_frame.generator_steps,
+    )
+    right_machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:guarded-enter-right",
+        frame_coordinate=protocol.generator_frame_cid,
+        binding_state=(),
+        steps=(YieldStepV1(IntLiteralSugar(23, site="yield:23")),),
+    )
+    guard = atomic("guarded_enter", ())
+    guarded = GuardedValue(guard, left_machine, right_machine)
+    original_resume = GeneratorConstructionV1.resume
+    monkeypatch.setattr(
+        GeneratorConstructionV1,
+        "resume",
+        lambda self: guarded if self is machine else original_resume(self),
+    )
+
+    outcome = protocol.enter_resource_outcome_for(machine)
+
+    assert isinstance(outcome, ExitSet)
+    completed = tuple(
+        exit_ for exit_ in outcome.exits if isinstance(exit_, Completed)
+    )
+    assert len(completed) == 2
+    assert {exit_.guard for exit_ in completed} == {
+        guard,
+        not_(guard),
+    }
+    assert {exit_.value.enter_value for exit_ in completed} == {
+        TermValue(17),
+        TermValue(23),
+    }
+
+
+def test_enter_bound_generator_refuses_foreign_guarded_machine_arm(monkeypatch):
+    protocol = _protocol()
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:guarded-enter-foreign",
+        frame_coordinate=protocol.generator_frame_cid,
+        binding_state=(),
+        steps=protocol.generator_frame.generator_steps,
+    )
+    local = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:guarded-enter-local-arm",
+        frame_coordinate=protocol.generator_frame_cid,
+        binding_state=(),
+        steps=protocol.generator_frame.generator_steps,
+    )
+    foreign = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:guarded-enter-foreign-arm",
+        frame_coordinate=cid_of_json({"frame": "foreign-guarded-arm"}),
+        binding_state=(),
+        steps=protocol.generator_frame.generator_steps,
+    )
+    guarded = GuardedValue(atomic("guarded_enter_foreign", ()), local, foreign)
+    original_resume = GeneratorConstructionV1.resume
+    monkeypatch.setattr(
+        GeneratorConstructionV1,
+        "resume",
+        lambda self: guarded if self is machine else original_resume(self),
+    )
+
+    with pytest.raises(SugarNotWritten) as raised:
+        protocol.enter_resource_outcome_for(machine)
+
+    assert raised.value.owner == "GeneratorBackedManagerProtocolV1.enter_resource_outcome"
+    assert "foreign frame coordinate" in raised.value.observed
+
+
+def test_enter_bound_generator_keeps_bad_guarded_arm_loud(monkeypatch):
+    protocol = _protocol()
+    machine = GeneratorConstructionV1.allocate(
+        allocation_coordinate="call:guarded-enter-bad-arm",
+        frame_coordinate=protocol.generator_frame_cid,
+        binding_state=(),
+        steps=protocol.generator_frame.generator_steps,
+    )
+    yielded = machine.resume()
+    assert isinstance(yielded, YieldEffect)
+    guarded = GuardedValue(
+        atomic("guarded_enter_bad_arm", ()), yielded, TermValue(99)
+    )
+    monkeypatch.setattr(GeneratorConstructionV1, "resume", lambda self: guarded)
+
+    with pytest.raises(SugarNotWritten) as raised:
+        protocol.enter_resource_outcome_for(machine)
+
+    assert raised.value.owner == "GeneratorBackedManagerProtocolV1.enter_resource_outcome"
+    assert raised.value.observed == "TermValue"
 
 
 def test_enter_bound_generator_construction_refuses_foreign_frame():

--- a/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
@@ -70,8 +70,12 @@ def _consumer(root: Path, source: str):
     return path, source_file, context
 
 
-def _frame_for_box_expected(tmp_path: Path, helpers: str):
-    distribution = _distribution(tmp_path, helpers)
+def _frame_for_box_expected(
+    tmp_path: Path,
+    helpers: str,
+    types: str = "class ArrayType:\n    pass\n",
+):
+    distribution = _distribution(tmp_path, helpers, types)
     path, source_file, context = _consumer(
         tmp_path,
         "from unprivileged import box_expected, ArrayType\n"
@@ -96,6 +100,31 @@ def _frame_for_box_expected(tmp_path: Path, helpers: str):
         context.source_call_resolutions[coordinate], SourceCallPreconstructionRefV1
     )
     return context.source_call_frames[coordinate]
+
+
+def test_sibling_dynamic_import_use_does_not_block_selected_runtime_frame(
+    tmp_path: Path,
+) -> None:
+    """Truthful: only the authenticated selected definition owns frame uses."""
+    frame = _frame_for_box_expected(
+        tmp_path,
+        "from unprivileged.types import ArrayType, F\n"
+        "def unrelated(value):\n"
+        "    return F\n"
+        "def box_expected(expected, box_cls=None):\n"
+        "    return expected if box_cls is None else box_cls\n",
+        "class ArrayType:\n"
+        "    pass\n"
+        "def choose_type():\n"
+        "    return object()\n"
+        "F = choose_type()\n",
+    )
+
+    assert frame.owner.name == "box_expected"
+    assert all(
+        resolved.definition.name != "F"
+        for resolved in frame.owner.unit._import_value_use_resolutions.values()
+    )
 
 
 def test_frame_seats_import_value_use_receipts_on_own_unit(tmp_path: Path) -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2894,25 +2894,21 @@ class FunctionDef(Statement):
             SourceVisibleFunctionBodySugar,
         )
 
-        substituted_body, _ = self._substitute_body(self.body, formal_scope)
-        generator_steps = self._source_visible_generator_steps_from(substituted_body)
-        lexical_definitions = tuple(
-            row.definition_occurrence
-            for row in self.unit.constructed_module.lexical_call_rows
+        lexical_rows = self.unit.constructed_module.lexical_call_rows
+        filtered_body = tuple(
+            statement
+            for statement in self.body
+            if all(
+                statement is not row.definition_occurrence for row in lexical_rows
+            )
         )
+        substituted_body, _ = self._substitute_body(filtered_body, formal_scope)
+        generator_steps = self._source_visible_generator_steps_from(substituted_body)
         body = SourceVisibleFunctionBodySugar(
             (
                 ()
                 if generator_steps is not None
-                else tuple(
-                    substituted.sugar()
-                    for original, substituted in zip(
-                        self.body, substituted_body, strict=True
-                    )
-                    if not any(
-                        original is definition for definition in lexical_definitions
-                    )
-                )
+                else tuple(statement.sugar() for statement in substituted_body)
             ),
             self.fragment,
         )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -554,7 +554,7 @@ class SourceUnit:
                 )
             elif isinstance(consumer, For):
                 targets = ((consumer.target, ("target",)),)
-            elif isinstance(consumer, (ListComp, SetComp, DictComp)):
+            elif isinstance(consumer, (ListComp, SetComp, DictComp, GeneratorExp)):
                 targets = tuple(
                     (generator.target, ("generators", index, "target"))
                     for index, generator in enumerate(consumer.generators)
@@ -562,10 +562,17 @@ class SourceUnit:
             if not targets:
                 continue
             owned = tuple(
-                self._construct_target_pattern(consumer, target, prefix)
+                pattern
                 for target, prefix in targets
+                if (
+                    pattern := self._construct_target_pattern(
+                        consumer, target, prefix
+                    )
+                )
+                is not None
             )
-            patterns[consumer.ref] = owned
+            if owned:
+                patterns[consumer.ref] = owned
             patterns_by_target.update(
                 (pattern.target_occurrence.ref, pattern) for pattern in owned
             )
@@ -576,7 +583,9 @@ class SourceUnit:
         # Identity keys include spans against the bound module; drop stale rows.
         object.__setattr__(self, "_exception_type_identity_cache", {})
 
-    def _construct_target_pattern(self, consumer, target, prefix) -> TargetPatternV1:
+    def _construct_target_pattern(
+        self, consumer, target, prefix
+    ) -> TargetPatternV1 | None:
         from .binding_state import mint_binding_coordinate_v1
 
         ordered = []
@@ -592,6 +601,11 @@ class SourceUnit:
                 for index, child in enumerate(node.elts):
                     visit(child, (*path, index))
                 return
+            if isinstance(node, (Attribute, Subscript)):
+                # Store leaves carry runtime store obligations; they do not
+                # introduce lexical bindings and therefore own no binding
+                # coordinate in this pattern.
+                return
             raise TargetPatternConstructionGapV1(
                 "unsupported-target-leaf",
                 consumer_occurrence=consumer,
@@ -600,11 +614,7 @@ class SourceUnit:
 
         visit(target, prefix)
         if not ordered:
-            raise TargetPatternConstructionGapV1(
-                "empty-target-pattern",
-                consumer_occurrence=consumer,
-                target_occurrence=target,
-            )
+            return None
         owner_cid = (
             consumer.owned_loop_target.target_cid
             if isinstance(consumer, For) and consumer.owned_loop_target is not None

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -551,6 +551,7 @@ class SourceUnit:
                     (target, ("targets", target_index))
                     for target_index, target in enumerate(consumer.targets)
                     if isinstance(target, (Tuple_, List))
+                    and self._is_binding_target_pattern(target)
                 )
             elif isinstance(consumer, For):
                 targets = ((consumer.target, ("target",)),)
@@ -582,6 +583,20 @@ class SourceUnit:
         object.__setattr__(self, "target_pattern_construction_count", constructed_count)
         # Identity keys include spans against the bound module; drop stale rows.
         object.__setattr__(self, "_exception_type_identity_cache", {})
+
+    @staticmethod
+    def _is_binding_target_pattern(target) -> bool:
+        """True only when every leaf is a lexical binding occurrence."""
+        if isinstance(target, Name):
+            return True
+        if isinstance(target, Starred):
+            return SourceUnit._is_binding_target_pattern(target.value)
+        if isinstance(target, (Tuple_, List)):
+            return all(
+                SourceUnit._is_binding_target_pattern(child)
+                for child in target.elts
+            )
+        return False
 
     def _construct_target_pattern(
         self, consumer, target, prefix

--- a/implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py
+++ b/implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py
@@ -21,7 +21,8 @@ def fixture(value, items):
     unique = {a for a, (b, *c) in items}
     mapped = {a: b for a, (b, *c) in items}
     recursive = [b for a, *rest in items for b in rest]
-    return listed, unique, mapped, recursive
+    generated = tuple(a for a, (b, *c) in items)
+    return listed, unique, mapped, recursive, generated
 """
 
 LIVE_SOURCE = """\
@@ -47,6 +48,7 @@ EXPECTED = {
     ("DictComp", 7, 0): (("a", ("generators", 0, "target", 0)), ("b", ("generators", 0, "target", 1, 0)), ("c", ("generators", 0, "target", 1, 1, "star"))),
     ("ListComp", 8, 0): (("a", ("generators", 0, "target", 0)), ("rest", ("generators", 0, "target", 1, "star"))),
     ("ListComp", 8, 1): (("b", ("generators", 1, "target")),),
+    ("GeneratorExp", 9, 0): (("a", ("generators", 0, "target", 0)), ("b", ("generators", 0, "target", 1, 0)), ("c", ("generators", 0, "target", 1, 1, "star"))),
 }
 
 
@@ -193,6 +195,49 @@ def test_same_unit_foreign_for_cannot_claim_local_target(tmp_path: Path):
     assert source_file.unit.target_pattern_construction_count == before
     assert loops[0].target_patterns[0] is first_pattern
     assert loops[1].target_patterns[0] is second_pattern
+
+
+def test_assign_rhs_rewrite_retains_its_authenticated_target_pattern(
+    tmp_path: Path,
+):
+    path = tmp_path / "rewritten_unpack.py"
+    path.write_text(
+        "def selected(value):\n"
+        "    key = normalize(value)\n"
+        "    root, leaf = split(key)\n"
+        "    return root[leaf]\n"
+    )
+    source_file = SourceFile.from_path(path)
+    function, = tuple(source_file.functions())
+    original = next(
+        node
+        for node in function.walk()
+        if node.kind == "Assign" and node.line_col_span().start_line == 3
+    )
+    original_pattern, = original.target_patterns
+
+    frame = function.source_visible_call_frame()
+
+    assert frame.owner is function
+    assert source_file.unit.require_target_pattern(
+        original, original.targets[0]
+    ) is original_pattern
+    assert source_file.unit.target_pattern_construction_count == 1
+
+
+def test_attribute_only_unpack_is_not_minted_as_a_binding_pattern(
+    tmp_path: Path,
+):
+    path = tmp_path / "attribute_unpack.py"
+    path.write_text(
+        "class Holder:\n"
+        "    def install(self, left, right):\n"
+        "        self.left, self.right = left, right\n"
+    )
+
+    source_file = SourceFile.from_path(path)
+
+    assert source_file.unit.target_pattern_construction_count == 0
 
 
 def test_legacy_reharvest_manifestations_are_retired():

--- a/implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py
+++ b/implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py
@@ -240,6 +240,20 @@ def test_attribute_only_unpack_is_not_minted_as_a_binding_pattern(
     assert source_file.unit.target_pattern_construction_count == 0
 
 
+def test_mixed_attribute_unpack_is_not_a_lexical_target_pattern(tmp_path: Path):
+    path = tmp_path / "mixed_store_target.py"
+    path.write_text(
+        "class Holder:\n"
+        "    def bind(self, func, args, kwds):\n"
+        "        self.func, self.args, self.kwds = func, args, kwds\n"
+    )
+    source_file = SourceFile.from_path(path)
+    assignment = next(node for node in source_file.nodes() if node.kind == "Assign")
+
+    assert assignment.target_patterns == ()
+    assert source_file.unit.target_pattern_construction_count == 0
+
+
 def test_legacy_reharvest_manifestations_are_retired():
     source = Path(nodes.__file__).read_text()
     offenders = tuple(


### PR DESCRIPTION
## What changed

- distribute `length` through `GuardedValue._map`, retaining guarded exit testimony and loud unsupported arms
- project generator manager entry results through existing `ExitSet.and_then`
- recursively resume exact same-frame `GeneratorConstructionV1` arms carried by `GuardedValue`
- preserve halted faces, guards, state, faces, and pending contracts; retain typed termination and unsupported-arm refusals

## Root cause

The option_context generator first-yield path can return a partitioned `ExitSet` whose completed value is a `GuardedValue` of branch successor machines. The entry consumer accepted only a direct `YieldEffect`, so it rejected authenticated partitioned and guarded transitions instead of consuming their completed arms.

## Evidence

- `bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_guarded_value_length.py implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py` — 21 passed
- exact option_context lifecycle advances beyond the enter projector and remains loudly red at the next independent transition gap: `undecided receiver runtime type or index semantics: CallSiteValue[SliceValue]`

## Vector

- R_guarded_length: 1 -> 0
- R_raw_exitset_enter: 1 -> 0
- R_guarded_machine_enter: 1 -> 0
- Epsilon: exact lifecycle advances to the next producer-owned SliceValue transition residual
- Floors: no ExitSet/carrier edits, no flattening, no vendor/name arm, unsupported arms remain typed loud


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add guarded generator manager entry outcomes with mutable global binding propagation
> - Introduces `_project_generator_enter_result` in [manager_protocol_construction.py](https://github.com/TSavo/sugar/pull/6851/files#diff-bdbfb97c4a5209dd6ce8e2b561f5dde22cdb35bce955d8d781c7c1e72ff11700) to handle `ExitSet` and `GuardedValue` outcomes when entering a generator-backed manager, projecting each arm independently.
> - Adds `enter_bound_generator_resource_outcome` to validate the generator machine against the protocol's frame coordinate before resuming, centralizing entry logic for both standard and partitioned receiver cases.
> - Propagates mutable global bindings from value-pin scanning into source-visible call frames in [manager_construction.py](https://github.com/TSavo/sugar/pull/6851/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1); import value-use receipts are now seated only for the resolved definition's owned spans.
> - Introduces `MutableGlobalValue` in [mutable_global_value.py](https://github.com/TSavo/sugar/pull/6851/files#diff-4361db2a9d0f4dcf761b14b736ed0abf7ef492dfdd8a9b489b108d0649db2439) as a new floor value type modeling mutable dict lookups as a split `ExitSet` with `KeyError` and success faces; cross-source lookups raise `SugarNotWritten`.
> - Extends `BoundSourceCallActualsV1` and `source_call_frame` in [source_call_frame.py](https://github.com/TSavo/sugar/pull/6851/files#diff-46ed9299504763bf181346656eb60c3f3f7782237167304b1201599c48319ab6) to carry projected variadic pairs and mutable global bindings, with strict validation on construction.
> - Risk: `_seat_import_value_use_receipts` now skips receipts outside the resolved target's owned spans, which is a behavioral change from previously seating all matching module receipts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 931aec0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for authenticated mutable global values and source-aware dictionary lookups.
  * Improved generator-backed resource handling, including guarded and mixed outcomes.
  * Expanded support for multi-level imported call paths.
  * Added stronger handling for variadic arguments and projected coordinates.

* **Bug Fixes**
  * Preserved halted and completed outcomes during conditional and subscript operations.
  * Improved resource-enter behavior for routed manager values.
  * Prevented invalid or foreign source bindings from being accepted.
  * Corrected target-pattern handling for attribute and subscript assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->