### PR TITLE
Seat authenticated imported class-field members

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1535,10 +1535,14 @@ def _resolve_source_visible_frame_uncached(
         )
     decorated_class_bindings = _construct_reachable_decorated_class_bindings(
         source_file=source_file,
+        module=module,
         target=target,
         module_definitions=tuple(source_file.root.body),
         reachable_definitions=definitions,
         frames=frames,
+        session=session,
+        context=context,
+        dependency_graphs=dependency_graphs,
     )
     if decorated_class_bindings:
         frame = replace(frame, decorated_class_bindings=decorated_class_bindings)
@@ -1546,7 +1550,16 @@ def _resolve_source_visible_frame_uncached(
 
 
 def _construct_reachable_decorated_class_bindings(
-    *, source_file, target, module_definitions, reachable_definitions, frames
+    *,
+    source_file,
+    module,
+    target,
+    module_definitions,
+    reachable_definitions,
+    frames,
+    session,
+    context,
+    dependency_graphs,
 ):
     """Execute exact decorated classes reached by the selected frame."""
     from dataclasses import dataclass
@@ -1759,6 +1772,14 @@ def _construct_reachable_decorated_class_bindings(
 
     result = []
     for definition in reached:
+        _seat_import_value_use_receipts(
+            source_file=source_file,
+            module=module,
+            target=definition,
+            session=session,
+            context=context,
+            dependency_graphs=dependency_graphs,
+        )
         sugar = definition.sugar()
         raw_outcome = sugar.desugar(ctx)
         if not isinstance(raw_outcome, Complete):


### PR DESCRIPTION
R_option_re_search_frame: 1
Predicted Epsilon R: -1

The re.search source frame reaches decorated RegexFlag construction. Before desugaring that exact reached ClassDef, seat its authenticated import-value receipts through the existing SourceUnit receipt table and dependency graph. This supplies the ordinary `_compiler.SRE_FLAG_ASCII` field RHS without a member-name, vendor, host, or SymbolicValue fallback.

The merged PR #6861 consumer instrument remains the acceptance tooth; foreign import-binding testimony remains loud.

Floors: exact source/module/ClassDef owned range, existing receipt revalidation and graph resolution, no consumer changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seat import value use receipts for authenticated imported class-field members during decorated class processing
> - `_construct_reachable_decorated_class_bindings` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6862/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) now accepts `module`, `session`, `context`, and `dependency_graphs` and calls `_seat_import_value_use_receipts` for each reachable decorated class definition before desugaring.
> - `_resolve_source_visible_frame_uncached` is updated to pass those four arguments through to `_construct_reachable_decorated_class_bindings`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d878284.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->