### PR TITLE
fix(python): retain boolop carriers through partitions

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -200,14 +200,33 @@ class BoolOpSugar(ConstructedTermSugar):
                 rhs_face, stop_face = partition(
                     ("BoolOpSugar", str(self.site), index, self.op_kind)
                 )
-                rhs = outcome_to_exitset(reduce_from(index + 1)).guarded(
-                    rhs_guard, rhs_face
-                )
                 stopped = ExitSet.completed(value, complement_guard(rhs_guard)).guarded(
                     true_guard(), stop_face
                 )
+                rhs_outcome = reduce_from(index + 1)
+                from sugar_lift_py_tests.caller_parameter_contract import (
+                    NativeOperationExitCarrierV1,
+                )
+
+                if isinstance(rhs_outcome, NativeOperationExitCarrierV1):
+                    return rhs_outcome.short_circuit(
+                        continuing_guard=rhs_guard,
+                        stopped=stopped,
+                        continuing_face=rhs_face,
+                        stopped_face=stop_face,
+                    )
+                rhs = outcome_to_exitset(rhs_outcome).guarded(rhs_guard, rhs_face)
                 return rhs.union(stopped)
 
-            return factored_operand(operand.desugar(ctx)).and_then(project_truth)
+            projected_operand = factored_operand(operand.desugar(ctx))
+            from sugar_lift_py_tests.caller_parameter_contract import (
+                NativeOperationExitCarrierV1,
+            )
+
+            if isinstance(projected_operand, ExitSet):
+                return NativeOperationExitCarrierV1.compose_prefix(
+                    projected_operand, project_truth
+                )
+            return projected_operand.and_then(project_truth)
 
         return reduce_from(0)


### PR DESCRIPTION
## Instrument

`R_boolop_tail_carrier=1`: enum.py:86 retained a formal subscript carrier, but BoolOp coerced both a carrier-valued tail and a carrier-valued completed prefix callback through `outcome_to_exitset`.

## Change

Use the carrier short-circuit product for deferred RHS tails and `compose_prefix` when a partitioned operand callback can return a carrier. Stopping arms bypass the deferred operation with their existing partition testimony. No scalar forcing or face selection.

## Receipt

- Direct enum producer advances past `_is_private` to a distinct bodyless builtin `hasattr` truth at enum.py:43.
- BoolOp suite contact: `15 passed`; 16 retained fixture failures predate this change because their probes are plain `Sugar` under the current `ConstructedTermSugar` constructor contract.
- Predicted `Epsilon R_boolop_tail_carrier=-1`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `BoolOpSugar.to_term` to retain boolop carriers through partition boundaries
> - When the tail reduction in a boolean fold returns a `NativeOperationExitCarrierV1`, `to_term` now short-circuits via `rhs_outcome.short_circuit(...)` instead of falling through to the prior `outcome_to_exitset(...).guarded(...)` path.
> - When the current operand projects to an `ExitSet`, prefix composition now goes through `NativeOperationExitCarrierV1.compose_prefix(projected_operand, project_truth)` instead of `projected_operand.and_then(project_truth)`.
> - Behavioral Change: both paths previously discarded carrier context across partition boundaries; they now propagate it, which changes the resulting term structure for boolean expressions involving exit carriers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8543fae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->