### PR TITLE
test: pin enum metaclass final block projection

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
@@ -48,6 +48,8 @@ class BuiltinSemanticCallable(FloorValue):
             return self._isinstance(operation)
         if self.operation == "python.len":
             return self._len(operation)
+        if self.operation == "python.enumerate.construct":
+            return self._enumerate(operation)
         if self.operation != "python.issubclass":
             return super().callable_application_with(operation, None)
         if len(operation.arguments) != 2 or operation.keyword_names:
@@ -118,6 +120,38 @@ class BuiltinSemanticCallable(FloorValue):
                 fix="project finite containers before len or keep the call loud",
             )
         return length(operation.site)
+
+    def _enumerate(self, operation):
+        """Construct the exact finite iterator for an authenticated sequence."""
+        if operation.keyword_names or len(operation.arguments) != 1:
+            return super().callable_application_with(operation, None)
+        from sugar_lift_py_tests.floor import (
+            ComprehensionValue,
+            ListIteratorValue,
+            ListValue,
+            TermValue,
+            TupleValue,
+        )
+        from sugar_lift_py_tests.outcome import Complete
+
+        source = operation.arguments[0]
+        if isinstance(source, (ListValue, TupleValue)):
+            elements = source.elements
+        elif (
+            isinstance(source, ComprehensionValue)
+            and source.finite_elements is not None
+        ):
+            elements = source.finite_elements
+        else:
+            return super().callable_application_with(operation, None)
+        return Complete(
+            ListIteratorValue(
+                tuple(
+                    TupleValue((TermValue(index), value))
+                    for index, value in enumerate(elements)
+                )
+            )
+        )
 
     def _isinstance(self, operation):
         """Exact ``isinstance(obj, classinfo)`` over authenticated floors.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -119,6 +119,7 @@ class CallSiteValue(FloorValue):
     body: SugarBody[Any] | FunctionBodyUniverse | None
     keyword_names: tuple[str, ...] = dataclass_field(default=(), compare=False)
     site: object = dataclass_field(default=None, compare=False)
+    call_occurrence: object | None = dataclass_field(default=None, compare=False)
     # A callee contract may cite the Python type object returned by this call.
     # Absent that citation, Python must execute the call to know whether its
     # result is a valid isinstance type operand.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
@@ -39,6 +39,19 @@ class ListIteratorValue(FloorValue):
     def denotes_value(self) -> bool:
         return True
 
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.floor.term_value import TermValue
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:list_iterator",
+            (
+                ctor("array", tuple(value.to_term(owner=owner) for value in self.elements)),
+                TermValue(self.index).to_term(owner=owner),
+            ),
+            symbol_kind="coordinate",
+        )
+
     def setattr(self, name, value, site):
         del name, value
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
@@ -715,26 +715,18 @@ def decode_loop_construction_v1(graph: Any) -> LoopConstructionV1:
         state(post.raw["projectedStateCid"])
         if post.raw["completedFaceCid"] not in completed_by_cid:
             raise LoopWireError("post binding face is not completed")
-        # The producer's DECLARED exit-route count for this loop occurrence.
-        # It is a partition size, so it must be at least two to be a split at
-        # all, and it must never name the latch: `BodyFallthrough` is the
-        # loop-back edge, not a way out.
+        # The producer's DECLARED completed-state route count for this loop
+        # occurrence.  `BodyFallthrough` is the internal latch route rather
+        # than an outward exit, but post-binding must still preserve its exact
+        # state testimony.  Outward break/exhaustion obligations remain a
+        # separate denominator on the root.
         arity = post.raw.get("exitPartitionArity")
         if not isinstance(arity, int) or isinstance(arity, bool) or arity < 1:
             raise LoopWireError(
                 "post binding must declare exitPartitionArity: the number of "
-                "exit routes this loop occurrence owns. Without it a downstream "
+                "completed state routes this loop occurrence owns. Without it a downstream "
                 "projection could only count the faces that happened to arrive, "
                 "and a dropped face would read as a complete partition"
-            )
-        if completed_by_cid[post.raw["completedFaceCid"]].completion_kind == (
-            "BodyFallthrough"
-        ):
-            raise LoopWireError(
-                "post binding must not project BodyFallthrough: it is the latch "
-                "input (the loop-back edge), not an exit route. Projecting it "
-                "would put the latch into the exit partition and assert an "
-                "exclusion against the real exits that nobody established"
             )
 
     for cid in root["outwardHaltedFaceCids"]:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -719,7 +719,15 @@ class SourceVisibleCallFrameV1:
         # than raising on the unspecialized BindingCoordinateRef formal.
         node_scope = dict(zip(self.parameters, bound, strict=True))
         rebuild = getattr(self.owner, "_source_visible_body", None)
-        body = self.body if rebuild is None else rebuild(node_scope)
+        if rebuild is None:
+            body = self.body
+        elif self.constructed_new_method is not None:
+            body = rebuild(
+                node_scope,
+                constructed_new_method=self.constructed_new_method,
+            )
+        else:
+            body = rebuild(node_scope)
         return replace(
             self,
             runtime_entries=entries,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -309,6 +309,7 @@ class SourceVisibleCallFrameV1:
     decorated_class_bindings: tuple[DecoratedClassBindingV1, ...] = field(
         default=(), compare=False
     )
+    constructed_new_method: object | None = field(default=None, compare=False)
     declaration_frame_cid: str | None = field(default=None, compare=False)
     frame_cid: str = field(init=False)
 
@@ -326,6 +327,42 @@ class SourceVisibleCallFrameV1:
         ):
             raise SourceCallBindingGap(
                 "decorated class binding source does not match source frame identity"
+            )
+        if self.constructed_new_method is not None:
+            from sugar_lift_py_tests.floor.class_definition_value import (
+                ConstructedClassMethodV1,
+            )
+            from sugar_lift_py_tests.sugar.class_constructor_body_sugar import (
+                ClassConstructorBodySugar,
+            )
+            from sugar_source_tree.nodes import ClassDef, FunctionDef
+
+            method = self.constructed_new_method
+            if (
+                type(method) is not ConstructedClassMethodV1
+                or not isinstance(self.owner, ClassDef)
+                or type(method.source_call_frame) is not SourceVisibleCallFrameV1
+                or not isinstance(method.source_call_frame.owner, FunctionDef)
+                or method.source_call_frame.owner.name != "__new__"
+                or not any(
+                    item is method.source_call_frame.owner for item in self.owner.body
+                )
+                or method.name != method.source_call_frame.owner.name
+                or method.definition_fragment_cid
+                != method.source_call_frame.owner.fragment.seal().cid
+                or method.source_call_frame.definition_fragment_cid
+                != method.definition_fragment_cid
+                or method.source_call_frame.source_identity_cid
+                != self.source_identity_cid
+                or type(self.body) is not ClassConstructorBodySugar
+                or self.body.constructed_new_method is not method
+            ):
+                raise SourceCallBindingGap(
+                    "constructed __new__ method testimony is foreign or cross-wired"
+                )
+        elif getattr(self.body, "constructed_new_method", None) is not None:
+            raise SourceCallBindingGap(
+                "constructor body carries unseated __new__ method testimony"
             )
         preimage = {
             "kind": "source-visible-call-frame",
@@ -352,6 +389,15 @@ class SourceVisibleCallFrameV1:
         }
         if self.declaration_frame_cid is not None:
             preimage["declarationFrameCid"] = self.declaration_frame_cid
+        if self.constructed_new_method is not None:
+            preimage["constructedNewMethod"] = {
+                "definitionFragmentCid": (
+                    self.constructed_new_method.definition_fragment_cid
+                ),
+                "sourceCallFrameCid": (
+                    self.constructed_new_method.source_call_frame.frame_cid
+                ),
+            }
         object.__setattr__(self, "frame_cid", cid_of_json(preimage))
         if self.declaration_frame_cid is None:
             object.__setattr__(self, "declaration_frame_cid", self.frame_cid)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -177,7 +177,19 @@ class CallSiteSugar(ConstructedTermSugar):
     def desugar(self, ctx: object = None) -> Outcome:
         if self.source_call_frame is not None and self.expected_definition_ref is not None:
             from sugar_source_tree.panic import SugarNotWritten
-            if self.source_call_frame.owner.ref is not self.expected_definition_ref:
+            from sugar_source_tree.nodes import FunctionDef, AsyncFunctionDef
+
+            if isinstance(
+                self.expected_definition_ref, (FunctionDef, AsyncFunctionDef)
+            ):
+                owner_matches = (
+                    self.source_call_frame.owner is self.expected_definition_ref
+                )
+            else:
+                owner_matches = (
+                    self.source_call_frame.owner.ref is self.expected_definition_ref
+                )
+            if not owner_matches:
                 raise SugarNotWritten(
                     owner="CallSiteSugar.desugar",
                     blame=self.site,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -183,7 +183,8 @@ class CallSiteSugar(ConstructedTermSugar):
                 self.expected_definition_ref, (FunctionDef, AsyncFunctionDef)
             ):
                 owner_matches = (
-                    self.source_call_frame.owner is self.expected_definition_ref
+                    self.source_call_frame.owner.ref
+                    is self.expected_definition_ref.ref
                 )
             else:
                 owner_matches = (
@@ -454,6 +455,7 @@ class CallSiteSugar(ConstructedTermSugar):
             body=source_body,
             keyword_names=tuple(name for name, _ in kw_values),
             site=self.site,
+            call_occurrence=self.call_occurrence,
             exception_type_coordinate=self.exception_type_coordinate,
             exception_type_mro=self.exception_type_mro,
             source_call_frame_cid=source_frame_cid,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
@@ -12,6 +12,28 @@ class ClassConstructorBodySugar(Sugar):
     initializer_body: Sugar | None
     receiver_coordinate_cid: str | None
     site: object = field(compare=False)
+    constructed_new_method: object | None = field(default=None, compare=False)
+
+    def __post_init__(self) -> None:
+        if self.constructed_new_method is None:
+            return
+        from sugar_lift_py_tests.floor.class_definition_value import (
+            ConstructedClassMethodV1,
+        )
+        from sugar_lift_py_tests.source_call_frame import SourceVisibleCallFrameV1
+
+        method = self.constructed_new_method
+        if (
+            type(method) is not ConstructedClassMethodV1
+            or type(method.source_call_frame) is not SourceVisibleCallFrameV1
+            or method.definition_fragment_cid
+            != method.source_call_frame.definition_fragment_cid
+        ):
+            from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+
+            raise SourceCallBindingGap(
+                "constructor body carries malformed __new__ method testimony"
+            )
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
@@ -196,6 +196,10 @@ class ComprehensionSugar(ConstructedTermSugar):
         from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
         from sugar_lift_py_tests.floor.dict_value import DictValue
         from sugar_lift_py_tests.floor.list_value import ListValue
+        from sugar_lift_py_tests.floor.iterator_value import (
+            ListIteratorValue,
+            TupleIteratorValue,
+        )
         from sugar_lift_py_tests.floor.tuple_value import TupleValue
         from sugar_lift_py_tests.ir import (
             PrimitiveSort,
@@ -208,6 +212,8 @@ class ComprehensionSugar(ConstructedTermSugar):
         members = None
         if isinstance(iterable, (TupleValue, ListValue)):
             members = iterable.elements
+        elif isinstance(iterable, (ListIteratorValue, TupleIteratorValue)):
+            members = iterable.elements[iterable.index :]
         elif isinstance(iterable, ComprehensionValue) and iterable.finite_elements is not None:
             members = iterable.finite_elements
         if members is None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
@@ -52,6 +52,8 @@ class ComprehensionGeneratorSugar:
     binding_coordinate_cid: str
     iterable: ConstructedTermSugar
     filters: tuple[ConstructedTermSugar, ...]
+    target_coordinates: tuple = dataclass_field(default=(), compare=False)
+    target_pattern: object | None = dataclass_field(default=None, compare=False)
 
     def __post_init__(self) -> None:
         require_constructed_term_sugar(
@@ -60,6 +62,16 @@ class ComprehensionGeneratorSugar:
         for filter_sugar in self.filters:
             require_constructed_term_sugar(
                 filter_sugar, owner="ComprehensionGeneratorSugar.filters"
+            )
+        if self.target_pattern is not None:
+            from sugar_source_tree.nodes import TargetPatternV1
+
+            if type(self.target_pattern) is not TargetPatternV1:
+                raise TypeError(
+                    "destructured comprehension target requires its exact TargetPatternV1"
+                )
+            self.target_pattern.source_unit.require_target_pattern_coordinates(
+                self.target_pattern, self.target_coordinates
             )
 
     def to_term(self, *, owner: str):
@@ -172,7 +184,6 @@ class ComprehensionSugar(ConstructedTermSugar):
             index == 0
             and len(self.generators) == 1
             and not generator.filters
-            and self.key is None
         ):
             finite = self._finite_map(generator, iterable, ctx)
             if finite is not None:
@@ -183,6 +194,7 @@ class ComprehensionSugar(ConstructedTermSugar):
 
     def _finite_map(self, generator, iterable, ctx):
         from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+        from sugar_lift_py_tests.floor.dict_value import DictValue
         from sugar_lift_py_tests.floor.list_value import ListValue
         from sugar_lift_py_tests.floor.tuple_value import TupleValue
         from sugar_lift_py_tests.ir import (
@@ -201,8 +213,7 @@ class ComprehensionSugar(ConstructedTermSugar):
         if members is None:
             return None
         target = generator.target
-        if target.source_name is None or target.coordinates is not None:
-            # Destructured targets need unpack projection; stay symbolic.
+        if target.coordinates is not None and generator.target_pattern is None:
             return None
         if ctx is None or not hasattr(ctx, "temporal"):
             return None
@@ -212,6 +223,8 @@ class ComprehensionSugar(ConstructedTermSugar):
 
         def project(index, projected):
             if index == len(members):
+                if self.key is not None:
+                    return Complete(DictValue(tuple(projected)))
                 if projected:
                     element_term = projected[0].to_term(owner=owner)
                 else:
@@ -239,18 +252,59 @@ class ComprehensionSugar(ConstructedTermSugar):
                     ComprehensionValue(term, finite_elements=tuple(projected))
                 )
 
-            member = members[index]
-            temporal = ctx.temporal.bind_value(
-                generator.binding_coordinate_cid, member
+            member = members[index].project_operation_receiver(
+                ctx, owner="ComprehensionSugar finite iterable member"
             )
-            if target.source_name is not None:
+            temporal = ctx.temporal.bind_value(generator.binding_coordinate_cid, member)
+            if target.coordinates is not None:
+                from sugar_lift_py_tests.operations.positional_unpack_operation import (
+                    PositionalUnpackOperation,
+                    UnpackMemberRoster,
+                )
+
+                leaves = _target_leaves(target)
+                unpacked = PositionalUnpackOperation(
+                    fixed_prefix=len(leaves),
+                    fixed_suffix=0,
+                    has_star=False,
+                    owner="ComprehensionSugar._finite_map.target",
+                    blame=self.site,
+                ).submit(member, ctx)
+                if not isinstance(unpacked, Complete) or not isinstance(
+                    unpacked.value, UnpackMemberRoster
+                ):
+                    return unpacked
+                for leaf, coordinate, value in zip(
+                    leaves,
+                    generator.target_coordinates,
+                    unpacked.value.members,
+                    strict=True,
+                ):
+                    temporal = temporal.bind_value(coordinate.cid, value)
+                    temporal = temporal.bind_value(leaf.source_name, value)
+            elif target.source_name is not None:
                 temporal = temporal.bind_value(target.source_name, member)
             try:
                 inner_ctx = replace(ctx, temporal=temporal)
             except TypeError:
                 return None
+            if self.key is not None:
+                return self.key.desugar(inner_ctx).and_then(
+                    lambda key: self.element.desugar(inner_ctx).and_then(
+                        lambda value: project(index + 1, (*projected, (key, value)))
+                    )
+                )
             return self.element.desugar(inner_ctx).and_then(
-                lambda value: project(index + 1, (*projected, value))
+                lambda value: project(
+                    index + 1,
+                    (
+                        *projected,
+                        value.project_operation_receiver(
+                            inner_ctx,
+                            owner="ComprehensionSugar finite constructed element",
+                        ),
+                    ),
+                )
             )
 
         # Outcome.and_then owns terminal/guarded propagation. ``None`` is the
@@ -378,6 +432,13 @@ def _projection(element, index: int, arity: int):
         [element, num(index), num(arity)],
         symbol_kind="coordinate",
     )
+
+
+def _target_leaves(target: ComprehensionTargetSugar) -> tuple[ComprehensionTargetSugar, ...]:
+    if target.source_name is not None:
+        return (target,)
+    assert target.coordinates is not None
+    return tuple(leaf for child in target.coordinates for leaf in _target_leaves(child))
 
 
 def _bind_target(target: ComprehensionTargetSugar, element, body):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/formal_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/formal_ref_sugar.py
@@ -37,7 +37,11 @@ class FormalRefSugar(ConstructedTermSugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        del ctx
+        temporal = getattr(ctx, "temporal", None) if ctx is not None else None
+        if temporal is not None:
+            bound = temporal.value_if_bound(self.coordinate.coordinate_cid)
+            if bound is not None:
+                return Complete(bound)
         return Complete(
             SymbolicValue(
                 make_var(self.coordinate.declared_name),

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/import_member_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/import_member_sugar.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field as dataclass_field
 
+from sugar_lift_python_source.canonical import cid_of_json
 from sugar_lift_py_tests.outcome import Complete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
@@ -15,6 +16,30 @@ class ImportMemberSugar(ConstructedTermSugar):
     qualified_name: str
     receipt: object = dataclass_field(compare=False, repr=False)
     site: object = dataclass_field(compare=False)
+
+    @property
+    def preimage(self) -> dict[str, object]:
+        """Closed testimony projected from the authenticated import receipt."""
+        from sugar_lift_py_tests.floor.import_member_value import (
+            _mint_import_member_value,
+        )
+
+        value = _mint_import_member_value(self.receipt)
+        if value.qualified_name != self.qualified_name:
+            raise ValueError("ImportMemberSugar receipt target mismatch")
+        return {
+            "kind": "python-import-member-sugar",
+            "schemaVersion": "1",
+            "qualifiedName": value.qualified_name,
+            "sourceCid": value.source_cid,
+            "importBindingCid": value.import_binding_cid,
+            "useCid": value.use_cid,
+            "exportedMemberPath": list(value.exported_member_path),
+        }
+
+    @property
+    def cid(self) -> str:
+        return cid_of_json(self.preimage)
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
@@ -260,6 +260,9 @@ def builtin_name_temporal():
         "len", BuiltinSemanticCallable(operation="python.len")
     )
     temporal = temporal.bind_value(
+        "enumerate", BuiltinSemanticCallable(operation="python.enumerate.construct")
+    )
+    temporal = temporal.bind_value(
         "set", BuiltinSemanticCallable(operation="python.set.construct")
     )
     temporal = temporal.bind_value(

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_augassign_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_augassign_formal_caller.py
@@ -398,6 +398,109 @@ def test_authenticated_discharge_get_iadd_setattr_updates_field() -> None:
         assert fields["field"] == TermValue(11)
 
 
+def test_enum_attribute_augassign_uses_one_authenticated_read_op_store(
+    monkeypatch,
+) -> None:
+    """Production path: CPython ``enum.py:292`` retains the exact operation chain."""
+    from sugar_lift_python_source.dependency_artifact import DependencyArtifactGraph
+    from sugar_lift_py_tests.sugar import augassign_sugar as aug_module
+    from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
+    from sugar_lift_py_tests.sugar.store_effect_sugar import AttributeStoreEffectSugar
+
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("enum")
+    module = graph.modules["enum"]
+    source = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    owner = min(
+        (
+            node
+            for node in source.nodes()
+            if isinstance(node, FunctionDef)
+            and node.line_col_span().start_line < 292
+            and node.line_col_span().end_line >= 292
+        ),
+        key=lambda node: node.line_col_span().end_line
+        - node.line_col_span().start_line,
+    )
+    events = []
+    original_read = AttributeSugar.project_attribute
+    original_op = aug_module.project_augmented
+    original_store = AttributeStoreEffectSugar.project_setattr
+
+    def at_target(site) -> bool:
+        return site.line_col_span().start_line == 292
+
+    def read(receiver, member, site, ctx=None):
+        if at_target(site):
+            events.append(("read", receiver, member, site))
+        return original_read(receiver, member, site, ctx)
+
+    def operate(left, right, *, operator, projector, site):
+        if at_target(site):
+            events.append(("operate", left, operator, site))
+        return original_op(
+            left,
+            right,
+            operator=operator,
+            projector=projector,
+            site=site,
+        )
+
+    def store(receiver, member, value, site):
+        if at_target(site):
+            events.append(("store", receiver, member, site))
+        return original_store(receiver, member, value, site)
+
+    monkeypatch.setattr(AttributeSugar, "project_attribute", staticmethod(read))
+    monkeypatch.setattr(aug_module, "project_augmented", operate)
+    monkeypatch.setattr(
+        AttributeStoreEffectSugar, "project_setattr", staticmethod(store)
+    )
+
+    owner.sugar().desugar(None)
+
+    assert tuple(event[0] for event in events) == ("read", "operate", "store")
+    read_event, op_event, store_event = events
+    assert read_event[1] is store_event[1]
+    assert read_event[2] == store_event[2] == "_flag_mask_"
+    assert op_event[2] == "ior"
+    assert len({event[3].source_cid for event in events}) == 1
+
+
+def test_unrelated_source_attribute_augassign_uses_the_same_projection() -> None:
+    """A renamed source helper uses the same read/inplace/store carrier chain."""
+    function, pending = _helper_definition(
+        "def renamed(receiver, increment):\n"
+        "    receiver.total += increment\n"
+    )
+    assert isinstance(pending, NativeOperationExitCarrierV1)
+    assert pending.demand.operator == "attribute_named"
+    coordinates = {
+        coordinate.declared_name: coordinate.coordinate_cid
+        for coordinate in function.sugar().formal_coordinates
+    }
+    receiver = ObjectValue(
+        "Renamed",
+        (ObjectField("total", TermValue(4)),),
+        (),
+        (),
+        "renamed-receiver",
+    )
+
+    result = pending.discharge(
+        {
+            coordinates["receiver"]: receiver,
+            coordinates["increment"]: TermValue(3),
+        }
+    )
+
+    assert isinstance(result, ExitSet)
+    assert len(result.exits) == 1
+    assert isinstance(result.exits[0], Completed)
+
+
 def test_formal_operands_mint_iadd_not_ordinary_add() -> None:
     from sugar_lift_py_tests.floor import SymbolicValue
     from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1

--- a/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
@@ -205,18 +205,22 @@ def test_finite_comprehensions_transport_exact_constructed_objects_in_order():
         "    def __init__(self, index, name):\n"
         "        self.index = index\n"
         "        self.name = name\n"
-        "def build():\n"
-        "    items = [Item(index, name) for index, name in [(0, 2), (1, 1)]]\n"
+        "def build(*names):\n"
+        "    items = [Item(index, name) for index, name in enumerate(names)]\n"
         "    return {item.name: item for item in items}\n"
+        "build(2, 1)\n"
     )
-    function = next(
-        node for node in _source_file(source).functions() if node.name == "build"
-    )
-
-    outcome = function.sugar().desugar(None)
+    call = tuple(
+        node
+        for node in _source_file(source).nodes()
+        if node.kind == "Call" and node.func.kind == "Name" and node.func.id == "build"
+    )[-1]
+    outcome = call.sugar().desugar(None)
 
     assert isinstance(outcome, Complete)
-    returned = outcome.value.record.statements[0].value
+    returned = outcome.value.project_operation_receiver(
+        None, owner="finite-comprehension-transport-test"
+    )
     assert isinstance(returned, DictValue)
     assert tuple(key.value for key, _ in returned.entries) == (2, 1)
     objects = tuple(value for _, value in returned.entries)

--- a/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass, replace
 
+import pytest
+
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
@@ -9,7 +11,9 @@ from sugar_lift_py_tests.effect.expectation_not_met_effect import (
 )
 from sugar_lift_py_tests.floor import (
     CallSiteValue,
+    DictValue,
     ListValue,
+    ObjectValue,
     SymbolicValue,
     TermValue,
 )
@@ -23,6 +27,7 @@ from sugar_lift_py_tests.sugar.comprehension_sugar import (
 )
 from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_source_tree.tree import SourceFile
+from sugar_source_tree.nodes import TargetPatternConstructionGapV1
 
 
 @dataclass(frozen=True)
@@ -191,3 +196,52 @@ def test_comprehension_target_coordinate_cannot_escape_into_enclosing_x():
     assert mutated_fold.args[1].param_name == "outer"
     assert mutated_fold.args[1].body == make_var("outer")
     assert post.args[0] == outer
+
+
+def test_finite_comprehensions_transport_exact_constructed_objects_in_order():
+    """The second comprehension binds the exact objects built by the first."""
+    source = (
+        "class Item:\n"
+        "    def __init__(self, index, name):\n"
+        "        self.index = index\n"
+        "        self.name = name\n"
+        "def build():\n"
+        "    items = [Item(index, name) for index, name in [(0, 2), (1, 1)]]\n"
+        "    return {item.name: item for item in items}\n"
+    )
+    function = next(
+        node for node in _source_file(source).functions() if node.name == "build"
+    )
+
+    outcome = function.sugar().desugar(None)
+
+    assert isinstance(outcome, Complete)
+    returned = outcome.value.record.statements[0].value
+    assert isinstance(returned, DictValue)
+    assert tuple(key.value for key, _ in returned.entries) == (2, 1)
+    objects = tuple(value for _, value in returned.entries)
+    assert all(type(value) is ObjectValue for value in objects)
+    assert tuple(value.fields[0].value.value for value in objects) == (0, 1)
+    assert tuple(value.fields[1].value.value for value in objects) == (2, 1)
+    assert returned.entries[0][1] is objects[0]
+    assert returned.entries[1][1] is objects[1]
+
+
+def test_finite_comprehension_refuses_swapped_tuple_target_coordinates():
+    source = (
+        "def build():\n"
+        "    return [(left, right) for left, right in [(1, 2)]]\n"
+    )
+    source_file = _source_file(source)
+    comprehension = next(
+        node for node in source_file.nodes() if node.kind == "ListComp"
+    ).sugar()
+    generator = comprehension.generators[0]
+
+    with pytest.raises(TargetPatternConstructionGapV1) as rejected:
+        replace(
+            generator,
+            target_coordinates=tuple(reversed(generator.target_coordinates)),
+        )
+
+    assert rejected.value.reason == "target-coordinate-order-mismatch"

--- a/implementations/python/sugar-lift-py-tests/tests/test_enum_loop_post_binding_partition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enum_loop_post_binding_partition.py
@@ -1,0 +1,121 @@
+"""Exact post-binding denominator for CPython ``enum.py:304``.
+
+The loop has three completed-state routes (break, internal latch fallthrough,
+normal exhaustion) but only two outward exits (break and exhaustion).  A
+post-binding projection conserves all three states; it must not borrow the
+two-route outward denominator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_python_source.dependency_artifact import DependencyArtifactGraph
+from sugar_lift_py_tests.context_manager_resolution import (
+    TreeConstructionContextV1,
+)
+from sugar_source_tree.binding_state import BindingStateWireGap
+from sugar_source_tree.nodes import For, FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _enum_loop_projection_calls(monkeypatch):
+    """Run the ordinary enum function and retain its exact projection inputs."""
+    from sugar_source_tree import loop_recurrence
+
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("enum")
+    module = graph.modules["enum"]
+    source = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    loop = next(
+        node
+        for node in source.nodes()
+        if isinstance(node, For) and node.line_col_span().start_line == 304
+    )
+    owner = min(
+        (
+            node
+            for node in source.nodes()
+            if isinstance(node, FunctionDef)
+            and node.line_col_span().start_line < 304
+            and node.line_col_span().end_line >= 304
+        ),
+        key=lambda node: node.line_col_span().end_line
+        - node.line_col_span().start_line,
+    )
+    calls = []
+    original = loop_recurrence.project_loop_post_binding
+
+    def observe(**kwargs):
+        calls.append((kwargs, None))
+        projected = original(**kwargs)
+        calls[-1] = (kwargs, projected)
+        return projected
+
+    monkeypatch.setattr(loop_recurrence, "project_loop_post_binding", observe)
+    try:
+        owner.sugar().desugar(None)
+    except BindingStateWireGap:
+        # The instrument's truthful tooth reports the exact current red.  The
+        # captured owner inputs remain usable by the independent lying twins.
+        pass
+    assert calls
+    return loop, calls, original
+
+
+def test_enum_post_binding_preserves_three_states_and_two_outward_routes(
+    monkeypatch,
+) -> None:
+    loop, calls, _original = _enum_loop_projection_calls(monkeypatch)
+    del loop
+    for kwargs, projected in calls:
+        assert projected is not None
+        construction = kwargs["construction"]
+        graph = construction.wire_graph()
+        post_records = tuple(
+            record
+            for record in graph["records"]
+            if record.get("kind") == "loop-post-binding"
+            and record["bindingCoordinateCid"]
+            == kwargs["binding_coordinate"].cid
+        )
+        assert {record["exitPartitionArity"] for record in post_records} == {3}
+        assert len(projected.completed_faces) == len(post_records) == 3
+        assert {
+            face.completion_kind for face in projected.completed_faces
+        } == {"BreakExit", "BodyFallthrough", "NormalExhaustion"}
+        assert len(
+            {face.guard_formula_cid for face in projected.completed_faces}
+        ) == 3
+        root = graph["root"]
+        assert len(root["breakExitObligationCids"]) == 1
+        assert root["exhaustionExitObligationCid"]
+
+
+@pytest.mark.parametrize(
+    "axis", ("missing", "duplicate", "foreign_coordinate", "guard_collapsed")
+)
+def test_enum_post_binding_route_lies_remain_typed_loud(monkeypatch, axis) -> None:
+    _loop, calls, original = _enum_loop_projection_calls(monkeypatch)
+    kwargs = dict(calls[0][0])
+    if axis == "missing":
+        states = dict(kwargs["runtime_states"])
+        states.pop(next(iter(states)))
+        kwargs["runtime_states"] = states
+    elif axis == "duplicate":
+        states = dict(kwargs["runtime_states"])
+        state_cid = next(iter(states))
+        states[state_cid] = (*states[state_cid], *states[state_cid])
+        kwargs["runtime_states"] = states
+    elif axis == "foreign_coordinate":
+        coordinate = kwargs["binding_coordinate"]
+        kwargs["binding_coordinate"] = coordinate.project("foreign")
+    else:
+        guards = dict(kwargs["live_guards"])
+        one_guard = next(iter(guards.values()))
+        kwargs["live_guards"] = dict.fromkeys(guards, one_guard)
+
+    with pytest.raises(BindingStateWireGap):
+        original(**kwargs)

--- a/implementations/python/sugar-lift-py-tests/tests/test_named_int_constant_attribute_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_named_int_constant_attribute_consumer.py
@@ -3,9 +3,43 @@
 from sugar_lift_py_tests.floor.object_value import ObjectField, ObjectValue
 from sugar_lift_py_tests.floor.string_value import StringValue
 from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_source_tree.panic import SugarNotWritten
-from sugar_source_tree.fragment import SourceFragment
 import pytest
+
+
+class _ReceiverSugar(ConstructedTermSugar):
+    def __init__(self, receiver):
+        self.receiver = receiver
+        self.site = _Site("receiver")
+
+    @classmethod
+    def witnesses(cls):
+        raise AssertionError("instrument leaf")
+
+    def desugar(self, ctx=None):
+        return Complete(self.receiver)
+
+    def to_term(self, *, owner):
+        del owner
+        return self.receiver.to_term(owner="instrument")
+
+
+class _Seal:
+    def __init__(self, cid):
+        self.cid = cid
+        self.source_cid = "source"
+        self.start = 0
+        self.end = 1
+
+
+class _Site:
+    def __init__(self, cid):
+        self._seal = _Seal(cid)
+
+    def seal(self):
+        return self._seal
 
 
 def test_named_int_constant_name_uses_object_field_owner() -> None:
@@ -13,9 +47,12 @@ def test_named_int_constant_name_uses_object_field_owner() -> None:
         "re._constants._NamedIntConstant",
         (ObjectField("name", StringValue("SRE_FLAG_ASCII")),),
     )
-    outcome = receiver.attribute("name", SourceFragment)
+    first = AttributeSugar(_ReceiverSugar(receiver), "name", _Site("first"))
+    outcome = first.desugar()
     assert type(outcome) is Complete
     assert outcome.value == StringValue("SRE_FLAG_ASCII")
+    second = AttributeSugar(_ReceiverSugar(receiver), "name", _Site("second"))
+    assert first.to_term(owner="test") != second.to_term(owner="test")
 
 
 def test_named_int_constant_foreign_member_stays_typed_loud() -> None:
@@ -24,4 +61,4 @@ def test_named_int_constant_foreign_member_stays_typed_loud() -> None:
         (ObjectField("name", StringValue("SRE_FLAG_ASCII")),),
     )
     with pytest.raises(SugarNotWritten, match="ObjectValue.attribute"):
-        receiver.attribute("foreign", SourceFragment)
+        AttributeSugar(_ReceiverSugar(receiver), "foreign", _Site("foreign")).desugar()

--- a/implementations/python/sugar-lift-py-tests/tests/test_named_int_constant_attribute_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_named_int_constant_attribute_consumer.py
@@ -1,0 +1,27 @@
+"""Bounded consumer instrument for authenticated ``_NamedIntConstant.name``."""
+
+from sugar_lift_py_tests.floor.object_value import ObjectField, ObjectValue
+from sugar_lift_py_tests.floor.string_value import StringValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.fragment import SourceFragment
+import pytest
+
+
+def test_named_int_constant_name_uses_object_field_owner() -> None:
+    receiver = ObjectValue(
+        "re._constants._NamedIntConstant",
+        (ObjectField("name", StringValue("SRE_FLAG_ASCII")),),
+    )
+    outcome = receiver.attribute("name", SourceFragment)
+    assert type(outcome) is Complete
+    assert outcome.value == StringValue("SRE_FLAG_ASCII")
+
+
+def test_named_int_constant_foreign_member_stays_typed_loud() -> None:
+    receiver = ObjectValue(
+        "re._constants._NamedIntConstant",
+        (ObjectField("name", StringValue("SRE_FLAG_ASCII")),),
+    )
+    with pytest.raises(SugarNotWritten, match="ObjectValue.attribute"):
+        receiver.attribute("foreign", SourceFragment)

--- a/implementations/python/sugar-lift-py-tests/tests/test_presealed_target_pattern_receipt.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_presealed_target_pattern_receipt.py
@@ -1,0 +1,170 @@
+"""RED: TargetPattern canonicalization consumes its eager sealed receipt."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import json
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree import backend, binding_state
+from sugar_source_tree.binding_state import (
+    ConstructedValueCategoryGap,
+    _constructed_preimage,
+    constructed_value_cid_v2,
+)
+from sugar_source_tree.nodes import Call, ListComp, SourceUnit, TargetPatternV1
+from sugar_source_tree.tree import SourceFile
+
+
+def _source(helper: str = "sink") -> str:
+    return (
+        f"result = {helper}([left for (left, right) in items])\n"
+        f"other = {helper}([first for (first, second) in more_items])\n"
+    )
+
+
+def _products(helper: str = "sink", *, suffix: str = ""):
+    source = _source(helper) + suffix
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (source, f"{helper}.py", blake3_512_of(source.encode())),
+        construction_context=context,
+    )
+    calls = tuple(node for node in tree.nodes() if isinstance(node, Call))
+    comprehensions = tuple(
+        node for node in tree.nodes() if isinstance(node, ListComp)
+    )
+    assert len(calls) == len(comprehensions) == 2
+    sugars = tuple(call._construct_sugar() for call in calls)
+    patterns = tuple(
+        sugar.args[0].generators[0].target_pattern for sugar in sugars
+    )
+    assert all(type(pattern) is TargetPatternV1 for pattern in patterns)
+    return tree, comprehensions, sugars, patterns
+
+
+def _forbid_late_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("presealed TargetPattern canonicalization did late work")
+
+    monkeypatch.setattr(binding_state, "node_construction_shape_cid", forbidden)
+    monkeypatch.setattr(backend, "materialize", forbidden)
+    monkeypatch.setattr(
+        binding_state.ConstructionTestimonyReporterV1,
+        "present_construction",
+        forbidden,
+    )
+
+
+@pytest.mark.parametrize("helper", ("sink", "unrelated_renamed"))
+def test_presealed_pattern_receipt_canonicalizes_without_late_work(
+    helper, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tree, _comprehensions, sugars, patterns = _products(helper)
+    pattern = patterns[0]
+    expected_source_cid = tree.unit.source_cid
+    expected_consumer = pattern.consumer_occurrence.fragment.seal()
+    expected_target = pattern.target_occurrence.fragment.seal()
+    expected_leaves = tuple(
+        (leaf.fragment.seal(), binding_state.node_construction_shape_cid(leaf))
+        for leaf in pattern.leaves
+    )
+    expected_coordinates = tuple(item.cid for item in pattern.coordinates)
+    _forbid_late_work(monkeypatch)
+
+    pattern_preimage = _constructed_preimage(pattern)
+    pattern_cid = constructed_value_cid_v2(pattern)
+    callsite_cid = constructed_value_cid_v2(sugars[0])
+    encoded = json.dumps(pattern_preimage, sort_keys=True)
+
+    assert pattern_cid.startswith("blake3-512:")
+    assert callsite_cid.startswith("blake3-512:")
+    assert expected_source_cid in encoded
+    assert expected_consumer.cid in encoded
+    assert expected_target.cid in encoded
+    for memento, shape_cid in expected_leaves:
+        assert memento.cid in encoded
+        assert shape_cid in encoded
+    for coordinate_cid in expected_coordinates:
+        assert coordinate_cid in encoded
+
+
+def _assert_loud(pattern: TargetPatternV1) -> None:
+    with pytest.raises(ConstructedValueCategoryGap):
+        constructed_value_cid_v2(pattern)
+
+
+@pytest.mark.parametrize(
+    "axis",
+    (
+        "missing-receipt",
+        "pre-roster-mint",
+        "foreign-source",
+        "foreign-consumer",
+        "foreign-target",
+        "reordered-leaves",
+        "missing-leaf",
+        "wrong-binding-coordinate",
+        "reminted-pattern-receipt",
+    ),
+)
+def test_unowned_or_cross_wired_target_pattern_receipts_stay_loud(axis) -> None:
+    tree, comprehensions, _sugars, patterns = _products()
+    exact, other = patterns
+
+    if axis == "missing-receipt":
+        candidate = TargetPatternV1(
+            exact.source_unit,
+            exact.consumer_occurrence,
+            exact.target_occurrence,
+            exact.leaves,
+            exact.coordinates,
+        )
+    elif axis == "pre-roster-mint":
+        source = tree.unit.source
+        pre_roster_unit = SourceUnit(
+            filename="pre_roster.py",
+            source=source,
+            source_cid=blake3_512_of(source.encode()),
+        )
+        candidate = TargetPatternV1(
+            pre_roster_unit,
+            exact.consumer_occurrence,
+            exact.target_occurrence,
+            exact.leaves,
+            exact.coordinates,
+        )
+    elif axis == "foreign-source":
+        foreign = _products(suffix="# foreign authenticated bytes\n")[0]
+        candidate = replace(exact, source_unit=foreign.unit)
+    elif axis == "foreign-consumer":
+        candidate = replace(exact, consumer_occurrence=comprehensions[1])
+    elif axis == "foreign-target":
+        candidate = replace(exact, target_occurrence=other.target_occurrence)
+    elif axis == "reordered-leaves":
+        candidate = replace(exact, leaves=tuple(reversed(exact.leaves)))
+    elif axis == "missing-leaf":
+        candidate = replace(exact, leaves=exact.leaves[:-1])
+    elif axis == "wrong-binding-coordinate":
+        candidate = replace(
+            exact, coordinates=(other.coordinates[0], exact.coordinates[1])
+        )
+    else:
+        candidate = replace(exact)
+
+    _assert_loud(candidate)
+
+
+@dataclass
+class _UnrelatedMutableDataclass:
+    value: int
+
+
+def test_generic_mutable_dataclass_remains_loud() -> None:
+    with pytest.raises(ConstructedValueCategoryGap) as gap:
+        constructed_value_cid_v2(_UnrelatedMutableDataclass(1))
+    assert "MUTABLE dataclass" in str(gap.value)
+

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1661,6 +1661,13 @@ def _resolve_source_visible_frame_uncached(
     dependency_graphs: dict[str, DependencyArtifactGraph] | None,
     session: SourceResolutionSession,
 ) -> tuple[object, Node, object] | ManagerConstructionGapV1:
+    from sugar_source_tree.backend import materialize
+    from sugar_source_tree.binding_state import (
+        ConstructionTestimonyReporterV1,
+        SubstitutionTraceBuilderV1,
+    )
+    from sugar_source_tree.reporter import NULL_REPORTER
+
     # frame_projection: dual-mode factories may nest With only on non-CM
     # branches; soft-require those so call-frame projection can complete.
     context = TreeConstructionContextV1.for_source_call_construction(
@@ -1669,6 +1676,12 @@ def _resolve_source_visible_frame_uncached(
     source_file = SourceFile(
         (module.source, module.source_seat, module.source_cid),
         construction_context=context,
+    )
+    producer_reporter = ConstructionTestimonyReporterV1(
+        NULL_REPORTER, SubstitutionTraceBuilderV1(module.source_cid)
+    )
+    producer_root = materialize(
+        source_file.unit, source_file.root.ref, producer_reporter
     )
     from sugar_lift_python_source.value_pins import scan_module_value_pins
     from sugar_lift_py_tests.source_call_frame import MutableGlobalBindingV1
@@ -1695,7 +1708,7 @@ def _resolve_source_visible_frame_uncached(
     dependency_graphs[resolved.module_name.split(".", 1)[0]] = graph
     definitions = tuple(
         item
-        for item in source_file.root.body
+        for item in producer_root.body
         if isinstance(item, (FunctionDef, ClassDef))
     )
     target = next(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -586,6 +586,11 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
         reduce_block_to_exitset,
     )
     from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+    from sugar_source_tree.backend import materialize
+    from sugar_source_tree.binding_state import (
+        ConstructionTestimonyReporterV1,
+        SubstitutionTraceBuilderV1,
+    )
     from sugar_source_tree.nodes import (
         AsyncFunctionDef,
         Delete,
@@ -593,20 +598,27 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
         Name,
         Subscript,
     )
+    from sugar_source_tree.reporter import NULL_REPORTER
 
     from .canonical import blake3_512_of
 
     if module.source_cid != blake3_512_of(module.source.encode("utf-8")):
         raise ValueError("module prefix source CID mismatch")
     construction_context = TreeConstructionContextV1.for_source_call_construction()
+    producer_reporter = ConstructionTestimonyReporterV1(
+        NULL_REPORTER, SubstitutionTraceBuilderV1(module.source_cid)
+    )
     source_file = SourceFile(
         (module.source, module.source_seat, module.source_cid),
         construction_context=construction_context,
     )
+    producer_root = materialize(
+        source_file.unit, source_file.root.ref, producer_reporter
+    )
     locus_key = (locus.lineno, locus.col_offset)
     prefix = tuple(
         statement
-        for statement in source_file.root.body
+        for statement in producer_root.body
         if (
             statement.line_col_span().start_line,
             statement.line_col_span().start_col,

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -209,10 +209,50 @@ class _ModuleNameAssignmentBindingSugar:
     target: Name
 
     def desugar(self, ctx=None):
+        from sugar_lift_py_tests.floor import (
+            CallSiteValue,
+            ComprehensionValue,
+            ListValue,
+        )
+        from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind
+        from sugar_lift_py_tests.ir import _Ctor
+        from sugar_lift_py_tests.outcome import Complete
+
+        def bind_projected_value(value):
+            if (
+                type(value) is ComprehensionValue
+                and type(value.term) is _Ctor
+                and value.term.name == "py.listcomp"
+                and value.finite_elements is not None
+            ):
+                value = ListValue(tuple(value.finite_elements))
+            return Complete(ScopeRebind(self.target.id, value))
+
+        def bind_completed_value(value):
+            if type(value) is CallSiteValue:
+                return value.project_operation_receiver_outcome(
+                    ctx,
+                    owner="module name assignment source return",
+                ).and_then(bind_projected_value)
+            return Complete(ScopeRebind(self.target.id, value))
+
+        return self.statement.value.sugar().desugar(ctx).and_then(
+            bind_completed_value
+        )
+
+
+@dataclass(frozen=True)
+class _ModuleSubscriptDeleteBindingSugar:
+    """Thread one exact module ``del name[index]`` result into its binding."""
+
+    statement: Delete
+    target: Name
+
+    def desugar(self, ctx=None):
         from sugar_lift_py_tests.floor.scope_rebind import ScopeRebind
         from sugar_lift_py_tests.outcome import Complete
 
-        return self.statement.value.sugar().desugar(ctx).and_then(
+        return self.statement.sugar().desugar(ctx).and_then(
             lambda value: Complete(ScopeRebind(self.target.id, value))
         )
 
@@ -546,7 +586,13 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
         reduce_block_to_exitset,
     )
     from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
-    from sugar_source_tree.nodes import AsyncFunctionDef, FunctionDef, Name
+    from sugar_source_tree.nodes import (
+        AsyncFunctionDef,
+        Delete,
+        FunctionDef,
+        Name,
+        Subscript,
+    )
 
     from .canonical import blake3_512_of
 
@@ -627,6 +673,15 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
                 isinstance(statement, Assign)
                 and len(statement.targets) == 1
                 and isinstance(statement.targets[0], Name)
+            )
+            else _ModuleSubscriptDeleteBindingSugar(
+                statement, statement.targets[0].value
+            )
+            if (
+                isinstance(statement, Delete)
+                and len(statement.targets) == 1
+                and isinstance(statement.targets[0], Subscript)
+                and isinstance(statement.targets[0].value, Name)
             )
             else statement.sugar()
         )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -586,7 +586,6 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
         reduce_block_to_exitset,
     )
     from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
-    from sugar_source_tree.backend import materialize
     from sugar_source_tree.binding_state import (
         ConstructionTestimonyReporterV1,
         SubstitutionTraceBuilderV1,
@@ -610,15 +609,13 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
     )
     source_file = SourceFile(
         (module.source, module.source_seat, module.source_cid),
+        reporter=producer_reporter,
         construction_context=construction_context,
-    )
-    producer_root = materialize(
-        source_file.unit, source_file.root.ref, producer_reporter
     )
     locus_key = (locus.lineno, locus.col_offset)
     prefix = tuple(
         statement
-        for statement in producer_root.body
+        for statement in source_file.root.body
         if (
             statement.line_col_span().start_line,
             statement.line_col_span().start_col,

--- a/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
@@ -527,3 +527,79 @@ def test_receipt_backed_import_member_is_constructed_call_argument(
     assert member.to_term(owner="test") == member.desugar(context).value.to_term(
         owner="test"
     )
+
+
+def test_import_member_testimony_canonicalizes_only_its_authenticated_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The enum.py:927 construction path must not expose a raw owner token."""
+    from sugar_lift_py_tests.import_binding import (
+        authenticated_import_value_use_receipts,
+    )
+    from sugar_lift_py_tests.sugar.import_member_sugar import ImportMemberSugar
+    from sugar_lift_python_source.dependency_artifact import AuthenticatedModuleSourceV1
+    from sugar_lift_python_source.manager_construction import (
+        _seat_import_value_use_receipts,
+    )
+    from sugar_lift_python_source.resolution_session import SourceResolutionSession
+    from sugar_source_tree.backend import materialize
+    from sugar_source_tree.binding_state import (
+        ConstructionTestimonyReporterV1,
+        SubstitutionTraceBuilderV1,
+    )
+    from sugar_source_tree.nodes import Attribute
+    from sugar_source_tree.panic import BackendDefect
+    from sugar_source_tree.reporter import CollectingReporter
+
+    source = "import sys\ndef selected():\n    return sys.modules\n"
+    path, source_file, context = _consumer(tmp_path, source)
+    function = next(node for node in source_file.nodes() if isinstance(node, FunctionDef))
+    attribute = next(node for node in source_file.nodes() if isinstance(node, Attribute))
+    module = AuthenticatedModuleSourceV1(
+        module_name="consumer",
+        source_seat="consumer.py",
+        source_cid=source_file.unit.source_cid,
+        source=source,
+    )
+    monkeypatch.chdir(tmp_path)
+    _seat_import_value_use_receipts(
+        source_file=source_file,
+        module=module,
+        target=function,
+        session=SourceResolutionSession(),
+        context=context,
+        dependency_graphs={},
+    )
+    reporter = ConstructionTestimonyReporterV1(
+        CollectingReporter(),
+        SubstitutionTraceBuilderV1(source_file.unit.source_cid),
+    )
+    root = materialize(source_file.unit, source_file.root.ref, reporter)
+    constructed_attribute = next(
+        node
+        for node in root.walk()
+        if isinstance(node, Attribute)
+        and node.line_col_span() == attribute.line_col_span()
+    )
+
+    member = constructed_attribute.sugar()
+    assert isinstance(member, ImportMemberSugar)
+    assert member.qualified_name == "sys.modules"
+
+    foreign_source = "import os\ndef selected():\n    return os.modules\n"
+    foreign_path, foreign_file, _ = _consumer(tmp_path, foreign_source)
+    foreign_receipts, _ = authenticated_import_value_use_receipts(
+        tmp_path,
+        foreign_path,
+        foreign_source,
+        foreign_file.unit.source_cid,
+        module_identities={},
+    )
+    foreign = next(row for row in foreign_receipts if row.target_symbol == "python:os.modules")
+    span = attribute.line_col_span()
+    with pytest.raises(BackendDefect, match="source_cid"):
+        source_file.unit.seat_import_value_use_resolution(
+            (span.start_line, span.start_col, span.end_line, span.end_col),
+            foreign,
+            source_cid=foreign_file.unit.source_cid,
+        )

--- a/implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py
@@ -1,0 +1,64 @@
+"""RED: enum's source metaclass return is projected before publication."""
+
+from __future__ import annotations
+
+import ast
+import enum
+
+import pytest
+
+from sugar_lift_python_source.dependency_artifact import AuthenticatedModuleSourceV1
+from sugar_lift_python_source.manager_construction import _module_prefix_outcome
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.floor import BlockValue, TermValue
+from sugar_lift_py_tests.floor.decorated_class_value import _floor_cid
+from sugar_lift_py_tests.floor.raise_value import RaiseValue
+from sugar_lift_py_tests.floor.return_value import ReturnValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.outcome import Completed
+from sugar_lift_py_tests.effect import RaiseEffect
+
+
+def test_enum_metaclass_publication_projects_completed_final_class() -> None:
+    source, seat, source_cid = path_source(enum.__file__)
+    parsed = ast.parse(source, filename=seat)
+    definition = next(
+        node
+        for node in parsed.body
+        if isinstance(node, ast.ClassDef) and node.name == "Enum"
+    )
+    module = AuthenticatedModuleSourceV1(
+        module_name="enum",
+        source_seat=seat,
+        source_cid=source_cid,
+        source=source,
+    )
+
+    exits = _module_prefix_outcome(module, definition)
+
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    published = completed.value.context.temporal.value_if_bound("Enum")
+    assert published.publication.final_class is not published.publication.raw_class
+    assert type(published.publication.final_class) is not BlockValue
+    assert published.publication.source_cid == source_cid
+
+
+@pytest.mark.parametrize(
+    "lying_final",
+    (
+        BlockValue((TermValue("foreign"),)),
+        BlockValue((ReturnValue(TermValue("malformed")),), can_fall_through=False),
+        BlockValue(
+            (RaiseValue(RaiseEffect(exception_name="RuntimeError")),),
+            can_fall_through=False,
+        ),
+    ),
+)
+def test_raw_block_final_class_controls_remain_loud(lying_final) -> None:
+    with pytest.raises(
+        ConstructionPanic,
+        match="owner=decorated class publication blame=BlockValue",
+    ):
+        _floor_cid(lying_final)

--- a/implementations/python/sugar-lift-python-source/tests/test_module_prefix_definition_reporter.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_module_prefix_definition_reporter.py
@@ -1,0 +1,181 @@
+"""RED: module-prefix FunctionDefs register before callable publication."""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.outcome import Completed
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import AuthenticatedModuleSourceV1
+from sugar_lift_python_source.manager_construction import _module_prefix_outcome
+from sugar_source_tree.backend import materialize
+from sugar_source_tree.binding_state import (
+    ConstructionTestimonyReporterV1,
+    SubstitutionTraceBuilderV1,
+)
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.panic import BackendDefect
+from sugar_source_tree.reporter import CollectingReporter, NullReporter
+from sugar_source_tree.tree import SourceFile
+
+
+def _source(name: str = "exact") -> str:
+    return (
+        f"def {name}(value):\n"
+        "    return value\n\n"
+        "prefix_marker = 0\n"
+        f"result = {name}(7)\n"
+    )
+
+
+def _module(name: str = "exact") -> AuthenticatedModuleSourceV1:
+    source = _source(name)
+    return AuthenticatedModuleSourceV1(
+        module_name=f"reporter_{name}",
+        source_seat=f"reporter_{name}.py",
+        source_cid=blake3_512_of(source.encode()),
+        source=source,
+    )
+
+
+def _coordinate(call: Call) -> SourceFragmentCoordinateV1:
+    span = call.line_col_span()
+    return SourceFragmentCoordinateV1(
+        call.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _published_definition(module: AuthenticatedModuleSourceV1, name: str):
+    locus = ast.parse(module.source).body[-1]
+    exits = _module_prefix_outcome(module, locus)
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    callable_value = completed.value.context.temporal.value_if_bound(name)
+    return callable_value.definition
+
+
+def _consumer(module: AuthenticatedModuleSourceV1, definition: FunctionDef):
+    context = TreeConstructionContextV1.for_source_call_construction()
+    collector = CollectingReporter()
+    source = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        reporter=collector,
+        construction_context=context,
+    )
+    original_call = next(node for node in source.nodes() if isinstance(node, Call))
+    context.source_call_frames[_coordinate(original_call)] = (
+        definition.source_visible_call_frame()
+    )
+    reporter = ConstructionTestimonyReporterV1(
+        collector, SubstitutionTraceBuilderV1(source.unit.source_cid)
+    )
+    root = materialize(source.unit, source.root.ref, reporter)
+    call = next(node for node in root.walk() if isinstance(node, Call))
+    return call, reporter
+
+
+@pytest.mark.parametrize("name", ("exact", "unrelated_renamed"))
+def test_module_prefix_definition_is_registered_before_publication(name) -> None:
+    module = _module(name)
+    definition = _published_definition(module, name)
+
+    assert type(definition.reporter) is ConstructionTestimonyReporterV1
+    assert definition.reporter.materialized_node_for_ref(definition.ref) is definition
+
+    call, consumer_reporter = _consumer(module, definition)
+    sugar = call.sugar()
+
+    assert sugar.expected_definition_ref is definition
+    assert sugar.call_occurrence == _coordinate(call)
+    assert consumer_reporter.materialized_node_for_ref(definition.ref) is definition
+
+
+def _registered_definition(source: str = "def exact():\n    return 1\n"):
+    identity = (source, "registered.py", blake3_512_of(source.encode()))
+    collector = CollectingReporter()
+    tree = SourceFile(identity, reporter=collector)
+    reporter = ConstructionTestimonyReporterV1(
+        collector, SubstitutionTraceBuilderV1(tree.unit.source_cid)
+    )
+    root = materialize(tree.unit, tree.root.ref, reporter)
+    definition = next(node for node in root.walk() if isinstance(node, FunctionDef))
+    return tree, definition, reporter
+
+
+def test_consumer_retains_the_exact_existing_registered_ref() -> None:
+    _tree, definition, producer = _registered_definition()
+    consumer = ConstructionTestimonyReporterV1(
+        CollectingReporter(), SubstitutionTraceBuilderV1(definition.unit.source_cid)
+    )
+
+    retained = consumer.retain_registered_node_from(definition, producer)
+
+    assert retained is definition
+    assert consumer.materialized_node_for_ref(definition.ref) is definition
+
+
+@pytest.mark.parametrize(
+    "axis",
+    (
+        "null-reporter",
+        "foreign-reporter-table-ref",
+        "late-retroactive-registration",
+        "duplicate-rematerialized-definition",
+    ),
+)
+def test_definition_registration_lies_stay_loud(axis) -> None:
+    tree, definition, producer = _registered_definition()
+    consumer = ConstructionTestimonyReporterV1(
+        CollectingReporter(), SubstitutionTraceBuilderV1(tree.unit.source_cid)
+    )
+
+    if axis == "null-reporter":
+        candidate = definition
+        candidate_reporter = NullReporter()
+    elif axis == "foreign-reporter-table-ref":
+        _foreign_tree, _foreign_definition, candidate_reporter = (
+            _registered_definition("def foreign():\n    return 2\n")
+        )
+        candidate = definition
+    elif axis == "late-retroactive-registration":
+        source = "def late():\n    return 3\n"
+        late_tree = SourceFile(
+            (source, "late.py", blake3_512_of(source.encode())),
+            reporter=NullReporter(),
+        )
+        candidate = next(
+            node for node in late_tree.nodes() if isinstance(node, FunctionDef)
+        )
+        candidate_reporter = ConstructionTestimonyReporterV1(
+            CollectingReporter(),
+            SubstitutionTraceBuilderV1(late_tree.unit.source_cid),
+        )
+        candidate_reporter.register(candidate)
+    else:
+        duplicate_reporter = ConstructionTestimonyReporterV1(
+            CollectingReporter(), SubstitutionTraceBuilderV1(tree.unit.source_cid)
+        )
+        duplicate_root = materialize(tree.unit, tree.root.ref, duplicate_reporter)
+        candidate = next(
+            node
+            for node in duplicate_root.walk()
+            if isinstance(node, FunctionDef)
+        )
+        candidate_reporter = producer
+        assert candidate is not definition
+        assert candidate.ref is definition.ref
+
+    with pytest.raises(BackendDefect):
+        consumer.retain_registered_node_from(candidate, candidate_reporter)
+

--- a/implementations/python/sugar-lift-python-source/tests/test_module_prefix_one_roll_materialization.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_module_prefix_one_roll_materialization.py
@@ -1,0 +1,119 @@
+"""Module-prefix construction is one reporter/SourceUnit roll."""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import AuthenticatedModuleSourceV1
+from sugar_lift_python_source import manager_construction
+from sugar_source_tree.binding_state import (
+    ConstructedValueCategoryGap,
+    ConstructionTestimonyReporterV1,
+    constructed_value_cid_v2,
+)
+from sugar_source_tree.nodes import FunctionDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _module(name: str) -> AuthenticatedModuleSourceV1:
+    source = (
+        f"def {name}(value):\n"
+        "    return value\n\n"
+        "left, right = (1, 2)\n"
+        "prefix_marker = 0\n"
+    )
+    return AuthenticatedModuleSourceV1(
+        module_name=f"one_roll_{name}",
+        source_seat=f"one_roll_{name}.py",
+        source_cid=blake3_512_of(source.encode()),
+        source=source,
+    )
+
+
+def _observe_prefix(monkeypatch, name: str):
+    module = _module(name)
+    observed = []
+
+    class RecordingSourceFile(SourceFile):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            observed.append(self)
+
+    monkeypatch.setattr(manager_construction, "SourceFile", RecordingSourceFile)
+    locus = ast.parse(module.source).body[-1]
+    manager_construction._module_prefix_outcome(module, locus)
+    assert len(observed) == 1
+    return observed[0]
+
+
+@pytest.mark.parametrize("name", ("exact", "unrelated_renamed"))
+def test_module_prefix_tables_are_from_one_reporter_roll(monkeypatch, name) -> None:
+    source_file = _observe_prefix(monkeypatch, name)
+    unit = source_file.unit
+    reporter = source_file.reporter
+
+    assert type(reporter) is ConstructionTestimonyReporterV1
+    assert source_file.root.reporter is reporter
+    assert source_file.constructed_module.reporting_projection is reporter
+    assert source_file.constructed_module.root is source_file.root
+    assert unit.typed_module is source_file.root
+
+    functions = source_file.constructed_module.function_nodes
+    assert functions == unit.function_nodes
+    assert len(functions) == 1
+    assert isinstance(functions[0], FunctionDef)
+    assert functions[0] is source_file.root.body[0]
+    assert functions[0].reporter is reporter
+
+    for rows in unit.module_direct_bindings.values():
+        for binding in rows:
+            assert binding in source_file.root.body
+            assert binding.reporter is reporter
+            assert binding.unit is unit
+
+    assign = source_file.root.body[1]
+    patterns = unit.target_patterns_for(assign)
+    assert len(patterns) == 1
+    assert patterns[0].consumer_occurrence is assign
+    assert patterns[0].source_unit is unit
+    assert unit.target_pattern_construction_count == 1
+
+    receipt = source_file.constructed_module.construction_event_receipt
+    assert constructed_value_cid_v2(receipt) == source_file.construction_event_receipt_cid
+    with pytest.raises(ConstructedValueCategoryGap):
+        constructed_value_cid_v2(source_file.constructed_module)
+
+
+def test_module_prefix_rejects_every_two_roll_cross_wire(monkeypatch) -> None:
+    exact = _observe_prefix(monkeypatch, "cross_wire")
+    foreign = SourceFile(
+        (
+            _module("foreign").source,
+            _module("foreign").source_seat,
+            _module("foreign").source_cid,
+        )
+    )
+
+    # These are the bounded manifestations of a second materialization roll:
+    # stale NULL-reporter bindings, a duplicate raw root, and foreign
+    # reporter/context/source/locus testimony.  None may inhabit the one-roll
+    # tables seated on the exact SourceUnit.
+    stale = tuple(
+        binding
+        for rows in exact.unit.module_direct_bindings.values()
+        for binding in rows
+        if binding.reporter is not exact.reporter
+    )
+    assert stale == ()
+    assert exact.constructed_module.root is exact.root
+    assert exact.root.unit is exact.unit
+    assert all(node.reporter is exact.reporter for node in exact.unit.function_nodes)
+    assert all(node.unit is exact.unit for node in exact.unit.function_nodes)
+    assert all(node is not foreign.root for node in exact.unit.function_nodes)
+    assert all(
+        node.fragment is not foreign.root.fragment
+        for node in exact.unit.function_nodes
+    )

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -829,6 +829,70 @@ def test_module_prefix_constructs_one_subscript_delete_statement(
     assert isinstance(exits.exits[0], Completed)
 
 
+def test_stdlib_makecodes_return_is_rebound_before_exact_slice_delete() -> None:
+    """The real ``re._constants`` prefix deletes from its returned ListValue."""
+    from sugar_lift_py_tests.floor import CallSiteValue, ListValue
+    from sugar_lift_py_tests.outcome import Completed
+    from sugar_lift_python_source import manager_construction
+
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("re")
+    module = graph.modules["re._constants"]
+    parsed = ast.parse(module.source)
+    delete = next(
+        statement
+        for statement in parsed.body
+        if isinstance(statement, ast.Delete) and statement.lineno == 124
+    )
+    next_statement = next(
+        statement for statement in parsed.body if statement.lineno > delete.lineno
+    )
+    assignment = next(
+        statement
+        for statement in parsed.body
+        if isinstance(statement, ast.Assign)
+        and statement.lineno == 75
+        and isinstance(statement.value, ast.Call)
+    )
+    expected_count = len(assignment.value.args) - 2
+
+    exits = manager_construction._module_prefix_outcome(
+        module, next_statement, graph=graph
+    )
+
+    assert len(exits.exits) == 1
+    completed = exits.exits[0]
+    assert isinstance(completed, Completed)
+    opcodes = completed.value.context.temporal.value_if_bound("OPCODES")
+    assert type(opcodes) is ListValue
+    assert not isinstance(opcodes, CallSiteValue)
+    assert len(opcodes.elements) == expected_count
+
+
+def test_bodyless_call_result_cannot_be_promoted_to_delete_list(tmp_path: Path) -> None:
+    """Lying twin: an unresolved return stays loud at the exact delete owner."""
+    from sugar_lift_python_source import manager_construction
+    from sugar_source_tree.panic import SugarNotWritten
+
+    source = "OPCODES = external()\ndel OPCODES[-2:]\nafter = 1\n"
+    dist = _dist(
+        tmp_path,
+        name="bodyless-delete-pkg",
+        files={"bodyless_delete_pkg/__init__.py": source},
+    )
+    module = DependencyArtifactGraph.authenticate(dist).modules[
+        "bodyless_delete_pkg"
+    ]
+    locus = ast.parse(source).body[-1]
+
+    with pytest.raises(SugarNotWritten) as raised:
+        manager_construction._module_prefix_outcome(module, locus)
+
+    assert raised.value.owner == "SubscriptDeleteEffectSugar._delete"
+    assert raised.value.observed == (
+        "undischarged subscript delete over runtime-selected receiver"
+    )
+
+
 def test_module_prefix_execution_publishes_exact_decorator_result(
     tmp_path: Path,
 ) -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -451,6 +451,46 @@ class _BackendConstructionEventReceiptV1(_SealedBackendRelation):
     _tamper_message = "sealed construction event receipt"
 
 
+def _validated_construction_event_receipt_cid(value: object) -> str | None:
+    """Project one producer-sealed module event to its immutable CID."""
+    if type(value) is not _BackendConstructionEventReceiptV1:
+        return None
+    token = value._owner_token
+    if not isinstance(token, _PrivateSeal) or token.owner_type is not type(value):
+        return None
+    visible = value._visible_fields()
+    if tuple(visible) != tuple(token.preimage):
+        return None
+    for name, expected in token.preimage.items():
+        actual = visible[name]
+        if (
+            actual is not expected
+            if not isinstance(expected, (str, int, float, tuple, type(None)))
+            else actual != expected
+        ):
+            return None
+    registered = value.registered_occurrences
+    if not registered:
+        return None
+    from sugar_lift_python_source.canonical import cid_of_json
+
+    expected_cid = cid_of_json(
+        {
+            "kind": "backend-module-construction-receipt",
+            "schemaVersion": "1",
+            "sourceCid": value.source_cid,
+            "backendFingerprint": value.backend_fingerprint,
+            "rootMemento": registered[0].fragment.seal().to_dict(),
+            "constructedNodeMementoCids": [
+                node.fragment.seal().cid for node in registered
+            ],
+        }
+    )
+    if expected_cid != value.construction_event_receipt_cid:
+        return None
+    return value.construction_event_receipt_cid
+
+
 @dataclass(init=False)
 class _ConstructedModuleV1(_SealedBackendRelation):
     """The private, atomic result of the sole backend module construction."""

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -401,7 +401,17 @@ class ConstructionTestimonyReporterV1:
         self._trace_builder = trace_builder
 
     def register(self, node: Node) -> None:
-        self._materialized_by_ref[node.ref] = node
+        if node.reporter is not self:
+            # Registration is construction-owned.  A later caller cannot turn
+            # a Node built under another reporter into testimony by replaying
+            # this public protocol method.
+            return
+        existing = self._materialized_by_ref.get(node.ref)
+        if existing is None:
+            # Lazy child access can rematerialize a view for the same backend
+            # ref.  The first constructor contact owns the testimony; a later
+            # view must not replace it.
+            self._materialized_by_ref[node.ref] = node
         self._delegate.register(node)
 
     def materialized_node_for_ref(self, ref: object) -> Node | None:
@@ -418,7 +428,8 @@ class ConstructionTestimonyReporterV1:
             else producer._materialized_by_ref.get(node.ref)
         )
         if (
-            not isinstance(registered, type(node))
+            registered is not node
+            or not isinstance(registered, type(node))
             or registered.unit.source_cid != node.unit.source_cid
             or registered.line_col_span() != node.line_col_span()
         ):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -426,8 +426,21 @@ class ConstructionTestimonyReporterV1:
             and isinstance(value, CallSiteSugar)
             and value.expected_definition_ref is not None
         ):
+            from sugar_lift_py_tests.context_manager_resolution import (
+                SourceFragmentCoordinateV1,
+            )
+
             definition = value.expected_definition_ref
             resolved_definition = node.unit.source_function_definition_for_call(node)
+            span = node.line_col_span()
+            call_occurrence = SourceFragmentCoordinateV1(
+                node.unit.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+            frame = value.source_call_frame
             if (
                 not isinstance(definition, (FunctionDef, AsyncFunctionDef))
                 or definition.ref not in self._materialized_by_ref
@@ -438,6 +451,10 @@ class ConstructionTestimonyReporterV1:
                 )
                 or resolved_definition.ref is not definition.ref
                 or resolved_definition.line_col_span() != definition.line_col_span()
+                or value.call_occurrence != call_occurrence
+                or frame is None
+                or frame.owner.ref is not definition.ref
+                or frame.definition_site.source_cid != node.unit.source_cid
             ):
                 self._testimony_gap(
                     node,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1216,7 +1216,16 @@ def _cv2_leaf(value: object) -> Any:
                     "method": "BinaryOperator.project_inplace",
                 }
             }
+    from sugar_source_tree.backend import _validated_construction_event_receipt_cid
     from sugar_source_tree.nodes import Node, TargetPatternV1
+
+    construction_event_receipt_cid = _validated_construction_event_receipt_cid(
+        value
+    )
+    if construction_event_receipt_cid is not None:
+        return {
+            "backendConstructionEventReceiptCid": construction_event_receipt_cid
+        }
 
     if type(value) is TargetPatternV1:
         receipt = value.receipt
@@ -1360,6 +1369,14 @@ def constructed_value_cid_v2(value: object) -> str:
     A value reached while it is still being expanded is a CYCLE: a typed gap,
     loudly, never a truncation or a placeholder.
     """
+    from sugar_source_tree.backend import _validated_construction_event_receipt_cid
+
+    construction_event_receipt_cid = _validated_construction_event_receipt_cid(
+        value
+    )
+    if construction_event_receipt_cid is not None:
+        return construction_event_receipt_cid
+
     from .construction_cache import (
         constructed_value_cid_v2_for,
         remember_constructed_value_cid_v2,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -408,6 +408,49 @@ class ConstructionTestimonyReporterV1:
         """The typed occurrence registered for ``ref`` in this exact roll."""
         return self._materialized_by_ref.get(ref)
 
+    def retain_registered_node_from(
+        self, node: Node, producer: "ConstructionTestimonyReporterV1"
+    ) -> Node:
+        """Retain one exact producer-roll registration in this consumer roll."""
+        registered = (
+            None
+            if type(producer) is not ConstructionTestimonyReporterV1
+            else producer._materialized_by_ref.get(node.ref)
+        )
+        if (
+            not isinstance(registered, type(node))
+            or registered.unit.source_cid != node.unit.source_cid
+            or registered.line_col_span() != node.line_col_span()
+        ):
+            from sugar_source_tree.panic import backend_defect
+
+            backend_defect(
+                blame=node.fragment,
+                owner="ConstructionTestimonyReporterV1.retain_registered_node_from",
+                observed="foreign or absent producer node registration",
+                requested="the producer reporter's exact typed Node/ref registration",
+                fix="retain the producer registration; never remint or search by name/span",
+            )
+        existing = self._materialized_by_ref.get(node.ref)
+        if existing is not None and (
+            not isinstance(existing, type(node))
+            or existing.unit.source_cid != node.unit.source_cid
+            or existing.line_col_span() != node.line_col_span()
+        ):
+            from sugar_source_tree.panic import backend_defect
+
+            backend_defect(
+                blame=node.fragment,
+                owner="ConstructionTestimonyReporterV1.retain_registered_node_from",
+                observed="consumer roll already carries a conflicting Node/ref registration",
+                requested="zero or one exact producer registration per backend ref",
+                fix="preserve materialization identity; never select between duplicate nodes",
+            )
+        if existing is not None:
+            return existing
+        self._materialized_by_ref[node.ref] = registered
+        return registered
+
     def present_fact(self, node: Node) -> None:
         self._delegate.present_fact(node)
 
@@ -449,8 +492,8 @@ class ConstructionTestimonyReporterV1:
                 or not isinstance(
                     resolved_definition, (FunctionDef, AsyncFunctionDef)
                 )
-                or resolved_definition.ref is not definition.ref
-                or resolved_definition.line_col_span() != definition.line_col_span()
+                or resolved_definition.fragment.seal()
+                != definition.fragment.seal()
                 or value.call_occurrence != call_occurrence
                 or frame is None
                 or frame.owner.ref is not definition.ref

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -384,6 +384,7 @@ class ConstructionTestimonyReporterV1:
         "_delegate",
         "_by_node_shape",
         "_failed_by_node_shape",
+        "_materialized_by_ref",
         "_trace_builder",
     )
 
@@ -396,10 +397,16 @@ class ConstructionTestimonyReporterV1:
         # could not be testified re-raises the SAME typed panic, and re-raising
         # adds no roll-call mass: the gap was testified once, when it happened.
         self._failed_by_node_shape: dict[str, BaseException] = {}
+        self._materialized_by_ref: dict[object, Node] = {}
         self._trace_builder = trace_builder
 
     def register(self, node: Node) -> None:
+        self._materialized_by_ref[node.ref] = node
         self._delegate.register(node)
+
+    def materialized_node_for_ref(self, ref: object) -> Node | None:
+        """The typed occurrence registered for ``ref`` in this exact roll."""
+        return self._materialized_by_ref.get(ref)
 
     def present_fact(self, node: Node) -> None:
         self._delegate.present_fact(node)
@@ -411,6 +418,35 @@ class ConstructionTestimonyReporterV1:
         self._delegate.report_gap(node, panic)
 
     def present_construction(self, node: Node, value: object) -> None:
+        from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+        from sugar_source_tree.nodes import Call, FunctionDef, AsyncFunctionDef
+
+        if (
+            isinstance(node, Call)
+            and isinstance(value, CallSiteSugar)
+            and value.expected_definition_ref is not None
+        ):
+            definition = value.expected_definition_ref
+            resolved_definition = node.unit.source_function_definition_for_call(node)
+            if (
+                not isinstance(definition, (FunctionDef, AsyncFunctionDef))
+                or definition.ref not in self._materialized_by_ref
+                or node.ref not in self._materialized_by_ref
+                or definition.unit.source_cid != node.unit.source_cid
+                or not isinstance(
+                    resolved_definition, (FunctionDef, AsyncFunctionDef)
+                )
+                or resolved_definition.ref is not definition.ref
+                or resolved_definition.line_col_span() != definition.line_col_span()
+            ):
+                self._testimony_gap(
+                    node,
+                    value,
+                    "constructed value",
+                    ValueError(
+                        "source call definition is not this call's exact typed occurrence"
+                    ),
+                )
         try:
             node_shape_cid = node_construction_shape_cid(node)
         except (TypeError, ValueError) as cause:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1056,6 +1056,7 @@ def _cv2_leaf(value: object) -> Any:
     enum type and member tags and never recurses into ``.value``.
     """
     from sugar_source_tree.fragment import SourceFragment, SourceMemento
+    from types import MethodType
 
     if value is None:
         return {"null": None}
@@ -1084,6 +1085,30 @@ def _cv2_leaf(value: object) -> Any:
         return {"sourceFragment": value.seal().to_dict()}
     if isinstance(value, SourceMemento):
         return {"sourceMemento": value.to_dict()}
+    if type(value) is MethodType:
+        from sugar_source_tree.operators import (
+            AUGASSIGN_BINARY_OPERATOR_CLASSES,
+            BinaryOperator,
+        )
+
+        operator = value.__self__
+        operator_type = type(operator)
+        if (
+            operator_type in AUGASSIGN_BINARY_OPERATOR_CLASSES
+            and operator is operator_type.instance()
+            and value.__func__ is BinaryOperator.project_inplace
+        ):
+            return {
+                "sourceOperatorMethod": {
+                    "operatorType": (
+                        f"{operator_type.__module__}.{operator_type.__qualname__}"
+                    ),
+                    "kind": operator.kind,
+                    "symbol": operator.symbol,
+                    "inplaceOperator": operator.inplace_operator,
+                    "method": "BinaryOperator.project_inplace",
+                }
+            }
     from sugar_source_tree.nodes import Node
 
     if isinstance(value, Node):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1216,7 +1216,17 @@ def _cv2_leaf(value: object) -> Any:
                     "method": "BinaryOperator.project_inplace",
                 }
             }
-    from sugar_source_tree.nodes import Node
+    from sugar_source_tree.nodes import Node, TargetPatternV1
+
+    if type(value) is TargetPatternV1:
+        receipt = value.receipt
+        if receipt is not None and _validated_native_cid(receipt) == receipt.cid:
+            return {
+                "targetPatternReceipt": {
+                    "cid": receipt.cid,
+                    "preimage": receipt.preimage,
+                }
+            }
 
     if isinstance(value, Node):
         # A Node is a tree VIEW, not content. Its content identity is its
@@ -1236,6 +1246,14 @@ def _cv2_entries(value: object) -> tuple[str, list[tuple[Any, object]]]:
     arm is a typed gap, never reflection over ``__dict__`` and never
     ``.wire()``.
     """
+    from sugar_source_tree.nodes import TargetPatternV1
+
+    if (
+        type(value) is TargetPatternV1
+        and value.receipt is not None
+        and _validated_native_cid(value.receipt) == value.receipt.cid
+    ):
+        return (_cv2_type_tag(value), [("receipt", value.receipt)])
     if isinstance(value, tuple):
         # Length and position are authenticated: ``at`` is the index, and
         # ``arity`` is encoded, so reordering, duplicating or omitting a child

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1165,6 +1165,8 @@ def _cv2_leaf(value: object) -> Any:
     from sugar_source_tree.fragment import SourceFragment, SourceMemento
     from types import MethodType
 
+    if value is Ellipsis:
+        return {"ellipsis": True}
     if value is None:
         return {"null": None}
     if isinstance(value, Enum):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -622,27 +622,18 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
         else_obligation_cid = else_obligation["elseExhaustionObligationCid"]
 
     post_records = []
-    # THE EXIT ROUTES, NAMED BY THE PRODUCER (#6336 family).
+    # THE COMPLETED-STATE ROUTES, NAMED BY THE PRODUCER.
     #
-    # A loop leaves exactly one way, and this tuple is the loop saying which
-    # ways exist. `BodyFallthrough` is deliberately absent and must stay absent:
-    # it is the LATCH input (`loop_construction.py` requires the latch
-    # obligation's input face to be exactly that kind), i.e. the loop-back edge,
-    # not an exit route. Stamping it as a third exit member would assert an
-    # exclusion between the loop-back edge and the two real exits that nobody
-    # established -- and, because a family admits only when it is COMPLETE,
-    # would cost the two genuine exit arms the admission they legitimately earn.
+    # Post-binding projects the carried state through every completed producer
+    # route, including `BodyFallthrough`: it is the internal latch input, not an
+    # outward exit, but it is still a distinct completed state whose exact
+    # guard/state/coordinate testimony must survive the projection.  The root's
+    # break/exhaustion obligations remain the separate outward denominator.
     #
-    # `exitPartitionArity` is that count carried on the wire so a downstream
-    # projection reads a DECLARED family size instead of counting whatever
-    # happened to arrive. A dropped post-binding record then makes the family
-    # short of its declared size, and the projection refuses loudly rather than
-    # certifying a partial partition as exhaustive.
-    completed_post_kinds = (
-        ("BreakExit", "NormalExhaustion")
-        if "BreakExit" in face_snapshots
-        else ("NormalExhaustion",)
-    )
+    # `exitPartitionArity` is the legacy wire field carrying that producer-owned
+    # completed-route count.  It is deliberately not derived from the outward
+    # obligation roster and not recounted from whatever projection arrived.
+    completed_post_kinds = tuple(kind for kind, _guard in completed_specs)
     exit_partition_arity = len(completed_post_kinds)
     for completion_kind in completed_post_kinds:
         face, state_record, _snapshot = (

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py
@@ -148,6 +148,10 @@ def project_loop_post_binding(
         and record["bindingCoordinateCid"] == binding_coordinate.cid
     ]
     post_face_cids = {record["completedFaceCid"] for record in post_records}
+    if len(post_face_cids) != len(post_records):
+        raise BindingStateWireGap(
+            "loop post-binding projection repeats one completed route"
+        )
     # The DECLARED size of this loop occurrence's exit family. Read off the
     # producer's own records, never counted from what arrived: counting would
     # make a dropped face silently re-read as a smaller complete partition,
@@ -160,16 +164,23 @@ def project_loop_post_binding(
             f"binding coordinate: observed {sorted(declared)}"
         )
     exit_partition_arity = declared.pop() if declared else None
+    completed_by_cid = {face.cid: face for face in construction.completed_faces}
     projected_faces = []
-    for face in construction.completed_faces:
-        if face.cid not in post_face_cids:
-            continue
-        record = records.get(face.cid)
+    for post_record in post_records:
+        face_cid = post_record["completedFaceCid"]
+        face = completed_by_cid.get(face_cid)
+        if face is None:
+            raise BindingStateWireGap("post-binding face missing from loop graph")
+        record = records.get(face_cid)
         if record is None:
             raise BindingStateWireGap("completed face missing from loop graph")
         if record["targetCid"] != target_cid:
             raise BindingStateWireGap("loop projected binding target mismatch")
         state_cid = record["stateCid"]
+        if post_record["projectedStateCid"] != state_cid:
+            raise BindingStateWireGap(
+                "loop post-binding projected state does not match completed route"
+            )
         snapshot = runtime_states.get(state_cid)
         if snapshot is None:
             raise BindingStateWireGap(
@@ -184,17 +195,27 @@ def project_loop_post_binding(
             raise BindingStateWireGap(
                 f"completed face {face.cid} has {len(matches)} entries for binding coordinate"
             )
+        live_guard = None if live_guards is None else live_guards.get(
+            record["guardFormulaCid"]
+        )
+        if live_guards is not None:
+            if live_guard is None:
+                raise BindingStateWireGap(
+                    "completed face has no authenticated live guard formula"
+                )
+            from .live_loop_construction import _formula_cid
+
+            if _formula_cid(live_guard) != record["guardFormulaCid"]:
+                raise BindingStateWireGap(
+                    "completed face live guard formula does not match producer testimony"
+                )
         projected_faces.append(
             LoopProjectedCompletedFace(
                 target_cid=target_cid,
                 completion_kind=face.completion_kind,
                 guard_formula_cid=record["guardFormulaCid"],
                 state=matches[0].state,
-                guard_formula=(
-                    None
-                    if live_guards is None
-                    else live_guards.get(record["guardFormulaCid"])
-                ),
+                guard_formula=live_guard,
                 exit_partition_arity=exit_partition_arity,
             )
         )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3969,7 +3969,26 @@ class ClassDef(Statement):
             return None
         if (self.unit.module_direct_bindings or {}).get("super"):
             return None
-        return constructor, allocation.targets[0], constructor.body[1:-1]
+        field_body = constructor.body[1:-1]
+        receiver_name = allocation.targets[0].id
+        formal_names = {param.name for param in constructor.params[1:]}
+        field_names = []
+        for statement in field_body:
+            if (
+                not isinstance(statement, Assign)
+                or len(statement.targets) != 1
+                or not isinstance(statement.targets[0], Attribute)
+                or not isinstance(statement.targets[0].value, Name)
+                or statement.targets[0].value.id != receiver_name
+                or not isinstance(statement.value, Name)
+                or statement.value.id not in formal_names
+                or statement.targets[0].attr != statement.value.id
+            ):
+                return None
+            field_names.append(statement.targets[0].attr)
+        if len(field_names) != len(set(field_names)):
+            return None
+        return constructor, allocation.targets[0], field_body
 
     def substitute(self, scope):
         """A class: decorators and type params evaluate in the enclosing scope;

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -202,6 +202,107 @@ class TargetPatternConstructionGapV1(TypeError):
         self.actual_coordinates = actual_coordinates
 
 
+_TARGET_PATTERN_RECEIPT_AUTHORITY = object()
+
+
+@dataclass(frozen=True, init=False)
+class TargetPatternReceiptV1:
+    """Closed semantic testimony minted with the completed module roster."""
+
+    source_cid: str
+    consumer_occurrence_cid: str
+    consumer_node_shape_cid: str
+    target_occurrence_cid: str
+    target_node_shape_cid: str
+    leaf_occurrence_cids: tuple[str, ...]
+    leaf_node_shape_cids: tuple[str, ...]
+    binding_coordinate_cids: tuple[str, ...]
+    cid: str
+    _authority: object = field(default=None, init=False, compare=False, repr=False)
+
+    @property
+    def preimage(self) -> dict[str, object]:
+        return {
+            "kind": "target-pattern-receipt",
+            "schemaVersion": "1",
+            "sourceCid": self.source_cid,
+            "consumerOccurrenceCid": self.consumer_occurrence_cid,
+            "consumerNodeShapeCid": self.consumer_node_shape_cid,
+            "targetOccurrenceCid": self.target_occurrence_cid,
+            "targetNodeShapeCid": self.target_node_shape_cid,
+            "leafOccurrenceCids": list(self.leaf_occurrence_cids),
+            "leafNodeShapeCids": list(self.leaf_node_shape_cids),
+            "bindingCoordinateCids": list(self.binding_coordinate_cids),
+        }
+
+    def __post_init__(self) -> None:
+        from sugar_lift_python_source.canonical import cid_of_json
+
+        if self._authority is not _TARGET_PATTERN_RECEIPT_AUTHORITY:
+            raise TargetPatternConstructionGapV1(
+                "target-pattern-receipt-not-producer-minted",
+                consumer_occurrence=self.consumer_occurrence_cid,
+                target_occurrence=self.target_occurrence_cid,
+            )
+        if (
+            not self.source_cid
+            or not self.consumer_occurrence_cid
+            or not self.consumer_node_shape_cid
+            or not self.target_occurrence_cid
+            or not self.target_node_shape_cid
+            or not self.leaf_occurrence_cids
+            or len(self.leaf_occurrence_cids) != len(self.leaf_node_shape_cids)
+            or len(self.leaf_occurrence_cids) != len(self.binding_coordinate_cids)
+            or cid_of_json(self.preimage) != self.cid
+        ):
+            raise TargetPatternConstructionGapV1(
+                "target-pattern-receipt-preimage-mismatch",
+                consumer_occurrence=self.consumer_occurrence_cid,
+                target_occurrence=self.target_occurrence_cid,
+            )
+
+
+def _mint_target_pattern_receipt(
+    *, source_unit, consumer_occurrence, target_occurrence, leaves, coordinates
+) -> TargetPatternReceiptV1:
+    from sugar_lift_python_source.canonical import cid_of_json
+    from sugar_source_tree.binding_state import node_construction_shape_cid
+
+    values = {
+        "source_cid": source_unit.source_cid,
+        "consumer_occurrence_cid": consumer_occurrence.fragment.seal().cid,
+        "consumer_node_shape_cid": node_construction_shape_cid(consumer_occurrence),
+        "target_occurrence_cid": target_occurrence.fragment.seal().cid,
+        "target_node_shape_cid": node_construction_shape_cid(target_occurrence),
+        "leaf_occurrence_cids": tuple(leaf.fragment.seal().cid for leaf in leaves),
+        "leaf_node_shape_cids": tuple(
+            node_construction_shape_cid(leaf) for leaf in leaves
+        ),
+        "binding_coordinate_cids": tuple(
+            coordinate.cid for coordinate in coordinates
+        ),
+    }
+    value = object.__new__(TargetPatternReceiptV1)
+    for name, field_value in values.items():
+        object.__setattr__(value, name, field_value)
+    preimage = {
+        "kind": "target-pattern-receipt",
+        "schemaVersion": "1",
+        "sourceCid": values["source_cid"],
+        "consumerOccurrenceCid": values["consumer_occurrence_cid"],
+        "consumerNodeShapeCid": values["consumer_node_shape_cid"],
+        "targetOccurrenceCid": values["target_occurrence_cid"],
+        "targetNodeShapeCid": values["target_node_shape_cid"],
+        "leafOccurrenceCids": list(values["leaf_occurrence_cids"]),
+        "leafNodeShapeCids": list(values["leaf_node_shape_cids"]),
+        "bindingCoordinateCids": list(values["binding_coordinate_cids"]),
+    }
+    object.__setattr__(value, "cid", cid_of_json(preimage))
+    object.__setattr__(value, "_authority", _TARGET_PATTERN_RECEIPT_AUTHORITY)
+    value.__post_init__()
+    return value
+
+
 @dataclass(frozen=True)
 class TargetPatternV1:
     """One eager, occurrence-owned destructuring projection."""
@@ -211,6 +312,10 @@ class TargetPatternV1:
     target_occurrence: "Node"
     leaves: tuple["Name", ...]
     coordinates: tuple[object, ...]
+    receipt: TargetPatternReceiptV1 | None = field(
+        default=None, init=False, compare=False, repr=False
+    )
+
 
     @property
     def names(self) -> tuple[str, ...]:
@@ -288,6 +393,23 @@ class TargetPatternV1:
             return result
 
         return project(self.target_occurrence, element)
+
+
+def _mint_target_pattern(
+    *, source_unit, consumer_occurrence, target_occurrence, leaves, coordinates
+) -> TargetPatternV1:
+    receipt = _mint_target_pattern_receipt(
+        source_unit=source_unit,
+        consumer_occurrence=consumer_occurrence,
+        target_occurrence=target_occurrence,
+        leaves=leaves,
+        coordinates=coordinates,
+    )
+    value = TargetPatternV1(
+        source_unit, consumer_occurrence, target_occurrence, leaves, coordinates
+    )
+    object.__setattr__(value, "receipt", receipt)
+    return value
 
 
 def _ordered_binding_keys(names):
@@ -708,7 +830,13 @@ class SourceUnit:
             )
             for leaf, path in ordered
         )
-        return TargetPatternV1(self, consumer, target, leaves, coordinates)
+        return _mint_target_pattern(
+            source_unit=self,
+            consumer_occurrence=consumer,
+            target_occurrence=target,
+            leaves=leaves,
+            coordinates=coordinates,
+        )
 
     def target_patterns_for(self, consumer: "Node") -> tuple[TargetPatternV1, ...]:
         patterns = self._target_patterns_by_consumer

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2426,7 +2426,9 @@ class Node(Typed):
             sugar=f"{self.kind}.sugar", role="construction", site=where
         ):
             try:
-                result = self._construct_sugar()
+                result = self._project_constructed_value_for_testimony(
+                    self._construct_sugar()
+                )
                 # Testimony projection is INSIDE the discharge, not after it.
                 # A constructed value whose testimony cannot be content-
                 # addressed raises ConstructedValueTestimonyNotWritten here, so
@@ -2443,6 +2445,10 @@ class Node(Typed):
             self.reporter.present_fact(self)
             cache.sugar_results[key] = result
             return result
+
+    def _project_constructed_value_for_testimony(self, value: object) -> object:
+        """Project parser machinery before constructed-value testimony."""
+        return value
 
     def _construct_sugar(self) -> object:
         """This node's sugar, constructed by the node itself.
@@ -9640,6 +9646,25 @@ class Call(Expression):
                 if isinstance(node, ObjectPlaceStateV1):
                     seen[node.object_identity_cid] = node
         return tuple(seen.values())
+
+    def _project_constructed_value_for_testimony(self, value: object) -> object:
+        """Replace a parser definition handle with this roll's typed occurrence."""
+        from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+
+        if not isinstance(value, CallSiteSugar):
+            return value
+        definition_ref = value.expected_definition_ref
+        if definition_ref is None or isinstance(
+            definition_ref, (FunctionDef, AsyncFunctionDef)
+        ):
+            return value
+        lookup = getattr(self.reporter, "materialized_node_for_ref", None)
+        if lookup is None:
+            return value
+        definition = lookup(definition_ref)
+        if not isinstance(definition, (FunctionDef, AsyncFunctionDef)):
+            return value
+        return replace(value, expected_definition_ref=definition)
 
     def _construct_sugar(self):
         """A call constructs its callee's sugar WITH the argument sugars.

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -9805,7 +9805,14 @@ class Call(Expression):
                     )
         if not isinstance(definition, (FunctionDef, AsyncFunctionDef)):
             return value
-        return replace(value, expected_definition_ref=definition)
+        source_call_frame = value.source_call_frame
+        if source_call_frame is not None:
+            source_call_frame = replace(source_call_frame, owner=definition)
+        return replace(
+            value,
+            expected_definition_ref=definition,
+            source_call_frame=source_call_frame,
+        )
 
     def _construct_sugar(self):
         """A call constructs its callee's sugar WITH the argument sugars.

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -6506,18 +6506,41 @@ class If(Statement):
         re-walk of the branches (the re-read was 2^nesting on real code)."""
         from .shadow import rewrite
 
+        expected_slot = branch_result_slot(self.test)
+        stored_slot_id = getattr(self, "branch_result_slot_id", None)
+        authenticated_slot_id = getattr(
+            self, "authenticated_branch_result_slot_id", None
+        )
+        retained_slot = (
+            stored_slot_id is not None or authenticated_slot_id is not None
+        )
+        if retained_slot and (
+            stored_slot_id != expected_slot.slot_id
+            or authenticated_slot_id != expected_slot.slot_id
+        ):
+            backend_defect(
+                blame=self.fragment,
+                owner="If.substitute",
+                observed="If retained a foreign branch-result slot",
+                requested="the stored and authenticated slot for this exact If.test",
+                fix="preserve the one slot minted by the first ordinary substitution",
+            )
+
         changed = {}
         new_test, d = self._substitute_field(self.test, scope)
         if d:
             changed["test"] = new_test
-        slot = branch_result_slot(self.test)
+        slot = expected_slot
         new_body, d, then_net = self._substitute_body_tracked(self.body, scope)
         if d:
             changed["body"] = new_body
         new_orelse, d, else_net = self._substitute_body_tracked(self.orelse, scope)
         if d:
             changed["orelse"] = new_orelse
-        node = self._rewrite_with_slot(changed, slot, authenticated_slot=slot)
+        if retained_slot:
+            node = self if not changed else rewrite(self, **changed)
+        else:
+            node = self._rewrite_with_slot(changed, slot, authenticated_slot=slot)
 
         names = set(then_net) | set(else_net)
         phis = []

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1056,6 +1056,8 @@ class SourceUnit:
         definition: "ClassDef",
     ) -> bool:
         """Whether ordinary attribute storage/lookup is source-constructed."""
+        if definition._authenticated_new_constructor_shape() is not None:
+            return True
         forbidden_methods = {
             "__new__",
             "__getattr__",
@@ -3915,6 +3917,60 @@ class ClassDef(Statement):
             return None
         return decorator.id
 
+    def _authenticated_new_constructor_shape(self):
+        """One source-owned ``__new__`` allocation followed by field stores."""
+        constructors = tuple(
+            item
+            for item in self.body
+            if isinstance(item, FunctionDef) and item.name == "__new__"
+        )
+        if len(constructors) != 1 or any(
+            isinstance(item, FunctionDef) and item.name == "__init__"
+            for item in self.body
+        ):
+            return None
+        constructor = constructors[0]
+        if len(constructor.params) < 2 or len(constructor.body) < 3:
+            return None
+        allocation = constructor.body[0]
+        returned = constructor.body[-1]
+        if (
+            not isinstance(allocation, Assign)
+            or len(allocation.targets) != 1
+            or not isinstance(allocation.targets[0], Name)
+            or not isinstance(returned, Return)
+            or not isinstance(returned.value, Name)
+            or returned.value.id != allocation.targets[0].id
+            or not isinstance(allocation.value, Call)
+            or allocation.value.keywords
+            or len(allocation.value.args) < 1
+            or not isinstance(allocation.value.func, Attribute)
+            or allocation.value.func.attr != "__new__"
+            or not isinstance(allocation.value.func.value, Call)
+        ):
+            return None
+        super_call = allocation.value.func.value
+        class_param = constructor.params[0]
+        if (
+            not isinstance(super_call.func, Name)
+            or super_call.func.id != "super"
+            or super_call.keywords
+            or len(super_call.args) != 2
+            or not isinstance(super_call.args[0], Name)
+            or super_call.args[0].id != self.name
+            or not isinstance(super_call.args[1], Name)
+            or super_call.args[1].id != class_param.name
+            or not isinstance(allocation.value.args[0], Name)
+            or allocation.value.args[0].id != class_param.name
+        ):
+            return None
+        bindings = (self.unit.module_direct_bindings or {}).get(self.name, ())
+        if len(bindings) != 1 or bindings[0] is not self:
+            return None
+        if (self.unit.module_direct_bindings or {}).get("super"):
+            return None
+        return constructor, allocation.targets[0], constructor.body[1:-1]
+
     def substitute(self, scope):
         """A class: decorators and type params evaluate in the enclosing scope;
         the type params then bind for the bases, keywords, and body. The body is
@@ -4177,6 +4233,10 @@ class ClassDef(Statement):
             ),
             None,
         )
+        new_shape = self._authenticated_new_constructor_shape()
+        constructor = initializer if initializer is not None else (
+            None if new_shape is None else new_shape[0]
+        )
         owner_cid = self.fragment.seal().cid
         span = self.line_col_span()
         site = SourceFragmentCoordinateV1(
@@ -4214,7 +4274,7 @@ class ClassDef(Statement):
                 body=self._source_visible_body({}),
                 owner=self,
             )
-        params = () if initializer is None else initializer.params[1:]
+        params = () if constructor is None else constructor.params[1:]
         coordinates = tuple(
             BindingCoordinateV1.mint(owner_cid, param.fragment, ("formal", index))
             for index, param in enumerate(params)
@@ -4341,6 +4401,32 @@ class ClassDef(Statement):
                 **scope,
             }
             initializer_body = initializer._source_visible_body(initializer_scope)
+        else:
+            new_shape = self._authenticated_new_constructor_shape()
+            if new_shape is not None:
+                from sugar_lift_py_tests.sugar.source_visible_function_body_sugar import (
+                    SourceVisibleFunctionBodySugar,
+                )
+
+                constructor, receiver_target, field_body = new_shape
+                coordinate = BindingCoordinateV1.mint(
+                    self.fragment.seal().cid,
+                    receiver_target.fragment,
+                    ("receiver", 0),
+                )
+                receiver = self._make_constructed_receiver_ref(coordinate.cid)
+                receiver_coordinate_cid = coordinate.cid
+                constructor_scope = {
+                    receiver_target.id: BindingEntryV1(coordinate, receiver, None),
+                    **scope,
+                }
+                substituted_body, _ = constructor._substitute_body(
+                    field_body, constructor_scope
+                )
+                initializer_body = SourceVisibleFunctionBodySugar(
+                    tuple(statement.sugar() for statement in substituted_body),
+                    constructor.fragment,
+                )
         return ClassConstructorBodySugar(
             definition=self.sugar(),
             initializer_body=initializer_body,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -8951,7 +8951,11 @@ class ListComp(Expression):
             changed["generators"] = new_gens
         if de:
             changed["elt"] = new_elt
-        return self if not changed else rewrite(self, **changed)
+        if not changed:
+            return self
+        rewritten = rewrite(self, **changed)
+        self.unit.retain_target_patterns(self, rewritten)
+        return rewritten
 
     def _try_unroll_to_display(self, scope):
         """The List display this comprehension dissolves to, or None. One
@@ -9980,6 +9984,7 @@ class Call(Expression):
                 formal_coordinate_cids = tuple(
                     coordinate.coordinate_cid for coordinate in formal_coordinates
                 )
+                source_call_frame = function_definition.source_visible_call_frame()
                 if lexical_row is not None:
                     if source_call_frame is not None:
                         if source_call_frame.owner is not lexical_row.definition_occurrence:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4256,6 +4256,18 @@ class ClassDef(Statement):
         constructor = initializer if initializer is not None else (
             None if new_shape is None else new_shape[0]
         )
+        constructed_new_method = None
+        if new_shape is not None:
+            from sugar_lift_py_tests.floor import ConstructedClassMethodV1
+
+            new_definition = new_shape[0]
+            constructed_new_method = ConstructedClassMethodV1(
+                new_definition.name,
+                new_definition.fragment.seal().cid,
+                new_definition.sugar(),
+                new_definition.source_visible_call_frame(),
+                self._method_descriptor_kind(new_definition),
+            )
         owner_cid = self.fragment.seal().cid
         span = self.line_col_span()
         site = SourceFragmentCoordinateV1(
@@ -4290,8 +4302,11 @@ class ClassDef(Statement):
                 default_nodes=(None,),
                 default_fragments=(None,),
                 default_fragment_cids=(None,),
-                body=self._source_visible_body({}),
+                body=self._source_visible_body(
+                    {}, constructed_new_method=constructed_new_method
+                ),
                 owner=self,
+                constructed_new_method=constructed_new_method,
             )
         params = () if constructor is None else constructor.params[1:]
         coordinates = tuple(
@@ -4328,8 +4343,11 @@ class ClassDef(Statement):
                 param.default.fragment.seal().cid if param.default is not None else None
                 for param in params
             ),
-            body=self._source_visible_body(formal_scope),
+            body=self._source_visible_body(
+                formal_scope, constructed_new_method=constructed_new_method
+            ),
             owner=self,
+            constructed_new_method=constructed_new_method,
         )
 
     def _inherits_default_exception_constructor(self) -> bool:
@@ -4387,7 +4405,7 @@ class ClassDef(Statement):
             self.reporter,
         )
 
-    def _source_visible_body(self, scope):
+    def _source_visible_body(self, scope, *, constructed_new_method=None):
         from sugar_lift_py_tests.sugar.class_constructor_body_sugar import (
             ClassConstructorBodySugar,
         )
@@ -4451,6 +4469,7 @@ class ClassDef(Statement):
             initializer_body=initializer_body,
             receiver_coordinate_cid=receiver_coordinate_cid,
             site=self.fragment,
+            constructed_new_method=constructed_new_method,
         )
 
     def _make_constructed_receiver_ref(self, receiver_coordinate_cid):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4257,10 +4257,15 @@ class ClassDef(Statement):
             None if new_shape is None else new_shape[0]
         )
         constructed_new_method = None
-        if new_shape is not None:
+        new_definitions = tuple(
+            item
+            for item in self.body
+            if isinstance(item, FunctionDef) and item.name == "__new__"
+        )
+        if len(new_definitions) == 1:
             from sugar_lift_py_tests.floor import ConstructedClassMethodV1
 
-            new_definition = new_shape[0]
+            new_definition = new_definitions[0]
             constructed_new_method = ConstructedClassMethodV1(
                 new_definition.name,
                 new_definition.fragment.seal().cid,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -9662,6 +9662,19 @@ class Call(Expression):
         if lookup is None:
             return value
         definition = lookup(definition_ref)
+        if definition is None and value.source_call_frame is not None:
+            producer_definition = value.source_call_frame.owner
+            if (
+                isinstance(producer_definition, (FunctionDef, AsyncFunctionDef))
+                and producer_definition.ref is definition_ref
+            ):
+                retain = getattr(
+                    self.reporter, "retain_registered_node_from", None
+                )
+                if retain is not None:
+                    definition = retain(
+                        producer_definition, producer_definition.reporter
+                    )
         if not isinstance(definition, (FunctionDef, AsyncFunctionDef)):
             return value
         return replace(value, expected_definition_ref=definition)
@@ -9898,6 +9911,7 @@ class Call(Expression):
                 target_name=f"python:resolved-source-call:{bound_frame.frame_cid}",
                 args=tuple(a.sugar() for a in self.args),
                 site=self.fragment,
+                call_occurrence=coordinate,
                 keywords=keyword_sugars,
                 source_call_frame=bound_frame,
                 source_call_frame_table=(
@@ -9911,6 +9925,7 @@ class Call(Expression):
                     if lexical_row is not None
                     else None
                 ),
+                expected_definition_ref=bound_frame.owner.ref,
             )
         if isinstance(self.func, Name):
             from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -9148,6 +9148,20 @@ class ListComp(Expression):
             target = ListComp._comprehension_target(self, gen.target)
             if target is None:
                 return None
+            target_pattern = None
+            target_coordinates = ()
+            if target.coordinates is not None:
+                matching_patterns = tuple(
+                    pattern
+                    for pattern in self.unit.target_patterns_for(self)
+                    if pattern.target_occurrence.ref is gen.target.ref
+                )
+                if len(matching_patterns) == 1:
+                    target_pattern = matching_patterns[0]
+                    target_coordinates = target_pattern.target_coordinates
+                    self.unit.require_target_pattern_coordinates(
+                        target_pattern, target_coordinates
+                    )
             specs.append(
                 ComprehensionGeneratorSugar(
                     target=target,
@@ -9158,6 +9172,8 @@ class ListComp(Expression):
                     ).cid,
                     iterable=gen.iter.sugar(),
                     filters=tuple(guard.sugar() for guard in gen.ifs),
+                    target_coordinates=target_coordinates,
+                    target_pattern=target_pattern,
                 )
             )
         return tuple(specs)

--- a/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
+++ b/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
@@ -1,0 +1,154 @@
+"""RED: CPython call handles must materialize before construction testimony."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sugar_lift_python_source.dependency_artifact import DependencyArtifactGraph
+from sugar_source_tree.backend import materialize
+from sugar_source_tree.binding_state import (
+    ConstructionTestimonyReporterV1,
+    SubstitutionTraceBuilderV1,
+)
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.panic import ConstructedValueTestimonyNotWritten
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.tree import SourceFile
+
+
+def _testimony_root(source: SourceFile, collector: CollectingReporter):
+    reporter = ConstructionTestimonyReporterV1(
+        collector, SubstitutionTraceBuilderV1(source.unit.source_cid)
+    )
+    return materialize(source.unit, source.root.ref, reporter), reporter
+
+
+def _enum_call() -> tuple[SourceFile, FunctionDef, Call]:
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("enum")
+    module = graph.modules["enum"]
+    reporter = CollectingReporter()
+    source = SourceFile(
+        (module.source, module.source_seat, module.source_cid), reporter=reporter
+    )
+    root, _testimony = _testimony_root(source, reporter)
+    definition = next(
+        node
+        for node in root.walk()
+        if isinstance(node, FunctionDef) and node.name == "_is_single_bit"
+    )
+    call = next(
+        node
+        for node in root.walk()
+        if isinstance(node, Call)
+        and node.line_col_span().start_line == 293
+        and node.line_col_span().start_col == 19
+    )
+    assert call.segment() == "_is_single_bit(value)"
+    return source, definition, call
+
+
+def _ordinary_call(tmp_path, *, helper: str, caller: str):
+    path = tmp_path / f"{helper}.py"
+    path.write_text(
+        f"def {helper}(value):\n"
+        "    return value\n\n"
+        f"def {caller}(value):\n"
+        f"    return {helper}(value)\n"
+    )
+    reporter = CollectingReporter()
+    source = SourceFile.from_path(path, reporter=reporter)
+    root, testimony = _testimony_root(source, reporter)
+    definition = next(
+        node
+        for node in root.walk()
+        if isinstance(node, FunctionDef) and node.name == helper
+    )
+    call = next(
+        node
+        for node in root.walk()
+        if isinstance(node, Call) and node.segment() == f"{helper}(value)"
+    )
+    return source, definition, call, testimony
+
+
+@pytest.mark.parametrize(
+    "case",
+    ("authenticated-enum", "unrelated-renamed-source"),
+)
+def test_parser_call_definition_is_materialized_before_reporter_testimony(
+    case, tmp_path
+) -> None:
+    if case == "authenticated-enum":
+        source, definition, call = _enum_call()
+    else:
+        source, definition, call, _reporter = _ordinary_call(
+            tmp_path, helper="unrelated_predicate", caller="apply_predicate"
+        )
+
+    constructed = call.sugar()
+
+    # The adapter handle is only parser machinery.  The semantic construction
+    # carries the exact typed definition occurrence materialized by this unit.
+    assert constructed.expected_definition_ref is definition
+    assert definition.unit is source.unit
+    assert definition.fragment.unit is call.fragment.unit
+    assert definition.fragment.seal().source_cid == source.unit.source_cid
+    assert definition.kind == "FunctionDef"
+
+
+def test_raw_or_reminted_parser_handle_never_becomes_semantic_testimony(
+    tmp_path,
+) -> None:
+    _source, _definition, call = _enum_call()
+    pre_reporter = call._construct_sugar()
+    raw_handle = pre_reporter.expected_definition_ref
+    _reminted_source, _reminted_definition, reminted_call, reminted_reporter = (
+        _ordinary_call(tmp_path, helper="_is_single_bit", caller="other_call")
+    )
+    reminted_handle = reminted_call._construct_sugar().expected_definition_ref
+    assert reminted_handle is not raw_handle
+
+    # The current offender is retained only to prove the adapter object itself
+    # is not the category to admit.  Both the raw occurrence and an independently
+    # parsed same-spelling occurrence remain loud at the reporter membrane.
+    with pytest.raises(ConstructedValueTestimonyNotWritten) as raw_gap:
+        call.reporter.present_construction(call, raw_handle)
+    assert "unclassified constructed value category" in str(raw_gap.value)
+    assert "cpython_adapter._Handle" in str(raw_gap.value)
+    with pytest.raises(ConstructedValueTestimonyNotWritten) as reminted_gap:
+        reminted_reporter.present_construction(reminted_call, reminted_handle)
+    assert "cpython_adapter._Handle" in str(reminted_gap.value)
+
+
+@pytest.mark.parametrize(
+    "axis",
+    ("foreign-source", "wrong-node", "wrong-kind", "method-shaped"),
+)
+def test_call_definition_testimony_rejects_foreign_or_wrong_occurrence(
+    axis, tmp_path
+) -> None:
+    _source, definition, call, reporter = _ordinary_call(
+        tmp_path, helper="predicate", caller="apply"
+    )
+    truthful = call._construct_sugar()
+    foreign_source, foreign_definition, foreign_call, _foreign_reporter = (
+        _ordinary_call(tmp_path, helper="predicate", caller="foreign_apply")
+    )
+    assert foreign_source.unit.source_cid != call.unit.source_cid
+
+    if axis == "foreign-source":
+        lie = foreign_definition
+    elif axis == "wrong-node":
+        lie = foreign_call
+    elif axis == "wrong-kind":
+        lie = definition.body[0]
+    else:
+        lie = definition.sugar
+
+    substituted = replace(truthful, expected_definition_ref=lie)
+    with pytest.raises(ConstructedValueTestimonyNotWritten) as gap:
+        reporter.present_construction(call, substituted)
+    assert "CollectingReporter.present_construction" in str(gap.value)
+    assert call.unit.filename in str(gap.value)

--- a/implementations/python/sugar-source-tree/tests/test_cross_unit_definition_registration.py
+++ b/implementations/python/sugar-source-tree/tests/test_cross_unit_definition_registration.py
@@ -1,0 +1,277 @@
+"""RED: source-frame calls retain producer-owned definition registration."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import replace
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import (
+    DependencyArtifactGraph,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
+from sugar_lift_python_source.manager_construction import resolve_source_visible_frame
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
+from sugar_source_tree.backend import materialize
+from sugar_source_tree.binding_state import (
+    ConstructionTestimonyReporterV1,
+    SubstitutionTraceBuilderV1,
+)
+from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.panic import BackendDefect, ConstructedValueTestimonyNotWritten
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.tree import SourceFile
+
+
+SOURCE = (
+    "def exact(value):\n"
+    "    return value\n\n"
+    "def other(value):\n"
+    "    return value\n\n"
+    "result = exact(7)\n"
+)
+
+
+def _identity(source: str = SOURCE, filename: str = "registration.py"):
+    return source, filename, blake3_512_of(source.encode())
+
+
+def _coordinate(call: Call) -> SourceFragmentCoordinateV1:
+    span = call.line_col_span()
+    return SourceFragmentCoordinateV1(
+        call.unit.source_cid,
+        span.start_line,
+        span.start_col,
+        span.end_line,
+        span.end_col,
+    )
+
+
+def _registered_unit(identity=None):
+    identity = _identity() if identity is None else identity
+    collector = CollectingReporter()
+    source = SourceFile(identity, reporter=collector)
+    reporter = ConstructionTestimonyReporterV1(
+        collector, SubstitutionTraceBuilderV1(source.unit.source_cid)
+    )
+    root = materialize(source.unit, source.root.ref, reporter)
+    definitions = tuple(
+        node for node in root.walk() if isinstance(node, FunctionDef)
+    )
+    calls = tuple(node for node in root.walk() if isinstance(node, Call))
+    assert len(definitions) == 2
+    assert len(calls) == 1
+    return source, definitions, calls[0], reporter
+
+
+def _consumer_with_frame(frame, identity=None):
+    identity = _identity() if identity is None else identity
+    context = TreeConstructionContextV1.for_source_call_construction()
+    collector = CollectingReporter()
+    source = SourceFile(identity, reporter=collector, construction_context=context)
+    original_call = next(node for node in source.nodes() if isinstance(node, Call))
+    context.source_call_frames[_coordinate(original_call)] = frame
+    reporter = ConstructionTestimonyReporterV1(
+        collector, SubstitutionTraceBuilderV1(source.unit.source_cid)
+    )
+    root = materialize(source.unit, source.root.ref, reporter)
+    definitions = tuple(
+        node for node in root.walk() if isinstance(node, FunctionDef)
+    )
+    call = next(node for node in root.walk() if isinstance(node, Call))
+    return source, definitions, call, reporter, context
+
+
+def _manager_frame(tmp_path: Path, name: str):
+    package = tmp_path / "reporter_pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        f"from reporter_pkg.implementation import {name}\n", encoding="utf-8"
+    )
+    (package / "implementation.py").write_text(
+        f"def {name}(value):\n    return value\n", encoding="utf-8"
+    )
+    metadata = tmp_path / "reporter_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: reporter-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (metadata / "top_level.txt").write_text("reporter_pkg\n", encoding="utf-8")
+    recorded = (
+        "reporter_pkg/__init__.py",
+        "reporter_pkg/implementation.py",
+        "reporter_dist-1.0.dist-info/METADATA",
+        "reporter_dist-1.0.dist-info/top_level.txt",
+        "reporter_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for path in recorded:
+            writer.writerow((path, "", ""))
+    graph = DependencyArtifactGraph.authenticate(
+        importlib.metadata.Distribution.at(metadata)
+    )
+    consumer_source = f"from reporter_pkg import {name}\nresult = {name}(7)\n"
+    consumer_path = tmp_path / "consumer.py"
+    consumer_path.write_text(consumer_source, encoding="utf-8")
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+
+    receipts, _ = authenticated_import_use_receipts(
+        tmp_path,
+        consumer_path,
+        consumer_source,
+        blake3_512_of(consumer_source.encode()),
+        module_identities={},
+    )
+    assert len(receipts) == 1
+    session = SourceResolutionSession()
+    resolved = resolve_import_binding(receipts[0], graph=graph, session=session)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    projected = resolve_source_visible_frame(resolved, graph=graph, session=session)
+    assert isinstance(projected, tuple)
+    return projected
+
+
+@pytest.mark.parametrize("name", ("exact", "unrelated_renamed"))
+def test_manager_resolver_returns_exact_reporter_roll_definition(
+    tmp_path: Path, name: str
+) -> None:
+    frame, target = _manager_frame(tmp_path, name)
+
+    assert type(target.reporter) is ConstructionTestimonyReporterV1
+    assert target.reporter.materialized_node_for_ref(target.ref) is target
+    assert frame.owner is target
+
+
+def test_cross_unit_call_consumes_exact_producer_definition_registration() -> None:
+    producer, definitions, _producer_call, producer_reporter = _registered_unit()
+    producer_definition = definitions[0]
+    frame = producer_definition.source_visible_call_frame()
+    consumer, _consumer_definitions, call, consumer_reporter, context = (
+        _consumer_with_frame(frame)
+    )
+
+    assert producer.unit.source_cid == consumer.unit.source_cid
+    assert producer_reporter.materialized_node_for_ref(producer_definition.ref) is (
+        producer_definition
+    )
+    assert frame.owner.ref is producer_definition.ref
+    assert context.source_call_frames[_coordinate(call)] is frame
+
+    sugar = call.sugar()
+
+    assert sugar.expected_definition_ref is producer_definition
+    assert sugar.source_call_frame.owner is producer_definition
+    assert sugar.call_occurrence == _coordinate(call)
+    assert consumer_reporter.materialized_node_for_ref(call.ref) is call
+
+
+def test_same_roll_definition_registration_remains_lawful() -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    collector = CollectingReporter()
+    source = SourceFile(_identity(), reporter=collector, construction_context=context)
+    definition = next(
+        node for node in source.nodes() if isinstance(node, FunctionDef)
+    )
+    call = next(node for node in source.nodes() if isinstance(node, Call))
+    context.source_call_frames[_coordinate(call)] = definition.source_visible_call_frame()
+    reporter = ConstructionTestimonyReporterV1(
+        collector, SubstitutionTraceBuilderV1(source.unit.source_cid)
+    )
+    root = materialize(source.unit, source.root.ref, reporter)
+    registered_definition = next(
+        node for node in root.walk() if isinstance(node, FunctionDef)
+    )
+    registered_call = next(node for node in root.walk() if isinstance(node, Call))
+
+    sugar = registered_call.sugar()
+
+    assert sugar.expected_definition_ref is registered_definition
+    assert sugar.source_call_frame.owner is registered_definition
+    assert sugar.call_occurrence == _coordinate(registered_call)
+
+
+def test_distinct_definition_from_empty_reporter_cannot_authorize_frame() -> None:
+    empty_collector = CollectingReporter()
+    empty_source = SourceFile(_identity(), reporter=empty_collector)
+    empty_definition = next(
+        node for node in empty_source.nodes() if isinstance(node, FunctionDef)
+    )
+    assert not isinstance(empty_definition.reporter, ConstructionTestimonyReporterV1)
+
+    _source, _definitions, call, _reporter, _context = _consumer_with_frame(
+        empty_definition.source_visible_call_frame()
+    )
+
+    with pytest.raises(BackendDefect) as gap:
+        call.sugar()
+    assert (
+        gap.value.owner
+        == "ConstructionTestimonyReporterV1.retain_registered_node_from"
+    )
+    assert gap.value.observed == "foreign or absent producer node registration"
+    assert gap.value.blame.seal() == empty_definition.fragment.seal()
+
+
+@pytest.mark.parametrize(
+    "axis",
+    (
+        "foreign-reporter-table-ref",
+        "duplicate-rematerialized-definition",
+        "wrong-definition-coordinate-scope-owner",
+        "foreign-source",
+        "reminted-call",
+    ),
+)
+def test_cross_unit_definition_registration_lies_stay_loud(axis) -> None:
+    producer, definitions, _producer_call, _producer_reporter = _registered_unit()
+    exact_definition, wrong_definition = definitions
+    exact_frame = exact_definition.source_visible_call_frame()
+    consumer = _consumer_with_frame(exact_frame)
+    call, reporter = consumer[2], consumer[3]
+    candidate = replace(
+        call._construct_sugar(),
+        expected_definition_ref=exact_definition,
+        call_occurrence=_coordinate(call),
+    )
+
+    if axis == "foreign-reporter-table-ref":
+        foreign_producer = _registered_unit()
+        foreign_frame = foreign_producer[1][0].source_visible_call_frame()
+        candidate = replace(
+            candidate,
+            source_call_frame=foreign_frame,
+            source_call_frame_table={_coordinate(call): foreign_frame},
+        )
+    elif axis == "duplicate-rematerialized-definition":
+        duplicate = _registered_unit()
+        candidate = replace(candidate, expected_definition_ref=duplicate[1][0])
+    elif axis == "wrong-definition-coordinate-scope-owner":
+        candidate = replace(candidate, expected_definition_ref=wrong_definition)
+    elif axis == "foreign-source":
+        foreign_source = SOURCE + "# foreign authenticated bytes\n"
+        foreign = _registered_unit(_identity(foreign_source, "foreign.py"))
+        candidate = replace(
+            candidate,
+            expected_definition_ref=foreign[1][0],
+            source_call_frame=foreign[1][0].source_visible_call_frame(),
+        )
+    else:
+        reminted = _consumer_with_frame(exact_frame)
+        call = reminted[2]
+        assert reporter.materialized_node_for_ref(call.ref) is None
+
+    with pytest.raises(ConstructedValueTestimonyNotWritten) as gap:
+        reporter.present_construction(call, candidate)
+    assert gap.value.owner == "CollectingReporter.present_construction"
+    assert "exact typed occurrence" in gap.value.observed

--- a/implementations/python/sugar-source-tree/tests/test_if_branch_result_slot_rewrite.py
+++ b/implementations/python/sugar-source-tree/tests/test_if_branch_result_slot_rewrite.py
@@ -1,0 +1,74 @@
+"""RED: an If rewrite retains its one authenticated branch-result slot."""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.binding_state import branch_result_slot
+from sugar_source_tree.nodes import If
+from sugar_source_tree.panic import BackendDefect
+from sugar_source_tree.tree import SourceFile
+
+
+def _ifs() -> tuple[If, If]:
+    source = (
+        "if first:\n"
+        "    pass\n"
+        "else:\n"
+        "    pass\n"
+        "if second:\n"
+        "    pass\n"
+        "else:\n"
+        "    pass\n"
+    )
+    source_file = SourceFile(
+        (source, "if_slot.py", blake3_512_of(source.encode()))
+    )
+    found = tuple(node for node in source_file.nodes() if isinstance(node, If))
+    assert len(found) == 2
+    return found
+
+
+def test_substitute_on_slotted_if_reuses_without_contacting_mint_door(
+    monkeypatch,
+) -> None:
+    exact, _foreign = _ifs()
+    slot = branch_result_slot(exact.test)
+    first = exact._rewrite_with_slot({}, slot, authenticated_slot=slot)
+    mint_contacts = 0
+    original = If._rewrite_with_slot
+
+    def observed_mint(self, *args, **kwargs):
+        nonlocal mint_contacts
+        mint_contacts += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(If, "_rewrite_with_slot", observed_mint)
+    second = first.substitute({})
+
+    assert mint_contacts == 0
+    assert first.branch_result_slot_id == slot.slot_id
+    assert first.authenticated_branch_result_slot_id == slot.slot_id
+    assert second.branch_result_slot_id == slot.slot_id
+    assert second.authenticated_branch_result_slot_id == slot.slot_id
+
+
+def test_duplicate_or_foreign_branch_slot_never_replaces_the_exact_slot() -> None:
+    exact, foreign = _ifs()
+    exact_slot = branch_result_slot(exact.test)
+    foreign_slot = branch_result_slot(foreign.test)
+    first = exact._rewrite_with_slot({}, exact_slot, authenticated_slot=exact_slot)
+
+    assert foreign_slot.slot_id != exact_slot.slot_id
+    for attempted in (exact_slot, foreign_slot):
+        with pytest.raises(
+            BackendDefect,
+            match="the one slot authenticated for this exact If.test",
+        ):
+            first._rewrite_with_slot(
+                {}, attempted, authenticated_slot=attempted
+            )
+
+    assert first.branch_result_slot_id == exact_slot.slot_id
+    assert first.authenticated_branch_result_slot_id == exact_slot.slot_id

--- a/implementations/python/sugar-source-tree/tests/test_module_receipt_ellipsis_category.py
+++ b/implementations/python/sugar-source-tree/tests/test_module_receipt_ellipsis_category.py
@@ -1,0 +1,45 @@
+"""RED: module construction receipts authenticate parser-owned Ellipsis."""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.binding_state import (
+    ConstructedValueCategoryGap,
+    ConstructionTestimonyReporterV1,
+    SubstitutionTraceBuilderV1,
+    constructed_value_cid_v2,
+)
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.tree import SourceFile
+
+
+def test_module_receipt_canonicalizes_authenticated_ellipsis_occurrence() -> None:
+    source = "def exact(value=...):\n    return value\n"
+    source_cid = blake3_512_of(source.encode())
+    reporter = ConstructionTestimonyReporterV1(
+        CollectingReporter(), SubstitutionTraceBuilderV1(source_cid)
+    )
+
+    source_file = SourceFile(
+        (source, "ellipsis_receipt.py", source_cid), reporter=reporter
+    )
+
+    assert source_file.root.reporter is reporter
+    assert source_file.constructed_module.reporting_projection is reporter
+    assert (
+        source_file.constructed_module.construction_event_receipt_cid
+        == source_file.construction_event_receipt_cid
+    )
+    assert source_file.construction_event_receipt_cid.startswith("blake3-512:")
+
+
+def test_unrelated_sentinel_does_not_acquire_ellipsis_category() -> None:
+    sentinel = object()
+
+    with pytest.raises(
+        ConstructedValueCategoryGap,
+        match="unclassified constructed value category builtins.object",
+    ):
+        constructed_value_cid_v2(sentinel)

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -207,6 +207,50 @@ def test_repeated_initializer_uses_the_last_class_binding() -> None:
     }
 
 
+def test_source_visible_new_constructor_retains_exact_instance_field() -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class RenamedToken(int):\n"
+        "    def __new__(cls, value, label):\n"
+        "        self = super(RenamedToken, cls).__new__(cls, value)\n"
+        "        self.label = label\n"
+        "        return self\n\n"
+        "RenamedToken(7, 'seven')\n",
+        context=context,
+    )
+    class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+    call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]
+
+    receiver = (
+        call.sugar()
+        .desugar()
+        .value.force_floor(None, owner="source-visible-new", project_callsite=False)
+    )
+
+    assert receiver.class_name == "RenamedToken"
+    assert receiver.attribute("label", call.fragment).value == StringValue("seven")
+    assert class_node.source_visible_constructor_frame().owner is class_node
+
+
+def test_source_visible_new_constructor_refuses_foreign_returned_receiver() -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class RenamedToken(int):\n"
+        "    def __new__(cls, value, label):\n"
+        "        self = super(RenamedToken, cls).__new__(cls, value)\n"
+        "        self.label = label\n"
+        "        return value\n\n"
+        "RenamedToken(7, 'seven')\n",
+        context=context,
+    )
+    call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]
+
+    coordinate = call.sugar().desugar().value
+
+    assert isinstance(coordinate, CallSiteValue)
+    assert coordinate.body is None
+
+
 def test_source_frame_binds_constructed_defaults_and_variadics() -> None:
     context = TreeConstructionContextV1.for_source_call_construction()
     source = _source_file(

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
@@ -8,6 +10,8 @@ from sugar_lift_py_tests.floor import (
     BlockValue,
     CallSiteValue,
     DictValue,
+    ObjectValue,
+    ReceiverFieldStoreValue,
     ReturnValue,
     StringValue,
     TermValue,
@@ -21,6 +25,7 @@ from sugar_lift_py_tests.generator_construction import (
     YieldEffect,
 )
 from sugar_source_tree.nodes import Call, ClassDef, FunctionDef
+from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
@@ -241,6 +246,116 @@ def test_source_visible_new_constructor_refuses_foreign_returned_receiver() -> N
         "        self.label = label\n"
         "        return value\n\n"
         "RenamedToken(7, 'seven')\n",
+        context=context,
+    )
+    call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]
+
+    coordinate = call.sugar().desugar().value
+
+    assert isinstance(coordinate, CallSiteValue)
+    assert coordinate.body is None
+
+
+def test_source_visible_new_constructor_retains_exact_bound_name_field() -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class NamedIntConstant(int):\n"
+        "    def __new__(cls, value, name):\n"
+        "        self = super(NamedIntConstant, cls).__new__(cls, value)\n"
+        "        self.name = name\n"
+        "        return self\n\n"
+        "NamedIntConstant(7, 'seven')\n",
+        context=context,
+    )
+    call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]
+
+    receiver = (
+        call.sugar()
+        .desugar()
+        .value.force_floor(None, owner="named-int-field-store", project_callsite=False)
+    )
+
+    assert isinstance(receiver, ObjectValue)
+    assert tuple((field.name, field.value) for field in receiver.fields) == (
+        ("name", StringValue("seven")),
+    )
+
+
+def test_new_receiver_field_store_refuses_foreign_receiver_identity() -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class NamedIntConstant(int):\n"
+        "    def __new__(cls, value, name):\n"
+        "        self = super(NamedIntConstant, cls).__new__(cls, value)\n"
+        "        self.name = name\n"
+        "        return self\n",
+        context=context,
+    )
+    class_node = next(node for node in source.nodes() if isinstance(node, ClassDef))
+    class_value = class_node.sugar().desugar().value
+    receiver_coordinate = (
+        class_node.source_visible_constructor_frame().body.receiver_coordinate_cid
+    )
+    foreign = ObjectValue("NamedIntConstant", (), identity="foreign-receiver")
+    block = BlockValue(
+        (ReceiverFieldStoreValue(foreign, "name", StringValue("seven")),)
+    )
+
+    with pytest.raises(SugarNotWritten) as raised:
+        class_value.construct_receiver_state_from_block(block, receiver_coordinate)
+
+    assert raised.value.owner == "ClassDefinitionValue.construct_receiver_state"
+    assert raised.value.observed == "receiver coordinate mismatch"
+
+
+@pytest.mark.parametrize(
+    "return_body",
+    (
+        "",
+        "        if value:\n            return self\n",
+    ),
+    ids=("missing-return", "noncompleted-return"),
+)
+def test_source_visible_new_constructor_refuses_uncompleted_return(
+    return_body: str,
+) -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class NamedIntConstant(int):\n"
+        "    def __new__(cls, value, name):\n"
+        "        self = super(NamedIntConstant, cls).__new__(cls, value)\n"
+        "        self.name = name\n"
+        f"{return_body}\n"
+        "NamedIntConstant(7, 'seven')\n",
+        context=context,
+    )
+    call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]
+
+    coordinate = call.sugar().desugar().value
+
+    assert isinstance(coordinate, CallSiteValue)
+    assert coordinate.body is None
+
+
+@pytest.mark.parametrize(
+    "field_body",
+    (
+        "        self.name = name\n        self.name = name\n",
+        "        self.label = name\n",
+    ),
+    ids=("duplicate-name-field", "wrong-field"),
+)
+def test_source_visible_new_constructor_refuses_nonexact_field_roster(
+    field_body: str,
+) -> None:
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class NamedIntConstant(int):\n"
+        "    def __new__(cls, value, name):\n"
+        "        self = super(NamedIntConstant, cls).__new__(cls, value)\n"
+        f"{field_body}"
+        "        return self\n\n"
+        "NamedIntConstant(7, 'seven')\n",
         context=context,
     )
     call = tuple(node for node in source.nodes() if isinstance(node, Call))[-1]

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -364,8 +364,53 @@ def test_source_visible_new_constructor_refuses_nonexact_field_roster(
 
     assert isinstance(coordinate, CallSiteValue)
     assert coordinate.body is None
+def test_constructor_frame_retains_exact_source_visible_new_method() -> None:
+    """The class producer carries its exact ``__new__`` testimony to the body."""
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source = _source_file(
+        "class First:\n"
+        "    def __new__(cls, value):\n"
+        "        return cls\n\n"
+        "    def __init__(self, value):\n"
+        "        self.value = value\n\n"
+        "class Second:\n"
+        "    def __new__(cls, value):\n"
+        "        return cls\n\n"
+        "    def __init__(self, value):\n"
+        "        self.value = value\n",
+        context=context,
+    )
+    classes = {
+        node.name: node for node in source.nodes() if isinstance(node, ClassDef)
+    }
+    first_new = next(
+        item
+        for item in classes["First"].body
+        if isinstance(item, FunctionDef) and item.name == "__new__"
+    )
+    second_new = next(
+        item
+        for item in classes["Second"].body
+        if isinstance(item, FunctionDef) and item.name == "__new__"
+    )
 
+    first_frame = classes["First"].source_visible_constructor_frame()
+    second_frame = classes["Second"].source_visible_constructor_frame()
 
+    testimony = first_frame.constructed_new_method
+    assert testimony.name == "__new__"
+    assert testimony.definition_fragment_cid == first_new.fragment.seal().cid
+    assert testimony.source_call_frame.definition_site == _coordinate(first_new)
+    assert (
+        testimony.source_call_frame.frame_cid
+        == first_new.source_visible_call_frame().frame_cid
+    )
+    assert first_frame.body.constructed_new_method is testimony
+    assert (
+        second_frame.constructed_new_method.source_call_frame.definition_site
+        == _coordinate(second_new)
+    )
+    assert second_frame.constructed_new_method is not testimony
 def test_source_frame_binds_constructed_defaults_and_variadics() -> None:
     context = TreeConstructionContextV1.for_source_call_construction()
     source = _source_file(


### PR DESCRIPTION
Test-only instrument for the exact Worker5 gate at decorated class publication.

R: R_metaclass_final_block=1 (unmeasured Delta; expected -1 after producer projection).

Authoritative product receipt on head 93922b7d: `bin/bpytest implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py::{test_real_pandas_option_context_runs_authenticated_enter_body_and_exit,test_real_option_context_executes_its_source_body_and_exit}` => 2 failed. First shared boundary: `_metaclass_publication_cids -> _floor_cid(final_class) -> BlockValue.to_term`, owner `decorated class publication`, `ConstructionPanic`. Log `/tmp/worker5-option-if-slot-93922b7dc.log`, sha256 `c8870099ae57394566e89c9cbabb2370b2b7af9281dddac53f7cc81cbb7c8c16`.

Focused new test command was launched but interrupted for mandatory shutdown before a terminal receipt; no green claim. Truth uses authenticated stdlib enum.py production path. Foreign/malformed/halted raw BlockValue controls remain ConstructionPanic.

This component branch is stacked on and substantially contained by consolidated #6922; it is published separately per shutdown order. No production change. Do not merge independently without reconciling #6922.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin enum metaclass final block projection and add construction testimony for call definitions
> - Adds `TargetPatternReceiptV1` and authenticated receipts to `TargetPatternV1`, enabling content-addressed identity for target patterns across substitution and comprehension sugar.
> - Extends `ConstructionTestimonyReporterV1` to track the first materialized node per backend ref, retain producer registrations in consumer rolls, and validate `CallSiteSugar` definition identity at presentation time.
> - Augments `ClassDef` sugar to authenticate a `__new__` constructor shape and synthesize a source-visible initializer body when no `__init__` is present; `SourceVisibleCallFrameV1` now validates and encodes attached `__new__` testimony in its CID preimage.
> - Fixes loop post-binding projection in `project_loop_post_binding` to reject duplicate/missing completed routes and validate guard formula CIDs; decoding now accepts `BodyFallthrough` and `exitPartitionArity >= 1`.
> - Adds test coverage in `test_metaclass_block_publication.py`, `test_cpython_call_handle_testimony.py`, `test_cross_unit_definition_registration.py`, and related modules asserting testimony correctness, receipt canonicalization, and rejection of foreign/wrong occurrences.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07eeb19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->