### PR TITLE
Restrict imported call-value subsumption to exact callees

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -2256,6 +2256,90 @@ def _call_callee_coordinate(call: Call):
     )
 
 
+def _import_call_value_relation_is_owned_by_target(
+    *,
+    target: Node,
+    receipt,
+    coordinate,
+    obligation,
+    relation,
+    call_receipt,
+    module,
+) -> bool:
+    """Prove one parked imported-call relation owns this exact callee use."""
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ImportedCallValueSubsumptionV1,
+        OpaqueSourceCallObligationV1,
+    )
+    from sugar_lift_py_tests.import_binding import AuthenticatedImportUseV1
+    from sugar_lift_python_source.canonical import cid_of_json
+    from sugar_source_tree.panic import BackendDefect
+
+    if (
+        type(relation) is not ImportedCallValueSubsumptionV1
+        or type(obligation) is not OpaqueSourceCallObligationV1
+        or type(receipt) is not AuthenticatedImportUseV1
+        or type(call_receipt) is not AuthenticatedImportUseV1
+    ):
+        raise BackendDefect(
+            blame=coordinate,
+            owner="manager_construction import call/value receipt subsumption",
+            observed="parked call/value relation has non-exact testimony types",
+            requested="exact authenticated call, value, relation, and obligation products",
+            fix="re-mint the relation through the closed imported-call producer",
+        )
+    receipt.revalidate()
+    call_receipt.revalidate()
+    identity = call_receipt.import_binding.value["target"]["moduleIdentity"]
+    call_site = call_receipt.use["useSite"]
+    value_site = receipt.use["useSite"]
+    expected = (
+        obligation.import_call_value_subsumption is relation
+        and relation.source_cid == module.source_cid == receipt.source_cid
+        and relation.module_identity_cid == cid_of_json(identity)
+        and relation.import_binding_cid
+        == call_receipt.import_binding.cid
+        == receipt.import_binding.cid
+        and relation.target_symbol
+        == call_receipt.target_symbol
+        == receipt.target_symbol
+        and relation.exported_member_path
+        == tuple(receipt.use["exportedMemberPath"])
+        and relation.call_use_cid == call_receipt.use["cid"]
+        and relation.value_use_cid == receipt.use["cid"]
+        and relation.call_coordinate.wire() == call_site
+        and relation.callee_coordinate.wire() == value_site
+        and relation.callee_coordinate == coordinate
+        and relation.call_coordinate == obligation.coordinate
+        and relation.resolution_kind == obligation.resolution_kind
+        and relation.resolved_object_cid == obligation.resolved_object_cid
+    )
+    if not expected:
+        raise BackendDefect(
+            blame=coordinate,
+            owner="manager_construction import call/value receipt subsumption",
+            observed="parked call/value relation disagrees with authenticated receipts",
+            requested="byte-identical one-to-one imported call/value relation",
+            fix="re-mint the relation from the exact lexical call and value receipts",
+        )
+    owned_calls = tuple(
+        call
+        for function in _scanned_definitions(target)
+        for call in _reachable_attribute_calls(function)
+        if _call_coordinate(call) == relation.call_coordinate
+        and _call_callee_coordinate(call) == relation.callee_coordinate
+    )
+    if len(owned_calls) > 1:
+        raise BackendDefect(
+            blame=coordinate,
+            owner="manager_construction import call/value receipt subsumption",
+            observed="multiple lexical Calls claim one imported callee relation",
+            requested="one exact target-owned Call and callee occurrence",
+            fix="repair reachable Attribute Call ownership before subsumption",
+        )
+    return len(owned_calls) == 1
+
+
 def _seat_import_value_use_receipts(
     *,
     source_file,
@@ -2405,52 +2489,16 @@ def _seat_import_value_use_receipts(
                     "subsumption relation cites no authenticated call receipt",
                 )
             call_receipt.revalidate()
-            from sugar_lift_python_source.canonical import cid_of_json
-
-            identity = call_receipt.import_binding.value["target"]["moduleIdentity"]
-            call_site = call_receipt.use["useSite"]
-            value_site = receipt.use["useSite"]
-            expected = (
-                relation.source_cid == module.source_cid == receipt.source_cid
-                and relation.module_identity_cid == cid_of_json(identity)
-                and relation.import_binding_cid
-                == call_receipt.import_binding.cid
-                == receipt.import_binding.cid
-                and relation.target_symbol
-                == call_receipt.target_symbol
-                == receipt.target_symbol
-                and relation.exported_member_path
-                == tuple(receipt.use["exportedMemberPath"])
-                and relation.call_use_cid == call_receipt.use["cid"]
-                and relation.value_use_cid == receipt.use["cid"]
-                and (
-                    relation.call_coordinate.start_line,
-                    relation.call_coordinate.start_col,
-                    relation.call_coordinate.end_line,
-                    relation.call_coordinate.end_col,
-                )
-                == (
-                    call_site["startLine"],
-                    call_site["startCol"],
-                    call_site["endLine"],
-                    call_site["endCol"],
-                )
-                and relation.callee_coordinate.wire() == value_site
-                and relation.callee_coordinate == coordinate
-                and relation.call_coordinate == obligation.coordinate
-                and relation.resolution_kind == obligation.resolution_kind
-                and relation.resolved_object_cid == obligation.resolved_object_cid
-            )
-            if not expected:
-                from sugar_source_tree.panic import BackendDefect
-
-                raise BackendDefect(
-                    blame=coordinate,
-                    owner="manager_construction import call/value receipt subsumption",
-                    observed="parked call/value relation disagrees with authenticated receipts",
-                    requested="byte-identical one-to-one imported call/value relation",
-                    fix="re-mint the relation from the exact lexical call and value receipts",
-                )
+            if not _import_call_value_relation_is_owned_by_target(
+                target=target,
+                receipt=receipt,
+                coordinate=coordinate,
+                obligation=obligation,
+                relation=relation,
+                call_receipt=call_receipt,
+                module=module,
+            ):
+                continue
             paired_obligations.append(obligation)
         paired_obligations = tuple(paired_obligations)
         if len(paired_obligations) > 1:
@@ -2542,6 +2590,13 @@ def _seat_import_value_use_receipts(
                 # and remains parked/loud at the full Call coordinate.  Its
                 # duplicate Attribute value receipt is deliberately unseated;
                 # no candidate definition or runtime branch is selected.
+                continue
+            if imported.kind == "ambiguous-static-export":
+                # An ordinary imported member value is still authenticated by
+                # its exact receipt even when static export resolution cannot
+                # select one definition.  Only a proven Call.func duplicate is
+                # suppressed in favor of its parked full-Call obligation.
+                seat_receipt()
                 continue
             raise ImportValueUseSeatingGap(
                 f"resolution-{imported.kind}",

--- a/implementations/python/sugar-lift-python-source/tests/test_regex_search_dependency_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regex_search_dependency_authority.py
@@ -21,12 +21,18 @@ from sugar_lift_python_source.dependency_artifact import (
     resolve_import_binding,
 )
 from sugar_lift_python_source.manager_construction import (
+    _import_call_value_relation_is_owned_by_target,
     _seat_import_value_use_receipts,
     resolve_source_visible_frame,
 )
 from sugar_lift_python_source.resolution_session import SourceResolutionSession
-from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
-from sugar_source_tree.nodes import Attribute, Call, FunctionDef
+from sugar_lift_py_tests.context_manager_resolution import (
+    OpaqueSourceCallObligationV1,
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+    _mint_import_call_value_subsumption,
+)
+from sugar_source_tree.nodes import Attribute, Call, ClassDef, FunctionDef
 from sugar_source_tree.panic import BackendDefect
 from sugar_source_tree.tree import SourceFile
 SOURCE = (
@@ -164,6 +170,114 @@ def test_exact_re_search_receipt_resolves_and_seats_cpython_definition_body(
     ):
         with pytest.raises(ValueError, match="producer authority"):
             replace(relation, **change)
+
+
+def test_import_call_value_subsumption_requires_the_exact_target_owned_call(
+    tmp_path: Path,
+) -> None:
+    outer_call, _ = _receipts(tmp_path)
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("re")
+    resolved = resolve_import_binding(outer_call, graph=graph)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    module = graph.modules["re"]
+    module_tree = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    calls, _ = authenticated_import_use_receipts(
+        Path("."),
+        Path(module.source_seat),
+        module.source,
+        module.source_cid,
+        module_identities={},
+    )
+    values, _ = authenticated_import_value_use_receipts(
+        Path("."),
+        Path(module.source_seat),
+        module.source,
+        module.source_cid,
+        module_identities={},
+    )
+    warnings_call = next(
+        item
+        for item in calls
+        if item.target_symbol == "python:warnings.warn"
+        and item.use["useSite"]["startLine"] == 302
+    )
+    warnings_value = next(
+        item
+        for item in values
+        if item.target_symbol == "python:warnings.warn"
+        and item.use["useSite"]["startLine"] == 302
+    )
+    call_node = next(
+        node
+        for node in module_tree.nodes()
+        if isinstance(node, Call)
+        and node.line_col_span().start_line == 302
+        and isinstance(node.func, Attribute)
+        and node.func.attr == "warn"
+    )
+    call_span = call_node.line_col_span()
+    callee_span = call_node.func.line_col_span()
+    call_coordinate = SourceFragmentCoordinateV1(
+        module.source_cid,
+        call_span.start_line,
+        call_span.start_col,
+        call_span.end_line,
+        call_span.end_col,
+    )
+    callee_coordinate = SourceFragmentCoordinateV1(
+        module.source_cid,
+        callee_span.start_line,
+        callee_span.start_col,
+        callee_span.end_line,
+        callee_span.end_col,
+    )
+    relation = _mint_import_call_value_subsumption(
+        call_receipt=warnings_call,
+        value_receipt=warnings_value,
+        call_coordinate=call_coordinate,
+        callee_coordinate=callee_coordinate,
+        resolution_kind="call-target-export-unresolved",
+        resolved_object_cid=resolved.cid,
+    )
+    obligation = OpaqueSourceCallObligationV1(
+        call_coordinate,
+        warnings_call.target_symbol,
+        resolved.cid,
+        resolution_kind="call-target-export-unresolved",
+        import_call_value_subsumption=relation,
+    )
+    compile_function = next(
+        node
+        for node in module_tree.root.body
+        if isinstance(node, FunctionDef) and node.name == "_compile"
+    )
+    regex_flag = next(
+        node
+        for node in module_tree.root.body
+        if isinstance(node, ClassDef) and node.name == "RegexFlag"
+    )
+
+    assert _import_call_value_relation_is_owned_by_target(
+        target=compile_function,
+        receipt=warnings_value,
+        coordinate=callee_coordinate,
+        obligation=obligation,
+        relation=relation,
+        call_receipt=warnings_call,
+        module=module,
+    )
+    assert not _import_call_value_relation_is_owned_by_target(
+        target=regex_flag,
+        receipt=warnings_value,
+        coordinate=callee_coordinate,
+        obligation=obligation,
+        relation=relation,
+        call_receipt=warnings_call,
+        module=module,
+    )
 
 
 def test_duplicate_identical_call_receipt_is_loud_before_pairing(


### PR DESCRIPTION
## What changed
- validate the closed ImportedCallValueSubsumptionV1 against the exact call/value receipts and parked obligation before candidate admission
- require the target lexical owner to contain exactly the authenticated full Call and Call.func coordinates
- leave ambiguous ordinary member values seated; suppress only a proven duplicate Call.func value receipt

## Instrument
- truthful real warnings.warn relation is owned by `_compile`
- the identical closed relation cannot be borrowed by `RegexFlag`
- direct RegexFlag imported class-field receipt remains truthful

## Evidence
- red: missing exact owner selector at collection
- green: 2 passed in 14.65s under CPython 3.12.13
- R_import_call_value_owner: 1 -> 0; Delta R=-1; Epsilon R=-1

## Floors
No name/vendor/host arm, generic attribute fallback, face selection, or receipt remint. The existing dormant warnings.warn obligation remains unchanged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict imported call-value subsumption to exact callees in `_seat_import_value_use_receipts`
> - Adds `_import_call_value_relation_is_owned_by_target` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6890/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to validate an imported call/value subsumption relation by enforcing byte-identical fields, strict type checks, and single-target ownership of the matching `Attribute` call.
> - Refactors `_seat_import_value_use_receipts` to delegate all relation/receipt/obligation validation to the new helper, replacing inlined field-by-field comparisons.
> - Changes `ambiguous-static-export` handling: authenticated value-use receipts are now seated by default unless exactly one paired call obligation exists (indicating a duplicate `Call.func`), rather than raising an `ImportValueUseSeatingGap`.
> - Risk: mismatched fields or ambiguous ownership now raise `BackendDefect` instead of silently skipping or erroring with a gap error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23af363.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->