### PR TITLE
Make ConstructionPanic catch membranes loud and exact

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
@@ -21,8 +21,9 @@ catch). Production construction, dig, floors, and reports must never convert
 ConstructionPanic into Incomplete or silence.
 
 Exit 1 while R > 0. Missing roots and source read/parse failures are separate
-``auditor_errors`` and also exit red. No baseline. No allowlist of production
-soft continues beyond the two named membranes.
+``auditor_errors`` and also exit red. No baseline. A named membrane is
+authorized only at its exact path, enclosing function, caught type, and handler
+body; a filename alone never suppresses inspection.
 """
 
 from __future__ import annotations
@@ -46,19 +47,6 @@ class PanicCatchOffender(NamedTuple):
     note: str
 
 
-# Paths relative to the scanned package root (src/sugar_lift_py_tests) OR
-# relative to the kit root when the scanner walks scripts/ too.
-_SANCTIONED_CATCH_MEMBRANES = frozenset(
-    {
-        "audit_only/collect_construction_gaps.py",
-        "desugar_repro.py",
-        "exit_set_arm_census.py",
-        "stablezero_classify.py",
-        "scripts/_production_lift_child.py",
-        "_production_lift_child.py",
-    }
-)
-
 _SOFT_AFTER_CATCH = frozenset(
     {
         "None",
@@ -73,10 +61,174 @@ _SOFT_AFTER_CATCH = frozenset(
 )
 
 
-def _is_sanctioned_catch_membrane(rel: str) -> bool:
-    return rel in _SANCTIONED_CATCH_MEMBRANES or rel.endswith(
-        "/_production_lift_child.py"
+def _canonical_handler(source: str) -> str:
+    """Return the location-free AST testimony for one readable handler."""
+    tree = ast.parse("try:\n    pass\n" + source)
+    try_node = tree.body[0]
+    assert isinstance(try_node, ast.Try)
+    assert len(try_node.handlers) == 1
+    return ast.dump(try_node.handlers[0], include_attributes=False)
+
+
+def _canonical_statement(source: str) -> str:
+    tree = ast.parse(source)
+    assert len(tree.body) == 1
+    return ast.dump(tree.body[0], include_attributes=False)
+
+
+# These are source-shape witnesses, not filename exemptions. Any new statement,
+# caught type, binding name, or fabricated return changes the handler AST and
+# makes the law red until the membrane itself is explicitly reviewed.
+_SANCTIONED_HANDLER_SHAPES = {
+    (
+        "audit_only/collect_construction_gaps.py",
+        "collect_construction_gaps",
+    ): frozenset(
+        {
+            _canonical_handler(
+                """
+except ConstructionPanic as panic:
+    gaps.append(gap_from_construction_panic(label, panic))
+"""
+            )
+        }
+    ),
+    (
+        "audit_only/collect_construction_gaps.py",
+        "collect_construction_panic",
+    ): frozenset(
+        {
+            _canonical_handler(
+                """
+except ConstructionPanic as panic:
+    return None, gap_from_construction_panic(label, panic)
+"""
+            )
+        }
+    ),
+    ("desugar_repro.py", "_desugar_one"): frozenset(
+        {
+            _canonical_handler(
+                """
+except BaseException as exc:
+    status = type(exc).__name__
+    detail = str(exc)
+    origin = [
+        f"{frame.filename}:{frame.lineno} {frame.name}"
+        for frame in traceback.extract_tb(exc.__traceback__)[-6:]
+    ]
+"""
+            )
+        }
+    ),
+    ("exit_set_arm_census.py", "patched_and_exit"): frozenset(
+        {
+            _canonical_handler(
+                """
+except BaseException as exc:
+    row.verdict_probe_error = f"{type(exc).__name__}: {exc}"
+    row.check()
+    return result
+"""
+            )
+        }
+    ),
+    ("stablezero_classify.py", "classify"): frozenset(
+        {
+            _canonical_handler(
+                """
+except ConstructionPanic as panic:
+    row["status"] = "ConstructionPanic"
+    row["testimony"] = _testimony(panic)
+"""
+            ),
+            _canonical_handler(
+                """
+except BaseException as error:
+    row["status"] = f"raised:{type(error).__name__}"
+    row["testimony"] = _testimony(error)
+"""
+            ),
+        }
+    ),
+    ("_production_lift_child.py", "production_lift_testimony"): frozenset(
+        {
+            _canonical_handler(
+                """
+except BaseException as error:
+    row = _typed_construction_row(error)
+    if row is None:
+        raise
+    gaps.append(row)
+    return {
+        "kind": _TERMINAL_KIND,
+        "outcome": OUTCOME_TYPED_GAP,
+        "file": rel,
+        "typed_gap_count": len(gaps),
+        "typed_gaps": gaps,
+    }
+"""
+            ),
+            _canonical_handler(
+                """
+except BaseException as error:
+    row = _typed_construction_row(error)
+    if row is None:
+        raise
+    gaps.append(row)
+"""
+            ),
+        }
+    ),
+}
+
+_SANCTIONED_ISINSTANCE_SHAPES = {
+    ("_production_lift_child.py", "_typed_construction_row"): frozenset(
+        {
+            _canonical_statement(
+                """
+if isinstance(error, ConstructionPanic):
+    return _construction_panic_row(error)
+"""
+            )
+        }
     )
+}
+
+
+def _enclosing_function_name(
+    node: ast.AST, parents: dict[ast.AST, ast.AST]
+) -> str | None:
+    parent = parents.get(node)
+    while parent is not None:
+        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return parent.name
+        parent = parents.get(parent)
+    return None
+
+
+def _is_sanctioned_handler(
+    rel: str,
+    handler: ast.ExceptHandler,
+    parents: dict[ast.AST, ast.AST],
+) -> bool:
+    function_name = _enclosing_function_name(handler, parents)
+    if function_name is None:
+        return False
+    shapes = _SANCTIONED_HANDLER_SHAPES.get((rel, function_name), frozenset())
+    return ast.dump(handler, include_attributes=False) in shapes
+
+
+def _is_sanctioned_isinstance(
+    rel: str,
+    node: ast.If,
+    parents: dict[ast.AST, ast.AST],
+) -> bool:
+    function_name = _enclosing_function_name(node, parents)
+    if function_name is None:
+        return False
+    shapes = _SANCTIONED_ISINSTANCE_SHAPES.get((rel, function_name), frozenset())
+    return ast.dump(node, include_attributes=False) in shapes
 
 
 def _handler_names(handler: ast.ExceptHandler) -> set[str]:
@@ -220,8 +372,6 @@ def scan_package(package_root: Path) -> list[PanicCatchOffender]:
         ]
     for path in paths:
         rel = path.relative_to(resolved_root).as_posix()
-        if _is_sanctioned_catch_membrane(rel):
-            continue
         try:
             source = path.read_text(encoding="utf-8")
         except (OSError, UnicodeError) as error:
@@ -246,10 +396,17 @@ def scan_package(package_root: Path) -> list[PanicCatchOffender]:
                 )
             )
             continue
+        parents = {
+            child: parent
+            for parent in ast.walk(tree)
+            for child in ast.iter_child_nodes(parent)
+        }
         for node in ast.walk(tree):
             if not isinstance(node, ast.ExceptHandler):
                 continue
             if not _catches_construction_panic(node):
+                continue
+            if _is_sanctioned_handler(rel, node, parents):
                 continue
             if _pure_reraise(node):
                 # pure re-raise is process-terminal — not a soft membrane
@@ -293,6 +450,8 @@ def scan_package(package_root: Path) -> list[PanicCatchOffender]:
                 == "ConstructionPanic"
                 for call in calls
             ):
+                continue
+            if _is_sanctioned_isinstance(rel, node, parents):
                 continue
             body_text = ast.unparse(node)
             if (

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 """R_construction_panic_catches_outside_audit — permanent floor.
 
-``ConstructionPanic`` is a sanctioned typed construction gap. Two membranes
+``ConstructionPanic`` is a sanctioned typed construction gap. Five membranes
 may catch it without pure re-raise:
 
-1. **Audit enumeration** — ``audit_only/collect_construction_gaps.py`` holds
-   the panic to emit a loud red ``AuditOnlyGap`` row.
+1. **Audit enumeration** — ``audit_only/collect_construction_gaps.py``,
+   ``scripts/desugar_repro.py``, ``scripts/exit_set_arm_census.py``, and
+   ``scripts/stablezero_classify.py`` hold the panic only to emit their named
+   loud-red gap/residual rows.
 2. **Production typed-gap classification** — ``scripts/_production_lift_child.py``
    marks the file ``typed-gap`` for the zero-tolerance floors so kit-domain
    construction panics are not misclassified as bare Python exceptions.
@@ -49,6 +51,9 @@ class PanicCatchOffender(NamedTuple):
 _SANCTIONED_CATCH_MEMBRANES = frozenset(
     {
         "audit_only/collect_construction_gaps.py",
+        "desugar_repro.py",
+        "exit_set_arm_census.py",
+        "stablezero_classify.py",
         "scripts/_production_lift_child.py",
         "_production_lift_child.py",
     }
@@ -257,9 +262,9 @@ def scan_package(package_root: Path) -> list[PanicCatchOffender]:
                     kind="construction-panic-catch-outside-membrane",
                     note=(
                         "except ConstructionPanic outside sanctioned membranes "
-                        "must not continue; only audit enumeration "
-                        "(collect_construction_gaps) or production typed-gap "
-                        "classification (_production_lift_child) may hold it"
+                        "must not continue; only the named per-file audit "
+                        "enumerators or production typed-gap classification "
+                        "(_production_lift_child) may hold it"
                     ),
                 )
             )

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
@@ -273,8 +273,8 @@ def _ends_in_raise(stmts: list[ast.stmt]) -> bool:
     if isinstance(last, ast.Raise):
         return True
     if isinstance(last, ast.If):
-        return _ends_in_raise(last.body) and _ends_in_raise(
-            last.orelse if last.orelse else [ast.Raise()]
+        return bool(last.orelse) and _ends_in_raise(last.body) and _ends_in_raise(
+            last.orelse
         )
     return False
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py
@@ -87,7 +87,6 @@ class FixtureSuppliedResourceObligationV1:
 class FixtureResourceOutcome(str, Enum):
     AUTHENTICATED_EXCEPTIONAL_EXIT = "authenticated-exceptional-exit"
     NAMED_REFUSAL = "named-refusal"
-    CONSTRUCTION_PANIC = "construction-panic"
 
 
 @dataclass(frozen=True)
@@ -102,16 +101,15 @@ def classify_fixture_resource_outcome(
     binding: BindingEntryV1,
     evaluator: Callable[[], object],
 ) -> FixtureResourceAttribution:
-    """Classify one formal-bound resource into the closed three-way result.
+    """Classify one formal-bound resource into the closed two-way result.
 
     Discharging the binding is necessary but not sufficient.  Satisfaction
     requires a positive authenticated exceptional edge from the evaluated
     body; ordinary or empty completion is a named refusal, never success by
-    absence.
+    absence. ConstructionPanic is not a result face and propagates unchanged.
     """
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
     from sugar_lift_py_tests.no_call_body_attribution import (
-        _exceptional_exit_present,
+        _exceptional_exit_effects,
     )
 
     try:
@@ -122,15 +120,8 @@ def classify_fixture_resource_outcome(
             FixtureResourceOutcome.NAMED_REFUSAL,
             refusal.detail,
         )
-    try:
-        evaluated = evaluator()
-    except ConstructionPanic as panic:
-        return FixtureResourceAttribution(
-            obligation.formal_coordinate_cid,
-            FixtureResourceOutcome.CONSTRUCTION_PANIC,
-            panic.info.owner,
-        )
-    if _exceptional_exit_present(evaluated):
+    evaluated = evaluator()
+    if _exceptional_exit_effects(evaluated):
         return FixtureResourceAttribution(
             obligation.formal_coordinate_cid,
             FixtureResourceOutcome.AUTHENTICATED_EXCEPTIONAL_EXIT,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_entry_refusal.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_entry_refusal.py
@@ -68,7 +68,7 @@ def observed_entry_refusal() -> GeneratorEntryRefusalV1:
     try:
         with _a_generator_that_never_yields():  # pragma: no branch
             pass
-    except BaseException as raised:  # noqa: BLE001 - the vendor names the type
+    except Exception as raised:  # the vendor conversion raises RuntimeError
         return GeneratorEntryRefusalV1(
             runtime=PythonRuntimeIdentity.current(),
             exception_name=type(raised).__name__,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/positional_unpack_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/positional_unpack_operation.py
@@ -209,7 +209,7 @@ class PositionalUnpackOperation:
         from sugar_lift_py_tests.floor import RaiseValue
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
         from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-        from sugar_lift_py_tests.gap.panic import ConstructionPanic, construction_panic
+        from sugar_lift_py_tests.gap.panic import construction_panic
         from sugar_lift_py_tests.outcome import Complete, Incomplete
 
         relation = "not enough" if members < self.arity else "too many"
@@ -218,20 +218,16 @@ class PositionalUnpackOperation:
             f"{self.arity} fixed targets ({relation} values)"
         )
         if hasattr(self.blame, "filename") and hasattr(self.blame, "line"):
-            try:
-                projected = ground_exceptional_exit(
-                    exception_name="ValueError",
-                    site=self.blame,
-                    owner=f"{self.owner}.arity_mismatch",
-                )
-            except ConstructionPanic:
-                projected = None
-            else:
-                if isinstance(projected, Complete) and isinstance(
-                    projected.value, RaiseValue
-                ):
-                    return Incomplete(projected.value.effect)
-                return projected
+            projected = ground_exceptional_exit(
+                exception_name="ValueError",
+                site=self.blame,
+                owner=f"{self.owner}.arity_mismatch",
+            )
+            if isinstance(projected, Complete) and isinstance(
+                projected.value, RaiseValue
+            ):
+                return Incomplete(projected.value.effect)
+            return projected
         construction_panic(
             ConstructionGap(
                 owner=self.owner,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/sequence_projection_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/sequence_projection_operation.py
@@ -224,7 +224,7 @@ class SequenceProjectionOperation:
         from sugar_lift_py_tests.floor import RaiseValue
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
         from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
-        from sugar_lift_py_tests.gap.panic import ConstructionPanic, construction_panic
+        from sugar_lift_py_tests.gap.panic import construction_panic
         from sugar_lift_py_tests.outcome import Complete, Incomplete
 
         relation = "not enough" if members < self.arity else "too many"
@@ -235,20 +235,16 @@ class SequenceProjectionOperation:
         # Only fragments (or objects answering the RuntimeEffectSite protocol)
         # may mint a ground exit.  Strings and synthetic loci stay the gap.
         if hasattr(self.blame, "filename") and hasattr(self.blame, "line"):
-            try:
-                projected = ground_exceptional_exit(
-                    exception_name="ValueError",
-                    site=self.blame,
-                    owner=f"{self.owner}.arity_mismatch",
-                )
-            except ConstructionPanic:
-                projected = None
-            else:
-                if isinstance(projected, Complete) and isinstance(
-                    projected.value, RaiseValue
-                ):
-                    return Incomplete(projected.value.effect)
-                return projected
+            projected = ground_exceptional_exit(
+                exception_name="ValueError",
+                site=self.blame,
+                owner=f"{self.owner}.arity_mismatch",
+            )
+            if isinstance(projected, Complete) and isinstance(
+                projected.value, RaiseValue
+            ):
+                return Incomplete(projected.value.effect)
+            return projected
         construction_panic(
             ConstructionGap(
                 owner=self.owner,

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
@@ -81,30 +81,16 @@ def audit():
     ]
 
 
-def test_scanner_allows_only_named_zero_tolerance_audit_membranes(
+def test_named_membrane_paths_do_not_authorize_soft_handlers(
     tmp_path: Path,
 ) -> None:
     package = tmp_path / "src" / "sugar_lift_py_tests"
     package.mkdir(parents=True)
+    audit_only = package / "audit_only"
+    audit_only.mkdir()
     scripts = tmp_path / "scripts"
     scripts.mkdir()
-    membrane = """
-from sugar_lift_py_tests.gap.panic import ConstructionPanic
-
-def audit():
-    try:
-        raise ConstructionPanic(None)
-    except ConstructionPanic as panic:
-        return {"status": "ConstructionPanic", "testimony": str(panic)}
-"""
-    for name in (
-        "desugar_repro.py",
-        "exit_set_arm_census.py",
-        "stablezero_classify.py",
-    ):
-        (scripts / name).write_text(membrane, encoding="utf-8")
-    (scripts / "desugar_repro_copy.py").write_text(
-        """
+    soft_handler = """
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
 def audit():
@@ -112,6 +98,76 @@ def audit():
         raise ConstructionPanic(None)
     except ConstructionPanic:
         return None
+"""
+    for name in (
+        "desugar_repro.py",
+        "exit_set_arm_census.py",
+        "stablezero_classify.py",
+        "_production_lift_child.py",
+    ):
+        (scripts / name).write_text(soft_handler, encoding="utf-8")
+    (audit_only / "collect_construction_gaps.py").write_text(
+        soft_handler,
+        encoding="utf-8",
+    )
+
+    offenders = _SCANNER.scan_repository(tmp_path)
+
+    assert {
+        (row.path, row.kind) for row in offenders
+    } == {
+        (
+            "src/sugar_lift_py_tests/audit_only/collect_construction_gaps.py",
+            "construction-panic-catch-outside-membrane",
+        ),
+        (
+            "scripts/desugar_repro.py",
+            "construction-panic-catch-outside-membrane",
+        ),
+        (
+            "scripts/exit_set_arm_census.py",
+            "construction-panic-catch-outside-membrane",
+        ),
+        (
+            "scripts/stablezero_classify.py",
+            "construction-panic-catch-outside-membrane",
+        ),
+        (
+            "scripts/_production_lift_child.py",
+            "construction-panic-catch-outside-membrane",
+        ),
+    }
+
+
+def test_named_membrane_path_does_not_hide_parse_error(tmp_path: Path) -> None:
+    package = tmp_path / "src" / "sugar_lift_py_tests"
+    package.mkdir(parents=True)
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "desugar_repro.py").write_text("def broken(:\n", encoding="utf-8")
+
+    offenders = _SCANNER.scan_repository(tmp_path)
+
+    assert [(row.path, row.line, row.kind) for row in offenders] == [
+        ("scripts/desugar_repro.py", 1, "auditor-parse-error")
+    ]
+
+
+def test_production_membrane_path_does_not_authorize_fabricated_success(
+    tmp_path: Path,
+) -> None:
+    package = tmp_path / "src" / "sugar_lift_py_tests"
+    package.mkdir(parents=True)
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "_production_lift_child.py").write_text(
+        """
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+def _typed_construction_row(error):
+    if isinstance(error, ConstructionPanic):
+        return {"outcome": "completed", "typed_gaps": []}
+    return None
 """,
         encoding="utf-8",
     )
@@ -120,10 +176,52 @@ def audit():
 
     assert [(row.path, row.kind) for row in offenders] == [
         (
-            "scripts/desugar_repro_copy.py",
-            "construction-panic-catch-outside-membrane",
+            "scripts/_production_lift_child.py",
+            "factory-panic-isinstance-soft-return",
         )
     ]
+
+
+def test_named_membrane_path_does_not_hide_read_error(
+    tmp_path: Path, monkeypatch
+) -> None:
+    package = tmp_path / "src" / "sugar_lift_py_tests"
+    package.mkdir(parents=True)
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    broken = scripts / "desugar_repro.py"
+    broken.write_text("pass\n", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def fail_target(path: Path, *args, **kwargs) -> str:
+        if path == broken:
+            raise OSError("planted unreadable named membrane")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_target)
+
+    offenders = _SCANNER.scan_repository(tmp_path)
+
+    assert [(row.path, row.line, row.kind) for row in offenders] == [
+        ("scripts/desugar_repro.py", 0, "auditor-read-error")
+    ]
+
+
+def test_current_named_membranes_match_their_exact_handler_shapes() -> None:
+    offenders = _SCANNER.scan_repository(_KIT)
+    named_membrane_suffixes = (
+        "audit_only/collect_construction_gaps.py",
+        "scripts/desugar_repro.py",
+        "scripts/exit_set_arm_census.py",
+        "scripts/stablezero_classify.py",
+        "scripts/_production_lift_child.py",
+    )
+
+    assert [
+        row
+        for row in offenders
+        if row.path.endswith(named_membrane_suffixes)
+    ] == []
 
 
 def test_current_repository_construction_panic_catch_law() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
@@ -81,6 +81,51 @@ def audit():
     ]
 
 
+def test_scanner_allows_only_named_zero_tolerance_audit_membranes(
+    tmp_path: Path,
+) -> None:
+    package = tmp_path / "src" / "sugar_lift_py_tests"
+    package.mkdir(parents=True)
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    membrane = """
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+def audit():
+    try:
+        raise ConstructionPanic(None)
+    except ConstructionPanic as panic:
+        return {"status": "ConstructionPanic", "testimony": str(panic)}
+"""
+    for name in (
+        "desugar_repro.py",
+        "exit_set_arm_census.py",
+        "stablezero_classify.py",
+    ):
+        (scripts / name).write_text(membrane, encoding="utf-8")
+    (scripts / "desugar_repro_copy.py").write_text(
+        """
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+def audit():
+    try:
+        raise ConstructionPanic(None)
+    except ConstructionPanic:
+        return None
+""",
+        encoding="utf-8",
+    )
+
+    offenders = _SCANNER.scan_repository(tmp_path)
+
+    assert [(row.path, row.kind) for row in offenders] == [
+        (
+            "scripts/desugar_repro_copy.py",
+            "construction-panic-catch-outside-membrane",
+        )
+    ]
+
+
 def test_current_repository_construction_panic_catch_law() -> None:
     """R_construction_panic_catches_outside_audit > 0 ⇒ red until production soft catches die."""
     offenders = _SCANNER.scan_repository(_KIT)

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
@@ -53,6 +53,57 @@ def dig():
     assert offenders == []
 
 
+def test_scanner_rejects_conditional_reraise_without_else(tmp_path: Path) -> None:
+    pkg = tmp_path / "sugar_lift_py_tests"
+    pkg.mkdir()
+    (pkg / "bad.py").write_text(
+        """
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+def dig(flag):
+    try:
+        raise ConstructionPanic(None)
+    except ConstructionPanic:
+        if flag:
+            raise
+    return None
+""",
+        encoding="utf-8",
+    )
+
+    offenders = _SCANNER.scan_package(pkg)
+
+    assert [(row.path, row.kind) for row in offenders] == [
+        ("bad.py", "construction-panic-catch-outside-membrane")
+    ]
+
+
+def test_scanner_allows_conditional_reraise_with_terminal_else(
+    tmp_path: Path,
+) -> None:
+    pkg = tmp_path / "sugar_lift_py_tests"
+    pkg.mkdir()
+    (pkg / "ok.py").write_text(
+        """
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+def dig(flag):
+    try:
+        raise ConstructionPanic(None)
+    except ConstructionPanic:
+        if flag:
+            raise
+        else:
+            raise
+""",
+        encoding="utf-8",
+    )
+
+    offenders = _SCANNER.scan_package(pkg)
+
+    assert offenders == []
+
+
 def test_scanner_flags_corpus_tooling_catch(tmp_path: Path) -> None:
     package = tmp_path / "src" / "sugar_lift_py_tests"
     package.mkdir(parents=True)

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_repro.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_repro.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+from sugar_lift_py_tests.gap.info import ConstructionGap
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
 _SCRIPT = (
     Path(__file__).parents[1] / "scripts" / "desugar_repro.py"
@@ -34,15 +36,27 @@ class _Function:
         return type("Span", (), {"start_line": 7})()
 
 
-def test_desugar_one_counts_success_and_construction_panic_as_completed_attempts():
+def test_desugar_one_emits_named_construction_panic_residual_row():
     clean = _MOD._desugar_one(_Function(object()), name="clean")
     panic = _MOD._desugar_one(
-        _Function(BaseException("construction panic")),
+        _Function(
+            ConstructionPanic(
+                ConstructionGap(
+                    owner="desugar-repro-test",
+                    blame="fixture.py:1:0",
+                    observed="missing construction",
+                    requested="source-owned construction",
+                    fix="implement the producer",
+                )
+            )
+        ),
         name="panic",
     )
 
     assert clean["status"] == "clean"
-    assert panic["status"] == "BaseException"
+    assert panic["status"] == "ConstructionPanic"
+    assert "desugar-repro-test" in panic["detail"]
+    assert panic["origin"]
     assert clean["timedOut"] is False
     assert panic["timedOut"] is False
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_dynamic_unpack_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dynamic_unpack_projection.py
@@ -263,6 +263,26 @@ def test_decidable_arity_mismatch_stays_loud(members, names, relation) -> None:
     assert str(len(names)) in info.observed
 
 
+def test_ground_exit_construction_panic_propagates_without_reconstruction() -> None:
+    """LYING TWIN: a fragment-shaped half-locus cannot mint a cited exit."""
+
+    class HalfFragment:
+        filename = "pkg/mod.py"
+        line = 1
+
+    operation = SequenceProjectionOperation(
+        target_names=("a", "b"),
+        owner="sequence-half-fragment",
+        blame=HalfFragment(),
+    )
+
+    with pytest.raises(ConstructionPanic) as raised:
+        operation.submit(TupleLiteralValue((TermValue(1),)), None)
+
+    assert raised.value.info.owner == "sequence-half-fragment.arity_mismatch"
+    assert "locus stating no source fragment" in raised.value.info.observed
+
+
 # ---------------------------------------------------------------------------
 # Law 7 -- an unwritten floor stays loud, and names the frontier.
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py
@@ -190,6 +190,49 @@ def test_reconcile_check_can_actually_fail() -> None:
     assert row.reconciles, row.reconcile_detail
 
 
+def test_verdict_probe_construction_panic_is_a_named_non_reconciling_row(
+    monkeypatch,
+) -> None:
+    """LYING TWIN: the audit may hold the panic only as an explicit red row."""
+    import sugar_lift_py_tests.outcome.exit_disposition as disposition_module
+
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    real_effect = disposition_module.exit_disposition_effect
+    calls = 0
+
+    def panic_on_audit_probe(disposition, incoming):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            construction_panic_gap(
+                owner="exit-arm-census.verdict-probe",
+                blame="instrument",
+                observed="probe reached missing construction",
+                requested="verdict testimony",
+                fix="repair the verdict producer",
+            )
+        return real_effect(disposition, incoming)
+
+    monkeypatch.setattr(
+        disposition_module,
+        "exit_disposition_effect",
+        panic_on_audit_probe,
+    )
+    body = _completed_only(1, "body")
+    exit_es = _completed_only(1, "exit")
+
+    with arm_census() as rows:
+        result = body.and_exit(exit_es, disposition=NeverSuppresses())
+
+    assert len(result.exits) == 1
+    (row,) = _rows_for(rows, "and_exit")
+    assert row.verdict_probe_error is not None
+    assert row.verdict_probe_error.startswith("ConstructionPanic:")
+    assert row.reconciles is False
+    assert totals(rows)["and_exit"]["non_reconciling"] == 1
+
+
 def test_instrument_restores_every_patched_method() -> None:
     originals = {
         name: getattr(ExitSet, name)

--- a/implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py
@@ -240,8 +240,11 @@ def test_population_outcomes_require_a_positive_authenticated_exceptional_exit()
     assert absent.detail == "positive-authenticated-exceptional-exit-absent"
 
 
-def test_population_keeps_construction_panic_separate_from_named_refusal():
-    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+def test_population_reraises_construction_panic_instead_of_attributing_success():
+    from sugar_lift_py_tests.gap.panic import (
+        ConstructionPanic,
+        construction_panic_gap,
+    )
 
     obligation, entry = _authenticated_obligation_and_entry()
 
@@ -254,11 +257,11 @@ def test_population_keeps_construction_panic_separate_from_named_refusal():
             fix="implement the producer",
         )
 
-    result = classify_fixture_resource_outcome(obligation, entry, panic)
+    with pytest.raises(ConstructionPanic) as caught:
+        classify_fixture_resource_outcome(obligation, entry, panic)
 
-    assert result.outcome is FixtureResourceOutcome.CONSTRUCTION_PANIC
-    assert result.coordinate == obligation.formal_coordinate_cid
-    assert result.detail == "fixture-resource-test"
+    assert caught.value.info.owner == "fixture-resource-test"
+    assert caught.value.info.blame == "fixture.py:2:4"
 
 
 def test_authenticated_pandas_303_temp_file_population_is_partitioned_by_formal():

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_entry_refusal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_entry_refusal.py
@@ -29,6 +29,9 @@ from __future__ import annotations
 import contextlib
 import inspect
 
+import pytest
+
+import sugar_lift_py_tests.generator_entry_refusal as generator_entry_refusal
 from sugar_lift_py_tests.generator_entry_refusal import (
     observed_entry_refusal,
 )
@@ -74,6 +77,39 @@ def test_the_observation_records_the_runtime_it_was_read_from() -> None:
 def test_the_observation_is_minted_once() -> None:
     """It is a property of the interpreter, not of a call site."""
     assert observed_entry_refusal() is observed_entry_refusal()
+
+
+def test_construction_panic_cannot_be_recorded_as_vendor_refusal(monkeypatch) -> None:
+    """LYING TWIN: a kit gap is not testimony about CPython's conversion."""
+    from sugar_lift_py_tests.gap.panic import (
+        ConstructionPanic,
+        construction_panic_gap,
+    )
+
+    @contextlib.contextmanager
+    def panic_instead_of_vendor_refusal():
+        construction_panic_gap(
+            owner="generator-entry-test",
+            blame="generator.py:1:0",
+            observed="missing generator construction",
+            requested="vendor entry refusal",
+            fix="repair generator construction",
+        )
+        yield  # pragma: no cover - construction panic is process-terminal
+
+    observed_entry_refusal.cache_clear()
+    monkeypatch.setattr(
+        generator_entry_refusal,
+        "_a_generator_that_never_yields",
+        panic_instead_of_vendor_refusal,
+    )
+    try:
+        with pytest.raises(ConstructionPanic) as caught:
+            observed_entry_refusal()
+    finally:
+        observed_entry_refusal.cache_clear()
+
+    assert caught.value.info.owner == "generator-entry-test"
 
 
 # -- lying twin: any other spelling must flip --------------------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_stablezero_classify.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_stablezero_classify.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import sugar_lift_python_source.source_oracle as source_oracle
+import sugar_source_tree.tree as source_tree
+
+from sugar_lift_py_tests.gap.info import ConstructionGap
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "stablezero_classify.py"
+_SPEC = importlib.util.spec_from_file_location("stablezero_classify", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+_MOD = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MOD)
+
+
+class _Span:
+    start_line = 7
+
+
+class _Sugar:
+    def __init__(self, result):
+        self._result = result
+
+    def desugar(self, _ctx=None):
+        if isinstance(self._result, BaseException):
+            raise self._result
+        return self._result
+
+
+class _Function:
+    def __init__(self, name: str, result):
+        self._name = name
+        self._result = result
+
+    def line_col_span(self):
+        return _Span()
+
+    def name(self):
+        return self._name
+
+    def sugar(self):
+        return _Sugar(self._result)
+
+
+class _SourceFile:
+    functions_in_file = ()
+
+    def __init__(self, _identity):
+        pass
+
+    def functions(self):
+        return iter(self.functions_in_file)
+
+
+def _classify(monkeypatch, tmp_path: Path, functions: tuple) -> dict:
+    source = tmp_path / "fixture.py"
+    source.write_text("def fixture():\n    pass\n", encoding="utf-8")
+    _SourceFile.functions_in_file = functions
+    monkeypatch.setattr(source_oracle, "path_source", lambda _path: object())
+    monkeypatch.setattr(source_tree, "SourceFile", _SourceFile)
+    return _MOD.classify(source, deadline=1.0)
+
+
+def test_clean_function_is_the_truthful_stable_zero_face(
+    monkeypatch, tmp_path: Path
+) -> None:
+    payload = _classify(
+        monkeypatch,
+        tmp_path,
+        (_Function("clean", object()),),
+    )
+
+    assert payload["statuses"] == {"clean": 1}
+    assert payload["completed_denominator"] == 1
+    assert payload["R(construction_panics)"] == 0
+    assert payload["stableZero"] is True
+
+
+def test_construction_panic_is_a_named_red_residual_not_clean(
+    monkeypatch, tmp_path: Path
+) -> None:
+    panic = ConstructionPanic(
+        ConstructionGap(
+            owner="stablezero-test",
+            blame="fixture.py:7:0",
+            observed="missing construction",
+            requested="source-owned construction",
+            fix="implement the producer",
+        )
+    )
+    payload = _classify(
+        monkeypatch,
+        tmp_path,
+        (_Function("panic", panic),),
+    )
+
+    assert payload["statuses"] == {"ConstructionPanic": 1}
+    assert payload["completed_denominator"] == 1
+    assert payload["R(construction_panics)"] == 1
+    assert payload["stableZero"] is False
+    assert payload["residuals"][0]["testimony"]["info"]["owner"] == "stablezero-test"

--- a/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
@@ -668,3 +668,29 @@ def test_positional_roster_has_no_string_keys() -> None:
     assert not hasattr(out.value, "bindings")
     assert out.value.occurrence is site
     assert out.value.demand_cid == op.demand_cid()
+
+
+def test_positional_ground_exit_panic_propagates_without_reconstruction() -> None:
+    """LYING TWIN: a source-looking half-locus remains the ground-door gap."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.operations.positional_unpack_operation import (
+        PositionalUnpackOperation,
+    )
+
+    class HalfFragment:
+        filename = "pkg/mod.py"
+        line = 1
+
+    operation = PositionalUnpackOperation(
+        fixed_prefix=2,
+        fixed_suffix=0,
+        has_star=False,
+        owner="positional-half-fragment",
+        blame=HalfFragment(),
+    )
+
+    with pytest.raises(ConstructionPanic) as raised:
+        operation.submit(ListValue((TermValue(1),)), None)
+
+    assert raised.value.info.owner == "positional-half-fragment.arity_mismatch"
+    assert "locus stating no source fragment" in raised.value.info.observed


### PR DESCRIPTION
## Summary

- remove the four production catch-and-reconstruct paths in fixture-resource, generator-entry, positional-unpack, and sequence-projection construction so producer-owned `ConstructionPanic` testimony propagates unchanged
- retain the three per-file audit membranes only where they emit named loud-red rows
- harden the permanent catch law: every source is read and parsed, and authorization requires exact relative path, enclosing function, caught type, and location-free handler AST; a filename alone grants nothing
- require real terminal control flow for pure re-raise: an `if` without `else` falls through and is red, while an explicit terminal `else` remains the truthful conditional face
- add real panic reproducers plus truthful/lying twins for every owned locus and hostile same-filename twins for `return None`, fabricated success, parse failure, read failure, and conditional fallthrough

## Predicted Epsilon R (construction / wall lanes)

No census was run per lane scope. Numeric movement is therefore intentionally unclaimed; the predicted semantic movement is reattribution from fabricated/soft outcomes to the original construction refusal.

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | unmeasured | no census; no new construction producer |
| `mandatory_panics` | unmeasured | previously caught panics now retain their producer-owned identity |
| `suppressed_descendants` | unmeasured | no census; no descendant-suppression mechanism added |
| `typed_effects` | unmeasured | fabricated replacement outcomes were removed |
| `silent` | 0 | no catch may convert panic to `None`, a green enum, or a fabricated result |

## Validation

- exact conditional-flow red/green cycle: no-else lying face failed before the fix; no-else red and explicit-else truthful faces both pass after it
- final immutable head `b7ef8a3ba600ac9e61a18ef8ed2587a43f8166f4`: 30 passed, 1 separately owned repository residual deselected
- 15/15 newly added reproducer and truthful/lying tests pass under `/usr/local/opt/python@3.12/bin/python3.12`
- direct law instrument: owned loci `8 -> 0`, `auditor_errors=0`; one surviving residual is `no_call_body_attribution.py:271`, owned by the parallel Grok lane
- native-crash and timeout zero-tolerance modules: 9 passed
- broad owning-file comparison at `origin/main` `f36f374209ce65e78bb699f236ea4bdf72091773`: base 67 passed / 16 failed; head 80 passed / 14 failed; no head-only failed nodes, with two stale fixture-classifier reds removed
- independent re-review of the eight production repairs: ready to merge; no Critical or Important findings
- `git diff --check` clean

## Floors preserved

- no census, scoreboard, pin-only, or broad CI-green work
- no fabricated values, control-flow branches, or replacement panic testimony
- no test deleted for green
- native-crash and timeout floors remain green
- `silent=0`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace file-level `ConstructionPanic` catch exemptions with exact AST-shape whitelists
> - The `ConstructionPanic` catch law scanner now approves only pre-registered, exact handler and isinstance-if AST shapes (keyed by relative path and enclosing function name) instead of exempting entire files via `_SANCTIONED_CATCH_MEMBRANES`.
> - Removes swallowed `ConstructionPanic` in `PositionalUnpackOperation._arity_mismatch_exit` and `SequenceProjectionOperation._arity_mismatch_exit`, letting panics propagate to callers.
> - Removes `FixtureResourceOutcome.CONSTRUCTION_PANIC` from the outcome enum; callers now receive a re-raised panic instead of a mapped outcome.
> - Fixes `_ends_in_raise` to require an explicit `else` branch; handlers without one are no longer treated as terminal re-raises.
> - Behavioral Change: previously exempt files are now fully scanned; any handler or isinstance shape not in the whitelist is flagged as a violation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7ef8a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Construction panics now propagate with their original diagnostic context instead of being converted into success or attribution results.
  * Stable-zero and census outputs now identify construction panics as named, non-reconciling residuals.

* **Bug Fixes**
  * Improved exception handling for generator entry refusal and unpacking operations.
  * Prevented unauthorized or incomplete panic handlers from being accepted.

* **Tests**
  * Added coverage for panic propagation, diagnostic preservation, handler validation, parse/read errors, and stable-zero classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->