### PR TITLE
Refuse ambiguous imported decorator enrollment

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1795,15 +1795,25 @@ def _construct_reachable_decorated_class_bindings(
             Path("."), Path(module.source_seat), module.source, module.source_cid,
             module_identities={},
         )
-        receipts_by_span = {
-            (
+        receipts_by_span = {}
+        for receipt in decorator_receipts:
+            receipt_span = (
                 receipt.use["useSite"]["startLine"],
                 receipt.use["useSite"]["startCol"],
                 receipt.use["useSite"]["endLine"],
                 receipt.use["useSite"]["endCol"],
-            ): receipt
-            for receipt in decorator_receipts
-        }
+            )
+            if receipt_span in receipts_by_span:
+                from sugar_source_tree.panic import BackendDefect
+
+                raise BackendDefect(
+                    blame=definition.fragment,
+                    owner="manager_construction imported decorator enrollment",
+                    observed="duplicate authenticated call receipt span",
+                    requested="one exact call receipt per decorator occurrence",
+                    fix="repair lexical call receipt enrollment uniqueness",
+                )
+            receipts_by_span[receipt_span] = receipt
         for decorator in definition.decorators:
             if not isinstance(decorator, Call) or not isinstance(
                 decorator.func, Attribute
@@ -1838,6 +1848,10 @@ def _construct_reachable_decorated_class_bindings(
                 continue
             from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
+            if any(keyword.arg is None for keyword in decorator.keywords):
+                raise SourceCallBindingGap(
+                    "decorator spread keyword requires typed variadic projection"
+                )
             try:
                 decorator_frame = decorator_frame.bind_node_actuals(
                     decorator.args,


### PR DESCRIPTION
Immediate PR #6899 correction. Duplicate authenticated decorator call receipt spans now raise BackendDefect before lookup. Decorator **kwargs now raise SourceCallBindingGap before bind_node_actuals, so no actual is silently dropped. Ordinary positional/named-keyword binding keeps the existing exactly-once bind.

No ordering, cache invalidation, fallback, name/vendor dispatch, or adjacent semantic changes. Predicted R_fail_open_decorator_receipt=1->0 and R_dropped_decorator_kwargs=1->0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise errors on ambiguous imported decorator enrollment instead of silently proceeding
> - Duplicate authenticated call receipt spans in `_construct_reachable_decorated_class_bindings` now raise a `BackendDefect` with context instead of silently overwriting the prior entry.
> - Decorator calls with spread keyword arguments (unnamed keywords) now raise `SourceCallBindingGap` before binding proceeds, requiring typed variadic projection instead.
> - Both changes are in [manager_construction.py](https://github.com/TSavo/sugar/pull/6900/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e7aa5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->