### PR TITLE
Preserve option-context component testimony

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/comprehension_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/comprehension_value.py
@@ -231,10 +231,43 @@ class ComprehensionValue(GuardStableValue):
         return super().multiply(other, site)
 
     def subscript(self, index, site):
-        # A runtime comprehension still has Python collection semantics, but
-        # neither its members nor its cardinality are available at lift time.
-        # Preserve the real lookup as a proof-bearing coordinate; do not invent
-        # an element or silently assume the lookup succeeds.
+        # A producer-authenticated finite comprehension owns its exact ordered
+        # members. Project an integer position directly from that testimony;
+        # never reconstruct a list or fabricate a member. Testimony-absent
+        # comprehensions retain the proof-bearing symbolic lookup below.
+        if self.finite_elements is not None:
+            from sugar_lift_py_tests.floor.term_value import TermValue
+            from sugar_lift_py_tests.outcome import Complete
+
+            if type(index) is TermValue and isinstance(index.value, int):
+                position = index.value
+                length = len(self.finite_elements)
+                if -length <= position < length:
+                    return Complete(self.finite_elements[position])
+                from sugar_lift_py_tests.floor.ground_index_error import (
+                    ground_index_error,
+                )
+
+                return ground_index_error(
+                    owner="ComprehensionValue.subscript",
+                    operation="comprehension subscript",
+                    index=position,
+                    length=length,
+                    site=site,
+                )
+            if index.python_index_protocol() is False:
+                from sugar_lift_py_tests.floor.ground_exit import (
+                    ground_exceptional_exit,
+                )
+
+                return ground_exceptional_exit(
+                    exception_name="TypeError",
+                    site=site,
+                    owner="ComprehensionValue.subscript",
+                )
+            return self.undecided_subscript(
+                index, site, owner="ComprehensionValue.subscript"
+            )
         return self.py_subscript_coordinate(index, site)
 
     def setitem(  # pyright: ignore[reportIncompatibleMethodOverride]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -636,11 +636,11 @@ class _Pass:
         if node.func.kind == "Name":
             local_name = node.func.id
             exported_path: tuple[str, ...] = ()
-        elif node.func.kind == "Attribute" and node.func.value.kind == "Name":
-            local_name = node.func.value.id
-            exported_path = (node.func.attr,)
         else:
-            return
+            parsed = self._attribute_export_path(node.func)
+            if parsed is None:
+                return
+            local_name, exported_path = parsed
         reaching = state.get(local_name, frozenset({_UNBOUND}))
         imports = {value for value in reaching if isinstance(value, _ImportDef)}
         nonimports = reaching - imports

--- a/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_call_contract_resolution.py
@@ -332,6 +332,32 @@ def test_import_binding_authenticates_alias_and_module_identity(tmp_path):
     assert rows[0]["importBindingCid"] != rows[1]["importBindingCid"]
 
 
+def test_imported_attribute_chain_call_keeps_exact_use_site_and_shadowing(tmp_path):
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.import_binding import authenticated_import_uses
+
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "import os\n"
+        "truth = os.path.dirname('value')\n"
+        "def shadowed(os):\n"
+        "    return os.path.dirname('value')\n"
+    )
+    source, _filename, source_cid = path_source(str(consumer))
+    rows, outcomes = authenticated_import_uses(
+        tmp_path, consumer, source, source_cid
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["targetSymbol"] == "python:os.path.dirname"
+    assert rows[0]["kind"] == "call-contract-demand"
+    assert rows[0]["authenticatedImportUse"]["useSite"] == rows[0]["useSite"]
+    assert rows[0]["authenticatedImportUse"]["importBindingCid"] == rows[0][
+        "importBindingCid"
+    ]
+    assert "shadowed-non-import" in outcomes.values()
+
+
 def test_import_binding_is_lexical_and_shadowing_never_inherits_import(tmp_path):
     from sugar_lift_python_source.source_oracle import path_source
     from sugar_lift_py_tests.import_binding import authenticated_import_uses

--- a/implementations/python/sugar-lift-py-tests/tests/test_comprehension_finite_subscript.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_comprehension_finite_subscript.py
@@ -1,0 +1,26 @@
+from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+from sugar_lift_py_tests.floor.string_value import StringValue
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.ir import ctor
+from sugar_lift_py_tests.outcome import Complete
+
+
+def test_finite_comprehension_subscript_returns_exact_constructed_member():
+    selected = StringValue("display.max_rows")
+    value = ComprehensionValue(
+        ctor("py.listcomp", ()), finite_elements=(selected,)
+    )
+
+    outcome = value.subscript(TermValue(0), "keys[0]")
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value is selected
+
+
+def test_comprehension_subscript_does_not_invent_missing_member_or_finiteness():
+    opaque = ComprehensionValue(ctor("py.listcomp", ()))
+    unresolved = opaque.subscript(TermValue(0), "keys[0]")
+    assert isinstance(unresolved, Complete)
+    assert isinstance(unresolved.value, CallSiteValue)
+    assert unresolved.value.target_name == "py.subscript"

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
@@ -150,6 +150,7 @@ class _Candidate:
     line: int
     confession: str | None
     col: int = 0
+    binding_site: Json | None = None
 
 
 def scan_module_value_pins(
@@ -195,7 +196,7 @@ def scan_module_value_pins(
                         name=candidate.name,
                         kind=mutable_kind,
                         term=mutable_global_pin_term(candidate.name, mutable_kind),
-                        binding_site=candidate.value.fragment.seal().wire(),
+                        binding_site=candidate.binding_site,
                     )
                 )
             continue
@@ -486,6 +487,7 @@ def _collect_candidates(tree: typed.Module) -> dict[str, _Candidate]:
             line=stmt.lineno,
             confession=confession,
             col=name_node.col_offset,
+            binding_site=name_node.fragment.seal().wire(),
         )
     # A duplicated candidate name surfaces through the binding-event scan
     # (two assignment events), so the first occurrence remains the candidate

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
@@ -108,11 +108,11 @@ class ValuePin:
 
 @dataclass(frozen=True)
 class MutableGlobalPin:
+    source_cid: str
     name: str
     kind: str
     term: Json
-    line: int
-    col: int
+    binding_site: Json
 
 
 @dataclass
@@ -191,11 +191,11 @@ def scan_module_value_pins(
             if mutable_kind is not None:
                 scan.mutable_global_pins.append(
                     MutableGlobalPin(
+                        source_cid=tree.unit.source_cid,
                         name=candidate.name,
                         kind=mutable_kind,
                         term=mutable_global_pin_term(candidate.name, mutable_kind),
-                        line=candidate.line,
-                        col=candidate.col,
+                        binding_site=candidate.value.fragment.seal().wire(),
                     )
                 )
             continue
@@ -411,8 +411,8 @@ def mutable_global_pin_opacity_entry(
 ) -> Json:
     return {
         "file": source_path,
-        "line": pin.line,
-        "col": pin.col,
+        "sourceCid": pin.source_cid,
+        "bindingSite": pin.binding_site,
         "name": pin.name,
         "kind": pin.kind,
         "term": pin.term,

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
@@ -150,7 +150,20 @@ class _Candidate:
     line: int
     confession: str | None
     col: int = 0
-    binding_site: Json | None = None
+    binding_site: object | None = None
+
+
+def _target_memento(node):
+    from sugar_lift_py_tests.kit_rpc.source_memento_dto import SourceMementoDto
+    from sugar_lift_py_tests.kit_rpc.source_span_dto import SourceSpanDto
+
+    span = node.line_col_span()
+    return SourceMementoDto(
+        file=node.unit.filename,
+        span=SourceSpanDto(span.start_line, span.start_col, span.end_line, span.end_col),
+        source_cid=node.unit.source_cid,
+        role="mutable-global-binding-target",
+    )
 
 
 def scan_module_value_pins(
@@ -263,6 +276,7 @@ def _scan_enum_member_pins(tree: typed.Module, scan: ValuePinScan) -> None:
                 value=class_stmt.value,
                 line=class_stmt.lineno,
                 confession=f"enum.{kind}",
+                binding_site=_target_memento(class_stmt.targets[0]),
             )
             scan.candidates += 1
             if stmt.decorators:
@@ -322,6 +336,7 @@ def _scan_enum_member_pins(tree: typed.Module, scan: ValuePinScan) -> None:
                 value=class_stmt.value,
                 line=class_stmt.lineno,
                 confession=f"enum.{kind}.value",
+                binding_site=_target_memento(class_stmt.targets[0]),
             )
             scan.candidates += 1
             if rebound:
@@ -413,7 +428,7 @@ def mutable_global_pin_opacity_entry(
     return {
         "file": source_path,
         "sourceCid": pin.source_cid,
-        "bindingSite": pin.binding_site,
+        "bindingSite": pin.binding_site.to_rpc(),
         "name": pin.name,
         "kind": pin.kind,
         "term": pin.term,
@@ -487,7 +502,7 @@ def _collect_candidates(tree: typed.Module) -> dict[str, _Candidate]:
             line=stmt.lineno,
             confession=confession,
             col=name_node.col_offset,
-            binding_site=name_node.fragment.seal().wire(),
+            binding_site=_target_memento(name_node),
         )
     # A duplicated candidate name surfaces through the binding-event scan
     # (two assignment events), so the first occurrence remains the candidate


### PR DESCRIPTION
## Scope

Publishes the preserved codex-2 option-context component branch for shutdown handoff:

- authenticate multi-segment imported call demands through the existing typed attribute path;
- project finite comprehension subscripts only from authenticated finite elements;
- enrich mutable-global pins with source testimony and the exact typed target `SourceMemento`.

This branch is intentionally preserved as a component artifact. It is based on an older option integration ancestor and overlaps/supersedes portions of consolidated draft #6922; it must not be merged independently without reconciliation against current `main` and #6922.

## Evidence

- Historical focused finite-comprehension truthful/lying receipt: `2 passed` under CPython 3.12.13.
- Historical imported attribute-chain receipt on the original component commit was blocked before tests by a crates.io DNS failure; the equivalent narrow receipt later passed on the replacement integration (`2 passed`).
- Current exact consolidated option lifecycle at `93922b7dcc8b9953fd7c602dbd45c22f741c1b94`: `0 passed, 2 failed` in 103.44s. First shared red is `decorated_class_value._metaclass_publication_cids -> _floor_cid(final_class) -> BlockValue.to_term`; immutable log `/tmp/worker5-option-if-slot-93922b7dc.log`, SHA-256 `c8870099ae57394566e89c9cbabb2370b2b7af9281dddac53f7cc81cbb7c8c16`.
- Current-main reconciliation and broad package status are unmeasured for this old component branch.

## Floors

- No pandas/vendor spelling arm.
- No carrier or ExitSet changes.
- No desugar-time authority lookup.
- No unrelated untracked work included.

## Excluded worktree file

`implementations/python/sugar-lift-python-source/tests/test_mutable_global_frame_transport.py` remains untracked and was not staged or committed because it is unrelated/user-owned in this checkout.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve option-context component testimony by enriching mutable global pins and import-use resolution
> - `MutableGlobalPin` in [value_pins.py](https://github.com/TSavo/sugar/pull/6929/files#diff-e99d058fd0cd211e60b4359aafe856b84edd7ce35fd64f8a87724beb348bc01f) now carries a structured `binding_site` memento and `source_cid` instead of raw `line`/`col` coordinates; opacity entries reflect these new fields.
> - `ComprehensionValue.project_sequence_with` in [comprehension_value.py](https://github.com/TSavo/sugar/pull/6929/files#diff-7dc15fbfa20a3355a349f31b0e79d3764c0bc44209535e5d63eb31054f746b9f) now distinguishes list comprehension subscripts, returning an `undecided_subscript` path annotated as `'comprehension subscript'` rather than routing through `py_subscript_coordinate`.
> - `_Pass._call` in [import_binding.py](https://github.com/TSavo/sugar/pull/6929/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) delegates to a unified `_attribute_export_path` parser, enabling chained attribute calls (e.g., `os.path.dirname`) to be recognized as authenticated import uses.
> - Behavioral Change: `mutable_global_pin_opacity_entry` output JSON shape changes from `line`/`col` to `sourceCid`/`bindingSite`, which may break consumers expecting the old coordinate fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 783e252.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->