### PR TITLE
fix(python): exclude live frames from value testimony

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -45,7 +45,15 @@ class CallSiteSugar(ConstructedTermSugar):
     contract_resolution_gap: str | None = dataclass_field(default=None, compare=False)
     exception_type_coordinate: Any = dataclass_field(default=None, compare=False)
     exception_type_mro: tuple | None = dataclass_field(default=None, compare=False)
-    source_call_frame: Any = dataclass_field(default=None, compare=False)
+    # Live reducer/frame machinery is an execution handle, not constructed
+    # semantic content. Stable frame/call/contract coordinates below carry the
+    # authenticated construction authority; serializing this object would walk
+    # private reducer continuations and invent identities for closures.
+    source_call_frame: Any = dataclass_field(
+        default=None,
+        compare=False,
+        metadata={"constructed_value": False},
+    )
     source_call_frame_table: Any = dataclass_field(default=None, compare=False)
     source_call_frame_coordinate: Any = dataclass_field(default=None, compare=False)
     expected_source_call_frame_owner: Any = dataclass_field(

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_value_v2_merkle.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_value_v2_merkle.py
@@ -33,7 +33,7 @@ These twins pin what the form must NOT lose and must NOT merge:
   * V1 and V2 never share an identity namespace.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum, IntEnum
 
 import pytest
@@ -167,6 +167,18 @@ def test_callsite_definition_authority_is_a_source_node_not_backend_handle(tmp_p
 
     assert sugar.expected_definition is helper
     _constructed_preimage(sugar)
+
+
+def test_explicit_execution_handle_field_is_not_constructed_value_content():
+    @dataclass(frozen=True)
+    class WithExecutionHandle:
+        meaning: str
+        continuation: object = field(metadata={"constructed_value": False})
+
+    left = _constructed_preimage(WithExecutionHandle("same", lambda: "left"))
+    right = _constructed_preimage(WithExecutionHandle("same", lambda: "right"))
+
+    assert left == right
 
 
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1149,7 +1149,11 @@ def _cv2_entries(value: object) -> tuple[str, list[tuple[Any, object]]]:
         if params is not None and params.frozen:
             return (
                 _cv2_type_tag(value),
-                [(field.name, getattr(value, field.name)) for field in fields(value)],
+                [
+                    (field.name, getattr(value, field.name))
+                    for field in fields(value)
+                    if field.metadata.get("constructed_value", True)
+                ],
             )
         raise ConstructedValueCategoryGap(
             f"{_cv2_type_tag(value)} is a MUTABLE dataclass: its content can "


### PR DESCRIPTION
## Instrument

`R_live_frame_closure_canonicalization=1`: ConstructedValueV2 walked `CallSiteSugar.source_call_frame` and reached reducer continuation closures, which have no lawful content identity.

## Change

Add an explicit per-dataclass-field ConstructedValue exclusion membrane and mark only the live `source_call_frame` execution handle excluded. Stable call occurrence, contract, formal and source-definition authority remain constructed content. No callable/closure category or reflective fallback.

## Receipt

- Red trace named six reducer closure functions under the source frame.
- Green focused: `2 passed, 31 deselected`; two distinct excluded lambdas produce the same semantic content.
- Direct enum producer advances to a separate typed boolean truth refusal at enum.py:84.
- Predicted `Epsilon R_live_frame_closure_canonicalization=-1`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude dataclass fields marked `constructed_value=False` from ConstructedValueV2 preimage
> - [`_cv2_entries`](https://github.com/TSavo/sugar/pull/6909/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40) now filters out dataclass fields whose `metadata["constructed_value"]` is `False` when building the semantic preimage, so those fields don't affect CID or equality.
> - [`CallSiteSugar.source_call_frame`](https://github.com/TSavo/sugar/pull/6909/files#diff-d7d594636ed207e69db76dd7b89c48760b0d3de93da23981143b3c45da88a3c7) is annotated with `{"constructed_value": False}` so live execution frames don't influence constructed value identity.
> - A new test in [`test_constructed_value_v2_merkle.py`](https://github.com/TSavo/sugar/pull/6909/files#diff-068882ce08054949e73197ec7a1a6220bc46b939728d16853b9c1a368557f722) verifies that two instances differing only in an excluded field produce equal `_constructed_preimage` results.
> - Behavioral Change: any dataclass field with `metadata["constructed_value"] = False` is now silently dropped from the preimage; existing dataclasses without this annotation are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6620268.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->