### PR TITLE
Authenticate zero-argument super class construction

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -19,6 +19,7 @@ from .builtin_exception_class_value import BuiltinExceptionClassValue
 from .builtin_object_class_value import BuiltinObjectClassValue
 from .builtin_dict_class_value import BuiltinDictClassValue
 from .builtin_semantic_callable import BuiltinSemanticCallable
+from .builtin_super_value import BuiltinSuperMethodValue, BuiltinSuperValue
 from .call_site_value import CallSiteValue
 from .class_definition_value import (
     ClassDefinitionValue,
@@ -69,6 +70,7 @@ from .object_field import ObjectField
 from .object_method_value import ObjectMethodValue
 from .object_value import ObjectValue
 from .mapping_object_value import MappingObjectValue
+from .runtime_class_value import RuntimeClassValue
 from .receiver_field_store_value import ReceiverFieldStoreValue
 from .guarded_receiver_field_store_value import GuardedReceiverFieldStoreValue
 from .receiver_state_partition_value import ReceiverStatePartitionValue
@@ -110,6 +112,8 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     BuiltinObjectClassValue,
     BuiltinDictClassValue,
     BuiltinSemanticCallable,
+    BuiltinSuperValue,
+    BuiltinSuperMethodValue,
     CallSiteValue,
     ClassValue,
     ComprehensionValue,
@@ -143,6 +147,7 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     ObjectMethodValue,
     ObjectValue,
     MappingObjectValue,
+    RuntimeClassValue,
     TupleIteratorValue,
     OpaqueOpCallsite,
     PredicateValue,
@@ -189,6 +194,8 @@ __all__ = [
     "BuiltinObjectClassValue",
     "BuiltinDictClassValue",
     "BuiltinSemanticCallable",
+    "BuiltinSuperValue",
+    "BuiltinSuperMethodValue",
     "CallSiteValue",
     "CurriedLoopBody",
     "CurriedLoopScope",
@@ -231,6 +238,7 @@ __all__ = [
     "ObjectMethodValue",
     "ObjectValue",
     "MappingObjectValue",
+    "RuntimeClassValue",
     "TupleIteratorValue",
     "ReceiverFieldStoreValue",
     "GuardedReceiverFieldStoreValue",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
@@ -33,7 +33,6 @@ class BuiltinSemanticCallable(FloorValue):
         )
 
     def callable_application_with(self, operation, ctx):
-        del ctx
         if self.operation == "python.set.construct":
             floored = self._construct_set(operation)
             if floored is not None:
@@ -55,6 +54,34 @@ class BuiltinSemanticCallable(FloorValue):
             return self._len(operation)
         if self.operation == "python.enumerate.construct":
             return self._enumerate(operation)
+        if self.operation == "python.super.construct":
+            if operation.arguments or operation.keyword_names:
+                return super().callable_application_with(operation, None)
+            from sugar_lift_py_tests.floor.builtin_super_value import BuiltinSuperValue
+            from sugar_lift_py_tests.outcome import Complete
+
+            current_class = ctx.temporal.value_if_bound("__class__")
+            receiver = next(
+                (
+                    ctx.temporal.value_if_bound(name)
+                    for name in ("self", "metacls", "cls")
+                    if ctx.temporal.value_if_bound(name) is not None
+                ),
+                None,
+            )
+            if current_class is None or receiver is None:
+                from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+                construction_panic_gap(
+                    owner="BuiltinSemanticCallable.python.super",
+                    blame=str(operation.site),
+                    observed="missing __class__ cell or first formal receiver",
+                    requested="authenticated zero-argument super context",
+                    fix="carry the defining class and bound first formal into the method body",
+                )
+            return Complete(
+                BuiltinSuperValue(current_class=current_class, receiver=receiver)
+            )
         if self.operation != "python.issubclass":
             return super().callable_application_with(operation, None)
         if len(operation.arguments) != 2 or operation.keyword_names:
@@ -255,7 +282,10 @@ class BuiltinSemanticCallable(FloorValue):
             return Complete(TupleValue(tuple(source.elements)))
         if isinstance(source, DictValue):
             return Complete(TupleValue(tuple(key for key, _ in source.entries)))
-        if isinstance(source, ComprehensionValue) and source.finite_elements is not None:
+        if (
+            isinstance(source, ComprehensionValue)
+            and source.finite_elements is not None
+        ):
             return Complete(TupleValue(tuple(source.finite_elements)))
         if isinstance(source, ComprehensionValue):
             from sugar_lift_py_tests.context_manager_resolution import (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_super_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_super_value.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class BuiltinSuperMethodValue(FloorValue):
+    """One selected method on an authenticated zero-argument ``super``."""
+
+    receiver: object
+    name: str
+
+    def callable_application_with(self, operation, ctx):
+        keyword_count = len(operation.keyword_names)
+        positional = (
+            operation.arguments[:-keyword_count]
+            if keyword_count
+            else operation.arguments
+        )
+        keywords = (
+            tuple(zip(operation.keyword_names, operation.arguments[-keyword_count:]))
+            if keyword_count
+            else ()
+        )
+        return self.receiver.call_method_value(
+            self.name,
+            positional,
+            owner="BuiltinSuperMethodValue",
+            blame=operation.site,
+            ctx=ctx,
+            keywords=keywords,
+        )
+
+
+@dataclass(frozen=True)
+class BuiltinSuperValue(FloorValue):
+    """Authenticated zero-argument ``super()`` language receiver."""
+
+    current_class: object
+    receiver: object
+
+    def attribute(self, name, site):
+        del site
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(BuiltinSuperMethodValue(self, name))
+
+    def call_method_value(
+        self,
+        name,
+        arguments,
+        *,
+        owner,
+        blame,
+        ctx=None,
+        keywords=(),
+        required_frame=None,
+    ):
+        del owner, ctx
+        if required_frame is not None:
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="BuiltinSuperValue.call_method_value",
+                blame=blame,
+                observed=name,
+                requested="authenticated builtin super method",
+                fix="model the selected base method or keep it loud",
+            )
+        bases = getattr(self.current_class, "base_classes", ())
+        if len(bases) != 1:
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="BuiltinSuperValue.call_method_value",
+                blame=blame,
+                observed=f"{len(bases)} direct bases",
+                requested="one authenticated next class in the MRO",
+                fix="construct C3 super selection before dispatching this method",
+            )
+        base = bases[0]
+        if name == "__new__" and getattr(base, "name", None) == "type":
+            return self._type_new(arguments, keywords, blame)
+        from sugar_lift_py_tests.floor.builtin_dict_class_value import (
+            BuiltinDictClassValue,
+        )
+        from sugar_lift_py_tests.floor.none_value import NoneValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        if (
+            name == "__init__"
+            and isinstance(base, BuiltinDictClassValue)
+            and not arguments
+            and not keywords
+        ):
+            return Complete(NoneValue())
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="BuiltinSuperValue.call_method_value",
+            blame=blame,
+            observed=f"{type(base).__name__}.{name}",
+            requested="authenticated selected-base method semantics",
+            fix="model the selected base method or keep it loud",
+        )
+
+    def _type_new(self, arguments, keywords, blame):
+        from sugar_lift_py_tests.floor.dict_value import DictValue
+        from sugar_lift_py_tests.floor.mapping_object_value import MappingObjectValue
+        from sugar_lift_py_tests.floor.runtime_class_value import RuntimeClassValue
+        from sugar_lift_py_tests.floor.string_value import StringValue
+        from sugar_lift_py_tests.floor.tuple_value import TupleValue
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        from sugar_lift_py_tests.outcome import Complete
+
+        if len(arguments) != 4:
+            construction_panic_gap(
+                owner="BuiltinSuperValue.type.__new__",
+                blame=blame,
+                observed=f"arity={len(arguments)}",
+                requested="metaclass, class name, bases, and namespace",
+                fix="retain exact type.__new__ operands or keep the call loud",
+            )
+        _metaclass, name, bases, namespace = arguments
+        if (
+            not isinstance(name, StringValue)
+            or not isinstance(bases, TupleValue)
+            or not isinstance(namespace, (DictValue, MappingObjectValue))
+        ):
+            construction_panic_gap(
+                owner="BuiltinSuperValue.type.__new__",
+                blame=blame,
+                observed=tuple(type(value).__name__ for value in arguments),
+                requested="authenticated class name, bases, and mapping namespace",
+                fix="transport metaclass __new__ actuals without symbolic projection",
+            )
+        # ``**kwds`` is evaluated and authenticated by MethodCallSugar.  It does
+        # not alter the namespace identity represented by this Floor.
+        del keywords
+        return Complete(
+            RuntimeClassValue(
+                name=name.value,
+                bases=tuple(bases.elements),
+                record=namespace,
+                namespace=namespace,
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -115,7 +115,12 @@ class ClassDefinitionValue(GuardStableValue):
             ),
             bound_source_actuals=bound,
         )
-        outcome = call.reduce_source_outcome(ctx)
+        method_ctx = ctx.with_temporal(
+            ctx.temporal.bind_value(
+                "__class__", self, blame=f"{self.class_name}.__init__"
+            )
+        )
+        outcome = call.reduce_source_outcome(method_ctx)
 
         def project(value):
             block = value if isinstance(value, BlockValue) else BlockValue((value,))
@@ -175,7 +180,12 @@ class ClassDefinitionValue(GuardStableValue):
             ),
             bound_source_actuals=bound,
         )
-        return call.producer_outcome(ctx)
+        method_ctx = ctx.with_temporal(
+            ctx.temporal.bind_value(
+                "__class__", self, blame=f"{self.class_name}.{name}"
+            )
+        )
+        return call.producer_outcome(method_ctx)
 
     def to_term(self, *, owner: str):
         del owner

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/runtime_class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/runtime_class_value.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .class_value import ClassValue
+
+
+@dataclass(frozen=True)
+class RuntimeClassValue(ClassValue):
+    """Class object minted by authenticated ``type.__new__`` arguments."""
+
+    namespace: object = None
+
+    def _namespace_entries(self):
+        if hasattr(self.namespace, "mapping_entries"):
+            return self.namespace.mapping_entries()
+        return self.namespace.entries
+
+    def attribute(self, name, site):
+        from sugar_lift_py_tests.floor.dict_value import DictValue
+        from sugar_lift_py_tests.floor.tuple_value import TupleValue
+        from sugar_lift_py_tests.outcome import Complete
+
+        if name == "__dict__":
+            return Complete(DictValue(self._namespace_entries()))
+        if name == "__mro__":
+            return Complete(TupleValue((self, *self.bases)))
+        for key, value in reversed(self._namespace_entries()):
+            if getattr(key, "value", object()) == name:
+                return Complete(value)
+        return super().attribute(name, site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_definition_sugar.py
@@ -108,11 +108,20 @@ class ClassDefinitionSugar(Sugar):
         base_values = []
         for base in self.base_sugars:
             outcome = base.desugar(ctx)
-            from sugar_lift_py_tests.floor import BuiltinDictClassValue
+            from sugar_lift_py_tests.floor import BuiltinDictClassValue, ClassValue
 
             if isinstance(outcome, Complete) and isinstance(
                 outcome.value, (ClassDefinitionValue, BuiltinDictClassValue)
             ):
+                base_values.append(outcome.value)
+            elif (
+                isinstance(outcome, Complete)
+                and type(outcome.value) is ClassValue
+                and outcome.value.name == "type"
+            ):
+                # ``type`` is an exact Python builtin class binding. Retaining
+                # it is what lets zero-argument super in a source metaclass
+                # select type.__new__; no other generic ClassValue is admitted.
                 base_values.append(outcome.value)
             # HEAD omitted unenrolled bases from this roster.  This increment
             # evaluates them only to discover the exact BuiltinDictClassValue;

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
@@ -269,6 +269,37 @@ class SpreadCallSugar(ConstructedTermSugar):
         return self.callee.desugar(ctx).and_then(after_callee)
 
     def _finish(self, callee_value, values, ctx=None) -> Outcome:
+        from sugar_lift_py_tests.floor import BuiltinSuperMethodValue
+
+        if isinstance(callee_value, BuiltinSuperMethodValue):
+            if any(role == "star" for role, _, _ in self.arguments):
+                from sugar_source_tree.panic import SugarNotWritten
+
+                raise SugarNotWritten(
+                    owner="SpreadCallSugar._finish",
+                    blame=self.site,
+                    observed="starred positional actual to selected super method",
+                    requested="an exact positional roster",
+                    fix="project the starred operand exactly or keep the call loud",
+                )
+            positional = tuple(
+                value
+                for (role, _name, _), value in zip(self.arguments, values)
+                if role == "positional"
+            )
+            keywords = tuple(
+                (("**" if role == "double-star" else name), value)
+                for (role, name, _), value in zip(self.arguments, values)
+                if role in {"keyword", "double-star"}
+            )
+            return callee_value.receiver.call_method_value(
+                callee_value.name,
+                positional,
+                owner="SpreadCallSugar._finish",
+                blame=self.site,
+                ctx=ctx,
+                keywords=keywords,
+            )
         from sugar_lift_py_tests.floor import CallSiteValue
         from sugar_lift_py_tests.ir import ctor, str_const
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py
@@ -269,6 +269,9 @@ def builtin_name_temporal():
         "enumerate", BuiltinSemanticCallable(operation="python.enumerate.construct")
     )
     temporal = temporal.bind_value(
+        "super", BuiltinSemanticCallable(operation="python.super.construct")
+    )
+    temporal = temporal.bind_value(
         "set", BuiltinSemanticCallable(operation="python.set.construct")
     )
     temporal = temporal.bind_value(

--- a/implementations/python/sugar-lift-py-tests/tests/test_authenticated_type_new_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_authenticated_type_new_transport.py
@@ -1,0 +1,70 @@
+"""Authenticated zero-argument super transports ``type.__new__`` results."""
+
+import pytest
+
+from sugar_lift_py_tests.floor import (
+    BuiltinSuperValue,
+    ClassValue,
+    MappingObjectValue,
+    RuntimeClassValue,
+    StringValue,
+    TermValue,
+    TupleValue,
+)
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.outcome import Complete
+
+
+def _super_value():
+    return BuiltinSuperValue(
+        current_class=type(
+            "CurrentClass",
+            (),
+            {"base_classes": (ClassValue(name="type", bases=(), record=None),)},
+        )(),
+        receiver=TermValue("metaclass"),
+    )
+
+
+def test_type_new_result_carries_the_exact_namespace_as_class_dict() -> None:
+    namespace = MappingObjectValue(
+        "Namespace",
+        (),
+        identity="namespace-coordinate",
+        entries=((StringValue("member"), TermValue(7)),),
+    )
+
+    outcome = _super_value().call_method_value(
+        "__new__",
+        (
+            TermValue("metaclass"),
+            StringValue("Made"),
+            TupleValue(()),
+            namespace,
+        ),
+        owner="test",
+        blame="new-site",
+        keywords=(("**", MappingObjectValue("Kwds", (), entries=())),),
+    )
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RuntimeClassValue)
+    assert outcome.value.name == "Made"
+    projected = outcome.value.attribute("__dict__", "dict-site")
+    assert isinstance(projected, Complete)
+    assert projected.value.entries == namespace.entries
+
+
+def test_type_new_refuses_a_non_mapping_namespace() -> None:
+    with pytest.raises(ConstructionPanic):
+        _super_value().call_method_value(
+            "__new__",
+            (
+                TermValue("metaclass"),
+                StringValue("Made"),
+                TupleValue(()),
+                TermValue("not-a-namespace"),
+            ),
+            owner="test",
+            blame="new-site",
+        )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -143,6 +143,7 @@ class _ModuleSourceFrameCallableV1(FloorValue):
 
     callable_name: str
     frame: object
+    defining_class: object | None = None
 
     def to_term(self, *, owner):
         del owner
@@ -187,7 +188,16 @@ class _ModuleSourceFrameCallableV1(FloorValue):
             ),
             bound_source_actuals=bound,
         )
-        produced = call.producer_outcome(ctx)
+        call_ctx = ctx
+        if self.defining_class is not None:
+            call_ctx = ctx.with_temporal(
+                ctx.temporal.bind_value(
+                    "__class__",
+                    self.defining_class,
+                    blame=f"{self.callable_name} defining class",
+                )
+            )
+        produced = call.producer_outcome(call_ctx)
         # Projection is a continuation over the producer ExitSet.  Completed
         # faces project their retained source return; halted faces remain owned
         # by the source call with their guards and effects unchanged.  Requiring
@@ -431,7 +441,9 @@ class _ModuleClassDefinitionBindingSugar:
                     )
                 constructor = constructors[0]
                 callable_floor = _ModuleSourceFrameCallableV1(
-                    constructor.name, constructor.source_call_frame
+                    constructor.name,
+                    constructor.source_call_frame,
+                    defining_class=metaclass_floor,
                 )
                 class_name_floor = StringValue(self.definition.name)
                 bases_floor = TupleValue(tuple(value.base_classes))
@@ -503,7 +515,9 @@ class _ModuleClassDefinitionBindingSugar:
                     return apply_new(fallback_namespace)
                 prepare = preparers[0]
                 prepare_callable = _ModuleSourceFrameCallableV1(
-                    prepare.name, prepare.source_call_frame
+                    prepare.name,
+                    prepare.source_call_frame,
+                    defining_class=metaclass_floor,
                 )
                 prepared = CallableApplication(
                     (metaclass_floor, class_name_floor, bases_floor),

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -159,7 +159,7 @@ class ControlConstructionContextV1:
                 observed="bare raise has no authenticated in-flight exception slot",
                 requested="an enclosing except handler effect-slot coordinate",
                 fix="construct bare raise only inside the handler that owns its effect",
-            )
+        )
         return self.exception_slots[-1]
 
 
@@ -8039,7 +8039,7 @@ class Try(Statement):
                 )
             else:
                 include = True
-            if include:
+            if include and self._block_has_completed_fallthrough(handler.body):
                 completion_nets.append(handler_net)
 
         merged = self._merge_completion_nets(
@@ -8233,6 +8233,27 @@ class Try(Statement):
                     exception_mro=right[1],
                 )
         return None
+
+    def _block_has_completed_fallthrough(self, statements) -> bool:
+        """Whether one source path reaches the statement after this block.
+
+        Completion-state merging must exclude handlers that unconditionally
+        leave by ``raise`` or ``return``. Including such a handler invents a
+        fallthrough edge and erases bindings carried by the real completed
+        try-body edge (for example ``enum_class`` after ``type.__new__``).
+        """
+        for statement in statements:
+            if isinstance(statement, (Raise, Return, Break, Continue)):
+                return False
+            if isinstance(statement, If):
+                if not statement.orelse:
+                    continue
+                if not (
+                    self._block_has_completed_fallthrough(statement.body)
+                    or self._block_has_completed_fallthrough(statement.orelse)
+                ):
+                    return False
+        return True
 
     def _merge_completion_nets(
         self,
@@ -10119,7 +10140,7 @@ class Call(Expression):
                 observed=f"{len(lexical_rows)} lexical rows for one call occurrence",
                 requested="zero or one sealed lexical call row",
                 fix="repair lexical call enrollment before constructing the source frame",
-        )
+            )
         lexical_row = lexical_rows[0] if lexical_rows else None
         if lexical_row is not None:
             function_definition = lexical_row.definition_occurrence


### PR DESCRIPTION
## Outcome

Advances the exact pandas option-context lifecycle through CPython enum class construction:

- authenticates zero-argument super() from the defining class cell and bound first formal
- transports exact 	ype.__new__ operands into a RuntimeClassValue
- exposes the authenticated class namespace through __dict__
- preserves try-body bindings when every matching handler exits without fallthrough
- keeps unsupported selected-base methods loud

## Evidence

- 	est_authenticated_type_new_transport.py: 2 passed
- 	est_mapping_pop_shadow_state.py: 5 passed
- exact lifecycle now advances from num.py:384 super().__init__ through num.py:603 enum_class.__dict__
- next named boundary: inherited _EnumDict.pop at num.py:538; this needs the separate receiver-mutation-plus-return transport, not a symbolic attribute side door

## Baseline caveats

Two broader focused files expose pre-existing harness defects unrelated to this diff:

- 	est_try_handler_temporal_state.py: _final_module_state() caller omits module_is_package
- 	est_module_decorated_class_publication.py: missing monkeypatch fixture and stale helper signature

This PR remains draft until its focused CI signal is available.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate zero-argument `super()` construction in the floor evaluator
> - Binds `super` in the builtin temporal environment as a `BuiltinSemanticCallable` with operation `python.super.construct`, making it available to all evaluated modules.
> - Zero-argument `super()` resolves `__class__` and the first formal receiver (`self`/`cls`/`metacls`) from the temporal context and returns a `BuiltinSuperValue`; missing either panics.
> - `BuiltinSuperValue.attribute` returns a `BuiltinSuperMethodValue` wrapper; calling it dispatches to the base class method, with special cases for `type.__new__` (producing a `RuntimeClassValue`) and `dict.__init__` (returning `None`).
> - `ClassDefinitionValue` and `_ModuleSourceFrameCallableV1` now bind `__class__` into the execution context so method bodies and metaclass callables (`__new__`, `__prepare__`) can resolve it.
> - `Try.substitute` now excludes a handler's completion net when the handler body cannot fall through, fixing variable binding merges after `try/except` blocks that unconditionally raise or return.
> - Behavioral Change: `try/except` handlers whose bodies always raise or return no longer contribute to the post-try binding merge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f376a39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->