### PR TITLE
Publish async definitions in module prefixes

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -26,6 +26,7 @@ from sugar_source_tree.binding_state import BindingEntryV1
 from sugar_source_tree.nodes import (
     AnnAssign,
     Assign,
+    AsyncFunctionDef,
     Attribute,
     AugAssign,
     Call,
@@ -143,9 +144,9 @@ class _ModuleSourceFrameCallableV1(FloorValue):
 
 @dataclass(frozen=True)
 class _ModuleFunctionDefinitionCallableV1(FloorValue):
-    """An exact module FunctionDef whose body is constructed only when called."""
+    """An exact module function definition constructed only when called."""
 
-    definition: FunctionDef
+    definition: FunctionDef | AsyncFunctionDef
 
     def to_term(self, *, owner):
         del owner
@@ -166,7 +167,7 @@ class _ModuleFunctionDefinitionCallableV1(FloorValue):
 
 @dataclass(frozen=True)
 class _ModuleFunctionDefinitionBindingSugar:
-    definition: FunctionDef
+    definition: FunctionDef | AsyncFunctionDef
 
     def desugar(self, ctx=None):
         from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind
@@ -174,10 +175,11 @@ class _ModuleFunctionDefinitionBindingSugar:
         from sugar_source_tree.panic import SugarNotWritten
 
         if self.definition.decorators:
+            definition_kind = type(self.definition).__name__
             raise SugarNotWritten(
                 owner="module function definition execution",
                 blame=self.definition.fragment,
-                observed="decorated FunctionDef has no completed publication",
+                observed=f"decorated {definition_kind} has no completed publication",
                 requested="the exact final decorated function Floor",
                 fix="execute and authenticate the function decorator chain",
             )
@@ -587,9 +589,7 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
     sugars = tuple(
         (
             _ModuleFunctionDefinitionBindingSugar(statement)
-            if isinstance(statement, FunctionDef)
-            else InertSugar(site=statement.fragment)
-            if isinstance(statement, AsyncFunctionDef)
+            if isinstance(statement, (FunctionDef, AsyncFunctionDef))
             else _ModuleClassDefinitionBindingSugar(
                 statement, source_file.construction_event_receipt_cid
             )

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -552,8 +552,82 @@ def test_module_prefix_does_not_construct_an_uncalled_function_body(
     completed = exits.exits[0]
     assert isinstance(completed, Completed)
     dormant = completed.value.context.temporal.value_if_bound("dormant")
-    assert type(dormant).__name__ == "_ModuleFunctionDefinitionCallableV1"
+    assert type(dormant) is manager_construction._ModuleFunctionDefinitionCallableV1
     assert dormant.definition.name == "dormant"
+
+
+def test_module_prefix_publishes_exact_async_definition_without_running_body(
+    tmp_path: Path,
+) -> None:
+    """An authenticated async definition binds its exact parser-owned occurrence."""
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source import manager_construction
+    from sugar_source_tree.nodes import AsyncFunctionDef
+
+    source = (
+        "async def dormant(manager):\n"
+        "    with manager:\n"
+        "        return 1\n"
+        "def build():\n"
+        "    return dormant\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="async-module-function-pkg",
+        files={"async_module_function_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "async_module_function_pkg"
+    ]
+
+    exits = manager_construction._module_prefix_outcome(
+        module, ast.parse(source).body[-1]
+    )
+
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    dormant = completed.value.context.temporal.value_if_bound("dormant")
+    assert type(dormant).__name__ == "_ModuleFunctionDefinitionCallableV1"
+    assert isinstance(dormant.definition, AsyncFunctionDef)
+    assert dormant.definition.fragment.source_cid == module.source_cid
+    assert dormant.definition.fragment.span.start == 0
+    assert dormant.definition.fragment.span.end == 62
+
+
+def test_module_prefix_refuses_decorated_async_definition_before_completion(
+    tmp_path: Path,
+) -> None:
+    """A different async-definition occurrence cannot borrow plain publication."""
+    from sugar_lift_python_source import manager_construction
+    from sugar_source_tree.panic import SugarNotWritten
+
+    source = (
+        "@decorate\n"
+        "async def dormant():\n"
+        "    return 1\n"
+        "def build():\n"
+        "    return dormant\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="decorated-async-module-function-pkg",
+        files={"decorated_async_module_function_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "decorated_async_module_function_pkg"
+    ]
+
+    with pytest.raises(SugarNotWritten) as raised:
+        manager_construction._module_prefix_outcome(
+            module, ast.parse(source).body[-1]
+        )
+
+    assert raised.value.owner == "module function definition execution"
+    assert raised.value.blame.source_cid == module.source_cid
+    assert raised.value.blame.span.start == 10
+    assert raised.value.blame.span.end == 43
+    assert raised.value.observed == "decorated AsyncFunctionDef has no completed publication"
 
 
 def test_module_prefix_constructs_one_subscript_delete_statement(


### PR DESCRIPTION
## Summary
- publish authenticated module-level `AsyncFunctionDef` through the existing deferred function-definition owner
- retain the exact parser-owned definition occurrence without executing its body
- refuse decorated async definitions loudly before prefix completion

## Instrument
- `R_module_prefix_async_definition_omission`: 1 -> 0
- predicted `Epsilon R = -1`
- floors: no consumer fallback, spelling/vendor arm, OPCODES edit, or PR #6901-#6914 surface

## Focused receipt
- CPython 3.12: `4 passed, 30 deselected in 1.90s`; exit 0
- log: `/tmp/agy2-async-prefix-focused.log`
- SHA-256: `45bb1d226e5125a49af1a576529ed019610358e2f3defd12e31e9692dcb10af2`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish async function definitions in module prefixes as callable bindings
> - `AsyncFunctionDef` nodes in the authenticated module prefix are now processed by `_ModuleFunctionDefinitionBindingSugar` instead of being wrapped in `InertSugar`, making them callable bindings like their sync counterparts.
> - `_ModuleFunctionDefinitionCallableV1` and `_ModuleFunctionDefinitionBindingSugar` now accept `FunctionDef | AsyncFunctionDef` for their `definition` field.
> - Error messages for decorated async definitions now include the concrete node kind (e.g. `'decorated AsyncFunctionDef ...'`) rather than a hardcoded `'FunctionDef'` string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b83685.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->