### PR TITLE
Bind module assignments during prefix execution

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -190,6 +190,22 @@ class _ModuleFunctionDefinitionBindingSugar:
 
 
 @dataclass(frozen=True)
+class _ModuleNameAssignmentBindingSugar:
+    """Execute one exact module ``Name = RHS`` into prefix temporal state."""
+
+    statement: Assign
+    target: Name
+
+    def desugar(self, ctx=None):
+        from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind
+        from sugar_lift_py_tests.outcome import Complete
+
+        return self.statement.value.sugar().desugar(ctx).and_then(
+            lambda value: Complete(ScopeRebind(self.target.id, value))
+        )
+
+
+@dataclass(frozen=True)
 class _ModuleClassDefinitionBindingSugar:
     """Execute one module ClassDef and bind its exact constructed Floor.
 
@@ -578,6 +594,12 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
                 statement, source_file.construction_event_receipt_cid
             )
             if isinstance(statement, ClassDef)
+            else _ModuleNameAssignmentBindingSugar(statement, statement.targets[0])
+            if (
+                isinstance(statement, Assign)
+                and len(statement.targets) == 1
+                and isinstance(statement.targets[0], Name)
+            )
             else statement.sugar()
         )
         for statement in prefix

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -563,7 +563,7 @@ def test_module_prefix_constructs_one_subscript_delete_statement(
     from sugar_lift_py_tests.outcome import Completed
     from sugar_lift_python_source import manager_construction
 
-    source = "del [1, 2, 3][-2:]\nresult = 1\n"
+    source = "values = [1, 2, 3]\ndel values[-2:]\nresult = values\n"
     dist = _dist(
         tmp_path,
         name="module-delete-prefix-pkg",


### PR DESCRIPTION
## What changed

- Execute exact single-name module assignments as prefix-owned ScopeRebind values.
- Preserve the evaluated RHS Floor for later module statements such as subscript deletion.

## Root cause

Ordinary AssignSugar is intentionally inert because function substitution consumes assignments. Module-prefix execution has no substitution pass, so OPCODES = _makecodes(...) never entered temporal state and the authenticated delete saw a free SymbolicValue.

## IDD receipts

- Focused: 1 passed in 1.35s.
- Parent main 829bfbb8: 2 failed at re/_constants.py:124 SymbolicValue OPCODES delete; /tmp/option-main829-lifecycle.log sha256 8835d248...
- Head ea3b58521: 2 failed later at re/_constants.py:71 item.name; /tmp/option-ea3b-lifecycle.log sha256 7d03ec91...
- Epsilon: R_module_prefix_name_assignment -1; no generic delete or attribute fallback.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind module-level name assignments during prefix execution
> - Adds `_ModuleNameAssignmentBindingSugar` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6917/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to handle `Name = <RHS>` assignments during module prefix evaluation, evaluating the RHS and rebinding the name in module scope via `ScopeRebind`.
> - Updates `_module_prefix_outcome` to detect single-target `Assign` statements with a `Name` target and wrap them with the new sugar class instead of falling through to `statement.sugar()`.
> - Updates a test fixture in [test_reexport_alias_star_warrants.py](https://github.com/TSavo/sugar/pull/6917/files#diff-2a4c0b7275c1bf7d3be5bf3269497bedc91adc368e4dd832207fd501feadb4f2) to exercise the new binding behavior before performing a subscript delete.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea3b585.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->