### PR TITLE
feat(python): share imported decorator enrollment in module execution

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field, replace as _replace
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    Sugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
@@ -200,7 +204,7 @@ class SpreadDictSugar(Sugar):
 
 
 @dataclass(frozen=True)
-class SpreadCallSugar(Sugar):
+class SpreadCallSugar(ConstructedTermSugar):
     """A call containing ``*``/``**``, using the reference call vocabulary.
 
     When an authenticated source-visible callee frame is enrolled (class
@@ -224,6 +228,31 @@ class SpreadCallSugar(Sugar):
             truthful="tuple(z)",
             lying="tuple((*z, 0))",
         )
+
+    def to_term(self, *, owner: str):
+        """Project the same call coordinate used by completed spread reduction."""
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        if self.callee_name is not None:
+            callee_term = str_const(self.callee_name)
+        else:
+            callee = require_constructed_term_sugar(
+                self.callee, owner="SpreadCallSugar.callee"
+            )
+            callee_term = callee.to_term(owner=owner)
+        arg_terms = []
+        for role, name, sugar in self.arguments:
+            term = require_constructed_term_sugar(
+                sugar, owner="SpreadCallSugar.arguments"
+            ).to_term(owner=owner)
+            if role == "star":
+                term = ctor("python:starred_arg", [term])
+            elif role == "double-star":
+                term = ctor("python:double_starred_kwarg", [term])
+            elif role == "keyword":
+                term = ctor("python:kwarg", [str_const(name), term])
+            arg_terms.append(term)
+        return ctor("python:call", [callee_term, *arg_terms])
 
     def desugar(self, ctx: object = None) -> Outcome:
         def after_callee(callee_value):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -336,6 +336,17 @@ class _ModuleClassDefinitionBindingSugar:
                     )
                 )
             ):
+                from sugar_lift_py_tests.floor import CallSiteValue
+
+                if (
+                    type(callable_floor) is CallSiteValue
+                    and callable_floor.body is not None
+                    and callable_floor.source_call_frame_cid is not None
+                ):
+                    callable_floor = callable_floor.force_floor(
+                        ctx,
+                        owner="module authenticated decorator factory return",
+                    )
                 before = current
                 applied = CallableApplication(
                     (before,),
@@ -379,7 +390,91 @@ class _ModuleClassDefinitionBindingSugar:
         return outcome.and_then(bind)
 
 
-def _module_prefix_outcome(module, locus):
+def _enroll_imported_decorator_frames(
+    *, module, definition, context, session, dependency_graphs
+) -> None:
+    """Seat exact imported Attribute decorator factories before Sugar caching."""
+    from pathlib import Path
+
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+    from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+    from sugar_source_tree.panic import BackendDefect
+
+    decorator_receipts, _ = authenticated_import_use_receipts(
+        Path("."),
+        Path(module.source_seat),
+        module.source,
+        module.source_cid,
+        module_identities={},
+    )
+    receipts_by_span = {}
+    for receipt in decorator_receipts:
+        receipt_span = (
+            receipt.use["useSite"]["startLine"],
+            receipt.use["useSite"]["startCol"],
+            receipt.use["useSite"]["endLine"],
+            receipt.use["useSite"]["endCol"],
+        )
+        if receipt_span in receipts_by_span:
+            raise BackendDefect(
+                blame=definition.fragment,
+                owner="manager_construction imported decorator enrollment",
+                observed="duplicate authenticated call receipt span",
+                requested="one exact call receipt per decorator occurrence",
+                fix="repair lexical call receipt enrollment uniqueness",
+            )
+        receipts_by_span[receipt_span] = receipt
+    for decorator in definition.decorators:
+        if not isinstance(decorator, Call) or not isinstance(
+            decorator.func, Attribute
+        ):
+            continue
+        span = decorator.line_col_span()
+        receipt = receipts_by_span.get(
+            (span.start_line, span.start_col, span.end_line, span.end_col)
+        )
+        if receipt is None:
+            continue
+        receipt.revalidate()
+        top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
+        graph = dependency_graphs.get(top_level)
+        if graph is None:
+            from .dependency_artifact import authenticate_dependency_top_level
+
+            graph = authenticate_dependency_top_level(top_level)
+            dependency_graphs[top_level] = graph
+        resolved_decorator = resolve_import_binding(
+            receipt, graph=graph, session=session
+        )
+        if not isinstance(resolved_decorator, ResolvedPythonObjectV1):
+            continue
+        projected_decorator = resolve_source_visible_frame(
+            resolved_decorator, graph=graph, session=session
+        )
+        if isinstance(projected_decorator, ManagerConstructionGapV1):
+            continue
+        decorator_frame, decorator_target = projected_decorator
+        if not isinstance(decorator_target, FunctionDef):
+            continue
+        if any(keyword.arg is None for keyword in decorator.keywords):
+            raise SourceCallBindingGap(
+                "decorator spread keyword requires typed variadic projection"
+            )
+        try:
+            decorator_frame = decorator_frame.bind_node_actuals(
+                decorator.args,
+                tuple(
+                    (keyword.arg, keyword.value)
+                    for keyword in decorator.keywords
+                    if keyword.arg is not None
+                ),
+            )
+        except SourceCallBindingGap:
+            continue
+        _install_source_call_frame(context, decorator, decorator_frame)
+
+
+def _module_prefix_outcome(module, locus, *, graph=None, session=None):
     """Execute the authenticated module prefix through its exact definitions."""
     from sugar_lift_py_tests.sugar.function_universe_sugar import (
         reduce_block_to_exitset,
@@ -431,6 +526,27 @@ def _module_prefix_outcome(module, locus):
         definition.unit.construction_context.source_class_bases[
             definition.fragment.seal().cid
         ] = tuple(bases)
+
+    dependency_graphs = {}
+    if graph is not None:
+        session = session_or_new(session)
+        dependency_graphs[module.module_name.split(".", 1)[0]] = graph
+        for definition in prefix_classes:
+            _seat_import_value_use_receipts(
+                source_file=source_file,
+                module=module,
+                target=definition,
+                session=session,
+                context=construction_context,
+                dependency_graphs=dependency_graphs,
+            )
+            _enroll_imported_decorator_frames(
+                module=module,
+                definition=definition,
+                context=construction_context,
+                session=session,
+                dependency_graphs=dependency_graphs,
+            )
 
     sugars = tuple(
         (
@@ -2172,86 +2288,14 @@ def _construct_reachable_decorated_class_bindings(
             dependency_graphs=dependency_graphs,
         )
 
-    def enroll_imported_decorator_frames(definition: ClassDef) -> None:
-        from pathlib import Path
-        from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
-
-        decorator_receipts, _ = authenticated_import_use_receipts(
-            Path("."), Path(module.source_seat), module.source, module.source_cid,
-            module_identities={},
-        )
-        receipts_by_span = {}
-        for receipt in decorator_receipts:
-            receipt_span = (
-                receipt.use["useSite"]["startLine"],
-                receipt.use["useSite"]["startCol"],
-                receipt.use["useSite"]["endLine"],
-                receipt.use["useSite"]["endCol"],
-            )
-            if receipt_span in receipts_by_span:
-                from sugar_source_tree.panic import BackendDefect
-
-                raise BackendDefect(
-                    blame=definition.fragment,
-                    owner="manager_construction imported decorator enrollment",
-                    observed="duplicate authenticated call receipt span",
-                    requested="one exact call receipt per decorator occurrence",
-                    fix="repair lexical call receipt enrollment uniqueness",
-                )
-            receipts_by_span[receipt_span] = receipt
-        for decorator in definition.decorators:
-            if not isinstance(decorator, Call) or not isinstance(
-                decorator.func, Attribute
-            ):
-                continue
-            span = decorator.line_col_span()
-            receipt = receipts_by_span.get(
-                (span.start_line, span.start_col, span.end_line, span.end_col)
-            )
-            if receipt is None:
-                continue
-            receipt.revalidate()
-            top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
-            graph = dependency_graphs.get(top_level)
-            if graph is None:
-                from .dependency_artifact import authenticate_dependency_top_level
-
-                graph = authenticate_dependency_top_level(top_level)
-                dependency_graphs[top_level] = graph
-            resolved_decorator = resolve_import_binding(
-                receipt, graph=graph, session=session
-            )
-            if not isinstance(resolved_decorator, ResolvedPythonObjectV1):
-                continue
-            projected_decorator = resolve_source_visible_frame(
-                resolved_decorator, graph=graph, session=session
-            )
-            if isinstance(projected_decorator, ManagerConstructionGapV1):
-                continue
-            decorator_frame, decorator_target = projected_decorator
-            if not isinstance(decorator_target, FunctionDef):
-                continue
-            from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
-
-            if any(keyword.arg is None for keyword in decorator.keywords):
-                raise SourceCallBindingGap(
-                    "decorator spread keyword requires typed variadic projection"
-                )
-            try:
-                decorator_frame = decorator_frame.bind_node_actuals(
-                    decorator.args,
-                    tuple(
-                        (keyword.arg, keyword.value)
-                        for keyword in decorator.keywords
-                        if keyword.arg is not None
-                    ),
-                )
-            except SourceCallBindingGap:
-                continue
-            _install_source_call_frame(context, decorator, decorator_frame)
-
     for definition in receipt_owned_classes:
-        enroll_imported_decorator_frames(definition)
+        _enroll_imported_decorator_frames(
+            module=module,
+            definition=definition,
+            context=context,
+            session=session,
+            dependency_graphs=dependency_graphs,
+        )
     for definition in module_definitions:
         if definition not in class_dependencies:
             continue

--- a/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
@@ -64,6 +64,21 @@ def test_spread_keyword_args_build_reference_method_call():
     assert spread.args[0].name == "d"
 
 
+def test_spread_call_is_a_constructed_method_argument_coordinate():
+    t = _out(
+        "def A(cls, values):\n"
+        "    value = str(*values)\n"
+        "    return str.__new__(cls, value)\n"
+    )
+
+    assert t.name == "call:__new__"
+    spread = t.args[2]
+    assert spread.name == "python:call"
+    assert spread.args[0].value == "str"
+    assert spread.args[1].name == "python:starred_arg"
+    assert spread.args[1].args[0].name == "values"
+
+
 if __name__ == "__main__":
     test_method_call_is_the_method_coordinate()
     test_method_chains_compose()


### PR DESCRIPTION
R_module_imported_decorator_enrollment: 1 -> 0
R_spread_call_term_carrier: 1 -> 0

Extracts the exact receipt-backed imported Attribute decorator frame enrollment owner and reuses it before module ClassDef construction. Promotes the existing SpreadCallSugar call coordinate to ConstructedTermSugar so source bodies such as str.__new__(cls, str(*values)) retain the spread call as a nested method actual.

Focused receipt (CPython 3.12.13): 4 passed
- three module-definition/publication producer tests
- spread call as exact MethodCallSugar argument

Epsilon: imported decorator source frames and spread-call term transport are now available to bounded module execution. The full stdlib prefix consumer remains intentionally disabled because naive replay currently exceeds the process boundary; next shot owns bounded sequencing.
Floors: duplicate receipt spans loud; **kwargs loud; no name/vendor/host fallback; no diagnostics.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share imported decorator enrollment across module prefix execution and class binding
> - Extracts the imported decorator frame enrollment logic into a shared `_enroll_imported_decorator_frames` helper in [manager_construction.py](https://github.com/TSavo/sugar/pull/6904/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1), replacing a previously inline-only helper in `_construct_reachable_decorated_class_bindings`.
> - Extends `_module_prefix_outcome` to accept a dependency graph and session; when provided, it authenticates import receipts and enrolls decorator frames for prefix classes before sugar reduction.
> - Adds `to_term` projection to `SpreadCallSugar` in [spread_sugar.py](https://github.com/TSavo/sugar/pull/6904/files#diff-462f912508b271ce479f5b6c3757a9e656e009ab945f3b9c632e8cb7bdfc4945), constructing a `python:call` term with support for starred, double-starred, and keyword arguments.
> - Fixes decorator application in `_ModuleClassDefinitionBindingSugar.desugar` to force-concretize call-site floor values before applying `CallableApplication`.
> - Risk: `SpreadCallSugar.to_term` and `_enroll_imported_decorator_frames` raise if callee or arguments are not `ConstructedTermSugar` instances or if spread keywords are encountered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa70191.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->