### PR TITLE
Authenticate builtin class member class fields

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_class_member_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_class_member_value.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.ir import _term_content_cid, ctor, num, str_const
+
+from .closed_operation_witness import PythonRuntimeIdentity
+from .floor_value import FloorValue
+
+
+_BUILTIN_CLASS_MEMBER_AUTHORITY = object()
+
+
+def _member_term(runtime: PythonRuntimeIdentity, owner_name: str, member_name: str):
+    return ctor(
+        "python:builtin-class-member",
+        (
+            str_const(runtime.implementation),
+            num(runtime.major),
+            num(runtime.minor),
+            str_const(owner_name),
+            str_const(member_name),
+        ),
+        symbol_kind="coordinate",
+    )
+
+
+@dataclass(frozen=True)
+class BuiltinClassMemberValue(FloorValue):
+    """Runtime-sealed member coordinate from the builtin namespace producer."""
+
+    runtime: PythonRuntimeIdentity
+    owner_name: str
+    member_name: str
+    coordinate_cid: str
+    _authority: object = field(
+        init=False, default=None, compare=False, repr=False
+    )
+
+    def __post_init__(self) -> None:
+        if self._authority is not _BUILTIN_CLASS_MEMBER_AUTHORITY:
+            raise ValueError("builtin class member is not producer-minted")
+        if type(self.runtime) is not PythonRuntimeIdentity:
+            raise ValueError("builtin class member runtime identity is malformed")
+        if self.runtime != PythonRuntimeIdentity.current():
+            raise ValueError("builtin class member runtime identity is foreign")
+        expected = _term_content_cid(
+            _member_term(self.runtime, self.owner_name, self.member_name)
+        )
+        if self.coordinate_cid != expected:
+            raise ValueError("builtin class member coordinate CID mismatch")
+
+    def to_term(self, *, owner: str):
+        del owner
+        return _member_term(self.runtime, self.owner_name, self.member_name)
+
+
+def _mint_builtin_class_member(
+    owner_name: str, member_name: str
+) -> BuiltinClassMemberValue:
+    runtime = PythonRuntimeIdentity.current()
+    term = _member_term(runtime, owner_name, member_name)
+    value = object.__new__(BuiltinClassMemberValue)
+    object.__setattr__(value, "runtime", runtime)
+    object.__setattr__(value, "owner_name", owner_name)
+    object.__setattr__(value, "member_name", member_name)
+    object.__setattr__(value, "coordinate_cid", _term_content_cid(term))
+    object.__setattr__(value, "_authority", _BUILTIN_CLASS_MEMBER_AUTHORITY)
+    value.__post_init__()
+    return value

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
@@ -85,6 +85,27 @@ class ClassValue(FloorValue):
         producer panics on BuiltinExceptionClassValue and exit summary stays
         exit-may-halt rather than sealing ExpectsMode.
         """
+        from sugar_lift_py_tests.floor.object_field import ObjectField
+
+        carried = tuple(
+            statement
+            for statement in self.record.statements
+            if type(statement) is ObjectField and statement.name == name
+        )
+        if len(carried) > 1:
+            from sugar_source_tree.panic import BackendDefect
+
+            raise BackendDefect(
+                blame=site,
+                owner="ClassValue.attribute",
+                observed="duplicate authenticated class member fields",
+                requested="one producer-owned class member coordinate",
+                fix="apply class-body overwrite ordering before publication",
+            )
+        if carried:
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(carried[0].value)
         if name in {"__name__", "__qualname__"}:
             from sugar_lift_py_tests.floor.string_value import StringValue
             from sugar_lift_py_tests.outcome import Complete

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
@@ -182,6 +182,14 @@ BUILTIN_EXCEPTION_BASES: dict[str, tuple[str, ...]] = {
 }
 
 
+# Closed runtime surface currently carried by the builtin producer. Extending
+# this roster is an explicit language/runtime testimony change; attribute
+# consumers never infer membership from spelling or host getattr/dir.
+BUILTIN_CLASS_MEMBER_SURFACE: dict[str, tuple[str, ...]] = {
+    "object": ("__str__",),
+}
+
+
 def builtin_name_temporal():
     """Return the shared immutable lexical floor for Python's builtin names.
 
@@ -202,15 +210,25 @@ def builtin_name_temporal():
         SymbolicValue,
     )
     from sugar_lift_py_tests.ir import ctor, str_const
+    from sugar_lift_py_tests.floor.builtin_class_member_value import (
+        _mint_builtin_class_member,
+    )
+    from sugar_lift_py_tests.floor.object_field import ObjectField
     from sugar_lift_py_tests.temporal.temporal_context import TemporalContext
 
     # Construct the raw root directly. TemporalContext.empty() delegates here
     # so every ordinary lexical scope starts with this one builtin floor.
     temporal = TemporalContext()
     for name in sorted(builtin_callable_names()):
+        class_record = BlockValue(
+            tuple(
+                ObjectField(member, _mint_builtin_class_member(name, member))
+                for member in BUILTIN_CLASS_MEMBER_SURFACE.get(name, ())
+            )
+        )
         temporal = temporal.bind_value(
             name,
-            ClassValue(name=name, bases=(), record=BlockValue(())),
+            ClassValue(name=name, bases=(), record=class_record),
         )
     for name in sorted(builtin_constant_names()):
         temporal = temporal.bind_value(

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_class_member_class_field.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_class_member_class_field.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context import ReduceContext
+from sugar_lift_py_tests.floor import ClassDefinitionValue, SymbolicValue
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.outcome import Complete
+from sugar_source_tree.nodes import ClassDef
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _class(tmp_path: Path, source: str) -> ClassDef:
+    path = tmp_path / "module.py"
+    path.write_text(source, encoding="utf-8")
+    tree = SourceFile.from_path(path)
+    return next(node for node in tree.nodes() if isinstance(node, ClassDef))
+
+
+def test_builtin_class_member_coordinate_constructs_real_class_field(
+    tmp_path: Path,
+) -> None:
+    definition = _class(
+        tmp_path,
+        "class Renamed:\n"
+        "    carried = object.__str__\n",
+    )
+
+    outcome = definition.sugar().desugar(
+        ReduceContext.root(owner="builtin class member class field")
+    )
+
+    assert type(outcome) is Complete
+    assert type(outcome.value) is ClassDefinitionValue
+    fields = {field.name: field.value for field in outcome.value.fields}
+    assert tuple(fields) == ("carried",)
+    assert type(fields["carried"]) is not SymbolicValue
+
+
+def test_shadowed_class_coordinate_cannot_borrow_builtin_member_authority(
+    tmp_path: Path,
+) -> None:
+    definition = _class(
+        tmp_path,
+        "class Renamed:\n"
+        "    carried = substitute.member\n",
+    )
+    ctx = ReduceContext.root(owner="shadowed class member").with_temporal(
+        ReduceContext.root(owner="shadow source").temporal.bind_value(
+            "substitute", SymbolicValue(make_var("foreign-class-coordinate"))
+        )
+    )
+
+    with pytest.raises(SugarNotWritten) as raised:
+        definition.sugar().desugar(ctx)
+    assert raised.value.owner == "SymbolicValue.attribute"

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_class_member_class_field.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_class_member_class_field.py
@@ -35,7 +35,7 @@ def test_builtin_class_member_coordinate_constructs_real_class_field(
 
     assert type(outcome) is Complete
     assert type(outcome.value) is ClassDefinitionValue
-    fields = {field.name: field.value for field in outcome.value.fields}
+    fields = {field.name: field.value for field in outcome.value.class_fields}
     assert tuple(fields) == ("carried",)
     assert type(fields["carried"]) is not SymbolicValue
 


### PR DESCRIPTION
R axis: authenticated builtin class member projection = 1 -> 0
Predicted Epsilon R: -1 at the exact ClassValue.attribute seam.

The builtin producer now privately mints runtime-sealed member coordinates into its ClassValue record. ClassValue.attribute performs generic authenticated record projection; it has no object/__str__ consumer arm and does not consult host getattr/dir for members. Shadowed receivers remain loud.

Focused CPython 3.12.13 receipt:
`/usr/local/bin/python -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_builtin_class_member_class_field.py`
`2 passed in 2.87s`

Broader pre-existing suite failures remain separately loud; no claims made for them.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate builtin class member class fields with validated `BuiltinClassMemberValue` type
> - Adds `BuiltinClassMemberValue` in [`builtin_class_member_value.py`](https://github.com/TSavo/sugar/pull/6883/files#diff-27e54018d16b6042dad399032b86c8486103a91a4917c68baeacd494e56b7fc1), a sealed `FloorValue` subtype representing builtin class member coordinates, validated against the current runtime on construction.
> - Adds `_mint_builtin_class_member` as the only supported path to create authenticated instances; construction validates the authority token, runtime identity, and that the provided CID matches the computed IR term.
> - Updates [`builtin_name_bindings.py`](https://github.com/TSavo/sugar/pull/6883/files#diff-61c663f349f832607b3966470d5dfecfcda065d57744eabcf0ed411db6501e7d) to populate `ClassValue` records with `ObjectField` entries for members listed in `BUILTIN_CLASS_MEMBER_SURFACE` (currently `{'object': ('__str__',)}`).
> - Updates `ClassValue.attribute` in [`class_value.py`](https://github.com/TSavo/sugar/pull/6883/files#diff-8c39758b3ac4077d066812f197a75b5786878a0cae336b77a3a3785017fd6272) to resolve attributes by scanning `ObjectField` entries in the record, raising `BackendDefect` on duplicate fields.
> - Adds tests asserting that a class body referencing `object.__str__` produces a concrete (non-symbolic) field, and that a shadowed coordinate cannot borrow builtin member authority.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f25613.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->