### PR TITLE
Use SourceFragment span property in import projection

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
@@ -100,7 +100,7 @@ class AttributeSugar(ConstructedTermSugar):
         from sugar_source_tree.fragment import SourceFragment
 
         if type(site) is SourceFragment:
-            span = site.line_col_span()
+            span = site.line_col_span
             receipt = site.unit.import_value_use_resolution(
                 (span.start_line, span.start_col, span.end_line, span.end_col)
             )


### PR DESCRIPTION
R_option_import_member_projection_api: 1
Predicted Epsilon R: -1

Exact one-line fix-forward for #6865: SourceFragment.line_col_span is a LineColSpan value, not a callable. No semantic or authority change.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `project_attribute` to access `line_col_span` as a property on `SourceFragment`
> In `AttributeSugar.project_attribute`, `site.line_col_span` was being called as a function when `site` is a `SourceFragment`, but `line_col_span` is a property, not a method. This caused a `TypeError` that prevented `import_value_use_resolution` from running. The fix replaces the call `site.line_col_span()` with direct attribute access `site.line_col_span`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8922511.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->