### PR TITLE
Move decorator frame enrollment before class dependency sugar

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1786,35 +1786,13 @@ def _construct_reachable_decorated_class_bindings(
             context=context,
             dependency_graphs=dependency_graphs,
         )
-    for definition in module_definitions:
-        if definition not in class_dependencies:
-            continue
-        outcome = definition.sugar().desugar(ctx)
-        if not isinstance(outcome, Complete):
-            raise SugarNotWritten(
-                owner="manager_construction decorated class dependency",
-                blame=definition.fragment,
-                observed="decorator class dependency reduced nonlinearly",
-                requested="one completed source class Floor",
-                fix="sequence module definition effects before decorator execution",
-            )
-        temporal = temporal.bind_value(definition.name, outcome.value)
-    ctx = replace(ctx, temporal=temporal, module_temporal=temporal)
 
-    result = []
-    for definition in reached:
-        # A reached imported Attribute decorator factory is an exact source
-        # call, not an opaque bodyless CallSiteValue.  Enroll only decorator
-        # Call coordinates owned by this reached ClassDef and authenticated by
-        # the lexical call receipt at that exact occurrence.
+    def enroll_imported_decorator_frames(definition: ClassDef) -> None:
         from pathlib import Path
         from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
 
         decorator_receipts, _ = authenticated_import_use_receipts(
-            Path("."),
-            Path(module.source_seat),
-            module.source,
-            module.source_cid,
+            Path("."), Path(module.source_seat), module.source, module.source_cid,
             module_identities={},
         )
         receipts_by_span = {
@@ -1872,6 +1850,26 @@ def _construct_reachable_decorated_class_bindings(
             except SourceCallBindingGap:
                 continue
             _install_source_call_frame(context, decorator, decorator_frame)
+
+    for definition in receipt_owned_classes:
+        enroll_imported_decorator_frames(definition)
+    for definition in module_definitions:
+        if definition not in class_dependencies:
+            continue
+        outcome = definition.sugar().desugar(ctx)
+        if not isinstance(outcome, Complete):
+            raise SugarNotWritten(
+                owner="manager_construction decorated class dependency",
+                blame=definition.fragment,
+                observed="decorator class dependency reduced nonlinearly",
+                requested="one completed source class Floor",
+                fix="sequence module definition effects before decorator execution",
+            )
+        temporal = temporal.bind_value(definition.name, outcome.value)
+    ctx = replace(ctx, temporal=temporal, module_temporal=temporal)
+
+    result = []
+    for definition in reached:
         sugar = definition.sugar()
         raw_outcome = sugar.desugar(ctx)
         if not isinstance(raw_outcome, Complete):
@@ -1900,8 +1898,6 @@ def _construct_reachable_decorated_class_bindings(
             tuple(zip(decorator_floors, sugar.decorator_occurrences, strict=True))
         ):
             from sugar_lift_py_tests.floor import CallSiteValue
-            print("FLOOR_TRACE", type(callable_floor), getattr(callable_floor, "body", "NA"), getattr(callable_floor, "source_call_frame_cid", "NA"))
-
             if (
                 type(callable_floor) is CallSiteValue
                 and callable_floor.body is not None


### PR DESCRIPTION
PR #6898 ordering fix-forward. Exact imported decorator frame enrollment now runs for the authenticated receipt-owned ClassDefs before any class-dependency or reached-class sugar construction inside _construct_reachable_decorated_class_bindings. The late duplicate enrollment block and accidental FLOOR_TRACE output are removed. No cache invalidation, name/span rebuild fallback, or generic CallSiteValue behavior.

Focused exact re.search remains RED at bodyless enum._simple_enum because an earlier source_visible_constructor_frame pass caches the ClassDef before this phase begins. That upstream cache owner is now the sole named residual; semantic Delta remains unmeasured.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move decorator frame enrollment before class dependency desugaring in `_construct_reachable_decorated_class_bindings`
> - Extracts decorator frame enrollment into a new `enroll_imported_decorator_frames` local helper in [manager_construction.py](https://github.com/TSavo/sugar/pull/6899/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1).
> - Calls this helper for each definition in `receipt_owned_classes` before desugaring `module_definitions` and before iterating reached classes, fixing the ordering so decorator source call frames are installed at the right stage.
> - Removes a debug `FLOOR_TRACE` stdout print that was previously emitted with `callable_floor` details.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71b91b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->