### PR TITLE
Refuse synchronous AsyncFunctionDef application

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -595,6 +595,119 @@ def test_module_prefix_publishes_exact_async_definition_without_running_body(
     assert dormant.definition.fragment.span.end == 62
 
 
+def test_module_prefix_refuses_synchronous_async_function_application(
+    tmp_path: Path,
+) -> None:
+    """Calling an async definition cannot reuse synchronous source-frame meaning."""
+    from sugar_lift_py_tests.callable_application import CallableApplication
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+    from sugar_lift_py_tests.floor import TermValue
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source import manager_construction
+    from sugar_source_tree.nodes import Call
+    from sugar_source_tree.panic import SugarNotWritten
+    from sugar_source_tree.tree import SourceFile
+
+    source = (
+        "async def produce(value):\n"
+        "    return value\n"
+        "result = produce(7)\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="async-module-call-pkg",
+        files={"async_module_call_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "async_module_call_pkg"
+    ]
+
+    exits = manager_construction._module_prefix_outcome(
+        module, ast.parse(source).body[-1]
+    )
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    callable_floor = completed.value.context.temporal.value_if_bound("produce")
+    tree = SourceFile.from_path(
+        tmp_path / "async_module_call_pkg/__init__.py",
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    call = next(node for node in tree.nodes() if isinstance(node, Call))
+    occurrence = manager_construction._call_coordinate(call)
+
+    with pytest.raises(SugarNotWritten) as raised:
+        CallableApplication(
+            (TermValue(7),),
+            (),
+            call.fragment,
+            owner="async module call test",
+            call_occurrence=occurrence,
+        ).apply(callable_floor, completed.value.context)
+
+    assert raised.value.owner == "module function definition application"
+    assert raised.value.blame.source_cid == module.source_cid
+    assert raised.value.observed == (
+        "AsyncFunctionDef reached the synchronous module callable floor"
+    )
+    assert raised.value.requested == "an authenticated coroutine-construction Floor"
+
+
+def test_module_prefix_sync_function_application_remains_completed(
+    tmp_path: Path,
+) -> None:
+    """Truthful twin: an ordinary FunctionDef keeps synchronous frame application."""
+    from sugar_lift_py_tests.callable_application import CallableApplication
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+    from sugar_lift_py_tests.floor import TermValue
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source import manager_construction
+    from sugar_source_tree.nodes import Call
+    from sugar_source_tree.tree import SourceFile
+
+    source = (
+        "def produce(value):\n"
+        "    return value\n"
+        "result = produce(7)\n"
+    )
+    dist = _dist(
+        tmp_path,
+        name="sync-module-call-pkg",
+        files={"sync_module_call_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "sync_module_call_pkg"
+    ]
+
+    exits = manager_construction._module_prefix_outcome(
+        module, ast.parse(source).body[-1]
+    )
+
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    callable_floor = completed.value.context.temporal.value_if_bound("produce")
+    tree = SourceFile.from_path(
+        tmp_path / "sync_module_call_pkg/__init__.py",
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    call = next(node for node in tree.nodes() if isinstance(node, Call))
+    occurrence = manager_construction._call_coordinate(call)
+
+    result = CallableApplication(
+        (TermValue(7),),
+        (),
+        call.fragment,
+        owner="sync module call test",
+        call_occurrence=occurrence,
+    ).apply(callable_floor, completed.value.context)
+
+    assert isinstance(result, Complete)
+    assert type(result.value) is TermValue
+    assert result.value.value == 7
+
+
 def test_module_prefix_refuses_decorated_async_definition_before_completion(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Adds the immediate post-merge callable law: module AsyncFunctionDef publication remains exact and lazy, but applying its published callable now raises a typed SugarNotWritten until authenticated coroutine construction exists. Ordinary FunctionDef application remains unchanged.

Production-path twins use ordinary module-prefix publication and exact source call occurrences.

Focused receipt: 3 passed in 0.92s. Law-only; product residual credit: none. Superseded component PRs: none.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse synchronous application of `AsyncFunctionDef` callables in module prefix
> Adds tests to verify that the module prefix callable floor correctly rejects synchronous application of async function definitions and accepts synchronous ones.
>
> - A new test asserts that applying an `AsyncFunctionDef` via `CallableApplication` raises `SugarNotWritten`, validating the exception's `owner`, `blame.source_cid`, `observed`, and `requested` fields.
> - A second test confirms that applying a regular `FunctionDef` still succeeds, returning a `Complete` with a `TermValue` of `7`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1a34c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->