### PR TITLE
Test comprehension item-value transport laws

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_comprehension_item_value_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_comprehension_item_value_transport.py
@@ -1,0 +1,131 @@
+"""Finite comprehensions transport exact item values or stay loudly unresolved."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.context import ReduceContext
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor import (
+    ComprehensionValue,
+    ListValue,
+    ObjectValue,
+    RaiseValue,
+    TermValue,
+)
+from sugar_lift_py_tests.floor.object_field import ObjectField
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_source_tree.nodes import ListComp, TargetPatternConstructionGapV1
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _source_list_comprehension(source: str):
+    tree = SourceFile(
+        (
+            source,
+            "tests/comprehension_item_value_transport.py",
+            blake3_512_of(source.encode()),
+        ),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    node = next(item for item in tree.nodes() if isinstance(item, ListComp))
+    return node.sugar()
+
+
+def _context_with_items(items) -> ReduceContext:
+    ctx = ReduceContext.root(owner="comprehension item transport")
+    return replace(ctx, temporal=ctx.temporal.bind_value("items", items))
+
+
+def _objects() -> tuple[ObjectValue, ObjectValue]:
+    return (
+        ObjectValue("_NamedIntConstant", (), identity="member:first"),
+        ObjectValue("_NamedIntConstant", (), identity="member:second"),
+    )
+
+
+def test_swapped_finite_members_preserve_each_object_identity() -> None:
+    first, second = _objects()
+    comprehension = _source_list_comprehension(
+        "def build(items):\n    return [item for item in items]\n"
+    )
+
+    forward = comprehension.desugar(_context_with_items(ListValue((first, second))))
+    swapped = comprehension.desugar(_context_with_items(ListValue((second, first))))
+
+    assert isinstance(forward, Complete)
+    assert isinstance(swapped, Complete)
+    assert forward.value.finite_elements == (first, second)
+    assert swapped.value.finite_elements == (second, first)
+    assert swapped.value.finite_elements[0] is second
+    assert swapped.value.finite_elements[1] is first
+
+
+def test_filtered_out_member_never_reaches_element_binding() -> None:
+    first = ObjectValue(
+        "_NamedIntConstant",
+        (ObjectField("keep", FalseBoolLiteralSugar(site="first.keep")),),
+        identity="member:first",
+    )
+    second = ObjectValue(
+        "_NamedIntConstant",
+        (ObjectField("keep", TrueBoolLiteralSugar(site="second.keep")),),
+        identity="member:second",
+    )
+    comprehension = _source_list_comprehension(
+        "def build(items):\n    return [item for item in items if item.keep]\n"
+    )
+
+    outcome = comprehension.desugar(_context_with_items(ListValue((first, second))))
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value.finite_elements == (second,)
+    assert outcome.value.finite_elements[0] is second
+    assert all(value is not first for value in outcome.value.finite_elements)
+
+
+def test_halted_constructor_arm_is_absent_from_finite_items() -> None:
+    first, second = _objects()
+    first = replace(first, fields=(ObjectField("values", ListValue((TermValue(7),))),))
+    second = replace(
+        second, fields=(ObjectField("values", ListValue((TermValue(9),))),)
+    )
+    comprehension = _source_list_comprehension(
+        "def build(items):\n    return [item.values[4] for item in items]\n"
+    )
+
+    outcome = comprehension.desugar(_context_with_items(ListValue((first, second))))
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert not isinstance(outcome.value, ComprehensionValue)
+
+
+def test_tuple_target_coordinate_swap_is_refused_by_source_owner() -> None:
+    comprehension = _source_list_comprehension(
+        "def build(pairs):\n    return [item for index, item in pairs]\n"
+    )
+    generator = comprehension.generators[0]
+
+    with pytest.raises(
+        TargetPatternConstructionGapV1, match="target-coordinate-order-mismatch"
+    ):
+        replace(
+            generator,
+            target_coordinates=tuple(reversed(generator.target_coordinates)),
+        )
+
+
+def test_nonfinite_iterable_with_undecided_filter_stays_loud() -> None:
+    comprehension = _source_list_comprehension(
+        "def build(items):\n    return [item for item in items if item.keep]\n"
+    )
+
+    with pytest.raises(SugarNotWritten, match="finite|filter|undecided"):
+        comprehension.desugar(_context_with_items(ObjectValue("UnknownIterable", ())))


### PR DESCRIPTION
## Scope

Adds one tests-only production-path instrument for finite comprehension item transport:

- swapped members preserve exact ObjectValue identity
- filtered-out members never reach element binding
- exceptional constructor results are absent from finite items
- tuple-target coordinate swaps are refused by the source owner
- nonfinite iterables with undecided filters remain loud

No production files changed.

## Focused receipt

Command:

    PYTHONPATH="$PWD/implementations/python/sugar-lift-python-source/src:$PWD/implementations/python/sugar-lift-py-tests/src:$PWD/implementations/python/sugar-source-tree/src" /usr/local/bin/python -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_comprehension_item_value_transport.py

Current honest result on origin/main: **3 passed, 2 failed in 4.58s**.

Live reds:

1. finite filter reduction reads unbound SymbolicValue(item) before seating the concrete member
2. ComprehensionGeneratorSugar lacks authenticated target_coordinates

Formatting and syntax:

- black --check: green
- py_compile: green

Corpus stable-zero and authenticated residual retirement remain unmeasured.

## Relationship to #6922

Draft PR #6922 contains the related consolidated production work and other comprehension tests, but not this exact test module. This component PR is intended for selective composition with #6922 and may be superseded once these exact teeth are incorporated there.

Do not merge independently while the production composition remains red.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Test comprehension item-value transport laws for list comprehension desugaring
> Adds tests in [test_comprehension_item_value_transport.py](https://github.com/TSavo/sugar/pull/6925/files#diff-b0ee67fb527848117b86ff009e30bc52393b2d304b6a4141a58633f98d2ef0fa) that verify the behavior of list comprehension desugaring across five scenarios:
>
> - Finite list desugaring preserves element identity and input order when members are swapped.
> - Filter predicates exclude falsey elements and preserve identity of included elements.
> - Out-of-bounds access inside a comprehension yields a `RaiseValue` rather than a partial `ComprehensionValue`.
> - Reordering tuple target coordinates raises `TargetPatternConstructionGapV1` with a `target-coordinate-order-mismatch` message.
> - Non-finite iterables with undecided filter conditions raise `SugarNotWritten` rather than resolving silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee55b97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->