### PR TITLE
Thread receiver field mutation through shadow-AST alias state

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_field_store_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_field_store_value.py
@@ -33,9 +33,15 @@ class ReceiverFieldStoreValue(FloorValue):
             ctx = ReduceContext.root(owner="ReceiverFieldStoreValue")
         updated = self.receiver.with_field_store(self.attr, self.value)
         temporal = ctx.temporal
+        identity = self.receiver.identity
         matched = False
         for binding in ctx.temporal.bindings:
-            if binding.value is self.receiver:
+            candidate = binding.value
+            if (
+                isinstance(candidate, ObjectValue)
+                and type(candidate) is type(self.receiver)
+                and candidate.identity == identity
+            ):
                 temporal = temporal.bind_value(
                     binding.name, updated, blame=binding.blame
                 )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_receiver_ref_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_receiver_ref_sugar.py
@@ -4,11 +4,11 @@ from dataclasses import dataclass, field
 
 from sugar_lift_py_tests.floor import ObjectValue
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
 
 @dataclass(frozen=True)
-class ConstructedReceiverRefSugar(Sugar):
+class ConstructedReceiverRefSugar(ConstructedTermSugar):
     class_name: str
     binding_coordinate_cid: str
     site: object = field(compare=False)
@@ -21,6 +21,19 @@ class ConstructedReceiverRefSugar(Sugar):
             sugar_name=cls.__name__,
             floor_name="ObjectValue",
             reason="a class call constructs its receiver from the authenticated class definition",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:constructed-receiver-ref",
+            (
+                self.occurrence_term(owner=owner),
+                str_const(self.class_name),
+                str_const(self.binding_coordinate_cid),
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/receiver_field_store_state_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/receiver_field_store_state_sugar.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
+
+
+@dataclass(frozen=True)
+class ReceiverFieldStoreStateSugar(ConstructedTermSugar):
+    receiver: ConstructedTermSugar
+    value: ConstructedTermSugar
+    attr: str
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def __post_init__(self):
+        require_constructed_term_sugar(
+            self.receiver, owner="ReceiverFieldStoreStateSugar.receiver"
+        )
+        require_constructed_term_sugar(
+            self.value, owner="ReceiverFieldStoreStateSugar.value"
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            "python:receiver-field-store-state",
+            (
+                self.occurrence_term(owner=owner),
+                self.receiver.to_term(owner=owner),
+                str_const(self.attr),
+                self.value.to_term(owner=owner),
+            ),
+            symbol_kind="coordinate",
+        )
+
+    def desugar(self, ctx=None):
+        from sugar_lift_py_tests.floor.object_value import ObjectValue
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        from sugar_lift_py_tests.outcome import Complete
+
+        def update(receiver, value):
+            if not isinstance(receiver, ObjectValue):
+                construction_panic_gap(
+                    owner="ReceiverFieldStoreStateSugar",
+                    blame=self.site,
+                    observed=type(receiver).__name__,
+                    requested="authenticated source receiver",
+                    fix="retain field mutation as typed loud until its receiver floors",
+                )
+            return Complete(receiver.with_field_store(self.attr, value))
+
+        return self.receiver.desugar(ctx).and_then(
+            lambda receiver: self.value.desugar(ctx).and_then(
+                lambda value: update(receiver, value)
+            )
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
@@ -1,10 +1,23 @@
 from dataclasses import dataclass
 
+from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_py_tests.context import ReduceContext
-from sugar_lift_py_tests.floor import ObjectValue, ReceiverFieldStoreValue, TermValue
+from sugar_lift_py_tests.floor import (
+    MappingObjectValue,
+    ObjectValue,
+    ReceiverFieldStoreValue,
+    ReturnValue,
+    StringValue,
+    TermValue,
+)
 from sugar_lift_py_tests.outcome import Complete, Completed
 from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.receiver_field_store_state_sugar import (
+    ReceiverFieldStoreStateSugar,
+)
+from sugar_source_tree.nodes import FunctionDef, ReceiverFieldStoreState, Return
+from sugar_source_tree.tree import SourceFile
 
 
 @dataclass(frozen=True)
@@ -30,6 +43,31 @@ class _ReadReceiverField(Sugar):
         return ctx.temporal.value_for("self").attribute("payload", "test")
 
 
+@dataclass(frozen=True)
+class _ReturnAlias(Sugar):
+    name: str
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        return Complete(ReturnValue(ctx.temporal.value_for(self.name)))
+
+
+@dataclass(frozen=True)
+class _FixedSugar(Sugar):
+    value: object
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+
 def test_receiver_field_store_rebinds_the_same_receiver_for_the_tail():
     """A completed ``self.x = value`` owns the later ``self.x`` projection."""
     receiver = ObjectValue("Renamed", (), identity="receiver-1")
@@ -46,3 +84,122 @@ def test_receiver_field_store_rebinds_the_same_receiver_for_the_tail():
     assert len(exits) == 1
     assert isinstance(exits[0], Completed)
     assert exits[0].value.entries[-1] is stored
+
+
+def test_returned_alias_observes_updated_mapping_receiver_identity():
+    receiver = MappingObjectValue(
+        "Namespace",
+        (),
+        identity="receiver-1",
+        entries=((StringValue("member"), TermValue(1)),),
+    )
+    alias = receiver.mapping_with_entries(receiver.entries)
+    context = ReduceContext.root(owner="receiver-alias")
+    temporal = context.temporal.bind_value("self", receiver)
+    temporal = temporal.bind_value("alias", alias)
+    context = context.with_temporal(temporal)
+
+    exits = reduce_block_to_exitset(
+        (_StoreReceiverField(receiver, TermValue(17)), _ReturnAlias("alias")),
+        context,
+    ).exits
+
+    assert len(exits) == 1
+    returned = next(
+        entry
+        for entry in exits[0].value.entries
+        if isinstance(entry, ReturnValue)
+    ).value
+    assert isinstance(returned, MappingObjectValue)
+    assert returned.identity == receiver.identity
+    assert returned.entries == receiver.entries
+    assert returned.attribute("payload", "test") == Complete(TermValue(17))
+
+
+def test_same_class_different_receiver_identity_is_not_rewritten():
+    receiver = MappingObjectValue("Namespace", (), identity="receiver-1")
+    distinct = MappingObjectValue("Namespace", (), identity="receiver-2")
+    context = ReduceContext.root(owner="receiver-alias")
+    temporal = context.temporal.bind_value("self", receiver)
+    temporal = temporal.bind_value("other", distinct)
+    context = context.with_temporal(temporal)
+
+    exits = reduce_block_to_exitset(
+        (_StoreReceiverField(receiver, TermValue(17)), _ReturnAlias("other")),
+        context,
+    ).exits
+
+    returned = next(
+        entry
+        for entry in exits[0].value.entries
+        if isinstance(entry, ReturnValue)
+    ).value
+    assert returned is distinct
+    assert returned.identity == "receiver-2"
+
+
+def test_shadow_return_of_mutated_alias_reads_post_state() -> None:
+    source = (
+        "class Namespace:\n"
+        "    pass\n\n"
+        "def prepare():\n"
+        "    namespace = Namespace()\n"
+        "    namespace.owner = 7\n"
+        "    return namespace\n"
+    )
+    tree = SourceFile((source, "receiver_return.py", blake3_512_of(source.encode())))
+    function = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == "prepare"
+    )
+
+    substituted = function.substitute({})
+    returned = next(node for node in substituted.walk() if isinstance(node, Return))
+
+    assert isinstance(returned.value, ReceiverFieldStoreState)
+
+
+def test_shadow_store_does_not_rewrite_distinct_alias_return() -> None:
+    source = (
+        "class Namespace:\n"
+        "    pass\n\n"
+        "def prepare():\n"
+        "    changed = Namespace()\n"
+        "    other = Namespace()\n"
+        "    changed.owner = 7\n"
+        "    return other\n"
+    )
+    tree = SourceFile((source, "receiver_return.py", blake3_512_of(source.encode())))
+    function = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == "prepare"
+    )
+
+    substituted = function.substitute({})
+    returned = next(node for node in substituted.walk() if isinstance(node, Return))
+
+    assert not isinstance(returned.value, ReceiverFieldStoreState)
+
+
+def test_receiver_field_post_state_preserves_mapping_identity_and_entries() -> None:
+    receiver = MappingObjectValue(
+        "Namespace",
+        (),
+        identity="receiver-1",
+        entries=((StringValue("member"), TermValue(1)),),
+    )
+
+    outcome = ReceiverFieldStoreStateSugar(
+        _FixedSugar(receiver),
+        _FixedSugar(TermValue(7)),
+        "owner",
+        "site",
+    ).desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, MappingObjectValue)
+    assert outcome.value.identity == receiver.identity
+    assert outcome.value.entries == receiver.entries
+    assert outcome.value.attribute("owner", "test") == Complete(TermValue(7))

--- a/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
@@ -12,7 +12,7 @@ from sugar_lift_py_tests.floor import (
 )
 from sugar_lift_py_tests.outcome import Complete, Completed
 from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
 from sugar_lift_py_tests.sugar.receiver_field_store_state_sugar import (
     ReceiverFieldStoreStateSugar,
 )
@@ -56,7 +56,7 @@ class _ReturnAlias(Sugar):
 
 
 @dataclass(frozen=True)
-class _FixedSugar(Sugar):
+class _FixedSugar(ConstructedTermSugar):
     value: object
 
     @classmethod
@@ -66,6 +66,9 @@ class _FixedSugar(Sugar):
     def desugar(self, ctx=None):
         del ctx
         return Complete(self.value)
+
+    def to_term(self, *, owner: str):
+        return self.value.to_term(owner=owner)
 
 
 def test_receiver_field_store_rebinds_the_same_receiver_for_the_tail():

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4947,6 +4947,9 @@ class Assign(Statement):
             return mapping_pop
 
         new_value, changed = self._substitute_field(self.value, scope)
+        field_state = self._receiver_field_store_state(scope, new_value)
+        if field_state is not None:
+            return field_state
         changes = {"value": new_value} if changed else {}
         if len(self.targets) == 1 and isinstance(
             self.targets[0], (Attribute, Subscript)
@@ -4964,6 +4967,45 @@ class Assign(Statement):
         if self.unit.target_patterns_for(self):
             self.unit.retain_target_patterns(self, rewritten)
         return rewritten
+
+    def _receiver_field_store_state(self, scope, new_value):
+        """Thread ``name.attr = value`` into later reads of that exact name."""
+        if len(self.targets) != 1 or not isinstance(self.targets[0], Attribute):
+            return None
+        target = self.targets[0]
+        if not isinstance(target.value, Name) or target.value.id not in scope:
+            return None
+        receiver = target.value.substitute(scope)
+        if not isinstance(receiver, Node):
+            return None
+        from .backend import Child, Leaf, materialize
+        from .shadow import ShadowNode, _handle_of
+
+        post_state = materialize(
+            self.unit,
+            ShadowNode(
+                "ReceiverFieldStoreState",
+                self.span,
+                (
+                    ("receiver", Child(_handle_of(receiver))),
+                    ("value", Child(_handle_of(new_value))),
+                    ("attr", Leaf(target.attr)),
+                ),
+            ),
+            self.reporter,
+        )
+        return materialize(
+            self.unit,
+            ShadowNode(
+                "ReceiverFieldStoreStatement",
+                self.span,
+                (
+                    ("receiver_name", Leaf(target.value.id)),
+                    ("post_state", Child(_handle_of(post_state))),
+                ),
+            ),
+            self.reporter,
+        )
 
     def _mapping_pop_assignment(self, scope):
         """Split ``result = mapping.pop(key, default)`` into two SSA bindings.
@@ -8877,6 +8919,25 @@ class Break(Statement):
         )
 
 
+class ReceiverFieldStoreStatement(Statement):
+    receiver_name: str
+    post_state: Expression
+    _child_fields = ("post_state",)
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def substitution_binding(self, scope):
+        del scope
+        return {self.receiver_name: self.post_state}
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.expr_statement_sugar import ExprStatementSugar
+
+        return ExprStatementSugar(self.post_state.sugar(), self.fragment)
+
+
 class Continue(Statement):
     pass
 
@@ -11484,6 +11545,26 @@ class MappingPopState(Expression):
             key=self.key.sugar(),
             default=self.default.sugar(),
             site=self.fragment,
+        )
+
+
+class ReceiverFieldStoreState(Expression):
+    receiver: Expression
+    value: Expression
+    attr: str
+    _child_fields = ("receiver", "value")
+
+    def substitute(self, scope):
+        del scope
+        return self
+
+    def _construct_sugar(self):
+        from sugar_lift_py_tests.sugar.receiver_field_store_state_sugar import (
+            ReceiverFieldStoreStateSugar,
+        )
+
+        return ReceiverFieldStoreStateSugar(
+            self.receiver.sugar(), self.value.sugar(), self.attr, self.fragment
         )
 
 


### PR DESCRIPTION
Implements receiver-owned field mutation as shadow-AST state, preserving exact receiver identity and mapping entries across alias returns. Adds authenticated term projection for the post-state and constructed receiver coordinate.\n\nEvidence: 6 focused laws pass. Exact option_context lifecycle clears enum.py:399 _cls_name and advances into re/_constants.py:71 at the next independent missing field (ObjectValue.name). No enum/vendor arm, no BlockValue.to_term, no in-place mutation.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Thread receiver field mutation through shadow-AST alias state during substitution
> - Attribute assignments (`name.attr = value`) are now rewritten during AST substitution into `ReceiverFieldStoreStatement`/`ReceiverFieldStoreState` shadow nodes in [nodes.py](https://github.com/TSavo/sugar/pull/6936/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0), which rebind the receiver name to its post-state going forward.
> - `ReceiverFieldStoreStateSugar` in [receiver_field_store_state_sugar.py](https://github.com/TSavo/sugar/pull/6936/files#diff-7581737fe4703c27d807ec8164dda93f2a6f413d02f267239355068c8a3992d8) desugars the post-state expression into an updated Floor `ObjectValue` via `with_field_store`.
> - `ReceiverFieldStoreValue.extend_scope` in [receiver_field_store_value.py](https://github.com/TSavo/sugar/pull/6936/files#diff-9b2216e57b448d21843f4a9517b3f1dd96beea51516d233190a541fc760f01b6) now matches bindings by structural identity (same concrete type + `.identity`) rather than object identity, so aliases of the same receiver see the updated mapping.
> - `ConstructedReceiverRefSugar` is promoted to a `ConstructedTermSugar` subclass and gains a `to_term` method for use in constructed-term pipelines.
> - Behavioral Change: `Assign.substitute` now produces a multi-node shadow structure for attribute stores instead of a plain assignment, which changes how downstream scope collection and bindings resolve for any `name.attr = value` statement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be0d7e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->