### PR TITLE
fix(python): retain callsite source definition authority

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -53,7 +53,7 @@ class CallSiteSugar(ConstructedTermSugar):
     )
     formal_function_sugar: Any = dataclass_field(default=None, compare=False)
     formal_coordinate_cids: tuple[str, ...] = dataclass_field(default=(), compare=False)
-    expected_definition_ref: object | None = dataclass_field(default=None, compare=False)
+    expected_definition: object | None = dataclass_field(default=None, compare=False)
     native_operation_formal_coordinates: tuple = dataclass_field(default=(), compare=False)
     call_occurrence: SourceFragmentCoordinateV1 | None = dataclass_field(
         default=None, compare=False
@@ -175,9 +175,9 @@ class CallSiteSugar(ConstructedTermSugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        if self.source_call_frame is not None and self.expected_definition_ref is not None:
+        if self.source_call_frame is not None and self.expected_definition is not None:
             from sugar_source_tree.panic import SugarNotWritten
-            if self.source_call_frame.owner.ref is not self.expected_definition_ref:
+            if self.source_call_frame.owner.ref is not self.expected_definition.ref:
                 raise SugarNotWritten(
                     owner="CallSiteSugar.desugar",
                     blame=self.site,

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_value_v2_merkle.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_value_v2_merkle.py
@@ -148,6 +148,27 @@ def test_arbitrary_bound_method_is_not_a_constructed_value_leaf():
         _constructed_preimage((Arbitrary().project,))
 
 
+def test_callsite_definition_authority_is_a_source_node_not_backend_handle(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.nodes import Call
+    from sugar_source_tree.tree import SourceFile
+
+    path = tmp_path / "calls.py"
+    path.write_text(
+        "def helper(value):\n"
+        "    return value\n\n"
+        "def caller(value):\n"
+        "    return helper(value)\n"
+    )
+    source = SourceFile(path_source(str(path)))
+    helper, caller = source.functions()
+    (call,) = tuple(node for node in caller.walk() if isinstance(node, Call))
+    sugar = call.sugar()
+
+    assert sugar.expected_definition is helper
+    _constructed_preimage(sugar)
+
+
 # ---------------------------------------------------------------------------
 # Domain separation and namespace disjointness
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -9875,9 +9875,7 @@ class Call(Expression):
                 source_call_frame=source_call_frame,
                 formal_function_sugar=formal_function_sugar,
                 formal_coordinate_cids=formal_coordinate_cids,
-                expected_definition_ref=(
-                    None if function_definition is None else function_definition.ref
-                ),
+                expected_definition=function_definition,
                 native_operation_formal_coordinates=tuple(formal_coordinates),
             )
         if isinstance(self.func, Attribute):


### PR DESCRIPTION
## Instrument

`R_callsite_backend_handle_authority=1`: local source-call `CallSiteSugar` retained the CPython adapter `_Handle` as `expected_definition_ref`, leaking backend identity into ConstructedValueV2.

## Change

Retain the exact source-tree `FunctionDef` node as definition authority and compare its adapter ref only at frame-owner validation. Node construction testimony now authenticates the callsite without admitting backend handles as a generic value category.

## Receipt

- Red before: source call lacked `expected_definition` and enum.py:293 failed on `_Handle`.
- Green after: exact source-node authority test `1 passed`.
- Direct enum producer advances to a distinct sealed reducer pre-effect-state category.
- Predicted `Epsilon R_callsite_backend_handle_authority=-1`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retain source definition object in `CallSiteSugar` instead of a bare ref
> Replaces the `expected_definition_ref` field on `CallSiteSugar` with `expected_definition`, which holds the full source `function_definition` object. The `.ref` attribute is accessed internally where needed. A new test asserts that `sugar.expected_definition` is the source node, not a backend handle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2997121.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->