### PR TITLE
Authenticate builtin hasattr operation coordinate

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
@@ -48,6 +48,8 @@ class BuiltinSemanticCallable(FloorValue):
             return self._isinstance(operation)
         if self.operation == "python.len":
             return self._len(operation)
+        if self.operation == "python.hasattr":
+            return self._hasattr(operation)
         if self.operation != "python.issubclass":
             return super().callable_application_with(operation, None)
         if len(operation.arguments) != 2 or operation.keyword_names:
@@ -64,6 +66,38 @@ class BuiltinSemanticCallable(FloorValue):
         subtype = self._resolve_type_operand(subtype, operation.site)
         supertype = self._resolve_type_operand(supertype, operation.site)
         return subtype.test_python_subtype(supertype, operation.site)
+
+    def _hasattr(self, operation):
+        """Retain authenticated ``hasattr`` as an opaque boolean coordinate."""
+        from sugar_lift_py_tests.floor.opaque_op_callsite import OpaqueOpCallsite
+        from sugar_lift_py_tests.floor.string_value import StringValue
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        from sugar_lift_py_tests.outcome import Complete
+
+        if (
+            len(operation.arguments) != 2
+            or operation.keyword_names
+            or type(operation.arguments[1]) is not StringValue
+        ):
+            construction_panic_gap(
+                owner="BuiltinSemanticCallable.python.hasattr",
+                blame=str(operation.site),
+                observed=(
+                    tuple(type(value).__name__ for value in operation.arguments),
+                    operation.keyword_names,
+                ),
+                requested="exact receiver plus concrete string member operand",
+                fix="construct Python hasattr operands exactly or keep it loud",
+            )
+        receiver, member = operation.arguments
+        return Complete(
+            OpaqueOpCallsite(
+                callee="hasattr",
+                arg=receiver,
+                computed=None,
+                extra_args=(member,),
+            )
+        )
 
     def _unhandled_construct(self, operation, name: str):
         """Opaque construct operands stay a dig cue, not a ConstructionPanic.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
@@ -260,6 +260,9 @@ def builtin_name_temporal():
         "len", BuiltinSemanticCallable(operation="python.len")
     )
     temporal = temporal.bind_value(
+        "hasattr", BuiltinSemanticCallable(operation="python.hasattr")
+    )
+    temporal = temporal.bind_value(
         "set", BuiltinSemanticCallable(operation="python.set.construct")
     )
     temporal = temporal.bind_value(

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_hasattr_semantic_callable.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_hasattr_semantic_callable.py
@@ -1,0 +1,51 @@
+"""Authenticated builtin ``hasattr`` remains a boolean operation coordinate."""
+
+import pytest
+
+from sugar_lift_py_tests.callable_application import CallableApplication
+from sugar_lift_py_tests.floor import BuiltinSemanticCallable, OpaqueOpCallsite
+from sugar_lift_py_tests.floor.string_value import StringValue
+from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.temporal.builtin_name_bindings import builtin_name_temporal
+
+
+def test_builtin_hasattr_returns_exact_opaque_boolean_coordinate():
+    receiver = SymbolicValue(make_var("receiver"))
+    member = StringValue("__get__")
+    builtin = builtin_name_temporal().value_if_bound("hasattr")
+
+    assert type(builtin) is BuiltinSemanticCallable
+    assert builtin.operation == "python.hasattr"
+    outcome = builtin.callable_application_with(
+        CallableApplication((receiver, member), (), "hasattr-site"), None
+    )
+
+    assert type(outcome) is Complete
+    assert type(outcome.value) is OpaqueOpCallsite
+    assert outcome.value.callee == "hasattr"
+    assert outcome.value.arg is receiver
+    assert outcome.value.extra_args == (member,)
+    assert outcome.value.computed is None
+    assert type(outcome.value.truth("truth-site")) is Complete
+
+
+@pytest.mark.parametrize(
+    "arguments, keyword_names",
+    [
+        ((SymbolicValue(make_var("receiver")),), ()),
+        (
+            (SymbolicValue(make_var("receiver")), StringValue("member")),
+            ("obj", "name"),
+        ),
+    ],
+)
+def test_builtin_hasattr_refuses_nonexact_call_shape(arguments, keyword_names):
+    builtin = builtin_name_temporal().value_if_bound("hasattr")
+
+    with pytest.raises(ConstructionPanic):
+        builtin.callable_application_with(
+            CallableApplication(arguments, keyword_names, "hasattr-site"), None
+        )


### PR DESCRIPTION
R_builtin_hasattr: 1 -> 0. Epsilon=-1. Enrolls language-owned hasattr as an authenticated BuiltinSemanticCallable and preserves its result as an opaque boolean operation coordinate. No attribute-presence inference, host lookup, or consumer name arm. Focused: 3 passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate builtin `hasattr` operation coordinate in the Python sugar-lift semantic callable
> - Adds a `_hasattr` helper to `BuiltinSemanticCallable` that validates call shape (exactly two positional args, no keywords, second arg must be a `StringValue`) and returns a `Complete(OpaqueOpCallsite)` on success or raises a `ConstructionPanic` on invalid input.
> - Registers `hasattr` in the builtin lexical floor via `builtin_name_temporal`, mapping it to `BuiltinSemanticCallable(operation="python.hasattr")`.
> - Adds tests covering the valid call shape and two invalid shapes (missing member arg, keywords present).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d40267d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->