### PR TITLE
WIP: Halted lineage and authenticated member instruments

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -86,6 +86,81 @@ class ExitSetFactoringGap(ValueError):
         return classify_factoring_gap(self.left, self.right)
 
 
+class _HaltLineageProducerMissingV1(TypeError):
+    """Typed refusal while Halted producer testimony is not yet migrated."""
+
+    def __init__(self, *, owner: str, effect: object, context: object, occurrence: object):
+        super().__init__("Halted lineage producer testimony is missing")
+        self.owner = owner
+        self.effect = effect
+        self.context = context
+        self.occurrence = occurrence
+
+
+class _HaltLineageRefusalV1(TypeError):
+    """Typed refusal for forged or reconstructed Halted lineage."""
+
+    def __init__(self, *, owner: str, reason: str, effect: object, context: object, receipt: object):
+        super().__init__(reason)
+        self.owner = owner
+        self.reason = reason
+        self.effect = effect
+        self.context = context
+        self.receipt = receipt
+
+
+def _legacy_halted_refusal(owner, effect, context):
+    raise _HaltLineageProducerMissingV1(
+        owner=owner, effect=effect, context=context, occurrence=effect
+    )
+
+
+def _build_halt_owner():
+    class Capability: __slots__ = ()
+    capability = Capability()
+    class Receipt:
+        __slots__ = ("owner", "source", "effect", "context", "occurrence", "_cap")
+        def __init__(self, cap, owner, source, effect, context, occurrence):
+            if cap is not capability: raise TypeError("private capability required")
+            object.__setattr__(self, "owner", owner); object.__setattr__(self, "source", source)
+            object.__setattr__(self, "effect", effect); object.__setattr__(self, "context", context)
+            object.__setattr__(self, "occurrence", occurrence); object.__setattr__(self, "_cap", cap)
+        def __setattr__(self, *_): raise TypeError("immutable receipt")
+    class PairedHalted(Halted):
+        __slots__ = ("receipt",)
+    class NonRaiseHalted(Halted):
+        __slots__ = ("receipt",)
+    def paired(owner, source, effect, context, occurrence, guard, faces, pending_contracts):
+        from sugar_lift_py_tests.effect import RaiseEffect
+        from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
+        effect = require_effect(effect)
+        if type(effect) not in (RaiseEffect, GroupedRaiseEffect) or effect.occurrence_id is not occurrence:
+            raise TypeError("paired Halted requires authenticated RaiseEffect occurrence")
+        receipt = Receipt(capability, owner, source, effect, context, occurrence)
+        face = object.__new__(PairedHalted)
+        object.__setattr__(face, "guard", guard); object.__setattr__(face, "effect", effect)
+        object.__setattr__(face, "state", context); object.__setattr__(face, "faces", faces)
+        object.__setattr__(face, "pending_contracts", pending_contracts); object.__setattr__(face, "receipt", receipt)
+        return face
+    def nonraise(owner, source, effect, context, occurrence, guard, faces, pending_contracts):
+        from sugar_lift_py_tests.effect.loop_control_effect import LoopControlEffect
+        effect = require_effect(effect)
+        if type(effect) is not LoopControlEffect or effect.occurrence_cid is not occurrence:
+            raise TypeError("nonraise Halted requires authenticated LoopControlEffect occurrence")
+        receipt = Receipt(capability, owner, source, effect, context, occurrence)
+        face = object.__new__(NonRaiseHalted)
+        object.__setattr__(face, "guard", guard); object.__setattr__(face, "effect", effect)
+        object.__setattr__(face, "state", context); object.__setattr__(face, "faces", faces)
+        object.__setattr__(face, "pending_contracts", pending_contracts); object.__setattr__(face, "receipt", receipt)
+        return face
+    def read(face):
+        if type(face) is PairedHalted or type(face) is NonRaiseHalted: return face.receipt
+        raise _HaltLineageProducerMissingV1(owner="_read_halt_lineage", effect=face.effect, context=face.state, occurrence=face.effect.occurrence_id)
+    return paired, nonraise, read
+
+
+
+
 @dataclass(frozen=True)
 class PartitionFace:
     """Testimony that this exit lies on ONE named side of a producer's split.
@@ -503,6 +578,11 @@ class Halted:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "effect", require_effect(self.effect))
+        _legacy_halted_refusal("Halted", self.effect, self.state)
+
+
+_construct_halted_from_lineage, _construct_nonraise_halted, _read_halt_lineage = _build_halt_owner()
+del _build_halt_owner
 
 
 Exit = Completed[T] | Halted
@@ -522,7 +602,7 @@ class ExitSet(Generic[T]):
     def halted(
         cls, effect: Effect, guard: Formula | None = None, state=None
     ) -> "ExitSet[T]":
-        return cls((Halted(guard or true_guard(), effect, state),)).normalize()
+        _legacy_halted_refusal("ExitSet.halted", effect, state)
 
     @classmethod
     def conditional_halt(cls, guard: Formula, effect: Effect, state: T) -> "ExitSet[T]":

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -602,6 +602,22 @@ class ExitSet(Generic[T]):
     def halted(
         cls, effect: Effect, guard: Formula | None = None, state=None
     ) -> "ExitSet[T]":
+        from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+        from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
+        from sugar_lift_py_tests.effect.loop_control_effect import LoopControlEffect
+        effect = require_effect(effect)
+        if type(effect) in (RaiseEffect, GroupedRaiseEffect):
+            face = _construct_halted_from_lineage(
+                "ExitSet.halted", state, effect, state, effect.occurrence_id,
+                guard or true_guard(), frozenset(), ()
+            )
+            return cls((face,)).normalize()
+        if type(effect) is LoopControlEffect:
+            face = _construct_nonraise_halted(
+                "ExitSet.halted", state, effect, state, effect.occurrence_cid,
+                guard or true_guard(), frozenset(), ()
+            )
+            return cls((face,)).normalize()
         _legacy_halted_refusal("ExitSet.halted", effect, state)
 
     @classmethod

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/exit_set_routing.py
@@ -91,10 +91,10 @@ def promote_raise_halts(exits):
                 # effect.  Keeping the raise entry in that state lets a later
                 # enclosing reducer promote the already-consumed edge again.
                 promoted.append(
-                    Halted(
-                        guard,
-                        entry.effect,
-                        replace(state, entries=tuple(prefix)),
+                    __import__("sugar_lift_py_tests.outcome.exit_set", fromlist=["_construct_halted_from_lineage"])._construct_halted_from_lineage(
+                        "promote_raise_halts", state, entry.effect,
+                        replace(state, entries=tuple(prefix)), entry.effect.occurrence_id,
+                        guard, frozenset(), ()
                     )
                 )
             else:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -154,7 +154,8 @@ def _enrol_exit_obligations(exits: ExitSet) -> ExitSet:
         if isinstance(exit_, Completed):
             enrolled.append(Completed(exit_.guard, widened, exit_.faces, ()))
         else:
-            enrolled.append(Halted(exit_.guard, exit_.effect, widened, exit_.faces, ()))
+            from sugar_lift_py_tests.outcome.exit_set import _construct_halted_from_lineage
+            enrolled.append(_construct_halted_from_lineage("function_universe", widened, exit_.effect, widened, exit_.effect.occurrence_id, exit_.guard, exit_.faces, ()))
     return ExitSet(tuple(enrolled)).normalize()
 
 
@@ -373,7 +374,7 @@ def reduce_block_to_exitset(
                             if len(entry.branch_conditions) == 1
                             else and_(list(entry.branch_conditions))
                         )
-                        exits.append(Halted(guard, entry.effect, state))
+                        exits.extend(ExitSet.halted(entry.effect, guard, state).exits)
                     else:
                         entries.append(entry)
                 completed_state = _ReducedBlock(
@@ -419,10 +420,8 @@ def reduce_block_to_exitset(
                 outcome = ExitSet(
                     tuple(
                         (
-                            Halted(
-                                exit_.guard,
-                                exit_.effect,
-                                _halt_state(state, exit_),
+                            __import__("sugar_lift_py_tests.outcome.exit_set", fromlist=["_construct_halted_from_lineage"])._construct_halted_from_lineage(
+                                "function_universe", state, exit_.effect, _halt_state(state, exit_), exit_.effect.occurrence_id, exit_.guard,
                                 # This rebuild used to state three fields, so it
                                 # dropped BOTH the arm's partition testimony and
                                 # its pending obligations on the way through --
@@ -462,7 +461,7 @@ def reduce_block_to_exitset(
 
                 return ExitSet(
                     (
-                        Halted(follow.halt_guard, outcome.effect, state),
+                        __import__("sugar_lift_py_tests.outcome.exit_set", fromlist=["_construct_halted_from_lineage"])._construct_halted_from_lineage("function_universe", state, outcome.effect, state, outcome.effect.occurrence_id, follow.halt_guard, frozenset(), ()),
                         Completed(
                             complement_guard(follow.halt_guard),
                             _ReducedBlock(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_control_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_control_sugar.py
@@ -19,7 +19,10 @@ class LoopControlSugar(Sugar):
         return ()
 
     def desugar(self, ctx: object = None):
-        return ExitSet.halted(
-            LoopControlEffect(self.action, self.target_cid, self.occurrence_cid),
-            state=ctx,
+        from sugar_lift_py_tests.outcome.exit_set import _construct_nonraise_halted
+        effect = LoopControlEffect(self.action, self.target_cid, self.occurrence_cid)
+        face = _construct_nonraise_halted(
+            "loop_control_sugar", self.site, effect, ctx, effect.occurrence_cid,
+            true_guard(), frozenset(), ()
         )
+        return ExitSet((face,)).normalize()

--- a/implementations/python/sugar-lift-py-tests/tests/test_halted_face_pairing_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_halted_face_pairing_instrument.py
@@ -1,0 +1,215 @@
+"""Two-axis honest-red instrument for the Halted lineage owner."""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+import pickle
+from pathlib import Path
+
+import pytest
+
+import sugar_lift_py_tests.outcome.exit_set as owner
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
+from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
+from sugar_source_tree.tree import SourceFile
+
+
+DEPENDENT_AXIS_STATUS = {
+    "migration_direct43_indirect20": "UNMEASURED: paired lineage door",
+    "effect_change_same_event": "UNMEASURED: paired lineage door",
+    "merge_same_and_distinct": "UNMEASURED: paired lineage door",
+    "handler_match_bind_counters": "UNMEASURED: paired lineage door",
+    "trystar_partition_substitution": "UNMEASURED: paired lineage door",
+    "public_capability_closure": "UNMEASURED: paired lineage door",
+    "constructor_copy_refusal_work0": "UNMEASURED: paired lineage door",
+}
+
+
+def _paired_gate(axis: str, tmp_path: Path | None = None):
+    if tmp_path is not None:
+        source, function, exits = _reduced(tmp_path, f"gate_{axis}", "def target():\n    raise ValueError('gate')\n")
+        (face,) = exits.exits
+        lineage = owner._read_halt_lineage(face)
+        assert type(lineage) is owner._PairedRaiseFaceV1
+        assert lineage.effect is face.effect
+        assert lineage.pre_effect_context is face.state.context
+        assert lineage.source_identity is source.unit
+        assert lineage.definition_locus is function.fragment
+        assert lineage.owner_receipt.source_identity is source.unit
+    return True
+
+
+def _reduced(tmp_path: Path, stem: str, text: str):
+    path = tmp_path / f"{stem}.py"
+    path.write_text(text, encoding="utf-8")
+    source = SourceFile.from_path(path)
+    functions = tuple(source.functions())
+    (function,) = functions
+    return source, function, reduce_block_to_exitset(function.sugar().statements, None)
+
+
+def _read(face):
+    """Ordinary producer reduction is the sole admission boundary."""
+    return owner._read_halt_lineage(face)
+
+
+def test_paired_lineage_owner_and_all_downstream_teeth(tmp_path: Path):
+    source, function, exits = _reduced(
+        tmp_path, "paired", "def target():\n    raise ValueError('boom')\n"
+    )
+    (face,) = exits.exits
+    assert isinstance(face.effect, RaiseEffect)
+    lineage = _read(face)
+    assert type(lineage) is owner._PairedRaiseFaceV1
+    assert lineage.effect is face.effect
+    assert lineage.pre_effect_context is face.state.context
+    assert lineage.source_identity is source.unit
+    assert lineage.definition_locus is function.fragment
+    assert lineage.effect_occurrence == face.effect.occurrence_id
+    assert lineage.owner_receipt.source_identity is source.unit
+
+    (guarded,) = owner.ExitSet((face,)).guarded(face.guard).exits
+    (normalized,) = owner.ExitSet((face,)).normalize().exits
+    sequenced = owner.ExitSet((face,)).sequence(lambda value: owner.ExitSet.completed(value))
+    assert _read(guarded) is lineage
+    assert _read(normalized) is lineage
+    (sequenced_face,) = sequenced.exits
+    (merged_same,) = owner.ExitSet((face, face)).normalize().exits
+    assert _read(sequenced_face) is lineage
+    assert _read(merged_same) is lineage
+
+    _, _, distinct_exits = _reduced(
+        tmp_path, "distinct", "def target():\n    raise KeyError('boom')\n"
+    )
+    (distinct,) = distinct_exits.exits
+    with pytest.raises(owner._HaltLineageConflictV1) as conflict:
+        owner.ExitSet((face, distinct)).normalize()
+    assert conflict.value.left_lineage is lineage
+    assert conflict.value.right_lineage is _read(distinct)
+
+
+    # Closed construction/refusal and public capability closure auto-activate
+    # with the owner product; no test-only replay/mutation API is introduced.
+    for operation in (
+        lambda: type(face)(face.guard, face.effect, face.state),
+        lambda: copy.copy(face),
+        lambda: copy.deepcopy(face),
+        lambda: dataclasses.replace(face, effect=face.effect),
+        lambda: pickle.loads(pickle.dumps(face)),
+    ):
+        with pytest.raises(owner._HaltLineageRefusalV1) as refusal:
+            operation()
+        assert refusal.value.effect is face.effect
+        assert refusal.value.context is face.state.context
+        assert refusal.value.source is source.unit
+        assert refusal.value.occurrence == face.effect.occurrence_id
+
+
+    # Real TryStar path: partition lineage retains distinct authenticated
+    # original/matched/residual occurrence objects.
+    star_source, _, star_exits = _reduced(
+        tmp_path,
+        "star",
+        "def target():\n"
+        "    try:\n"
+        "        raise ExceptionGroup('g', [ValueError('v'), TypeError('t')])\n"
+        "    except* ValueError:\n"
+        "        raise RuntimeError('handler')\n",
+    )
+    grouped = tuple(face for face in star_exits.exits if isinstance(face.effect, GroupedRaiseEffect))
+    (grouped_face,) = grouped
+    partition = _read(grouped_face).partition_lineage
+    assert partition.source_identity is star_source.unit
+    assert partition.original_occurrence is not partition.matched_occurrence
+    assert partition.original_occurrence is not partition.residual_occurrence
+    assert partition.matched_occurrence is not partition.residual_occurrence
+
+
+def test_authenticated_nonraise_producer_and_cross_variant_refusal(tmp_path: Path):
+    # This is an independent producer door: it must not key off the paired
+    # reader.  Missing producer testimony is the sole honest red for this axis.
+    variant_name = "_AuthenticatedNonRaiseHaltV1"
+    if variant_name not in owner.__dict__:
+        pytest.fail(
+        "R_missing_authenticated_nonraise_producer=1: no canonical ordinary "
+            "authenticated nonraise producer is available; do not fabricate one",
+            pytrace=False,
+        )
+    pytest.fail(
+        "R_missing_authenticated_nonraise_producer=1: canonical ordinary "
+        "nonraise Halted specimen is unavailable; no fabricated Returned fixture",
+        pytrace=False,
+    )
+
+
+def _semantic_raise(tmp_path: Path, stem: str = "semantic"):
+    source, function, exits = _reduced(
+        tmp_path, stem, "def target():\n    raise ValueError('ordinary')\n"
+    )
+    (face,) = exits.exits
+    assert isinstance(face.effect, RaiseEffect)
+    return source, function, face
+
+
+def test_migration_and_transform_closure_is_producer_owned(tmp_path: Path):
+    if not _paired_gate("migration_direct43_indirect20", tmp_path):
+        return
+    source, function, face = _semantic_raise(tmp_path, "migration")
+    lineage = _read(face)
+    assert lineage.source_identity is source.unit
+    assert lineage.definition_locus is function.fragment
+
+
+def test_effect_change_and_merge_laws_are_ordinary(tmp_path: Path):
+    if not _paired_gate("effect_change_same_event", tmp_path):
+        return
+    if not _paired_gate("merge_same_and_distinct", tmp_path):
+        return
+    source, _, face = _semantic_raise(tmp_path, "effect_change")
+    lineage = _read(face)
+    changed = owner.ExitSet((face,)).normalize()
+    (same,) = changed.exits
+    assert _read(same) is lineage
+    _, _, other = _semantic_raise(tmp_path, "merge_conflict")
+    with pytest.raises(owner._HaltLineageConflictV1):
+        owner.ExitSet((face, other)).normalize()
+
+
+def test_handler_matching_binding_has_external_work_counters(tmp_path: Path):
+    if not _paired_gate("handler_match_bind_counters", tmp_path):
+        return
+    source, function, exits = _reduced(
+        tmp_path, "handler", "def target():\n    try:\n        raise ValueError('x')\n    except ValueError as error:\n        raise RuntimeError(str(error))\n    finally:\n        pass\n"
+    )
+    (face,) = exits.exits
+    assert face.effect is not None
+    assert source.unit is not None and function.fragment is not None
+
+
+def test_trystar_partition_refusal_is_typed_and_observed(tmp_path: Path):
+    if not _paired_gate("trystar_partition_substitution", tmp_path):
+        return
+    source, _, exits = _reduced(
+        tmp_path, "partition", "def target():\n    try:\n        raise ExceptionGroup('g', [ValueError('v'), TypeError('t')])\n    except* ValueError:\n        raise RuntimeError('handled')\n"
+    )
+    grouped = tuple(f for f in exits.exits if isinstance(f.effect, GroupedRaiseEffect))
+    (face,) = grouped
+    partition = _read(face).partition_lineage
+    assert partition.source_identity is source.unit
+    assert partition.original_occurrence is not partition.matched_occurrence
+
+
+def test_public_capability_closure_is_semantic():
+    if not _paired_gate("public_capability_closure"):
+        return
+    raise AssertionError("semantic capability closure requires authenticated audit")
+
+
+def test_closed_constructor_refusal_has_external_observation(tmp_path: Path):
+    if not _paired_gate("constructor_copy_refusal_work0", tmp_path):
+        return
+    _, _, face = _semantic_raise(tmp_path, "refusal")
+    with pytest.raises(owner._HaltLineageRefusalV1):
+        type(face)(face.guard, face.effect, face.state)

--- a/implementations/python/sugar-lift-py-tests/tests/test_halted_lineage_owner_prerequisite_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_halted_lineage_owner_prerequisite_instrument.py
@@ -1,0 +1,83 @@
+"""Focused owner-first instrument for Halted lineage seating (test-only)."""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+import pickle
+from pathlib import Path
+
+import pytest
+
+import sugar_lift_py_tests.outcome.exit_set as owner
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.effect.loop_control_effect import LoopControlEffect
+from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
+from sugar_source_tree.tree import SourceFile
+
+
+def _reduce(tmp_path: Path, stem: str, text: str):
+    path = tmp_path / f"{stem}.py"
+    path.write_text(text, encoding="utf-8")
+    source = SourceFile.from_path(path)
+    (function,) = tuple(source.functions())
+    return source, function, reduce_block_to_exitset(function.sugar().statements, None)
+
+
+def test_raise_owner_seats_exact_paired_lineage(tmp_path: Path, monkeypatch):
+    from sugar_lift_py_tests.sugar import exit_set_routing
+    seen = []
+    original = exit_set_routing.promote_raise_halts
+    def observe(exits):
+        seen.append(exits)
+        return original(exits)
+    monkeypatch.setattr(exit_set_routing, "promote_raise_halts", observe)
+    with pytest.raises(owner._HaltLineageProducerMissingV1):
+        _reduce(tmp_path, "raise", "def target():\n    raise ValueError('x')\n")
+    assert len(seen) == 1
+
+
+@pytest.mark.parametrize("statement", ["break", "continue"])
+def test_loop_control_owner_seats_authenticated_nonraise(tmp_path: Path, statement: str, monkeypatch):
+    from sugar_lift_py_tests.sugar.loop_control_sugar import LoopControlSugar
+    seen = []
+    original = LoopControlSugar.desugar
+    def observe(self, ctx=None):
+        seen.append((self, ctx))
+        return original(self, ctx)
+    monkeypatch.setattr(LoopControlSugar, "desugar", observe)
+    with pytest.raises(owner._HaltLineageProducerMissingV1):
+        _reduce(tmp_path, statement, f"def target(xs):\n    for x in xs:\n        {statement}\n")
+    assert len(seen) == 1
+    assert seen[0][0].target_cid != seen[0][0].occurrence_cid
+
+
+def test_legacy_and_forged_faces_refuse_with_external_zero_work(tmp_path: Path):
+    pytest.importorskip("sugar_lift_py_tests.outcome.exit_set")
+    source, _, exits = _reduce(tmp_path, "plain", "def target():\n    raise ValueError('x')\n")
+    (face,) = exits.exits
+    refusal_type = owner._HaltLineageRefusalV1
+    for operation in (
+        lambda: type(face)(face.guard, face.effect, face.state),
+        lambda: copy.copy(face),
+        lambda: copy.deepcopy(face),
+        lambda: dataclasses.replace(face, effect=face.effect),
+        lambda: pickle.loads(pickle.dumps(face)),
+    ):
+        with pytest.raises(refusal_type) as raised:
+            operation()
+        assert raised.value.effect is face.effect
+        assert raised.value.context is face.state.context
+        assert raised.value.source is source.unit
+        assert raised.value.occurrence == face.effect.occurrence_id
+        assert raised.value.downstream_work == 0
+
+
+def test_transforms_preserve_identity_and_cross_variant_refuses(tmp_path: Path):
+    _, _, exits = _reduce(tmp_path, "transform", "def target():\n    raise ValueError('x')\n")
+    (face,) = exits.exits
+    lineage = owner._read_halt_lineage(face)
+    (guarded,) = owner.ExitSet((face,)).guarded(face.guard).exits
+    (normalized,) = owner.ExitSet((face,)).normalize().exits
+    assert owner._read_halt_lineage(guarded) is lineage
+    assert owner._read_halt_lineage(normalized) is lineage

--- a/implementations/python/sugar-lift-py-tests/tests/test_named_int_constant_attribute_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_named_int_constant_attribute_consumer.py
@@ -3,9 +3,43 @@
 from sugar_lift_py_tests.floor.object_value import ObjectField, ObjectValue
 from sugar_lift_py_tests.floor.string_value import StringValue
 from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_source_tree.panic import SugarNotWritten
-from sugar_source_tree.fragment import SourceFragment
 import pytest
+
+
+class _ReceiverSugar(ConstructedTermSugar):
+    def __init__(self, receiver):
+        self.receiver = receiver
+        self.site = _Site("receiver")
+
+    @classmethod
+    def witnesses(cls):
+        raise AssertionError("instrument leaf")
+
+    def desugar(self, ctx=None):
+        return Complete(self.receiver)
+
+    def to_term(self, *, owner):
+        del owner
+        return self.receiver.to_term(owner="instrument")
+
+
+class _Seal:
+    def __init__(self, cid):
+        self.cid = cid
+        self.source_cid = "source"
+        self.start = 0
+        self.end = 1
+
+
+class _Site:
+    def __init__(self, cid):
+        self._seal = _Seal(cid)
+
+    def seal(self):
+        return self._seal
 
 
 def test_named_int_constant_name_uses_object_field_owner() -> None:
@@ -13,9 +47,12 @@ def test_named_int_constant_name_uses_object_field_owner() -> None:
         "re._constants._NamedIntConstant",
         (ObjectField("name", StringValue("SRE_FLAG_ASCII")),),
     )
-    outcome = receiver.attribute("name", SourceFragment)
+    first = AttributeSugar(_ReceiverSugar(receiver), "name", _Site("first"))
+    outcome = first.desugar()
     assert type(outcome) is Complete
     assert outcome.value == StringValue("SRE_FLAG_ASCII")
+    second = AttributeSugar(_ReceiverSugar(receiver), "name", _Site("second"))
+    assert first.to_term(owner="test") != second.to_term(owner="test")
 
 
 def test_named_int_constant_foreign_member_stays_typed_loud() -> None:
@@ -24,4 +61,4 @@ def test_named_int_constant_foreign_member_stays_typed_loud() -> None:
         (ObjectField("name", StringValue("SRE_FLAG_ASCII")),),
     )
     with pytest.raises(SugarNotWritten, match="ObjectValue.attribute"):
-        receiver.attribute("foreign", SourceFragment)
+        AttributeSugar(_ReceiverSugar(receiver), "foreign", _Site("foreign")).desugar()

--- a/implementations/python/sugar-lift-py-tests/tests/test_named_int_constant_attribute_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_named_int_constant_attribute_consumer.py
@@ -1,0 +1,27 @@
+"""Bounded consumer instrument for authenticated ``_NamedIntConstant.name``."""
+
+from sugar_lift_py_tests.floor.object_value import ObjectField, ObjectValue
+from sugar_lift_py_tests.floor.string_value import StringValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.fragment import SourceFragment
+import pytest
+
+
+def test_named_int_constant_name_uses_object_field_owner() -> None:
+    receiver = ObjectValue(
+        "re._constants._NamedIntConstant",
+        (ObjectField("name", StringValue("SRE_FLAG_ASCII")),),
+    )
+    outcome = receiver.attribute("name", SourceFragment)
+    assert type(outcome) is Complete
+    assert outcome.value == StringValue("SRE_FLAG_ASCII")
+
+
+def test_named_int_constant_foreign_member_stays_typed_loud() -> None:
+    receiver = ObjectValue(
+        "re._constants._NamedIntConstant",
+        (ObjectField("name", StringValue("SRE_FLAG_ASCII")),),
+    )
+    with pytest.raises(SugarNotWritten, match="ObjectValue.attribute"):
+        receiver.attribute("foreign", SourceFragment)

--- a/implementations/python/sugar-lift-python-source/tests/test_authenticated_import_member_value_instrument.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_authenticated_import_member_value_instrument.py
@@ -1,0 +1,190 @@
+"""Honest-red instrument for a closed imported-module member value producer.
+
+Only the missing typed producer door is red.  Active fixture preflights consume
+existing authenticated lexical and dependency-artifact products.  Every axis
+that requires the absent producer's typed closed result remains dormant and is
+not counted as a semantic red.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.import_binding import (
+    AuthenticatedImportUseV1,
+    authenticated_import_value_use_receipts,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import DependencyArtifactGraph
+
+
+PRODUCTION_MODULE = "sugar_lift_python_source.authenticated_import_member_value"
+
+
+def _distribution(root: Path) -> importlib.metadata.Distribution:
+    package = root / "provider_pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("member = 7\n", encoding="utf-8")
+    metadata = root / "provider_pkg_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: provider-pkg-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (metadata / "top_level.txt").write_text("provider_pkg\n", encoding="utf-8")
+    recorded = (
+        "provider_pkg/__init__.py",
+        "provider_pkg_dist-1.0.dist-info/METADATA",
+        "provider_pkg_dist-1.0.dist-info/top_level.txt",
+        "provider_pkg_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for seat in recorded:
+            writer.writerow((seat, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _receipt(root: Path, *, scoped: bool = False) -> AuthenticatedImportUseV1:
+    if scoped:
+        source = (
+            "def scope():\n"
+            "    from provider_pkg import member\n"
+            "    observed = member\n"
+        )
+    else:
+        source = "from provider_pkg import member\nobserved = member\n"
+    path = root / "consumer.py"
+    path.write_text(source, encoding="utf-8")
+    receipts, outcomes = authenticated_import_value_use_receipts(
+        root,
+        path,
+        source,
+        blake3_512_of(source.encode("utf-8")),
+        module_identities={},
+    )
+    assert set(outcomes.values()) == {"authenticated-import-value-use"}
+    # ImportFrom binds the member directly, so the lexical producer emits one
+    # value-use receipt.  No caller coordinate or spelling selection exists.
+    (receipt,) = receipts
+    return receipt
+
+
+def test_fixture_preflight_constructs_sole_occurrence_and_scope(tmp_path: Path) -> None:
+    """Active fixture: exact occurrence/scope come from the lexical producer."""
+    _distribution(tmp_path)
+    receipt = _receipt(tmp_path)
+
+    assert receipt.use["useSite"] == {
+        "sourceCid": receipt.source_cid,
+        "startLine": 2,
+        "startCol": 11,
+        "endLine": 2,
+        "endCol": 17,
+    }
+    assert receipt.import_binding.to_value()["scope"] == {
+        "sourceCid": receipt.source_cid,
+        "startLine": 1,
+        "startCol": 0,
+        "endLine": 2,
+        "endCol": 17,
+    }
+
+
+def test_fixture_preflight_constructs_independent_typed_dependency_graph(
+    tmp_path: Path,
+) -> None:
+    """Active fixture: graph intake is typed; no receipt relationship is claimed."""
+    graph = DependencyArtifactGraph.authenticate(_distribution(tmp_path))
+
+    assert type(graph) is DependencyArtifactGraph
+    assert graph.distribution_artifact_cid.startswith("blake3-512:")
+
+
+def test_scoped_fixture_preflight_proves_real_indentation_and_scope(
+    tmp_path: Path,
+) -> None:
+    """Active fixture: the scoped receipt is independently authenticated."""
+    receipt = _receipt(tmp_path, scoped=True)
+
+    assert receipt.use["useSite"] == {
+        "sourceCid": receipt.source_cid,
+        "startLine": 3,
+        "startCol": 15,
+        "endLine": 3,
+        "endCol": 21,
+    }
+    scope = receipt.import_binding.to_value()["scope"]
+    assert scope["sourceCid"] == receipt.source_cid
+    assert (scope["startLine"], scope["startCol"]) == (1, 0)
+    assert (scope["endLine"], scope["endCol"]) == (3, 21)
+
+
+def test_missing_closed_producer_door_is_one_red() -> None:
+    """R_missing_door=1: the typed producer module does not exist yet."""
+    assert importlib.util.find_spec(PRODUCTION_MODULE) is not None, (
+        "missing typed closed imported-module member producer door"
+    )
+
+
+_DORMANT_SEMANTIC_TEETH = (
+    "TermValue(31400)-recomputed-hash-and-fully-matching-tuple-refuse",
+    "dataclass-replace-refuses",
+    "deserialize-refuses",
+    "wrong-import-use-occurrence-refuses",
+    "wrong-member-coordinate-refuses",
+    "wrong-module-capability-refuses",
+    "wrong-module-source-cid-refuses",
+    "wrong-dependency-artifact-cid-refuses",
+    "wrong-lexical-scope-identity-refuses",
+    "wrong-value-sort-refuses",
+    "cross-wired-construction-result-refuses",
+    "missing-source-construction-testimony-refuses-before-consumer",
+    "same-spelling-foreign-member-refuses-and-pure-resolver-preserves-identity",
+)
+
+
+@pytest.mark.skip(reason="dormant until one truthful typed closed result exists")
+@pytest.mark.parametrize("tooth", _DORMANT_SEMANTIC_TEETH)
+def test_semantic_constructor_refusal_tooth_is_dormant(tooth: str) -> None:
+    """Thirteen semantic teeth are named but explicitly unmeasured."""
+    raise AssertionError(f"semantic tooth must be activated: {tooth}")
+
+
+@pytest.mark.skip(
+    reason=(
+        "dormant until a semantic cross-file provenance/dataflow auditor "
+        "discovers and audits the full public alias/reexport/caller closure"
+    )
+)
+def test_future_producer_side_door_closure_is_dormant() -> None:
+    """Unmeasured future tooth; a spelling/leaf checklist is not evidence.
+
+    The eventual live instrument must discover the repository closure and
+    require discovered == audited for producer inputs, graph selection,
+    traversal, occurrence sealing, introspection, fallback flow, and public
+    aliases/reexports/wrappers.  Until that semantic instrument exists this
+    tooth stays skipped rather than claiming a plausible green.
+    """
+    from sugar_lift_python_source.import_member_authority_audit import (
+        audit_import_member_authority_closure,
+    )
+
+    report = audit_import_member_authority_closure(
+        repository_root=Path(__file__).parents[4]
+    )
+    assert report.discovered == report.audited
+    assert report.unaudited == ()
+    assert report.caller_semantic_authority == ()
+    assert report.alternate_construction_doors == ()
+    assert report.unproven_graph_selections == ()
+    assert report.ast_or_body_reconstructions == ()
+    assert report.occurrence_reseals == ()
+    assert report.runtime_introspection == ()
+    assert report.fallback_flows == ()
+    assert report.public_aliases_without_closed_provenance == ()


### PR DESCRIPTION
Draft shutdown handoff.

Scoped commits:
- 87bb7dcc1 Halted lineage producer wiring/instruments
- 5368e4be4 authenticated imported-member instrument
- 6343b06c9 / 753bb05ce consumer instrument history

Status: focused semantic receipts remain RED/UNMEASURED; no claim of lifecycle clearance. Halted and imported-member work may be contained/superseded by consolidated #6922; do not merge this draft independently.

Excluded: no unrelated user files; no merge performed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add authenticated lineage construction and typed refusals for halted exit set faces
> - Introduces an owner-based authentication model for `Halted` faces: `PairedHalted` and `NonRaiseHalted` subclasses are constructed via `_construct_halted_from_lineage` and `_construct_nonraise_halted`, which verify effect occurrence IDs before issuing a receipt.
> - Direct `Halted(...)` construction now raises `_HaltLineageProducerMissingV1` (a `TypeError` subclass), blocking legacy unauthenticated instantiation.
> - All call sites in `exit_set_routing.py`, `function_universe_sugar.py`, and `loop_control_sugar.py` are updated to use the authenticated constructors.
> - Adds test modules covering lineage readback, identity preservation, typed refusal on copy/pickle/replace, and prerequisite producer behavior.
> - Risk: any code constructing `Halted` directly outside these authenticated paths will now raise at runtime instead of producing a usable face.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5368e4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->