### PR TITLE
Test package-relative import receipt discrimination

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
@@ -9,6 +9,7 @@ value.  No AST-scan fallback, first-candidate, or spelling resolver.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -86,6 +87,49 @@ def test_package_init_relative_import_owns_exact_member_value_use(
     assert len(member) == 1
     assert member[0].use["exportedMemberPath"] == ["FLAG"]
     assert _site_key(member[0]) == (4, 12, 4, 23)
+
+
+def test_package_relative_member_receipts_refuse_cross_package_substitution(
+    tmp_path: Path,
+) -> None:
+    receipts = []
+    for package_name in ("first_package", "second_package"):
+        package = tmp_path / package_name
+        package.mkdir()
+        path = package / "__init__.py"
+        source, source_cid = _write(
+            path, "from . import helper\nvalue = helper.FLAG\n"
+        )
+        rows, _ = authenticated_import_value_use_receipts(
+            tmp_path, path, source, source_cid, module_identities={}
+        )
+        receipts.append(next(row for row in rows if row.use["exportedMemberPath"]))
+
+    first, second = receipts
+    assert first.target_symbol == "python:first_package.helper.FLAG"
+    assert second.target_symbol == "python:second_package.helper.FLAG"
+    assert first.import_binding.cid != second.import_binding.cid
+    assert first.use["cid"] != second.use["cid"]
+    with pytest.raises(ValueError, match="cites another binding"):
+        replace(first, import_binding=second.import_binding)
+
+
+def test_non_init_module_relative_import_keeps_parent_package(
+    tmp_path: Path,
+) -> None:
+    package = tmp_path / "sibling_control"
+    package.mkdir()
+    path = package / "consumer.py"
+    source, source_cid = _write(
+        path, "from . import helper\nvalue = helper.FLAG\n"
+    )
+
+    rows, _ = authenticated_import_value_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    member = tuple(row for row in rows if row.use["exportedMemberPath"])
+    assert len(member) == 1
+    assert member[0].target_symbol == "python:sibling_control.helper.FLAG"
 
 
 def test_non_imported_name_gets_no_value_use_receipt(tmp_path: Path) -> None:


### PR DESCRIPTION
Test-only follow-up to #6872. Pins renamed package truth, cross-package binding substitution refusal, and non-init sibling relative-import behavior. Production delta zero.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Test package-relative import receipt discrimination in value-use receipts
> - Adds `test_package_relative_member_receipts_refuse_cross_package_substitution` in [test_import_value_use_receipts.py](https://github.com/TSavo/sugar/pull/6873/files#diff-40ca073a577d6917938b0db669bf87128cc80df826b627dc3a03d7a90c6c2a47): verifies that swapping the `import_binding` from one sibling package's receipt into another raises `ValueError` with 'cites another binding'.
> - Adds `test_non_init_module_relative_import_keeps_parent_package`: verifies that a relative import from a non-`__init__` module produces a member receipt whose `target_symbol` retains the parent package name (e.g. `python:sibling_control.helper.FLAG`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3dd3688.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->