### PR TITLE
fix(python): authenticate operator projector testimony

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_value_v2_merkle.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_value_v2_merkle.py
@@ -127,6 +127,27 @@ class HonestCid:
         return cid_of_json(self.preimage)
 
 
+def test_producer_owned_binary_operator_projector_is_a_closed_leaf():
+    from sugar_source_tree.operators import Add, Sub
+
+    add = BS._cv2_leaf(Add.instance().project_inplace)
+    subtract = BS._cv2_leaf(Sub.instance().project_inplace)
+
+    assert add != subtract
+    assert add == {
+        "operatorProjector": {"operatorKind": "Add", "inplaceOperator": "iadd"}
+    }
+
+
+def test_arbitrary_bound_method_is_not_a_constructed_value_leaf():
+    class Arbitrary:
+        def project(self, left, right, site):
+            return left, right, site
+
+    with pytest.raises(ConstructedValueCategoryGap, match="builtins.method"):
+        _constructed_preimage((Arbitrary().project,))
+
+
 # ---------------------------------------------------------------------------
 # Domain separation and namespace disjointness
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import weakref
 from dataclasses import dataclass, fields, is_dataclass, replace
 from enum import Enum
+from types import MethodType
 from typing import TYPE_CHECKING, Any, Callable, NoReturn, TypeAlias
 
 from sugar_lift_python_source.canonical import cid_of_json
@@ -1084,6 +1085,25 @@ def _cv2_leaf(value: object) -> Any:
         return {"sourceFragment": value.seal().to_dict()}
     if isinstance(value, SourceMemento):
         return {"sourceMemento": value.to_dict()}
+    # AugAssign constructors retain the operator-owned double-dispatch method.
+    # This is not an arbitrary Python callable category: the sole admitted
+    # function is BinaryOperator.project_inplace bound to the exact registered
+    # singleton whose closed kind/in-place carrier names already define the
+    # operation.  Every other bound method remains an unclassified loud gap.
+    from sugar_source_tree.operators import BinaryOperator
+
+    if (
+        type(value) is MethodType
+        and value.__func__ is BinaryOperator.project_inplace
+        and isinstance(value.__self__, BinaryOperator)
+        and type(value.__self__).instance() is value.__self__
+    ):
+        return {
+            "operatorProjector": {
+                "operatorKind": value.__self__.kind,
+                "inplaceOperator": value.__self__.inplace_operator,
+            }
+        }
     from sugar_source_tree.nodes import Node
 
     if isinstance(value, Node):


### PR DESCRIPTION
## Instrument

`R_constructed_value_operator_projector=1`: enum.py:292 constructs `AttributeAugAssignSugar`, whose producer-owned `BinaryOperator.project_inplace` bound method had no closed ConstructedValueV2 category.

## Change

Admit only the exact `BinaryOperator.project_inplace` function bound to its registered singleton, encoding the operator kind and in-place carrier. Arbitrary bound methods remain `ConstructedValueCategoryGap`; there is no reflective callable fallback.

## Receipt

- Red before: truthful operator projector raised `ConstructedValueCategoryGap: builtins.method`.
- Green after: `2 passed, 29 deselected`; arbitrary method twin remains loud.
- Direct enum producer advances to a distinct unclassified CPython adapter handle at enum.py:293.
- Predicted `Epsilon R_constructed_value_operator_projector=-1`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate operator projector testimony by encoding `BinaryOperator.project_inplace` as a leaf in `_cv2_leaf`
> - In [`binding_state.py`](https://github.com/TSavo/sugar/pull/6907/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40), `_cv2_leaf` now recognizes bound methods where the underlying function is `BinaryOperator.project_inplace` and the bound instance is the registered singleton, encoding them as an `operatorProjector` leaf with `operatorKind` and `inplaceOperator` fields.
> - Arbitrary bound methods that don't match this pattern continue to raise `ConstructedValueCategoryGap`.
> - Tests in [`test_constructed_value_v2_merkle.py`](https://github.com/TSavo/sugar/pull/6907/files#diff-068882ce08054949e73197ec7a1a6220bc46b939728d16853b9c1a368557f722) verify that `Add` and `Sub` projectors produce distinct and correctly structured leaves, and that non-singleton bound methods are rejected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee5d282.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->