### PR TITLE
Refuse synchronous application of async module functions

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -159,6 +159,16 @@ class _ModuleFunctionDefinitionCallableV1(FloorValue):
         )
 
     def callable_application_with(self, operation, ctx):
+        from sugar_source_tree.panic import SugarNotWritten
+
+        if isinstance(self.definition, AsyncFunctionDef):
+            raise SugarNotWritten(
+                owner="module function definition application",
+                blame=operation.site,
+                observed="AsyncFunctionDef reached the synchronous module callable floor",
+                requested="an authenticated coroutine-construction Floor",
+                fix="publish and consume a dedicated async callable owner before application",
+            )
         return _ModuleSourceFrameCallableV1(
             self.definition.name,
             self.definition.source_visible_call_frame(),

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -630,6 +630,67 @@ def test_module_prefix_refuses_decorated_async_definition_before_completion(
     assert raised.value.observed == "decorated AsyncFunctionDef has no completed publication"
 
 
+def test_module_async_function_application_stays_typed_loud_while_plain_function_applies(
+    tmp_path: Path,
+) -> None:
+    """Publication does not authorize synchronous execution of an async frame."""
+    from sugar_lift_py_tests.callable_application import CallableApplication
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_python_source import manager_construction
+    from sugar_source_tree.panic import SugarNotWritten
+
+    source = (
+        "async def async_target():\n"
+        "    return 1\n"
+        "def plain_target():\n"
+        "    return 1\n"
+        "def build():\n"
+        "    return async_target\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="async-call-application-pkg",
+        files={"async_call_application_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "async_call_application_pkg"
+    ]
+    published = manager_construction._module_prefix_outcome(
+        module, ast.parse(source).body[-1]
+    )
+    async_callable = published.exits[0].value.context.temporal.value_if_bound(
+        "async_target"
+    )
+    with pytest.raises(SugarNotWritten) as raised:
+        CallableApplication((), (), async_callable.definition.fragment).apply(
+            async_callable, None
+        )
+    assert raised.value.owner == "module function definition application"
+    assert "AsyncFunctionDef" in raised.value.observed
+
+    plain_module = DependencyArtifactGraph.authenticate(
+        _dist(
+            tmp_path / "plain",
+            name="plain-call-application-pkg",
+            files={
+                "plain_call_application_pkg/__init__.py": source.replace(
+                    "return async_target", "return plain_target"
+                )
+            },
+        )
+    ).modules["plain_call_application_pkg"]
+    plain_published = manager_construction._module_prefix_outcome(
+        plain_module, ast.parse(source).body[-1]
+    )
+    plain_callable = plain_published.exits[0].value.context.temporal.value_if_bound(
+        "plain_target"
+    )
+    applied = CallableApplication(
+        (), (), plain_callable.definition.fragment
+    ).apply(plain_callable, None)
+    assert isinstance(applied, Complete)
+
+
 def test_module_prefix_constructs_one_subscript_delete_statement(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Adds a typed SugarNotWritten refusal when AsyncFunctionDef reaches the synchronous module callable floor. Keeps ordinary FunctionDef application green and adds an exact async production-path twin.

Focused receipt: 3 passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `SugarNotWritten` when applying async module functions via synchronous callable path
> - `_ModuleFunctionDefinitionCallableV1.callable_application_with` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6920/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) now checks if the stored definition is an `AsyncFunctionDef` and raises `SugarNotWritten` instead of proceeding.
> - A new test in [test_reexport_alias_star_warrants.py](https://github.com/TSavo/sugar/pull/6920/files#diff-2a4c0b7275c1bf7d3be5bf3269497bedc91adc368e4dd832207fd501feadb4f2) verifies async functions raise `SugarNotWritten` while plain functions still return a `Complete` outcome.
> - Behavioral Change: async module-level functions that were previously handled (likely incorrectly) by the synchronous path now fail loudly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41911c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->