### PR TITLE
Refine authenticated relative member call resolution

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -844,9 +844,8 @@ def resolve_import_binding(
     base = module_name.split(".")
     bound = list(bound_path)
     if bound:
-        member_path = list(authenticated_use.use.get("exportedMemberPath") or ())
-        expected = base + bound + member_path
-        if requested != expected or len(bound) != 1:
+        binding_prefix = base + bound
+        if len(bound) != 1:
             return _gap(
                 "target-outside-binding",
                 binding_cid,
@@ -854,9 +853,24 @@ def resolve_import_binding(
                 module_name,
                 target_symbol,
             )
-        if member_path:
-            nested_module = ".".join(base + bound)
-            if len(member_path) != 1 or nested_module not in graph.modules:
+        if requested == binding_prefix:
+            exported_name = bound[0]
+        else:
+            suffix = requested[len(binding_prefix) :]
+            nested_module = ".".join(binding_prefix)
+            demand_kind = authenticated_use.demand.get("kind")
+            if (
+                requested[: len(binding_prefix)] != binding_prefix
+                or len(suffix) != 1
+                or nested_module not in graph.modules
+                or (
+                    demand_kind == "import-value-use-demand"
+                    and list(
+                        authenticated_use.use.get("exportedMemberPath") or ()
+                    )
+                    != suffix
+                )
+            ):
                 return _gap(
                     "target-outside-binding",
                     binding_cid,
@@ -865,9 +879,7 @@ def resolve_import_binding(
                     target_symbol,
                 )
             module_name = nested_module
-            exported_name = member_path[0]
-        else:
-            exported_name = bound[0]
+            exported_name = suffix[0]
     elif requested[: len(base)] == base and len(requested) == len(base) + 1:
         exported_name = requested[-1]
     else:


### PR DESCRIPTION
Fix-forward after #6874 merged its pre-audit head. Direct bound exports retain the old path. Exactly one extra call member is admitted only when the authenticated binding prefix names a module in the same graph; value receipts must also match exportedMemberPath. No spelling/vendor/host fallback.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refine authenticated relative member call resolution in `resolve_import_binding`
> - Replaces the prior `member_path`/`expected` equality check with a `binding_prefix` + suffix approach in [`dependency_artifact.py`](https://github.com/TSavo/sugar/pull/6875/files#diff-153692407653e4eda2c94b6899d612575f4b0f569fd4ee8a0ac674aef4e90464).
> - Rejects bindings where `bound` length != 1, then derives `exported_name` from the requested path's suffix relative to `binding_prefix`, validating that the suffix has length 1 and the nested module exists in `graph.modules`.
> - Only enforces `use.exportedMemberPath == suffix` equality for the `import-value-use-demand` kind; other demand kinds now resolve from the requested path alone.
> - Behavioral Change: mismatches between `exportedMemberPath` and the requested suffix for `import-value-use-demand` now yield a `target-outside-binding` gap, whereas previously such cases could resolve successfully.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13b111b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->