### PR TITLE
Refuse untransported class creation keywords

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -233,6 +233,24 @@ class _ModuleClassDefinitionBindingSugar:
         from sugar_lift_py_tests.outcome import Complete
         from sugar_source_tree.panic import SugarNotWritten
 
+        unsupported_keywords = tuple(
+            keyword
+            for keyword in self.definition.keywords
+            if keyword.arg != "metaclass"
+        )
+        if unsupported_keywords:
+            keyword = unsupported_keywords[0]
+            label = keyword.arg if keyword.arg is not None else "**"
+            raise SugarNotWritten(
+                owner="module definition execution",
+                blame=keyword.value.fragment,
+                observed=f"unsupported class creation keyword {label}",
+                requested="one transported class creation keyword roster",
+                fix=(
+                    "transport the exact parser-owned class keyword through "
+                    "the metaclass call or keep publication loud"
+                ),
+            )
         sugar = self.definition.sugar()
         outcome = sugar.desugar(ctx)
 

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -681,6 +681,78 @@ def test_module_prefix_execution_publishes_exact_metaclass_result(
     )
 
 
+@pytest.mark.parametrize(
+    ("class_keywords", "observed"),
+    (
+        ("flag=True", "unsupported class creation keyword flag"),
+        ("**{'flag': True}", "unsupported class creation keyword **"),
+    ),
+)
+def test_module_prefix_refuses_untransported_class_creation_keywords(
+    tmp_path: Path, class_keywords: str, observed: str
+) -> None:
+    """Only the exact metaclass keyword has a constructed publication path."""
+    from sugar_source_tree.panic import SugarNotWritten
+    from sugar_lift_python_source import manager_construction
+
+    source = (
+        f"class Published({class_keywords}):\n"
+        "    TOKEN = 7\n"
+        "def build():\n"
+        "    return Published\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="module-class-keyword-prefix-pkg",
+        files={"module_class_keyword_prefix_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "module_class_keyword_prefix_pkg"
+    ]
+
+    with pytest.raises(SugarNotWritten) as raised:
+        manager_construction._module_prefix_outcome(
+            module, ast.parse(source).body[-1]
+        )
+
+    assert raised.value.owner == "module definition execution"
+    assert raised.value.observed == observed
+    assert raised.value.requested == "one transported class creation keyword roster"
+
+
+def test_module_prefix_without_class_creation_keywords_still_publishes(
+    tmp_path: Path,
+) -> None:
+    """Truthful twin: an empty keyword roster needs no invented transport."""
+    from sugar_lift_py_tests.floor import ClassDefinitionValue
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source import manager_construction
+
+    source = (
+        "class Published:\n"
+        "    TOKEN = 7\n"
+        "def build():\n"
+        "    return Published\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="module-class-no-keyword-prefix-pkg",
+        files={"module_class_no_keyword_prefix_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "module_class_no_keyword_prefix_pkg"
+    ]
+
+    exits = manager_construction._module_prefix_outcome(
+        module, ast.parse(source).body[-1]
+    )
+
+    assert len(exits.exits) == 1
+    assert isinstance(exits.exits[0], Completed)
+    published = exits.exits[0].value.context.temporal.value_if_bound("Published")
+    assert type(published) is ClassDefinitionValue
+
+
 def test_prefix_adapter_propagates_missing_construction_producer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes the post-merge ClassDef publication law: module prefix execution now refuses parser-owned class creation keywords other than the exact transported metaclass keyword before publishing a class.

Production-path twins cover flag= and **kwargs refusal, an empty keyword roster, and unchanged exact metaclass publication. No OPCODES or PR6901-6914 scope touched.

Focused receipt: 4 passed in 0.94s. R_untransported_class_keywords: 2 -> 0.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse unsupported class creation keywords in `_ModuleClassDefinitionBindingSugar.desugar`
> Adds a validation step in [`manager_construction.py`](https://github.com/TSavo/sugar/pull/6918/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) that inspects class definition keywords before desugaring. Any keyword other than `metaclass`, including `**` dict expansion, causes `SugarNotWritten` to be raised with blame pointed at the offending keyword's fragment. Tests cover both the rejection of unsupported keywords and the success path when no extra keywords are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0a0dc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->