### PR TITLE
Seat class member receipts before constructor caching

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1472,6 +1472,16 @@ def _resolve_source_visible_frame_uncached(
             continue
         # Target class (or a local class the target actually reaches): panics
         # stay loud. There is no soft-green for a reached broken definition.
+        # Seat its exact imported member coordinates before constructor-frame
+        # construction can cache an AttributeSugar for a class-body field.
+        _seat_import_value_use_receipts(
+            source_file=source_file,
+            module=module,
+            target=item,
+            session=session,
+            context=context,
+            dependency_graphs=dependency_graphs,
+        )
         frames[item.name] = item.source_visible_constructor_frame()
 
     pending = [item for item in definitions if isinstance(item, FunctionDef)]
@@ -1772,14 +1782,6 @@ def _construct_reachable_decorated_class_bindings(
 
     result = []
     for definition in reached:
-        _seat_import_value_use_receipts(
-            source_file=source_file,
-            module=module,
-            target=definition,
-            session=session,
-            context=context,
-            dependency_graphs=dependency_graphs,
-        )
         sugar = definition.sugar()
         raw_outcome = sugar.desugar(ctx)
         if not isinstance(raw_outcome, Complete):


### PR DESCRIPTION
R_option_class_member_cache_order: 1
Predicted Epsilon R: -1

Fix-forward after #6862: seat each reached ClassDef's exact authenticated import-value receipts before source_visible_constructor_frame can cache its class-field Attribute sugar. Removes the later duplicate seating call.

No member spelling/vendor/host arm and no consumer fallback; existing receipt validation and dependency graph remain the sole authority.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seat class member receipts before constructor caching in `_resolve_source_visible_frame_uncached`
> Moves the call to `_seat_import_value_use_receipts` from `_construct_reachable_decorated_class_bindings` into `_resolve_source_visible_frame_uncached`, so receipts are seated for each `ClassDef` before constructor frames are built. Previously, receipts were seated during decorated class binding construction, which was too late in the pipeline.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c5a29d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->