### PR TITLE
Project authenticated imported class members at reduction

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
@@ -92,6 +92,63 @@ class AttributeSugar(ConstructedTermSugar):
                 owner="authenticated attribute receiver",
                 project_callsite=False,
             )
+
+        # Class-definition construction can cache this sugar before its
+        # receipt-backed import member is seated.  At reduction, consume only
+        # the exact full-Attribute occurrence row minted by the lexical import
+        # producer; absent/resolved rows retain the ordinary Floor law below.
+        from sugar_source_tree.fragment import SourceFragment
+
+        if type(site) is SourceFragment:
+            span = site.line_col_span()
+            receipt = site.unit.import_value_use_resolution(
+                (span.start_line, span.start_col, span.end_line, span.end_col)
+            )
+            from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
+
+            if type(receipt) is AuthenticatedImportUseV1:
+                receipt.revalidate()
+                use_site = receipt.use["useSite"]
+                exported_path = tuple(receipt.use["exportedMemberPath"])
+                if (
+                    receipt.source_cid != site.unit.source_cid
+                    or use_site.get("sourceCid") != site.unit.source_cid
+                    or (
+                        use_site.get("startLine"),
+                        use_site.get("startCol"),
+                        use_site.get("endLine"),
+                        use_site.get("endCol"),
+                    )
+                    != (span.start_line, span.start_col, span.end_line, span.end_col)
+                    or not exported_path
+                    or exported_path[-1] != name
+                ):
+                    from sugar_source_tree.panic import BackendDefect
+
+                    raise BackendDefect(
+                        blame=site,
+                        owner="AttributeSugar.project_attribute",
+                        observed="import member receipt does not own this Attribute",
+                        requested="same-source exact member-use occurrence testimony",
+                        fix="transport the lexical import-value receipt unchanged",
+                    )
+                target = receipt.target_symbol
+                if not target.startswith("python:"):
+                    from sugar_source_tree.panic import BackendDefect
+
+                    raise BackendDefect(
+                        blame=site,
+                        owner="AttributeSugar.project_attribute",
+                        observed=f"target_symbol={target!r}",
+                        requested="authenticated python: import target symbol",
+                        fix="preserve the receipt targetSymbol unchanged",
+                    )
+                from sugar_lift_py_tests.floor.import_member_value import (
+                    ImportMemberValue,
+                )
+                from sugar_lift_py_tests.outcome import Complete
+
+                return Complete(ImportMemberValue(target.removeprefix("python:")))
         return receiver.attribute(name, site)
 
     def desugar(self, ctx: object = None) -> Outcome:


### PR DESCRIPTION
R_option_import_member_projection: 1
Predicted Epsilon R: -1

Consumes an exact AuthenticatedImportUseV1 row at the live full Attribute occurrence after formal/callsite handling and before the ordinary receiver.attribute law. This closes cached class-field sugars such as the authenticated stdlib re compiler flag coordinate.

Validation pins source CID, exact use span, exported member path, and python target symbol. Resolved/absent/nonfragment rows preserve the existing loud path. No name/vendor/host or generic SymbolicValue fallback.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Project authenticated imported class members at reduction in `AttributeSugar.project_attribute`
> - When `project_attribute` is called with a `SourceFragment` site, it now resolves the attribute via the import-use receipt rather than delegating to `receiver.attribute`.
> - The receipt is validated against four strict checks: same source CID as the unit, matching span, non-empty exported member path whose last component equals the attribute name, and a `python:` prefixed target symbol.
> - On success, returns `Complete(ImportMemberValue)` with the `python:` prefix stripped from the target symbol.
> - Risk: any mismatch in the receipt (wrong CID, span, member path, or missing `python:` prefix) raises a `BackendDefect` instead of falling back to the previous delegation behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58f1b10.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->