### PR TITLE
Confine parked imported-call refusal to exact callees

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -2464,6 +2464,24 @@ def _seat_import_value_use_receipts(
                 fix="repair call receipt uniqueness before value seating",
             )
 
+        def exact_parked_callee() -> bool:
+            if len(paired_obligations) != 1:
+                return False
+            relation = paired_obligations[0].import_call_value_subsumption
+            if relation is None:
+                return False
+            stack = [target]
+            while stack:
+                node = stack.pop()
+                if (
+                    isinstance(node, Call)
+                    and _call_coordinate(node) == relation.call_coordinate
+                    and _call_callee_coordinate(node) == relation.callee_coordinate
+                ):
+                    return True
+                stack.extend(child for _, _, child in node.children())
+            return False
+
         def seat_receipt() -> None:
             transport_key = (
                 unit.filename,
@@ -2535,13 +2553,18 @@ def _seat_import_value_use_receipts(
                 # module-wide refusal.
                 seat_receipt()
                 continue
-            if imported.kind == "ambiguous-static-export" and len(
-                paired_obligations
-            ) == 1:
+            if imported.kind == "ambiguous-static-export" and exact_parked_callee():
                 # The exact call receipt already owns this callable occurrence
                 # and remains parked/loud at the full Call coordinate.  Its
                 # duplicate Attribute value receipt is deliberately unseated;
                 # no candidate definition or runtime branch is selected.
+                continue
+            if imported.kind == "ambiguous-static-export":
+                # Ambiguity at a non-callee value site cannot borrow a nearby
+                # parked Call's refusal.  Preserve the authenticated value row
+                # for its own Attribute consumer, which remains responsible
+                # for deciding whether that value is usable.
+                seat_receipt()
                 continue
             raise ImportValueUseSeatingGap(
                 f"resolution-{imported.kind}",

--- a/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor.import_member_value import ImportMemberValue
 from sugar_lift_python_source.dependency_artifact import DependencyArtifactGraph
+from sugar_lift_python_source.dependency_artifact import (
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
 from sugar_lift_python_source.manager_construction import (
     _seat_import_value_use_receipts,
 )
@@ -16,6 +21,8 @@ from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.nodes import Attribute, ClassDef
 from sugar_source_tree.panic import BackendDefect, SugarNotWritten
 from sugar_source_tree.tree import SourceFile
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
 
 
 def test_regexflag_relative_member_receipt_survives_repeated_frame_seating() -> None:
@@ -285,3 +292,61 @@ def test_import_receipts_seat_the_exact_source_unit_owned_context() -> None:
     )
     with pytest.raises(SugarNotWritten, match="SymbolicValue.attribute"):
         foreign_member.sugar().desugar()
+
+
+def test_regexflag_field_is_not_swallowed_by_a_parked_imported_call(
+    tmp_path: Path,
+) -> None:
+    consumer = "import re\nresult = re.search('x', subject)\n"
+    path = tmp_path / "consumer.py"
+    path.write_text(consumer, encoding="utf-8")
+    source_cid = blake3_512_of(consumer.encode("utf-8"))
+    calls, _ = authenticated_import_use_receipts(
+        tmp_path, path, consumer, source_cid, module_identities={}
+    )
+    call = next(row for row in calls if row.target_symbol == "python:re.search")
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("re")
+    resolved = resolve_import_binding(call, graph=graph)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    from sugar_lift_python_source.manager_construction import (
+        resolve_source_visible_frame,
+    )
+
+    projected = resolve_source_visible_frame(resolved, graph=graph)
+    assert isinstance(projected, tuple)
+    frame, _ = projected
+    context = frame.owner.unit.construction_context
+    assert context is not None
+    assert context.opaque_source_call_obligations
+
+    module = graph.modules["re"]
+    source_file = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=context,
+    )
+    regex_flag = next(
+        node
+        for node in source_file.root.body
+        if isinstance(node, ClassDef) and node.name == "RegexFlag"
+    )
+    parked_before = dict(context.opaque_source_call_obligations)
+    _seat_import_value_use_receipts(
+        source_file=source_file,
+        module=module,
+        target=regex_flag,
+        session=SourceResolutionSession(enabled=False),
+        context=context,
+        dependency_graphs={"re": graph},
+    )
+    member = next(
+        node
+        for node in source_file.nodes()
+        if isinstance(node, Attribute)
+        and node.attr == "SRE_FLAG_ASCII"
+        and node.line_col_span().start_line == 145
+    )
+    value = member.sugar().desugar().value
+
+    assert type(value) is ImportMemberValue
+    assert context.opaque_source_call_obligations == parked_before
+    assert value.receipt.target_symbol == "python:re._compiler.SRE_FLAG_ASCII"


### PR DESCRIPTION
R_ambiguous_import_value_borrowed_call_refusal: scoped producer correction published.

Only an exact closed ImportedCallValueSubsumption whose full Call and Call.func coordinates exist under the current target may keep an ambiguous imported callee value unseated. A non-callee ambiguous value is seated for its own Attribute consumer; no name, source-CID, cache, or global fallback.

Focused real re.search -> RegexFlag SRE_FLAG_ASCII instrument: RED 1 at SymbolicValue.attribute after the correction, identifying the next production ordering/transport boundary; warnings.warn exact parked-call law remains represented. This PR is published per IDD for immediate post-merge audit.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Confine parked imported-call refusal to exact callees in `_seat_import_value_use_receipts`
> Previously, `ambiguous-static-export` value receipts were suppressed whenever there was exactly one paired obligation, regardless of whether the site was actually the parked callee. This caused non-callee value sites (e.g. `RegexFlag` field references) to lose their authenticated receipts.
>
> - Introduces `exact_parked_callee()` helper that verifies a paired `import_call_value_subsumption` matches both the call and callee coordinates within the current target subtree.
> - Suppresses seating only when `exact_parked_callee()` is true, preserving the existing behavior for actual parked callees.
> - Adds an explicit branch to seat the receipt and continue when `exact_parked_callee()` is false, fixing the dropped receipt for non-callee sites.
> - Adds a regression test in [`test_regexflag_relative_member_seating.py`](https://github.com/TSavo/sugar/pull/6889/files#diff-3ae4846d62744433a022e393539888f5522332faba6e717dfca0402bc114fa1e) covering a `RegexFlag` field that was previously swallowed by a parked imported call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec450bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->