### PR TITLE
Execute authenticated module prefixes for export admission

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/decorated_class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/decorated_class_value.py
@@ -10,6 +10,7 @@ from .floor_value import FloorValue
 _APPLICATION_AUTHORITY = object()
 _PUBLICATION_AUTHORITY = object()
 _MEMBER_AUTHORITY = object()
+_METACLASS_AUTHORITY = object()
 
 
 def _floor_cid(value: FloorValue) -> str:
@@ -247,6 +248,181 @@ class DecoratedClassValue(FloorValue):
 
             return Complete(TrueBoolLiteralSugar(site=site))
         return super().test_python_type(value, site)
+
+
+@dataclass(frozen=True, init=False)
+class MetaclassClassPublicationV1:
+    """One exact metaclass application during module class publication."""
+
+    source_cid: str
+    definition: object
+    binding_occurrence: object
+    metaclass_occurrence: object
+    raw_class: FloorValue = field(compare=False)
+    metaclass_floor: FloorValue = field(compare=False)
+    metaclass_callable: FloorValue = field(compare=False)
+    class_name_floor: FloorValue = field(compare=False)
+    bases_floor: FloorValue = field(compare=False)
+    namespace_floor: FloorValue = field(compare=False)
+    final_class: FloorValue = field(compare=False)
+    module_construction_receipt_cid: str
+    application_cid: str
+    publication_cid: str
+    _authority: object = field(default=None, init=False, compare=False, repr=False)
+
+    def __post_init__(self):
+        from sugar_lift_py_tests.context_manager_resolution import (
+            SourceFragmentCoordinateV1,
+        )
+        from sugar_lift_py_tests.floor.class_definition_value import (
+            ClassDefinitionValue,
+        )
+
+        if self._authority is not _METACLASS_AUTHORITY:
+            raise ValueError("metaclass class publication is not producer-minted")
+        if (
+            type(self.definition) is not SourceFragmentCoordinateV1
+            or type(self.binding_occurrence) is not SourceFragmentCoordinateV1
+            or type(self.metaclass_occurrence) is not SourceFragmentCoordinateV1
+            or self.definition.source_cid != self.source_cid
+            or self.binding_occurrence.source_cid != self.source_cid
+            or self.metaclass_occurrence.source_cid != self.source_cid
+            or type(self.raw_class) is not ClassDefinitionValue
+            or self.raw_class.binding_target_occurrence != self.binding_occurrence
+        ):
+            raise ValueError("metaclass class publication coordinate mismatch")
+        application_cid, publication_cid = _metaclass_publication_cids(
+            source_cid=self.source_cid,
+            definition=self.definition,
+            binding_occurrence=self.binding_occurrence,
+            metaclass_occurrence=self.metaclass_occurrence,
+            raw_class=self.raw_class,
+            metaclass_floor=self.metaclass_floor,
+            metaclass_callable=self.metaclass_callable,
+            class_name_floor=self.class_name_floor,
+            bases_floor=self.bases_floor,
+            namespace_floor=self.namespace_floor,
+            final_class=self.final_class,
+            module_construction_receipt_cid=self.module_construction_receipt_cid,
+        )
+        if (
+            self.application_cid != application_cid
+            or self.publication_cid != publication_cid
+        ):
+            raise ValueError("metaclass class publication CID mismatch")
+
+
+def _metaclass_publication_cids(
+    *,
+    source_cid,
+    definition,
+    binding_occurrence,
+    metaclass_occurrence,
+    raw_class,
+    metaclass_floor,
+    metaclass_callable,
+    class_name_floor,
+    bases_floor,
+    namespace_floor,
+    final_class,
+    module_construction_receipt_cid,
+):
+    application_cid = cid_of_json(
+        {
+            "kind": "metaclass-class-application",
+            "schemaVersion": "1",
+            "occurrence": metaclass_occurrence.wire(),
+            "metaclassFloorCid": _floor_cid(metaclass_floor),
+            "metaclassCallableCid": _floor_cid(metaclass_callable),
+            "actualFloorCids": [
+                _floor_cid(metaclass_floor),
+                _floor_cid(class_name_floor),
+                _floor_cid(bases_floor),
+                _floor_cid(namespace_floor),
+            ],
+            "resultFloorCid": _floor_cid(final_class),
+        }
+    )
+    publication_cid = cid_of_json(
+        {
+            "kind": "metaclass-class-publication",
+            "schemaVersion": "1",
+            "sourceCid": source_cid,
+            "definition": definition.wire(),
+            "bindingOccurrence": binding_occurrence.wire(),
+            "rawClassCid": _floor_cid(raw_class),
+            "applicationCid": application_cid,
+            "moduleConstructionReceiptCid": module_construction_receipt_cid,
+        }
+    )
+    return application_cid, publication_cid
+
+
+def _mint_metaclass_class_publication(
+    *,
+    source_cid,
+    definition,
+    binding_occurrence,
+    metaclass_occurrence,
+    raw_class,
+    metaclass_floor,
+    metaclass_callable,
+    class_name_floor,
+    bases_floor,
+    namespace_floor,
+    final_class,
+    module_construction_receipt_cid,
+):
+    application_cid, publication_cid = _metaclass_publication_cids(
+        source_cid=source_cid,
+        definition=definition,
+        binding_occurrence=binding_occurrence,
+        metaclass_occurrence=metaclass_occurrence,
+        raw_class=raw_class,
+        metaclass_floor=metaclass_floor,
+        metaclass_callable=metaclass_callable,
+        class_name_floor=class_name_floor,
+        bases_floor=bases_floor,
+        namespace_floor=namespace_floor,
+        final_class=final_class,
+        module_construction_receipt_cid=module_construction_receipt_cid,
+    )
+    value = object.__new__(MetaclassClassPublicationV1)
+    for name, field_value in (
+        ("source_cid", source_cid),
+        ("definition", definition),
+        ("binding_occurrence", binding_occurrence),
+        ("metaclass_occurrence", metaclass_occurrence),
+        ("raw_class", raw_class),
+        ("metaclass_floor", metaclass_floor),
+        ("metaclass_callable", metaclass_callable),
+        ("class_name_floor", class_name_floor),
+        ("bases_floor", bases_floor),
+        ("namespace_floor", namespace_floor),
+        ("final_class", final_class),
+        ("module_construction_receipt_cid", module_construction_receipt_cid),
+        ("application_cid", application_cid),
+        ("publication_cid", publication_cid),
+    ):
+        object.__setattr__(value, name, field_value)
+    object.__setattr__(value, "_authority", _METACLASS_AUTHORITY)
+    value.__post_init__()
+    return value
+
+
+@dataclass(frozen=True)
+class MetaclassClassValue(FloorValue):
+    publication: MetaclassClassPublicationV1
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:metaclass_class_publication",
+            [str_const(self.publication.publication_cid)],
+            symbol_kind="coordinate",
+        )
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field, replace as _replace
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    Sugar,
+    require_constructed_term_sugar,
+)
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 
 
@@ -200,7 +204,7 @@ class SpreadDictSugar(Sugar):
 
 
 @dataclass(frozen=True)
-class SpreadCallSugar(Sugar):
+class SpreadCallSugar(ConstructedTermSugar):
     """A call containing ``*``/``**``, using the reference call vocabulary.
 
     When an authenticated source-visible callee frame is enrolled (class
@@ -224,6 +228,31 @@ class SpreadCallSugar(Sugar):
             truthful="tuple(z)",
             lying="tuple((*z, 0))",
         )
+
+    def to_term(self, *, owner: str):
+        """Project the same call coordinate used by completed spread reduction."""
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        if self.callee_name is not None:
+            callee_term = str_const(self.callee_name)
+        else:
+            callee = require_constructed_term_sugar(
+                self.callee, owner="SpreadCallSugar.callee"
+            )
+            callee_term = callee.to_term(owner=owner)
+        arg_terms = []
+        for role, name, sugar in self.arguments:
+            term = require_constructed_term_sugar(
+                sugar, owner="SpreadCallSugar.arguments"
+            ).to_term(owner=owner)
+            if role == "star":
+                term = ctor("python:starred_arg", [term])
+            elif role == "double-star":
+                term = ctor("python:double_starred_kwarg", [term])
+            elif role == "keyword":
+                term = ctor("python:kwarg", [str_const(name), term])
+            arg_terms.append(term)
+        return ctor("python:call", [callee_term, *arg_terms])
 
     def desugar(self, ctx: object = None) -> Outcome:
         def after_callee(callee_value):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -137,7 +137,9 @@ def _resolve_export_uncached(
     )
     # Normal-completion authority for the prefix (statements strictly before
     # the unique export-binding locus): producer-owned Completed faces only.
-    if locus is not None and not _prefix_has_completed_fallthrough(module, locus):
+    if locus is not None and not _prefix_has_completed_fallthrough(
+        module, locus, graph=graph, session=session
+    ):
         return _gap(
             "dynamic-export", binding_cid, graph, module_name, exported_name
         )
@@ -829,7 +831,9 @@ def _export_statement_with_locus(statement: ast.stmt, name: str, state):
     return new_state, (statement if new_state is not state else None)
 
 
-def _prefix_has_completed_fallthrough(module, locus: ast.stmt) -> bool:
+def _prefix_has_completed_fallthrough(
+    module, locus: ast.stmt, *, graph=None, session=None
+) -> bool:
     """Delegate prefix meaning to the construction producer.
 
     The dependency adapter owns export recognition only. It must not import
@@ -838,7 +842,11 @@ def _prefix_has_completed_fallthrough(module, locus: ast.stmt) -> bool:
     """
     from .manager_construction import prefix_has_completed_fallthrough
 
-    return prefix_has_completed_fallthrough(module, locus)
+    if graph is None and session is None:
+        return prefix_has_completed_fallthrough(module, locus)
+    return prefix_has_completed_fallthrough(
+        module, locus, graph=graph, session=session
+    )
 
 
 def _absolute_import(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -142,6 +142,29 @@ class _ModuleSourceFrameCallableV1(FloorValue):
 
 
 @dataclass(frozen=True)
+class _ModuleFunctionDefinitionCallableV1(FloorValue):
+    """An exact module FunctionDef whose body is constructed only when called."""
+
+    definition: FunctionDef
+
+    def to_term(self, *, owner):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:module-function-definition-callable",
+            [str_const(self.definition.fragment.seal().cid)],
+            symbol_kind="coordinate",
+        )
+
+    def callable_application_with(self, operation, ctx):
+        return _ModuleSourceFrameCallableV1(
+            self.definition.name,
+            self.definition.source_visible_call_frame(),
+        ).callable_application_with(operation, ctx)
+
+
+@dataclass(frozen=True)
 class _ModuleFunctionDefinitionBindingSugar:
     definition: FunctionDef
 
@@ -161,10 +184,7 @@ class _ModuleFunctionDefinitionBindingSugar:
         return Complete(
             ScopeRebind(
                 self.definition.name,
-                _ModuleSourceFrameCallableV1(
-                    self.definition.name,
-                    self.definition.source_visible_call_frame(),
-                ),
+                _ModuleFunctionDefinitionCallableV1(self.definition),
             )
         )
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -64,44 +64,514 @@ class ImportValueUseSeatingGap(ValueError):
         super().__init__(f"{kind}: {detail}")
 
 
-def prefix_has_completed_fallthrough(module, locus) -> bool:
-    """Construction-owned five-step prefix meaning for export recognition."""
-    from sugar_lift_py_tests.outcome import Completed, true_guard
-    from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
+@dataclass(frozen=True)
+class _ModuleSourceFrameCallableV1(FloorValue):
+    """Exact module FunctionDef callable used during definition execution."""
+
+    callable_name: str
+    frame: object
+
+    def to_term(self, *, owner):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:module-source-frame-callable",
+            [str_const(self.frame.frame_cid)],
+            symbol_kind="coordinate",
+        )
+
+    def callable_application_with(self, operation, ctx):
+        from sugar_lift_py_tests.floor import CallSiteValue
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_source_tree.panic import SugarNotWritten
+
+        if operation.keyword_names:
+            raise SugarNotWritten(
+                owner="module definition source callable",
+                blame=operation.site,
+                observed="keyword decorator application lacks value pairing",
+                requested="ordered authenticated keyword actuals",
+                fix="carry keyword values with their formal names",
+            )
+        bound = self.frame.bind_actuals(operation.arguments, (), ctx)
+        call = CallSiteValue(
+            self.callable_name,
+            bound.actuals,
+            self.frame.parameters,
+            ctor(
+                "call:module-source-frame",
+                [
+                    self.to_term(owner=self.callable_name),
+                    *(
+                        item.to_term(owner=self.callable_name)
+                        for item in bound.actuals
+                    ),
+                ],
+            ),
+            self.frame.body,
+            site=operation.site,
+            source_call_frame_cid=self.frame.frame_cid,
+            formal_coordinate_cids=tuple(
+                coordinate.cid for coordinate in self.frame.formal_coordinates
+            ),
+            bound_source_actuals=bound,
+        )
+        produced = call.producer_outcome(ctx)
+        if not isinstance(produced, Complete) or type(produced.value) is not CallSiteValue:
+            raise SugarNotWritten(
+                owner="module definition source callable",
+                blame=operation.site,
+                observed="source decorator produced a nonlinear outcome",
+                requested="one completed retained source-call coordinate",
+                fix="sequence decorator effects before module publication",
+            )
+        projected = produced.value.project_operation_receiver_outcome(
+            ctx, owner="module definition source callable"
+        )
+        if not isinstance(projected, Complete):
+            raise SugarNotWritten(
+                owner="module definition source callable",
+                blame=operation.site,
+                observed="source decorator return projected nonlinearly",
+                requested="one completed decorator result Floor",
+                fix="sequence decorator return effects before publication",
+            )
+        return projected
+
+
+@dataclass(frozen=True)
+class _ModuleFunctionDefinitionBindingSugar:
+    definition: FunctionDef
+
+    def desugar(self, ctx=None):
+        from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_source_tree.panic import SugarNotWritten
+
+        if self.definition.decorators:
+            raise SugarNotWritten(
+                owner="module function definition execution",
+                blame=self.definition.fragment,
+                observed="decorated FunctionDef has no completed publication",
+                requested="the exact final decorated function Floor",
+                fix="execute and authenticate the function decorator chain",
+            )
+        return Complete(
+            ScopeRebind(
+                self.definition.name,
+                _ModuleSourceFrameCallableV1(
+                    self.definition.name,
+                    self.definition.source_visible_call_frame(),
+                ),
+            )
+        )
+
+
+@dataclass(frozen=True)
+class _ModuleClassDefinitionBindingSugar:
+    """Execute one module ClassDef and bind its exact constructed Floor.
+
+    This is deliberately a producer-owned wrapper rather than a Name-based
+    reconstruction in the prefix consumer.  Decorated definitions require the
+    separate publication chain and remain loud here until that chain supplies
+    the final class Floor.
+    """
+
+    definition: ClassDef
+    module_construction_receipt_cid: str
+
+    def desugar(self, ctx=None):
+        from sugar_lift_py_tests.floor import ClassDefinitionValue
+        from sugar_lift_py_tests.callable_application import CallableApplication
+        from sugar_lift_py_tests.floor.decorated_class_value import (
+            DecoratedClassPublicationV1,
+            DecoratedClassValue,
+            DecoratorApplicationPublicationV1,
+            MetaclassClassValue,
+            _mint_metaclass_class_publication,
+        )
+        from sugar_lift_py_tests.floor import DictValue, StringValue, TupleValue
+        from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_source_tree.panic import SugarNotWritten
+
+        sugar = self.definition.sugar()
+        outcome = sugar.desugar(ctx)
+
+        def bind(value):
+            if type(value) is not ClassDefinitionValue:
+                raise SugarNotWritten(
+                    owner="module definition execution",
+                    blame=self.definition.fragment,
+                    observed=f"ClassDef constructed {type(value).__name__}",
+                    requested="one exact ClassDefinitionValue",
+                    fix="keep nonlinear or substituted class construction loud",
+                )
+            metaclass_keywords = tuple(
+                keyword
+                for keyword in self.definition.keywords
+                if keyword.arg == "metaclass"
+            )
+            if len(metaclass_keywords) > 1:
+                raise SugarNotWritten(
+                    owner="module definition execution",
+                    blame=self.definition.fragment,
+                    observed="multiple metaclass keyword occurrences",
+                    requested="one exact metaclass application",
+                    fix="preserve the parser-owned class keyword roster",
+                )
+            if metaclass_keywords:
+                if sugar.decorator_sugars:
+                    raise SugarNotWritten(
+                        owner="module definition execution",
+                        blame=self.definition.fragment,
+                        observed="combined metaclass and decorator publication",
+                        requested="one ordered metaclass-then-decorator publication",
+                        fix="compose both authenticated application products",
+                    )
+                keyword = metaclass_keywords[0]
+                metaclass_outcome = keyword.value.sugar().desugar(ctx)
+                if not isinstance(metaclass_outcome, Complete) or type(
+                    metaclass_outcome.value
+                ) is not ClassDefinitionValue:
+                    raise SugarNotWritten(
+                        owner="module definition execution",
+                        blame=keyword.value.fragment,
+                        observed="metaclass expression did not construct a source class",
+                        requested="one exact ClassDefinitionValue metaclass",
+                        fix="retain the metaclass binding and source definition",
+                    )
+                metaclass_floor = metaclass_outcome.value
+                constructors = tuple(
+                    method
+                    for method in metaclass_floor.methods
+                    if method.name == "__new__"
+                )
+                if len(constructors) != 1:
+                    raise SugarNotWritten(
+                        owner="module definition execution",
+                        blame=keyword.value.fragment,
+                        observed=f"metaclass has {len(constructors)} __new__ methods",
+                        requested="one exact source-visible metaclass constructor",
+                        fix="preserve unique method-definition testimony",
+                    )
+                constructor = constructors[0]
+                callable_floor = _ModuleSourceFrameCallableV1(
+                    constructor.name, constructor.source_call_frame
+                )
+                class_name_floor = StringValue(self.definition.name)
+                bases_floor = TupleValue(tuple(value.base_classes))
+                namespace_floor = DictValue(
+                    tuple(
+                        (StringValue(field.name), field.value)
+                        for field in value.class_fields
+                    )
+                )
+                occurrence = _call_coordinate(keyword.value)
+                applied = CallableApplication(
+                    (
+                        metaclass_floor,
+                        class_name_floor,
+                        bases_floor,
+                        namespace_floor,
+                    ),
+                    (),
+                    occurrence,
+                    owner="module metaclass application",
+                    call_occurrence=occurrence,
+                ).apply(callable_floor, ctx)
+                if not isinstance(applied, Complete):
+                    raise SugarNotWritten(
+                        owner="module definition execution",
+                        blame=keyword.value.fragment,
+                        observed="metaclass application reduced nonlinearly",
+                        requested="one completed published class Floor",
+                        fix="sequence metaclass effects before module publication",
+                    )
+                publication = _mint_metaclass_class_publication(
+                    source_cid=self.definition.unit.source_cid,
+                    definition=_call_coordinate(self.definition),
+                    binding_occurrence=sugar.binding_target_occurrence,
+                    metaclass_occurrence=occurrence,
+                    raw_class=value,
+                    metaclass_floor=metaclass_floor,
+                    metaclass_callable=callable_floor,
+                    class_name_floor=class_name_floor,
+                    bases_floor=bases_floor,
+                    namespace_floor=namespace_floor,
+                    final_class=applied.value,
+                    module_construction_receipt_cid=(
+                        self.module_construction_receipt_cid
+                    ),
+                )
+                return Complete(
+                    ScopeRebind(
+                        self.definition.name, MetaclassClassValue(publication)
+                    )
+                )
+            if not sugar.decorator_sugars:
+                return Complete(ScopeRebind(self.definition.name, value))
+            decorator_floors = []
+            for decorator_sugar in sugar.decorator_sugars:
+                decorator_outcome = decorator_sugar.desugar(ctx)
+                if not isinstance(decorator_outcome, Complete):
+                    raise SugarNotWritten(
+                        owner="module definition execution",
+                        blame=self.definition.fragment,
+                        observed="decorator expression reduced nonlinearly",
+                        requested="one completed source decorator callable",
+                        fix="sequence decorator expression effects before publication",
+                    )
+                decorator_floors.append(decorator_outcome.value)
+            current = value
+            applications = []
+            for callable_floor, occurrence in reversed(
+                tuple(
+                    zip(
+                        decorator_floors,
+                        sugar.decorator_occurrences,
+                        strict=True,
+                    )
+                )
+            ):
+                from sugar_lift_py_tests.floor import CallSiteValue
+
+                if (
+                    type(callable_floor) is CallSiteValue
+                    and callable_floor.body is not None
+                    and callable_floor.source_call_frame_cid is not None
+                ):
+                    callable_floor = callable_floor.force_floor(
+                        ctx,
+                        owner="module authenticated decorator factory return",
+                    )
+                before = current
+                applied = CallableApplication(
+                    (before,),
+                    (),
+                    occurrence,
+                    owner="module decorated class application",
+                    call_occurrence=occurrence,
+                ).apply(callable_floor, ctx)
+                if not isinstance(applied, Complete):
+                    raise SugarNotWritten(
+                        owner="module definition execution",
+                        blame=occurrence,
+                        observed="decorator application reduced nonlinearly",
+                        requested="one completed final class Floor",
+                        fix="sequence decorator application effects before publication",
+                    )
+                current = applied.value
+                applications.append(
+                    DecoratorApplicationPublicationV1.mint(
+                        occurrence=occurrence,
+                        callable_floor=callable_floor,
+                        input_floor=before,
+                        output_floor=current,
+                    )
+                )
+            publication = DecoratedClassPublicationV1.mint(
+                source_cid=self.definition.unit.source_cid,
+                definition=_call_coordinate(self.definition),
+                binding_occurrence=sugar.binding_target_occurrence,
+                raw_class=value,
+                decorator_applications=tuple(applications),
+                final_class=current,
+                module_construction_receipt_cid=(
+                    self.module_construction_receipt_cid
+                ),
+            )
+            return Complete(
+                ScopeRebind(self.definition.name, DecoratedClassValue(publication))
+            )
+
+        return outcome.and_then(bind)
+
+
+def _enroll_imported_decorator_frames(
+    *, module, definition, context, session, dependency_graphs
+) -> None:
+    """Seat exact imported Attribute decorator factories before Sugar caching."""
+    from pathlib import Path
+
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+    from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+    from sugar_source_tree.panic import BackendDefect
+
+    decorator_receipts, _ = authenticated_import_use_receipts(
+        Path("."),
+        Path(module.source_seat),
+        module.source,
+        module.source_cid,
+        module_identities={},
+    )
+    receipts_by_span = {}
+    for receipt in decorator_receipts:
+        receipt_span = (
+            receipt.use["useSite"]["startLine"],
+            receipt.use["useSite"]["startCol"],
+            receipt.use["useSite"]["endLine"],
+            receipt.use["useSite"]["endCol"],
+        )
+        if receipt_span in receipts_by_span:
+            raise BackendDefect(
+                blame=definition.fragment,
+                owner="manager_construction imported decorator enrollment",
+                observed="duplicate authenticated call receipt span",
+                requested="one exact call receipt per decorator occurrence",
+                fix="repair lexical call receipt enrollment uniqueness",
+            )
+        receipts_by_span[receipt_span] = receipt
+    for decorator in definition.decorators:
+        if not isinstance(decorator, Call) or not isinstance(
+            decorator.func, Attribute
+        ):
+            continue
+        span = decorator.line_col_span()
+        receipt = receipts_by_span.get(
+            (span.start_line, span.start_col, span.end_line, span.end_col)
+        )
+        if receipt is None:
+            continue
+        receipt.revalidate()
+        top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
+        graph = dependency_graphs.get(top_level)
+        if graph is None:
+            from .dependency_artifact import authenticate_dependency_top_level
+
+            graph = authenticate_dependency_top_level(top_level)
+            dependency_graphs[top_level] = graph
+        resolved_decorator = resolve_import_binding(
+            receipt, graph=graph, session=session
+        )
+        if not isinstance(resolved_decorator, ResolvedPythonObjectV1):
+            continue
+        projected_decorator = resolve_source_visible_frame(
+            resolved_decorator, graph=graph, session=session
+        )
+        if isinstance(projected_decorator, ManagerConstructionGapV1):
+            continue
+        decorator_frame, decorator_target = projected_decorator
+        if not isinstance(decorator_target, FunctionDef):
+            continue
+        if any(keyword.arg is None for keyword in decorator.keywords):
+            raise SourceCallBindingGap(
+                "decorator spread keyword requires typed variadic projection"
+            )
+        try:
+            decorator_frame = decorator_frame.bind_node_actuals(
+                decorator.args,
+                tuple(
+                    (keyword.arg, keyword.value)
+                    for keyword in decorator.keywords
+                    if keyword.arg is not None
+                ),
+            )
+        except SourceCallBindingGap:
+            continue
+        _install_source_call_frame(context, decorator, decorator_frame)
+
+
+def _module_prefix_outcome(module, locus, *, graph=None, session=None):
+    """Execute the authenticated module prefix through its exact definitions."""
+    from sugar_lift_py_tests.sugar.function_universe_sugar import (
+        reduce_block_to_exitset,
+    )
     from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
-    from sugar_source_tree.nodes import AsyncFunctionDef, ClassDef, FunctionDef
-    from sugar_source_tree.panic import BackendDefect, SugarNotWritten
+    from sugar_source_tree.nodes import AsyncFunctionDef, FunctionDef, Name
 
     from .canonical import blake3_512_of
 
-    expected_cid = blake3_512_of(module.source.encode("utf-8"))
-    if module.source_cid != expected_cid:
-        return False
-    try:
-        source_file = SourceFile((module.source, module.source_seat, module.source_cid))
-    except (BackendDefect, ValueError, TypeError):
-        return False
+    if module.source_cid != blake3_512_of(module.source.encode("utf-8")):
+        raise ValueError("module prefix source CID mismatch")
+    construction_context = TreeConstructionContextV1.for_source_call_construction()
+    source_file = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=construction_context,
+    )
     locus_key = (locus.lineno, locus.col_offset)
-    prefix = []
-    for statement in source_file.root.body:
-        span = statement.line_col_span()
-        if (span.start_line, span.start_col) >= locus_key:
-            break
-        prefix.append(statement)
-    if not prefix:
-        return True
-    try:
-        sugars = tuple(
-            InertSugar(site=statement.fragment)
-            if isinstance(statement, (FunctionDef, AsyncFunctionDef, ClassDef))
-            else statement.sugar()
-            for statement in prefix
+    prefix = tuple(
+        statement
+        for statement in source_file.root.body
+        if (
+            statement.line_col_span().start_line,
+            statement.line_col_span().start_col,
         )
-        exits = reduce_block_to_exitset(sugars)
-    except SugarNotWritten:
-        return False
-    except (BackendDefect, ValueError, TypeError):
-        return False
+        < locus_key
+    )
+
+    # Base testimony is installed from exact parser-owned module bindings,
+    # never from a class-name scan.  Only earlier module ClassDefs can be a
+    # source-visible base at this prefix boundary.
+    prefix_classes = tuple(item for item in prefix if isinstance(item, ClassDef))
+    class_roster = set(prefix_classes)
+    for definition in prefix_classes:
+        bases = []
+        for base in definition.bases:
+            if not isinstance(base, Name):
+                continue
+            bindings = tuple(
+                (definition.unit.module_direct_bindings or {}).get(base.id, ())
+            )
+            if (
+                len(bindings) == 1
+                and isinstance(bindings[0], ClassDef)
+                and bindings[0] in class_roster
+                and bindings[0].line_col_span().start_line
+                < definition.line_col_span().start_line
+            ):
+                bases.append(bindings[0].sugar())
+        definition.unit.construction_context.source_class_bases[
+            definition.fragment.seal().cid
+        ] = tuple(bases)
+
+    dependency_graphs = {}
+    if graph is not None:
+        session = session_or_new(session)
+        dependency_graphs[module.module_name.split(".", 1)[0]] = graph
+        for definition in prefix_classes:
+            _seat_import_value_use_receipts(
+                source_file=source_file,
+                module=module,
+                target=definition,
+                session=session,
+                context=construction_context,
+                dependency_graphs=dependency_graphs,
+            )
+            _enroll_imported_decorator_frames(
+                module=module,
+                definition=definition,
+                context=construction_context,
+                session=session,
+                dependency_graphs=dependency_graphs,
+            )
+
+    sugars = tuple(
+        (
+            _ModuleFunctionDefinitionBindingSugar(statement)
+            if isinstance(statement, FunctionDef)
+            else InertSugar(site=statement.fragment)
+            if isinstance(statement, AsyncFunctionDef)
+            else _ModuleClassDefinitionBindingSugar(
+                statement, source_file.construction_event_receipt_cid
+            )
+            if isinstance(statement, ClassDef)
+            else statement.sugar()
+        )
+        for statement in prefix
+    )
+    return reduce_block_to_exitset(sugars)
+
+
+def prefix_has_completed_fallthrough(
+    module, locus, *, graph=None, session=None
+) -> bool:
+    """Admit an export only through the authenticated module-prefix producer."""
+    from sugar_lift_py_tests.outcome import Completed, true_guard
+
+    exits = _module_prefix_outcome(module, locus, graph=graph, session=session)
     if len(exits.exits) != 1:
         return False
     face = exits.exits[0]
@@ -1787,86 +2257,14 @@ def _construct_reachable_decorated_class_bindings(
             dependency_graphs=dependency_graphs,
         )
 
-    def enroll_imported_decorator_frames(definition: ClassDef) -> None:
-        from pathlib import Path
-        from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
-
-        decorator_receipts, _ = authenticated_import_use_receipts(
-            Path("."), Path(module.source_seat), module.source, module.source_cid,
-            module_identities={},
-        )
-        receipts_by_span = {}
-        for receipt in decorator_receipts:
-            receipt_span = (
-                receipt.use["useSite"]["startLine"],
-                receipt.use["useSite"]["startCol"],
-                receipt.use["useSite"]["endLine"],
-                receipt.use["useSite"]["endCol"],
-            )
-            if receipt_span in receipts_by_span:
-                from sugar_source_tree.panic import BackendDefect
-
-                raise BackendDefect(
-                    blame=definition.fragment,
-                    owner="manager_construction imported decorator enrollment",
-                    observed="duplicate authenticated call receipt span",
-                    requested="one exact call receipt per decorator occurrence",
-                    fix="repair lexical call receipt enrollment uniqueness",
-                )
-            receipts_by_span[receipt_span] = receipt
-        for decorator in definition.decorators:
-            if not isinstance(decorator, Call) or not isinstance(
-                decorator.func, Attribute
-            ):
-                continue
-            span = decorator.line_col_span()
-            receipt = receipts_by_span.get(
-                (span.start_line, span.start_col, span.end_line, span.end_col)
-            )
-            if receipt is None:
-                continue
-            receipt.revalidate()
-            top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
-            graph = dependency_graphs.get(top_level)
-            if graph is None:
-                from .dependency_artifact import authenticate_dependency_top_level
-
-                graph = authenticate_dependency_top_level(top_level)
-                dependency_graphs[top_level] = graph
-            resolved_decorator = resolve_import_binding(
-                receipt, graph=graph, session=session
-            )
-            if not isinstance(resolved_decorator, ResolvedPythonObjectV1):
-                continue
-            projected_decorator = resolve_source_visible_frame(
-                resolved_decorator, graph=graph, session=session
-            )
-            if isinstance(projected_decorator, ManagerConstructionGapV1):
-                continue
-            decorator_frame, decorator_target = projected_decorator
-            if not isinstance(decorator_target, FunctionDef):
-                continue
-            from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
-
-            if any(keyword.arg is None for keyword in decorator.keywords):
-                raise SourceCallBindingGap(
-                    "decorator spread keyword requires typed variadic projection"
-                )
-            try:
-                decorator_frame = decorator_frame.bind_node_actuals(
-                    decorator.args,
-                    tuple(
-                        (keyword.arg, keyword.value)
-                        for keyword in decorator.keywords
-                        if keyword.arg is not None
-                    ),
-                )
-            except SourceCallBindingGap:
-                continue
-            _install_source_call_frame(context, decorator, decorator_frame)
-
     for definition in receipt_owned_classes:
-        enroll_imported_decorator_frames(definition)
+        _enroll_imported_decorator_frames(
+            module=module,
+            definition=definition,
+            context=context,
+            session=session,
+            dependency_graphs=dependency_graphs,
+        )
     for definition in module_definitions:
         if definition not in class_dependencies:
             continue

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -517,8 +517,43 @@ def test_module_prefix_defers_forward_function_body_until_prefix_temporal_is_liv
     completed = exits.exits[0]
     assert isinstance(completed, Completed)
     caller = completed.value.context.temporal.value_if_bound("caller")
-    assert type(caller).__name__ == "_ModuleSourceFrameCallableV1"
-    assert caller.frame.owner.name == "caller"
+    assert type(caller).__name__ == "_ModuleFunctionDefinitionCallableV1"
+    assert caller.definition.name == "caller"
+
+
+def test_module_prefix_does_not_construct_an_uncalled_function_body(
+    tmp_path: Path,
+) -> None:
+    """Publishing a FunctionDef retains its body until authenticated application."""
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source import manager_construction
+
+    source = (
+        "def dormant(manager):\n"
+        "    with manager:\n"
+        "        return 1\n"
+        "def build():\n"
+        "    return 2\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="lazy-module-function-pkg",
+        files={"lazy_module_function_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "lazy_module_function_pkg"
+    ]
+
+    exits = manager_construction._module_prefix_outcome(
+        module, ast.parse(source).body[-1]
+    )
+
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    dormant = completed.value.context.temporal.value_if_bound("dormant")
+    assert type(dormant).__name__ == "_ModuleFunctionDefinitionCallableV1"
+    assert dormant.definition.name == "dormant"
 
 
 def test_module_prefix_execution_publishes_exact_decorator_result(

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -556,6 +556,31 @@ def test_module_prefix_does_not_construct_an_uncalled_function_body(
     assert dormant.definition.name == "dormant"
 
 
+def test_module_prefix_constructs_one_subscript_delete_statement(
+    tmp_path: Path,
+) -> None:
+    """A module prefix executes its exact subscript delete target."""
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source import manager_construction
+
+    source = "del [1, 2, 3][-2:]\nresult = 1\n"
+    dist = _dist(
+        tmp_path,
+        name="module-delete-prefix-pkg",
+        files={"module_delete_prefix_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "module_delete_prefix_pkg"
+    ]
+
+    exits = manager_construction._module_prefix_outcome(
+        module, ast.parse(source).body[-1]
+    )
+
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Completed)
+
+
 def test_module_prefix_execution_publishes_exact_decorator_result(
     tmp_path: Path,
 ) -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -439,6 +439,151 @@ def test_prefix_raise_refuses_binding_via_completed_fallthrough(tmp_path: Path) 
     assert result.kind == "dynamic-export"
 
 
+def test_module_prefix_execution_binds_exact_class_definition_once(
+    tmp_path: Path,
+) -> None:
+    """Module definition execution retains the class Floor for later loads.
+
+    This is the producer boundary needed by authenticated module prefixes: a
+    later statement must consume the exact class constructed by the earlier
+    ClassDef, rather than seeing a reconstructed SymbolicValue with the same
+    name.
+    """
+    from sugar_lift_py_tests.floor import ClassDefinitionValue
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source import manager_construction
+
+    source = (
+        "class Boundary:\n"
+        "    FIRST = 1\n"
+        "    SECOND = 2\n"
+        "alias = Boundary\n"
+        "def build():\n"
+        "    return alias\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="module-definition-prefix-pkg",
+        files={"module_definition_prefix_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "module_definition_prefix_pkg"
+    ]
+    locus = ast.parse(source).body[-1]
+
+    exits = manager_construction._module_prefix_outcome(module, locus)
+
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    boundary = completed.value.context.temporal.value_if_bound("Boundary")
+    assert type(boundary) is ClassDefinitionValue
+    assert tuple(field.name for field in boundary.class_fields) == (
+        "FIRST",
+        "SECOND",
+    )
+
+
+def test_module_prefix_execution_publishes_exact_decorator_result(
+    tmp_path: Path,
+) -> None:
+    """A source decorator publishes its returned Floor, never the raw class."""
+    from sugar_lift_py_tests.floor import ClassDefinitionValue
+    from sugar_lift_py_tests.floor.decorated_class_value import DecoratedClassValue
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source import manager_construction
+
+    source = (
+        "def identity(candidate):\n"
+        "    return candidate\n"
+        "@identity\n"
+        "class Published:\n"
+        "    TOKEN = 7\n"
+        "def build():\n"
+        "    return Published\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="module-decoration-prefix-pkg",
+        files={"module_decoration_prefix_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "module_decoration_prefix_pkg"
+    ]
+
+    exits = manager_construction._module_prefix_outcome(
+        module, ast.parse(source).body[-1]
+    )
+
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    published = completed.value.context.temporal.value_if_bound("Published")
+    assert type(published) is DecoratedClassValue
+    publication = published.publication
+    assert type(publication.raw_class) is ClassDefinitionValue
+    assert publication.final_class is publication.raw_class
+    assert len(publication.decorator_applications) == 1
+    application = publication.decorator_applications[0]
+    assert application.input_floor is publication.raw_class
+    assert application.output_floor is publication.final_class
+    assert publication.binding_occurrence == (
+        publication.raw_class.binding_target_occurrence
+    )
+
+
+def test_module_prefix_execution_publishes_exact_metaclass_result(
+    tmp_path: Path,
+) -> None:
+    """Metaclass application retains its four exact source-owned actuals."""
+    from sugar_lift_py_tests.floor import DictValue, StringValue
+    from sugar_lift_py_tests.floor.decorated_class_value import MetaclassClassValue
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source import manager_construction
+
+    source = (
+        "class Meta:\n"
+        "    def __new__(metacls, name, bases, namespace):\n"
+        "        return namespace\n"
+        "class Published(metaclass=Meta):\n"
+        "    TOKEN = 7\n"
+        "def build():\n"
+        "    return Published\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="module-metaclass-prefix-pkg",
+        files={"module_metaclass_prefix_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "module_metaclass_prefix_pkg"
+    ]
+
+    exits = manager_construction._module_prefix_outcome(
+        module, ast.parse(source).body[-1]
+    )
+
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    published = completed.value.context.temporal.value_if_bound("Published")
+    assert type(published) is MetaclassClassValue
+    publication = published.publication
+    assert publication.metaclass_floor is (
+        completed.value.context.temporal.value_if_bound("Meta")
+    )
+    assert type(publication.namespace_floor) is DictValue
+    assert publication.final_class is publication.namespace_floor
+    assert tuple(
+        key.value
+        for key, _value in publication.namespace_floor.entries
+        if type(key) is StringValue
+    ) == ("TOKEN",)
+    assert publication.raw_class.binding_target_occurrence == (
+        publication.binding_occurrence
+    )
+
+
 def test_prefix_adapter_propagates_missing_construction_producer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -461,6 +606,43 @@ def test_prefix_adapter_propagates_missing_construction_producer(
         dependency_export_adapter._prefix_has_completed_fallthrough(
             SimpleNamespace(), locus
         )
+
+
+def test_prefix_adapter_routes_exact_graph_and_session_to_module_execution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Export admission consumes the authenticated module-prefix producer."""
+    from sugar_lift_py_tests.outcome import ExitSet
+    from sugar_lift_python_source import (
+        dependency_export_adapter,
+        manager_construction,
+    )
+    from sugar_lift_python_source.resolution_session import SourceResolutionSession
+
+    source = "value = 1\ndef build():\n    return value\n"
+    dist = _dist(
+        tmp_path,
+        name="prefix-consumer-pkg",
+        files={"prefix_consumer_pkg/__init__.py": source},
+    )
+    graph = DependencyArtifactGraph.authenticate(dist)
+    module = graph.modules["prefix_consumer_pkg"]
+    locus = ast.parse(source).body[-1]
+    session = SourceResolutionSession()
+    observed = []
+
+    def completed_prefix(actual_module, actual_locus, *, graph, session):
+        observed.append((actual_module, actual_locus, graph, session))
+        return ExitSet.completed(SimpleNamespace(can_fall_through=True))
+
+    monkeypatch.setattr(
+        manager_construction, "_module_prefix_outcome", completed_prefix
+    )
+
+    assert dependency_export_adapter._prefix_has_completed_fallthrough(
+        module, locus, graph=graph, session=session
+    )
+    assert observed == [(module, locus, graph, session)]
 
 
 def test_prefix_assert_false_refuses_binding(tmp_path: Path) -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -484,6 +484,43 @@ def test_module_prefix_execution_binds_exact_class_definition_once(
     )
 
 
+def test_module_prefix_defers_forward_function_body_until_prefix_temporal_is_live(
+    tmp_path: Path,
+) -> None:
+    """Construction does not execute a forward function without prefix state."""
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source import manager_construction
+
+    source = (
+        "registry: dict[str, int] = {}\n"
+        "def caller(key):\n"
+        "    return lookup(key)\n"
+        "def lookup(key):\n"
+        "    return registry[key]\n"
+        "def build():\n"
+        "    return caller\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="module-local-call-prefix-pkg",
+        files={"module_local_call_prefix_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "module_local_call_prefix_pkg"
+    ]
+
+    exits = manager_construction._module_prefix_outcome(
+        module, ast.parse(source).body[-1]
+    )
+
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    caller = completed.value.context.temporal.value_if_bound("caller")
+    assert type(caller).__name__ == "_ModuleSourceFrameCallableV1"
+    assert caller.frame.owner.name == "caller"
+
+
 def test_module_prefix_execution_publishes_exact_decorator_result(
     tmp_path: Path,
 ) -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4417,6 +4417,23 @@ class Delete(Statement):
             operations.append(operation)
         return operations[0] if len(operations) == 1 else _Splice(tuple(operations))
 
+    def _construct_sugar(self):
+        """Construct the exact module-level subscript-delete statement."""
+        if len(self.targets) == 1 and isinstance(self.targets[0], Subscript):
+            target = self.targets[0]
+            return self._make_delete_subscript(
+                target.value, target.slice_, target.span
+            ).sugar()
+        from .panic import SugarNotWritten
+
+        raise SugarNotWritten(
+            blame=self.fragment,
+            owner="Delete._construct_sugar",
+            observed="delete statement is not one exact subscript target",
+            requested="one source-authenticated subscript delete occurrence",
+            fix="lower other delete targets through their typed construction owner",
+        )
+
     def _make_delete_name(
         self, name: str, prior: BindingState, span: Span | None = None
     ) -> "Node":

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -9832,14 +9832,6 @@ class Call(Expression):
                             )
                     else:
                         source_call_frame = function_definition.source_visible_call_frame()
-                elif source_call_frame is None:
-                    pending = formal_function_sugar.desugar(None)
-                    from sugar_lift_py_tests.outcome import NativeOperationExitCarrierV1
-
-                    if isinstance(pending, NativeOperationExitCarrierV1):
-                        source_call_frame = function_definition.source_visible_call_frame().with_native_operation_projection(
-                            formal_coordinates, pending
-                        )
             definition = self.unit.source_allocation_definition_for_call(self)
             if (
                 definition is not None

--- a/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
@@ -64,6 +64,21 @@ def test_spread_keyword_args_build_reference_method_call():
     assert spread.args[0].name == "d"
 
 
+def test_spread_call_is_a_constructed_method_argument_coordinate():
+    t = _out(
+        "def A(cls, values):\n"
+        "    value = str(*values)\n"
+        "    return str.__new__(cls, value)\n"
+    )
+
+    assert t.name == "call:__new__"
+    spread = t.args[2]
+    assert spread.name == "python:call"
+    assert spread.args[0].value == "str"
+    assert spread.args[1].name == "python:starred_arg"
+    assert spread.args[1].args[0].name == "values"
+
+
 if __name__ == "__main__":
     test_method_call_is_the_method_coordinate()
     test_method_chains_compose()


### PR DESCRIPTION
Consolidated producer candidate only; HOLD for measured lifecycle receipt, no immediate merge request.\n\nExact ancestry: main 193090d54937beaa8995d6980833f67f2f46d118 plus the minimal 6901-6904 producer substrate and the root export-consumer connection. PR6905 and PR6906-6914 are excluded.\n\nR_bodyless_enum_simple: 1 -> 0 (Delta=-1). Parent two-node non-synthetic lifecycle: 2 failed at manager decorated class application, bodyless enum._simple_enum CallSiteValue; log /tmp/option-stack-main.log sha256 f598e69bdf354735a3d61af477c8102d43825142ec0f5258711a49b7bfcc239b. Head: 2 failed at later pandas/_config/config.py:685 SymbolicValue.subscript; log /tmp/option-root-prefix-consumer-lifecycle.log sha256 03008912e37d22d3d0a4cf412ffe021e8ccaed667051ce5c5947c8869f76dbb7. Focused graph/session consumer instrument: 2 passed. No diagnostics.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Execute authenticated module prefixes for export admission with class and function publication
> - Adds `_module_prefix_outcome` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6916/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to execute a module prefix through exact definitions up to the export locus, producing an `ExitSet` that reflects authenticated binding side-effects for functions and classes.
> - Introduces `_ModuleClassDefinitionBindingSugar` and `_ModuleFunctionDefinitionBindingSugar` to publish class and function definitions during prefix execution: classes support metaclass applications and decorator chains with authenticated CIDs; undecorated functions become deferred-callable Floors.
> - Adds `MetaclassClassPublicationV1` and `MetaclassClassValue` in [decorated_class_value.py](https://github.com/TSavo/sugar/pull/6916/files#diff-092894e1d0a6313a4952d3c0dc2eb9271383bb35919fbfd663f5290161e82e63) to represent and authenticate metaclass class publications with stable CIDs.
> - Updates `_prefix_has_completed_fallthrough` and the export adapter in [dependency_export_adapter.py](https://github.com/TSavo/sugar/pull/6916/files#diff-9ae971bf7816ef0dc9d57fc56a4b8eef1daa1b6955b6c0bd851f772712bbc01f) to forward `graph` and `session` into the module prefix check.
> - Extends `SpreadCallSugar` in [spread_sugar.py](https://github.com/TSavo/sugar/pull/6916/files#diff-462f912508b271ce479f5b6c3757a9e656e009ab945f3b9c632e8cb7bdfc4945) to project a constructed `python:call` coordinate, enforcing that callee and argument sugars are constructed-term-capable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5cabcbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for publishing and representing metaclass-created class values.
  - Improved handling of function calls with starred, double-starred, and keyword arguments.
  - Enhanced module loading to preserve exact class, decorator, and metaclass results.

- **Bug Fixes**
  - Improved export resolution when evaluating completed module prefixes.
  - Preserved execution context during dependency and module resolution.

- **Tests**
  - Added coverage for decorated and metaclass-created classes, aliases, export routing, and spread-call expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->