### PR TITLE
Key imported receipt rosters by module identity

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1216,8 +1216,8 @@ def _resolve_source_visible_frame_uncached(
             module.source_cid,
             module_identities={},
         )
-        value_receipts = context.source_import_value_receipts.setdefault(
-            module.source_cid, tuple(value_receipts)
+        value_receipts = _retain_import_value_receipt_roster(
+            context, module, tuple(value_receipts)
         )
     else:
         import_receipts = ()
@@ -2299,7 +2299,8 @@ def _seat_import_value_use_receipts(
             fix="refuse dual-door repair; re-mint module via path_source",
         )
     # No ValueError swallow: authenticated mint refuses tamper/mismatch loud.
-    receipts = context.source_import_value_receipts.get(module.source_cid)
+    roster_key = (module.module_name, module.source_seat, module.source_cid)
+    receipts = context.source_import_value_receipts.get(roster_key)
     if receipts is None:
         minted, _ = authenticated_import_value_use_receipts(
             Path("."),
@@ -2308,8 +2309,9 @@ def _seat_import_value_use_receipts(
             module.source_cid,
             module_identities={},
         )
-        receipts = tuple(minted)
-        context.source_import_value_receipts[module.source_cid] = receipts
+        receipts = _retain_import_value_receipt_roster(
+            context, module, tuple(minted)
+        )
     from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
 
     call_receipts, _ = authenticated_import_use_receipts(
@@ -2517,6 +2519,93 @@ def _seat_import_value_use_receipts(
         unit.seat_import_value_use_resolution(
             span_key, imported, source_cid=module.source_cid
         )
+
+
+def _retain_import_value_receipt_roster(
+    context: TreeConstructionContextV1,
+    module,
+    receipts: tuple,
+) -> tuple:
+    """Retain one producer roster under its exact authenticated module seat."""
+    from sugar_lift_py_tests.import_binding import module_name_for_path
+    from sugar_source_tree.panic import BackendDefect
+
+    key = (module.module_name, module.source_seat, module.source_cid)
+    seen = set()
+    identities = []
+    for receipt in receipts:
+        receipt.revalidate()
+        receipt_module = module_name_for_path(receipt.root, receipt.path)
+        try:
+            receipt_seat = receipt.path.relative_to(receipt.root).as_posix()
+        except ValueError:
+            receipt_seat = ""
+        if (
+            receipt.source_cid != module.source_cid
+            or receipt.source != module.source
+            or receipt_module != module.module_name
+            or receipt_seat != module.source_seat
+        ):
+            raise BackendDefect(
+                blame=module.source_seat,
+                owner="manager_construction import value receipt roster",
+                observed="receipt has foreign authenticated module identity",
+                requested="same module name, source seat, source CID, and bytes",
+                fix="retain the producer roster only under its own module identity",
+            )
+        site = receipt.use["useSite"]
+        row_key = (
+            site["startLine"],
+            site["startCol"],
+            site["endLine"],
+            site["endCol"],
+        )
+        if row_key in seen:
+            raise BackendDefect(
+                blame=row_key,
+                owner="manager_construction import value receipt roster",
+                observed="duplicate exact value-use row",
+                requested="one producer receipt per exact occurrence",
+                fix="repair lexical receipt enrollment before retaining the roster",
+            )
+        seen.add(row_key)
+        identities.append(
+            (
+                row_key,
+                receipt.target_symbol,
+                receipt.import_binding.cid,
+                receipt.use["cid"],
+                tuple(receipt.use["exportedMemberPath"]),
+            )
+        )
+    existing = context.source_import_value_receipts.get(key)
+    if existing is None:
+        context.source_import_value_receipts[key] = receipts
+        return receipts
+    existing_identities = tuple(
+        (
+            (
+                row.use["useSite"]["startLine"],
+                row.use["useSite"]["startCol"],
+                row.use["useSite"]["endLine"],
+                row.use["useSite"]["endCol"],
+            ),
+            row.target_symbol,
+            row.import_binding.cid,
+            row.use["cid"],
+            tuple(row.use["exportedMemberPath"]),
+        )
+        for row in existing
+    )
+    if existing_identities != tuple(identities):
+        raise BackendDefect(
+            blame=module.source_seat,
+            owner="manager_construction import value receipt roster",
+            observed="conflicting exact value-use row identities",
+            requested="byte-identical target/binding/use/member roster",
+            fix="preserve the first producer-owned roster unchanged",
+        )
+    return existing
 
 
 def _install_opaque_call_obligation(

--- a/implementations/python/sugar-lift-python-source/tests/test_import_value_receipt_roster_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_import_value_receipt_roster_authority.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.import_binding import authenticated_import_value_use_receipts
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import AuthenticatedModuleSourceV1
+from sugar_lift_python_source.manager_construction import (
+    _retain_import_value_receipt_roster,
+)
+from sugar_source_tree.panic import BackendDefect
+
+
+SOURCE = "from . import helper\nfirst = helper.FLAG\nsecond = helper.OTHER\n"
+
+
+def _module_and_rows(root: Path, package: str):
+    path = root / package / "__init__.py"
+    path.parent.mkdir(parents=True)
+    path.write_text(SOURCE, encoding="utf-8")
+    source_cid = blake3_512_of(SOURCE.encode("utf-8"))
+    rows, _ = authenticated_import_value_use_receipts(
+        root, path, SOURCE, source_cid, module_identities={}
+    )
+    module = AuthenticatedModuleSourceV1(
+        package, f"{package}/__init__.py", source_cid, SOURCE
+    )
+    return module, tuple(rows)
+
+
+def test_identical_package_bytes_retain_distinct_authenticated_rosters(
+    tmp_path: Path,
+) -> None:
+    first_module, first_rows = _module_and_rows(tmp_path, "first_package")
+    second_module, second_rows = _module_and_rows(tmp_path, "second_package")
+    context = TreeConstructionContextV1.for_source_call_construction()
+
+    first = _retain_import_value_receipt_roster(context, first_module, first_rows)
+    second = _retain_import_value_receipt_roster(context, second_module, second_rows)
+
+    assert first is first_rows
+    assert second is second_rows
+    assert first is not second
+    assert {row.target_symbol for row in first} != {
+        row.target_symbol for row in second
+    }
+    assert {row.import_binding.cid for row in first}.isdisjoint(
+        row.import_binding.cid for row in second
+    )
+    assert {row.use["cid"] for row in first}.isdisjoint(
+        row.use["cid"] for row in second
+    )
+    assert len(first) == len(second) == 4
+
+
+def test_same_module_reuses_objects_and_foreign_or_duplicate_rosters_refuse(
+    tmp_path: Path,
+) -> None:
+    first_module, first_rows = _module_and_rows(tmp_path, "first_package")
+    second_module, second_rows = _module_and_rows(tmp_path, "second_package")
+    context = TreeConstructionContextV1.for_source_call_construction()
+    retained = _retain_import_value_receipt_roster(
+        context, first_module, first_rows
+    )
+
+    repeated = _retain_import_value_receipt_roster(
+        context, first_module, tuple(first_rows)
+    )
+    assert repeated is retained
+    assert all(left is right for left, right in zip(repeated, first_rows))
+
+    with pytest.raises(BackendDefect, match="module identity"):
+        _retain_import_value_receipt_roster(context, second_module, first_rows)
+    with pytest.raises(BackendDefect, match="duplicate exact value-use row"):
+        _retain_import_value_receipt_roster(
+            TreeConstructionContextV1.for_source_call_construction(),
+            first_module,
+            (*first_rows, first_rows[-1]),
+        )
+    assert len(retained) == 4
+    assert second_rows

--- a/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
@@ -53,7 +53,9 @@ def test_regexflag_relative_member_receipt_survives_repeated_frame_seating() -> 
     assert outcome.value.qualified_name == "re._compiler.SRE_FLAG_ASCII"
     assert any(
         outcome.value.receipt is receipt
-        for receipt in context.source_import_value_receipts[module.source_cid]
+        for receipt in context.source_import_value_receipts[
+            (module.module_name, module.source_seat, module.source_cid)
+        ]
     )
 
 
@@ -92,7 +94,9 @@ def test_regexflag_relative_member_missing_foreign_and_crosswired_receipts_refus
     )
     receipt = next(
         row
-        for row in context.source_import_value_receipts[module.source_cid]
+        for row in context.source_import_value_receipts[
+            (module.module_name, module.source_seat, module.source_cid)
+        ]
         if row.target_symbol == "python:re._compiler.SRE_FLAG_ASCII"
     )
     span = member.line_col_span()


### PR DESCRIPTION
Post-merge fix-forward for #6879.

Identical source bytes can occur under differently named package roots, so source CID alone is not an import-binding authority. This keys the retained value-use roster by exact authenticated `(module_name, source_seat, source_cid)` and reconciles every occurrence row by target, binding CID, use CID, and exported member path.

Truth/lying teeth cover renamed package roots, distinct binding/target/use/member identities, same-module exact-object reuse, foreign module/context substitution, unrelated-row retention, duplicate exact keys, and the existing RegexFlag projection. No generic cache fallback or adjacent producer change.

R_import_receipt_roster_crosswire: 1 -> 0. Predicted Epsilon R: -1. Corpus stableZero unknown.

Focused CPython 3.12 receipt: `4 passed in 17.19s`, exit 0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Key imported receipt rosters by module identity tuple instead of source CID alone
> - Replaces the `source_cid`-only key in `context.source_import_value_receipts` with a composite key `(module_name, source_seat, source_cid)` so that distinct modules with identical source bytes get separate rosters.
> - Introduces `_retain_import_value_receipt_roster` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6880/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to enforce roster integrity: one roster per module identity, one-to-one use-site span mapping, and `BackendDefect` on conflicting or duplicate rosters.
> - Adds [test_import_value_receipt_roster_authority.py](https://github.com/TSavo/sugar/pull/6880/files#diff-ab192505f9b26db418bf7660f0734609f81da9dee3ab3b5bc0e25107f309d28f) covering distinct-package isolation and rejection of foreign-module or duplicate-row rosters.
> - Updates existing tests in [test_regexflag_relative_member_seating.py](https://github.com/TSavo/sugar/pull/6880/files#diff-3ae4846d62744433a022e393539888f5522332faba6e717dfca0402bc114fa1e) to use the new composite key.
> - Behavioral Change: any code reading `source_import_value_receipts` by `source_cid` alone will no longer find its entries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f42f8a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->