### PR TITLE
Close imported member values over authenticated receipts

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
@@ -8,16 +8,77 @@ AttributeError.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .floor_value import FloorValue
 
 
-@dataclass(frozen=True)
+_IMPORT_MEMBER_AUTHORITY = object()
+
+
+@dataclass(frozen=True, init=False)
 class ImportMemberValue(FloorValue):
     """Source-authenticated ``module.attr[.attr…]`` export coordinate."""
 
-    qualified_name: str
+    source_cid: str
+    import_binding_cid: str
+    value_use_cid: str
+    target_symbol: str
+    exported_member_path: tuple[str, ...]
+    use_site: tuple[int, int, int, int]
+    _authority: object = field(repr=False, compare=False)
+
+    def __init__(self, *args, **kwargs):
+        del args, kwargs
+        from sugar_source_tree.panic import BackendDefect
+
+        raise BackendDefect(
+            owner="ImportMemberValue",
+            blame="public constructor",
+            observed="caller attempted to forge imported member authority",
+            requested="private authenticated import-use producer mint",
+            fix="construct through ImportMemberSugar with the exact receipt",
+        )
+
+    @classmethod
+    def _from_authenticated_use(cls, receipt):
+        from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
+        from sugar_source_tree.panic import BackendDefect
+
+        if type(receipt) is not AuthenticatedImportUseV1:
+            raise BackendDefect(
+                owner="ImportMemberValue._from_authenticated_use",
+                blame=receipt,
+                observed=type(receipt).__name__,
+                requested="exact AuthenticatedImportUseV1",
+                fix="mint imported members only from the lexical value-use receipt",
+            )
+        receipt.revalidate()
+        site = receipt.use["useSite"]
+        path = tuple(receipt.use["exportedMemberPath"])
+        if not receipt.target_symbol.startswith("python:") or not path:
+            raise BackendDefect(
+                owner="ImportMemberValue._from_authenticated_use",
+                blame=site,
+                observed="receipt lacks an authenticated python member path",
+                requested="python: targetSymbol with nonempty exportedMemberPath",
+                fix="preserve the import-value receipt testimony unchanged",
+            )
+        value = object.__new__(cls)
+        object.__setattr__(value, "source_cid", receipt.source_cid)
+        object.__setattr__(value, "import_binding_cid", receipt.import_binding.cid)
+        object.__setattr__(value, "value_use_cid", receipt.use["cid"])
+        object.__setattr__(value, "target_symbol", receipt.target_symbol)
+        object.__setattr__(value, "exported_member_path", path)
+        object.__setattr__(value, "use_site", (
+            site["startLine"], site["startCol"], site["endLine"], site["endCol"]
+        ))
+        object.__setattr__(value, "_authority", _IMPORT_MEMBER_AUTHORITY)
+        return value
+
+    @property
+    def qualified_name(self) -> str:
+        return self.target_symbol.removeprefix("python:")
 
     def denotes_value(self) -> bool:
         """An import-bound export denotes a runtime value at the member path."""
@@ -31,7 +92,18 @@ class ImportMemberValue(FloorValue):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const
 
-        return ctor("python:import_member", [str_const(self.qualified_name)])
+        return ctor(
+            "python:import_member",
+            [
+                str_const(self.target_symbol),
+                str_const(self.source_cid),
+                str_const(self.import_binding_cid),
+                str_const(self.value_use_cid),
+                *(str_const(item) for item in self.exported_member_path),
+                *(str_const(str(item)) for item in self.use_site),
+            ],
+            symbol_kind="coordinate",
+        )
 
     def exception_type_identity(self):
         """The same import coordinate the exception authenticator mints."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
@@ -143,12 +143,11 @@ class AttributeSugar(ConstructedTermSugar):
                         requested="authenticated python: import target symbol",
                         fix="preserve the receipt targetSymbol unchanged",
                     )
-                from sugar_lift_py_tests.floor.import_member_value import (
-                    ImportMemberValue,
+                from sugar_lift_py_tests.sugar.import_member_sugar import (
+                    ImportMemberSugar,
                 )
-                from sugar_lift_py_tests.outcome import Complete
 
-                return Complete(ImportMemberValue(target.removeprefix("python:")))
+                return ImportMemberSugar(receipt, site).desugar(ctx)
         return receiver.attribute(name, site)
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/import_member_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/import_member_sugar.py
@@ -12,8 +12,22 @@ from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 class ImportMemberSugar(ConstructedTermSugar):
     """``import M as h; h.a.b`` as the closed coordinate ``M.a.b``."""
 
-    qualified_name: str
+    authenticated_use: object
     site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
+        from sugar_source_tree.panic import BackendDefect
+
+        if type(self.authenticated_use) is not AuthenticatedImportUseV1:
+            raise BackendDefect(
+                owner="ImportMemberSugar",
+                blame=self.site,
+                observed=type(self.authenticated_use).__name__,
+                requested="exact AuthenticatedImportUseV1",
+                fix="carry the lexical import-value receipt into member construction",
+            )
+        self.authenticated_use.revalidate()
 
     @classmethod
     def witnesses(cls):
@@ -29,9 +43,11 @@ class ImportMemberSugar(ConstructedTermSugar):
         del ctx
         from sugar_lift_py_tests.floor.import_member_value import ImportMemberValue
 
-        return Complete(ImportMemberValue(self.qualified_name))
+        return Complete(ImportMemberValue._from_authenticated_use(self.authenticated_use))
 
     def to_term(self, *, owner: str):
         from sugar_lift_py_tests.floor.import_member_value import ImportMemberValue
 
-        return ImportMemberValue(self.qualified_name).to_term(owner=owner)
+        return ImportMemberValue._from_authenticated_use(
+            self.authenticated_use
+        ).to_term(owner=owner)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -10666,9 +10666,8 @@ class Attribute(Expression):
                     requested="authenticated python: import target symbol",
                     fix="preserve the lexical receipt targetSymbol unchanged",
                 )
-            qualified_name = qualified_name[len("python:") :]
             return ImportMemberSugar(
-                qualified_name=qualified_name,
+                authenticated_use=receipt,
                 site=self.fragment,
             )
 


### PR DESCRIPTION
R_import_member_string_authority: 1
Predicted Epsilon R: -1

ImportMemberValue is now privately minted only from an exact revalidated AuthenticatedImportUseV1. The value seals source CID, import binding CID, use CID, target symbol, exported member path, and exact occurrence span into its coordinate term.

Both construction-time and cached runtime Attribute paths carry the receipt through ImportMemberSugar. Resolved/absent rows remain on their existing paths. No name/vendor/host fallback.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close imported member values over authenticated receipts
> - `ImportMemberValue` is redesigned as a frozen dataclass that can only be constructed via the new `_from_authenticated_use` factory classmethod; direct instantiation now raises `BackendDefect`.
> - `ImportMemberSugar` now carries the full `AuthenticatedImportUseV1` receipt instead of a stripped qualified name, and validates it at construction.
> - The IR term emitted by `ImportMemberValue.to_term` now includes the target symbol (with `python:` prefix), source/import/use CIDs, exported member path, use-site span, and `symbol_kind='coordinate'`.
> - `Attribute._construct_sugar` and `AttributeSugar.project_attribute` are updated to pass the full receipt to `ImportMemberSugar` rather than stripping the `python:` prefix early.
> - Behavioral Change: any code constructing `ImportMemberValue` directly or passing a bare qualified name to `ImportMemberSugar` will now raise `BackendDefect` at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f9e31f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->