### PR TITLE
Seat import receipts in the exact SourceUnit context

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -2286,6 +2286,20 @@ def _seat_import_value_use_receipts(
     from sugar_lift_python_source.canonical import blake3_512_of
 
     unit = source_file.unit
+    unit_context = unit.construction_context
+    if type(unit_context) is not TreeConstructionContextV1:
+        from sugar_source_tree.panic import BackendDefect
+
+        raise BackendDefect(
+            blame=unit,
+            owner="manager_construction._seat_import_value_use_receipts",
+            observed="target SourceUnit has no exact construction context",
+            requested="the exact SourceUnit-owned TreeConstructionContextV1",
+            fix="construct the target SourceUnit with its manager-owned context",
+        )
+    # The target SourceUnit owns the context consumed by AttributeSugar.  A
+    # caller's distinct context has no authority to receive this unit's rows.
+    context = unit_context
     # Path-source law: refuse dual-door / mismatched CID loudly at mint.
     expected_cid = blake3_512_of(module.source.encode("utf-8"))
     if module.source_cid != expected_cid or unit.source_cid != module.source_cid:

--- a/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
@@ -215,3 +215,73 @@ def test_regexflag_cached_class_sugar_retains_manager_context_product() -> None:
     assert outcome.value.receipt in manager_context.source_import_value_receipts[
         (module.module_name, module.source_seat, module.source_cid)
     ]
+
+
+def test_import_receipts_seat_the_exact_source_unit_owned_context() -> None:
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("re")
+    module = graph.modules["re"]
+    external_context = TreeConstructionContextV1.for_source_call_construction()
+    unit_context = TreeConstructionContextV1.for_source_call_construction()
+    source_file = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=unit_context,
+    )
+    regex_flag = next(
+        node
+        for node in source_file.root.body
+        if isinstance(node, ClassDef) and node.name == "RegexFlag"
+    )
+
+    _seat_import_value_use_receipts(
+        source_file=source_file,
+        module=module,
+        target=regex_flag,
+        session=SourceResolutionSession(enabled=False),
+        context=external_context,
+        dependency_graphs={"re": graph},
+    )
+
+    member = next(
+        node
+        for node in source_file.nodes()
+        if isinstance(node, Attribute)
+        and node.attr == "SRE_FLAG_ASCII"
+        and node.line_col_span().start_line == 145
+    )
+    outcome = member.sugar().desugar()
+    roster_key = (module.module_name, module.source_seat, module.source_cid)
+    span = member.line_col_span()
+    site_key = (
+        source_file.unit.filename,
+        module.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+    assert type(outcome.value) is ImportMemberValue
+    assert outcome.value.receipt is unit_context.source_import_value_receipts_by_site[
+        site_key
+    ]
+    assert outcome.value.receipt in unit_context.source_import_value_receipts[
+        roster_key
+    ]
+    assert len(unit_context.source_import_value_receipts_by_site) > 1
+    assert not external_context.source_import_value_receipts
+    assert not external_context.source_import_value_receipts_by_site
+    assert not external_context.source_import_value_resolutions
+
+    foreign = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=external_context,
+    )
+    foreign_member = next(
+        node
+        for node in foreign.nodes()
+        if isinstance(node, Attribute)
+        and node.attr == "SRE_FLAG_ASCII"
+        and node.line_col_span().start_line == 145
+    )
+    with pytest.raises(SugarNotWritten, match="SymbolicValue.attribute"):
+        foreign_member.sugar().desugar()


### PR DESCRIPTION
R_context_split_receipt_seating: 1 -> 0 (predicted/ focused).

The manager now seats authenticated imported-member receipt rows into the exact target SourceUnit-owned TreeConstructionContextV1 consumed by AttributeSugar. A distinct caller context receives no authority.

Focused instrument: new same-SourceUnit A/B mismatch tooth was 1 red before production; after the correction the focused file advances through all tests (pytest emitted progress dots; runner did not emit its terminal summary in this shell capture).

Floors: no global/cache/source-CID lookup bridge or fallback; unrelated exact rows retained; foreign A stays empty/loud.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seat import receipts into the target SourceUnit's own `TreeConstructionContextV1`
> - `_seat_import_value_use_receipts` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6887/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) now retrieves and uses the target `SourceUnit`'s own `construction_context` instead of the caller-provided context, ensuring receipts are always recorded in the correct unit-owned context.
> - Raises `BackendDefect` if the unit's `construction_context` is not exactly a `TreeConstructionContextV1`.
> - A new test in [test_regexflag_relative_member_seating.py](https://github.com/TSavo/sugar/pull/6887/files#diff-3ae4846d62744433a022e393539888f5522332faba6e717dfca0402bc114fa1e) verifies that receipts are written only to the unit-owned context, the external context remains empty, and desugaring against a foreign `SourceFile` raises `SugarNotWritten`.
> - Behavioral Change: callers can no longer influence which context receives receipts by passing a different context; the unit-owned context is always used.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a684fdf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import handling so imported members use the correct source unit context.
  * Added validation for incompatible construction contexts, producing a clear backend error.
  * Prevented incorrect desugaring when the required source-owned context is unavailable.

* **Tests**
  * Added coverage confirming exact import receipt usage and isolation between source contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->