### PR TITLE
feat(python): execute module class definitions in prefix producer

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -64,6 +64,114 @@ class ImportValueUseSeatingGap(ValueError):
         super().__init__(f"{kind}: {detail}")
 
 
+@dataclass(frozen=True)
+class _ModuleClassDefinitionBindingSugar:
+    """Execute one module ClassDef and bind its exact constructed Floor.
+
+    This is deliberately a producer-owned wrapper rather than a Name-based
+    reconstruction in the prefix consumer.  Decorated definitions require the
+    separate publication chain and remain loud here until that chain supplies
+    the final class Floor.
+    """
+
+    definition: ClassDef
+
+    def desugar(self, ctx=None):
+        from sugar_lift_py_tests.floor import ClassDefinitionValue
+        from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_source_tree.panic import SugarNotWritten
+
+        if self.definition.decorators:
+            raise SugarNotWritten(
+                owner="module definition execution",
+                blame=self.definition.fragment,
+                observed="decorated ClassDef has no completed publication",
+                requested="the exact final decorated class Floor",
+                fix="execute and authenticate the decorator publication chain",
+            )
+        outcome = self.definition.sugar().desugar(ctx)
+
+        def bind(value):
+            if type(value) is not ClassDefinitionValue:
+                raise SugarNotWritten(
+                    owner="module definition execution",
+                    blame=self.definition.fragment,
+                    observed=f"ClassDef constructed {type(value).__name__}",
+                    requested="one exact ClassDefinitionValue",
+                    fix="keep nonlinear or substituted class construction loud",
+                )
+            return Complete(ScopeRebind(self.definition.name, value))
+
+        return outcome.and_then(bind)
+
+
+def _module_prefix_outcome(module, locus):
+    """Execute the authenticated module prefix through its exact definitions."""
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        reduce_block_to_exitset,
+    )
+    from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+    from sugar_source_tree.nodes import AsyncFunctionDef, FunctionDef, Name
+
+    from .canonical import blake3_512_of
+
+    if module.source_cid != blake3_512_of(module.source.encode("utf-8")):
+        raise ValueError("module prefix source CID mismatch")
+    construction_context = TreeConstructionContextV1.for_source_call_construction()
+    source_file = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=construction_context,
+    )
+    locus_key = (locus.lineno, locus.col_offset)
+    prefix = tuple(
+        statement
+        for statement in source_file.root.body
+        if (
+            statement.line_col_span().start_line,
+            statement.line_col_span().start_col,
+        )
+        < locus_key
+    )
+
+    # Base testimony is installed from exact parser-owned module bindings,
+    # never from a class-name scan.  Only earlier module ClassDefs can be a
+    # source-visible base at this prefix boundary.
+    prefix_classes = tuple(item for item in prefix if isinstance(item, ClassDef))
+    class_roster = set(prefix_classes)
+    for definition in prefix_classes:
+        bases = []
+        for base in definition.bases:
+            if not isinstance(base, Name):
+                continue
+            bindings = tuple(
+                (definition.unit.module_direct_bindings or {}).get(base.id, ())
+            )
+            if (
+                len(bindings) == 1
+                and isinstance(bindings[0], ClassDef)
+                and bindings[0] in class_roster
+                and bindings[0].line_col_span().start_line
+                < definition.line_col_span().start_line
+            ):
+                bases.append(bindings[0].sugar())
+        definition.unit.construction_context.source_class_bases[
+            definition.fragment.seal().cid
+        ] = tuple(bases)
+
+    sugars = tuple(
+        (
+            InertSugar(site=statement.fragment)
+            if isinstance(statement, (FunctionDef, AsyncFunctionDef))
+            else _ModuleClassDefinitionBindingSugar(statement)
+            if isinstance(statement, ClassDef)
+            else statement.sugar()
+        )
+        for statement in prefix
+    )
+    return reduce_block_to_exitset(sugars)
+
+
 def prefix_has_completed_fallthrough(module, locus) -> bool:
     """Construction-owned five-step prefix meaning for export recognition."""
     from sugar_lift_py_tests.outcome import Completed, true_guard

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -439,6 +439,51 @@ def test_prefix_raise_refuses_binding_via_completed_fallthrough(tmp_path: Path) 
     assert result.kind == "dynamic-export"
 
 
+def test_module_prefix_execution_binds_exact_class_definition_once(
+    tmp_path: Path,
+) -> None:
+    """Module definition execution retains the class Floor for later loads.
+
+    This is the producer boundary needed by authenticated module prefixes: a
+    later statement must consume the exact class constructed by the earlier
+    ClassDef, rather than seeing a reconstructed SymbolicValue with the same
+    name.
+    """
+    from sugar_lift_py_tests.floor import ClassDefinitionValue
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source import manager_construction
+
+    source = (
+        "class Boundary:\n"
+        "    FIRST = 1\n"
+        "    SECOND = 2\n"
+        "alias = Boundary\n"
+        "def build():\n"
+        "    return alias\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="module-definition-prefix-pkg",
+        files={"module_definition_prefix_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "module_definition_prefix_pkg"
+    ]
+    locus = ast.parse(source).body[-1]
+
+    exits = manager_construction._module_prefix_outcome(module, locus)
+
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    boundary = completed.value.context.temporal.value_if_bound("Boundary")
+    assert type(boundary) is ClassDefinitionValue
+    assert tuple(field.name for field in boundary.class_fields) == (
+        "FIRST",
+        "SECOND",
+    )
+
+
 def test_prefix_adapter_propagates_missing_construction_producer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
R_module_prefix_class_binding: 1 -> 0

Adds a closed module-prefix execution producer that constructs each exact parser-owned ClassDef once, binds its ClassDefinitionValue into temporal scope, and carries exact local base testimony. Decorated definitions remain loud until their publication chain supplies the final Floor. Existing export resolution is intentionally unchanged until that full chain is present.

Focused receipt (CPython 3.12.13):
- test_module_prefix_execution_binds_exact_class_definition_once: PASS
- prefix raise/pass regressions: PASS

Epsilon: retires the missing module ClassDef binding producer; next exact residual is authenticated iterable/metaclass publication for FlagBoundary.
Floors: no name/vendor/host fallback; no raw decorated-class substitution; no diagnostics.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Execute module class definitions in the prefix producer to bind exact class definition values into scope
> - Adds `_ModuleClassDefinitionBindingSugar` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6901/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1), a frozen dataclass that executes an undecorated `ClassDef` and binds its constructed `ClassDefinitionValue` into scope via `ScopeRebind`; raises `SugarNotWritten` for decorated classes or non-class results.
> - Adds `_module_prefix_outcome`, which authenticates the module source via blake3 hash, seeds `construction_context.source_class_bases` for `ClassDef`s whose bases refer to earlier module-bound classes, materializes sugars for the statement prefix, and reduces the block to an exitset.
> - Adds a test in [test_reexport_alias_star_warrants.py](https://github.com/TSavo/sugar/pull/6901/files#diff-2a4c0b7275c1bf7d3be5bf3269497bedc91adc368e4dd832207fd501feadb4f2) that verifies the exitset contains an exact `ClassDefinitionValue` with expected field names.
> - Risk: `_module_prefix_outcome` raises `ValueError` on source CID mismatch, which is a new hard failure mode for mismatched module authentication.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ee6400.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for executing module prefixes while preserving exact class-definition bindings.
  - Class definitions can now be correctly authenticated and rebound by their precise names during prefix processing.
  - Improved handling of class bases that reference earlier module-level classes.

- **Bug Fixes**
  - Added validation and clear errors for unsupported decorated or improperly constructed class definitions.

- **Tests**
  - Added coverage confirming class definitions are bound exactly once with their expected fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->