### PR TITLE
Preserve nested carrier reducer state

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -336,6 +336,12 @@ def reduce_block_to_exitset(
                 # Retain the ordinary statement projection as a continuation;
                 # discharge will feed its Completed face through this exact
                 # block seam, while its Halted face bypasses the tail.
+                if outcome.pre_effect_state is not None:
+                    # A nested source reduction already enrolled the state at
+                    # its own reducer boundary.  This outer block contributes
+                    # only its captured continuation; reseating the outer
+                    # prefix would overwrite the operation's effect locus.
+                    return outcome.and_then(project)
                 return outcome.and_then(
                     project,
                     pre_effect_state=ReducerPreEffectStateV1._from_reducer(state),

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_pre_effect_state.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_pre_effect_state.py
@@ -21,7 +21,10 @@ from sugar_lift_py_tests.floor.class_definition_value import ClassDefinitionValu
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import ctor, str_const
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
-from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
+from sugar_lift_py_tests.sugar.function_universe_sugar import (
+    _ReducedBlock,
+    reduce_block_to_exitset,
+)
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import ClassDef, FunctionDef
 from sugar_source_tree.tree import SourceFile
@@ -177,3 +180,25 @@ def test_equal_state_reenrollment_retains_original_testimony() -> None:
     )
 
     assert retained.pre_effect_state is original
+
+
+def test_outer_reducer_appends_to_already_enrolled_carrier_without_reseating():
+    pending, _ = _pending_and_receiver()
+    original = pending.pre_effect_state
+    before = len(pending.continuations)
+
+    class _AlreadyEnrolled:
+        def desugar(self, ctx=None):
+            del ctx
+            return pending
+
+    class _Prefix:
+        def desugar(self, ctx=None):
+            del ctx
+            return Complete(TermValue(41))
+
+    reduced = reduce_block_to_exitset((_Prefix(), _AlreadyEnrolled()))
+
+    assert type(reduced) is NativeOperationExitCarrierV1
+    assert reduced.pre_effect_state is original
+    assert len(reduced.continuations) == before + 1


### PR DESCRIPTION
R_nested_carrier_state_conflict: 1 -> 0. Epsilon=-1. A reducer appends its captured continuation to a carrier already enrolled by a nested reducer without attempting a conflicting second pre-effect state seat. Fresh carriers retain the existing sole enrollment path. Focused: 9 passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve nested carrier `pre_effect_state` in `reduce_block_to_exitset`
> When a statement reduction yields a `NativeOperationExitCarrierV1` that already has a `pre_effect_state` set, `reduce_block_to_exitset` was overwriting it with the outer reducer's state. It now only sets `pre_effect_state` when the carrier does not already have one, and otherwise appends the continuation directly.
>
> A new test in [test_native_operation_pre_effect_state.py](https://github.com/TSavo/sugar/pull/6915/files#diff-6d78a0e57d2324b5481336149fcdbb52b5b6ec439107bf91151b339affe3257e) covers the case where a nested desugaring returns an already-enrolled carrier, asserting the original state is retained after block reduction.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54792d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->