### PR TITLE
Resolve authenticated relative module members

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -844,7 +844,8 @@ def resolve_import_binding(
     base = module_name.split(".")
     bound = list(bound_path)
     if bound:
-        expected = base + bound
+        member_path = list(authenticated_use.use.get("exportedMemberPath") or ())
+        expected = base + bound + member_path
         if requested != expected or len(bound) != 1:
             return _gap(
                 "target-outside-binding",
@@ -853,7 +854,20 @@ def resolve_import_binding(
                 module_name,
                 target_symbol,
             )
-        exported_name = bound[0]
+        if member_path:
+            nested_module = ".".join(base + bound)
+            if len(member_path) != 1 or nested_module not in graph.modules:
+                return _gap(
+                    "target-outside-binding",
+                    binding_cid,
+                    graph,
+                    module_name,
+                    target_symbol,
+                )
+            module_name = nested_module
+            exported_name = member_path[0]
+        else:
+            exported_name = bound[0]
     elif requested[: len(base)] == base and len(requested) == len(base) + 1:
         exported_name = requested[-1]
     else:


### PR DESCRIPTION
R_option_relative_module_member_resolution: 1
Predicted Epsilon R: -1

Extends an exact authenticated import binding by its receipt-owned structural exportedMemberPath. For a bound package submodule present in the authenticated artifact graph, resolution enters that exact module and resolves its one exact member.

This closes re._compiler.isstring without a re/compiler/member spelling arm. Foreign source/binding/use/path remain excluded by receipt revalidation and exact target composition.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve authenticated relative module members in `resolve_import_binding`
> Extends `resolve_import_binding` in [dependency_artifact.py](https://github.com/TSavo/sugar/pull/6874/files#diff-153692407653e4eda2c94b6899d612575f4b0f569fd4ee8a0ac674aef4e90464) to handle imports that specify an `exportedMemberPath` on `authenticated_use.use`.
>
> - When `exportedMemberPath` is present, the bound path is treated as a nested module and the single member path element becomes the exported name.
> - Validates that the member path has exactly one segment and that the nested module (`base + bound`) exists in `graph.modules`; returns a `target-outside-binding` gap otherwise.
> - Updates the requested path equality check to compare against `base + bound + member_path` instead of `base + bound`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 875b417.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved import resolution for nested exported members.
  - Correctly identifies module and member names when imports reference members within nested modules.
  - Added validation for unsupported or ambiguous nested member paths, ensuring these cases are reported consistently instead of being resolved incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->