### PR TITLE
Authenticate builtin object __str__ member

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_class_member_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_class_member_value.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+
+from .class_value import ClassValue
+from .closed_operation_witness import PythonRuntimeIdentity
+from .floor_value import FloorValue
+
+
+_BUILTIN_CLASS_MEMBER_AUTHORITY = object()
+
+
+@dataclass(frozen=True, init=False)
+class BuiltinClassMemberValue(FloorValue):
+    """Callable coordinate published by the closed builtin class registry."""
+
+    receiver: "BuiltinObjectClassValue"
+    member_name: str
+    runtime: PythonRuntimeIdentity
+    occurrence: SourceFragmentCoordinateV1
+    use_site: object = field(compare=False, repr=False)
+    _authority: object = field(init=False, compare=False, repr=False, default=None)
+
+    def __post_init__(self) -> None:
+        from sugar_source_tree.fragment import SourceFragment
+
+        if self._authority is not _BUILTIN_CLASS_MEMBER_AUTHORITY:
+            raise ValueError("builtin class member lacks producer authority")
+        if type(self.receiver) is not BuiltinObjectClassValue:
+            raise ValueError("builtin class member receiver is not the registry object")
+        if self.runtime != self.receiver.runtime_identity:
+            raise ValueError("builtin class member runtime identity mismatch")
+        if self.member_name != "__str__":
+            raise ValueError("builtin object member is outside the closed roster")
+        if type(self.use_site) is not SourceFragment:
+            raise ValueError("builtin class member requires an exact source use")
+        span = self.use_site.line_col_span
+        expected = SourceFragmentCoordinateV1(
+            self.use_site.unit.source_cid,
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+        )
+        if self.occurrence != expected:
+            raise ValueError("builtin class member occurrence mismatch")
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:builtin_class_member",
+            [
+                self.receiver.to_term(owner="builtin class member"),
+                str_const(self.member_name),
+                str_const(self.runtime.implementation),
+                str_const(f"{self.runtime.major}.{self.runtime.minor}"),
+                str_const(self.occurrence.cid),
+            ],
+            symbol_kind="builtin",
+        )
+
+
+@dataclass(frozen=True)
+class BuiltinObjectClassValue(ClassValue):
+    """The exact ``object`` class published by the builtin registry."""
+
+    runtime_identity: PythonRuntimeIdentity = field(
+        default_factory=PythonRuntimeIdentity.current
+    )
+
+    def attribute(self, name, site):
+        if name == "__str__":
+            return _mint_builtin_object_str_member(self, site)
+        return super().attribute(name, site)
+
+
+def _mint_builtin_object_str_member(receiver, site):
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_source_tree.fragment import SourceFragment
+
+    if type(receiver) is not BuiltinObjectClassValue:
+        raise ValueError("builtin object member requires the registry receiver")
+    if type(site) is not SourceFragment:
+        return super(BuiltinObjectClassValue, receiver).attribute("__str__", site)
+    span = site.line_col_span
+    value = object.__new__(BuiltinClassMemberValue)
+    object.__setattr__(value, "receiver", receiver)
+    object.__setattr__(value, "member_name", "__str__")
+    object.__setattr__(value, "runtime", receiver.runtime_identity)
+    object.__setattr__(
+        value,
+        "occurrence",
+        SourceFragmentCoordinateV1(
+            site.unit.source_cid,
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+        ),
+    )
+    object.__setattr__(value, "use_site", site)
+    object.__setattr__(value, "_authority", _BUILTIN_CLASS_MEMBER_AUTHORITY)
+    value.__post_init__()
+    return Complete(value)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
@@ -212,6 +212,17 @@ def builtin_name_temporal():
             name,
             ClassValue(name=name, bases=(), record=BlockValue(())),
         )
+    # ``object`` owns one closed class-member roster.  Construct its distinct
+    # receiver at the sole builtin registry door so an arbitrary ClassValue
+    # cannot borrow that authority from a matching spelling.
+    from sugar_lift_py_tests.floor.builtin_class_member_value import (
+        BuiltinObjectClassValue,
+    )
+
+    temporal = temporal.bind_value(
+        "object",
+        BuiltinObjectClassValue(name="object", bases=(), record=BlockValue(())),
+    )
     for name in sorted(builtin_constant_names()):
         temporal = temporal.bind_value(
             name,

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_object_member_authority.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_object_member_authority.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.floor.builtin_class_member_value import (
+    BuiltinClassMemberValue,
+)
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.temporal.builtin_name_bindings import builtin_name_temporal
+from sugar_source_tree.nodes import Attribute
+from sugar_source_tree.tree import SourceFile
+
+
+def _attribute_site(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    path = tmp_path / "builtin_member.py"
+    path.write_text("value = object.__str__\n", encoding="utf-8")
+    tree = SourceFile.from_path(path.name)
+    return next(node.fragment for node in tree.nodes() if isinstance(node, Attribute))
+
+
+def test_builtin_object_str_member_retains_receiver_runtime_and_use(
+    tmp_path, monkeypatch
+) -> None:
+    site = _attribute_site(tmp_path, monkeypatch)
+    receiver = builtin_name_temporal().value_if_bound("object")
+
+    outcome = receiver.attribute("__str__", site)
+
+    assert type(outcome) is Complete
+    assert type(outcome.value) is BuiltinClassMemberValue
+    assert outcome.value.receiver is receiver
+    assert outcome.value.member_name == "__str__"
+    assert outcome.value.use_site is site
+    assert outcome.value.runtime == receiver.runtime_identity
+
+
+def test_builtin_object_member_authority_does_not_cross_class_member_or_use(
+    tmp_path, monkeypatch
+) -> None:
+    site = _attribute_site(tmp_path, monkeypatch)
+    temporal = builtin_name_temporal()
+    receiver = temporal.value_if_bound("object")
+
+    with pytest.raises(ConstructionPanic):
+        temporal.value_if_bound("type").attribute("__str__", site)
+    with pytest.raises(ConstructionPanic):
+        receiver.attribute("__repr__", site)
+    with pytest.raises(ConstructionPanic):
+        receiver.attribute("__str__", "foreign-use")


### PR DESCRIPTION
## What changed
- publish the builtin registry's exact `object` receiver as a distinct authenticated class floor
- privately mint an occurrence-bound `object.__str__` callable coordinate carrying receiver identity, CPython runtime identity, and exact source use
- keep every other class/member/use on the existing loud attribute floor

## Why
The real pandas option lifecycle advanced to `re/__init__.py:155`, where the authenticated builtin `object` receiver assigns `object.__str__` into `RegexFlag`. Generic `ClassValue.attribute` had no producer testimony for that builtin member.

## Instrument
- `R_builtin_object_str_member`: 1 -> 0
- predicted `Epsilon R`: -1
- floors: no host introspection, generic member map, vendor/name dispatch, or all-ClassValue fallback

## Focused receipt
`/usr/local/bin/python -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_builtin_object_member_authority.py`

2 passed in 7.13s on CPython 3.12.13.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate builtin `object.__str__` member via `BuiltinClassMemberValue`
> - Adds `BuiltinClassMemberValue`, a frozen dataclass in [builtin_class_member_value.py](https://github.com/TSavo/sugar/pull/6895/files#diff-27e54018d16b6042dad399032b86c8486103a91a4917c68baeacd494e56b7fc1) that validates authority, receiver type, runtime identity, and source occurrence for `object.__str__`, and serializes to an IR `python:builtin_class_member` term.
> - Adds `BuiltinObjectClassValue`, a `ClassValue` subtype that routes `attribute('__str__', site)` through a strict minting path (`_mint_builtin_object_str_member`) instead of generic class attribute lookup.
> - Updates [builtin_name_bindings.py](https://github.com/TSavo/sugar/pull/6895/files#diff-61c663f349f832607b3966470d5dfecfcda065d57744eabcf0ed411db6501e7d) to bind the builtin name `object` to `BuiltinObjectClassValue` instead of a generic `ClassValue`.
> - Cross-class, wrong-member, or foreign-use-site attempts raise `ConstructionPanic`, as covered by the new tests in [test_builtin_object_member_authority.py](https://github.com/TSavo/sugar/pull/6895/files#diff-f4ed5c01a38b5805235731f8b578138de18f3d03f74d1a497cfbd966f72454b9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0dc5c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->