### PR TITLE
Privatize ImportMemberValue construction

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
@@ -16,7 +16,7 @@ from .floor_value import FloorValue
 _IMPORT_MEMBER_AUTHORITY = object()
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class ImportMemberValue(FloorValue):
     """Source-authenticated ``module.attr[.attr…]`` export coordinate."""
 
@@ -27,27 +27,6 @@ class ImportMemberValue(FloorValue):
     exported_member_path: tuple[str, ...]
     receipt: object = field(compare=False, repr=False)
     _authority: object = field(default=None, compare=False, repr=False)
-
-    @classmethod
-    def mint(cls, receipt):
-        from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
-
-        if type(receipt) is not AuthenticatedImportUseV1:
-            raise TypeError("ImportMemberValue requires exact authenticated receipt")
-        receipt.revalidate()
-        target = receipt.target_symbol
-        path = tuple(receipt.use["exportedMemberPath"])
-        if not target.startswith("python:") or not path:
-            raise ValueError("ImportMemberValue receipt has no imported member path")
-        return cls(
-            target.removeprefix("python:"),
-            receipt.source_cid,
-            receipt.import_binding.cid,
-            receipt.use["cid"],
-            path,
-            receipt,
-            _IMPORT_MEMBER_AUTHORITY,
-        )
 
     def __post_init__(self):
         from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
@@ -99,3 +78,29 @@ class ImportMemberValue(FloorValue):
             "python:exception_type_identity",
             [str_const("import"), str_const(self.qualified_name)],
         )
+
+
+def _mint_import_member_value(receipt) -> ImportMemberValue:
+    """The sole producer door for an exact authenticated imported value."""
+    from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
+
+    if type(receipt) is not AuthenticatedImportUseV1:
+        raise TypeError("ImportMemberValue requires exact authenticated receipt")
+    receipt.revalidate()
+    target = receipt.target_symbol
+    path = tuple(receipt.use["exportedMemberPath"])
+    if not target.startswith("python:") or not path:
+        raise ValueError("ImportMemberValue receipt has no imported member path")
+    value = object.__new__(ImportMemberValue)
+    for name, item in (
+        ("qualified_name", target.removeprefix("python:")),
+        ("source_cid", receipt.source_cid),
+        ("import_binding_cid", receipt.import_binding.cid),
+        ("use_cid", receipt.use["cid"]),
+        ("exported_member_path", path),
+        ("receipt", receipt),
+        ("_authority", _IMPORT_MEMBER_AUTHORITY),
+    ):
+        object.__setattr__(value, name, item)
+    value.__post_init__()
+    return value

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
@@ -144,11 +144,11 @@ class AttributeSugar(ConstructedTermSugar):
                         fix="preserve the receipt targetSymbol unchanged",
                     )
                 from sugar_lift_py_tests.floor.import_member_value import (
-                    ImportMemberValue,
+                    _mint_import_member_value,
                 )
                 from sugar_lift_py_tests.outcome import Complete
 
-                return Complete(ImportMemberValue.mint(receipt))
+                return Complete(_mint_import_member_value(receipt))
         return receiver.attribute(name, site)
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/import_member_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/import_member_sugar.py
@@ -28,14 +28,18 @@ class ImportMemberSugar(ConstructedTermSugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         del ctx
-        from sugar_lift_py_tests.floor.import_member_value import ImportMemberValue
+        from sugar_lift_py_tests.floor.import_member_value import (
+            _mint_import_member_value,
+        )
 
-        value = ImportMemberValue.mint(self.receipt)
+        value = _mint_import_member_value(self.receipt)
         if value.qualified_name != self.qualified_name:
             raise ValueError("ImportMemberSugar receipt target mismatch")
         return Complete(value)
 
     def to_term(self, *, owner: str):
-        from sugar_lift_py_tests.floor.import_member_value import ImportMemberValue
+        from sugar_lift_py_tests.floor.import_member_value import (
+            _mint_import_member_value,
+        )
 
-        return ImportMemberValue.mint(self.receipt).to_term(owner=owner)
+        return _mint_import_member_value(self.receipt).to_term(owner=owner)


### PR DESCRIPTION
Immediate private-mint closure fix-forward for merged #6868.

- `ImportMemberValue` has `init=False`; public dataclass construction is unavailable.
- Public classmethod `mint` is removed.
- Sole module-private producer `_mint_import_member_value` revalidates exact `AuthenticatedImportUseV1` and initializes the closed carrier.
- Both authenticated `ImportMemberSugar` and exact late Attribute projection use the private door.
- Receipt/source/binding/use/path identity validation remains unchanged.
- No generic fallback, spelling dispatch, or #6866 span duplication.

Published immediately without premerge test/review/CI gate per active fix-forward order.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Privatize `ImportMemberValue` construction via module-level `_mint_import_member_value` factory
> Moves `ImportMemberValue` instantiation out of the public `ImportMemberValue.mint` classmethod into a private module-level factory function `_mint_import_member_value`. The dataclass is changed to `frozen=True, init=False`, removing the auto-generated `__init__`; the factory constructs instances via `object.__new__` and `object.__setattr__`. Callers in [`attribute_sugar.py`](https://github.com/TSavo/sugar/pull/6871/files#diff-dbd736f4cfe3d43f5f03b925994f117b1b962d9a10a2a832805468df2f8b7272) and [`import_member_sugar.py`](https://github.com/TSavo/sugar/pull/6871/files#diff-c87c3eadc2fad9aeec7b1f3b96a2923e6a35e9c4107ec40c9075a206cc1bb7a1) are updated to use the new function. Behavioral Change: `ImportMemberValue` can no longer be instantiated directly or via `.mint()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 153ae54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->