### PR TITLE
Thread mapping pop result and receiver state

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_result_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_result_sugar.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
+
+
+@dataclass(frozen=True)
+class MappingPopResultSugar(ConstructedTermSugar):
+    """Return-value projection of inherited ``mapping.pop(key, default)``."""
+
+    receiver: ConstructedTermSugar
+    key: ConstructedTermSugar
+    default: ConstructedTermSugar
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def __post_init__(self):
+        for name in ("receiver", "key", "default"):
+            require_constructed_term_sugar(
+                getattr(self, name), owner=f"MappingPopResultSugar.{name}"
+            )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:mapping-pop-result",
+            (
+                self.occurrence_term(owner=owner),
+                self.receiver.to_term(owner=owner),
+                self.key.to_term(owner=owner),
+                self.default.to_term(owner=owner),
+            ),
+            symbol_kind="coordinate",
+        )
+
+    def desugar(self, ctx=None):
+        return self.receiver.desugar(ctx).and_then(
+            lambda receiver: self.key.desugar(ctx).and_then(
+                lambda key: self.default.desugar(ctx).and_then(
+                    lambda default: self._apply(receiver, key, default)
+                )
+            )
+        )
+
+    def _apply(self, receiver, key, default):
+        from sugar_lift_py_tests.floor.dict_value import DictValue
+        from sugar_lift_py_tests.floor.mapping_object_value import MappingObjectValue
+        from sugar_lift_py_tests.floor.set_value import _closed_member_equal
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        from sugar_lift_py_tests.outcome import Complete
+
+        if not isinstance(receiver, (DictValue, MappingObjectValue)):
+            construction_panic_gap(
+                owner="MappingPopResultSugar",
+                blame=self.site,
+                observed=type(receiver).__name__,
+                requested="constructed mapping receiver",
+                fix="retain pop as typed loud until its receiver floors",
+            )
+        entries = receiver.mapping_entries()
+        decisions = tuple(_closed_member_equal(key, candidate) for candidate, _ in entries)
+        if any(decision is None for decision in decisions):
+            construction_panic_gap(
+                owner="MappingPopResultSugar",
+                blame=self.site,
+                observed="undecidable mapping key equality",
+                requested="one source-decided finite mapping key",
+                fix="construct key equality or keep pop typed loud",
+            )
+        matches = tuple(index for index, decision in enumerate(decisions) if decision)
+        if len(matches) > 1:
+            construction_panic_gap(
+                owner="MappingPopResultSugar",
+                blame=self.site,
+                observed="duplicate equal keys in constructed mapping",
+                requested="one canonical mapping entry per key",
+                fix="repair mapping construction before pop",
+            )
+        return Complete(entries[matches[0]][1] if matches else default)

--- a/implementations/python/sugar-lift-py-tests/tests/test_mapping_pop_shadow_state.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_mapping_pop_shadow_state.py
@@ -11,6 +11,7 @@ from sugar_lift_py_tests.floor import (
 )
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.mapping_pop_state_sugar import MappingPopStateSugar
+from sugar_lift_py_tests.sugar.mapping_pop_result_sugar import MappingPopResultSugar
 from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
 
@@ -47,6 +48,17 @@ def _pop(receiver, key):
     return outcome.value
 
 
+def _pop_result(receiver, key, default):
+    outcome = MappingPopResultSugar(
+        receiver=_FloorSugar(receiver, [], "receiver"),
+        key=_FloorSugar(key, [], "key"),
+        default=_FloorSugar(default, [], "default"),
+        site="pop-site",
+    ).desugar(None)
+    assert isinstance(outcome, Complete)
+    return outcome.value
+
+
 def test_present_key_is_removed_without_replacing_receiver_identity() -> None:
     receiver = MappingObjectValue(
         "DerivedDict",
@@ -75,6 +87,18 @@ def test_absent_key_with_default_preserves_exact_receiver() -> None:
     )
 
     assert _pop(receiver, StringValue("missing")) is receiver
+
+
+def test_pop_result_is_the_removed_value_not_the_receiver_state() -> None:
+    receiver = MappingObjectValue(
+        "DerivedDict",
+        (),
+        identity="receiver-coordinate",
+        entries=((StringValue("present"), TermValue(2)),),
+    )
+
+    assert _pop_result(receiver, StringValue("present"), TermValue(9)) == TermValue(2)
+    assert _pop_result(receiver, StringValue("missing"), TermValue(9)) == TermValue(9)
 
 
 def test_same_spelling_wrong_key_does_not_remove_an_entry() -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4942,6 +4942,10 @@ class Assign(Statement):
         """
         from .shadow import rewrite
 
+        mapping_pop = self._mapping_pop_assignment(scope)
+        if mapping_pop is not None:
+            return mapping_pop
+
         new_value, changed = self._substitute_field(self.value, scope)
         changes = {"value": new_value} if changed else {}
         if len(self.targets) == 1 and isinstance(
@@ -4960,6 +4964,66 @@ class Assign(Statement):
         if self.unit.target_patterns_for(self):
             self.unit.retain_target_patterns(self, rewritten)
         return rewritten
+
+    def _mapping_pop_assignment(self, scope):
+        """Split ``result = mapping.pop(key, default)`` into two SSA bindings.
+
+        Python's operation has two products: the expression result and the
+        receiver's post-mutation state.  Both are derived from the same source
+        occurrence and threaded by the shadow tree; neither is reconstructed
+        from a later spelling of the receiver.
+        """
+        if not (
+            len(self.targets) == 1
+            and isinstance(self.targets[0], Name)
+            and isinstance(self.value, Call)
+            and not self.value.keywords
+            and len(self.value.args) == 2
+            and isinstance(self.value.func, Attribute)
+            and self.value.func.attr == "pop"
+            and isinstance(self.value.func.value, Name)
+        ):
+            return None
+        receiver_name = self.value.func.value.id
+        receiver = self.value.func.value.substitute(scope)
+        if _has_authenticated_source_method(receiver, "pop"):
+            return None
+
+        from .backend import Child, Leaf, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        key = self.value.args[0].substitute(scope)
+        default = self.value.args[1].substitute(scope)
+
+        def projection(kind):
+            return materialize(
+                self.unit,
+                ShadowNode(
+                    kind,
+                    self.span,
+                    (
+                        ("receiver", Child(_handle_of(receiver))),
+                        ("key", Child(_handle_of(key))),
+                        ("default", Child(_handle_of(default))),
+                    ),
+                ),
+                self.reporter,
+            )
+
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "MappingPopAssignStatement",
+                self.span,
+                (
+                    ("target_name", Leaf(self.targets[0].id)),
+                    ("receiver_name", Leaf(receiver_name)),
+                    ("result", Child(_handle_of(projection("MappingPopResult")))),
+                    ("post_state", Child(_handle_of(projection("MappingPopState")))),
+                ),
+            ),
+            self.reporter,
+        )
 
     def _destructured_binding(self):
         # Destructure only an already-constructed Tuple/List display.  This is
@@ -8753,6 +8817,34 @@ class MappingPopStatement(DictSetDefaultAppendStatement):
     """Shadow statement for completed ``mapping.pop(key, default)`` state."""
 
 
+class MappingPopAssignStatement(Statement):
+    """One pop occurrence exporting its result and receiver post-state."""
+
+    target_name: str
+    receiver_name: str
+    result: Expression
+    post_state: Expression
+    _child_fields = ("result", "post_state")
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def substitution_binding(self, scope):
+        del scope
+        return {
+            self.target_name: self.result,
+            self.receiver_name: self.post_state,
+        }
+
+    def _construct_sugar(self):
+        # The shadow projections own the operation.  This statement only
+        # publishes them into the temporal rewrite and states no second call.
+        from sugar_lift_py_tests.sugar.inert_sugar import InertSugar
+
+        return InertSugar(site=self.fragment)
+
+
 class Pass(Statement):
     pass
 
@@ -11388,6 +11480,22 @@ class MappingPopState(Expression):
         )
 
         return MappingPopStateSugar(
+            receiver=self.receiver.sugar(),
+            key=self.key.sugar(),
+            default=self.default.sugar(),
+            site=self.fragment,
+        )
+
+
+class MappingPopResult(MappingPopState):
+    """Shadow expression result of inherited ``mapping.pop(key, default)``."""
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.mapping_pop_result_sugar import (
+            MappingPopResultSugar,
+        )
+
+        return MappingPopResultSugar(
             receiver=self.receiver.sugar(),
             key=self.key.sugar(),
             default=self.default.sugar(),


### PR DESCRIPTION
## Outcome

Models two-argument inherited mapping.pop as one shadow-AST occurrence with two authenticated projections:

- the returned value binds the assignment target
- the post-mutation mapping binds the receiver for the remaining source block

No generic method or spelling-based side door is added. Source-defined pop methods remain on their ordinary body path.

## Evidence

- mapping pop focused laws: 6 passed
- exact pandas option-context lifecycle advances from _EnumDict.pop near num.py:538 to RuntimeClassValue._member_map_ at num.py:692
- construction remains loud at the next missing receiver-state law


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add thread mapping for `mapping.pop()` result and receiver post-state
> - Introduces `MappingPopResultSugar` in [mapping_pop_result_sugar.py](https://github.com/TSavo/sugar/pull/6931/files#diff-9f5df5b7a7643f43672b2638d014c4b9210e44d0582235511fc0b7bc4800f654) to desugar `mapping.pop(key, default)` into the removed value (or default if key is absent), raising construction panics for non-mapping receivers, undecidable key equality, or duplicate equal keys.
> - Rewrites assignments of the form `result = receiver.pop(key, default)` in [`nodes.py`](https://github.com/TSavo/sugar/pull/6931/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) into a `MappingPopAssignStatement` that binds two SSA names: the pop result and the receiver's post-pop state, both derived from the same occurrence.
> - Adds `MappingPopResult` and `MappingPopAssignStatement` shadow node classes to wire result and post-state projections through backend materialization.
> - Behavioral Change: assignments matching the `name = name.pop(key, default)` pattern are no longer treated as normal assignments when the receiver lacks an authenticated `pop` source method.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48c25f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->