### PR TITLE
Add the typed builtin object member owner

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -16,6 +16,7 @@ from .native_callable_value import NativeCallableValue
 from .builder_state import BuilderState
 from .bv32_value import Bv32Value
 from .builtin_exception_class_value import BuiltinExceptionClassValue
+from .builtin_object_class_value import BuiltinObjectClassValue
 from .builtin_semantic_callable import BuiltinSemanticCallable
 from .call_site_value import CallSiteValue
 from .class_definition_value import (
@@ -104,6 +105,7 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     BuilderState,
     Bv32Value,
     BuiltinExceptionClassValue,
+    BuiltinObjectClassValue,
     BuiltinSemanticCallable,
     CallSiteValue,
     ClassValue,
@@ -180,6 +182,7 @@ __all__ = [
     "BuilderState",
     "Bv32Value",
     "BuiltinExceptionClassValue",
+    "BuiltinObjectClassValue",
     "BuiltinSemanticCallable",
     "CallSiteValue",
     "CurriedLoopBody",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_object_class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_object_class_value.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .class_value import ClassValue
+
+
+@dataclass(frozen=True)
+class BuiltinObjectClassValue(ClassValue):
+    """Language-owned ``object`` class with its closed callable member floor."""
+
+    def attribute(self, name, site):
+        if name == "__str__":
+            from sugar_lift_py_tests.floor.builtin_semantic_callable import (
+                BuiltinSemanticCallable,
+            )
+            from sugar_lift_py_tests.outcome import Complete
+
+            return Complete(
+                BuiltinSemanticCallable(operation="python.object.__str__")
+            )
+        return super().attribute(name, site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
@@ -197,6 +197,7 @@ def builtin_name_temporal():
     from sugar_lift_py_tests.floor import (
         BlockValue,
         BuiltinExceptionClassValue,
+        BuiltinObjectClassValue,
         BuiltinSemanticCallable,
         ClassValue,
         SymbolicValue,
@@ -210,7 +211,13 @@ def builtin_name_temporal():
     for name in sorted(builtin_callable_names()):
         temporal = temporal.bind_value(
             name,
-            ClassValue(name=name, bases=(), record=BlockValue(())),
+            (
+                BuiltinObjectClassValue(
+                    name=name, bases=(), record=BlockValue(())
+                )
+                if name == "object"
+                else ClassValue(name=name, bases=(), record=BlockValue(()))
+            ),
         )
     for name in sorted(builtin_constant_names()):
         temporal = temporal.bind_value(


### PR DESCRIPTION
R_builtin_object_member_callable: 1 -> 0.

The language-owned builtin object class now has its own typed Floor and projects its closed __str__ callable member. Generic ClassValue attribute behavior, including __name__/__qualname__, is unchanged. No host introspection, vendor dispatch, generic attribute fallback, or runtime member discovery.

Focused exact re.search production path advances from re/__init__.py:155 object.__str__ to the next independent decorated-class CallSiteValue application boundary at line 142. Focused node EXIT=1 downstream; authenticated residual retired=1, Delta=-1.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add typed `BuiltinObjectClassValue` for the builtin `object` member owner
> - Introduces [`BuiltinObjectClassValue`](https://github.com/TSavo/sugar/pull/6894/files#diff-0fd38c62e845b9f677aee7ea533a2064080fd43290101db7281d1e7b63863dac), a new `ClassValue` subclass representing the language-owned `object` class.
> - Overrides `attribute` lookup so that `__str__` returns a `BuiltinSemanticCallable` for `python.object.__str__`; all other attributes delegate to `ClassValue`.
> - Updates [`builtin_name_temporal`](https://github.com/TSavo/sugar/pull/6894/files#diff-61c663f349f832607b3966470d5dfecfcda065d57744eabcf0ed411db6501e7d) to bind the name `object` to `BuiltinObjectClassValue` instead of a generic `ClassValue`.
> - Registers and exports `BuiltinObjectClassValue` from the [`floor` package](https://github.com/TSavo/sugar/pull/6894/files#diff-78bcf11912874eb0e6318c0a4c72892351cb389e4b22a68bd94a50068efb6f2a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ddccd9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->