### PR TITLE
fix(python): enroll decorators at first class construction

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -181,6 +181,11 @@ class _ModuleClassDefinitionBindingSugar:
 
     definition: ClassDef
     module_construction_receipt_cid: str
+    source_file: object | None = field(default=None, compare=False)
+    module: object | None = field(default=None, compare=False)
+    session: object | None = field(default=None, compare=False)
+    construction_context: object | None = field(default=None, compare=False)
+    dependency_graphs: object | None = field(default=None, compare=False)
 
     def desugar(self, ctx=None):
         from sugar_lift_py_tests.floor import ClassDefinitionValue
@@ -197,6 +202,22 @@ class _ModuleClassDefinitionBindingSugar:
         from sugar_lift_py_tests.outcome import Complete
         from sugar_source_tree.panic import SugarNotWritten
 
+        if self.source_file is not None:
+            _seat_import_value_use_receipts(
+                source_file=self.source_file,
+                module=self.module,
+                target=self.definition,
+                session=self.session,
+                context=self.construction_context,
+                dependency_graphs=self.dependency_graphs,
+            )
+            _enroll_imported_decorator_frames(
+                module=self.module,
+                definition=self.definition,
+                context=self.construction_context,
+                session=self.session,
+                dependency_graphs=self.dependency_graphs,
+            )
         sugar = self.definition.sugar()
         outcome = sugar.desugar(ctx)
 
@@ -400,6 +421,13 @@ def _enroll_imported_decorator_frames(
     from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
     from sugar_source_tree.panic import BackendDefect
 
+    imported_factory_decorators = tuple(
+        decorator
+        for decorator in definition.decorators
+        if isinstance(decorator, Call) and isinstance(decorator.func, Attribute)
+    )
+    if not imported_factory_decorators:
+        return
     decorator_receipts, _ = authenticated_import_use_receipts(
         Path("."),
         Path(module.source_seat),
@@ -424,11 +452,7 @@ def _enroll_imported_decorator_frames(
                 fix="repair lexical call receipt enrollment uniqueness",
             )
         receipts_by_span[receipt_span] = receipt
-    for decorator in definition.decorators:
-        if not isinstance(decorator, Call) or not isinstance(
-            decorator.func, Attribute
-        ):
-            continue
+    for decorator in imported_factory_decorators:
         span = decorator.line_col_span()
         receipt = receipts_by_span.get(
             (span.start_line, span.start_col, span.end_line, span.end_col)
@@ -531,22 +555,6 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
     if graph is not None:
         session = session_or_new(session)
         dependency_graphs[module.module_name.split(".", 1)[0]] = graph
-        for definition in prefix_classes:
-            _seat_import_value_use_receipts(
-                source_file=source_file,
-                module=module,
-                target=definition,
-                session=session,
-                context=construction_context,
-                dependency_graphs=dependency_graphs,
-            )
-            _enroll_imported_decorator_frames(
-                module=module,
-                definition=definition,
-                context=construction_context,
-                session=session,
-                dependency_graphs=dependency_graphs,
-            )
 
     sugars = tuple(
         (
@@ -555,7 +563,13 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
             else InertSugar(site=statement.fragment)
             if isinstance(statement, AsyncFunctionDef)
             else _ModuleClassDefinitionBindingSugar(
-                statement, source_file.construction_event_receipt_cid
+                statement,
+                source_file.construction_event_receipt_cid,
+                source_file if graph is not None else None,
+                module if graph is not None else None,
+                session,
+                construction_context if graph is not None else None,
+                dependency_graphs if graph is not None else None,
             )
             if isinstance(statement, ClassDef)
             else statement.sugar()


### PR DESCRIPTION
## Instrument

`R_bodyless_imported_decorator=1`: authenticated enum `_simple_enum` remained bodyless because eager module-wide enrollment was not synchronized with the exact first class construction.

## Change

Seat exact class-owned import receipts and imported decorator frames inside the producer-owned class binding sugar immediately before its first `definition.sugar()` call. Classes without imported Attribute decorator factories do not scan the receipt roster. No cache invalidation, name/vendor arm, or fallback.

## Receipt

- CPython 3.12 focused module-prefix tests: `3 passed, 25 deselected`
- Direct authenticated enum producer advances past the bodyless decorator to a distinct loop completed-face roster defect.
- Predicted `Epsilon R_bodyless_imported_decorator=-1`; floors preserve exact receipt/source/span/frame authority.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enroll decorators during class construction instead of upfront in `_module_prefix_outcome`
> - Moves the calls to `_seat_import_value_use_receipts` and `_enroll_imported_decorator_frames` from `_module_prefix_outcome` into `_ModuleClassDefinitionBindingSugar.desugar()`, so decorator enrollment happens per-class at desugar time rather than in a single upfront pass.
> - Adds five optional fields (`source_file`, `module`, `session`, `construction_context`, `dependency_graphs`) to `_ModuleClassDefinitionBindingSugar` to carry the context needed for desugar-time enrollment.
> - Adds a pre-filter in `_enroll_imported_decorator_frames` that restricts processing to `Call(Attribute(...))` decorators and returns early when none are present.
> - Behavioral Change: decorator enrollment now occurs at first class construction rather than before any class is processed, which changes the ordering of side effects during module desugaring.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad572c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->