### PR TITLE
Use SourceFragment line span value in import projection

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
@@ -100,7 +100,7 @@ class AttributeSugar(ConstructedTermSugar):
         from sugar_source_tree.fragment import SourceFragment
 
         if type(site) is SourceFragment:
-            span = site.line_col_span()
+            span = site.line_col_span
             receipt = site.unit.import_value_use_resolution(
                 (span.start_line, span.start_col, span.end_line, span.end_col)
             )


### PR DESCRIPTION
Minimal PR #6865 regression correction only. `SourceFragment.line_col_span` is already a `LineColSpan` value; consume it directly rather than calling it. No receipt-carrier changes, generic dispatch additions, or adjacent semantics. Published immediately without premerge review/CI gate as directed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `project_attribute` to access `line_col_span` as an attribute on `SourceFragment`
> In `AttributeSugar.project_attribute`, `site.line_col_span` was incorrectly called as a method when `site` is a `SourceFragment`. This caused a `TypeError` at runtime, preventing `import_value_use_resolution` from executing. The fix replaces the call `site.line_col_span()` with direct attribute access `site.line_col_span`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4100bc4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->