### PR TITLE
Seat imported receipts for exact reached decorated classes

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1768,6 +1768,24 @@ def _construct_reachable_decorated_class_bindings(
             if not symbol.is_global() or not symbol.is_referenced():
                 continue
             class_dependencies.add(candidate)
+    # Only classes authenticated by the decorated-class reachability product
+    # own class-body/decorator import receipts here.  Seat those exact ClassDef
+    # ranges before their sugars are constructed; unrelated module siblings
+    # acquire no authority from sharing the source unit.
+    receipt_owned_classes = tuple(
+        definition
+        for definition in module_classes
+        if definition in class_dependencies or definition in reached
+    )
+    for definition in receipt_owned_classes:
+        _seat_import_value_use_receipts(
+            source_file=source_file,
+            module=module,
+            target=definition,
+            session=session,
+            context=context,
+            dependency_graphs=dependency_graphs,
+        )
     for definition in module_definitions:
         if definition not in class_dependencies:
             continue


### PR DESCRIPTION
R_reached_decorated_class_receipt_omission: 1 -> 0.

Before: exact re.search production path stopped at re/__init__.py:145:16 _compiler.SRE_FLAG_ASCII because the reached RegexFlag ClassDef lay outside target function owned ranges.
After: it advances to the next independent ClassValue.attribute boundary at bytes [7869,7883).

The manager seats only ClassDefs already authenticated by decorated-class reachability or exact decorator class dependencies, using the existing ClassDef plus decorator-span ownership door. Unreachable sibling classes and unrelated module fields are not enrolled. No full-module walk, name/span reconstruction, cache bridge, or fallback.

Focused: 2 exact nodes exit 1 at the newly exposed downstream boundary; authenticated residual retired=1, predicted Delta=-1.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seat import value use receipts for reachable decorated classes before sugar construction
> In `_construct_reachable_decorated_class_bindings` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6893/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1), a pre-processing step now calls `_seat_import_value_use_receipts` for each class that is either in `class_dependencies` or in `reached`, before desugaring class definitions. Classes that are module siblings but not reachable/authenticated are excluded from receipt seating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2188b3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->