### PR TITLE
Make shared sugarbin cells peer-readable

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -769,11 +769,11 @@ try:
 except OSError:
     raise SystemExit(1)
 
-if directory_mode & 0o005 != 0o005:
+if directory_mode != 0o755:
     raise SystemExit(1)
-if candidate_mode & 0o005 != 0o005:
+if candidate_mode != 0o755:
     raise SystemExit(1)
-if manifest_mode & 0o004 != 0o004:
+if manifest_mode != 0o644:
     raise SystemExit(1)
 PY
 }
@@ -1214,9 +1214,9 @@ try:
 except OSError:
     raise SystemExit(1)
 
-if cell_mode & 0o005 != 0o005:
+if cell_mode != 0o755:
     raise SystemExit(1)
-if any(mode & 0o004 != 0o004 for mode in artifact_modes):
+if any(mode != 0o644 for mode in artifact_modes):
     raise SystemExit(1)
 PY
 }

--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -712,6 +712,7 @@ data = {"schema": 1, "binary": binary, "package": package, "sourceStamp": stamp,
 os.makedirs(os.path.dirname(path), exist_ok=True)
 fd, tmp = tempfile.mkstemp(prefix=".sugarbin-manifest-", dir=os.path.dirname(path))
 with os.fdopen(fd, "w") as out: json.dump(data, out, indent=2, sort_keys=True); out.write("\n")
+os.chmod(tmp, 0o644)
 os.replace(tmp, path)
 PY
 }
@@ -751,6 +752,30 @@ github_repo() {
 
 cache_dir() {
   printf '%s\n' "${SUGAR_BINARY_CACHE_DIR:-$HOME/.cache/sugar/binaries}"
+}
+
+shared_cache_cell_is_peer_readable() {
+  local candidate="$1" manifest="$2"
+  python3 - "$candidate" "$manifest" <<'PY'
+import os
+import stat
+import sys
+
+candidate, manifest = sys.argv[1:]
+try:
+    directory_mode = stat.S_IMODE(os.stat(os.path.dirname(candidate)).st_mode)
+    candidate_mode = stat.S_IMODE(os.stat(candidate).st_mode)
+    manifest_mode = stat.S_IMODE(os.stat(manifest).st_mode)
+except OSError:
+    raise SystemExit(1)
+
+if directory_mode & 0o005 != 0o005:
+    raise SystemExit(1)
+if candidate_mode & 0o005 != 0o005:
+    raise SystemExit(1)
+if manifest_mode & 0o004 != 0o004:
+    raise SystemExit(1)
+PY
 }
 
 # The cache is ONE host directory reached under two names: HOME is
@@ -1087,7 +1112,8 @@ pull_from_shelf() {
   mkdir -p "$candidate_dir"
   cp "$downloaded" "$candidate"
   cp "$downloaded_manifest" "$manifest"
-  chmod +x "$candidate"
+  chmod 0755 "$candidate_dir" "$candidate"
+  chmod 0644 "$manifest"
   verify_artifact_manifest "$candidate" "$stamp" "$identity" "downloaded shelf artifact" || return 1
   verify_attestation_if_present "$candidate" "$stamp"
   materialize_cached_artifact "$candidate" "$stamp" "$identity"
@@ -1171,19 +1197,81 @@ filesystem_shelf_complete() {
     && -f "$cell/$name.metadata.json" ]]
 }
 
+filesystem_shelf_cell_is_peer_readable() {
+  local cell="$1" name="$2"
+  python3 - "$cell" "$name" <<'PY'
+import os
+import stat
+import sys
+
+cell, name = sys.argv[1:]
+try:
+    cell_mode = stat.S_IMODE(os.stat(cell).st_mode)
+    artifact_modes = [
+        stat.S_IMODE(os.stat(os.path.join(cell, f"{name}{suffix}")).st_mode)
+        for suffix in (".gz", ".sugarbin.json", ".metadata.json")
+    ]
+except OSError:
+    raise SystemExit(1)
+
+if cell_mode & 0o005 != 0o005:
+    raise SystemExit(1)
+if any(mode & 0o004 != 0o004 for mode in artifact_modes):
+    raise SystemExit(1)
+PY
+}
+
+ensure_shared_shelf_staging() {
+  local root="$1" target="$2"
+  python3 - "$root" "$target" <<'PY'
+import os
+import pathlib
+import stat
+import sys
+
+root = pathlib.Path(sys.argv[1]).resolve()
+target = pathlib.Path(sys.argv[2]).resolve()
+try:
+    target.relative_to(root)
+except ValueError:
+    raise SystemExit(2)
+
+current = root
+current.mkdir(parents=True, exist_ok=True)
+if stat.S_IMODE(current.stat().st_mode) != 0o777:
+    os.chmod(current, 0o777)
+for part in target.relative_to(root).parts:
+    current /= part
+    current.mkdir(exist_ok=True)
+    if stat.S_IMODE(current.stat().st_mode) != 0o777:
+        os.chmod(current, 0o777)
+PY
+}
+
 publish_to_filesystem_shelf() {
-  local bin="$1" stamp="$2" name="$3" kind="${4:-binary}" runtime="${5:-}" manifest cell parent tmp actor sha meta
+  local bin="$1" stamp="$2" name="$3" kind="${4:-binary}" runtime="${5:-}" manifest cell parent tmp actor sha meta shelf_root
   manifest="$(artifact_manifest_path "$bin")"
   [[ "${SUGAR_BINARY_PUBLISH:-1}" != "0" ]] || { log "publish disabled by SUGAR_BINARY_PUBLISH=0"; return 0; }
   cell="$(filesystem_shelf_cell "$kind" "$stamp" "$name" "$runtime")"
   if filesystem_shelf_complete "$cell" "$name"; then
+    if ! filesystem_shelf_cell_is_peer_readable "$cell" "$name"; then
+      log "crime=private-filesystem-shelf-cell owner=bin/sugarbin cell=$cell illegal shape=a content-addressed shelf cell is readable only by its creating identity replacement=repair the cell to directory mode 0755 and artifact modes 0644, then keep publication behind bin/sugarbin"
+      return 2
+    fi
     log "filesystem shelf already has $name"
     return 0
   fi
   command -v gzip >/dev/null 2>&1 || { log "gzip not found; cannot publish $name"; return 1; }
   parent="$(dirname "$cell")"
-  mkdir -p "$parent/.incoming"
-  tmp="$(mktemp -d "$parent/.incoming/$name.XXXXXX")"
+  shelf_root="$(filesystem_shelf_root)"
+  if ! ensure_shared_shelf_staging "$shelf_root" "$parent/.incoming"; then
+    log "crime=uncreatable-filesystem-shelf-staging owner=bin/sugarbin path=$parent/.incoming current-uid=$(id -u) illegal shape=the host-shared shelf staging directory could not be initialized replacement=make the mounted shelf root writable by every runner identity; do not redirect the shelf or fall through to an empty temp path"
+    return 2
+  fi
+  if ! tmp="$(mktemp -d "$parent/.incoming/$name.XXXXXX")"; then
+    log "crime=uncreatable-filesystem-shelf-staging owner=bin/sugarbin path=$parent/.incoming current-uid=$(id -u) illegal shape=the host-shared shelf staging directory could not create an atomic cell replacement=repair the mounted shelf parent; do not redirect the shelf or fall through to an empty temp path"
+    return 2
+  fi
   gzip -9 -c "$bin" >"$tmp/$name.gz"
   cp "$manifest" "$tmp/$name.sugarbin.json"
   actor="${GITHUB_ACTOR:-${USER:-unknown}}"
@@ -1208,6 +1296,8 @@ with open(path, "w", encoding="utf-8") as out:
     }, out, indent=2, sort_keys=True)
     out.write("\n")
 PY
+  chmod 0755 "$tmp"
+  chmod 0644 "$tmp/$name.gz" "$tmp/$name.sugarbin.json" "$tmp/$name.metadata.json"
   # Atomic cell install. Concurrent publishers race on the same cell:
   # Linux raises ENOTEMPTY (not FileExistsError) when renaming onto a
   # non-empty destination directory. Treat complete peer cells as success;
@@ -1263,7 +1353,8 @@ PY
   # peer could still have won the rename). Success iff the cell is complete by
   # ANY publisher -- content is content-addressed and immutable, so a peer's
   # complete cell is exactly ours.
-  if filesystem_shelf_complete "$cell" "$name"; then
+  if filesystem_shelf_complete "$cell" "$name" \
+    && filesystem_shelf_cell_is_peer_readable "$cell" "$name"; then
     log "filesystem shelf publish raced for $name; peer won"
     return 0
   fi
@@ -1277,6 +1368,11 @@ pull_from_filesystem_shelf() {
   candidate_dir="$dir/$name"
   candidate="$candidate_dir/$bin_name"
   manifest="$(artifact_manifest_path "$candidate")"
+  if [[ -f "$candidate" && -f "$manifest" ]] \
+    && ! shared_cache_cell_is_peer_readable "$candidate" "$manifest"; then
+    log "crime=private-shared-cache-cell owner=bin/sugarbin cell=$candidate_dir illegal shape=a content-addressed binary cache cell is readable only by its creating identity replacement=repair the cell to directory/binary mode 0755 and manifest mode 0644; do not repoint SUGAR_BINARY_CACHE_DIR"
+    return 2
+  fi
   if verify_artifact_manifest "$candidate" "$stamp" "$identity" "prebuilt cache"; then
     log "prebuilt cache hit for $name"
     materialize_cached_artifact "$candidate" "$stamp" "$identity"
@@ -1284,6 +1380,11 @@ pull_from_filesystem_shelf() {
   fi
   [[ "${SUGAR_BINARY_NO_SHELF:-0}" != "1" ]] || { log "shelf pull disabled by SUGAR_BINARY_NO_SHELF=1"; return 1; }
   cell="$(filesystem_shelf_cell binary "$stamp" "$name")"
+  if filesystem_shelf_complete "$cell" "$name" \
+    && ! filesystem_shelf_cell_is_peer_readable "$cell" "$name"; then
+    log "crime=private-filesystem-shelf-cell owner=bin/sugarbin cell=$cell illegal shape=a content-addressed shelf cell is readable only by its creating identity replacement=repair the cell to directory mode 0755 and artifact modes 0644, then keep publication behind bin/sugarbin"
+    return 2
+  fi
   if ! filesystem_shelf_complete "$cell" "$name"; then
     log "filesystem shelf miss for $name"
     return 1
@@ -1293,7 +1394,8 @@ pull_from_filesystem_shelf() {
   tmp="$candidate.sugarbin-stage.$$"
   gzip -dc "$cell/$name.gz" >"$tmp"
   cp "$cell/$name.sugarbin.json" "$manifest"
-  chmod +x "$tmp"
+  chmod 0755 "$candidate_dir" "$tmp"
+  chmod 0644 "$manifest"
   mv -f "$tmp" "$candidate"
   if ! verify_artifact_manifest "$candidate" "$stamp" "$identity" "filesystem shelf artifact"; then
     log "crime=corrupt-shelf-cell owner=bin/sugarbin cell=$cell replacement=remove the corrupt cell and rebuild from declared inputs"
@@ -1328,6 +1430,7 @@ fd, temporary = tempfile.mkstemp(prefix=".sugarbin-artifact-manifest-", dir=os.p
 with os.fdopen(fd, "w", encoding="utf-8") as out:
     json.dump(data, out, indent=2, sort_keys=True)
     out.write("\n")
+os.chmod(temporary, 0o644)
 os.replace(temporary, path)
 PY
 }
@@ -1383,6 +1486,11 @@ publish_payload_artifact() {
 pull_payload_artifact() {
   local kind="$1" key="$2" runtime="$3" output="$4" name="$5" cell staging payload manifest output_manifest
   cell="$(filesystem_shelf_cell "$kind" "$key" "$name" "$runtime")"
+  if filesystem_shelf_complete "$cell" "$name" \
+    && ! filesystem_shelf_cell_is_peer_readable "$cell" "$name"; then
+    log "crime=private-filesystem-shelf-cell owner=bin/sugarbin cell=$cell illegal shape=a content-addressed shelf cell is readable only by its creating identity replacement=repair the cell to directory mode 0755 and artifact modes 0644, then keep publication behind bin/sugarbin"
+    return 2
+  fi
   if ! filesystem_shelf_complete "$cell" "$name"; then
     log "filesystem shelf miss for $kind key $key"
     return 1

--- a/tests/sugarbin_artifact_manifest.sh
+++ b/tests/sugarbin_artifact_manifest.sh
@@ -161,7 +161,34 @@ grep -Fq 'crime=private-shared-cache-cell' <<<"$private_cache_refusal" || {
   printf '%s\n' "$private_cache_refusal" >&2
   exit 1
 }
-find "$tmp/cache" -type f -name '*.sugarbin.json' -exec chmod 0644 {} +
+for cache_cell in "$tmp/cache"/sugar-*; do
+  chmod 0777 "$cache_cell"
+  find "$cache_cell" -maxdepth 1 -type f ! -name '*.sugarbin.json' -exec chmod 0777 {} +
+  find "$cache_cell" -maxdepth 1 -type f -name '*.sugarbin.json' -exec chmod 0666 {} +
+done
+# Peer-readable is insufficient for a content-addressed resident. A second
+# runner must not be able to mutate the directory, executable, or manifest
+# after the creating identity has authenticated its content.
+set +e
+mutable_cache_refusal="$(
+  SUGAR_BINARY_ALLOW_BUILD=0 "$repo/bin/sugarbin" --bin sugar 2>&1 >/dev/null
+)"
+mutable_cache_status=$?
+set -e
+[[ "$mutable_cache_status" != 0 ]] || {
+  echo 'a world-writable shared-cache cell was accepted by its creating identity' >&2
+  exit 1
+}
+grep -Fq 'crime=private-shared-cache-cell' <<<"$mutable_cache_refusal" || {
+  echo 'a world-writable shared-cache cell did not refuse by name' >&2
+  printf '%s\n' "$mutable_cache_refusal" >&2
+  exit 1
+}
+for cache_cell in "$tmp/cache"/sugar-*; do
+  chmod 0755 "$cache_cell"
+  find "$cache_cell" -maxdepth 1 -type f ! -name '*.sugarbin.json' -exec chmod 0755 {} +
+  find "$cache_cell" -maxdepth 1 -type f -name '*.sugarbin.json' -exec chmod 0644 {} +
+done
 cat >"$tmp/bin/gh" <<'SH'
 #!/usr/bin/env bash
 exit 1

--- a/tests/sugarbin_artifact_manifest.sh
+++ b/tests/sugarbin_artifact_manifest.sh
@@ -88,8 +88,9 @@ chmod +x "$tmp/target/release/sugar-ir-smt-lib"
 build_dirs="$(find "$tmp/cache/.build" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
 [[ "$build_dirs" == 1 ]] || { echo "binary misses used $build_dirs Cargo target families" >&2; exit 1; }
 python3 - "$tmp/target/release/sugar.sugarbin.json" <<'PY'
-import json, sys
-with open(sys.argv[1]) as f: data = json.load(f)
+import json, pathlib, stat, sys
+manifest = pathlib.Path(sys.argv[1])
+with manifest.open() as f: data = json.load(f)
 required = {"schema", "binary", "package", "sourceStamp", "buildIdentity", "platform",
             "targetTriple", "profile", "features", "rustc", "cargo", "sha256", "built", "executed"}
 assert set(data) == required
@@ -100,6 +101,10 @@ assert data["cargo"].startswith("cargo 1.96.0")
 assert "\nrelease: 1.96.0\n" in data["cargo"]
 assert "\nhost: x86_64-unknown-linux-gnu\n" in data["cargo"]
 assert data["built"] is True and data["executed"] is False
+assert stat.S_IMODE(manifest.stat().st_mode) == 0o644, (
+    "an immutable manifest is shared across runner identities and must be "
+    f"peer-readable, got {stat.S_IMODE(manifest.stat().st_mode):04o}"
+)
 PY
 
 # A valid manifest is a cache hit, but cache hits skip compilation only.
@@ -123,7 +128,7 @@ grep -Fq 'artifact checksum mismatch' "$tmp/corrupt.err"
 
 # Separate shelf identity directories are coalesced into one truthful run PATH.
 python3 - "$tmp/target/release" "$tmp/cache" <<'PY'
-import json, pathlib, shutil, sys
+import json, os, pathlib, shutil, sys
 target, cache = map(pathlib.Path, sys.argv[1:])
 for binary in ("sugar", "sugar-ir-smt-lib"):
     manifest = target / f"{binary}.sugarbin.json"
@@ -133,9 +138,30 @@ for binary in ("sugar", "sugar-ir-smt-lib"):
     cell.mkdir(parents=True)
     shutil.copy2(target / binary, cell / binary)
     shutil.copy2(manifest, cell / f"{binary}.sugarbin.json")
+    os.chmod(cell / f"{binary}.sugarbin.json", 0o600)
     (target / binary).unlink()
     manifest.unlink()
 PY
+# A private manifest may be readable by its creating identity (and by root),
+# but it is not a valid resident of the host-shared cache. The broker must
+# refuse the lying face by mode before a privileged caller can bless it as a
+# cache hit that the next runner identity cannot read.
+set +e
+private_cache_refusal="$(
+  SUGAR_BINARY_ALLOW_BUILD=0 "$repo/bin/sugarbin" --bin sugar 2>&1 >/dev/null
+)"
+private_cache_status=$?
+set -e
+[[ "$private_cache_status" != 0 ]] || {
+  echo 'a private shared-cache manifest was accepted by its creating identity' >&2
+  exit 1
+}
+grep -Fq 'crime=private-shared-cache-cell' <<<"$private_cache_refusal" || {
+  echo 'a private shared-cache manifest did not refuse by name' >&2
+  printf '%s\n' "$private_cache_refusal" >&2
+  exit 1
+}
+find "$tmp/cache" -type f -name '*.sugarbin.json' -exec chmod 0644 {} +
 cat >"$tmp/bin/gh" <<'SH'
 #!/usr/bin/env bash
 exit 1

--- a/tests/sugarbin_python_demand_table_fixture.sh
+++ b/tests/sugarbin_python_demand_table_fixture.sh
@@ -9,6 +9,7 @@ mkdir -p \
   "$tmp/corpus/pkg" \
   "$tmp/seed-shelf" \
   "$tmp/private-shelf" \
+  "$tmp/mutable-shelf" \
   "$tmp/blocked-shelf" \
   "$tmp/partial-shelf" \
   "$tmp/race-shelf"
@@ -152,6 +153,33 @@ grep -Fq 'crime=private-filesystem-shelf-cell' "$tmp/private.err" || {
 }
 [[ ! -e "$tmp/private-pull.json" ]] || {
   echo 'a private filesystem-shelf cell materialized output' >&2
+  exit 1
+}
+
+# Lying immutability face. Peer read/traverse bits do not make a
+# content-addressed resident immutable: another runner identity can rewrite a
+# 0777 cell or any 0666 byte after the creator has authenticated it.
+cp -R "$tmp/seed-shelf/." "$tmp/mutable-shelf/"
+mutable_cell="$(
+  find "$tmp/mutable-shelf" -type f -name '*.metadata.json' -exec dirname {} \;
+)"
+chmod 0777 "$mutable_cell"
+find "$mutable_cell" -type f -exec chmod 0666 {} +
+set +e
+pull "$tmp/mutable-shelf" "$tmp/mutable-pull.json" 2>"$tmp/mutable.err"
+mutable_status=$?
+set -e
+[[ "$mutable_status" != 0 ]] || {
+  echo 'a world-writable filesystem-shelf cell was accepted by its creating identity' >&2
+  exit 1
+}
+grep -Fq 'crime=private-filesystem-shelf-cell' "$tmp/mutable.err" || {
+  echo 'a world-writable filesystem-shelf cell did not refuse by name' >&2
+  cat "$tmp/mutable.err" >&2
+  exit 1
+}
+[[ ! -e "$tmp/mutable-pull.json" ]] || {
+  echo 'a world-writable filesystem-shelf cell materialized output' >&2
   exit 1
 }
 

--- a/tests/sugarbin_python_demand_table_fixture.sh
+++ b/tests/sugarbin_python_demand_table_fixture.sh
@@ -5,7 +5,13 @@ repo="${1:?usage: sugarbin_python_demand_table_fixture.sh REPO_ROOT}"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-mkdir -p "$tmp/corpus/pkg" "$tmp/seed-shelf" "$tmp/partial-shelf" "$tmp/race-shelf"
+mkdir -p \
+  "$tmp/corpus/pkg" \
+  "$tmp/seed-shelf" \
+  "$tmp/private-shelf" \
+  "$tmp/blocked-shelf" \
+  "$tmp/partial-shelf" \
+  "$tmp/race-shelf"
 printf 'alpha = 1\n' >"$tmp/corpus/pkg/a.py"
 printf 'beta = 2\n' >"$tmp/corpus/pkg/b.py"
 printf '{"rows":["publisher-a"]}\n' >"$tmp/table-a.json"
@@ -85,6 +91,98 @@ grep -Fq 'required=cpython-3.12.13 requested=cpython-3.14.4' "$tmp/wrong-runtime
 # its compressed payload in a separate shelf. Pull must refuse that incomplete
 # cell without materializing a placeholder into the destination.
 publish "$tmp/seed-shelf" "$tmp/table-a.json"
+
+# Truthful shared-permission face. The publisher and consumer may be root,
+# uid 1001 in a runner container, or uid 1000 over SSH. Structural directories
+# therefore remain writable by the next identity, while immutable cell bytes
+# are world-readable and never need to be rewritten.
+python3 - "$tmp/seed-shelf" <<'PY'
+import pathlib
+import stat
+import sys
+
+shelf = pathlib.Path(sys.argv[1]).resolve()
+metadata = list(shelf.rglob("*.metadata.json"))
+assert len(metadata) == 1, metadata
+cell = metadata[0].parent
+stamp_parent = cell.parent
+
+current = shelf
+while True:
+    mode = stat.S_IMODE(current.stat().st_mode)
+    assert mode == 0o777, (
+        f"shared shelf structure must be writable by the next identity: "
+        f"{current} mode={mode:04o}"
+    )
+    if current == stamp_parent:
+        break
+    relative = stamp_parent.relative_to(current)
+    current = current / relative.parts[0]
+
+incoming = stamp_parent / ".incoming"
+assert stat.S_IMODE(incoming.stat().st_mode) == 0o777
+assert stat.S_IMODE(cell.stat().st_mode) == 0o755
+for artifact in cell.iterdir():
+    assert artifact.is_file(), artifact
+    mode = stat.S_IMODE(artifact.stat().st_mode)
+    assert mode == 0o644, f"immutable shelf byte is not peer-readable: {artifact} mode={mode:04o}"
+PY
+
+# Lying shared-permission face. A privileged creator can read a private cell,
+# but accepting it would manufacture a warm-shelf hit that uid 1001 cannot
+# reproduce. The broker must reject the resident by its shared mode contract.
+cp -R "$tmp/seed-shelf/." "$tmp/private-shelf/"
+private_cell="$(
+  find "$tmp/private-shelf" -type f -name '*.metadata.json' -exec dirname {} \;
+)"
+chmod 0700 "$private_cell"
+find "$private_cell" -type f -exec chmod 0600 {} +
+set +e
+pull "$tmp/private-shelf" "$tmp/private-pull.json" 2>"$tmp/private.err"
+private_status=$?
+set -e
+[[ "$private_status" != 0 ]] || {
+  echo 'a private filesystem-shelf cell was accepted by its creating identity' >&2
+  exit 1
+}
+grep -Fq 'crime=private-filesystem-shelf-cell' "$tmp/private.err" || {
+  echo 'a private filesystem-shelf cell did not refuse by name' >&2
+  cat "$tmp/private.err" >&2
+  exit 1
+}
+[[ ! -e "$tmp/private-pull.json" ]] || {
+  echo 'a private filesystem-shelf cell materialized output' >&2
+  exit 1
+}
+
+# Staging refusal face. In bash, errexit is disabled inside a function invoked
+# by an `if`/`||` caller; an unchecked failed mktemp therefore assigns tmp=""
+# and turns "$tmp/$name.gz" into a write under "/". Pin the real blocked
+# staging shape and require refusal before any derived root path is attempted.
+seed_incoming="$(find "$tmp/seed-shelf" -type d -name .incoming -print -quit)"
+relative_incoming="${seed_incoming#"$tmp/seed-shelf/"}"
+blocked_incoming="$tmp/blocked-shelf/$relative_incoming"
+mkdir -p "$(dirname "$blocked_incoming")"
+: >"$blocked_incoming"
+set +e
+publish "$tmp/blocked-shelf" "$tmp/table-a.json" 2>"$tmp/blocked.err"
+blocked_status=$?
+set -e
+[[ "$blocked_status" != 0 ]] || {
+  echo 'an uncreatable filesystem-shelf staging directory reported success' >&2
+  exit 1
+}
+grep -Fq 'crime=uncreatable-filesystem-shelf-staging' "$tmp/blocked.err" || {
+  echo 'an uncreatable filesystem-shelf staging directory did not refuse by name' >&2
+  cat "$tmp/blocked.err" >&2
+  exit 1
+}
+if grep -Fq '/python-demand-table.gz' "$tmp/blocked.err"; then
+  echo 'failed shelf staging fell through to a derived write under /' >&2
+  cat "$tmp/blocked.err" >&2
+  exit 1
+fi
+
 cp -R "$tmp/seed-shelf/." "$tmp/partial-shelf/"
 payload_count="$(find "$tmp/partial-shelf" -type f -name '*.gz' | wc -l | tr -d ' ')"
 [[ "$payload_count" == 1 ]] || {


### PR DESCRIPTION
## Summary

- make broker-created executable manifests and immutable shelf bytes peer-readable across the host user, privileged producers, and uid 1001 runner containers
- initialize the one shared shelf's structural directories and `.incoming` as shared-writable while retaining content-addressed immutable cells and the existing shared-device lease
- refuse private resident cells by name, and refuse failed staging before an empty `mktemp` result can derive writes under `/`

Root cause: Python `mkstemp` created manifests as `0600`, `mktemp -d` created shelf cells as `0700`, and root-created stamp parents/`.incoming` were `0755`. The runner therefore could not read the manifest or create staging. Because Bash disables `errexit` for a function invoked in a conditional, the failed `mktemp` assignment left `tmp=""` and publication continued toward `/$name.*`.

Originating Buzz channel: Sugar (`b23229c2-e64d-4815-aa60-05b21a3c31d3`). Reproduced from Actions run 30580466733 at `47f5f3101763e9a1e924af94e8599e3dd75e76d5`.

## Predicted Epsilon R (construction / wall lanes)

n/a — not a construction PR. This changes only the binary/artifact broker filesystem contract.

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | no construction semantics changed |
| `mandatory_panics` | 0 | no construction semantics changed |
| `suppressed_descendants` | 0 | no construction semantics changed |
| `typed_effects` | 0 | no construction semantics changed |
| `silent` | 0 | permission and staging failures remain loud and named |

## Validation

At committed SHA `231d0ebbaaaae51d42331c9307eef7b7609b6c33` rebased directly on `origin/main` `0ced04edd74083a09626dd8c48c825a0076d217e`:

- `bash -n bin/sugarbin tests/sugarbin_artifact_manifest.sh tests/sugarbin_python_demand_table_fixture.sh`
- `bash tests/sugarbin_python_demand_table_fixture.sh "$PWD"`
- `bash tests/sugarbin_build_root_identity.sh "$PWD"`
- `bash tests/sugarbin_shelf_immutability.sh "$PWD"`
- remaining non-Docker broker contract tests passed: build identity, bx exec, Docker daemon guard/stub execution, local exec, mount-proof guard, and task exec
- live two-way cross-identity proof on Battleaxe: root published and uid/gid `1001:1001` consumed one content-addressed cell; uid/gid `1001:1001` published into a root-owned `0777` shelf and root consumed it. Both directions reported `filesystem shelf hit`; cells/files remained `0755`/`0644`
- PR CI: `shared Rust build` passes after warming the repaired shelf; `prepare-python-test-environment` passes; `R_native_crashes discrimination` passes; `R_timeouts discrimination` passes

The live host stores were reconciled in place. Initial audit found 1,151 private shelf cells and 857 private binary manifests; one unpatched concurrent producer recreated the exact private shelf cell before this branch's run, and it was reconciled too. Final complete audit: private shelf cells `0/1214`, private shelf files `0/3636`, unwritable `.incoming` directories `0/1153`, private binary manifests `0/857`, non-executable cached binaries `0/857`. The exact independently corrupt Cargo-identity cell exposed after repair was moved recoverably to `/home/tsavo/.cache/sugar/quarantine/2026-07-30-b536f988` rather than deleted or bypassed.

Two broad shell tests are red identically on unmodified `origin/main` at `ff6ccb1400d8e94fe74c06c3bb7f02b096236d20`: `tests/sugarbin_artifact_manifest.sh` (pre-existing remote-route assertion) and `tests/sugarbin_wrapper_compat.sh` (pre-existing `SUGAR_BUILD_GIT_HEAD` vocabulary assertion). Current PR CI also has a separate shared `Panic-catch self-check` red at `no_call_body_attribution.py:271`; the timeout discrimination step itself passes. These are not changed for green in this lane.

## Floors preserved

- [x] `data_loss=0`
- [x] no secret committed
- [x] no test deleted for green
- [x] `silent=0`
- [x] no cache redirect or build bypass
- [x] permission failure cannot fall through to writes under `/`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make shared sugarbin cells peer-readable by enforcing strict file permission modes
> - Manifest files and artifact manifests are now written with mode 0644 before atomic replace, ensuring world-readable output.
> - New helpers `shared_cache_cell_is_peer_readable` and `filesystem_shelf_cell_is_peer_readable` validate that shelf cells have correct permission shapes (dir 0755, binary 0755, manifest 0644) before use.
> - `pull_from_shelf` and `pull_from_filesystem_shelf` now reject cache candidates and shelf cells with incorrect permissions and set standardized modes on materialized artifacts.
> - `publish_to_filesystem_shelf` uses a new `ensure_shared_shelf_staging` helper to create staging dirs at 0777 and refuses to publish cells that are not peer-readable; certain failures return exit code 2.
> - Risk: existing shelf cells or cache candidates with non-conforming permissions will be refused rather than used, which may cause fetch failures until cells are republished or re-fetched.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a51c53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->