### PR TITLE
Enroll builtin object from static language authority

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
@@ -209,16 +209,19 @@ def builtin_name_temporal():
     # so every ordinary lexical scope starts with this one builtin floor.
     temporal = TemporalContext()
     for name in sorted(builtin_callable_names()):
+        if name == "object":
+            continue
         temporal = temporal.bind_value(
             name,
-            (
-                BuiltinObjectClassValue(
-                    name=name, bases=(), record=BlockValue(())
-                )
-                if name == "object"
-                else ClassValue(name=name, bases=(), record=BlockValue(()))
-            ),
+            ClassValue(name=name, bases=(), record=BlockValue(())),
         )
+    # ``object`` is a language-owned builtin type, not a fact discovered from
+    # the host's callable roster. Its distinct floor owns the closed member
+    # dispatch used by source construction.
+    temporal = temporal.bind_value(
+        "object",
+        BuiltinObjectClassValue(name="object", bases=(), record=BlockValue(())),
+    )
     for name in sorted(builtin_constant_names()):
         temporal = temporal.bind_value(
             name,

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_object_static_enrollment.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_object_static_enrollment.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+
+def test_builtin_object_owner_does_not_depend_on_host_callable_enumeration(
+    monkeypatch,
+) -> None:
+    from sugar_lift_py_tests.floor import BuiltinObjectClassValue
+    from sugar_lift_py_tests.temporal import builtin_name_bindings as bindings
+
+    monkeypatch.setattr(bindings, "_EMPTY_BUILTIN_TEMPORAL", None)
+    monkeypatch.setattr(bindings, "builtin_callable_names", lambda: frozenset())
+    try:
+        temporal = bindings.builtin_name_temporal()
+        assert type(temporal.value_if_bound("object")) is BuiltinObjectClassValue
+    finally:
+        bindings._EMPTY_BUILTIN_TEMPORAL = None


### PR DESCRIPTION
## What changed
- enroll the language-owned builtin `object` floor in an explicit static registry step
- exclude `object` from the generic host-derived callable loop
- pin the owner with a test that empties host callable enumeration

## Why
PR #6894 made builtin member dispatch type-owned, but construction of that owner still depended on `dir/getattr(builtins)` discovering `object`. The owner is Python-language testimony and must survive an empty host enumeration.

## Instrument
- `R_builtin_object_host_enrollment`: 1 -> 0
- predicted `Epsilon R`: -1
- no broader builtin mapping or decorator changes

## Focused receipt
`/usr/local/bin/python -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_builtin_object_static_enrollment.py`

1 passed in 11.39s on CPython 3.12.13.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind `object` to `BuiltinObjectClassValue` unconditionally in `builtin_name_temporal`
> Previously, `object` was bound as `BuiltinObjectClassValue` only when it appeared in `builtin_callable_names()`. Now it is always bound explicitly after the enumeration loop, making the binding independent of host callable enumeration. A test is added to verify this behavior when `builtin_callable_names` returns an empty set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3228536.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->