### PR TITLE
feat(python): authenticate module metaclass publication

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/decorated_class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/decorated_class_value.py
@@ -10,6 +10,7 @@ from .floor_value import FloorValue
 _APPLICATION_AUTHORITY = object()
 _PUBLICATION_AUTHORITY = object()
 _MEMBER_AUTHORITY = object()
+_METACLASS_AUTHORITY = object()
 
 
 def _floor_cid(value: FloorValue) -> str:
@@ -247,6 +248,181 @@ class DecoratedClassValue(FloorValue):
 
             return Complete(TrueBoolLiteralSugar(site=site))
         return super().test_python_type(value, site)
+
+
+@dataclass(frozen=True, init=False)
+class MetaclassClassPublicationV1:
+    """One exact metaclass application during module class publication."""
+
+    source_cid: str
+    definition: object
+    binding_occurrence: object
+    metaclass_occurrence: object
+    raw_class: FloorValue = field(compare=False)
+    metaclass_floor: FloorValue = field(compare=False)
+    metaclass_callable: FloorValue = field(compare=False)
+    class_name_floor: FloorValue = field(compare=False)
+    bases_floor: FloorValue = field(compare=False)
+    namespace_floor: FloorValue = field(compare=False)
+    final_class: FloorValue = field(compare=False)
+    module_construction_receipt_cid: str
+    application_cid: str
+    publication_cid: str
+    _authority: object = field(default=None, init=False, compare=False, repr=False)
+
+    def __post_init__(self):
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+        )
+        from sugar_lift_py_tests.floor.class_definition_value import (
+            ClassDefinitionValue,
+        )
+
+        if self._authority is not _METACLASS_AUTHORITY:
+            raise ValueError("metaclass class publication is not producer-minted")
+        if (
+            type(self.definition) is not SourceFragmentCoordinateV1
+            or type(self.binding_occurrence) is not SourceFragmentCoordinateV1
+            or type(self.metaclass_occurrence) is not SourceFragmentCoordinateV1
+            or self.definition.source_cid != self.source_cid
+            or self.binding_occurrence.source_cid != self.source_cid
+            or self.metaclass_occurrence.source_cid != self.source_cid
+            or type(self.raw_class) is not ClassDefinitionValue
+            or self.raw_class.binding_target_occurrence != self.binding_occurrence
+        ):
+            raise ValueError("metaclass class publication coordinate mismatch")
+        application_cid, publication_cid = _metaclass_publication_cids(
+            source_cid=self.source_cid,
+            definition=self.definition,
+            binding_occurrence=self.binding_occurrence,
+            metaclass_occurrence=self.metaclass_occurrence,
+            raw_class=self.raw_class,
+            metaclass_floor=self.metaclass_floor,
+            metaclass_callable=self.metaclass_callable,
+            class_name_floor=self.class_name_floor,
+            bases_floor=self.bases_floor,
+            namespace_floor=self.namespace_floor,
+            final_class=self.final_class,
+            module_construction_receipt_cid=self.module_construction_receipt_cid,
+        )
+        if (
+            self.application_cid != application_cid
+            or self.publication_cid != publication_cid
+        ):
+            raise ValueError("metaclass class publication CID mismatch")
+
+
+def _metaclass_publication_cids(
+    *,
+    source_cid,
+    definition,
+    binding_occurrence,
+    metaclass_occurrence,
+    raw_class,
+    metaclass_floor,
+    metaclass_callable,
+    class_name_floor,
+    bases_floor,
+    namespace_floor,
+    final_class,
+    module_construction_receipt_cid,
+):
+    application_cid = cid_of_json(
+        {
+            "kind": "metaclass-class-application",
+            "schemaVersion": "1",
+            "occurrence": metaclass_occurrence.wire(),
+            "metaclassFloorCid": _floor_cid(metaclass_floor),
+            "metaclassCallableCid": _floor_cid(metaclass_callable),
+            "actualFloorCids": [
+                _floor_cid(metaclass_floor),
+                _floor_cid(class_name_floor),
+                _floor_cid(bases_floor),
+                _floor_cid(namespace_floor),
+            ],
+            "resultFloorCid": _floor_cid(final_class),
+        }
+    )
+    publication_cid = cid_of_json(
+        {
+            "kind": "metaclass-class-publication",
+            "schemaVersion": "1",
+            "sourceCid": source_cid,
+            "definition": definition.wire(),
+            "bindingOccurrence": binding_occurrence.wire(),
+            "rawClassCid": _floor_cid(raw_class),
+            "applicationCid": application_cid,
+            "moduleConstructionReceiptCid": module_construction_receipt_cid,
+        }
+    )
+    return application_cid, publication_cid
+
+
+def _mint_metaclass_class_publication(
+    *,
+    source_cid,
+    definition,
+    binding_occurrence,
+    metaclass_occurrence,
+    raw_class,
+    metaclass_floor,
+    metaclass_callable,
+    class_name_floor,
+    bases_floor,
+    namespace_floor,
+    final_class,
+    module_construction_receipt_cid,
+):
+    application_cid, publication_cid = _metaclass_publication_cids(
+        source_cid=source_cid,
+        definition=definition,
+        binding_occurrence=binding_occurrence,
+        metaclass_occurrence=metaclass_occurrence,
+        raw_class=raw_class,
+        metaclass_floor=metaclass_floor,
+        metaclass_callable=metaclass_callable,
+        class_name_floor=class_name_floor,
+        bases_floor=bases_floor,
+        namespace_floor=namespace_floor,
+        final_class=final_class,
+        module_construction_receipt_cid=module_construction_receipt_cid,
+    )
+    value = object.__new__(MetaclassClassPublicationV1)
+    for name, field_value in (
+        ("source_cid", source_cid),
+        ("definition", definition),
+        ("binding_occurrence", binding_occurrence),
+        ("metaclass_occurrence", metaclass_occurrence),
+        ("raw_class", raw_class),
+        ("metaclass_floor", metaclass_floor),
+        ("metaclass_callable", metaclass_callable),
+        ("class_name_floor", class_name_floor),
+        ("bases_floor", bases_floor),
+        ("namespace_floor", namespace_floor),
+        ("final_class", final_class),
+        ("module_construction_receipt_cid", module_construction_receipt_cid),
+        ("application_cid", application_cid),
+        ("publication_cid", publication_cid),
+    ):
+        object.__setattr__(value, name, field_value)
+    object.__setattr__(value, "_authority", _METACLASS_AUTHORITY)
+    value.__post_init__()
+    return value
+
+
+@dataclass(frozen=True)
+class MetaclassClassValue(FloorValue):
+    publication: MetaclassClassPublicationV1
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:metaclass_class_publication",
+            [str_const(self.publication.publication_cid)],
+            symbol_kind="coordinate",
+        )
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -68,7 +68,7 @@ class ImportValueUseSeatingGap(ValueError):
 class _ModuleSourceFrameCallableV1(FloorValue):
     """Exact module FunctionDef callable used during definition execution."""
 
-    definition: FunctionDef
+    callable_name: str
     frame: object
 
     def to_term(self, *, owner):
@@ -97,15 +97,15 @@ class _ModuleSourceFrameCallableV1(FloorValue):
             )
         bound = self.frame.bind_actuals(operation.arguments, (), ctx)
         call = CallSiteValue(
-            self.definition.name,
+            self.callable_name,
             bound.actuals,
             self.frame.parameters,
             ctor(
                 "call:module-source-frame",
                 [
-                    self.to_term(owner=self.definition.name),
+                    self.to_term(owner=self.callable_name),
                     *(
-                        item.to_term(owner=self.definition.name)
+                        item.to_term(owner=self.callable_name)
                         for item in bound.actuals
                     ),
                 ],
@@ -162,7 +162,8 @@ class _ModuleFunctionDefinitionBindingSugar:
             ScopeRebind(
                 self.definition.name,
                 _ModuleSourceFrameCallableV1(
-                    self.definition, self.definition.source_visible_call_frame()
+                    self.definition.name,
+                    self.definition.source_visible_call_frame(),
                 ),
             )
         )
@@ -188,7 +189,10 @@ class _ModuleClassDefinitionBindingSugar:
             DecoratedClassPublicationV1,
             DecoratedClassValue,
             DecoratorApplicationPublicationV1,
+            MetaclassClassValue,
+            _mint_metaclass_class_publication,
         )
+        from sugar_lift_py_tests.floor import DictValue, StringValue, TupleValue
         from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind
         from sugar_lift_py_tests.outcome import Complete
         from sugar_source_tree.panic import SugarNotWritten
@@ -204,6 +208,108 @@ class _ModuleClassDefinitionBindingSugar:
                     observed=f"ClassDef constructed {type(value).__name__}",
                     requested="one exact ClassDefinitionValue",
                     fix="keep nonlinear or substituted class construction loud",
+                )
+            metaclass_keywords = tuple(
+                keyword
+                for keyword in self.definition.keywords
+                if keyword.arg == "metaclass"
+            )
+            if len(metaclass_keywords) > 1:
+                raise SugarNotWritten(
+                    owner="module definition execution",
+                    blame=self.definition.fragment,
+                    observed="multiple metaclass keyword occurrences",
+                    requested="one exact metaclass application",
+                    fix="preserve the parser-owned class keyword roster",
+                )
+            if metaclass_keywords:
+                if sugar.decorator_sugars:
+                    raise SugarNotWritten(
+                        owner="module definition execution",
+                        blame=self.definition.fragment,
+                        observed="combined metaclass and decorator publication",
+                        requested="one ordered metaclass-then-decorator publication",
+                        fix="compose both authenticated application products",
+                    )
+                keyword = metaclass_keywords[0]
+                metaclass_outcome = keyword.value.sugar().desugar(ctx)
+                if not isinstance(metaclass_outcome, Complete) or type(
+                    metaclass_outcome.value
+                ) is not ClassDefinitionValue:
+                    raise SugarNotWritten(
+                        owner="module definition execution",
+                        blame=keyword.value.fragment,
+                        observed="metaclass expression did not construct a source class",
+                        requested="one exact ClassDefinitionValue metaclass",
+                        fix="retain the metaclass binding and source definition",
+                    )
+                metaclass_floor = metaclass_outcome.value
+                constructors = tuple(
+                    method
+                    for method in metaclass_floor.methods
+                    if method.name == "__new__"
+                )
+                if len(constructors) != 1:
+                    raise SugarNotWritten(
+                        owner="module definition execution",
+                        blame=keyword.value.fragment,
+                        observed=f"metaclass has {len(constructors)} __new__ methods",
+                        requested="one exact source-visible metaclass constructor",
+                        fix="preserve unique method-definition testimony",
+                    )
+                constructor = constructors[0]
+                callable_floor = _ModuleSourceFrameCallableV1(
+                    constructor.name, constructor.source_call_frame
+                )
+                class_name_floor = StringValue(self.definition.name)
+                bases_floor = TupleValue(tuple(value.base_classes))
+                namespace_floor = DictValue(
+                    tuple(
+                        (StringValue(field.name), field.value)
+                        for field in value.class_fields
+                    )
+                )
+                occurrence = _call_coordinate(keyword.value)
+                applied = CallableApplication(
+                    (
+                        metaclass_floor,
+                        class_name_floor,
+                        bases_floor,
+                        namespace_floor,
+                    ),
+                    (),
+                    occurrence,
+                    owner="module metaclass application",
+                    call_occurrence=occurrence,
+                ).apply(callable_floor, ctx)
+                if not isinstance(applied, Complete):
+                    raise SugarNotWritten(
+                        owner="module definition execution",
+                        blame=keyword.value.fragment,
+                        observed="metaclass application reduced nonlinearly",
+                        requested="one completed published class Floor",
+                        fix="sequence metaclass effects before module publication",
+                    )
+                publication = _mint_metaclass_class_publication(
+                    source_cid=self.definition.unit.source_cid,
+                    definition=_call_coordinate(self.definition),
+                    binding_occurrence=sugar.binding_target_occurrence,
+                    metaclass_occurrence=occurrence,
+                    raw_class=value,
+                    metaclass_floor=metaclass_floor,
+                    metaclass_callable=callable_floor,
+                    class_name_floor=class_name_floor,
+                    bases_floor=bases_floor,
+                    namespace_floor=namespace_floor,
+                    final_class=applied.value,
+                    module_construction_receipt_cid=(
+                        self.module_construction_receipt_cid
+                    ),
+                )
+                return Complete(
+                    ScopeRebind(
+                        self.definition.name, MetaclassClassValue(publication)
+                    )
                 )
             if not sugar.decorator_sugars:
                 return Complete(ScopeRebind(self.definition.name, value))

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -532,6 +532,58 @@ def test_module_prefix_execution_publishes_exact_decorator_result(
     )
 
 
+def test_module_prefix_execution_publishes_exact_metaclass_result(
+    tmp_path: Path,
+) -> None:
+    """Metaclass application retains its four exact source-owned actuals."""
+    from sugar_lift_py_tests.floor import DictValue, StringValue
+    from sugar_lift_py_tests.floor.decorated_class_value import MetaclassClassValue
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source import manager_construction
+
+    source = (
+        "class Meta:\n"
+        "    def __new__(metacls, name, bases, namespace):\n"
+        "        return namespace\n"
+        "class Published(metaclass=Meta):\n"
+        "    TOKEN = 7\n"
+        "def build():\n"
+        "    return Published\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="module-metaclass-prefix-pkg",
+        files={"module_metaclass_prefix_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "module_metaclass_prefix_pkg"
+    ]
+
+    exits = manager_construction._module_prefix_outcome(
+        module, ast.parse(source).body[-1]
+    )
+
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    published = completed.value.context.temporal.value_if_bound("Published")
+    assert type(published) is MetaclassClassValue
+    publication = published.publication
+    assert publication.metaclass_floor is (
+        completed.value.context.temporal.value_if_bound("Meta")
+    )
+    assert type(publication.namespace_floor) is DictValue
+    assert publication.final_class is publication.namespace_floor
+    assert tuple(
+        key.value
+        for key, _value in publication.namespace_floor.entries
+        if type(key) is StringValue
+    ) == ("TOKEN",)
+    assert publication.raw_class.binding_target_occurrence == (
+        publication.binding_occurrence
+    )
+
+
 def test_prefix_adapter_propagates_missing_construction_producer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
R_module_metaclass_publication: 1 -> 0

Adds a private-minted MetaclassClassPublicationV1 sealing exact definition/binding/metaclass occurrence, raw class, metaclass and __new__ callable, four source-owned actual Floors, backend construction receipt, and final result. Module execution applies the exact source frame once and binds MetaclassClassValue.

Focused receipt (CPython 3.12.13): 3 passed
- undecorated class identity/field roster
- decorator application/publication identity
- metaclass actual roster/final namespace identity

Epsilon: establishes explicit metaclass execution. Next exact residual is inherited metaclass transport and EnumType.__new__ body coverage.
Floors: private mint, no name/vendor/host inference, combined metaclass+decorator stays loud.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add metaclass module publication with authority authentication to Python sugar lift
> - Introduces `MetaclassClassPublicationV1`, a frozen dataclass in [decorated_class_value.py](https://github.com/TSavo/sugar/pull/6903/files#diff-092894e1d0a6313a4952d3c0dc2eb9271383bb35919fbfd663f5290161e82e63) that stores the inputs and result of a metaclass application and validates an internal authority token at construction.
> - Adds `_mint_metaclass_class_publication` as the sole authorized factory for producing authenticated `MetaclassClassPublicationV1` instances, bypassing `__init__` to set fields before invoking `__post_init__` validation.
> - Extends `_ModuleClassDefinitionBindingSugar` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6903/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to detect and apply a `metaclass` keyword on `ClassDef`, applying the metaclass via a four-actual call site and minting a publication before any decorator handling.
> - `MetaclassClassValue` wraps the publication and serializes to a `python:metaclass_class_publication` IR term keyed by the publication CID.
> - Behavioral Change: classes using a `metaclass` keyword now go through a new publication path; combining metaclass and decorators in the same definition raises a `SugarNotWritten` error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 683bb3f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->