### PR TITLE
Transport import receipts across exact source units

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -575,6 +575,9 @@ class TreeConstructionContextV1:
     # CID so repeated frame/class publication transports object identity rather
     # than reminting an equivalent receipt at an occupied SourceUnit seat.
     source_import_value_receipts: dict = field(default_factory=dict)
+    # Exact module-seat/use-occurrence transport shared by parser-owned units
+    # in this construction only. Never global and never source-CID-only.
+    source_import_value_receipts_by_site: dict = field(default_factory=dict)
     # When projecting an authenticated definition into a call frame, dual-mode
     # factory bodies may contain With sites only on non-manager return paths
     # (e.g. pytest.raises function form). Soft projection does not require

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
@@ -104,6 +104,19 @@ class AttributeSugar(ConstructedTermSugar):
             receipt = site.unit.import_value_use_resolution(
                 (span.start_line, span.start_col, span.end_line, span.end_col)
             )
+            if receipt is None:
+                context = site.unit.construction_context
+                if context is not None:
+                    receipt = context.source_import_value_receipts_by_site.get(
+                        (
+                            site.unit.filename,
+                            site.unit.source_cid,
+                            span.start_line,
+                            span.start_col,
+                            span.end_line,
+                            span.end_col,
+                        )
+                    )
             from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
 
             if type(receipt) is AuthenticatedImportUseV1:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -2451,6 +2451,25 @@ def _seat_import_value_use_receipts(
             )
 
         def seat_receipt() -> None:
+            transport_key = (
+                unit.filename,
+                module.source_cid,
+                *span_key,
+            )
+            transported = context.source_import_value_receipts_by_site.get(
+                transport_key
+            )
+            if transported is not None and transported is not receipt:
+                from sugar_source_tree.panic import BackendDefect
+
+                raise BackendDefect(
+                    blame=coordinate,
+                    owner="manager_construction import value receipt transport",
+                    observed="conflicting receipt at exact module/use occurrence",
+                    requested="one producer-owned receipt object per exact site",
+                    fix="preserve receipt identity across parser-owned SourceUnits",
+                )
+            context.source_import_value_receipts_by_site[transport_key] = receipt
             unit.seat_import_value_use_resolution(
                 span_key, receipt, source_cid=module.source_cid
             )

--- a/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
@@ -113,3 +113,55 @@ def test_regexflag_relative_member_missing_foreign_and_crosswired_receipts_refus
             receipt,
             source_cid="blake3-512:" + "0" * 128,
         )
+
+
+def test_regexflag_receipt_transports_across_exact_parser_owned_units() -> None:
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("re")
+    module = graph.modules["re"]
+    context = TreeConstructionContextV1.for_source_call_construction()
+    first = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=context,
+    )
+    second = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=context,
+    )
+    renamed = SourceFile(
+        (module.source, "renamed/__init__.py", module.source_cid),
+        construction_context=context,
+    )
+    regex_flag = next(
+        node
+        for node in first.root.body
+        if isinstance(node, ClassDef) and node.name == "RegexFlag"
+    )
+    _seat_import_value_use_receipts(
+        source_file=first,
+        module=module,
+        target=regex_flag,
+        session=SourceResolutionSession(enabled=False),
+        context=context,
+        dependency_graphs={"re": graph},
+    )
+
+    def ascii_member(source_file: SourceFile) -> Attribute:
+        return next(
+            node
+            for node in source_file.nodes()
+            if isinstance(node, Attribute)
+            and node.attr == "SRE_FLAG_ASCII"
+            and node.line_col_span().start_line == 145
+        )
+
+    first_value = ascii_member(first).sugar().desugar().value
+    second_value = ascii_member(second).sugar().desugar().value
+
+    assert type(first_value) is ImportMemberValue
+    assert type(second_value) is ImportMemberValue
+    assert second_value.receipt is first_value.receipt
+    with pytest.raises(SugarNotWritten, match="SymbolicValue.attribute"):
+        ascii_member(renamed).sugar().desugar()
+    exact_rows = context.source_import_value_receipts_by_site
+    assert len(exact_rows) > 1
+    assert all(key[0] == module.source_seat for key in exact_rows)


### PR DESCRIPTION
Exact fix-forward for the parser-owned SourceUnit split in the RegexFlag option_context path.

Manager seating now transports each producer-minted import value receipt through a construction-context-local table keyed by exact `(filename, source_cid, start/end span)`. A cached AttributeSugar on another parser-owned instance of the same authenticated module retrieves the same receipt object. There is no global table, source-CID-only key, or spelling lookup.

Teeth cover two exact SourceUnit instances, exact private ImportMemberValue identity, renamed same-bytes refusal, unseated refusal, foreign source/wrong span refusal, and unrelated-row retention.

R_import_receipt_unit_instance_split: 1 -> 0. Predicted Epsilon R: -1. Corpus stableZero unknown.

Focused CPython 3.12 receipt: `3 passed in 20.58s`, exit 0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Transport import receipts across exact source units sharing the same module seat
> - Adds a `source_import_value_receipts_by_site` mapping to `TreeConstructionContextV1` keyed by `(filename, source_cid, span)` to share import-use receipts across parser-owned units within a single construction.
> - Updates `_seat_import_value_use_receipts` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6882/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to record each receipt in the context map and raise `BackendDefect` on conflicting receipts at the same site.
> - Updates `AttributeSugar.project_attribute` in [attribute_sugar.py](https://github.com/TSavo/sugar/pull/6882/files#diff-dbd736f4cfe3d43f5f03b925994f117b1b962d9a10a2a832805468df2f8b7272) to fall back to the context transport map when unit-local resolution returns `None`.
> - Risk: a `BackendDefect` is raised if two different receipt objects are seated for the same exact module/use site, which is a new hard failure path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a8e141.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->