### PR TITLE
Retain imported member receipts across frame seating

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -571,6 +571,10 @@ class TreeConstructionContextV1:
     # of the frame's own SourceUnit (source_cid-matched).  Never carries
     # cross-unit spans; keyed by SourceFragmentCoordinateV1 of this unit.
     source_import_value_resolutions: dict = field(default_factory=dict)
+    # Producer-minted value-use receipt roster, retained once per exact source
+    # CID so repeated frame/class publication transports object identity rather
+    # than reminting an equivalent receipt at an occupied SourceUnit seat.
+    source_import_value_receipts: dict = field(default_factory=dict)
     # When projecting an authenticated definition into a call frame, dual-mode
     # factory bodies may contain With sites only on non-manager return paths
     # (e.g. pytest.raises function form). Soft projection does not require

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1216,6 +1216,9 @@ def _resolve_source_visible_frame_uncached(
             module.source_cid,
             module_identities={},
         )
+        value_receipts = context.source_import_value_receipts.setdefault(
+            module.source_cid, tuple(value_receipts)
+        )
     else:
         import_receipts = ()
         value_receipts = ()
@@ -2296,13 +2299,17 @@ def _seat_import_value_use_receipts(
             fix="refuse dual-door repair; re-mint module via path_source",
         )
     # No ValueError swallow: authenticated mint refuses tamper/mismatch loud.
-    receipts, _ = authenticated_import_value_use_receipts(
-        Path("."),
-        Path(module.source_seat),
-        module.source,
-        module.source_cid,
-        module_identities={},
-    )
+    receipts = context.source_import_value_receipts.get(module.source_cid)
+    if receipts is None:
+        minted, _ = authenticated_import_value_use_receipts(
+            Path("."),
+            Path(module.source_seat),
+            module.source,
+            module.source_cid,
+            module_identities={},
+        )
+        receipts = tuple(minted)
+        context.source_import_value_receipts[module.source_cid] = receipts
     from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
 
     call_receipts, _ = authenticated_import_use_receipts(

--- a/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
@@ -1,0 +1,111 @@
+"""Exact receipt transport for ``re.RegexFlag`` imported class fields."""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor.import_member_value import ImportMemberValue
+from sugar_lift_python_source.dependency_artifact import DependencyArtifactGraph
+from sugar_lift_python_source.manager_construction import (
+    _seat_import_value_use_receipts,
+)
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
+from sugar_source_tree.nodes import Attribute, ClassDef
+from sugar_source_tree.panic import BackendDefect, SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def test_regexflag_relative_member_receipt_survives_repeated_frame_seating() -> None:
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("re")
+    module = graph.modules["re"]
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source_file = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=context,
+    )
+    regex_flag = next(
+        node
+        for node in source_file.root.body
+        if isinstance(node, ClassDef) and node.name == "RegexFlag"
+    )
+    session = SourceResolutionSession(enabled=False)
+
+    for _ in range(2):
+        _seat_import_value_use_receipts(
+            source_file=source_file,
+            module=module,
+            target=regex_flag,
+            session=session,
+            context=context,
+            dependency_graphs={"re": graph},
+        )
+
+    member = next(
+        node
+        for node in source_file.nodes()
+        if isinstance(node, Attribute)
+        and node.attr == "SRE_FLAG_ASCII"
+        and node.line_col_span().start_line == 145
+    )
+    outcome = member.sugar().desugar()
+    assert type(outcome.value) is ImportMemberValue
+    assert outcome.value.qualified_name == "re._compiler.SRE_FLAG_ASCII"
+    assert any(
+        outcome.value.receipt is receipt
+        for receipt in context.source_import_value_receipts[module.source_cid]
+    )
+
+
+def test_regexflag_relative_member_missing_foreign_and_crosswired_receipts_refuse() -> (
+    None
+):
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("re")
+    module = graph.modules["re"]
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source_file = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=context,
+    )
+    regex_flag = next(
+        node
+        for node in source_file.root.body
+        if isinstance(node, ClassDef) and node.name == "RegexFlag"
+    )
+    member = next(
+        node
+        for node in source_file.nodes()
+        if isinstance(node, Attribute)
+        and node.attr == "SRE_FLAG_ASCII"
+        and node.line_col_span().start_line == 145
+    )
+    with pytest.raises(SugarNotWritten, match="SymbolicValue.attribute"):
+        member.sugar().desugar()
+
+    _seat_import_value_use_receipts(
+        source_file=source_file,
+        module=module,
+        target=regex_flag,
+        session=SourceResolutionSession(enabled=False),
+        context=context,
+        dependency_graphs={"re": graph},
+    )
+    receipt = next(
+        row
+        for row in context.source_import_value_receipts[module.source_cid]
+        if row.target_symbol == "python:re._compiler.SRE_FLAG_ASCII"
+    )
+    span = member.line_col_span()
+    exact = (span.start_line, span.start_col, span.end_line, span.end_col)
+    with pytest.raises(BackendDefect, match="does not match exact value-use seat"):
+        source_file.unit.seat_import_value_use_resolution(
+            (exact[0], exact[1], exact[2], exact[3] - 1),
+            receipt,
+            source_cid=module.source_cid,
+        )
+    with pytest.raises(BackendDefect, match="this unit only"):
+        source_file.unit.seat_import_value_use_resolution(
+            exact,
+            receipt,
+            source_cid="blake3-512:" + "0" * 128,
+        )


### PR DESCRIPTION
Exact option_context producer fix for the current `re.RegexFlag` boundary.

The lexical producer now retains one authenticated import value-use receipt roster per source CID in the construction context. Repeated class/frame seating transports the same receipt identity instead of reminting an equivalent receipt into an occupied SourceUnit occurrence. This lets the exact `re/__init__.py:145:16` `_compiler.SRE_FLAG_ASCII` Attribute project the existing private `ImportMemberValue`; there is no spelling, vendor, or generic Attribute fallback.

Truth/lying teeth cover repeated exact seating, exact private member projection, missing receipt, foreign source CID, and crosswired span refusal.

R_regexflag_import_member_transport: 1 -> 0. Predicted Epsilon R: -1. Corpus stableZero remains unknown.

Focused CPython 3.12 receipt: `2 passed in 14.84s`, exit 0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retain imported member receipts across frame seating by caching receipts per source CID
> - Adds `source_import_value_receipts` dict to `TreeConstructionContextV1` to store value-use receipts keyed by source CID.
> - Updates `_resolve_source_visible_frame_uncached` and `_seat_import_value_use_receipts` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6879/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to mint receipts once per source CID and reuse them from the context cache on subsequent calls.
> - Adds tests in [test_regexflag_relative_member_seating.py](https://github.com/TSavo/sugar/pull/6879/files#diff-3ae4846d62744433a022e393539888f5522332faba6e717dfca0402bc114fa1e) verifying receipt object identity is stable across repeated frame seating passes, and that invalid coordinates or foreign source CIDs raise `BackendDefect`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d67347.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->