### PR TITLE
Bind decorated class publications to exact targets

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_source_tree.panic import SugarNotWritten
 
 from .guard_stable_value import GuardStableValue
@@ -30,11 +31,19 @@ class ClassDefinitionValue(GuardStableValue):
     class_definition_cid: str
     methods: tuple[ConstructedClassMethodV1, ...]
     initializer: ConstructedClassMethodV1 | None
+    binding_target_occurrence: SourceFragmentCoordinateV1 = field(compare=False)
     class_fields: tuple[object, ...] = ()
     docstring_cid: str | None = None
     annotation_cids: tuple[str, ...] = ()
     decorator_cids: tuple[str, ...] = ()
     base_classes: tuple["ClassDefinitionValue", ...] = ()
+
+    def __post_init__(self):
+        if type(self.binding_target_occurrence) is not SourceFragmentCoordinateV1:
+            raise TypeError(
+                "ClassDefinitionValue binding target must be an exact "
+                "SourceFragmentCoordinateV1"
+            )
 
     def to_term(self, *, owner: str):
         del owner

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/decorated_class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/decorated_class_value.py
@@ -91,6 +91,7 @@ class DecoratedClassPublicationV1:
     decorator_applications: tuple[DecoratorApplicationPublicationV1, ...]
     final_class: FloorValue = field(compare=False)
     module_construction_receipt_cid: str
+    binding_occurrence_cid: str
     raw_class_cid: str
     final_class_cid: str
     publication_cid: str
@@ -111,6 +112,9 @@ class DecoratedClassPublicationV1:
         from sugar_lift_py_tests.context_manager_resolution import (
             SourceFragmentCoordinateV1,
         )
+        from sugar_lift_py_tests.floor.class_definition_value import (
+            ClassDefinitionValue,
+        )
 
         if (
             type(definition) is not SourceFragmentCoordinateV1
@@ -119,6 +123,14 @@ class DecoratedClassPublicationV1:
             or binding_occurrence.source_cid != source_cid
         ):
             raise ValueError("decorated class publication source coordinate mismatch")
+        if (
+            type(raw_class) is not ClassDefinitionValue
+            or type(raw_class.binding_target_occurrence)
+            is not SourceFragmentCoordinateV1
+            or raw_class.binding_target_occurrence != binding_occurrence
+            or raw_class.binding_target_occurrence.cid != binding_occurrence.cid
+        ):
+            raise ValueError("decorated class publication binding target mismatch")
         applications = tuple(decorator_applications)
         current = raw_class
         for application in applications:
@@ -154,6 +166,7 @@ class DecoratedClassPublicationV1:
             applications,
             final_class,
             module_construction_receipt_cid,
+            binding_occurrence.cid,
             raw_cid,
             final_cid,
             publication_cid,
@@ -162,8 +175,25 @@ class DecoratedClassPublicationV1:
         return value
 
     def __post_init__(self):
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+        )
+        from sugar_lift_py_tests.floor.class_definition_value import (
+            ClassDefinitionValue,
+        )
+
         if getattr(self, "_authority", None) is not _PUBLICATION_AUTHORITY:
             raise ValueError("decorated class publication is not producer-minted")
+        if (
+            self.binding_occurrence_cid != self.binding_occurrence.cid
+            or type(self.raw_class) is not ClassDefinitionValue
+            or type(self.raw_class.binding_target_occurrence)
+            is not SourceFragmentCoordinateV1
+            or self.raw_class.binding_target_occurrence != self.binding_occurrence
+            or self.raw_class.binding_target_occurrence.cid
+            != self.binding_occurrence_cid
+        ):
+            raise ValueError("decorated class publication binding target mismatch")
         current = self.raw_class
         for application in self.decorator_applications:
             if application.input_floor is not current:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.floor.class_definition_value import (
     ClassDefinitionValue,
     ConstructedClassFieldV1,
@@ -31,7 +32,7 @@ class ClassDefinitionSugar(Sugar):
     docstring_cid: str | None
     annotation_cids: tuple[str, ...]
     decorator_cids: tuple[str, ...]
-    binding_target_occurrence: object
+    binding_target_occurrence: SourceFragmentCoordinateV1
     base_sugars: tuple[Sugar, ...]
     base_fragment_cids: tuple[str, ...]
     site: object = field(compare=False)
@@ -67,6 +68,7 @@ class ClassDefinitionSugar(Sugar):
             "schemaVersion": "1",
             "sourceIdentityCid": self.source_identity_cid,
             "definitionFragmentCid": self.definition_fragment_cid,
+            "bindingTargetOccurrence": self.binding_target_occurrence.wire(),
             "methods": [
                 {
                     "name": method.name,
@@ -178,6 +180,7 @@ class ClassDefinitionSugar(Sugar):
                 self.class_definition_cid,
                 self.methods,
                 initializer,
+                self.binding_target_occurrence,
                 tuple(class_fields),
                 self.docstring_cid,
                 self.annotation_cids,

--- a/implementations/python/sugar-lift-py-tests/tests/test_class_definition_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_class_definition_subscript_mutation.py
@@ -1,5 +1,6 @@
 import pytest
 
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.floor import ClassDefinitionValue, TermValue
 from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.tree import SourceFile
@@ -19,7 +20,13 @@ def _sites(tmp_path):
 
 
 def _value():
-    return ClassDefinitionValue("C", "class-cid", (), None)
+    return ClassDefinitionValue(
+        "C",
+        "class-cid",
+        (),
+        None,
+        SourceFragmentCoordinateV1("source-cid", 1, 6, 1, 7),
+    )
 
 
 @pytest.mark.parametrize(

--- a/implementations/python/sugar-lift-py-tests/tests/test_decorated_class_binding_target_publication.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_decorated_class_binding_target_publication.py
@@ -1,0 +1,213 @@
+"""Exact ClassDef binding-target authority for decorated publication."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context import ReduceContext
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+from sugar_lift_py_tests.floor import ClassDefinitionValue, SymbolicValue
+from sugar_lift_py_tests.floor.decorated_class_value import (
+    DecoratedClassPublicationV1,
+    DecoratedClassValue,
+    DecoratorApplicationPublicationV1,
+)
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.source_call_frame import (
+    DecoratedClassBindingV1,
+    SourceCallBindingGap,
+)
+from sugar_source_tree.nodes import ClassDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _coordinate(node) -> SourceFragmentCoordinateV1:
+    span = node.line_col_span()
+    return SourceFragmentCoordinateV1(
+        node.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _class_value(definition: ClassDef) -> ClassDefinitionValue:
+    outcome = definition.sugar().desugar(
+        ReduceContext.root(owner="decorated binding target test")
+    )
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, ClassDefinitionValue)
+    return outcome.value
+
+
+def _classes(tmp_path: Path):
+    path = tmp_path / "decorated_binding.py"
+    path.write_text(
+        "class Replacement:\n"
+        "    token = 7\n"
+        "\n"
+        "class Original:\n"
+        "    stale = 1\n"
+        "\n"
+        "class Original:\n"
+        "    foreign = 2\n",
+        encoding="utf-8",
+    )
+    tree = SourceFile.from_path(path)
+    definitions = tuple(
+        item for item in tree.root.body if isinstance(item, ClassDef)
+    )
+    replacement, original, same_name_foreign = definitions
+    raw = _class_value(original)
+    final = _class_value(replacement)
+    application = DecoratorApplicationPublicationV1.mint(
+        occurrence=_coordinate(original),
+        callable_floor=SymbolicValue(make_var("replace")),
+        input_floor=raw,
+        output_floor=final,
+    )
+    return tree, replacement, original, same_name_foreign, raw, final, application
+
+
+def _publication(
+    tree,
+    original,
+    raw,
+    final,
+    application,
+    *,
+    binding_occurrence=None,
+    final_class=None,
+):
+    return DecoratedClassPublicationV1.mint(
+        source_cid=tree.root.unit.source_cid,
+        definition=_coordinate(original),
+        binding_occurrence=(
+            _coordinate(original.binding_target)
+            if binding_occurrence is None
+            else binding_occurrence
+        ),
+        raw_class=raw,
+        decorator_applications=(application,),
+        final_class=final if final_class is None else final_class,
+        module_construction_receipt_cid="blake3-512:" + "42" * 64,
+    )
+
+
+def test_publication_connects_exact_class_binding_target_to_replacement_fields(
+    tmp_path: Path,
+) -> None:
+    tree, _, original, _, raw, final, application = _classes(tmp_path)
+
+    publication = _publication(tree, original, raw, final, application)
+    binding = DecoratedClassBindingV1(
+        "Original", publication, DecoratedClassValue(publication)
+    )
+
+    assert publication.definition == _coordinate(original)
+    assert publication.binding_occurrence == _coordinate(original.binding_target)
+    assert binding.publication is publication
+    assert binding.value.published_floor is final
+    assert {field.name for field in final.class_fields} == {"token"}
+    assert "stale" not in {field.name for field in final.class_fields}
+    assert {field.name for field in raw.class_fields} == {"stale"}
+
+
+def test_same_name_binding_target_from_same_source_cannot_substitute(
+    tmp_path: Path,
+) -> None:
+    tree, _, original, same_name_foreign, raw, final, application = _classes(tmp_path)
+
+    with pytest.raises(ValueError, match="binding target"):
+        _publication(
+            tree,
+            original,
+            raw,
+            final,
+            application,
+            binding_occurrence=_coordinate(same_name_foreign.binding_target),
+        )
+
+
+def test_same_definition_different_header_token_cannot_substitute(
+    tmp_path: Path,
+) -> None:
+    tree, _, original, _, raw, final, application = _classes(tmp_path)
+    definition = _coordinate(original)
+    class_keyword = SourceFragmentCoordinateV1(
+        definition.source_cid,
+        definition.start_line,
+        definition.start_col,
+        definition.start_line,
+        definition.start_col + len("class"),
+    )
+
+    with pytest.raises(ValueError, match="binding target"):
+        _publication(
+            tree,
+            original,
+            raw,
+            final,
+            application,
+            binding_occurrence=class_keyword,
+        )
+
+
+def test_foreign_source_binding_target_cannot_substitute(tmp_path: Path) -> None:
+    tree, _, original, _, raw, final, application = _classes(tmp_path)
+    foreign_path = tmp_path / "foreign.py"
+    foreign_path.write_text("class Original:\n    stale = 1\n", encoding="utf-8")
+    foreign = next(
+        item
+        for item in SourceFile.from_path(foreign_path).root.body
+        if isinstance(item, ClassDef)
+    )
+
+    with pytest.raises(ValueError, match="source coordinate mismatch"):
+        _publication(
+            tree,
+            original,
+            raw,
+            final,
+            application,
+            binding_occurrence=_coordinate(foreign.binding_target),
+        )
+
+
+def test_class_definition_value_refuses_missing_or_wrong_binding_authority() -> None:
+    with pytest.raises(TypeError):
+        ClassDefinitionValue("Original", "class-cid", (), None)  # type: ignore[call-arg]
+
+    with pytest.raises(
+        TypeError, match="exact SourceFragmentCoordinateV1"
+    ):
+        ClassDefinitionValue(
+            "Original",
+            "class-cid",
+            (),
+            None,
+            object(),  # type: ignore[arg-type]
+        )
+
+
+def test_raw_class_definition_cannot_substitute_after_replacement(
+    tmp_path: Path,
+) -> None:
+    tree, _, original, _, raw, final, application = _classes(tmp_path)
+    publication = _publication(tree, original, raw, final, application)
+
+    with pytest.raises(ValueError, match="final result mismatch"):
+        _publication(
+            tree,
+            original,
+            raw,
+            final,
+            application,
+            final_class=raw,
+        )
+    with pytest.raises(SourceCallBindingGap, match="exact publication testimony"):
+        DecoratedClassBindingV1("Original", publication, raw)

--- a/implementations/python/sugar-lift-py-tests/tests/test_decorated_class_publication.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_decorated_class_publication.py
@@ -7,7 +7,7 @@ import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.context import ReduceContext
-from sugar_lift_py_tests.floor import SymbolicValue
+from sugar_lift_py_tests.floor import ClassDefinitionValue, SymbolicValue
 from sugar_lift_py_tests.floor.decorated_class_value import (
     DecoratedClassMemberValue,
     DecoratedClassPublicationV1,
@@ -28,7 +28,14 @@ def _publication(tmp_path: Path, monkeypatch, *, stem: str = "publication"):
     path.write_text("class Published:\n    member = 1\n", encoding="utf-8")
     source_file = SourceFile.from_path(path)
     source = source_file.unit.source_cid
-    raw = SymbolicValue(_Var("raw_class"))
+    binding_occurrence = SourceFragmentCoordinateV1(source, 3, 6, 3, 13)
+    raw = ClassDefinitionValue(
+        "Raw",
+        "blake3-512:" + "10" * 64,
+        (),
+        None,
+        binding_target_occurrence=binding_occurrence,
+    )
     replaced = SymbolicValue(_Var("replacement_class"))
     final = SymbolicValue(_Var("published_class"))
     first = DecoratorApplicationPublicationV1.mint(
@@ -46,7 +53,7 @@ def _publication(tmp_path: Path, monkeypatch, *, stem: str = "publication"):
     publication = DecoratedClassPublicationV1.mint(
         source_cid=source,
         definition=SourceFragmentCoordinateV1(source, 3, 0, 5, 9),
-        binding_occurrence=SourceFragmentCoordinateV1(source, 3, 6, 3, 13),
+        binding_occurrence=binding_occurrence,
         raw_class=raw,
         decorator_applications=(first, second),
         final_class=final,

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_floor_value_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_floor_value_law.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.floor.block_value import BlockValue
 from sugar_lift_py_tests.floor.class_definition_value import ClassDefinitionValue
 from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
@@ -36,6 +37,9 @@ GUARD = atomic("renamed_guard", [])
             "blake3-512:renamed-class-definition",
             (),
             None,
+            SourceFragmentCoordinateV1(
+                "blake3-512:renamed-source", 1, 6, 1, 18
+            ),
         ),
         ComprehensionValue(ctor("renamed-comprehension", [])),
         GuardedValue(


### PR DESCRIPTION
Carries the exact producer-owned ClassDef binding-target coordinate through ClassDefinitionValue and requires DecoratedClassPublicationV1 to validate exact typed coordinate and CID equality.

Focused CPython 3.12.13 instrument: base 3 failed/3 passed; head 6 passed.

Merged immediately under the fix-forward workflow; lifecycle, audit, and CI are latent post-merge signals.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind decorated class publications to exact `SourceFragmentCoordinateV1` targets
> - `ClassDefinitionValue` gains a required `binding_target_occurrence` field typed as exactly `SourceFragmentCoordinateV1` (no subclasses), enforced in `__post_init__`.
> - `DecoratedClassPublicationV1.mint` now validates that the raw class's `binding_target_occurrence` exactly matches the provided `binding_occurrence`, including CID equality.
> - `DecoratedClassPublicationV1.__post_init__` adds the same integrity checks, plus a new `binding_occurrence_cid` field that must match `binding_occurrence.cid`.
> - `ClassDefinitionSugar.preimage` now serializes `bindingTargetOccurrence`, and `desugar` passes `binding_target_occurrence` when constructing `ClassDefinitionValue`.
> - A new test module ([test_decorated_class_binding_target_publication.py](https://github.com/TSavo/sugar/pull/6855/files#diff-c4db8ba5acb558ca3b7aad499520fb7fa33247db235af5153c1822b6c424aa3a)) covers binding-target authority checks and mismatch rejection.
> - Behavioral Change: existing code constructing `ClassDefinitionValue` or calling `DecoratedClassPublicationV1.mint` without a matching `binding_target_occurrence` will raise `TypeError` or `ValueError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92f23bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->