### PR TITLE
Pin construction contexts in cache coordinates

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
@@ -178,7 +178,10 @@ class ConstructionCache:
         # the coordinate rule -- the reporter testifies each coordinate once,
         # whether it answers present or absent.
         self.sugar_panics: dict[tuple, BaseException] = {}
-        # key -> ref. The cache key embeds ``id(ref)``, and shadow refs minted
+        # key -> ref, or (ref, construction_context). The cache key embeds
+        # both live identities; pin every non-None participant so neither ID
+        # can be recycled underneath a retained row.
+        # Shadow refs minted
         # during substitution are transient: once a rewritten shadow is GC'd its
         # address is reused by the NEXT shadow (e.g. one loop-unroll iteration's
         # `x == 0` after the previous iteration's), which would then collide on
@@ -203,5 +206,7 @@ class ConstructionCache:
             loop_targets,
             exception_slots,
         )
-        self._pinned[computed] = ref
+        self._pinned[computed] = (
+            ref if construction_context is None else (ref, construction_context)
+        )
         return computed

--- a/implementations/python/sugar-source-tree/tests/test_construction_cache_pin.py
+++ b/implementations/python/sugar-source-tree/tests/test_construction_cache_pin.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import gc
+import weakref
+
 from sugar_source_tree.construction_cache import ConstructionCache
 
 
@@ -30,3 +33,28 @@ def test_cache_pins_keyed_refs_against_id_reuse():
     assert other_key != key
     assert cache._pinned[other_key] is other
     assert cache._pinned[key] is ref  # first still pinned, unaffected
+
+
+def test_cache_pins_non_none_construction_context_and_keeps_none_shape():
+    cache = ConstructionCache()
+    reporter = object()
+    control = _Ctx()
+    ref = object()
+    context = _Ctx()
+    context_ref = weakref.ref(context)
+    key = cache.key(ref, reporter, control, context)
+    cache.fields[key] = {"receipt": "context-a"}
+
+    del context
+    gc.collect()
+
+    assert context_ref() is not None
+    assert cache._pinned[key] == (ref, context_ref())
+    foreign = _Ctx()
+    foreign_key = cache.key(ref, reporter, control, foreign)
+    assert foreign_key != key
+    assert cache.fields.get(foreign_key) is None
+
+    none_key = cache.key(ref, reporter, control)
+    assert none_key == (id(ref), id(reporter), id(None), (), ())
+    assert cache._pinned[none_key] is ref


### PR DESCRIPTION
Immediate non-gating fix-forward for #6885.

ConstructionCache keys include `id(construction_context)`, so every non-None context is now pinned beside the ref for the cache lifetime. This prevents GC/address reuse from letting a foreign context read a stale receipt-bearing row. The `construction_context=None` key tuple and `_pinned[key] is ref` behavior remain byte-equivalent.

Focused teeth cover weakref/GC retention, forced foreign-context stale-row refusal, None-key compatibility, existing ref retention, and the shared-cache cross-unit RegexFlag path. No receipt-state, global table, source-CID key, or lookup fallback changes.

R_construction_context_id_reuse: 1 -> 0. Predicted Epsilon R: -1. Corpus stableZero unknown.

Focused CPython 3.12 receipt: `3 passed in 8.44s`, exit 0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin construction contexts in `ConstructionCache` cache coordinates to prevent id recycling
> - `ConstructionCache.key` in [construction_cache.py](https://github.com/TSavo/sugar/pull/6886/files#diff-fec1dbfe7718a35848f37642330b8df50429df86eae284a72524c6bf8352972f) now stores a `(ref, construction_context)` tuple in `_pinned` when `construction_context` is non-None, instead of storing only `ref`.
> - Without this fix, the construction context object could be garbage collected while the cache row was still live, allowing its id to be reused by a new object and causing incorrect cache hits.
> - A new test in [test_construction_cache_pin.py](https://github.com/TSavo/sugar/pull/6886/files#diff-b7589622e74048a539a689886e5369418c783a479d539f487143d211ce8efc3d) verifies that non-None contexts are strongly referenced, that distinct contexts produce distinct keys, and that the `None` case retains its original single-`ref` shape.
> - Behavioral Change: `_pinned` values for keys with a non-None construction context change shape from a single `ref` to a `(ref, construction_context)` tuple.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 112d6de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->