### PR TITLE
Test authenticated new receiver field stores

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_named_int_constant_attribute_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_named_int_constant_attribute_consumer.py
@@ -1,0 +1,27 @@
+"""Bounded consumer instrument for authenticated ``_NamedIntConstant.name``."""
+
+from sugar_lift_py_tests.floor.object_value import ObjectField, ObjectValue
+from sugar_lift_py_tests.floor.string_value import StringValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.fragment import SourceFragment
+import pytest
+
+
+def test_named_int_constant_name_uses_object_field_owner() -> None:
+    receiver = ObjectValue(
+        "re._constants._NamedIntConstant",
+        (ObjectField("name", StringValue("SRE_FLAG_ASCII")),),
+    )
+    outcome = receiver.attribute("name", SourceFragment)
+    assert type(outcome) is Complete
+    assert outcome.value == StringValue("SRE_FLAG_ASCII")
+
+
+def test_named_int_constant_foreign_member_stays_typed_loud() -> None:
+    receiver = ObjectValue(
+        "re._constants._NamedIntConstant",
+        (ObjectField("name", StringValue("SRE_FLAG_ASCII")),),
+    )
+    with pytest.raises(SugarNotWritten, match="ObjectValue.attribute"):
+        receiver.attribute("foreign", SourceFragment)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1056,6 +1056,8 @@ class SourceUnit:
         definition: "ClassDef",
     ) -> bool:
         """Whether ordinary attribute storage/lookup is source-constructed."""
+        if definition._authenticated_new_constructor_shape() is not None:
+            return True
         forbidden_methods = {
             "__new__",
             "__getattr__",
@@ -3915,6 +3917,60 @@ class ClassDef(Statement):
             return None
         return decorator.id
 
+    def _authenticated_new_constructor_shape(self):
+        """One source-owned ``__new__`` allocation followed by field stores."""
+        constructors = tuple(
+            item
+            for item in self.body
+            if isinstance(item, FunctionDef) and item.name == "__new__"
+        )
+        if len(constructors) != 1 or any(
+            isinstance(item, FunctionDef) and item.name == "__init__"
+            for item in self.body
+        ):
+            return None
+        constructor = constructors[0]
+        if len(constructor.params) < 2 or len(constructor.body) < 3:
+            return None
+        allocation = constructor.body[0]
+        returned = constructor.body[-1]
+        if (
+            not isinstance(allocation, Assign)
+            or len(allocation.targets) != 1
+            or not isinstance(allocation.targets[0], Name)
+            or not isinstance(returned, Return)
+            or not isinstance(returned.value, Name)
+            or returned.value.id != allocation.targets[0].id
+            or not isinstance(allocation.value, Call)
+            or allocation.value.keywords
+            or len(allocation.value.args) < 1
+            or not isinstance(allocation.value.func, Attribute)
+            or allocation.value.func.attr != "__new__"
+            or not isinstance(allocation.value.func.value, Call)
+        ):
+            return None
+        super_call = allocation.value.func.value
+        class_param = constructor.params[0]
+        if (
+            not isinstance(super_call.func, Name)
+            or super_call.func.id != "super"
+            or super_call.keywords
+            or len(super_call.args) != 2
+            or not isinstance(super_call.args[0], Name)
+            or super_call.args[0].id != self.name
+            or not isinstance(super_call.args[1], Name)
+            or super_call.args[1].id != class_param.name
+            or not isinstance(allocation.value.args[0], Name)
+            or allocation.value.args[0].id != class_param.name
+        ):
+            return None
+        bindings = (self.unit.module_direct_bindings or {}).get(self.name, ())
+        if len(bindings) != 1 or bindings[0] is not self:
+            return None
+        if (self.unit.module_direct_bindings or {}).get("super"):
+            return None
+        return constructor, allocation.targets[0], constructor.body[1:-1]
+
     def substitute(self, scope):
         """A class: decorators and type params evaluate in the enclosing scope;
         the type params then bind for the bases, keywords, and body. The body is
@@ -4177,6 +4233,10 @@ class ClassDef(Statement):
             ),
             None,
         )
+        new_shape = self._authenticated_new_constructor_shape()
+        constructor = initializer if initializer is not None else (
+            None if new_shape is None else new_shape[0]
+        )
         owner_cid = self.fragment.seal().cid
         span = self.line_col_span()
         site = SourceFragmentCoordinateV1(
@@ -4214,7 +4274,7 @@ class ClassDef(Statement):
                 body=self._source_visible_body({}),
                 owner=self,
             )
-        params = () if initializer is None else initializer.params[1:]
+        params = () if constructor is None else constructor.params[1:]
         coordinates = tuple(
             BindingCoordinateV1.mint(owner_cid, param.fragment, ("formal", index))
             for index, param in enumerate(params)
@@ -4341,6 +4401,32 @@ class ClassDef(Statement):
                 **scope,
             }
             initializer_body = initializer._source_visible_body(initializer_scope)
+        else:
+            new_shape = self._authenticated_new_constructor_shape()
+            if new_shape is not None:
+                from sugar_lift_py_tests.sugar.source_visible_function_body_sugar import (
+                    SourceVisibleFunctionBodySugar,
+                )
+
+                constructor, receiver_target, field_body = new_shape
+                coordinate = BindingCoordinateV1.mint(
+                    self.fragment.seal().cid,
+                    receiver_target.fragment,
+                    ("receiver", 0),
+                )
+                receiver = self._make_constructed_receiver_ref(coordinate.cid)
+                receiver_coordinate_cid = coordinate.cid
+                constructor_scope = {
+                    receiver_target.id: BindingEntryV1(coordinate, receiver, None),
+                    **scope,
+                }
+                substituted_body, _ = constructor._substitute_body(
+                    field_body, constructor_scope
+                )
+                initializer_body = SourceVisibleFunctionBodySugar(
+                    tuple(statement.sugar() for statement in substituted_body),
+                    constructor.fragment,
+                )
         return ClassConstructorBodySugar(
             definition=self.sugar(),
             initializer_body=initializer_body,

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -207,6 +207,50 @@ def test_repeated_initializer_uses_the_last_class_binding() -> None:
     }
 
 
+def test_source_visible_new_constructor_retains_exact_instance_field() -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class RenamedToken(int):\n"
+        "    def __new__(cls, value, label):\n"
+        "        self = super(RenamedToken, cls).__new__(cls, value)\n"
+        "        self.label = label\n"
+        "        return self\n\n"
+        "RenamedToken(7, 'seven')\n",
+        context=context,
+    )
+    class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+    call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]
+
+    receiver = (
+        call.sugar()
+        .desugar()
+        .value.force_floor(None, owner="source-visible-new", project_callsite=False)
+    )
+
+    assert receiver.class_name == "RenamedToken"
+    assert receiver.attribute("label", call.fragment).value == StringValue("seven")
+    assert class_node.source_visible_constructor_frame().owner is class_node
+
+
+def test_source_visible_new_constructor_refuses_foreign_returned_receiver() -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class RenamedToken(int):\n"
+        "    def __new__(cls, value, label):\n"
+        "        self = super(RenamedToken, cls).__new__(cls, value)\n"
+        "        self.label = label\n"
+        "        return value\n\n"
+        "RenamedToken(7, 'seven')\n",
+        context=context,
+    )
+    call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]
+
+    coordinate = call.sugar().desugar().value
+
+    assert isinstance(coordinate, CallSiteValue)
+    assert coordinate.body is None
+
+
 def test_source_frame_binds_constructed_defaults_and_variadics() -> None:
     context = TreeConstructionContextV1.for_source_call_construction()
     source = _source_file(

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
@@ -8,6 +10,8 @@ from sugar_lift_py_tests.floor import (
     BlockValue,
     CallSiteValue,
     DictValue,
+    ObjectValue,
+    ReceiverFieldStoreValue,
     ReturnValue,
     StringValue,
     TermValue,
@@ -21,6 +25,7 @@ from sugar_lift_py_tests.generator_construction import (
     YieldEffect,
 )
 from sugar_source_tree.nodes import Call, ClassDef, FunctionDef
+from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
@@ -241,6 +246,116 @@ def test_source_visible_new_constructor_refuses_foreign_returned_receiver() -> N
         "        self.label = label\n"
         "        return value\n\n"
         "RenamedToken(7, 'seven')\n",
+        context=context,
+    )
+    call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]
+
+    coordinate = call.sugar().desugar().value
+
+    assert isinstance(coordinate, CallSiteValue)
+    assert coordinate.body is None
+
+
+def test_source_visible_new_constructor_retains_exact_bound_name_field() -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class NamedIntConstant(int):\n"
+        "    def __new__(cls, value, name):\n"
+        "        self = super(NamedIntConstant, cls).__new__(cls, value)\n"
+        "        self.name = name\n"
+        "        return self\n\n"
+        "NamedIntConstant(7, 'seven')\n",
+        context=context,
+    )
+    call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]
+
+    receiver = (
+        call.sugar()
+        .desugar()
+        .value.force_floor(None, owner="named-int-field-store", project_callsite=False)
+    )
+
+    assert isinstance(receiver, ObjectValue)
+    assert tuple((field.name, field.value) for field in receiver.fields) == (
+        ("name", StringValue("seven")),
+    )
+
+
+def test_new_receiver_field_store_refuses_foreign_receiver_identity() -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class NamedIntConstant(int):\n"
+        "    def __new__(cls, value, name):\n"
+        "        self = super(NamedIntConstant, cls).__new__(cls, value)\n"
+        "        self.name = name\n"
+        "        return self\n",
+        context=context,
+    )
+    class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+    class_value = class_node.sugar().desugar().value
+    receiver_coordinate = (
+        class_node.source_visible_constructor_frame().body.receiver_coordinate_cid
+    )
+    foreign = ObjectValue("NamedIntConstant", (), identity="foreign-receiver")
+    block = BlockValue(
+        (ReceiverFieldStoreValue(foreign, "name", StringValue("seven")),)
+    )
+
+    with pytest.raises(SugarNotWritten) as raised:
+        class_value.construct_receiver_state_from_block(block, receiver_coordinate)
+
+    assert raised.value.owner == "ClassDefinitionValue.construct_receiver_state"
+    assert raised.value.observed == "receiver coordinate mismatch"
+
+
+@pytest.mark.parametrize(
+    "return_body",
+    (
+        "",
+        "        if value:\n            return self\n",
+    ),
+    ids=("missing-return", "noncompleted-return"),
+)
+def test_source_visible_new_constructor_refuses_uncompleted_return(
+    return_body: str,
+) -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class NamedIntConstant(int):\n"
+        "    def __new__(cls, value, name):\n"
+        "        self = super(NamedIntConstant, cls).__new__(cls, value)\n"
+        "        self.name = name\n"
+        f"{return_body}\n"
+        "NamedIntConstant(7, 'seven')\n",
+        context=context,
+    )
+    call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]
+
+    coordinate = call.sugar().desugar().value
+
+    assert isinstance(coordinate, CallSiteValue)
+    assert coordinate.body is None
+
+
+@pytest.mark.parametrize(
+    "field_body",
+    (
+        "        self.name = name\n        self.name = name\n",
+        "        self.label = name\n",
+    ),
+    ids=("duplicate-name-field", "wrong-field"),
+)
+def test_source_visible_new_constructor_refuses_nonexact_field_roster(
+    field_body: str,
+) -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class NamedIntConstant(int):\n"
+        "    def __new__(cls, value, name):\n"
+        "        self = super(NamedIntConstant, cls).__new__(cls, value)\n"
+        f"{field_body}"
+        "        return self\n\n"
+        "NamedIntConstant(7, 'seven')\n",
         context=context,
     )
     call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]


### PR DESCRIPTION
## Scope

Publishes the isolated NamedIntConstant receiver-field component for shutdown recovery:

- instruments the ObjectValue attribute consumer,
- constructs source-visible `__new__` receiver fields,
- adds exact `ReceiverFieldStoreValue` truthful and lying teeth.

## Validation

Focused command:

`/usr/local/opt/python@3.12/bin/python3.12 -m pytest -q implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py`

Current receipt: **2 failed, 17 passed in 2.05s**.

Expected RED boundaries:

- duplicate `self.name` field stores are still admitted;
- wrong-field `self.label` is still admitted.

Already-green teeth include exact bound-name retention, foreign receiver identity refusal, missing return refusal, and noncompleted return refusal.

Corpus stable-zero status is **UNKNOWN**. Authenticated residual retirement is **unmeasured**.

## Consolidation status

This component is superseded/contained by consolidated draft #6922. PR #6922 contains exact commits `4d4fa6e34` and `f4adf01aa`, plus the equivalent integrated field-store test/correction sequence. This draft is published only for explicit all-fleet shutdown recovery and must not be merged independently while #6922 is authoritative.

No unrelated files are included.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Test authenticated `__new__`-only constructor receiver field stores
> - Adds `_authenticated_new_constructor_shape` to [`ClassDef`](https://github.com/TSavo/sugar/pull/6926/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to detect `__new__` methods that allocate a receiver via `super().__new__`, store fields, and return the same receiver.
> - Extends `source_visible_constructor_frame` to synthesize a constructor frame from authenticated `__new__`-only classes, projecting receiver field stores into a `ClassConstructorBodySugar`.
> - Updates `source_class_has_authenticated_default_attribute_behavior` to treat classes matching the new shape as having default attribute behavior.
> - Adds tests in [`test_source_visible_constructor_door.py`](https://github.com/TSavo/sugar/pull/6926/files#diff-9288a8bc1cf994dda474c8215c5c7fde6dd842bb2c2c2a98c72d27fbe379256f) and [`test_named_int_constant_attribute_consumer.py`](https://github.com/TSavo/sugar/pull/6926/files#diff-a7a113951a202c7bee44fb3f487af89fdaf72f7e6deaeb8b2f0d99766df0a087) covering field retention, foreign receiver rejection, incomplete return paths, and duplicate/wrong field names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df65444.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->