### PR TITLE
Statically enroll the builtin object Floor owner

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
@@ -209,16 +209,19 @@ def builtin_name_temporal():
     # so every ordinary lexical scope starts with this one builtin floor.
     temporal = TemporalContext()
     for name in sorted(builtin_callable_names()):
+        if name == "object":
+            continue
         temporal = temporal.bind_value(
             name,
-            (
-                BuiltinObjectClassValue(
-                    name=name, bases=(), record=BlockValue(())
-                )
-                if name == "object"
-                else ClassValue(name=name, bases=(), record=BlockValue(()))
-            ),
+            ClassValue(name=name, bases=(), record=BlockValue(())),
         )
+    # ``object`` is Python language vocabulary, not a host-discovered callable.
+    # Its typed owner remains enrolled even when host builtin enumeration is
+    # absent or substituted.
+    temporal = temporal.bind_value(
+        "object",
+        BuiltinObjectClassValue(name="object", bases=(), record=BlockValue(())),
+    )
     for name in sorted(builtin_constant_names()):
         temporal = temporal.bind_value(
             name,

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_object_class_member.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_object_class_member.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.floor import (
+    BlockValue,
+    BuiltinObjectClassValue,
+    BuiltinSemanticCallable,
+    ClassValue,
+    StringValue,
+)
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.temporal import builtin_name_bindings
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Attribute
+from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+
+def _sites():
+    source = "object.__str__\nobject.missing\n"
+    tree = SourceFile((source, "builtin_object.py", blake3_512_of(source.encode())))
+    return tuple(node.fragment for node in tree.nodes() if isinstance(node, Attribute))
+
+
+def test_builtin_object_is_static_and_owns_only_its_closed_callable_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(builtin_name_bindings, "_EMPTY_BUILTIN_TEMPORAL", None)
+    monkeypatch.setattr(
+        builtin_name_bindings, "builtin_callable_names", lambda: frozenset()
+    )
+    temporal = builtin_name_bindings.builtin_name_temporal()
+    receiver = temporal.value_for("object")
+    member_site, missing_site = _sites()
+
+    assert type(receiver) is BuiltinObjectClassValue
+    outcome = receiver.attribute("__str__", member_site)
+    assert isinstance(outcome, Complete)
+    assert type(outcome.value) is BuiltinSemanticCallable
+    assert outcome.value.operation == "python.object.__str__"
+    assert outcome.value.to_term(owner="test") == BuiltinSemanticCallable(
+        operation="python.object.__str__"
+    ).to_term(owner="test")
+    with pytest.raises(ConstructionPanic):
+        receiver.attribute("missing", missing_site)
+
+    ordinary = ClassValue(name="object", bases=(), record=BlockValue(()))
+    with pytest.raises(ConstructionPanic):
+        ordinary.attribute("__str__", member_site)
+    name = receiver.attribute("__name__", member_site)
+    qualname = receiver.attribute("__qualname__", member_site)
+    assert name == Complete(StringValue("object"))
+    assert qualname == Complete(StringValue("object"))


### PR DESCRIPTION
Non-gating PR #6894 fix-forward. The language-owned builtin object binding is now installed statically and excluded from the host-derived builtin_callable_names loop. BuiltinObjectClassValue keeps type-owned dispatch. No receiver.name dispatch, vendor table, host introspection, or broader builtin mapping.

Focused: 1 passed in 12.51s, literal exit 0. Test replaces host callable enumeration with the empty set and proves the exact object.__str__ typed callable term/runtime identity remains; ordinary ClassValue.__str__ and arbitrary object members stay loud; __name__/__qualname__ remain unchanged. Production product boundary remains downstream.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Statically enroll the builtin `object` Floor owner as `BuiltinObjectClassValue`
> - Updates `builtin_name_temporal()` in [builtin_name_bindings.py](https://github.com/TSavo/sugar/pull/6897/files#diff-61c663f349f832607b3966470d5dfecfcda065d57744eabcf0ed411db6501e7d) to skip `object` during the loop over `builtin_callable_names()` and bind it explicitly as a `BuiltinObjectClassValue` after all other names.
> - This ensures `object` is always present in the temporal regardless of whether `builtin_callable_names()` enumerates it.
> - Adds tests in [test_builtin_object_class_member.py](https://github.com/TSavo/sugar/pull/6897/files#diff-b8c58081610bbd0d31d08b0ad5526d4eaeac19da4f3e54788cf3485bd0751de8) verifying that `object` resolves as `BuiltinObjectClassValue`, exposes `__str__` as a `BuiltinSemanticCallable`, raises `ConstructionPanic` for missing attributes, and correctly returns `__name__`/`__qualname__`.
> - Behavioral Change: `object` is now bound after all other callable names and is no longer dependent on host builtin enumeration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd50f55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->