### PR TITLE
Key construction cache by receipt context

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
@@ -165,3 +167,51 @@ def test_regexflag_receipt_transports_across_exact_parser_owned_units() -> None:
     exact_rows = context.source_import_value_receipts_by_site
     assert len(exact_rows) > 1
     assert all(key[0] == module.source_seat for key in exact_rows)
+
+
+def test_regexflag_cached_class_sugar_retains_manager_context_product() -> None:
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("re")
+    module = graph.modules["re"]
+    manager_context = TreeConstructionContextV1.for_source_call_construction()
+    foreign_context = TreeConstructionContextV1.for_source_call_construction()
+    foreign = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=foreign_context,
+    )
+    manager = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=manager_context,
+    )
+
+    def regex_flag(source_file: SourceFile) -> ClassDef:
+        return next(
+            node
+            for node in source_file.root.body
+            if isinstance(node, ClassDef) and node.name == "RegexFlag"
+        )
+
+    foreign_class = regex_flag(foreign)
+    foreign_sugar = foreign_class.sugar()
+    object.__setattr__(
+        manager.unit, "construction_cache", foreign.unit.construction_cache
+    )
+    manager_class = replace(foreign_class, unit=manager.unit)
+    _seat_import_value_use_receipts(
+        source_file=manager,
+        module=module,
+        target=manager_class,
+        session=SourceResolutionSession(enabled=False),
+        context=manager_context,
+        dependency_graphs={"re": graph},
+    )
+    manager_sugar = manager_class.sugar()
+    assert manager_sugar is not foreign_sugar
+    manager_sugar = regex_flag(manager).sugar()
+    ascii_field = next(field for field in manager_sugar.fields if field.name == "ASCII")
+    outcome = ascii_field.value_sugar.desugar()
+
+    assert type(outcome.value) is ImportMemberValue
+    assert not foreign_context.source_import_value_receipts_by_site
+    assert outcome.value.receipt in manager_context.source_import_value_receipts[
+        (module.module_name, module.source_seat, module.source_cid)
+    ]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -86,7 +86,7 @@ def materialize(
         cache = ConstructionCache()
         object.__setattr__(unit, "construction_cache", cache)
     # Ensure the field row exists (filled lazily on first accessor).
-    key = cache.key(ref, reporter, ctx)
+    key = cache.key(ref, reporter, ctx, unit.construction_context)
     cache.fields.setdefault(key, {})
 
     cls = ref.resolve_type()
@@ -791,6 +791,7 @@ class Backend:
                 node.value.ref,
                 node.value.reporter,
                 node.value.control_context,
+                node.value.unit.construction_context,
             )
             value_cache.sugar_results[value_key] = value_sugar
             node.value.reporter.present_fact(node.value)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
@@ -192,9 +192,16 @@ class ConstructionCache:
         ref: object,
         reporter: object,
         control_context: object,
+        construction_context: object = None,
     ) -> tuple:
         loop_targets = getattr(control_context, "loop_targets", ())
         exception_slots = getattr(control_context, "exception_slots", ())
-        computed = (id(ref), id(reporter), loop_targets, exception_slots)
+        computed = (
+            id(ref),
+            id(reporter),
+            id(construction_context),
+            loop_targets,
+            exception_slots,
+        )
         self._pinned[computed] = ref
         return computed

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1832,7 +1832,12 @@ class Node(Typed):
         if name.startswith("_"):
             raise AttributeError(name)
         cache = self._construction_cache()
-        key = cache.key(self.ref, self.reporter, self.control_context)
+        key = cache.key(
+            self.ref,
+            self.reporter,
+            self.control_context,
+            self.unit.construction_context,
+        )
         row = cache.fields.setdefault(key, {})
         if name in row:
             return row[name]
@@ -2396,7 +2401,12 @@ class Node(Typed):
         # with the node it replaced. ``cache.key`` pins the ref, which is what
         # keeps a dead shadow's recycled address from serving stale work.
         cache = self._construction_cache()
-        key = cache.key(self.ref, self.reporter, self.control_context)
+        key = cache.key(
+            self.ref,
+            self.reporter,
+            self.control_context,
+            self.unit.construction_context,
+        )
         remembered_panic = cache.sugar_panics.get(key)
         if remembered_panic is not None:
             # A gap stays a gap, every time. Same panic, re-raised loudly.


### PR DESCRIPTION
Exact fix-forward for the option_context construction-context split.

ConstructionCache coordinates now include the exact TreeConstructionContext identity at materialization, field lookup, and Sugar result/panic lookup. A ClassDefinitionSugar cached under foreign context B can no longer answer manager context A; A constructs its own AttributeSugar bound to A's authenticated receipt-table product. No global table, source-CID lookup, or consumer fallback is added.

The focused production-path tooth pre-caches RegexFlag under B, shares the underlying cache/ref coordinate, seats the exact `_compiler.SRE_FLAG_ASCII` receipt under A, proves cache separation, private ImportMemberValue projection, an empty foreign table, and exact receipt identity. Existing renamed/unit/span refusal teeth remain.

R_construction_context_cache_crosswire: 1 -> 0. Predicted Epsilon R: -1. Corpus stableZero unknown.

Focused CPython 3.12 receipt: `1 passed in 5.50s`, exit 0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Partition construction cache keys by receipt context to prevent cross-context cache reuse
> - `ConstructionCache.key` now includes `id(construction_context)` in the key tuple, so fields, sugar results, and panics for the same ref are stored separately per context.
> - `Node.__getattr__` and `Node.sugar` pass `self.unit.construction_context` to cache key lookups, and `backend.materialize` does the same when pre-constructing constant values.
> - A new test in [test_regexflag_relative_member_seating.py](https://github.com/TSavo/sugar/pull/6885/files#diff-3ae4846d62744433a022e393539888f5522332faba6e717dfca0402bc114fa1e) verifies that sharing a `ConstructionCache` across two contexts keeps import receipts and sugar objects isolated per context.
> - Behavioral Change: any code that relied on sugar or field results being shared across construction contexts will now get separate instances.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca7941c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->