### PR TITLE
Instrument real pandas option lifecycle

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -322,7 +322,7 @@ def test_authenticated_pandas_303_get_handle_is_real_resource_reproducer():
 
 
 def test_real_option_context_coordinates_drive_every_resource_lifecycle_face():
-    """The producer's two real coordinates are the sole lifecycle authority."""
+    """Real pandas option_context enters, reduces its real body, then exits."""
     import platform
     import sys
 
@@ -377,66 +377,22 @@ def test_real_option_context_coordinates_drive_every_resource_lifecycle_face():
     assert isinstance(exit_definition, SourceFragmentCoordinateV1)
     assert enter_definition != exit_definition
 
-    class RecordingDefinitionDoor:
-        def __init__(self, delegate):
-            self.delegate = delegate
-            self.calls = []
-
-        def __getattr__(self, name):
-            return getattr(self.delegate, name)
-
-        def require_native_definition(self, use_site, slot):
-            self.calls.append((use_site, slot))
-            return self.delegate.require_native_definition(use_site, slot)
-
-    recording = RecordingDefinitionDoor(refs)
-    object.__setattr__(context, "contract_refs", recording)
     resource = with_node.sugar()
 
     assert isinstance(resource, WithSourceResourceSugar)
-    assert recording.calls == [
-        (receiver, NativeProtocolSlot.CONTEXT_ENTER),
-        (receiver, NativeProtocolSlot.CONTEXT_EXIT),
-    ]
     assert resource.enter.native_definition_coordinate == enter_definition
     assert resource.exit.native_definition_coordinate == exit_definition
     assert resource.enter_definition == enter_definition
     assert resource.exit_definition == exit_definition
     assert resource.protocol.enter_definition == enter_definition
     assert resource.protocol.exit_definition == exit_definition
+    assert len(resource.body) == len(with_node.body) == 1
+    assert resource.body[0].site.node is with_node.body[0]
 
-    completed = replace(
-        resource,
-        body=(_FixedSugar(Complete(BlockValue((), can_fall_through=True))),),
-    ).desugar()
-    returned = replace(
-        resource,
-        body=(
-            _FixedSugar(
-                Complete(
-                    BlockValue(
-                        (ReturnValue(TermValue(7)),), can_fall_through=False
-                    )
-                )
-            ),
-        ),
-    ).desugar()
-    effect = RaiseEffect(exception_name="ValueError", occurrence="consumer.py:26:8")
-    halted = replace(
-        resource,
-        body=(_FixedSugar(Incomplete(effect)),),
-    ).desugar()
+    lifecycle = resource.desugar()
 
-    assert any(isinstance(face, Completed) for face in completed.exits)
-    assert any(
-        isinstance(entry, ReturnValue)
-        for face in returned.exits
-        if isinstance(face, Completed)
-        for entry in face.value.contribution()
-    )
-    assert any(
-        isinstance(face, Halted) and face.effect is effect for face in halted.exits
-    )
+    assert lifecycle.exits
+    assert any(isinstance(face, Completed) for face in lifecycle.exits)
 
 
 def test_real_option_context_published_ref_selects_source_resource_at_construction():


### PR DESCRIPTION
Replaces the synthetic `_FixedSugar` body substitutions in the authenticated pandas option_context lifecycle test with the actual parsed With body and real source-derived protocol execution.

This is an intentionally red IDD instrument. It currently stops at the real `call-target-export-unresolved:python:re.search` transition while entering option_context.

CPython 3.12.13 / pandas 3.0.3 receipt: 0 passed, 1 failed in 21.21s.

R_synthetic_option_lifecycle=1 -> 0. R_authenticated_option_lifecycle=1 remains loud.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Simplify pandas `option_context` lifecycle test to use `resource.desugar()`
> Updates [test_returned_resource_with_construction.py](https://github.com/TSavo/sugar/pull/6857/files#diff-516e8891dc248d2149005b9dfa3dfc5e559fe9652a9f705bca9ebd9c97741685) to test the real pandas `option_context` lifecycle rather than simulating it with mock wrappers.
>
> - Removes the `RecordingDefinitionDoor` wrapper and associated `require_native_definition` call assertions
> - Replaces manual construction of three variant resources (completed, returned, halted) with a single `resource.desugar()` call
> - Narrows assertions to check that the desugared lifecycle has exits including a `Completed` face and that `resource.body` mirrors `with_node.body` by identity
> - Behavioral Change: the test no longer validates returned and halted exit scenarios or that `require_native_definition` is invoked
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ae29f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->