### PR TITLE
fix(python): retain subscript carriers through partitions

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
@@ -118,12 +118,18 @@ class SubscriptSugar(ConstructedTermSugar):
         receiver_partitioned = isinstance(receiver_outcome, _ExitSet)
         index_partitioned = isinstance(index_outcome, _ExitSet)
         if receiver_partitioned or index_partitioned:
-            subscripted = outcome_to_exitset(receiver_outcome).and_then(
-                lambda receiver: outcome_to_exitset(index_outcome).and_then(
-                    lambda index: outcome_to_exitset(
-                        self._subscript(receiver, index, ctx)
-                    )
+            from sugar_lift_py_tests.caller_parameter_contract import (
+                NativeOperationExitCarrierV1,
+            )
+
+            def subscript_receiver(receiver):
+                return NativeOperationExitCarrierV1.compose_prefix(
+                    outcome_to_exitset(index_outcome),
+                    lambda index: self._subscript(receiver, index, ctx),
                 )
+
+            subscripted = NativeOperationExitCarrierV1.compose_prefix(
+                outcome_to_exitset(receiver_outcome), subscript_receiver
             )
         else:
             # Single-outcome path: undecided lookups raise SugarNotWritten


### PR DESCRIPTION
## Instrument

`R_partitioned_subscript_carrier=1`: enum.py:86 built an authenticated formal subscript carrier under preceding BoolOp faces, but `SubscriptSugar` coerced its callback result through `outcome_to_exitset`.

## Change

Use `NativeOperationExitCarrierV1.compose_prefix` for partitioned receiver and index prefixes. Completed faces may retain the carrier; halted faces and their guards/state/faces/pending bypass unchanged. Linear subscript behavior is untouched.

## Receipt

- Focused subscript suites: `33 passed`.
- Direct enum trace advances the intact carrier to the next owner, BoolOp sequencing, instead of failing inside SubscriptSugar.
- Predicted `Epsilon R_partitioned_subscript_carrier=-1`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix subscript carriers to be retained through partitions in `SubscriptSugar`
> In the `ExitSet` control path of [`subscript_sugar.py`](https://github.com/TSavo/sugar/pull/6911/files#diff-0a35660414dc62dca7c8656f2f0c64e6e5547d02aa7e1017e20304426061fb05), the nested `outcome_to_exitset(...).and_then(...)` chaining is replaced with `NativeOperationExitCarrierV1.compose_prefix` to correctly retain carriers through partition boundaries. The single-outcome path is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1dada6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->