### PR TITLE
Route construction side doors through typed testimony

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -319,7 +319,7 @@ class NativeOperationDemandV1:
         )
 
 
-def _ast_minted_native_operator_constants() -> frozenset[str]:
+def _typed_minted_native_operator_constants() -> frozenset[str]:
     """String ``operator=`` kwargs that feed native-operation carrier mints.
 
     Discovers:
@@ -336,8 +336,9 @@ def _ast_minted_native_operator_constants() -> frozenset[str]:
     term coordinates ``"+"``) are excluded — those are term spellings, not
     carrier operator names.
     """
-    import ast
     from pathlib import Path
+    from sugar_source_tree.nodes import Call, Constant
+    from sugar_source_tree.tree import SourceFile
 
     package_root = Path(__file__).resolve().parent
     found: set[str] = set()
@@ -345,19 +346,20 @@ def _ast_minted_native_operator_constants() -> frozenset[str]:
         if path.name == "caller_parameter_contract.py":
             # This module defines projectors and mint plumbing, not producers.
             continue
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        except SyntaxError:
-            continue
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
+        source_file = SourceFile.from_path(path)
+        registered = (
+            source_file.constructed_module.construction_event_receipt
+            .registered_occurrences
+        )
+        for node in registered:
+            if not isinstance(node, Call):
                 continue
             for keyword in node.keywords:
                 if keyword.arg != "operator":
                     continue
                 value = keyword.value
                 if not (
-                    isinstance(value, ast.Constant) and isinstance(value.value, str)
+                    isinstance(value, Constant) and isinstance(value.value, str)
                 ):
                     continue
                 name = value.value
@@ -373,7 +375,8 @@ def production_native_operation_operators() -> frozenset[str]:
 
     Sources (union — each is a real mint path, not a guess):
 
-    * AST string constants on ``NativeOperationExitCarrierV1.mint(operator=...)``
+    * typed source string constants on
+      ``NativeOperationExitCarrierV1.mint(operator=...)``
     * ``_BINARY_OPERATOR_COORDINATE`` keys (``operator=owner`` formal binary path)
     * ``COMPARE_METHODS`` values (``operator=method`` formal ordering path)
     * contracted store operators whose producers pin the mint shape for this
@@ -398,7 +401,7 @@ def production_native_operation_operators() -> frozenset[str]:
 
     contracted_inplace_operators = production_augassign_inplace_operators()
     return (
-        _ast_minted_native_operator_constants()
+        _typed_minted_native_operator_constants()
         | frozenset(_BINARY_OPERATOR_COORDINATE)
         | frozenset(COMPARE_METHODS.values())
         | contracted_store_operators

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -156,14 +156,12 @@ class NativeOperationResolutionV1:
                     blame=str(occurrence.wire()),
                 )
             if not isinstance(effect, RaiseEffect):
-                raise TypeError("exceptional native operation effect must be RaiseEffect")
+                raise TypeError(
+                    "exceptional native operation effect must be RaiseEffect"
+                )
             return ExitSet.halted(
                 effect,
-                state=(
-                    None
-                    if testimony is None
-                    else testimony.state
-                ),
+                state=(None if testimony is None else testimony.state),
             )
         raise SugarNotWritten(
             blame=str(source_node),
@@ -216,6 +214,7 @@ def authenticated_exceptional_resolution_count(resolutions) -> int:
     return sum(
         resolution.is_authenticated_exceptional_exit for resolution in resolutions
     )
+
 
 def _json(value) -> Any:
     return json.loads(encode_jcs(value))
@@ -348,8 +347,7 @@ def _typed_minted_native_operator_constants() -> frozenset[str]:
             continue
         source_file = SourceFile.from_path(path)
         registered = (
-            source_file.constructed_module.construction_event_receipt
-            .registered_occurrences
+            source_file.constructed_module.construction_event_receipt.registered_occurrences
         )
         for node in registered:
             if not isinstance(node, Call):
@@ -358,9 +356,7 @@ def _typed_minted_native_operator_constants() -> frozenset[str]:
                 if keyword.arg != "operator":
                     continue
                 value = keyword.value
-                if not (
-                    isinstance(value, Constant) and isinstance(value.value, str)
-                ):
+                if not (isinstance(value, Constant) and isinstance(value.value, str)):
                     continue
                 name = value.value
                 # Carrier operators are Floor method names (identifiers), never
@@ -978,8 +974,7 @@ class NativeOperationExitCarrierV1:
                 continue
             if coordinate_cid not in actuals_by_formal_coordinate:
                 return undischarged(
-                    "authenticated caller actual absent for "
-                    f"{coordinate_cid}"
+                    "authenticated caller actual absent for " f"{coordinate_cid}"
                 )
             actual_operands.append(actuals_by_formal_coordinate[coordinate_cid])
 
@@ -1033,6 +1028,7 @@ class NativeOperationExitCarrierV1:
 
         exits = apply_exitset_steps(exits, 0)
         for index, continuation in enumerate(self.continuations, start=1):
+
             def resume(value, *, step=continuation):
                 next_outcome = step(value)
                 if isinstance(next_outcome, NativeOperationExitCarrierV1):
@@ -1048,7 +1044,12 @@ class NativeOperationExitCarrierV1:
         guard = _conjoin_guards(self.guards)
         if guard is not None:
             exits = exits.guarded(guard)
-        for continuing_guard, stopped, continuing_face, stopped_face in self.short_circuits:
+        for (
+            continuing_guard,
+            stopped,
+            continuing_face,
+            stopped_face,
+        ) in self.short_circuits:
             stopping_exits = []
             for exit_ in stopped.exits:
                 if isinstance(exit_, Halted):
@@ -1162,9 +1163,7 @@ def merge_pending(*groups) -> tuple:
             by_candidate[entry.candidate_cid] = (
                 entry
                 if prior is None
-                else replace(
-                    prior, demands=merge_demands(prior.demands, entry.demands)
-                )
+                else replace(prior, demands=merge_demands(prior.demands, entry.demands))
             )
     return tuple(by_candidate[cid] for cid in sorted(by_candidate))
 
@@ -1316,9 +1315,7 @@ class ContractConditionalConstructionV1:
         Nested guards compose by repeated application, innermost first, which
         is the same accumulation `Incomplete.guarded` records positionally.
         """
-        return replace(
-            self.demanded_under(formula), value=self.value.guarded(formula)
-        )
+        return replace(self.demanded_under(formula), value=self.value.guarded(formula))
 
     def contribution(self):
         """One row per demand: the SET collapses back to singletons HERE.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -1,10 +1,11 @@
 """Per-family attribution for assertion bodies whose root is not a Call.
 
 The authenticated runner owns discovery and shared-table transport.  This
-module owns the closed accounting algebra: every enrolled body is attributed
-to exactly one producer family and exactly one of three outcomes.  A named
-``SugarNotWritten`` refusal is accounted semantics, not a failure.  A
-``ConstructionPanic`` remains a separate loud axis.
+module owns the closed accounting algebra: every completed probe is attributed
+to exactly one producer family and one closed outcome. A named
+``SugarNotWritten`` refusal is accounted semantics, not a failure.
+``ConstructionPanic`` never enters this accounting boundary; it remains
+producer-owned and propagates loud.
 """
 
 from __future__ import annotations
@@ -254,7 +255,6 @@ def _exceptional_exit_effects(outcome: object) -> tuple[object, ...]:
 
 
 def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
     from sugar_source_tree.panic import SugarNotWritten, UnattributableRefusal
 
     try:
@@ -268,14 +268,6 @@ def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
             AttributionOutcome.NAMED_REFUSAL,
             refusal.owner,
         )
-    except ConstructionPanic as panic:
-        return BodyAttribution(
-            probe.body_id,
-            probe.family,
-            AttributionOutcome.CONSTRUCTION_PANIC,
-            panic.info.owner,
-        )
-
     exceptional_effects = _exceptional_exit_effects(outcome)
     if exceptional_effects:
         unnamed = tuple(
@@ -499,8 +491,6 @@ def discover_no_call_body_probes(
     selects the producer family; no manager or vendor spelling selects it or
     grants semantic behavior to a producer.
     """
-    import ast
-
     from sugar_lift_py_tests.context_manager_resolution import (
         TreeConstructionContextV1,
     )
@@ -531,17 +521,7 @@ def discover_no_call_body_probes(
         for node_type, family in family_by_type.items()
         if family in selected_families
     }
-    native_type_by_family = {
-        ProducerFamily.SUBSCRIPT: ast.Subscript,
-        ProducerFamily.BINOP: ast.BinOp,
-        ProducerFamily.COMPARE: ast.Compare,
-        ProducerFamily.ATTRIBUTE: ast.Attribute,
-        ProducerFamily.UNARYOP: ast.UnaryOp,
-        ProducerFamily.BOOLOP: ast.BoolOp,
-    }
-    selected_native_types = tuple(
-        native_type_by_family[family] for family in selected_families
-    )
+    selected_root_types = tuple(family_by_type)
     paths_by_cid = {}
     for path in SourceTree(corpus_root).paths():
         paths_by_cid[blake3_512_of(path.read_bytes())] = path
@@ -567,44 +547,20 @@ def discover_no_call_body_probes(
                 f"demand table names source CID absent from authenticated corpus: {source_cid}"
             )
         source = path.read_text(encoding="utf-8")
-        candidate_spans = set()
-        for node in ast.walk(ast.parse(source, filename=str(path))):
-            if not isinstance(node, (ast.With, ast.AsyncWith)):
-                continue
-            if len(node.body) != 1 or not isinstance(node.body[0], ast.Expr):
-                continue
-            if not isinstance(node.body[0].value, selected_native_types):
-                continue
-            for item in node.items:
-                manager = item.context_expr
-                candidate_spans.add(
-                    (
-                        manager.lineno,
-                        manager.col_offset,
-                        manager.end_lineno,
-                        manager.end_col_offset,
-                    )
-                )
-        demands = [
-            use_site
-            for use_site in demands
-            if (
-                use_site.get("startLine"),
-                use_site.get("startCol"),
-                use_site.get("endLine"),
-                use_site.get("endCol"),
-            )
-            in candidate_spans
-        ]
-        if not demands:
-            continue
         tree = SourceFile(
             (source, str(path), source_cid),
             construction_context=TreeConstructionContextV1.for_source_call_construction(),
         )
         managers_by_span: dict[tuple[int, int, int, int], list[With]] = {}
-        for node in tree.nodes():
+        registered = (
+            tree.constructed_module.construction_event_receipt.registered_occurrences
+        )
+        for node in registered:
             if not isinstance(node, With):
+                continue
+            if len(node.body) != 1 or not isinstance(node.body[0], Expr):
+                continue
+            if not isinstance(node.body[0].value, selected_root_types):
                 continue
             for item in node.items:
                 span = item.context_expr.line_col_span()
@@ -627,6 +583,8 @@ def discover_no_call_body_probes(
                 ),
                 (),
             )
+            if not managers:
+                continue
             if len(managers) != 1:
                 raise AttributionInvariantError(
                     f"assertion demand resolves to {len(managers)} With nodes: {use_site!r}"

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -11,6 +11,7 @@ from sugar_lift_py_tests.no_call_body_attribution import (
     HISTORICAL_PATH_SHAPE_DIGEST,
     AttributionOutcome,
     AttributionInvariantError,
+    BodyAttribution,
     BodyProbe,
     DemandTableRefusal,
     ProducerFamily,
@@ -180,7 +181,12 @@ def test_unattributable_refusal_escapes_regardless_of_owner_spelling() -> None:
 def test_shared_outcome_summary_keeps_refusals_separate_from_panics() -> None:
     bodies = (
         attribute_body_probe(_probe(ProducerFamily.BINOP, _named_refusal)),
-        attribute_body_probe(_probe(ProducerFamily.BINOP, _construction_panic)),
+        BodyAttribution(
+            "pandas/example.py:1:BinOp",
+            ProducerFamily.BINOP,
+            AttributionOutcome.CONSTRUCTION_PANIC,
+            "producer-construction",
+        ),
         attribute_body_probe(_probe(ProducerFamily.BINOP, _raise_value)),
     )
 
@@ -192,25 +198,26 @@ def test_shared_outcome_summary_keeps_refusals_separate_from_panics() -> None:
     assert summary.construction_panics == 1
 
 
-def test_report_names_every_refusal_coordinate_and_panic_node_owner() -> None:
-    report = attribute_body_probes(
-        (
-            _probe(ProducerFamily.BINOP, _named_refusal),
-            _probe(ProducerFamily.SUBSCRIPT, _construction_panic),
+def test_probe_batch_stops_at_construction_panic_before_following_body() -> None:
+    """A producer panic cannot be collected while later probes keep running."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    reached_following_probe = False
+
+    def following_probe():
+        nonlocal reached_following_probe
+        reached_following_probe = True
+        return _raise_value()
+
+    with pytest.raises(ConstructionPanic, match="producer-construction"):
+        attribute_body_probes(
+            (
+                _probe(ProducerFamily.SUBSCRIPT, _construction_panic),
+                _probe(ProducerFamily.BINOP, following_probe),
+            )
         )
-    )
 
-    rendered = report.render()
-
-    assert (
-        "namedRefusal body=pandas/example.py:1:BinOp "
-        "coordinate=native-producer" in rendered
-    )
-    assert (
-        "constructionPanic body=pandas/example.py:1:Subscript "
-        "node=Subscript owner=producer-construction" in rendered
-    )
-    assert report.construction_panic_count == 1
+    assert reached_following_probe is False
 
 
 def test_report_keeps_all_six_families_separate() -> None:
@@ -230,16 +237,12 @@ def test_report_keeps_all_six_families_separate() -> None:
     assert [row.family for row in report.rows()] == list(ProducerFamily)
 
 
-def test_construction_panic_remains_a_separate_loud_axis() -> None:
-    report = attribute_body_probes(
-        (_probe(ProducerFamily.ATTRIBUTE, _construction_panic),)
-    )
-    row = report.by_family[ProducerFamily.ATTRIBUTE]
-    assert row.authenticated_exceptional_exits == 0
-    assert row.named_refusals == 0
-    assert row.construction_panics == 1
-    assert row.failures == 1
-    assert report.bodies[0].outcome is AttributionOutcome.CONSTRUCTION_PANIC
+def test_construction_panic_propagates_instead_of_becoming_attribution() -> None:
+    """Producer-owned construction failure must halt the attribution run."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(ConstructionPanic, match="producer-construction"):
+        attribute_body_probes((_probe(ProducerFamily.ATTRIBUTE, _construction_panic),))
 
 
 def test_silent_completion_stays_a_separate_loud_discrepancy() -> None:
@@ -267,74 +270,39 @@ def test_silent_completion_stays_a_separate_loud_discrepancy() -> None:
     )
 
 
-def test_construction_panics_are_rendered_with_site_and_failing_node_owner() -> None:
-    report = attribute_body_probes(
-        (_probe(ProducerFamily.SUBSCRIPT, _construction_panic),)
-    )
+def test_construction_panic_keeps_producer_owner_not_probe_family() -> None:
+    """Lying twin: a Subscript enrollment cannot steal the panic owner."""
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
-    assert (
-        "constructionPanic body=pandas/example.py:1:Subscript "
-        "node=Subscript owner=producer-construction"
-    ) in report.render()
-    assert report.construction_panic_count == 1
+    with pytest.raises(ConstructionPanic) as raised:
+        attribute_body_probe(_probe(ProducerFamily.SUBSCRIPT, _construction_panic))
 
-
-def test_join_collects_construction_panic_and_outcome_discrepancy_before_failing() -> (
-    None
-):
-    """#6540 + #6541: both loud axes survive one report transaction."""
-    report = attribute_body_probes(
-        (
-            _probe(ProducerFamily.SUBSCRIPT, _construction_panic),
-            _probe(ProducerFamily.BOOLOP, lambda: Complete(object())),
-        )
-    )
-
-    assert len(report.bodies) == 1
-    assert len(report.discrepancies) == 1
-    assert report.construction_panic_count == 1
-    assert report.outcome_total == 1
-    assert report.loud_failure_count == 2
-    assert "constructionPanic body=pandas/example.py:1:Subscript" in report.render()
-    assert (
-        "OUTCOME TOTAL DISCREPANCY enrolled=2 outcomeTotal=1 unaccounted=1"
-        in report.render()
-    )
+    assert raised.value.info.owner == "producer-construction"
 
 
 def test_receiver_call_panic_is_owned_by_call_before_subscript_is_reached() -> None:
     """Lying twin: root shape cannot steal a failure from its receiver Call."""
-    from sugar_lift_py_tests.gap.panic import construction_panic_gap
-    from sugar_lift_py_tests.sugar.subscript_sugar import SubscriptSugar
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic, construction_panic_gap
 
-    class RaisingCall:
-        def desugar(self, ctx=None):
-            construction_panic_gap(
-                owner="Call",
-                blame="pandas/example.py:1:receiver",
-                observed="receiver call raised before returning a value",
-                requested="a completed receiver before Subscript evaluation",
-                fix="attribute this failing edge to Call",
-            )
-
-    class UnreachedIndex:
-        def desugar(self, ctx=None):
-            raise AssertionError("Subscript index was evaluated after receiver halt")
-
-    expression = SubscriptSugar(
-        receiver=RaisingCall(), index=UnreachedIndex(), site="pandas/example.py:1"
-    )
-    body = attribute_body_probe(
-        BodyProbe(
-            body_id="pandas/example.py:1:Subscript",
-            family=ProducerFamily.SUBSCRIPT,
-            evaluator=expression.desugar,
+    def receiver_call_panic():
+        construction_panic_gap(
+            owner="Call",
+            blame="pandas/example.py:1:receiver",
+            observed="receiver call raised before returning a value",
+            requested="a completed receiver before Subscript evaluation",
+            fix="attribute this failing edge to Call",
         )
-    )
 
-    assert body.family is ProducerFamily.SUBSCRIPT
-    assert body.outcome is AttributionOutcome.CONSTRUCTION_PANIC
-    assert body.detail == "Call"
+    with pytest.raises(ConstructionPanic) as raised:
+        attribute_body_probe(
+            BodyProbe(
+                body_id="pandas/example.py:1:Subscript",
+                family=ProducerFamily.SUBSCRIPT,
+                evaluator=receiver_call_panic,
+            )
+        )
+
+    assert raised.value.info.owner == "Call"
 
 
 def test_receiver_call_exceptional_exit_is_not_claimed_by_root_subscript() -> None:
@@ -458,7 +426,7 @@ def test_population_selection_never_reads_manager_target_symbol() -> None:
     assert "targetSymbol" not in discover_no_call_body_probes.__code__.co_consts
 
 
-def test_discovery_projects_one_family_without_constructing_peer_sources(
+def test_discovery_projects_one_family_through_one_typed_construction_per_source(
     tmp_path, monkeypatch
 ) -> None:
     from sugar_lift_py_tests.context_manager_resolution import (
@@ -510,18 +478,23 @@ def test_discovery_projects_one_family_without_constructing_peer_sources(
         )
 
     original = SourceFile.__init__
+    constructed_source_cids = []
 
-    def refuse_peer_construction(self, source, *args, **kwargs):
-        if source[2] == subscript_cid:
-            raise AssertionError("peer producer source was constructed")
+    def record_construction(self, source, *args, **kwargs):
+        constructed_source_cids.append(source[2])
         return original(self, source, *args, **kwargs)
 
-    monkeypatch.setattr(SourceFile, "__init__", refuse_peer_construction)
+    def refuse_second_traversal(self):
+        raise AssertionError("consumer started a second typed traversal")
+
+    monkeypatch.setattr(SourceFile, "__init__", record_construction)
+    monkeypatch.setattr(SourceFile, "nodes", refuse_second_traversal)
     probes = discover_no_call_body_probes(
         {"rows": rows}, package, families=frozenset({ProducerFamily.ATTRIBUTE})
     )
 
     assert [probe.body_id for probe in probes] == ["attribute_body.py:3:Attribute"]
+    assert constructed_source_cids == [rows[0]["useSite"]["sourceCid"], subscript_cid]
 
 
 def test_discovery_carries_source_property_binding_to_attribute_exit(tmp_path) -> None:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/external_exception_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/external_exception_construction.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import ast
 from dataclasses import dataclass
 from pathlib import Path
 import re
@@ -143,21 +142,20 @@ def _ancestry_labels(
 def _exception_ancestry_names(
     graph: DependencyArtifactGraph, resolved: ResolvedPythonObjectV1
 ) -> tuple[str, ...] | None:
+    from sugar_source_tree.nodes import ClassDef, Name
+    from sugar_source_tree.tree import SourceFile
+
     module = graph.modules.get(resolved.module_name)
     if module is not None and module.source_cid == resolved.source_cid:
-        tree = ast.parse(module.source, filename=module.source_seat)
+        tree = SourceFile((module.source, module.source_seat, module.source_cid)).root
         classes = {
-            node.name: tuple(
-                base.id for base in node.bases if isinstance(base, ast.Name)
-            )
+            node.name: tuple(base.id for base in node.bases if isinstance(base, Name))
             for node in tree.body
-            if isinstance(node, ast.ClassDef)
-            and all(isinstance(base, ast.Name) for base in node.bases)
+            if isinstance(node, ClassDef)
+            and all(isinstance(base, Name) for base in node.bases)
         }
         starts = {
-            node.name: node.lineno
-            for node in tree.body
-            if isinstance(node, ast.ClassDef)
+            node.name: node.lineno for node in tree.body if isinstance(node, ClassDef)
         }
     else:
         recorded = [
@@ -419,15 +417,27 @@ def _returned_module_parameter(
     graph: DependencyArtifactGraph, resolved: ResolvedPythonObjectV1
 ) -> int | None:
     """Parameter projected by a source function as ``sys.modules[param]``."""
+    from sugar_source_tree.nodes import (
+        Assign,
+        AsyncFunctionDef,
+        Attribute,
+        FunctionDef,
+        Import,
+        Name,
+        Return,
+        Subscript,
+    )
+    from sugar_source_tree.tree import SourceFile
+
     module = graph.modules.get(resolved.module_name)
     if module is None or module.source_cid != resolved.source_cid:
         return None
-    tree = ast.parse(module.source, filename=module.source_seat)
+    tree = SourceFile((module.source, module.source_seat, module.source_cid)).root
     function = next(
         (
             node
             for node in tree.body
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            if isinstance(node, (FunctionDef, AsyncFunctionDef))
             and node.name == resolved.definition.name
             and node.lineno == resolved.definition.start_line
         ),
@@ -439,36 +449,30 @@ def _returned_module_parameter(
     sys_names = {
         alias.asname or alias.name
         for statement in tree.body
-        if isinstance(statement, ast.Import)
+        if isinstance(statement, Import)
         for alias in statement.names
         if alias.name == "sys"
     }
     projected: dict[str, str] = {}
-    for statement in ast.walk(function):
-        if not isinstance(statement, ast.Assign) or len(statement.targets) != 1:
-            continue
-        target = statement.targets[0]
-        value = statement.value
-        if not isinstance(target, ast.Name) or not isinstance(value, ast.Subscript):
-            continue
-        owner = value.value
-        if not (
-            isinstance(owner, ast.Attribute)
-            and owner.attr == "modules"
-            and isinstance(owner.value, ast.Name)
-            and owner.value.id in sys_names
-            and isinstance(value.slice, ast.Name)
-            and value.slice.id in parameters
-        ):
-            continue
-        projected[target.id] = value.slice.id
-    returned = {
-        projected[node.value.id]
-        for node in ast.walk(function)
-        if isinstance(node, ast.Return)
-        and isinstance(node.value, ast.Name)
-        and node.value.id in projected
-    }
+    returned_names: set[str] = set()
+    for statement in function.body:
+        if isinstance(statement, Assign) and len(statement.targets) == 1:
+            target = statement.targets[0]
+            value = statement.value
+            if isinstance(target, Name) and isinstance(value, Subscript):
+                owner = value.value
+                if (
+                    isinstance(owner, Attribute)
+                    and owner.attr == "modules"
+                    and isinstance(owner.value, Name)
+                    and owner.value.id in sys_names
+                    and isinstance(value.slice_, Name)
+                    and value.slice_.id in parameters
+                ):
+                    projected[target.id] = value.slice_.id
+        if isinstance(statement, Return) and isinstance(statement.value, Name):
+            returned_names.add(statement.value.id)
+    returned = {projected[name] for name in returned_names if name in projected}
     if len(returned) != 1:
         return None
     return parameters.index(next(iter(returned)))

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/external_exception_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/external_exception_construction.py
@@ -432,7 +432,8 @@ def _returned_module_parameter(
     module = graph.modules.get(resolved.module_name)
     if module is None or module.source_cid != resolved.source_cid:
         return None
-    tree = SourceFile((module.source, module.source_seat, module.source_cid)).root
+    source_file = SourceFile((module.source, module.source_seat, module.source_cid))
+    tree = source_file.root
     function = next(
         (
             node
@@ -455,7 +456,34 @@ def _returned_module_parameter(
     }
     projected: dict[str, str] = {}
     returned_names: set[str] = set()
-    for statement in function.body:
+    registered = (
+        source_file.constructed_module.construction_event_receipt.registered_occurrences
+    )
+    function_span = function.span
+    nested_function_spans = tuple(
+        node.span
+        for node in registered
+        if (
+            node is not function
+            and isinstance(node, (FunctionDef, AsyncFunctionDef))
+            and function_span.start <= node.span.start
+            and node.span.end <= function_span.end
+        )
+    )
+    owned_occurrences = (
+        node
+        for node in registered
+        if (
+            node is not function
+            and function_span.start <= node.span.start
+            and node.span.end <= function_span.end
+            and not any(
+                nested.start <= node.span.start and node.span.end <= nested.end
+                for nested in nested_function_spans
+            )
+        )
+    )
+    for statement in owned_occurrences:
         if isinstance(statement, Assign) and len(statement.targets) == 1:
             target = statement.targets[0]
             value = statement.value

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -130,14 +130,19 @@ def _install_cython_include_distribution(
     return importlib.metadata.Distribution.at(metadata)
 
 
-def _install_returned_module_gate(root: Path) -> importlib.metadata.Distribution:
+def _install_returned_module_gate(
+    root: Path, *, source: str | None = None
+) -> importlib.metadata.Distribution:
     package = root / "gate_pkg"
     package.mkdir()
     (package / "__init__.py").write_text(
-        "import sys\n"
-        "def load(module_name):\n"
-        "    loaded = sys.modules[module_name]\n"
-        "    return loaded\n",
+        source
+        or (
+            "import sys\n"
+            "def load(module_name):\n"
+            "    loaded = sys.modules[module_name]\n"
+            "    return loaded\n"
+        ),
         encoding="utf-8",
     )
     metadata = root / "gate_dist-1.0.dist-info"
@@ -158,6 +163,40 @@ def _install_returned_module_gate(root: Path) -> importlib.metadata.Distribution
         for path in recorded:
             writer.writerow((path, "", ""))
     return importlib.metadata.Distribution.at(metadata)
+
+
+def _returned_module_testimony(tmp_path: Path, *, gate_source: str | None = None):
+    from sugar_lift_python_source.external_exception_construction import (
+        construct_provider_exception_attribute,
+    )
+    from sugar_lift_python_source.resolution_session import SourceResolutionSession
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.tree import SourceFile
+
+    provider = _install_stub_defined_distribution(tmp_path)
+    gate = _install_returned_module_gate(tmp_path, source=gate_source)
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(
+        "import gate_pkg\n"
+        'provider = gate_pkg.load("provider_pkg")\n'
+        "def expected():\n"
+        "    return provider.ProviderError\n",
+        encoding="utf-8",
+    )
+    tree = SourceFile(path_source(str(consumer)))
+    attribute = next(
+        node
+        for node in tree.nodes()
+        if node.kind == "Attribute" and node.attr == "ProviderError"
+    )
+    return construct_provider_exception_attribute(
+        attribute,
+        root=tmp_path,
+        path=consumer,
+        graph_cache={},
+        session=SourceResolutionSession(),
+        distribution_index={"gate_pkg": gate, "provider_pkg": provider},
+    )
 
 
 def test_stub_defined_provider_exception_resolves_to_its_definition(tmp_path: Path):
@@ -267,43 +306,63 @@ def test_returned_module_binding_constructs_provider_exception_without_vendor_na
     tmp_path: Path,
 ):
     """A source-returned module carries its provider class definition through."""
-    from sugar_lift_python_source.external_exception_construction import (
-        construct_provider_exception_attribute,
-    )
-    from sugar_lift_python_source.resolution_session import SourceResolutionSession
-    from sugar_lift_python_source.source_oracle import path_source
-    from sugar_source_tree.tree import SourceFile
-
-    provider = _install_stub_defined_distribution(tmp_path)
-    gate = _install_returned_module_gate(tmp_path)
-    consumer = tmp_path / "consumer.py"
-    consumer.write_text(
-        "import gate_pkg\n"
-        'provider = gate_pkg.load("provider_pkg")\n'
-        "def expected():\n"
-        "    return provider.ProviderError\n",
-        encoding="utf-8",
-    )
-    tree = SourceFile(path_source(str(consumer)))
-    attribute = next(
-        node
-        for node in tree.nodes()
-        if node.kind == "Attribute" and node.attr == "ProviderError"
-    )
-
-    testimony = construct_provider_exception_attribute(
-        attribute,
-        root=tmp_path,
-        path=consumer,
-        graph_cache={},
-        session=SourceResolutionSession(),
-        distribution_index={"gate_pkg": gate, "provider_pkg": provider},
-    )
+    testimony = _returned_module_testimony(tmp_path)
 
     assert testimony is not None
     assert testimony.resolved.definition.name == "ProviderError"
     assert testimony.resolved.module_name == "provider_pkg.lib"
     assert testimony.class_value().name == "provider_pkg.lib.ProviderError"
+
+
+def test_nested_returned_module_binding_preserves_authenticated_projection(
+    tmp_path: Path,
+) -> None:
+    """Truthful: control-flow nesting does not erase the gate's source testimony."""
+    testimony = _returned_module_testimony(
+        tmp_path,
+        gate_source=(
+            "import sys\n"
+            "def load(module_name):\n"
+            "    if module_name:\n"
+            "        loaded = sys.modules[module_name]\n"
+            "        return loaded\n"
+        ),
+    )
+
+    assert testimony is not None, "nested authenticated projection was lost"
+    assert testimony.resolved.definition.name == "ProviderError"
+    assert testimony.resolved.module_name == "provider_pkg.lib"
+
+
+@pytest.mark.parametrize(
+    "gate_source",
+    (
+        (
+            "import sys\n"
+            "def decoy(module_name):\n"
+            "    loaded = sys.modules[module_name]\n"
+            "    return loaded\n"
+            "def load(module_name):\n"
+            "    return None\n"
+        ),
+        (
+            "import sys\n"
+            "def load(module_name):\n"
+            "    def decoy():\n"
+            "        loaded = sys.modules[module_name]\n"
+            "        return loaded\n"
+            "    return None\n"
+        ),
+    ),
+    ids=("sibling-function", "nested-function"),
+)
+def test_returned_module_binding_cannot_borrow_another_function_projection(
+    tmp_path: Path, gate_source: str
+) -> None:
+    """Lying: source coordinates cannot cross sibling or nested ownership."""
+    testimony = _returned_module_testimony(tmp_path, gate_source=gate_source)
+
+    assert testimony is None
 
 
 def _demand(


### PR DESCRIPTION
## Summary

- replace the three owned raw `ast` parse/walk side doors with typed nodes projected from the producer-sealed `construction_event_receipt.registered_occurrences` roster or direct typed body fields
- remove the `ConstructionPanic` catch in no-call body attribution so the original producer owner remains loud and stops the batch
- add truthful/lying twins for one construction per demanded source, refusal of a second typed traversal, batch halt, and owner-preserving panic propagation

Root cause: the owned helpers bypassed the source-owned construction product with raw stdlib AST scans. `discover_no_call_body_probes` then traversed the same source again through `SourceFile`, while `attribute_body_probe` converted a producer `ConstructionPanic` into an ordinary `BodyAttribution` row and continued.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | one authenticated `SourceFile` construction supplies the sealed roster; no corpus census was run |
| `mandatory_panics` | 0 | no producer panic is added or removed; existing panic ownership now propagates unchanged |
| `suppressed_descendants` | 0 | a producer panic halts the attribution batch instead of permitting later probes |
| `typed_effects` | 0 | no effect or exit construction changes |
| `silent` | 0 | floor preserved |

## Validation

- `construction_side_door_law.py`: `R_construction_side_doors=0`, `R_sole_path_construction_side_doors=0`, `R_foreign_ast_import=0`, `R_ast_semantic_above_adapter=0`, `auditor_errors=0`
- `construction_panic_catch_law.py`: `R_construction_panic_catches_outside_audit=0`
- attribution plus both law test modules: `50 passed`
- exact native-operation projector twins: `2 passed`
- in-lane external-exception construction tests: `3 passed`
- native-crash and timeout floor modules: `9 passed`
- independent diff review: no Critical or Important findings

All receipts were rerun at `089caad58524fefeb253af5334896fd827318099` after a clean rebase onto `origin/main` `0ced04edd74083a09626dd8c48c825a0076d217e`.

## Floors preserved

- data loss: 0
- secret commits: 0
- panic suppression: 0
- native-crash and timeout floor tests: unchanged, 9/9 green
- no census, scoreboard, re-pin, or broad CI cleanup was run

Known unrelated base red: `test_stub_provider_cannot_testify_for_a_different_exception` raises the same `ClassDef._construct_sugar` unsupported-member `Expr` panic at base and head before reaching this lane.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route construction side doors through typed testimony for source tree traversal
> - Replaces AST-based scanning with typed `sugar_source_tree` traversal in several modules: operator constant discovery, no-call body probe discovery, exception ancestry resolution, and returned-module parameter detection.
> - `ConstructionPanic` exceptions in `attribute_body_probe` now propagate instead of being caught and converted into a `BodyAttribution` with `CONSTRUCTION_PANIC` outcome.
> - Returned-module parameter detection in [external_exception_construction.py](https://github.com/TSavo/sugar/pull/6937/files#diff-41bbd498dc18ea7e4b478eccef54cc4953b94a7195456399cfed5c99da975acd) now only considers assignments and returns owned by the target function, preventing borrowing from sibling or nested functions.
> - Tests in [test_no_call_body_attribution.py](https://github.com/TSavo/sugar/pull/6937/files#diff-1e9a303b50b18c61fae64f67414871f8a70627ad861506b60b958def25145321) are updated to expect `ConstructionPanic` to raise rather than be rendered in reports.
> - Risk: Non-parseable files previously skipped silently via `SyntaxError` catch during operator discovery are no longer handled; errors will now propagate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c36b594.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->