### PR TITLE
Route four construction tests through the canonical door

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_halted_face_pairing_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_halted_face_pairing_instrument.py
@@ -10,10 +10,11 @@ from pathlib import Path
 import pytest
 
 import sugar_lift_py_tests.outcome.exit_set as owner
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
 from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
-from sugar_source_tree.tree import SourceFile
 
 
 DEPENDENT_AXIS_STATUS = {
@@ -44,7 +45,13 @@ def _paired_gate(axis: str, tmp_path: Path | None = None):
 def _reduced(tmp_path: Path, stem: str, text: str):
     path = tmp_path / f"{stem}.py"
     path.write_text(text, encoding="utf-8")
-    source = SourceFile.from_path(path)
+    source = open_source_file_for_construction(
+        path,
+        root=tmp_path,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(
+            workspace_root=str(tmp_path)
+        ),
+    )
     functions = tuple(source.functions())
     (function,) = functions
     return source, function, reduce_block_to_exitset(function.sugar().statements, None)

--- a/implementations/python/sugar-lift-py-tests/tests/test_halted_lineage_owner_prerequisite_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_halted_lineage_owner_prerequisite_instrument.py
@@ -10,16 +10,23 @@ from pathlib import Path
 import pytest
 
 import sugar_lift_py_tests.outcome.exit_set as owner
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.effect.loop_control_effect import LoopControlEffect
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
 from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
-from sugar_source_tree.tree import SourceFile
 
 
 def _reduce(tmp_path: Path, stem: str, text: str):
     path = tmp_path / f"{stem}.py"
     path.write_text(text, encoding="utf-8")
-    source = SourceFile.from_path(path)
+    source = open_source_file_for_construction(
+        path,
+        root=tmp_path,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(
+            workspace_root=str(tmp_path)
+        ),
+    )
     (function,) = tuple(source.functions())
     return source, function, reduce_block_to_exitset(function.sugar().statements, None)
 

--- a/implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py
+++ b/implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py
@@ -7,6 +7,8 @@ import re
 
 import pytest
 
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
 from sugar_source_tree import nodes
 from sugar_source_tree.binding_provenance import BindingCoordinateV1
 from sugar_source_tree.tree import SourceFile
@@ -40,6 +42,16 @@ def two_loops(left_items, right_items):
 """
 
 
+def _open_source_file(path: Path, root: Path) -> SourceFile:
+    return open_source_file_for_construction(
+        path,
+        root=root,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(
+            workspace_root=str(root)
+        ),
+    )
+
+
 EXPECTED = {
     ("Assign", 2, 0): (("a", ("targets", 0, 0)), ("b", ("targets", 0, 1, 0)), ("c", ("targets", 0, 1, 1, "star"))),
     ("For", 3, 0): (("a", ("target", 0)), ("b", ("target", 1, 0)), ("c", ("target", 1, 1, "star"))),
@@ -55,7 +67,7 @@ EXPECTED = {
 def _source_file(tmp_path: Path, name: str = "target_patterns.py") -> SourceFile:
     path = tmp_path / name
     path.write_text(SOURCE)
-    return SourceFile.from_path(path)
+    return _open_source_file(path, tmp_path)
 
 
 def _products(source_file: SourceFile):
@@ -114,7 +126,7 @@ def test_ordinary_nested_star_consumers_construct_exact_patterns_once(tmp_path: 
 
     live_path = tmp_path / "live.py"
     live_path.write_text(LIVE_SOURCE)
-    live_file = SourceFile.from_path(live_path)
+    live_file = _open_source_file(live_path, tmp_path)
     live_function, = tuple(live_file.functions())
     live_loop = next(node for node in live_function.walk() if node.kind == "For")
     live_pattern, = live_loop.target_patterns
@@ -176,7 +188,7 @@ def test_target_pattern_rejects_wrong_occurrence_and_order(tmp_path: Path):
 def test_same_unit_foreign_for_cannot_claim_local_target(tmp_path: Path):
     path = tmp_path / "two_loops.py"
     path.write_text(TWO_LOOPS_SOURCE)
-    source_file = SourceFile.from_path(path)
+    source_file = _open_source_file(path, tmp_path)
     function, = tuple(source_file.functions())
     loops = tuple(node for node in function.walk() if node.kind == "For")
     assert len(loops) == 2
@@ -207,7 +219,7 @@ def test_assign_rhs_rewrite_retains_its_authenticated_target_pattern(
         "    root, leaf = split(key)\n"
         "    return root[leaf]\n"
     )
-    source_file = SourceFile.from_path(path)
+    source_file = _open_source_file(path, tmp_path)
     function, = tuple(source_file.functions())
     original = next(
         node
@@ -235,7 +247,7 @@ def test_attribute_only_unpack_is_not_minted_as_a_binding_pattern(
         "        self.left, self.right = left, right\n"
     )
 
-    source_file = SourceFile.from_path(path)
+    source_file = _open_source_file(path, tmp_path)
 
     assert source_file.unit.target_pattern_construction_count == 0
 
@@ -247,7 +259,7 @@ def test_mixed_attribute_unpack_is_not_a_lexical_target_pattern(tmp_path: Path):
         "    def bind(self, func, args, kwds):\n"
         "        self.func, self.args, self.kwds = func, args, kwds\n"
     )
-    source_file = SourceFile.from_path(path)
+    source_file = _open_source_file(path, tmp_path)
     assignment = next(node for node in source_file.nodes() if node.kind == "Assign")
 
     assert assignment.target_patterns == ()

--- a/implementations/python/sugar-source-tree/tests/test_while_return_else_source_visible.py
+++ b/implementations/python/sugar-source-tree/tests/test_while_return_else_source_visible.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
 from sugar_lift_py_tests.floor import BlockValue, ReturnValue
 from sugar_lift_py_tests.outcome import Complete, ExitSet
-from sugar_source_tree.tree import SourceFile
 
 
 def _outcome(tmp_path, source: str):
     path = tmp_path / "while_return_else.py"
     path.write_text(source, encoding="utf-8")
-    function = next(SourceFile.from_path(path).functions())
+    function = next(
+        open_source_file_for_construction(
+            path,
+            root=tmp_path,
+            construction_context=TreeConstructionContextV1.for_source_call_construction(
+                workspace_root=str(tmp_path)
+            ),
+        ).functions()
+    )
     return function.sugar().desugar()
 
 


### PR DESCRIPTION
## Summary

Routes the four live `R_bare_construction_door` offenders through `open_source_file_for_construction` with the existing explicit source-call construction context:

- `test_halted_face_pairing_instrument.py::_reduced`
- `test_halted_lineage_owner_prerequisite_instrument.py::_reduce`
- `test_target_pattern_law_of_one.py` construction helpers
- `test_while_return_else_source_visible.py::_outcome`

Root cause: each helper opened a context-less `SourceFile.from_path(...)` and then constructed Sugar in the same scope. That door can paint `With` resolvability. The replacement context carries an empty resolved-manager table, so any fixture that later introduces a `With` use-site remains loud rather than being painted.

The canonical helper's default provisional-demand path currently reaches `authenticated_module_exports`, whose `_final_module_state` call is missing the new required `module_is_package` argument. These fixture-only modules therefore pass the already-existing explicit source-call construction context; this PR does not alter that shared out-of-scope defect.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | test construction entrypoint only; no product semantics change |
| `mandatory_panics` | 0 | existing halted-lineage red set is identical base/head |
| `suppressed_descendants` | 0 | no catch, fallback, or suppression change |
| `typed_effects` | 0 | no effect producer changes |
| `silent` | 0 | floor preserved |

Instrument delta: `R_bare_construction_door 4 -> 0` at base `a0dd64729` / head `9141b4e7a`.

No shell retires yet: this remains a permanent open-boundary auditor. Its production-door clean twin and planted bare-door offender remain falsifiable and pass.

## Validation

- `/usr/local/opt/python@3.12/bin/python3.12 .../construction_context_door_law.py --json`
  - base: `R=4`, four named offenders, `unreadable=[]`
  - head: `R=0`, `offenders=[]`, `unreadable=[]`
- `python3.12 -m pytest --noconftest .../test_construction_context_door_law.py -q`
  - `11 passed`
- focused `sugar-source-tree` files
  - `9 passed`
- focused halted-lineage A/B with one immutable release-profile `SUGAR_BIN` (`sha256 5a04851c933a5fae769a1848bf21e4f481f0746ee9efb55c145adf11c33d345b`)
  - base: `13 failed`
  - head: `13 failed`
  - exact failed node sets identical; both processes completed, with no native crash or timeout
- independent diff review: no Critical, Important, or Minor findings
- pre/post-rebase patch identity: identical SHA-256 and stable patch-id

Broad census/scoreboard runs were not performed, per lane scope.

## Floors preserved

- `data_loss=0`
- no secret committed
- no test deleted or assertion weakened for green
- `silent=0`
- no spelling dispatch, compatibility model, or fabricated resolvability
- only the four assigned test files changed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route four construction tests through `open_source_file_for_construction`
> Replaces direct `SourceFile.from_path()` calls in four test files with `open_source_file_for_construction()`, passing an explicit `root` and a `TreeConstructionContextV1` construction context. Affected files are [test_halted_face_pairing_instrument.py](https://github.com/TSavo/sugar/pull/6932/files#diff-c9d2559bc98079727e5665ceb46214b50524ae34915f2a249da28ae802431973), [test_halted_lineage_owner_prerequisite_instrument.py](https://github.com/TSavo/sugar/pull/6932/files#diff-945a7d2a67d8f8849e4582e2f587e58b53364bc031784372374b8d6511e91a9a), [test_target_pattern_law_of_one.py](https://github.com/TSavo/sugar/pull/6932/files#diff-a7672643e0339a4a3aa5cbb0a5f6ade56321d7588572023e792b61ce6260aea5), and [test_while_return_else_source_visible.py](https://github.com/TSavo/sugar/pull/6932/files#diff-aa264081627c1b3d34158e5e77f3456d7737e5538f7b1b105b5ddd6941354a88). The last file introduces a shared `_open_source_file` helper to avoid repeating the construction context setup across multiple tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9141b4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->