### PR TITLE
Transport source mapping mutation through class construction

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -72,6 +72,7 @@ from .object_value import ObjectValue
 from .mapping_object_value import MappingObjectValue
 from .runtime_class_value import RuntimeClassValue
 from .receiver_field_store_value import ReceiverFieldStoreValue
+from .receiver_owned_mutation_result import ReceiverOwnedMutationResult
 from .guarded_receiver_field_store_value import GuardedReceiverFieldStoreValue
 from .receiver_state_partition_value import ReceiverStatePartitionValue
 from .opaque_op_callsite import OpaqueOpCallsite
@@ -154,6 +155,7 @@ REGISTERED_FLOOR_TYPES: tuple[type[FloorDispatchSurface], ...] = (
     RaiseValue,
     RaisesWithValue,
     ReceiverFieldStoreValue,
+    ReceiverOwnedMutationResult,
     GuardedReceiverFieldStoreValue,
     ReceiverStatePartitionValue,
     ReturnValue,
@@ -241,6 +243,7 @@ __all__ = [
     "RuntimeClassValue",
     "TupleIteratorValue",
     "ReceiverFieldStoreValue",
+    "ReceiverOwnedMutationResult",
     "GuardedReceiverFieldStoreValue",
     "ReceiverStatePartitionValue",
     "OpaqueOpCallsite",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_super_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_super_value.py
@@ -87,6 +87,7 @@ class BuiltinSuperValue(FloorValue):
             BuiltinDictClassValue,
         )
         from sugar_lift_py_tests.floor.none_value import NoneValue
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
         from sugar_lift_py_tests.outcome import Complete
 
         if (
@@ -96,8 +97,35 @@ class BuiltinSuperValue(FloorValue):
             and not keywords
         ):
             return Complete(NoneValue())
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        if (
+            name == "__setitem__"
+            and isinstance(base, BuiltinDictClassValue)
+            and len(arguments) == 2
+            and not keywords
+        ):
+            from sugar_lift_py_tests.floor.mapping_object_value import (
+                MappingObjectValue,
+            )
+            from sugar_lift_py_tests.floor.receiver_owned_mutation_result import (
+                ReceiverOwnedMutationResult,
+            )
 
+            if not isinstance(self.receiver, MappingObjectValue):
+                construction_panic_gap(
+                    owner="BuiltinSuperValue.call_method_value",
+                    blame=blame,
+                    observed=type(self.receiver).__name__,
+                    requested="authenticated mapping receiver for dict.__setitem__",
+                    fix="preserve the source method receiver through zero-arg super",
+                )
+            key, value = arguments
+            return self.receiver.mapping_builtin_setitem(key, value, blame).and_then(
+                lambda updated: Complete(
+                    ReceiverOwnedMutationResult(
+                        self.receiver, updated, NoneValue()
+                    )
+                )
+            )
         construction_panic_gap(
             owner="BuiltinSuperValue.call_method_value",
             blame=blame,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -135,6 +135,12 @@ class CallSiteValue(FloorValue):
     runtime_dispatch_receiver: FloorValue | None = dataclass_field(
         default=None, compare=False
     )
+    # Definition-owned class cell for a source method body.  Runtime receiver
+    # type is deliberately insufficient: inherited methods must bind the class
+    # that defined the body for zero-argument ``super()``.
+    lexical_defining_class: FloorValue | None = dataclass_field(
+        default=None, compare=False, repr=False
+    )
     # Authority to treat this call result as an exception instance.  This is
     # issued only for ``type(caught_exception)(...)``: the coordinate names the
     # genuinely runtime-selected exception class.  Ordinary call-result shapes
@@ -1393,6 +1399,16 @@ class CallSiteValue(FloorValue):
             self.arg_values,
             self.formal_coordinate_cids,
         )
+        if self.lexical_defining_class is not None:
+            from sugar_lift_py_tests.temporal import curry_temporal
+
+            reduce_ctx = curry_temporal(
+                reduce_ctx,
+                ("__class__",),
+                (self.lexical_defining_class,),
+                owner="CallSiteValue lexical class cell",
+                blame=self.target_name,
+            )
         return _reduce_callsite_body(self.body, reduce_ctx, blame=self.target_name)
 
     def producer_outcome(self, ctx: Any = None, *, carrier_actuals: dict | None = None):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -246,7 +246,7 @@ class ClassDefinitionValue(GuardStableValue):
             methods=self._object_methods(),
             class_fields=self.class_fields,
             identity=receiver_coordinate_cid or self.class_definition_cid,
-            **({"defining_class": self} if receiver_type is MappingObjectValue else {}),
+            defining_class=self,
         )
         if block is None:
             return receiver
@@ -346,7 +346,7 @@ class ClassDefinitionValue(GuardStableValue):
             methods=self._object_methods(),
             class_fields=self.class_fields,
             identity=_term_content_cid(identity_term),
-            **({"defining_class": self} if receiver_type is MappingObjectValue else {}),
+            defining_class=self,
         )
 
     def _object_methods(self):
@@ -356,8 +356,11 @@ class ClassDefinitionValue(GuardStableValue):
         # tail before this class's methods.  A base method is retained with its
         # original authenticated source frame; nothing is reconstructed here.
         inherited = tuple(
-            method for base in reversed(self._c3_tail()) for method in base.methods
+            (base, method)
+            for base in reversed(self._c3_tail())
+            for method in base.methods
         )
+        owned = (*inherited, *((self, method) for method in self.methods))
         return tuple(
             ObjectMethodValue(
                 method.name,
@@ -370,8 +373,9 @@ class ClassDefinitionValue(GuardStableValue):
                 ),
                 method.source_call_frame,
                 method.descriptor_kind,
+                defining_class=defining_class,
             )
-            for method in (*inherited, *self.methods)
+            for defining_class, method in owned
         )
 
     def _c3_tail(self) -> tuple["ClassDefinitionValue", ...]:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -246,6 +246,7 @@ class ClassDefinitionValue(GuardStableValue):
             methods=self._object_methods(),
             class_fields=self.class_fields,
             identity=receiver_coordinate_cid or self.class_definition_cid,
+            **({"defining_class": self} if receiver_type is MappingObjectValue else {}),
         )
         if block is None:
             return receiver
@@ -345,6 +346,7 @@ class ClassDefinitionValue(GuardStableValue):
             methods=self._object_methods(),
             class_fields=self.class_fields,
             identity=_term_content_cid(identity_term),
+            **({"defining_class": self} if receiver_type is MappingObjectValue else {}),
         )
 
     def _object_methods(self):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mapping_object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mapping_object_value.py
@@ -17,6 +17,7 @@ class MappingObjectValue(ObjectValue):
     """
 
     entries: tuple = ()
+    defining_class: object | None = None
 
     def guarded(self, formula):
         """A constructed mapping state contributes no independent control.
@@ -48,6 +49,50 @@ class MappingObjectValue(ObjectValue):
         return DictValue(self.entries).subscript(index, site)
 
     def setitem(self, index, value, site):
+        if self.has_method("__setitem__"):
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="MappingObjectValue.setitem",
+                blame=site,
+                observed="source-defined __setitem__ without reduction context",
+                requested="setitem_with_context through the ordinary store producer",
+                fix="thread the caller context; zero-arg super requires its __class__ cell",
+            )
+        return self.mapping_builtin_setitem(index, value, site)
+
+    def setitem_with_context(self, index, value, site, ctx):
+        if not self.has_method("__setitem__"):
+            return self.mapping_builtin_setitem(index, value, site)
+        if self.defining_class is None:
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="MappingObjectValue.setitem_with_context",
+                blame=site,
+                observed="mapping receiver lacks defining class",
+                requested="authenticated source class for __setitem__ dispatch",
+                fix="transport the class definition into its constructed receiver",
+            )
+        method_ctx = ctx.with_temporal(
+            ctx.temporal.bind_value(
+                "__class__", self.defining_class, blame=f"{self.class_name}.__setitem__"
+            )
+        )
+        return super().call_method_value(
+                "__setitem__",
+                (index, value),
+                owner="MappingObjectValue.setitem",
+                blame=site,
+                ctx=method_ctx,
+            ).and_then(
+                lambda callsite: callsite.reduce_source_outcome(method_ctx).and_then(
+                    self._project_setitem_receiver
+                )
+            )
+
+    def mapping_builtin_setitem(self, index, value, site):
+        """Apply authenticated builtin-dict storage without source redispatch."""
         from sugar_lift_py_tests.outcome import Complete
 
         return (
@@ -57,6 +102,32 @@ class MappingObjectValue(ObjectValue):
                 lambda updated: Complete(self.mapping_with_entries(updated.entries))
             )
         )
+
+    def _project_setitem_receiver(self, value):
+        from sugar_lift_py_tests.floor.block_value import BlockValue
+        from sugar_lift_py_tests.floor.receiver_owned_mutation_result import (
+            ReceiverOwnedMutationResult,
+        )
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        from sugar_lift_py_tests.outcome import Complete
+
+        entries = value.statements if isinstance(value, BlockValue) else (value,)
+        mutations = tuple(
+            entry
+            for entry in entries
+            if isinstance(entry, ReceiverOwnedMutationResult)
+            and type(entry.receiver_before) is type(self)
+            and entry.receiver_before.identity == self.identity
+        )
+        if len(mutations) != 1:
+            construction_panic_gap(
+                owner="MappingObjectValue.setitem",
+                blame=self.identity,
+                observed=f"{len(mutations)} receiver-owned mutation results",
+                requested="one authenticated __setitem__ receiver transition",
+                fix="preserve the source __setitem__ body mutation or keep loud",
+            )
+        return Complete(mutations[0].receiver_after)
 
     def delitem(self, index, site):
         from sugar_lift_py_tests.outcome import Complete
@@ -84,8 +155,12 @@ class MappingObjectValue(ObjectValue):
         if required_frame is None and not keywords:
             if name == "__getitem__" and len(arguments) == 1:
                 return self.subscript(arguments[0], blame)
-            if name == "__setitem__" and len(arguments) == 2:
-                return self.setitem(arguments[0], arguments[1], blame)
+            if (
+                name == "__setitem__"
+                and len(arguments) == 2
+                and not self.has_method("__setitem__")
+            ):
+                return self.mapping_builtin_setitem(arguments[0], arguments[1], blame)
             if name == "__delitem__" and len(arguments) == 1:
                 return self.delitem(arguments[0], blame)
             if (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mapping_object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mapping_object_value.py
@@ -17,8 +17,6 @@ class MappingObjectValue(ObjectValue):
     """
 
     entries: tuple = ()
-    defining_class: object | None = None
-
     def guarded(self, formula):
         """A constructed mapping state contributes no independent control.
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_method_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_method_value.py
@@ -24,6 +24,10 @@ class ObjectMethodValue(FloorValue):
     formal_coordinate_cids: tuple[str, ...] = ()
     source_call_frame: object | None = field(default=None, compare=False, repr=False)
     descriptor_kind: str | None = None
+    # Exact lexical owner of this method body.  Inherited methods retain their
+    # defining class rather than being rebound to the runtime receiver class;
+    # this is the authenticated ``__class__`` cell used by zero-arg super().
+    defining_class: object | None = field(default=None, compare=False, repr=False)
 
     def __post_init__(self) -> None:
         from sugar_lift_py_tests.sugar.sugar_base import Sugar

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -108,6 +108,11 @@ class ObjectValue(FloorValue):
     deleted_instance_fields: tuple[str, ...] = dataclass_field(
         default=(), compare=False
     )
+    # Definition-owned class identity transported by ClassDefinitionValue.
+    # This is never reconstructed from class_name.
+    defining_class: object | None = dataclass_field(
+        default=None, compare=False, repr=False
+    )
 
     def format_data_model(self, spec, site, ctx):
         return self.call_method_value(
@@ -681,6 +686,7 @@ class ObjectValue(FloorValue):
                 source_call_frame_cid=method.source_call_frame_cid,
                 formal_coordinate_cids=method.formal_coordinate_cids,
                 bound_source_actuals=bound_source_actuals,
+                lexical_defining_class=method.defining_class,
             )
             if not any(
                 isinstance(value, (SymbolicValue, CallSiteValue))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_owned_mutation_result.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_owned_mutation_result.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+
+
+@dataclass(frozen=True)
+class ReceiverOwnedMutationResult(FloorValue):
+    """One immutable receiver transition plus the operation's Python result."""
+
+    receiver_before: FloorValue
+    receiver_after: FloorValue
+    result: FloorValue
+
+    def contribution(self):
+        return (self,)
+
+    def as_expression_statement(self):
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(self)
+
+    def answer(self, ctx=None):
+        del ctx
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(self.result)
+
+    def project_operation_receiver(self, ctx, *, owner):
+        del ctx, owner
+        return self.result
+
+    def extend_scope(self, ctx):
+        """Advance every alias carrying this exact receiver identity."""
+        if ctx is None:
+            from sugar_lift_py_tests.context import ReduceContext
+
+            ctx = ReduceContext.root(owner="ReceiverOwnedMutationResult")
+        identity = getattr(self.receiver_before, "identity", None)
+        if not isinstance(identity, str) or not identity:
+            return ctx
+        temporal = ctx.temporal
+        matched = False
+        for binding in ctx.temporal.bindings:
+            candidate = binding.value
+            if (
+                type(candidate) is type(self.receiver_before)
+                and getattr(candidate, "identity", None) == identity
+            ):
+                temporal = temporal.bind_value(
+                    binding.name, self.receiver_after, blame=binding.blame
+                )
+                matched = True
+        return ctx.with_temporal(temporal) if matched else ctx
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor
+
+        return ctor(
+            "python:receiver-owned-mutation-result",
+            (
+                self.receiver_before.to_term(owner=owner),
+                self.receiver_after.to_term(owner=owner),
+                self.result.to_term(owner=owner),
+            ),
+        )
+

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/dict_setdefault_append_state_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/dict_setdefault_append_state_sugar.py
@@ -49,13 +49,15 @@ class DictSetDefaultAppendStateSugar(ConstructedTermSugar):
             lambda receiver: self.key.desugar(ctx).and_then(
                 lambda key: self.default.desugar(ctx).and_then(
                     lambda default: self.appended.desugar(ctx).and_then(
-                        lambda appended: self._apply(receiver, key, default, appended)
+                        lambda appended: self._apply(
+                            receiver, key, default, appended, ctx
+                        )
                     )
                 )
             )
         )
 
-    def _apply(self, receiver, key, default, appended):
+    def _apply(self, receiver, key, default, appended, ctx):
         from sugar_lift_py_tests.floor.dict_value import DictValue
         from sugar_lift_py_tests.floor.mapping_object_value import MappingObjectValue
         from sugar_lift_py_tests.floor.string_value import StringValue
@@ -92,6 +94,9 @@ class DictSetDefaultAppendStateSugar(ConstructedTermSugar):
         appended_outcome = selected.append_with(appended, self.site)
 
         def with_appended(appended_value):
+            setitem_with_context = getattr(updated, "setitem_with_context", None)
+            if setitem_with_context is not None:
+                return setitem_with_context(key, appended_value, self.site, ctx)
             return updated.setitem(key, appended_value, self.site)
 
         return appended_outcome.and_then(with_appended)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
@@ -241,7 +241,12 @@ class SubscriptStoreEffectSugar(Sugar):
                 ),
                 fix="attach the three-operand carrier seam owned by 9883",
             )
-        projected = receiver.setitem(index, value, self.site)
+        source_aware = getattr(receiver, "setitem_with_context", None)
+        projected = (
+            source_aware(index, value, self.site, ctx)
+            if callable(source_aware)
+            else receiver.setitem(index, value, self.site)
+        )
         from sugar_lift_py_tests.floor import RaiseValue
         from sugar_lift_py_tests.outcome import Complete, Incomplete
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_enum_setitem_lineage.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enum_setitem_lineage.py
@@ -51,13 +51,15 @@ def _source_method_outcome(receiver, context, key="member", value=7):
     assert isinstance(selected.value, CallSiteValue), (
         "a source __setitem__ override must be selected before builtin dict mutation"
     )
-    return selected.value.producer_outcome(context)
+    return receiver.setitem_with_context(
+        StringValue(key), TermValue(value), "setitem-site", context
+    )
 
 
 def _mutation_products(outcome):
     assert isinstance(outcome, Complete)
     result = getattr(outcome.value, "result", None)
-    receiver = getattr(outcome.value, "receiver", None)
+    receiver = getattr(outcome.value, "receiver_after", None)
     assert isinstance(result, NoneValue)
     assert isinstance(receiver, MappingObjectValue)
     return result, receiver
@@ -90,7 +92,8 @@ def test_source_setitem_runs_then_super_returns_none_with_updated_receiver() -> 
     )
 
     outcome = _source_method_outcome(receiver, context)
-    _result, updated = _mutation_products(outcome)
+    assert isinstance(outcome, Complete)
+    updated = outcome.value
 
     assert updated.identity == receiver.identity
     assert updated.entries == ((StringValue("member"), TermValue(7)),)
@@ -165,4 +168,3 @@ def test_type_new_consumes_the_post_setitem_namespace_not_its_pre_state() -> Non
         (StringValue("_member_map_"), TermValue(7)),
     )
     assert class_dict.value.entries != namespace.entries
-

--- a/implementations/python/sugar-lift-py-tests/tests/test_enum_setitem_lineage.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enum_setitem_lineage.py
@@ -1,0 +1,168 @@
+"""Enum namespace writes retain source override and builtin mutation lineage."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sugar_lift_py_tests.context import ReduceContext
+from sugar_lift_py_tests.floor import (
+    BuiltinDictClassValue,
+    BuiltinSuperValue,
+    CallSiteValue,
+    MappingObjectValue,
+    NoneValue,
+    RuntimeClassValue,
+    StringValue,
+    TermValue,
+    TupleValue,
+)
+from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import ClassDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _source_receiver(source: str):
+    tree = SourceFile(
+        (source, "enum_setitem_lineage.py", blake3_512_of(source.encode()))
+    )
+    definition = next(
+        node for node in tree.root.body if isinstance(node, ClassDef)
+    )
+    context = ReduceContext.root(owner="test_enum_setitem_lineage")
+    class_outcome = definition.sugar().desugar(context)
+    assert isinstance(class_outcome, Complete)
+    receiver = class_outcome.value.construct_receiver_state_from_block(
+        None, "namespace-coordinate"
+    )
+    assert isinstance(receiver, MappingObjectValue)
+    return receiver, context
+
+
+def _source_method_outcome(receiver, context, key="member", value=7):
+    selected = receiver.call_method_value(
+        "__setitem__",
+        (StringValue(key), TermValue(value)),
+        owner="test_enum_setitem_lineage",
+        blame="setitem-site",
+        ctx=context,
+    )
+    assert isinstance(selected, Complete)
+    assert isinstance(selected.value, CallSiteValue), (
+        "a source __setitem__ override must be selected before builtin dict mutation"
+    )
+    return selected.value.producer_outcome(context)
+
+
+def _mutation_products(outcome):
+    assert isinstance(outcome, Complete)
+    result = getattr(outcome.value, "result", None)
+    receiver = getattr(outcome.value, "receiver", None)
+    assert isinstance(result, NoneValue)
+    assert isinstance(receiver, MappingObjectValue)
+    return result, receiver
+
+
+def test_source_setitem_halt_precedes_and_blocks_builtin_dict_mutation() -> None:
+    """Lying face: direct builtin mutation cannot bypass the source override."""
+    receiver, context = _source_receiver(
+        "class EnumNamespace(dict):\n"
+        "    def __setitem__(self, key, value):\n"
+        "        raise ValueError('source override ran')\n"
+    )
+
+    outcome = _source_method_outcome(receiver, context)
+
+    assert isinstance(outcome, ExitSet)
+    halted = tuple(face for face in outcome.exits if isinstance(face, Halted))
+    assert len(halted) == 1
+    assert halted[0].effect.exception_name == "ValueError"
+    assert receiver.entries == ()
+
+
+def test_source_setitem_runs_then_super_returns_none_with_updated_receiver() -> None:
+    """Truthful face: source effects precede one receiver-owned base mutation."""
+    receiver, context = _source_receiver(
+        "class EnumNamespace(dict):\n"
+        "    def __setitem__(self, key, value):\n"
+        "        self.seen = key\n"
+        "        super().__setitem__(key, value)\n"
+    )
+
+    outcome = _source_method_outcome(receiver, context)
+    _result, updated = _mutation_products(outcome)
+
+    assert updated.identity == receiver.identity
+    assert updated.entries == ((StringValue("member"), TermValue(7)),)
+    seen = updated.attribute("seen", "seen-site")
+    assert isinstance(seen, Complete)
+    assert seen.value == StringValue("member")
+
+
+def test_super_setitem_returns_none_and_carries_updated_namespace() -> None:
+    """The builtin base call has two products; neither may replace the other."""
+    base = BuiltinDictClassValue(operation="python.dict.construct")
+    receiver = MappingObjectValue(
+        "EnumNamespace", (), identity="namespace-coordinate", entries=()
+    )
+    selected_super = BuiltinSuperValue(
+        current_class=SimpleNamespace(base_classes=(base,)),
+        receiver=receiver,
+    )
+
+    outcome = selected_super.call_method_value(
+        "__setitem__",
+        (StringValue("_member_map_"), TermValue(7)),
+        owner="test_enum_setitem_lineage",
+        blame="super-setitem-site",
+    )
+    _result, updated = _mutation_products(outcome)
+
+    assert updated.identity == receiver.identity
+    assert updated.entries == ((StringValue("_member_map_"), TermValue(7)),)
+
+
+def test_type_new_consumes_the_post_setitem_namespace_not_its_pre_state() -> None:
+    """Deleting receiver transport makes ``_member_map_`` vanish at type.__new__."""
+    type_base = SimpleNamespace(name="type")
+    type_super = BuiltinSuperValue(
+        current_class=SimpleNamespace(base_classes=(type_base,)),
+        receiver=TermValue("metaclass"),
+    )
+    dict_base = BuiltinDictClassValue(operation="python.dict.construct")
+    namespace = MappingObjectValue(
+        "EnumNamespace", (), identity="namespace-coordinate", entries=()
+    )
+    dict_super = BuiltinSuperValue(
+        current_class=SimpleNamespace(base_classes=(dict_base,)),
+        receiver=namespace,
+    )
+    mutation = dict_super.call_method_value(
+        "__setitem__",
+        (StringValue("_member_map_"), TermValue(7)),
+        owner="test_enum_setitem_lineage",
+        blame="super-setitem-site",
+    )
+    _result, updated = _mutation_products(mutation)
+
+    created = type_super.call_method_value(
+        "__new__",
+        (
+            TermValue("metaclass"),
+            StringValue("Made"),
+            TupleValue(()),
+            updated,
+        ),
+        owner="test_enum_setitem_lineage",
+        blame="type-new-site",
+    )
+
+    assert isinstance(created, Complete)
+    assert isinstance(created.value, RuntimeClassValue)
+    class_dict = created.value.attribute("__dict__", "dict-site")
+    assert isinstance(class_dict, Complete)
+    assert class_dict.value.entries == (
+        (StringValue("_member_map_"), TermValue(7)),
+    )
+    assert class_dict.value.entries != namespace.entries
+

--- a/implementations/python/sugar-lift-py-tests/tests/test_method_defining_class_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_method_defining_class_transport.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from sugar_lift_py_tests.context import ReduceContext
+from sugar_lift_py_tests.floor import CallSiteValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import ClassDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _definitions():
+    source = (
+        "class Base:\n"
+        "    def owner(self):\n"
+        "        return __class__\n"
+        "\n"
+        "class Derived(Base):\n"
+        "    pass\n"
+    )
+    tree = SourceFile((source, "defining_class.py", blake3_512_of(source.encode())))
+    return tuple(node for node in tree.root.body if isinstance(node, ClassDef))
+
+
+def _constructed_pair():
+    base, derived = _definitions()
+    context = ReduceContext.root(owner="test")
+    base_value = base.sugar().desugar(context).value
+    context.temporal = context.temporal.bind_value("Base", base_value)
+    derived_value = derived.sugar().desugar(context).value
+    return context, base_value, derived_value
+
+
+def test_receiver_and_inherited_method_retain_distinct_class_owners() -> None:
+    _context, base, derived = _constructed_pair()
+
+    receiver = derived.construct_receiver_state_from_block(None, "receiver")
+    (owner_method,) = tuple(method for method in receiver.methods if method.name == "owner")
+
+    assert receiver.defining_class is derived
+    assert owner_method.defining_class is base
+
+
+def test_inherited_method_binds_lexical_class_not_runtime_receiver_class() -> None:
+    context, base, derived = _constructed_pair()
+    receiver = derived.construct_receiver_state_from_block(None, "receiver")
+
+    projected = receiver.call_method_value(
+        "owner", (), owner="test", blame="call-owner", ctx=context
+    )
+
+    assert isinstance(projected, Complete)
+    assert isinstance(projected.value, CallSiteValue)
+    assert projected.value.lexical_defining_class is base
+    reduced = projected.value.reduce_source_outcome(context)
+    assert isinstance(reduced, Complete)
+    assert reduced.value.statements[0].value is base
+
+
+def test_overriding_method_uses_derived_defining_class() -> None:
+    base, _ = _definitions()
+    source = (
+        "class Derived:\n"
+        "    def owner(self):\n"
+        "        return __class__\n"
+    )
+    tree = SourceFile((source, "derived_owner.py", blake3_512_of(source.encode())))
+    (derived,) = tuple(node for node in tree.root.body if isinstance(node, ClassDef))
+    context = ReduceContext.root(owner="test")
+    derived_value = derived.sugar().desugar(context).value
+    receiver = derived_value.construct_receiver_state_from_block(None, "receiver")
+
+    projected = receiver.call_method_value(
+        "owner", (), owner="test", blame="call-owner", ctx=context
+    ).value
+
+    assert projected.lexical_defining_class is derived_value
+    reduced = projected.reduce_source_outcome(context)
+    assert reduced.value.statements[0].value is derived_value

--- a/implementations/python/sugar-lift-py-tests/tests/test_receiver_owned_mapping_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_receiver_owned_mapping_mutation.py
@@ -1,0 +1,79 @@
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.context import ReduceContext
+from sugar_lift_py_tests.floor import (
+    BuiltinSuperValue,
+    MappingObjectValue,
+    NoneValue,
+    ReceiverOwnedMutationResult,
+    StringValue,
+    TermValue,
+)
+from sugar_lift_py_tests.outcome import Complete
+from sugar_source_tree.nodes import ClassDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _definition_and_receiver():
+    source = (
+        "class Mapping(dict):\n"
+        "    def __setitem__(self, key, value):\n"
+        "        super().__setitem__(key, value)\n"
+    )
+    tree = SourceFile((source, "mapping_setitem.py", blake3_512_of(source.encode())))
+    definition = next(node for node in tree.root.body if isinstance(node, ClassDef))
+    value = definition.sugar().desugar(ReduceContext.root(owner="test")).value
+    return value, value.construct_receiver_state_from_block(None, "receiver")
+
+
+def test_builtin_super_setitem_carries_receiver_transition_and_none_separately():
+    definition, receiver = _definition_and_receiver()
+    outcome = BuiltinSuperValue(definition, receiver).call_method_value(
+        "__setitem__",
+        (StringValue("member"), TermValue(7)),
+        owner="test",
+        blame="site",
+    )
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, ReceiverOwnedMutationResult)
+    assert isinstance(outcome.value.project_operation_receiver(None, owner="test"), NoneValue)
+    assert outcome.value.receiver_before is receiver
+    assert outcome.value.receiver_after.identity == receiver.identity
+    assert outcome.value.receiver_after.entries == ((StringValue("member"), TermValue(7)),)
+
+
+def test_receiver_transition_updates_every_exact_identity_alias_only():
+    definition, receiver = _definition_and_receiver()
+    distinct = MappingObjectValue("Mapping", (), identity="other")
+    result = BuiltinSuperValue(definition, receiver).call_method_value(
+        "__setitem__",
+        (StringValue("member"), TermValue(7)),
+        owner="test",
+        blame="site",
+    ).value
+    ctx = ReduceContext.root(owner="test")
+    ctx = ctx.with_temporal(ctx.temporal.bind_value("left", receiver))
+    ctx = ctx.with_temporal(ctx.temporal.bind_value("alias", receiver.mapping_with_entries(())))
+    ctx = ctx.with_temporal(ctx.temporal.bind_value("distinct", distinct))
+
+    updated = result.extend_scope(ctx)
+
+    assert updated.temporal.value_for("left") == result.receiver_after
+    assert updated.temporal.value_for("alias") == result.receiver_after
+    assert updated.temporal.value_for("distinct") is distinct
+
+
+def test_source_setitem_body_projects_updated_receiver_not_none_result():
+    _definition, receiver = _definition_and_receiver()
+
+    outcome = receiver.setitem_with_context(
+        StringValue("member"),
+        TermValue(7),
+        "caller",
+        ReduceContext.root(owner="caller"),
+    )
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, MappingObjectValue)
+    assert outcome.value.identity == receiver.identity
+    assert outcome.value.entries == ((StringValue("member"), TermValue(7)),)


### PR DESCRIPTION
Vertical fix for the option_context lifecycle. Threads defining-class authority and receiver-owned mapping mutation through ordinary source method reduction, then routes dict.setdefault(...).append(...) through the same context-aware setitem producer.\n\nEvidence: 10 focused laws pass. The exact lifecycle advances from MappingObjectValue.setitem / missing reduction context to the next independent enum.py:399 _cls_name receiver-return-state boundary; it remains honestly red there.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Transport source mapping mutation through class construction by propagating `defining_class` and `__class__` cell
> - Adds `defining_class` to `ObjectMethodValue`, `ObjectValue`, and `CallSiteValue` so each method call carries its lexical class owner; `CallSiteValue.reduce_source_outcome` binds this as `__class__` before reducing the body, enabling zero-arg `super()`.
> - Introduces `ReceiverOwnedMutationResult`, a new `FloorValue` that pairs a before/after receiver with an operation result, allowing mutations to propagate updated receiver state through scope aliases.
> - Adds `MappingObjectValue.setitem_with_context` and `mapping_builtin_setitem` to support source-defined `__setitem__` with a proper `__class__` cell; `BuiltinSuperValue` now handles `super().__setitem__` against dict by returning a `ReceiverOwnedMutationResult` instead of panicking.
> - Updates `SubscriptStoreEffectSugar` and `DictSetDefaultAppendStateSugar` to prefer `setitem_with_context` when available, preserving source semantics during subscript stores.
> - Risk: `MappingObjectValue.setitem` now raises a `construction_panic_gap` if a source-defined `__setitem__` exists but no reduction context is provided, where previously it would silently dispatch to builtin semantics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da4867c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->