### PR TITLE
Return authenticated receiver state from source __new__

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -261,6 +261,7 @@ class ObjectValue(FloorValue):
             self.identity,
             self.deferred_helper_fields,
             still_deleted,
+            self.defining_class,
         )
 
     def authenticates_plain_attribute_store(self, name: str) -> bool:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/class_constructor_body_sugar.py
@@ -46,6 +46,51 @@ class ClassConstructorBodySugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
+        def project_new_return(definition, block):
+            """Return the shadow receiver state produced by source ``__new__``.
+
+            ``ReceiverFieldStoreStateSugar`` updates the immutable receiver in
+            the substituted method body.  Re-scanning that body for the old
+            ReceiverFieldStoreValue statement shape discards the constructed
+            return and recreates the pre-store receiver.  Only the authenticated
+            source ``__new__`` arm may return this value; ``__init__`` keeps its
+            ordinary receiver-construction path below.
+            """
+            if (
+                self.constructed_new_method is None
+                or definition.initializer is not None
+            ):
+                return None
+            from sugar_lift_py_tests.floor import ObjectValue
+            from sugar_lift_py_tests.floor.source_return_projection import (
+                project_authenticated_source_return,
+            )
+
+            returned = project_authenticated_source_return(block)
+            if (
+                returned is block
+                and len(block.statements) == 1
+                and isinstance(block.statements[0], ObjectValue)
+            ):
+                # reduce_body has already projected the sole ReturnValue and
+                # retained its value as the block's only completed statement.
+                returned = block.statements[0]
+            if (
+                isinstance(returned, ObjectValue)
+                and getattr(returned.defining_class, "class_definition_cid", None)
+                == definition.class_definition_cid
+            ):
+                return returned
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                blame=self.site,
+                owner="ClassConstructorBodySugar.__new__",
+                observed=type(returned).__name__,
+                requested="the authenticated immutable receiver returned by source __new__",
+                fix="preserve the shadow receiver binding through the source return",
+            )
+
         def construct(value):
             if self.initializer_body is None:
                 return Complete(
@@ -89,11 +134,16 @@ class ClassConstructorBodySugar(Sugar):
                     block = face.value
                     if not isinstance(block, BlockValue):
                         block = BlockValue((block,), can_fall_through=True)
+                    returned = project_new_return(value, block)
                     projected.append(
                         Completed(
                             face.guard,
-                            value.construct_receiver_state_from_block(
-                                block, self.receiver_coordinate_cid
+                            (
+                                returned
+                                if returned is not None
+                                else value.construct_receiver_state_from_block(
+                                    block, self.receiver_coordinate_cid
+                                )
                             ),
                             face.faces,
                             face.pending_contracts,
@@ -121,6 +171,9 @@ class ClassConstructorBodySugar(Sugar):
                     requested="one source-visible runtime initializer implementation",
                     fix="keep overload-only or stub-only constructors typed loud",
                 )
+            returned = project_new_return(value, block)
+            if returned is not None:
+                return Complete(returned)
             return Complete(
                 value.construct_receiver_state_from_block(
                     block, self.receiver_coordinate_cid

--- a/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
@@ -206,3 +206,33 @@ def test_receiver_field_post_state_preserves_mapping_identity_and_entries() -> N
     assert outcome.value.identity == receiver.identity
     assert outcome.value.entries == receiver.entries
     assert outcome.value.attribute("owner", "test") == Complete(TermValue(7))
+
+
+def test_receiver_field_post_state_preserves_defining_class_authority() -> None:
+    defining_class = object()
+    receiver = ObjectValue(
+        "Namespace", (), identity="receiver-1", defining_class=defining_class
+    )
+
+    outcome = ReceiverFieldStoreStateSugar(
+        _FixedSugar(receiver), _FixedSugar(TermValue(7)), "owner", "site"
+    ).desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value.defining_class is defining_class
+
+
+def test_receiver_field_post_state_does_not_borrow_foreign_class_authority() -> None:
+    own_class = object()
+    foreign_class = object()
+    receiver = ObjectValue(
+        "Namespace", (), identity="receiver-1", defining_class=own_class
+    )
+    foreign = ObjectValue(
+        "Namespace", (), identity="receiver-1", defining_class=foreign_class
+    )
+
+    updated = receiver.with_field_store("owner", TermValue(7))
+
+    assert updated.defining_class is own_class
+    assert updated.defining_class is not foreign.defining_class


### PR DESCRIPTION
Consumes the source __new__ shadow receiver only when its authenticated defining class matches the constructor. Preserves defining-class authority through immutable field stores; __init__ and foreign returns keep their existing loud paths.\n\nEvidence: 11 focused laws pass. Exact option_context lifecycle clears re/_constants.py:71 _NamedIntConstant.name and advances to enum.py:84 BoolOp truth for name.startswith(...).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return authenticated receiver state from source `__new__` in `ClassConstructorBodySugar`
> - `ClassConstructorBodySugar.desugar` now checks if a source `__new__` returns an `ObjectValue` for the same class; if so, it uses that value directly instead of calling `construct_receiver_state_from_block`.
> - A new inner helper `project_new_return` handles the projection, validating that the returned `ObjectValue.defining_class.class_definition_cid` matches the current definition. Invalid or mismatched returns raise `SugarNotWritten`.
> - `ObjectValue.with_field_store` now passes `self.defining_class` to the constructor, so updated instances retain the original defining class instead of resetting to the default.
> - Behavioral Change: constructors that return a mismatched or invalid `ObjectValue` from `__new__` now fail at desugar time rather than silently constructing receiver state from the block.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acd28c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved class ownership information when updating object fields.
  - Improved class construction to correctly retain and validate the object returned by `__new__`.
  - Prevented updated objects from inheriting class authority from unrelated objects.
- **Tests**
  - Added coverage confirming class ownership remains consistent through receiver field updates and object construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->