### PR TITLE
Close ImportMemberValue over authenticated receipts

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
@@ -8,9 +8,12 @@ AttributeError.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .floor_value import FloorValue
+
+
+_IMPORT_MEMBER_AUTHORITY = object()
 
 
 @dataclass(frozen=True)
@@ -18,6 +21,52 @@ class ImportMemberValue(FloorValue):
     """Source-authenticated ``module.attr[.attr…]`` export coordinate."""
 
     qualified_name: str
+    source_cid: str
+    import_binding_cid: str
+    use_cid: str
+    exported_member_path: tuple[str, ...]
+    receipt: object = field(compare=False, repr=False)
+    _authority: object = field(default=None, compare=False, repr=False)
+
+    @classmethod
+    def mint(cls, receipt):
+        from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
+
+        if type(receipt) is not AuthenticatedImportUseV1:
+            raise TypeError("ImportMemberValue requires exact authenticated receipt")
+        receipt.revalidate()
+        target = receipt.target_symbol
+        path = tuple(receipt.use["exportedMemberPath"])
+        if not target.startswith("python:") or not path:
+            raise ValueError("ImportMemberValue receipt has no imported member path")
+        return cls(
+            target.removeprefix("python:"),
+            receipt.source_cid,
+            receipt.import_binding.cid,
+            receipt.use["cid"],
+            path,
+            receipt,
+            _IMPORT_MEMBER_AUTHORITY,
+        )
+
+    def __post_init__(self):
+        from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
+
+        if self._authority is not _IMPORT_MEMBER_AUTHORITY:
+            raise ValueError("ImportMemberValue is not producer-minted")
+        if type(self.receipt) is not AuthenticatedImportUseV1:
+            raise TypeError("ImportMemberValue requires exact authenticated receipt")
+        self.receipt.revalidate()
+        if (
+            self.qualified_name
+            != self.receipt.target_symbol.removeprefix("python:")
+            or self.source_cid != self.receipt.source_cid
+            or self.import_binding_cid != self.receipt.import_binding.cid
+            or self.use_cid != self.receipt.use["cid"]
+            or self.exported_member_path
+            != tuple(self.receipt.use["exportedMemberPath"])
+        ):
+            raise ValueError("ImportMemberValue receipt authority mismatch")
 
     def denotes_value(self) -> bool:
         """An import-bound export denotes a runtime value at the member path."""
@@ -31,7 +80,16 @@ class ImportMemberValue(FloorValue):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const
 
-        return ctor("python:import_member", [str_const(self.qualified_name)])
+        return ctor(
+            "python:import_member",
+            [
+                str_const(self.qualified_name),
+                str_const(self.source_cid),
+                str_const(self.import_binding_cid),
+                str_const(self.use_cid),
+                *[str_const(item) for item in self.exported_member_path],
+            ],
+        )
 
     def exception_type_identity(self):
         """The same import coordinate the exception authenticator mints."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
@@ -148,7 +148,7 @@ class AttributeSugar(ConstructedTermSugar):
                 )
                 from sugar_lift_py_tests.outcome import Complete
 
-                return Complete(ImportMemberValue(target.removeprefix("python:")))
+                return Complete(ImportMemberValue.mint(receipt))
         return receiver.attribute(name, site)
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/import_member_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/import_member_sugar.py
@@ -13,6 +13,7 @@ class ImportMemberSugar(ConstructedTermSugar):
     """``import M as h; h.a.b`` as the closed coordinate ``M.a.b``."""
 
     qualified_name: str
+    receipt: object = dataclass_field(compare=False, repr=False)
     site: object = dataclass_field(compare=False)
 
     @classmethod
@@ -29,9 +30,12 @@ class ImportMemberSugar(ConstructedTermSugar):
         del ctx
         from sugar_lift_py_tests.floor.import_member_value import ImportMemberValue
 
-        return Complete(ImportMemberValue(self.qualified_name))
+        value = ImportMemberValue.mint(self.receipt)
+        if value.qualified_name != self.qualified_name:
+            raise ValueError("ImportMemberSugar receipt target mismatch")
+        return Complete(value)
 
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.floor.import_member_value import ImportMemberValue
 
-        return ImportMemberValue(self.qualified_name).to_term(owner=owner)
+        return ImportMemberValue.mint(self.receipt).to_term(owner=owner)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -10669,6 +10669,7 @@ class Attribute(Expression):
             qualified_name = qualified_name[len("python:") :]
             return ImportMemberSugar(
                 qualified_name=qualified_name,
+                receipt=receipt,
                 site=self.fragment,
             )
 


### PR DESCRIPTION
Closed producer-owned authority carrier for imported member values.

- `ImportMemberValue` is privately minted only from exact `AuthenticatedImportUseV1`.
- Carrier retains source CID, import-binding CID, exact use CID, exported member path, and original receipt.
- Post-init revalidates the receipt and every carried identity field.
- Term identity includes receipt authority; same `qualified_name` cannot collapse foreign binding/use testimony.
- Both early `ImportMemberSugar` and the merged late class-field projection call the private mint.
- Direct/string-only construction is refused.
- No spelling/vendor dispatch, generic fallback, or PR #6866 span change duplication.

Published immediately; focused audit is intentionally post-merge per active workflow.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close `ImportMemberValue` over authenticated receipts to embed source/import/use identity in IR
> - `ImportMemberValue` now stores `source_cid`, `import_binding_cid`, `use_cid`, `exported_member_path`, and the raw `receipt`; a new `mint(receipt)` classmethod is the only supported construction path, enforcing `AuthenticatedImportUseV1` receipts.
> - `__post_init__` revalidates the receipt on every instantiation and rejects mismatches between stored fields and receipt contents with `ValueError`.
> - `ImportMemberSugar` gains a `receipt` field; `desugar()` and `to_term()` now mint via `ImportMemberValue.mint(receipt)` and assert that the lexical `qualified_name` matches the receipt target.
> - The emitted `python:import_member` IR term now includes `source_cid`, `import_binding_cid`, `use_cid`, and each element of `exported_member_path` as positional fields.
> - Risk: any code that constructs `ImportMemberValue` directly (without `mint`) will raise `ValueError` at instantiation time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 321d048.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->