### PR TITLE
Project authenticated native string method truth

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -649,6 +649,31 @@ class StringValue(GuardStableValue):
             fix=f"add StringValue method floor for `{operation.name}`",
         )
 
+    def call_named_method(
+        self, name, arguments, *, owner, blame, ctx=None, keywords=()
+    ):
+        """Apply an already-authenticated native ``str`` method floor.
+
+        MethodCallSugar owns the source occurrence and this exact StringValue
+        owns native string semantics.  A method name alone grants nothing:
+        unsupported methods and non-ground argument types return ``None`` so
+        the ordinary call coordinate remains loud.
+        """
+        del ctx
+        if keywords:
+            return None
+        from types import SimpleNamespace
+
+        return _fold_string_method(
+            self,
+            SimpleNamespace(
+                name=name,
+                arguments=tuple(arguments),
+                owner=owner,
+                blame=blame,
+            ),
+        )
+
     def contains_with(self, operation, ctx):
         return operation.contains_string(self, ctx)
 
@@ -720,6 +745,29 @@ def _fold_string_method(receiver: StringValue, operation: MethodCallOperation):
             # Opaque / symbolic chars: mint call:strip(self, chars), never invent.
             return opaque_coordinate()
         return None
+
+    if name in {"startswith", "endswith"} and 1 <= len(args) <= 3:
+        prefix = args[0]
+        if not isinstance(prefix, StringValue):
+            return None
+        bounds = []
+        for value in args[1:]:
+            if not isinstance(value, TermValue) or type(value.value) is not int:
+                return None
+            bounds.append(value.value)
+        result = getattr(receiver.value, name)(prefix.value, *bounds)
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        return Complete(
+            TrueBoolLiteralSugar(site=operation.blame)
+            if result
+            else FalseBoolLiteralSugar(site=operation.blame)
+        )
 
     if name == "join" and len(args) == 1:
         iterable = args[0]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/method_call_sugar.py
@@ -176,6 +176,18 @@ class MethodCallSugar(ConstructedTermSugar):
                 keywords=kw_values,
                 required_frame=self.source_call_frame,
             )
+        call_named_method = getattr(receiver, "call_named_method", None)
+        if callable(call_named_method):
+            native = call_named_method(
+                self.name,
+                positional,
+                owner="MethodCallSugar",
+                blame=self.site,
+                ctx=ctx,
+                keywords=kw_values,
+            )
+            if native is not None:
+                return native
         if self.source_call_frame is not None:
             from sugar_source_tree.panic import SugarNotWritten
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_string_native_method_truth.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_string_native_method_truth.py
@@ -1,0 +1,89 @@
+from sugar_lift_py_tests.floor import CallSiteValue, StringValue, SymbolicValue
+from sugar_lift_py_tests.ir import atomic
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+from sugar_lift_py_tests.sugar.string_literal_sugar import StringLiteralSugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+
+class _Site:
+    def __init__(self, cid):
+        self.cid = cid
+
+    def seal(self):
+        return type(
+            "Seal",
+            (),
+            {
+                "cid": self.cid,
+                "source_cid": "source",
+                "start": 0,
+                "end": 1,
+            },
+        )()
+
+
+class _FixedSugar(ConstructedTermSugar):
+    def __init__(self, value, cid):
+        self.value = value
+        self.site = _Site(cid)
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+    def to_term(self, *, owner):
+        return self.value.to_term(owner=owner)
+
+
+def test_string_receiver_owns_startswith_boolean_return() -> None:
+    outcome = MethodCallSugar(
+        StringLiteralSugar("_member_", _Site("receiver")),
+        "startswith",
+        (StringLiteralSugar("_", _Site("prefix")),),
+        _Site("call"),
+    ).desugar()
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, TrueBoolLiteralSugar)
+
+
+def test_string_receiver_owns_endswith_boolean_return() -> None:
+    outcome = MethodCallSugar(
+        StringLiteralSugar("_member_", _Site("receiver")),
+        "endswith",
+        (StringLiteralSugar("_", _Site("suffix")),),
+        _Site("call"),
+    ).desugar()
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, TrueBoolLiteralSugar)
+
+
+def test_symbolic_receiver_cannot_borrow_native_string_return_type() -> None:
+    outcome = MethodCallSugar(
+        _FixedSugar(SymbolicValue(atomic("receiver", [])), "receiver"),
+        "startswith",
+        (StringLiteralSugar("_", _Site("prefix")),),
+        _Site("call"),
+    ).desugar()
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, CallSiteValue)
+
+
+def test_string_receiver_with_undecided_prefix_stays_untyped() -> None:
+    outcome = MethodCallSugar(
+        StringLiteralSugar("_member_", _Site("receiver")),
+        "startswith",
+        (_FixedSugar(SymbolicValue(atomic("prefix", [])), "prefix"),),
+        _Site("call"),
+    ).desugar()
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, CallSiteValue)


### PR DESCRIPTION
Adds the receiver-owned native floor for str.startswith/endswith with ground prefix/suffix and optional bounds. Symbolic receivers and undecided arguments remain on the ordinary loud CallSite path; BoolOp gains no spelling arm.\n\nEvidence: 52 focused tests pass. Exact option_context lifecycle clears enum.py:84 and advances to the next independent boundary: a fully decidable GuardedValue dictionary setitem incorrectly routed through the runtime-effect constructor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native support for evaluating string `startswith` and `endswith` calls.
  - Valid calls with known string and integer arguments now resolve directly to boolean results.
  - String method calls now reject keyword arguments where unsupported.

- **Bug Fixes**
  - Improved return-type handling so literal string checks are recognized as booleans.
  - Symbolic or undecidable string expressions remain unresolved instead of receiving incorrect inferred types.

- **Tests**
  - Added coverage for literal, symbolic, and undecidable string method calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `startswith`/`endswith` folding to `StringValue.call_named_method`
> - Adds `call_named_method` to `StringValue` in [string_value.py](https://github.com/TSavo/sugar/pull/6939/files#diff-7f7cef79e8741c9f5ef0a7a75ab1e3f73d2cf58f59cc5d53870d530f4ffcbda5), which folds `startswith`/`endswith` calls to `TrueBoolLiteralSugar` or `FalseBoolLiteralSugar` when the prefix/suffix is a `StringValue` and optional bounds are integer `TermValue`s.
> - Updates `MethodCallSugar.desugar` in [method_call_sugar.py](https://github.com/TSavo/sugar/pull/6939/files#diff-1a6a1e058898693a04db89a8dda185ad15e19277c08fb04e58876c1736c68088) to dispatch to `call_named_method` on the receiver first, returning early if a non-None result is produced.
> - Symbolic receivers or symbolic prefixes fall through to the existing `CallSiteValue` path unchanged.
> - Tests in [test_string_native_method_truth.py](https://github.com/TSavo/sugar/pull/6939/files#diff-903561269e40653508f2cba1165414114d11a6e43869d9724473db7428959c49) cover both the folded and unfolded cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7fe9fb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->