### PR TITLE
Authenticate package-relative import member uses

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -381,12 +381,15 @@ def module_name_for_path(root: Path, path: Path) -> str:
     return ".".join(parts)
 
 
-def _import_from_module(current: str, node: Node) -> str | None:
+def _import_from_module(
+    current: str, node: Node, *, current_is_package: bool
+) -> str | None:
     if node.level == 0:
         return node.module
     package = current.split(".")
-    # A non-__init__ module's package excludes its final component.
-    if package:
+    # A non-package module's package excludes its final component.  An
+    # authenticated ``__init__.py`` already names the package itself.
+    if package and not current_is_package:
         package.pop()
     ascend = node.level - 1
     if ascend > len(package):
@@ -432,12 +435,14 @@ class _Pass:
         *,
         source_cid: str,
         module_name: str,
+        module_is_package: bool,
         module_identities: dict[str, dict[str, Any]],
         module_state: State | None = None,
         analyze_nested: bool = True,
     ):
         self.source_cid = source_cid
         self.module_name = module_name
+        self.module_is_package = module_is_package
         self.module_identities = module_identities
         self.rows: list[dict[str, Any]] = []
         self.outcomes: dict[tuple[int, int, int, int], str] = {}
@@ -457,6 +462,7 @@ class _Pass:
         transfer = _Pass(
             source_cid=self.source_cid,
             module_name=self.module_name,
+            module_is_package=self.module_is_package,
             module_identities=self.module_identities,
             module_state=self.module_state,
             analyze_nested=False,
@@ -694,7 +700,11 @@ class _Pass:
     def statement(self, node: Statement, state: State, scope: Node) -> State:
         state = dict(state)
         if node.kind == "ImportFrom":
-            module = _import_from_module(self.module_name, node)
+            module = _import_from_module(
+                self.module_name,
+                node,
+                current_is_package=self.module_is_package,
+            )
             if module is None:
                 return state
             for alias in node.names:
@@ -992,11 +1002,13 @@ def _final_module_state(
     module: Module,
     source_cid: str,
     module_name: str,
+    module_is_package: bool,
     module_identities: dict[str, dict[str, Any]],
 ) -> State:
     prepass = _Pass(
         source_cid=source_cid,
         module_name=module_name,
+        module_is_package=module_is_package,
         module_identities=module_identities,
         analyze_nested=False,
     )
@@ -1146,11 +1158,13 @@ def _run_lexical_import_pass(
         module=module,
         source_cid=source_cid,
         module_name=module_name,
+        module_is_package=path.name == "__init__.py",
         module_identities=identities,
     )
     runner = _Pass(
         source_cid=source_cid,
         module_name=module_name,
+        module_is_package=path.name == "__init__.py",
         module_identities=identities,
         module_state=module_state,
     )
@@ -1207,11 +1221,13 @@ def import_bound_name_targets(
         module=module,
         source_cid=source_cid,
         module_name=module_name,
+        module_is_package=Path(module.unit.filename).name == "__init__.py",
         module_identities=identities,
     )
     runner = _Pass(
         source_cid=source_cid,
         module_name=module_name,
+        module_is_package=Path(module.unit.filename).name == "__init__.py",
         module_identities=identities,
         module_state=module_state,
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
@@ -63,6 +63,31 @@ def test_value_use_receipt_changes_when_source_moves(tmp_path: Path) -> None:
     )
 
 
+def test_package_init_relative_import_owns_exact_member_value_use(
+    tmp_path: Path,
+) -> None:
+    package = tmp_path / "renamed_package"
+    package.mkdir()
+    path = package / "__init__.py"
+    source, source_cid = _write(
+        path,
+        "from . import helper\n\nclass C:\n    A = B = helper.FLAG\n",
+    )
+
+    receipts, _ = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+
+    member = tuple(
+        receipt
+        for receipt in receipts
+        if receipt.target_symbol == "python:renamed_package.helper.FLAG"
+    )
+    assert len(member) == 1
+    assert member[0].use["exportedMemberPath"] == ["FLAG"]
+    assert _site_key(member[0]) == (4, 12, 4, 23)
+
+
 def test_non_imported_name_gets_no_value_use_receipt(tmp_path: Path) -> None:
     path = tmp_path / "local.py"
     source, source_cid = _write(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -2481,7 +2481,11 @@ def _seat_import_value_use_receipts(
             receipt, graph=dependency_graph, session=session
         )
         if not isinstance(imported, ResolvedPythonObjectV1):
-            if imported.kind in {"dynamic-export", "static-export-absent"}:
+            if imported.kind in {
+                "dynamic-export",
+                "static-export-absent",
+                "reexport-cycle",
+            }:
                 # Honest open-world value exports carry no definition
                 # coordinate to seat. Leave the exact use unresolved so its
                 # ordinary consumer remains typed-loud if execution reaches


### PR DESCRIPTION
R_option_package_relative_member_receipt: 1
Predicted Epsilon R: -1

The lexical import producer now carries whether the authenticated source path is package __init__.py. Relative imports in package initializers retain the package component instead of being treated as non-package modules.

This mints the exact re._compiler.SRE_FLAG_* value-use receipts needed by decorated class field construction. The focused renamed-package chained-field tooth pins target symbol, member path, and full occurrence. No re/compiler/name/vendor/host arm.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix relative import resolution for package `__init__.py` modules
> - Fixes `_import_from_module` in [import_binding.py](https://github.com/TSavo/sugar/pull/6872/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) to treat `__init__.py` as the package itself when resolving relative imports, rather than dropping the final path component as it does for regular modules.
> - Threads a new `module_is_package` flag through `_Pass`, `_final_module_state`, `_run_lexical_import_pass`, and `import_bound_name_targets` so all relative import resolution is package-aware.
> - Fixes `_seat_import_value_use_receipts` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6872/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to handle `reexport-cycle` resolutions without raising, seating the receipt and leaving the use unresolved.
> - Behavioral Change: relative imports in `__init__.py` now resolve to a different module path than before (no final component drop).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88540bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->