### PR TITLE
Require import receipt seating through target context

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1126,7 +1126,7 @@ def _resolve_source_visible_frame_uncached(
         module=module,
         target=target,
         session=session,
-        context=context,
+        context=target.unit.construction_context,
         dependency_graphs=dependency_graphs,
     )
     # Nested method export: project its ordinary frame without requiring the
@@ -1482,7 +1482,7 @@ def _resolve_source_visible_frame_uncached(
             module=module,
             target=item,
             session=session,
-            context=context,
+            context=item.unit.construction_context,
             dependency_graphs=dependency_graphs,
         )
         frames[item.name] = item.source_visible_constructor_frame()
@@ -1529,7 +1529,7 @@ def _resolve_source_visible_frame_uncached(
                     module=module,
                     target=function,
                     session=session,
-                    context=context,
+                    context=function.unit.construction_context,
                     dependency_graphs=dependency_graphs,
                 )
             frames[function.name] = with_mutable_globals(
@@ -2285,21 +2285,28 @@ def _seat_import_value_use_receipts(
     )
     from sugar_lift_python_source.canonical import blake3_512_of
 
-    unit = source_file.unit
-    unit_context = unit.construction_context
-    if type(unit_context) is not TreeConstructionContextV1:
+    unit = target.unit
+    owned_context = unit.construction_context
+    if type(owned_context) is not TreeConstructionContextV1:
         from sugar_source_tree.panic import BackendDefect
 
         raise BackendDefect(
-            blame=unit,
+            blame=target.fragment,
             owner="manager_construction._seat_import_value_use_receipts",
             observed="target SourceUnit has no exact construction context",
-            requested="the exact SourceUnit-owned TreeConstructionContextV1",
+            requested="the target SourceUnit-owned TreeConstructionContextV1",
             fix="construct the target SourceUnit with its manager-owned context",
         )
-    # The target SourceUnit owns the context consumed by AttributeSugar.  A
-    # caller's distinct context has no authority to receive this unit's rows.
-    context = unit_context
+    if context is not owned_context:
+        from sugar_source_tree.panic import BackendDefect
+
+        raise BackendDefect(
+            blame=target.fragment,
+            owner="manager_construction._seat_import_value_use_receipts",
+            observed="target SourceUnit construction context disagrees with seating context",
+            requested="the exact target SourceUnit-owned construction context",
+            fix="route receipt seating through target.unit.construction_context",
+        )
     # Path-source law: refuse dual-door / mismatched CID loudly at mint.
     expected_cid = blake3_512_of(module.source.encode("utf-8"))
     if module.source_cid != expected_cid or unit.source_cid != module.source_cid:

--- a/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
@@ -217,14 +217,14 @@ def test_regexflag_cached_class_sugar_retains_manager_context_product() -> None:
     ]
 
 
-def test_import_receipts_seat_the_exact_source_unit_owned_context() -> None:
+def test_import_receipt_seating_requires_the_target_unit_owned_context() -> None:
     graph = DependencyArtifactGraph.authenticate_stdlib_module("re")
     module = graph.modules["re"]
-    external_context = TreeConstructionContextV1.for_source_call_construction()
-    unit_context = TreeConstructionContextV1.for_source_call_construction()
+    owned_context = TreeConstructionContextV1.for_source_call_construction()
+    foreign_context = TreeConstructionContextV1.for_source_call_construction()
     source_file = SourceFile(
         (module.source, module.source_seat, module.source_cid),
-        construction_context=unit_context,
+        construction_context=owned_context,
     )
     regex_flag = next(
         node
@@ -232,14 +232,34 @@ def test_import_receipts_seat_the_exact_source_unit_owned_context() -> None:
         if isinstance(node, ClassDef) and node.name == "RegexFlag"
     )
 
+    with pytest.raises(
+        BackendDefect,
+        match="target SourceUnit construction context disagrees",
+    ):
+        _seat_import_value_use_receipts(
+            source_file=source_file,
+            module=module,
+            target=regex_flag,
+            session=SourceResolutionSession(enabled=False),
+            context=foreign_context,
+            dependency_graphs={"re": graph},
+        )
+
+    assert not foreign_context.source_import_value_receipts
+    assert not foreign_context.source_import_value_receipts_by_site
+    assert not owned_context.source_import_value_receipts
+
     _seat_import_value_use_receipts(
         source_file=source_file,
         module=module,
         target=regex_flag,
         session=SourceResolutionSession(enabled=False),
-        context=external_context,
+        context=owned_context,
         dependency_graphs={"re": graph},
     )
+    assert owned_context is regex_flag.unit.construction_context
+    assert owned_context.source_import_value_receipts
+    assert owned_context.source_import_value_receipts_by_site
 
     member = next(
         node
@@ -259,22 +279,17 @@ def test_import_receipts_seat_the_exact_source_unit_owned_context() -> None:
         span.end_line,
         span.end_col,
     )
-
     assert type(outcome.value) is ImportMemberValue
-    assert outcome.value.receipt is unit_context.source_import_value_receipts_by_site[
+    assert outcome.value.receipt is owned_context.source_import_value_receipts_by_site[
         site_key
     ]
-    assert outcome.value.receipt in unit_context.source_import_value_receipts[
+    assert outcome.value.receipt in owned_context.source_import_value_receipts[
         roster_key
     ]
-    assert len(unit_context.source_import_value_receipts_by_site) > 1
-    assert not external_context.source_import_value_receipts
-    assert not external_context.source_import_value_receipts_by_site
-    assert not external_context.source_import_value_resolutions
 
     foreign = SourceFile(
         (module.source, module.source_seat, module.source_cid),
-        construction_context=external_context,
+        construction_context=foreign_context,
     )
     foreign_member = next(
         node


### PR DESCRIPTION
## What changed
- route all manager import-value receipt seating through the exact target SourceUnit-owned construction context
- reject a foreign passed context before minting or seating any receipt
- retain exact receipt identity and the existing AttributeSugar consumer truth

## Instrument
- R_target_context_mismatch: 1 -> 0 in the focused new tooth
- Delta R: -1
- Epsilon R: -1

## Evidence
- pre-fix: 1 failed, `DID NOT RAISE BackendDefect`
- post-fix exact tooth: 1 passed, 4 deselected in 6.79s
- the broader focused file remains background telemetry per IDD

## Floors
No cache/global bridge, source-CID lookup, spelling fallback, or generic attribute admission.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require import receipt seating to use the target unit's owned construction context
> - `_seat_import_value_use_receipts` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6888/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) now derives the construction context from `target.unit` instead of `source_file.unit`, and asserts the passed context is exactly the same object as `target.unit.construction_context`.
> - All call sites in `_resolve_source_visible_frame_uncached` are updated to pass `target.unit.construction_context`, `item.unit.construction_context`, or `function.unit.construction_context` as appropriate.
> - A `BackendDefect` is raised if the passed context is missing, is not a `TreeConstructionContextV1`, or does not match the target unit's owned context.
> - Tests in [test_regexflag_relative_member_seating.py](https://github.com/TSavo/sugar/pull/6888/files#diff-3ae4846d62744433a022e393539888f5522332faba6e717dfca0402bc114fa1e) verify that seating with a foreign context raises `BackendDefect` and seating with the owned context records receipts correctly.
> - Behavioral Change: receipts are now always seated in each target `SourceUnit`'s own context rather than the ambient function context, which may change receipt placement for targets whose unit differs from the ambient context's unit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff57b93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->