### PR TITLE
Authenticate decorated class lexical reach

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -21,6 +21,7 @@ class ConstructedClassFieldV1:
     name: str
     definition_fragment_cid: str
     value_sugar: object = field(compare=False)
+    evaluation_group_cid: str | None = None
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
@@ -53,6 +53,7 @@ class ClassDefinitionSugar(Sugar):
                 return {
                     "name": item.name,
                     "definitionFragmentCid": item.definition_fragment_cid,
+                    "evaluationGroupCid": item.evaluation_group_cid,
                 }
             return {
                 "kind": "conditional",
@@ -110,6 +111,8 @@ class ClassDefinitionSugar(Sugar):
                 )
             base_values.append(outcome.value)
 
+        evaluated_groups = {}
+
         def append_field(item):
             if isinstance(item, ConstructedClassConditionalFieldsV1):
                 condition = item.condition_sugar.desugar(ctx)
@@ -143,7 +146,15 @@ class ClassDefinitionSugar(Sugar):
                 for child in selected:
                     append_field(child)
                 return
-            outcome = item.value_sugar.desugar(ctx)
+            outcome = (
+                evaluated_groups.get(item.evaluation_group_cid)
+                if item.evaluation_group_cid is not None
+                else None
+            )
+            if outcome is None:
+                outcome = item.value_sugar.desugar(ctx)
+                if item.evaluation_group_cid is not None:
+                    evaluated_groups[item.evaluation_group_cid] = outcome
             if not isinstance(outcome, Complete):
                 from sugar_source_tree.panic import SugarNotWritten
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_decorated_class_publication.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_decorated_class_publication.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 
@@ -18,45 +19,52 @@ from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.source_call_frame import DecoratedClassBindingV1
 from sugar_lift_py_tests.sugar.call_site_sugar import _with_frame_mutable_globals
 from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_source_tree.tree import SourceFile
 
 
-SOURCE = "blake3-512:" + "11" * 64
-
-
-def _publication():
+def _publication(tmp_path: Path, monkeypatch, *, stem: str = "publication"):
+    monkeypatch.chdir(tmp_path)
+    path = Path(f"{stem}.py")
+    path.write_text("class Published:\n    member = 1\n", encoding="utf-8")
+    source_file = SourceFile.from_path(path)
+    source = source_file.unit.source_cid
     raw = SymbolicValue(_Var("raw_class"))
     replaced = SymbolicValue(_Var("replacement_class"))
     final = SymbolicValue(_Var("published_class"))
     first = DecoratorApplicationPublicationV1.mint(
-        occurrence=SourceFragmentCoordinateV1(SOURCE, 2, 1, 2, 17),
+        occurrence=SourceFragmentCoordinateV1(source, 2, 1, 2, 17),
         callable_floor=SymbolicValue(_Var("replace_class")),
         input_floor=raw,
         output_floor=replaced,
     )
     second = DecoratorApplicationPublicationV1.mint(
-        occurrence=SourceFragmentCoordinateV1(SOURCE, 1, 1, 1, 16),
+        occurrence=SourceFragmentCoordinateV1(source, 1, 1, 1, 16),
         callable_floor=SymbolicValue(_Var("publish_members")),
         input_floor=replaced,
         output_floor=final,
     )
     publication = DecoratedClassPublicationV1.mint(
-        source_cid=SOURCE,
-        definition=SourceFragmentCoordinateV1(SOURCE, 3, 0, 5, 9),
-        binding_occurrence=SourceFragmentCoordinateV1(SOURCE, 3, 6, 3, 13),
+        source_cid=source,
+        definition=SourceFragmentCoordinateV1(source, 3, 0, 5, 9),
+        binding_occurrence=SourceFragmentCoordinateV1(source, 3, 6, 3, 13),
         raw_class=raw,
         decorator_applications=(first, second),
         final_class=final,
-        module_construction_receipt_cid="blake3-512:" + "22" * 64,
+        module_construction_receipt_cid=source_file.construction_event_receipt_cid,
     )
-    return publication, raw, replaced, final, first, second
+    return publication, raw, replaced, final, first, second, source_file
 
 
-def test_replacing_decorator_publication_ties_member_to_final_class() -> None:
-    publication, _, _, final, _, _ = _publication()
+def test_replacing_decorator_publication_ties_member_to_final_class(
+    tmp_path: Path, monkeypatch
+) -> None:
+    publication, _, _, final, _, _, _ = _publication(tmp_path, monkeypatch)
     class_value = DecoratedClassValue(publication)
     member = DecoratedClassMemberValue.mint(
         publication=publication,
-        member_definition=SourceFragmentCoordinateV1(SOURCE, 4, 4, 4, 10),
+        member_definition=SourceFragmentCoordinateV1(
+            publication.source_cid, 4, 4, 4, 10
+        ),
         member_floor=SymbolicValue(_Var("member")),
     )
 
@@ -69,8 +77,12 @@ def test_replacing_decorator_publication_ties_member_to_final_class() -> None:
 
 
 @pytest.mark.parametrize("variant", ("swapped", "omitted", "duplicated", "raw"))
-def test_publication_refuses_decorator_chain_reconstruction(variant: str) -> None:
-    publication, raw, _, final, first, second = _publication()
+def test_publication_refuses_decorator_chain_reconstruction(
+    variant: str, tmp_path: Path, monkeypatch
+) -> None:
+    publication, raw, _, final, first, second, _ = _publication(
+        tmp_path, monkeypatch
+    )
     applications = {
         "swapped": (second, first),
         "omitted": (second,),
@@ -93,21 +105,26 @@ def test_publication_refuses_decorator_chain_reconstruction(variant: str) -> Non
         )
 
 
-def test_member_refuses_cross_wired_publication() -> None:
-    publication, *_ = _publication()
+def test_member_refuses_cross_wired_publication(tmp_path: Path, monkeypatch) -> None:
+    publication, *_ = _publication(tmp_path, monkeypatch, stem="truthful")
+    foreign, *_ = _publication(tmp_path, monkeypatch, stem="foreign")
     with pytest.raises(ValueError, match="publication CID"):
         replace(
             publication,
-            publication_cid="blake3-512:" + "99" * 64,
+            publication_cid=foreign.publication_cid,
         )
 
 
-def test_frame_transports_exact_published_class_and_member_into_module_temporal() -> None:
-    publication, *_ = _publication()
+def test_frame_transports_exact_published_class_and_member_into_module_temporal(
+    tmp_path: Path, monkeypatch
+) -> None:
+    publication, *_ = _publication(tmp_path, monkeypatch)
     class_value = DecoratedClassValue(publication)
     member = DecoratedClassMemberValue.mint(
         publication=publication,
-        member_definition=SourceFragmentCoordinateV1(SOURCE, 4, 4, 4, 10),
+        member_definition=SourceFragmentCoordinateV1(
+            publication.source_cid, 4, 4, 4, 10
+        ),
         member_floor=SymbolicValue(_Var("member")),
     )
     bindings = (
@@ -118,7 +135,7 @@ def test_frame_transports_exact_published_class_and_member_into_module_temporal(
         "Frame",
         (),
         {
-            "source_identity_cid": SOURCE,
+            "source_identity_cid": publication.source_cid,
             "mutable_global_bindings": (),
             "decorated_class_bindings": bindings,
         },

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1628,6 +1628,40 @@ def _construct_reachable_decorated_class_bindings(
 
     if not isinstance(target, FunctionDef):
         return ()
+
+    def owned_lexical_load_occurrences(function):
+        from sugar_source_tree.nodes import AsyncFunctionDef, Lambda
+
+        def visit(node):
+            if isinstance(node, (FunctionDef, AsyncFunctionDef)):
+                for field_name in ("decorators", "type_params", "params", "returns"):
+                    value = getattr(node, field_name)
+                    if value is None:
+                        continue
+                    items = (value,) if isinstance(value, Node) else tuple(value)
+                    for item in items:
+                        yield from visit(item)
+                return
+            if isinstance(node, ClassDef):
+                for field_name in ("decorators", "type_params", "bases", "keywords"):
+                    for item in tuple(getattr(node, field_name)):
+                        yield from visit(item)
+                return
+            if isinstance(node, Lambda):
+                for parameter in node.params:
+                    yield from visit(parameter)
+                return
+            if isinstance(node, Name):
+                yield node
+                return
+            for field_name, _, child in node.children():
+                if field_name in {"target", "targets", "optional_vars"}:
+                    continue
+                yield from visit(child)
+
+        for statement in function.body:
+            yield from visit(statement)
+
     module_classes = tuple(
         item for item in module_definitions if isinstance(item, ClassDef)
     )
@@ -1638,22 +1672,25 @@ def _construct_reachable_decorated_class_bindings(
         table = function.unit.function_symtable(
             function.name, function.line_col_span().start_line
         )
-        for node in function.walk():
-            if not isinstance(node, Name):
-                continue
+        for node in owned_lexical_load_occurrences(function):
             bindings = tuple(
                 (function.unit.module_direct_bindings or {}).get(node.id, ())
             )
-            if (
-                table.lookup(node.id).is_global()
-                and len(bindings) == 1
-                and isinstance(bindings[0], ClassDef)
-                and any(bindings[0] is item for item in module_classes)
-                and bindings[0].decorators
-            ):
-                candidate = bindings[0]
-                if candidate not in reached:
-                    reached.append(candidate)
+            if len(bindings) != 1 or not isinstance(bindings[0], ClassDef):
+                continue
+            candidate = bindings[0]
+            if not any(candidate is item for item in module_classes):
+                continue
+            if not candidate.decorators:
+                continue
+            try:
+                symbol = table.lookup(node.id)
+            except KeyError:
+                continue
+            if not symbol.is_global() or not symbol.is_referenced():
+                continue
+            if candidate not in reached:
+                reached.append(candidate)
     if not reached:
         return ()
 
@@ -1691,17 +1728,20 @@ def _construct_reachable_decorated_class_bindings(
         function_table = function.unit.function_symtable(
             function.name, function.line_col_span().start_line
         )
-        for node in function.walk():
-            if not isinstance(node, Name):
-                continue
+        for node in owned_lexical_load_occurrences(function):
             bindings = tuple((function.unit.module_direct_bindings or {}).get(node.id, ()))
-            if (
-                function_table.lookup(node.id).is_global()
-                and len(bindings) == 1
-                and isinstance(bindings[0], ClassDef)
-                and any(bindings[0] is item for item in module_classes)
-            ):
-                class_dependencies.add(bindings[0])
+            if len(bindings) != 1 or not isinstance(bindings[0], ClassDef):
+                continue
+            candidate = bindings[0]
+            if not any(candidate is item for item in module_classes):
+                continue
+            try:
+                symbol = function_table.lookup(node.id)
+            except KeyError:
+                continue
+            if not symbol.is_global() or not symbol.is_referenced():
+                continue
+            class_dependencies.add(candidate)
     for definition in module_definitions:
         if definition not in class_dependencies:
             continue

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1628,12 +1628,9 @@ def _construct_reachable_decorated_class_bindings(
 
     if not isinstance(target, FunctionDef):
         return ()
-    module_classes = {
-        item.name: item for item in module_definitions if isinstance(item, ClassDef)
-    }
-    module_functions = {
-        item.name: item for item in module_definitions if isinstance(item, FunctionDef)
-    }
+    module_classes = tuple(
+        item for item in module_definitions if isinstance(item, ClassDef)
+    )
     reached = []
     for function in reachable_definitions:
         if not isinstance(function, FunctionDef):
@@ -1644,13 +1641,17 @@ def _construct_reachable_decorated_class_bindings(
         for node in function.walk():
             if not isinstance(node, Name):
                 continue
-            candidate = module_classes.get(node.id)
-            if candidate is None or not candidate.decorators:
-                continue
             bindings = tuple(
                 (function.unit.module_direct_bindings or {}).get(node.id, ())
             )
-            if table.lookup(node.id).is_global() and bindings == (candidate,):
+            if (
+                table.lookup(node.id).is_global()
+                and len(bindings) == 1
+                and isinstance(bindings[0], ClassDef)
+                and any(bindings[0] is item for item in module_classes)
+                and bindings[0].decorators
+            ):
+                candidate = bindings[0]
                 if candidate not in reached:
                     reached.append(candidate)
     if not reached:
@@ -1670,12 +1671,21 @@ def _construct_reachable_decorated_class_bindings(
         frame = frames.get(definition.name)
         if frame is None:
             frame = definition.source_visible_call_frame()
+        elif frame.owner is not definition:
+            from sugar_source_tree.panic import BackendDefect
+
+            raise BackendDefect(
+                owner="manager_construction decorated callable frame",
+                blame=definition.fragment,
+                observed="name-keyed frame does not belong to bound decorator definition",
+                requested="the exact module-direct-binding FunctionDef frame",
+                fix="preserve definition identity when indexing source call frames",
+            )
         temporal = temporal.bind_value(
             definition.name, _SourceFrameCallableV1(definition, frame)
         )
 
     ctx = ReduceContext.root(owner="manager decorated class publication")
-    raw_classes = {}
     class_dependencies = set()
     for function in decorator_functions:
         function_table = function.unit.function_symtable(
@@ -1684,14 +1694,14 @@ def _construct_reachable_decorated_class_bindings(
         for node in function.walk():
             if not isinstance(node, Name):
                 continue
-            candidate = module_classes.get(node.id)
             bindings = tuple((function.unit.module_direct_bindings or {}).get(node.id, ()))
             if (
-                candidate is not None
-                and function_table.lookup(node.id).is_global()
-                and bindings == (candidate,)
+                function_table.lookup(node.id).is_global()
+                and len(bindings) == 1
+                and isinstance(bindings[0], ClassDef)
+                and any(bindings[0] is item for item in module_classes)
             ):
-                class_dependencies.add(candidate)
+                class_dependencies.add(bindings[0])
     for definition in module_definitions:
         if definition not in class_dependencies:
             continue
@@ -1704,7 +1714,6 @@ def _construct_reachable_decorated_class_bindings(
                 requested="one completed source class Floor",
                 fix="sequence module definition effects before decorator execution",
             )
-        raw_classes[definition.name] = outcome.value
         temporal = temporal.bind_value(definition.name, outcome.value)
     ctx = replace(ctx, temporal=temporal, module_temporal=temporal)
 

--- a/implementations/python/sugar-lift-python-source/tests/test_module_decorated_class_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_module_decorated_class_publication.py
@@ -17,7 +17,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
-from sugar_source_tree.nodes import ClassDef, SourceUnit
+from sugar_source_tree.nodes import ClassDef
 from sugar_source_tree.tree import SourceFile
 
 
@@ -135,8 +135,18 @@ def _install(root: Path) -> importlib.metadata.Distribution:
         "def worker(value):\n"
         "    return isinstance(value, Original)\n"
         "\n"
+        "def misleading(value):\n"
+        "    global Unreachable\n"
+        "    Unreachable = value\n"
+        "    def nested():\n"
+        "        return Unreachable\n"
+        "    return value\n"
+        "\n"
         "def selected(value):\n"
-        "    return worker(value)\n",
+        "    def unrelated(frame: FrameType):\n"
+        "        return frame\n"
+        "    marker = int(misleading(value))\n"
+        "    return worker(marker)\n",
         encoding="utf-8",
     )
     metadata = root / "decorated_dist-1.0.dist-info"
@@ -166,7 +176,8 @@ def _install_admission_fixture(root: Path) -> importlib.metadata.Distribution:
     package = root / "admission_pkg"
     package.mkdir()
     (package / "__init__.py").write_text(
-        "from admission_pkg.implementation import selected\n", encoding="utf-8"
+        "from admission_pkg.implementation import body_selected, selected\n",
+        encoding="utf-8",
     )
     (package / "implementation.py").write_text(
         "from types import FrameType\n"
@@ -191,10 +202,16 @@ def _install_admission_fixture(root: Path) -> importlib.metadata.Distribution:
         "class Decorated:\n"
         "    token = 11\n"
         "\n"
+        "@retain\n"
+        "class BodyOnly:\n"
+        "    token = 17\n"
+        "\n"
         "def global_worker(value):\n"
         "    int\n"
         "    FrameType\n"
         "    Decorated\n"
+        "    def nested(header: BodyOnly = BodyOnly):\n"
+        "        return BodyOnly\n"
         "    return value\n"
         "\n"
         "def shadowed_worker(value):\n"
@@ -202,6 +219,14 @@ def _install_admission_fixture(root: Path) -> importlib.metadata.Distribution:
         "    int\n"
         "    FrameType\n"
         "    return value\n"
+        "\n"
+        "def body_worker(value):\n"
+        "    def nested():\n"
+        "        return BodyOnly\n"
+        "    return value\n"
+        "\n"
+        "def body_selected(value):\n"
+        "    return body_worker(value)\n"
         "\n"
         "def selected(value):\n"
         "    global_worker(value)\n"
@@ -232,7 +257,7 @@ def _install_admission_fixture(root: Path) -> importlib.metadata.Distribution:
 
 
 def test_reachable_decorated_class_admission_filters_before_symtable_contact(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path,
 ) -> None:
     distribution = _install_admission_fixture(tmp_path)
     graph = DependencyArtifactGraph.authenticate(distribution)
@@ -252,25 +277,6 @@ def test_reachable_decorated_class_admission_filters_before_symtable_contact(
     resolved = resolve_import_binding(receipts[0], graph=graph, session=session)
     assert isinstance(resolved, ResolvedPythonObjectV1)
 
-    contacted: list[tuple[str, str]] = []
-    original_function_symtable = SourceUnit.function_symtable
-
-    class _ObservedSymtable:
-        def __init__(self, owner: str, table) -> None:
-            self._owner = owner
-            self._table = table
-
-        def lookup(self, name: str):
-            contacted.append((self._owner, name))
-            return self._table.lookup(name)
-
-    def observed_function_symtable(self, name: str, lineno: int):
-        return _ObservedSymtable(
-            name, original_function_symtable(self, name, lineno)
-        )
-
-    monkeypatch.setattr(SourceUnit, "function_symtable", observed_function_symtable)
-
     projected = resolve_source_visible_frame(resolved, graph=graph, session=session)
 
     assert isinstance(projected, tuple)
@@ -278,12 +284,31 @@ def test_reachable_decorated_class_admission_filters_before_symtable_contact(
     assert target.name == "selected"
     assert tuple(binding.name for binding in frame.decorated_class_bindings) == (
         "Decorated",
+        "BodyOnly",
     )
-    assert ("global_worker", "Decorated") in contacted
-    assert ("shadowed_worker", "Decorated") in contacted
-    assert ("retain", "Dependency") in contacted
-    assert ("locally_shadowed_retain", "Dependency") in contacted
-    assert all(name not in {"int", "FrameType"} for _, name in contacted)
+    body_source = "import admission_pkg\nadmission_pkg.body_selected(1)\n"
+    body_consumer = tmp_path / "body_consumer.py"
+    body_consumer.write_text(body_source, encoding="utf-8")
+    body_receipts, _ = authenticated_import_use_receipts(
+        tmp_path,
+        body_consumer,
+        body_source,
+        blake3_512_of(body_source.encode("utf-8")),
+        module_identities={},
+    )
+    body_session = SourceResolutionSession()
+    body_resolved = resolve_import_binding(
+        body_receipts[0], graph=graph, session=body_session
+    )
+    body_projected = resolve_source_visible_frame(
+        body_resolved, graph=graph, session=body_session
+    )
+    assert isinstance(body_projected, tuple)
+    body_frame, _ = body_projected
+    assert all(
+        binding.name != "BodyOnly"
+        for binding in body_frame.decorated_class_bindings
+    )
 
 
 def test_reachable_decorated_class_publication_is_attached_to_selected_frame(

--- a/implementations/python/sugar-lift-python-source/tests/test_module_decorated_class_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_module_decorated_class_publication.py
@@ -17,7 +17,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
-from sugar_source_tree.nodes import ClassDef
+from sugar_source_tree.nodes import ClassDef, SourceUnit
 from sugar_source_tree.tree import SourceFile
 
 
@@ -160,6 +160,130 @@ def _install(root: Path) -> importlib.metadata.Distribution:
     sys.modules.pop("decorated_pkg", None)
     sys.modules.pop("decorated_pkg.implementation", None)
     return importlib.metadata.Distribution.at(metadata)
+
+
+def _install_admission_fixture(root: Path) -> importlib.metadata.Distribution:
+    package = root / "admission_pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from admission_pkg.implementation import selected\n", encoding="utf-8"
+    )
+    (package / "implementation.py").write_text(
+        "from types import FrameType\n"
+        "\n"
+        "class Dependency:\n"
+        "    token = 7\n"
+        "\n"
+        "def retain(raw):\n"
+        "    int\n"
+        "    FrameType\n"
+        "    Dependency\n"
+        "    return raw\n"
+        "\n"
+        "def locally_shadowed_retain(raw):\n"
+        "    Dependency = raw\n"
+        "    int\n"
+        "    FrameType\n"
+        "    return raw\n"
+        "\n"
+        "@locally_shadowed_retain\n"
+        "@retain\n"
+        "class Decorated:\n"
+        "    token = 11\n"
+        "\n"
+        "def global_worker(value):\n"
+        "    int\n"
+        "    FrameType\n"
+        "    Decorated\n"
+        "    return value\n"
+        "\n"
+        "def shadowed_worker(value):\n"
+        "    Decorated = value\n"
+        "    int\n"
+        "    FrameType\n"
+        "    return value\n"
+        "\n"
+        "def selected(value):\n"
+        "    global_worker(value)\n"
+        "    return shadowed_worker(value)\n",
+        encoding="utf-8",
+    )
+    metadata = root / "admission_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: admission-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (metadata / "top_level.txt").write_text("admission_pkg\n", encoding="utf-8")
+    recorded = (
+        "admission_pkg/__init__.py",
+        "admission_pkg/implementation.py",
+        "admission_dist-1.0.dist-info/METADATA",
+        "admission_dist-1.0.dist-info/top_level.txt",
+        "admission_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for item in recorded:
+            writer.writerow((item, "", ""))
+    sys.modules.pop("admission_pkg", None)
+    sys.modules.pop("admission_pkg.implementation", None)
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def test_reachable_decorated_class_admission_filters_before_symtable_contact(
+    tmp_path: Path, monkeypatch
+) -> None:
+    distribution = _install_admission_fixture(tmp_path)
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    consumer = tmp_path / "consumer.py"
+    source = "import admission_pkg\nadmission_pkg.selected(1)\n"
+    consumer.write_text(source, encoding="utf-8")
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+
+    receipts, _ = authenticated_import_use_receipts(
+        tmp_path,
+        consumer,
+        source,
+        blake3_512_of(source.encode("utf-8")),
+        module_identities={},
+    )
+    session = SourceResolutionSession()
+    resolved = resolve_import_binding(receipts[0], graph=graph, session=session)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+
+    contacted: list[tuple[str, str]] = []
+    original_function_symtable = SourceUnit.function_symtable
+
+    class _ObservedSymtable:
+        def __init__(self, owner: str, table) -> None:
+            self._owner = owner
+            self._table = table
+
+        def lookup(self, name: str):
+            contacted.append((self._owner, name))
+            return self._table.lookup(name)
+
+    def observed_function_symtable(self, name: str, lineno: int):
+        return _ObservedSymtable(
+            name, original_function_symtable(self, name, lineno)
+        )
+
+    monkeypatch.setattr(SourceUnit, "function_symtable", observed_function_symtable)
+
+    projected = resolve_source_visible_frame(resolved, graph=graph, session=session)
+
+    assert isinstance(projected, tuple)
+    frame, target = projected
+    assert target.name == "selected"
+    assert tuple(binding.name for binding in frame.decorated_class_bindings) == (
+        "Decorated",
+    )
+    assert ("global_worker", "Decorated") in contacted
+    assert ("shadowed_worker", "Decorated") in contacted
+    assert ("retain", "Dependency") in contacted
+    assert ("locally_shadowed_retain", "Dependency") in contacted
+    assert all(name not in {"int", "FrameType"} for _, name in contacted)
 
 
 def test_reachable_decorated_class_publication_is_attached_to_selected_frame(

--- a/implementations/python/sugar-lift-python-source/tests/test_module_decorated_class_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_module_decorated_class_publication.py
@@ -55,6 +55,25 @@ def test_backend_module_construction_owns_a_stable_receipt_cid(
     )
 
 
+def test_backend_module_construction_receipt_discriminates_foreign_source(
+    tmp_path: Path, monkeypatch
+) -> None:
+    truthful = _tree(tmp_path, monkeypatch)
+    foreign_path = Path("foreign_decorated_module.py")
+    foreign_path.write_text(
+        "def replace(raw):\n    return raw\n\n"
+        "@replace\nclass Original:\n    token = 8\n",
+        encoding="utf-8",
+    )
+    foreign = SourceFile.from_path(
+        foreign_path,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+    assert truthful.unit.source_cid != foreign.unit.source_cid
+    assert truthful.construction_event_receipt_cid != foreign.construction_event_receipt_cid
+
+
 def test_class_definition_carries_ordered_decorator_sugars_and_occurrences(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -104,6 +123,14 @@ def _install(root: Path) -> importlib.metadata.Distribution:
         "@replace\n"
         "class Original:\n"
         "    stale = 1\n"
+        "\n"
+        "@replace\n"
+        "class Unreachable:\n"
+        "    stale = 2\n"
+        "\n"
+        "def shadowed(value):\n"
+        "    Original = value\n"
+        "    return isinstance(value, Original)\n"
         "\n"
         "def worker(value):\n"
         "    return isinstance(value, Original)\n"
@@ -171,3 +198,25 @@ def test_reachable_decorated_class_publication_is_attached_to_selected_frame(
     assert binding.value.publication is binding.publication
     assert binding.value.published_floor is binding.publication.final_class
     assert binding.publication.final_class is not binding.publication.raw_class
+    original = next(
+        item
+        for item in target.unit.constructed_module.root.body
+        if isinstance(item, ClassDef) and item.name == "Original"
+    )
+    sugar = original.sugar()
+    assert binding.publication.binding_occurrence == sugar.binding_target_occurrence
+    assert len(binding.publication.decorator_applications) == 2
+    first, second = binding.publication.decorator_applications
+    assert first.occurrence == sugar.decorator_occurrences[1]
+    assert second.occurrence == sugar.decorator_occurrences[0]
+    assert first.input_floor is binding.publication.raw_class
+    assert second.input_floor is first.output_floor
+    assert second.output_floor is binding.publication.final_class
+    assert binding.publication.final_class.class_name == "Replacement"
+    assert tuple(
+        field.name for field in binding.publication.final_class.class_fields
+    ) == ("token",)
+    assert binding.publication.raw_class.class_name == "Original"
+    assert tuple(field.name for field in binding.publication.raw_class.class_fields) == (
+        "stale",
+    )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3979,8 +3979,8 @@ class ClassDef(Statement):
             )
             and not (
                 isinstance(item, Assign)
-                and len(item.targets) == 1
-                and isinstance(item.targets[0], Name)
+                and item.targets
+                and all(isinstance(target, Name) for target in item.targets)
             )
             and not (isinstance(item, AnnAssign) and isinstance(item.target, Name))
         )
@@ -4011,15 +4011,18 @@ class ClassDef(Statement):
             for item in statements:
                 if (
                     isinstance(item, Assign)
-                    and len(item.targets) == 1
-                    and isinstance(item.targets[0], Name)
+                    and item.targets
+                    and all(isinstance(target, Name) for target in item.targets)
                 ):
-                    fields.append(
+                    value_sugar = item.value.sugar()
+                    fields.extend(
                         ConstructedClassFieldV1(
-                            item.targets[0].id,
+                            target.id,
+                            target.fragment.seal().cid,
+                            value_sugar,
                             item.fragment.seal().cid,
-                            item.value.sugar(),
                         )
+                        for target in item.targets
                     )
                     continue
                 if isinstance(item, AnnAssign) and isinstance(item.target, Name):

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -260,12 +260,24 @@ def test_class_body_assign_of_free_call_is_opaque_dig_cue() -> None:
     assert field.value.body is None
 
 
-def test_class_body_chained_assign_constructs_each_exact_binding() -> None:
+def test_class_body_chained_assign_constructs_each_exact_binding(monkeypatch) -> None:
     """One class-body Assign publishes every parser-owned Name target in order."""
-    source = _source_file("class RenamedFlags:\n    long_name = short = 7\n")
+    source = _source_file(
+        "class RenamedFlags:\n    long_name = short = provider.member\n"
+    )
     class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+    sugar = class_node.sugar()
+    attribute = sugar.fields[0].value_sugar
+    calls = []
 
-    value = class_node.sugar().desugar().value
+    def complete_attribute(self, ctx=None):
+        assert self is attribute
+        calls.append((self, ctx))
+        return Complete(TermValue(7))
+
+    monkeypatch.setattr(type(attribute), "desugar", complete_attribute)
+
+    value = sugar.desugar().value
 
     assert tuple(field.name for field in value.class_fields) == (
         "long_name",
@@ -273,6 +285,7 @@ def test_class_body_chained_assign_constructs_each_exact_binding() -> None:
     )
     assert value.class_fields[0].value is value.class_fields[1].value
     assert value.class_fields[0].value == TermValue(7)
+    assert calls == [(attribute, None)]
 
 
 def test_yield_from_only_function_allocates_a_generator_not_an_eager_call() -> None:

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -260,6 +260,21 @@ def test_class_body_assign_of_free_call_is_opaque_dig_cue() -> None:
     assert field.value.body is None
 
 
+def test_class_body_chained_assign_constructs_each_exact_binding() -> None:
+    """One class-body Assign publishes every parser-owned Name target in order."""
+    source = _source_file("class RenamedFlags:\n    long_name = short = 7\n")
+    class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+
+    value = class_node.sugar().desugar().value
+
+    assert tuple(field.name for field in value.class_fields) == (
+        "long_name",
+        "short",
+    )
+    assert value.class_fields[0].value is value.class_fields[1].value
+    assert value.class_fields[0].value == TermValue(7)
+
+
 def test_yield_from_only_function_allocates_a_generator_not_an_eager_call() -> None:
     """TRUTHFUL FACE: `yield from` owns the suspension boundary just as `yield` does.
 


### PR DESCRIPTION
IDD fix-forward for the current option_context ClassDef Assign boundary.

R: authenticated decorated-class lexical reach residual.
Predicted Epsilon R: -1 at the current producer boundary.
Floors: exact module binding rejection; scope-owned authenticated load occurrences; no name fallback.

Merge immediately; lifecycle and broader telemetry run post-merge.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate decorated class lexical reach to exclude unreachable and shadowed globals
> - Reworks `_construct_reachable_decorated_class_bindings` in [`manager_construction.py`](https://github.com/TSavo/sugar/pull/6854/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to only include decorated classes that appear as global lexical loads within the target function's body, excluding assignment targets, shadowed names, and unreferenced globals.
> - Adds `owned_lexical_load_occurrences` helper to traverse only function-owned `Name` load nodes, used both for class reachability and for collecting decorator function dependencies.
> - Supports chained assignments (`a = b = value`) in class bodies via [`sugar_source_tree/nodes.py`](https://github.com/TSavo/sugar/pull/6854/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0): each `Name` target becomes a distinct `ConstructedClassFieldV1` sharing a single evaluated value, grouped by `evaluation_group_cid`.
> - Adds memoization in `ClassDefinitionSugar.desugar` so fields sharing an `evaluation_group_cid` reuse one evaluated outcome, avoiding duplicate evaluations.
> - Risk: a provided frame whose owner does not match the bound decorator definition now raises `BackendDefect` instead of silently proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ff7afe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->