### PR TITLE
Preserve nested source If branch slots

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -6267,17 +6267,27 @@ class If(Statement):
         from .shadow import ShadowNode, rewrite
 
         try:
-            self.branch_result_slot_id
+            existing_slot_id = self.branch_result_slot_id
+            existing_authenticated_slot_id = (
+                self.authenticated_branch_result_slot_id
+            )
         except AttributeError:
             pass
         else:
-            backend_defect(
-                blame=self.fragment,
-                owner="If._rewrite_with_slot",
-                observed="If attempted to mint a second branch-result slot",
-                requested="the one slot authenticated for this exact If.test",
-                fix="route the source If through ordinary substitution exactly once",
-            )
+            if existing_slot_id != existing_authenticated_slot_id:
+                backend_defect(
+                    blame=self.fragment,
+                    owner="If._rewrite_with_slot",
+                    observed="nested substitution carried a foreign branch-result slot",
+                    requested="the one slot authenticated for this exact If.test",
+                    fix="preserve the source condition slot across lexical substitution",
+                )
+            # An outer function substitutes captured names through a nested
+            # function before the nested function opens and substitutes its own
+            # formal scope.  Its transformed test can therefore address a new
+            # formal coordinate; it cannot mint a new source-branch identity.
+            # The sealed stored/authenticated pair remains the authority.
+            return rewrite(self, **changed)
         rewritten = rewrite(self, **changed)
         if authenticated_slot is None:
             authenticated_slot = branch_result_slot(rewritten.test)

--- a/implementations/python/sugar-source-tree/tests/test_branch_result_slot.py
+++ b/implementations/python/sugar-source-tree/tests/test_branch_result_slot.py
@@ -78,3 +78,26 @@ def test_effectful_condition_is_constructed_once_and_one_slot_drives_all_faces(
         if node.kind == "Call" and node.fragment.text == "predicate()"
     }
     assert len(predicate_cids) == 1
+
+
+def test_nested_function_reuses_source_if_slot_across_lexical_substitution(tmp_path):
+    path = tmp_path / "nested_if.py"
+    path.write_text(
+        "def outer(captured):\n"
+        " def inner(condition):\n"
+        "  if condition:\n"
+        "   return captured\n"
+        "  return condition\n"
+        " return inner(captured)\n",
+        encoding="utf-8",
+    )
+    reporter = CollectingReporter()
+    outer = next(SourceFile(path_source(path), reporter=reporter).functions())
+
+    sugar = outer.sugar()
+
+    inner = sugar.statements[0]
+    nested_if = inner.statements[0]
+    assert nested_if.branch_slot.slot_id.startswith("branch-result:")
+    source_ifs = [node for node in reporter.present if node.kind == "If"]
+    assert len({node.fragment.seal().cid for node in source_ifs}) == 1


### PR DESCRIPTION
R_nested_if_second_slot: 1 -> 0. Epsilon=-1. Nested lexical substitution preserves the already sealed source If slot/authentication pair while rewriting captured/formal children; it never remints the branch coordinate. Focused branch-slot suite: 3 passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `If._rewrite_with_slot` to preserve nested source If branch slots across lexical substitution
> - `If._rewrite_with_slot` in [nodes.py](https://github.com/TSavo/sugar/pull/6914/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) previously raised a `backend_defect` whenever an `If` node already had a `branch_result_slot_id`, treating it unconditionally as an attempt to mint a duplicate slot.
> - Now it checks both `branch_result_slot_id` and `authenticated_branch_result_slot_id`: if they match, the existing slot is preserved and the node is rewritten normally; only mismatched IDs (indicating a foreign slot) raise an error.
> - A new test in [test_branch_result_slot.py](https://github.com/TSavo/sugar/pull/6914/files#diff-543b8543385405a55a4229bcde13d3ee27036e923125b3d3c726f9a02e81588f) verifies that nested functions sharing an inner `If` reuse the same sealed CID across lexical substitution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0d2112.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->