### PR TITLE
Seat decorated class import member receipts

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1771,6 +1771,14 @@ def _construct_reachable_decorated_class_bindings(
     for definition in module_definitions:
         if definition not in class_dependencies:
             continue
+        _seat_import_value_use_receipts(
+            source_file=source_file,
+            module=module,
+            target=definition,
+            session=session,
+            context=context,
+            dependency_graphs=dependency_graphs,
+        )
         outcome = definition.sugar().desugar(ctx)
         if not isinstance(outcome, Complete):
             raise SugarNotWritten(
@@ -1785,6 +1793,19 @@ def _construct_reachable_decorated_class_bindings(
 
     result = []
     for definition in reached:
+        # Decorated publication reduces the class body in this exact context,
+        # after ordinary frame preparation may already have cached its field
+        # AttributeSugar.  Seat the lexical value-use receipts owned by this
+        # ClassDef before that reduction so the full Attribute occurrence—not
+        # receiver/member spelling—authorizes ImportMemberValue projection.
+        _seat_import_value_use_receipts(
+            source_file=source_file,
+            module=module,
+            target=definition,
+            session=session,
+            context=context,
+            dependency_graphs=dependency_graphs,
+        )
         sugar = definition.sugar()
         raw_outcome = sugar.desugar(ctx)
         if not isinstance(raw_outcome, Complete):


### PR DESCRIPTION
## What changed

Seats existing authenticated import-value receipts for every exact reached decorated ClassDef and its exact class dependencies before their first class sugar reduction. This lets cached class-field AttributeSugar consume the full source occurrence receipt without any receiver/member spelling fallback.

## Exact frontier

Before: `SymbolicValue.attribute` at `re/__init__.py:145:16` for `_compiler.SRE_FLAG_ASCII`, with both SourceUnit/context rows absent.

After: that residual retires; the focused pandas re.search consumer advances to the distinct `ClassValue.attribute` boundary at `re/__init__.py [7869,7883)`.

## Receipt

`test_pandas_regex_source_frame_consumer.py`: `1 failed, 1 passed in 13.22s`; the failure moved to the named next producer. Production scope is one file, +21 lines.

- `R_decorated_class_import_receipt_absent: 1 -> 0`
- predicted `Epsilon R=-1`
- no AttributeSugar fallback, name arm, vendor arm, or host lookup.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seat import value use receipts for decorated class dependencies in `_construct_reachable_decorated_class_bindings`
> Adds two calls to `_seat_import_value_use_receipts` in [`manager_construction.py`](https://github.com/TSavo/sugar/pull/6878/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) within `_construct_reachable_decorated_class_bindings`. The first call runs before desugaring each class dependency; the second runs before desugaring each reached decorated class body. Both calls pass the current definition as the target along with the source file, module, session, context, and dependency graphs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9e3bce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->