### PR TITLE
fix(python): route methods through floor dispatch

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/method_call_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/method_call_operation.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MethodCallOperation:
+    """Exact receiver-owned method dispatch request.
+
+    The sugar owns evaluation order and supplies already-reduced positional
+    values.  The receiver Floor owns whether that method is foldable, symbolic,
+    or loud; this product carries no spelling-derived return semantics.
+    """
+
+    name: str
+    arguments: tuple[object, ...]
+    owner: str
+    blame: object
+
+    method_name = "call_method_with"
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise TypeError("MethodCallOperation requires a method name")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
@@ -184,6 +184,20 @@ class MethodCallSugar(ConstructedTermSugar):
                 requested="authenticated constructed receiver matching the method frame",
                 fix="preserve receiver identity or keep authenticated dispatch loud",
             )
+        if not kw_values:
+            from sugar_lift_py_tests.operations.method_call_operation import (
+                MethodCallOperation,
+            )
+
+            return receiver.call_method_with(
+                MethodCallOperation(
+                    name=self.name,
+                    arguments=positional,
+                    owner="MethodCallSugar",
+                    blame=self.site,
+                ),
+                ctx,
+            )
         from sugar_lift_py_tests.floor import CallSiteValue
         from sugar_lift_py_tests.ir import ctor, str_const
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_method_call_operation_dispatch.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_method_call_operation_dispatch.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.floor import SymbolicValue
+from sugar_lift_py_tests.floor.opaque_op_callsite import OpaqueOpCallsite
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+
+
+@dataclass(frozen=True)
+class _FloorSugar(ConstructedTermSugar):
+    value: object
+    site: object = field(compare=False)
+
+    def desugar(self, ctx=None):
+        return Complete(self.value)
+
+    def to_term(self, *, owner: str):
+        return self.value.to_term(owner=owner)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+
+def test_symbolic_string_compatible_method_uses_floor_owned_dispatch():
+    receiver = SymbolicValue(make_var("name"))
+    pattern = SymbolicValue(make_var("pattern"))
+    sugar = MethodCallSugar(
+        _FloorSugar(receiver, "receiver"),
+        "startswith",
+        (_FloorSugar(pattern, "pattern"),),
+        "call-site",
+    )
+
+    outcome = sugar.desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, OpaqueOpCallsite)
+    assert outcome.value.callee == "startswith"
+    assert outcome.value.arg is receiver
+    assert outcome.value.extra_args == (pattern,)
+    assert isinstance(outcome.value.truth("truth-site"), Complete)


### PR DESCRIPTION
## Instrument

`R_symbolic_method_truth=1`: enum.py `_is_private` produced a bodyless `CallSiteValue` for `name.startswith(pattern)`, so BoolOp truth remained undecided despite the receiver Floor owning symbolic method projection.

## Change

Add the closed `MethodCallOperation` product and route evaluated positional method calls through `receiver.call_method_with`. The receiver remains sole owner of folding, symbolic coordinates, or loud refusal. Keyword calls retain the existing path; there is no `startswith` or enum special case.

## Receipt

- Red before: exact symbolic method test returned bodyless `CallSiteValue`.
- Green after: `3 passed, 19 deselected`; result is receiver-owned `OpaqueOpCallsite` and its existing truth predicate.
- Direct enum producer advances to an undischarged formal subscript demand at enum.py:86.
- Predicted `Epsilon R_symbolic_method_truth=-1`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route Python method calls through floor dispatch via `MethodCallOperation`
> - Adds a `MethodCallOperation` frozen dataclass in [method_call_operation.py](https://github.com/TSavo/sugar/pull/6910/files#diff-e9d4504efafc27afaa834686ba430c5b00a3faa98d2ba6b1a271d5b2fbeb5f5d) to represent a receiver-owned method dispatch request, with validation that `name` is non-empty.
> - Updates `MethodCallSugar.desugar` in [method_call_sugar.py](https://github.com/TSavo/sugar/pull/6910/files#diff-1a6a1e058898693a04db89a8dda185ad15e19277c08fb04e58876c1736c68088) to short-circuit when there are no keyword arguments: it now delegates to `receiver.call_method_with(MethodCallOperation(...))` instead of constructing a `CallSiteValue`.
> - Behavioral Change: method calls with no keyword arguments now follow the floor dispatch path, bypassing the previous IR construction path entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f77443.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->