### PR TITLE
Authenticate import value receipt cache

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1216,8 +1216,11 @@ def _resolve_source_visible_frame_uncached(
             module.source_cid,
             module_identities={},
         )
-        value_receipts = context.source_import_value_receipts.setdefault(
-            module.source_cid, tuple(value_receipts)
+        value_receipts = _cache_import_value_receipts(
+            context,
+            module,
+            dependency_graphs,
+            value_receipts,
         )
     else:
         import_receipts = ()
@@ -2256,6 +2259,120 @@ def _call_callee_coordinate(call: Call):
     )
 
 
+def _source_import_value_receipt_cache_key(module, dependency_graphs):
+    """Closed cache identity for one authenticated module source roster."""
+    from sugar_source_tree.panic import BackendDefect
+
+    graph = dependency_graphs.get(module.module_name.split(".", 1)[0])
+    if graph is None or graph.modules.get(module.module_name) is not module:
+        raise BackendDefect(
+            blame=module.source_seat,
+            owner="manager_construction import value receipt cache",
+            observed="module source is not owned by the carried dependency graph",
+            requested="exact module name/source/seat/artifact identity",
+            fix="carry the authenticated graph that minted this module source",
+        )
+    return (
+        module.module_name,
+        module.source_cid,
+        module.source_seat,
+        graph.distribution_artifact_cid,
+    )
+
+
+def _validated_import_value_receipt_roster(module, receipts):
+    """Validate and retain one exact immutable receipt roster."""
+    from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
+    from sugar_source_tree.panic import BackendDefect
+
+    roster = tuple(receipts)
+    exact_rows = {}
+    uses = {}
+    for receipt in roster:
+        if type(receipt) is not AuthenticatedImportUseV1:
+            raise BackendDefect(
+                blame=module.source_seat,
+                owner="manager_construction import value receipt cache",
+                observed="receipt roster contains an unadmitted product",
+                requested="exact AuthenticatedImportUseV1 rows",
+                fix="cache only lexical-pass value-use receipts",
+            )
+        receipt.revalidate()
+        exported = tuple(receipt.use.get("exportedMemberPath") or ())
+        row_key = (
+            receipt.source_cid,
+            receipt.import_binding.cid,
+            receipt.use["cid"],
+            exported,
+        )
+        if receipt.source_cid != module.source_cid:
+            raise BackendDefect(
+                blame=module.source_seat,
+                owner="manager_construction import value receipt cache",
+                observed="receipt roster contains a foreign source CID",
+                requested="same-module authenticated value-use rows",
+                fix="partition receipt rosters by authenticated module identity",
+            )
+        if row_key in exact_rows:
+            raise BackendDefect(
+                blame=module.source_seat,
+                owner="manager_construction import value receipt cache",
+                observed="duplicate exact import value receipt row",
+                requested="one row per source/binding/use/path identity",
+                fix="repair lexical receipt enrollment uniqueness",
+            )
+        prior = uses.get(receipt.use["cid"])
+        if prior is not None and prior != row_key:
+            raise BackendDefect(
+                blame=module.source_seat,
+                owner="manager_construction import value receipt cache",
+                observed="conflicting import value receipt use CID",
+                requested="one exact row identity for each use CID",
+                fix="repair cross-wired receipt preimages before caching",
+            )
+        exact_rows[row_key] = receipt
+        uses[receipt.use["cid"]] = row_key
+    return roster
+
+
+def _cache_import_value_receipts(context, module, dependency_graphs, minted):
+    key = _source_import_value_receipt_cache_key(module, dependency_graphs)
+    candidate = _validated_import_value_receipt_roster(module, minted)
+    existing = context.source_import_value_receipts.get(key)
+    if existing is None:
+        context.source_import_value_receipts[key] = candidate
+        return candidate
+    existing_keys = tuple(
+        (
+            row.source_cid,
+            row.import_binding.cid,
+            row.use["cid"],
+            tuple(row.use.get("exportedMemberPath") or ()),
+        )
+        for row in existing
+    )
+    candidate_keys = tuple(
+        (
+            row.source_cid,
+            row.import_binding.cid,
+            row.use["cid"],
+            tuple(row.use.get("exportedMemberPath") or ()),
+        )
+        for row in candidate
+    )
+    if existing_keys != candidate_keys:
+        from sugar_source_tree.panic import BackendDefect
+
+        raise BackendDefect(
+            blame=module.source_seat,
+            owner="manager_construction import value receipt cache",
+            observed="conflicting roster for authenticated module identity",
+            requested="byte-identical ordered receipt row identities",
+            fix="keep module receipt enrollment deterministic",
+        )
+    return existing
+
+
 def _seat_import_value_use_receipts(
     *,
     source_file,
@@ -2299,7 +2416,8 @@ def _seat_import_value_use_receipts(
             fix="refuse dual-door repair; re-mint module via path_source",
         )
     # No ValueError swallow: authenticated mint refuses tamper/mismatch loud.
-    receipts = context.source_import_value_receipts.get(module.source_cid)
+    cache_key = _source_import_value_receipt_cache_key(module, dependency_graphs)
+    receipts = context.source_import_value_receipts.get(cache_key)
     if receipts is None:
         minted, _ = authenticated_import_value_use_receipts(
             Path("."),
@@ -2308,8 +2426,9 @@ def _seat_import_value_use_receipts(
             module.source_cid,
             module_identities={},
         )
-        receipts = tuple(minted)
-        context.source_import_value_receipts[module.source_cid] = receipts
+        receipts = _cache_import_value_receipts(
+            context, module, dependency_graphs, minted
+        )
     from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
 
     call_receipts, _ = authenticated_import_use_receipts(

--- a/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
@@ -9,6 +9,7 @@ from sugar_lift_py_tests.floor.import_member_value import ImportMemberValue
 from sugar_lift_python_source.dependency_artifact import DependencyArtifactGraph
 from sugar_lift_python_source.manager_construction import (
     _seat_import_value_use_receipts,
+    _source_import_value_receipt_cache_key,
 )
 from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.nodes import Attribute, ClassDef
@@ -30,6 +31,7 @@ def test_regexflag_relative_member_receipt_survives_repeated_frame_seating() -> 
         if isinstance(node, ClassDef) and node.name == "RegexFlag"
     )
     session = SourceResolutionSession(enabled=False)
+    cache_key = _source_import_value_receipt_cache_key(module, {"re": graph})
 
     for _ in range(2):
         _seat_import_value_use_receipts(
@@ -53,7 +55,7 @@ def test_regexflag_relative_member_receipt_survives_repeated_frame_seating() -> 
     assert outcome.value.qualified_name == "re._compiler.SRE_FLAG_ASCII"
     assert any(
         outcome.value.receipt is receipt
-        for receipt in context.source_import_value_receipts[module.source_cid]
+        for receipt in context.source_import_value_receipts[cache_key]
     )
 
 
@@ -90,9 +92,10 @@ def test_regexflag_relative_member_missing_foreign_and_crosswired_receipts_refus
         context=context,
         dependency_graphs={"re": graph},
     )
+    cache_key = _source_import_value_receipt_cache_key(module, {"re": graph})
     receipt = next(
         row
-        for row in context.source_import_value_receipts[module.source_cid]
+        for row in context.source_import_value_receipts[cache_key]
         if row.target_symbol == "python:re._compiler.SRE_FLAG_ASCII"
     )
     span = member.line_col_span()


### PR DESCRIPTION
R axis: cross-package import-value receipt cache authority
Predicted Epsilon R: -1 cross-wire class; no claimed OPTION_CONTEXT single-package delta.

The cache is now keyed by the authenticated module name, source CID, source seat, and dependency artifact CID. Each roster validates exact source/binding/use/export-path row identity, rejects duplicates/conflicts, and preserves the originally seated receipt objects on identical reseating.

Focused receipt (CPython 3.12.13):
`/usr/local/bin/python -m pytest -q implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py`
`2 passed in 16.30s`

Floors: no filename/name-only fallback; no adjacent producer or consumer semantics.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate import value receipt cache with graph-verified keys and roster validation
> - Replaces direct storage of import value receipts keyed by `module.source_cid` with a graph-aware cache key computed by `_source_import_value_receipt_cache_key`, which verifies module ownership against the dependency graph.
> - Adds `_validated_import_value_receipt_roster` to enforce strict receipt validation before caching: checks exact types, same-module `source_cid`, unique row identities, and detects cross-wired use CIDs.
> - Adds `_cache_import_value_receipts` to guarantee deterministic, validated rosters and raise `BackendDefect` on identity conflicts for the same authenticated module.
> - Updates tests in [test_regexflag_relative_member_seating.py](https://github.com/TSavo/sugar/pull/6881/files#diff-3ae4846d62744433a022e393539888f5522332faba6e717dfca0402bc114fa1e) to retrieve receipts via the new graph-aware cache key.
> - Risk: foreign CIDs, duplicate rows, mixed types, or cross-wired use CIDs that were previously silently accepted now raise `BackendDefect`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea7c733.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->