### PR TITLE
Transport import receipts to target construction context

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -2288,7 +2288,16 @@ def _seat_import_value_use_receipts(
     unit = source_file.unit
     # Path-source law: refuse dual-door / mismatched CID loudly at mint.
     expected_cid = blake3_512_of(module.source.encode("utf-8"))
-    if module.source_cid != expected_cid or unit.source_cid != module.source_cid:
+    target_unit = target.unit
+    if (
+        module.source_cid != expected_cid
+        or unit.source_cid != module.source_cid
+        or target_unit.source_cid != module.source_cid
+        or unit.source != module.source
+        or target_unit.source != module.source
+        or unit.filename != module.source_seat
+        or target_unit.filename != module.source_seat
+    ):
         from sugar_source_tree.panic import BackendDefect
 
         raise BackendDefect(
@@ -2456,20 +2465,39 @@ def _seat_import_value_use_receipts(
                 module.source_cid,
                 *span_key,
             )
-            transported = context.source_import_value_receipts_by_site.get(
-                transport_key
-            )
-            if transported is not None and transported is not receipt:
+
+            def retain_in(owner_context) -> None:
+                transported = owner_context.source_import_value_receipts_by_site.get(
+                    transport_key
+                )
+                if transported is not None and transported is not receipt:
+                    from sugar_source_tree.panic import BackendDefect
+
+                    raise BackendDefect(
+                        blame=coordinate,
+                        owner="manager_construction import value receipt transport",
+                        observed="conflicting receipt at exact module/use occurrence",
+                        requested="one producer-owned receipt object per exact site",
+                        fix="preserve receipt identity across parser-owned SourceUnits",
+                    )
+                owner_context.source_import_value_receipts_by_site[transport_key] = (
+                    receipt
+                )
+
+            retain_in(context)
+            target_context = target_unit.construction_context
+            if type(target_context) is not TreeConstructionContextV1:
                 from sugar_source_tree.panic import BackendDefect
 
                 raise BackendDefect(
                     blame=coordinate,
                     owner="manager_construction import value receipt transport",
-                    observed="conflicting receipt at exact module/use occurrence",
-                    requested="one producer-owned receipt object per exact site",
-                    fix="preserve receipt identity across parser-owned SourceUnits",
+                    observed="target SourceUnit lacks its construction context",
+                    requested="the exact context retained by the target-owned Sugar",
+                    fix="construct source-visible targets through the manager context door",
                 )
-            context.source_import_value_receipts_by_site[transport_key] = receipt
+            if target_context is not context:
+                retain_in(target_context)
             unit.seat_import_value_use_resolution(
                 span_key, receipt, source_cid=module.source_cid
             )

--- a/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
@@ -165,3 +165,55 @@ def test_regexflag_receipt_transports_across_exact_parser_owned_units() -> None:
     exact_rows = context.source_import_value_receipts_by_site
     assert len(exact_rows) > 1
     assert all(key[0] == module.source_seat for key in exact_rows)
+
+
+def test_regexflag_receipt_transports_to_target_owned_context() -> None:
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("re")
+    module = graph.modules["re"]
+    manager_context = TreeConstructionContextV1.for_source_call_construction()
+    target_context = TreeConstructionContextV1.for_source_call_construction()
+    manager_file = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=manager_context,
+    )
+    target_file = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=target_context,
+    )
+    regex_flag = next(
+        node
+        for node in target_file.root.body
+        if isinstance(node, ClassDef) and node.name == "RegexFlag"
+    )
+
+    _seat_import_value_use_receipts(
+        source_file=manager_file,
+        module=module,
+        target=regex_flag,
+        session=SourceResolutionSession(enabled=False),
+        context=manager_context,
+        dependency_graphs={"re": graph},
+    )
+
+    member = next(
+        node
+        for node in target_file.nodes()
+        if isinstance(node, Attribute)
+        and node.attr == "SRE_FLAG_ASCII"
+        and node.line_col_span().start_line == 145
+    )
+    value = member.sugar().desugar().value
+    span = member.line_col_span()
+    key = (
+        module.source_seat,
+        module.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+    assert type(value) is ImportMemberValue
+    assert manager_context is not target_context
+    assert manager_context.source_import_value_receipts_by_site[key] is value.receipt
+    assert target_context.source_import_value_receipts_by_site[key] is value.receipt


### PR DESCRIPTION
R axis: cross-context imported member receipt transport = 1
Predicted Epsilon R: -1 for the exact context split; no broader OPTION_CONTEXT delta claimed until the lifecycle runs.

Manager seating now retains the exact producer-owned receipt object in both the manager context and the distinct target SourceUnit context, under the existing filename/source CID/full-use key. Full oracle triples are validated; conflicts remain BackendDefect. No global table or source-CID/name fallback.

Focused CPython 3.12.13 receipt:
`/usr/local/bin/python -m pytest -q implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py`
`4 passed in 28.97s`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Transport import receipts to target SourceUnit's construction context in `_seat_import_value_use_receipts`
> - `_seat_import_value_use_receipts` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6884/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) now retains authenticated import-value receipts in both the manager context and the target `SourceUnit`'s `TreeConstructionContextV1` when they are distinct.
> - A new `retain_in(owner_context)` helper enforces identity: it raises `BackendDefect` if a conflicting receipt object exists for the same `transport_key`.
> - Path-source identity validation is expanded to also check `target.unit` fields (`source_cid`, `source`, `filename`) against the module, tightening invariants across parser-owned `SourceUnit`s.
> - A hard check is added requiring `target_unit.construction_context` to be exactly a `TreeConstructionContextV1`; any mismatch raises `BackendDefect`.
> - A new test in [test_regexflag_relative_member_seating.py](https://github.com/TSavo/sugar/pull/6884/files#diff-3ae4846d62744433a022e393539888f5522332faba6e717dfca0402bc114fa1e) verifies that receipts appear in both contexts' `source_import_value_receipts_by_site` under the same key.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87d21c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->