### PR TITLE
Distribute dictionary stores over authenticated guarded operands

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py
@@ -253,6 +253,9 @@ class DictValue(GuardStableValue):
         return self.undecided_subscript(index, site, owner="DictValue.subscript")
 
     def setitem(self, index, value, site):
+        guarded = self._guarded_setitem(index, value, site)
+        if guarded is not None:
+            return guarded
         from sugar_lift_py_tests.floor.string_value import StringValue
         from sugar_lift_py_tests.floor.term_value import TermValue
         from sugar_lift_py_tests.outcome import Complete, Incomplete
@@ -277,6 +280,37 @@ class DictValue(GuardStableValue):
                 **runtime_effect_evidence("py.setitem", index, site),
             )
         )
+
+    def _guarded_setitem(self, index, value, site):
+        """Store once on every authenticated guarded key/value face.
+
+        A GuardedValue's conditional term is lift-time decidable and therefore
+        cannot mint RuntimeEffect authority.  Preserve the source partition:
+        recursively apply this dict's ordinary store law to each face and
+        rejoin under the original guard and its exact complement.
+        """
+        from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+        from sugar_lift_py_tests.ir import not_
+        from sugar_lift_py_tests.outcome.exit_set import outcome_to_exitset
+
+        operands = (index, value)
+        for position, operand in enumerate(operands):
+            if not isinstance(operand, GuardedValue):
+                continue
+
+            def project(face):
+                selected = list(operands)
+                selected[position] = face
+                return self.setitem(*selected, site)
+
+            when_true = outcome_to_exitset(project(operand.when_true)).guarded(
+                operand.guard
+            )
+            when_false = outcome_to_exitset(project(operand.when_false)).guarded(
+                not_(operand.guard)
+            )
+            return when_true.union(when_false)
+        return None
 
     def delitem(self, index, site):
         from sugar_lift_py_tests.floor.string_value import StringValue

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_setitem_distribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_setitem_distribution.py
@@ -1,0 +1,54 @@
+from sugar_lift_py_tests.floor import DictValue, GuardedValue, StringValue, TermValue
+from sugar_lift_py_tests.ir import atomic, not_
+from sugar_lift_py_tests.outcome import ExitSet
+from sugar_lift_py_tests.outcome.exit_set import Completed
+
+
+def _store(receiver, index, value):
+    return receiver.setitem(index, value, "store-site")
+
+
+def _entry_map(value):
+    return {key.value: item.value for key, item in value.entries}
+
+
+def test_guarded_index_distributes_store_under_complementary_guards() -> None:
+    guard = atomic("selected", [])
+    outcome = _store(
+        DictValue(()),
+        GuardedValue(guard, StringValue("left"), StringValue("right")),
+        TermValue(7),
+    )
+
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 2
+    assert all(isinstance(face, Completed) for face in outcome.exits)
+    assert {face.guard for face in outcome.exits} == {guard, not_(guard)}
+    assert {
+        tuple(sorted(_entry_map(face.value).items())) for face in outcome.exits
+    } == {(("left", 7),), (("right", 7),)}
+
+
+def test_guarded_value_distributes_without_choosing_one_face() -> None:
+    guard = atomic("selected", [])
+    outcome = _store(
+        DictValue(()),
+        StringValue("member"),
+        GuardedValue(guard, TermValue(1), TermValue(2)),
+    )
+
+    assert isinstance(outcome, ExitSet)
+    assert len(outcome.exits) == 2
+    assert {face.guard for face in outcome.exits} == {guard, not_(guard)}
+    assert {_entry_map(face.value)["member"] for face in outcome.exits} == {1, 2}
+
+
+def test_guarded_index_never_mints_a_runtime_store_effect() -> None:
+    guard = atomic("selected", [])
+    outcome = _store(
+        DictValue(()),
+        GuardedValue(guard, StringValue("left"), StringValue("right")),
+        TermValue(7),
+    )
+
+    assert all(isinstance(face, Completed) for face in outcome.exits)


### PR DESCRIPTION
Distributes guarded dict keys and values across both authenticated faces, preserving exact complementary guards and distinct mapping post-states. Decidable faces never enter the runtime-effect constructor; no face is selected or collapsed.\n\nEvidence: 3 focused tests pass. Exact option_context lifecycle advances to enum.py [19640,19695], where LoopRecurrenceSugar lacks authenticated CallSiteValue.iter_with projection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Guarded dictionary assignments now correctly distribute across complementary guard conditions.
  - Guarded keys and values preserve their corresponding combinations without selecting a single outcome.
  - Prevented guarded assignments from producing unintended runtime store effects.

- **Tests**
  - Added coverage for guarded index and value assignments, including completion and side-effect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Distribute dictionary stores over authenticated guarded operands in `DictValue.setitem`
> - Adds `DictValue._guarded_setitem` in [dict_value.py](https://github.com/TSavo/sugar/pull/6940/files#diff-76c3d825471eeab5a86de09645ff49d3e80a9f865138d6646ad5b6ef3e2e1002) to detect when either the index or value is a `GuardedValue` and distribute the store across each guarded face.
> - Each face is projected by calling `setitem` recursively, converted to an `ExitSet`, guarded with complementary guards, and returned as a union — replacing what would otherwise produce an `Incomplete SubscriptStoreRuntimeEffect`.
> - Adds tests in [test_guarded_setitem_distribution.py](https://github.com/TSavo/sugar/pull/6940/files#diff-95849b74247ac4c7c6e86471c109830cc375f092146c8745ce1ed7918619a0d4) covering guarded key, guarded value, and absence of runtime store effects.
> - Behavioral Change: callers of `DictValue.setitem` may now receive an `ExitSet` of guarded `Completed` outcomes instead of a single `Complete`/`Incomplete` outcome when operands are `GuardedValue`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c023b53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->