### PR TITLE
fix(python): conserve loop completed-face identity

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
@@ -572,6 +572,8 @@ def _root(raw: Any) -> dict[str, Any]:
             raise LoopWireError(f"{field} must be an array")
         for cid in raw[field]:
             _require_cid(cid, field)
+    if len(raw["completedFaceCids"]) != len(set(raw["completedFaceCids"])):
+        raise LoopWireError("duplicate completedFaceCids")
     _validate_seal(raw, "loopConstructionCid", "LoopConstructionV1")
     return raw
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_exit_partition_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_exit_partition_carrier.py
@@ -480,6 +480,41 @@ def test_the_real_wire_declares_two_exit_routes(tmp_path):
     decode_loop_construction_v1(graph)  # the real decoder accepts it
 
 
+def test_loop_else_that_preserves_carried_binding_enrolls_each_face_once(tmp_path):
+    """A no-op else must not duplicate its identical exhaustion face CID."""
+    source = """\
+def compute(items, seed):
+    carried = seed
+    for item in items:
+        carried = item
+        if item.done:
+            break
+    else:
+        pass
+    return carried
+"""
+
+    graph = None
+    from sugar_source_tree import loop_recurrence as module
+
+    original = module.project_loop_post_binding
+
+    def capture(*, construction, **kwargs):
+        nonlocal graph
+        graph = construction.wire_graph()
+        return original(construction=construction, **kwargs)
+
+    module.project_loop_post_binding = capture
+    try:
+        _desugar_all(_write(tmp_path, source))
+    finally:
+        module.project_loop_post_binding = original
+
+    assert graph is not None
+    face_cids = graph["root"]["completedFaceCids"]
+    assert len(face_cids) == len(set(face_cids))
+
+
 def _with_producer_records(tmp_path, rewrite):
     """Run the fixture with one rewrite applied to preimages BEFORE they seal.
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -682,7 +682,15 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
             "exhaustionExitObligationCid": exhaustion["exhaustionExitObligationCid"],
             "elseBodyCid": else_body_cid,
             "elseExhaustionObligationCid": else_obligation_cid,
-            "completedFaceCids": [face["completedFaceCid"] for face in face_records],
+            # A no-op loop ``else`` can seal to the SAME NormalExhaustion face
+            # as the pre-else exhaustion input.  The CID is the face identity;
+            # enrolling it twice would counterfeit a third route in the closed
+            # root roster even though the producer declared only break and
+            # exhaustion exits.  Conserve exact product identity in first
+            # construction order, just as the record store below does.
+            "completedFaceCids": list(
+                dict.fromkeys(face["completedFaceCid"] for face in face_records)
+            ),
             "outwardHaltedFaceCids": outward_face_cids,
             "postBindingObligationCids": post_records,
         },


### PR DESCRIPTION
## Instrument

`R_duplicate_loop_exit_face=1`: enum.py:304 sealed the same `NormalExhaustion` completed-face CID twice when its loop `else` preserved the carried binding. Projection then observed three roster entries against the producer-declared two-route family.

## Change

Conserve exact completed-face product identity in first construction order and make the closed decoder refuse duplicate `completedFaceCids`. No exit selection, guard factoring, or consumer-side deduplication.

## Receipt

- Red before: exact fixture raised `BindingStateWireGap`, declared 2 / retained 3.
- Green after: focused exact fixture `1 passed`.
- Neighbor run: `7 passed, 1 failed`; retained failure is the pre-existing multi-face `_seal_runtime_state` expectation, outside this producer roster seam.
- Direct authenticated enum producer advances to a new `ConstructedValueCategoryGap` at enum.py:292 AttributeAugAssignSugar.
- Predicted `Epsilon R_duplicate_loop_exit_face=-1`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate entries in `completedFaceCids` for loops with a no-op else
> - De-duplicates `completedFaceCids` in [`construct_live_loop_recurrence`](https://github.com/TSavo/sugar/pull/6906/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094) using `dict.fromkeys()` to preserve insertion order while dropping duplicates.
> - Duplicates occurred when a no-op else branch sealed to the same `NormalExhaustion` face as the loop body, causing the same CID to appear multiple times.
> - Adds a validation check in [`loop_construction.py`](https://github.com/TSavo/sugar/pull/6906/files#diff-82ae08e844ec0a3ad333125f7e4a0609af140be5e2413837fe63ad5a63de3bbc) that raises `LoopWireError` on decode if `completedFaceCids` contains duplicates.
> - Adds a regression test covering the no-op else case in [`test_loop_exit_partition_carrier.py`](https://github.com/TSavo/sugar/pull/6906/files#diff-25e0b71583cab3c158e2b837b617149bfba6c10c3b1e50901e3e21eada8b1e46).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12b1cd0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->