### PR TITLE
Test real pandas option_context body lifecycle

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -496,6 +496,60 @@ def test_real_option_context_published_ref_selects_source_resource_at_constructi
     assert resource.exit.native_definition_coordinate == exit_definition
 
 
+def test_real_option_context_executes_its_source_body_and_exit():
+    """The installed pandas With runs its own body through the resource exit."""
+    import platform
+    import sys
+
+    import pandas
+
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+
+    assert sys.executable == "/usr/local/bin/python"
+    assert platform.python_version() == "3.12.13"
+    assert pandas.__file__ == "/usr/local/lib/python3.12/site-packages/pandas/__init__.py"
+    print(f"sys.executable={sys.executable}")
+    print(f"sys.version={sys.version}")
+    print(f"pandas.__file__={pandas.__file__}")
+
+    corpus = authenticated_pandas_corpus()
+    root = corpus.root.parent
+    path = root / "pandas/tests/io/formats/test_ipython_compat.py"
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = open_source_file_for_construction(
+        path, root=root, construction_context=context, populate_derived=False
+    )
+    populate_source_derived_resource_refs(tree, root=root, path=path)
+    with_node = next(
+        node
+        for node in tree.nodes()
+        if node.kind == "With" and node.line_col_span().start_line == 25
+    )
+    receiver = next(
+        coordinate
+        for coordinate in context.source_manager_provider_calls
+        if coordinate.start_line == 25
+    )
+    enter_definition = context.contract_refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_ENTER
+    )
+    exit_definition = context.contract_refs.require_native_definition(
+        receiver, NativeProtocolSlot.CONTEXT_EXIT
+    )
+
+    resource = with_node.sugar()
+
+    assert isinstance(resource, WithSourceResourceSugar)
+    assert resource.body
+    assert resource.enter.native_definition_coordinate == enter_definition
+    assert resource.exit.native_definition_coordinate == exit_definition
+
+    outcome = resource.desugar()
+
+    assert any(isinstance(face, Completed) for face in outcome.exits)
+
+
 @pytest.mark.parametrize("manager_name", ("borrowed_state", "temporary_setting"))
 def test_renamed_source_generator_resources_use_the_same_closed_factory_arm(
     tmp_path: Path, manager_name: str


### PR DESCRIPTION
Adds the non-synthetic installed-pandas lifecycle gate. The test constructs through the real pandas With node and executes its untouched source body: no _FixedSugar, no resource body replacement, and no direct Sugar construction.\n\nAuthenticated CPython 3.12.13 / pandas 3.0.3 receipt: 1 failed in 59.71s at GeneratorConstructionV1.transition, call-target-export-unresolved:python:re.search. This red is the exact next product boundary.\n\nLog: /tmp/codex2-option-main-1bad5c5f-real-body.log\nSHA-256: 0806c1b35640bc1aefb1198fa536cadb988f501188871c7e7577a56f10fab2bd

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test validating `WithSourceResourceSugar` desugars with a `Completed` exit for pandas `option_context`
> Adds a pytest test in [test_returned_resource_with_construction.py](https://github.com/TSavo/sugar/pull/6858/files#diff-516e8891dc248d2149005b9dfa3dfc5e559fe9652a9f705bca9ebd9c97741685) that constructs a `TreeConstructionContextV1` against a pandas source file, locates the `With` node for `option_context` at line 25, retrieves the `WithSourceResourceSugar`, calls `desugar()`, and asserts at least one exit in the result is a `Completed` instance. The test also pins `sys.executable`, Python version, and `pandas.__file__` to catch environment drift.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 922c1e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->