### PR TITLE
Privatize imported member value minting

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
@@ -28,27 +28,6 @@ class ImportMemberValue(FloorValue):
     receipt: object = field(compare=False, repr=False)
     _authority: object = field(default=None, compare=False, repr=False)
 
-    @classmethod
-    def mint(cls, receipt):
-        from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
-
-        if type(receipt) is not AuthenticatedImportUseV1:
-            raise TypeError("ImportMemberValue requires exact authenticated receipt")
-        receipt.revalidate()
-        target = receipt.target_symbol
-        path = tuple(receipt.use["exportedMemberPath"])
-        if not target.startswith("python:") or not path:
-            raise ValueError("ImportMemberValue receipt has no imported member path")
-        return cls(
-            target.removeprefix("python:"),
-            receipt.source_cid,
-            receipt.import_binding.cid,
-            receipt.use["cid"],
-            path,
-            receipt,
-            _IMPORT_MEMBER_AUTHORITY,
-        )
-
     def __post_init__(self):
         from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
 
@@ -99,3 +78,25 @@ class ImportMemberValue(FloorValue):
             "python:exception_type_identity",
             [str_const("import"), str_const(self.qualified_name)],
         )
+
+
+def _mint_import_member_value(receipt):
+    """Module-private producer door from exact lexical import testimony."""
+    from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
+
+    if type(receipt) is not AuthenticatedImportUseV1:
+        raise TypeError("ImportMemberValue requires exact authenticated receipt")
+    receipt.revalidate()
+    target = receipt.target_symbol
+    path = tuple(receipt.use["exportedMemberPath"])
+    if not target.startswith("python:") or not path:
+        raise ValueError("ImportMemberValue receipt has no imported member path")
+    return ImportMemberValue(
+        target.removeprefix("python:"),
+        receipt.source_cid,
+        receipt.import_binding.cid,
+        receipt.use["cid"],
+        path,
+        receipt,
+        _IMPORT_MEMBER_AUTHORITY,
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
@@ -143,12 +143,13 @@ class AttributeSugar(ConstructedTermSugar):
                         requested="authenticated python: import target symbol",
                         fix="preserve the receipt targetSymbol unchanged",
                     )
-                from sugar_lift_py_tests.floor.import_member_value import (
-                    ImportMemberValue,
+                from sugar_lift_py_tests.sugar.import_member_sugar import (
+                    ImportMemberSugar,
                 )
-                from sugar_lift_py_tests.outcome import Complete
 
-                return Complete(ImportMemberValue.mint(receipt))
+                return ImportMemberSugar(
+                    target.removeprefix("python:"), receipt, site
+                ).desugar(ctx)
         return receiver.attribute(name, site)
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/import_member_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/import_member_sugar.py
@@ -28,14 +28,18 @@ class ImportMemberSugar(ConstructedTermSugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx
-        from sugar_lift_py_tests.floor.import_member_value import ImportMemberValue
+        from sugar_lift_py_tests.floor.import_member_value import (
+            _mint_import_member_value,
+        )
 
-        value = ImportMemberValue.mint(self.receipt)
+        value = _mint_import_member_value(self.receipt)
         if value.qualified_name != self.qualified_name:
             raise ValueError("ImportMemberSugar receipt target mismatch")
         return Complete(value)
 
     def to_term(self, *, owner: str):
-        from sugar_lift_py_tests.floor.import_member_value import ImportMemberValue
+        from sugar_lift_py_tests.floor.import_member_value import (
+            _mint_import_member_value,
+        )
 
-        return ImportMemberValue.mint(self.receipt).to_term(owner=owner)
+        return _mint_import_member_value(self.receipt).to_term(owner=owner)


### PR DESCRIPTION
R_import_member_public_replay: 1
Predicted Epsilon R: -1

Removes the public ImportMemberValue.mint classmethod. A module-private producer door accepts only exact AuthenticatedImportUseV1 testimony; ImportMemberSugar is the sole caller. Cached Attribute projection now routes through ImportMemberSugar.

All receipt fields and post-init revalidation remain unchanged. No public replay helper, name/vendor/host path, or resolved-object downgrade.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Privatize `ImportMemberValue` minting by replacing `mint` classmethod with a module-private function
> - Removes `ImportMemberValue.mint` classmethod and replaces it with `_mint_import_member_value`, a module-private function in [import_member_value.py](https://github.com/TSavo/sugar/pull/6870/files#diff-52543859d7b61d7f09f33bbbaf5908f0ce01fcb0d84531c91e455d3643151917) with equivalent validation logic.
> - Updates [import_member_sugar.py](https://github.com/TSavo/sugar/pull/6870/files#diff-c87c3eadc2fad9aeec7b1f3b96a2923e6a35e9c4107ec40c9075a206cc1bb7a1) to call `_mint_import_member_value` in both `desugar` and `to_term`.
> - Updates [attribute_sugar.py](https://github.com/TSavo/sugar/pull/6870/files#diff-dbd736f4cfe3d43f5f03b925994f117b1b962d9a10a2a832805468df2f8b7272) to route import attribute projection through `ImportMemberSugar.desugar(ctx)` instead of completing directly with a floor value.
> - Risk: `ImportMemberValue.mint` is no longer available at runtime; any external callers will fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1427852.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->