### PR TITLE
Stop fabricating MatchDecided(False) outside written sugar

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -194,17 +194,23 @@ def _and_finally_with_raise_context(pre_finally, finalbody, *, ctx, site):
 
 
 def _effect_match_verdict(effect, matcher, ctx=None, *, site=None):
-    """Bare except matches any raise; typed arms use constructed identity.
+    """Bare except matches any raise; typed arms use the ONE matcher.
 
-    The codomain is the shared matcher's: ``MatchDecided`` when the arm settles
-    at lift, ``MatchRetained`` when the identity test is real and open. The
-    caller must route BOTH faces of a retention -- never treat it as a match
-    and never as a miss.
+    LAW OF ONE: tree shadows → sugar → meaning. Settled match/miss meaning is
+    only ``matches_raise_effect`` in ``authenticated_exception_matching``
+    (authenticated operands in, ``MatchDecided`` / ``MatchRetained`` out).
+    This function does not decide miss. It either:
 
-    Ordinary except routes only ``RaiseEffect``. ``GroupedRaiseEffect`` is a
-    sibling dataclass (not a subclass); minting ``MatchDecided(False)`` for it
-    fabricates a miss on an effect kind this router cannot read. Mirror
-    ``TryStarSugar``: throw a named ``SugarNotWritten`` instead.
+    - refuses with ``SugarNotWritten`` when the effect kind is not what ordinary
+      except sugar reads (``GroupedRaiseEffect`` is a sibling of ``RaiseEffect``,
+      not a subclass — same membrane as ``TryStarSugar``), or when the handler
+      type did not construct; or
+    - returns the one matcher's verdict for typed arms; or
+    - returns ``MatchDecided(True)`` for bare except over a real ``RaiseEffect``
+      (written bare-except sugar — no type operand to match).
+
+    Minting ``MatchDecided(False)`` here would be a second mechanism: ad-hoc
+    Python fabricating a miss outside the tree→sugar path.
     """
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
     from sugar_lift_py_tests.authenticated_exception_matching import (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -193,13 +193,18 @@ def _and_finally_with_raise_context(pre_finally, finalbody, *, ctx, site):
     return ExitSet(tuple(exits)).normalize()
 
 
-def _effect_match_verdict(effect, matcher, ctx=None):
+def _effect_match_verdict(effect, matcher, ctx=None, *, site=None):
     """Bare except matches any raise; typed arms use constructed identity.
 
     The codomain is the shared matcher's: ``MatchDecided`` when the arm settles
     at lift, ``MatchRetained`` when the identity test is real and open. The
     caller must route BOTH faces of a retention -- never treat it as a match
     and never as a miss.
+
+    Ordinary except routes only ``RaiseEffect``. ``GroupedRaiseEffect`` is a
+    sibling dataclass (not a subclass); minting ``MatchDecided(False)`` for it
+    fabricates a miss on an effect kind this router cannot read. Mirror
+    ``TryStarSugar``: throw a named ``SugarNotWritten`` instead.
     """
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
     from sugar_lift_py_tests.authenticated_exception_matching import (
@@ -210,7 +215,14 @@ def _effect_match_verdict(effect, matcher, ctx=None):
     from sugar_source_tree.panic import SugarNotWritten
 
     if not isinstance(effect, RaiseEffect):
-        return MatchDecided(False)
+        blame = getattr(effect, "occurrence_id", None) or site
+        raise SugarNotWritten(
+            blame=blame,
+            owner="TrySugar._effect_match_verdict",
+            observed=type(effect).__name__,
+            requested="RaiseEffect for ordinary except routing",
+            fix="keep ordinary except and except* distinct",
+        )
     if matcher is None:
         return MatchDecided(True)
     expected = matcher.desugar(ctx)
@@ -343,7 +355,7 @@ def _route_one_halt(exit_, handlers: tuple, *, site, ctx) -> list:
         if not residual.exits:
             return parts
         residual_guard = residual.exits[0].guard
-        verdict = _effect_match_verdict(exit_.effect, matcher, ctx)
+        verdict = _effect_match_verdict(exit_.effect, matcher, ctx, site=site)
         if isinstance(verdict, MatchDecided):
             if not verdict.value:
                 continue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -448,10 +448,12 @@ def _route_warning_boundary(*, body, ctx, manager_exit, expected, pattern, mode,
             refusal.unresolved_warning_producers = unresolved_members
             raise refusal
         if len(observations) != 1:
-            # pytest.warns is EXISTENTIAL: one authenticated observation is the
-            # written surface. Cardinality ≠ 1 is not a decided miss — deciding
-            # False here fabricates ExpectationNotMet without asking the
-            # three-valued matcher. Sugar not written for multi-obs (yet).
+            # LAW OF ONE: match/miss meaning is only warning_effect_message_verdict
+            # (the one matcher) after sugar produced one authenticated observation.
+            # pytest.warns is EXISTENTIAL — one written surface. Cardinality ≠ 1
+            # is not a settled miss: deciding MatchDecided(False) here would be a
+            # second mechanism (ad-hoc count → fabricated ExpectationNotMet).
+            # Sugar not written for multi-obs yet; throw, do not decide.
             raise SugarNotWritten(
                 blame=site,
                 owner="WithEffectBoundarySugar.warning_observation",
@@ -468,6 +470,7 @@ def _route_warning_boundary(*, body, ctx, manager_exit, expected, pattern, mode,
                 ),
             )
         index, observation = observations[0]
+        # ONE matcher: identity + optional message. No local MatchDecided mint.
         verdict = warning_effect_message_verdict(
             observation.effect, expected, pattern
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -448,13 +448,29 @@ def _route_warning_boundary(*, body, ctx, manager_exit, expected, pattern, mode,
             refusal.unresolved_warning_producers = unresolved_members
             raise refusal
         if len(observations) != 1:
-            verdict = MatchDecided(False)
-            index = None
-        else:
-            index, observation = observations[0]
-            verdict = warning_effect_message_verdict(
-                observation.effect, expected, pattern
+            # pytest.warns is EXISTENTIAL: one authenticated observation is the
+            # written surface. Cardinality ≠ 1 is not a decided miss — deciding
+            # False here fabricates ExpectationNotMet without asking the
+            # three-valued matcher. Sugar not written for multi-obs (yet).
+            raise SugarNotWritten(
+                blame=site,
+                owner="WithEffectBoundarySugar.warning_observation",
+                observed=(
+                    f"{len(observations)} authenticated warning observations"
+                ),
+                requested=(
+                    "exactly one source-authenticated WarningObservationValue "
+                    "on the completed face"
+                ),
+                fix=(
+                    "write multi-observation warning-boundary sugar; never "
+                    "decide miss by cardinality alone"
+                ),
             )
+        index, observation = observations[0]
+        verdict = warning_effect_message_verdict(
+            observation.effect, expected, pattern
+        )
 
         def successful(guard, faces):
             assert index is not None
@@ -548,6 +564,7 @@ def _route_no_warning_boundary(*, body, ctx, manager_exit, mode, site):
     # population predicate in its single owner rather than restating it here.
     if not body_es.exits:
         raise SugarNotWritten(
+            blame=site,
             owner="WithEffectBoundarySugar.warning_observation",
             observed="body has no authenticated exit edge",
             requested="a resolved ExitSet containing a Completed edge",

--- a/implementations/python/sugar-lift-py-tests/tests/test_match_decided_one_matcher_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_match_decided_one_matcher_law.py
@@ -1,0 +1,172 @@
+"""LAW OF ONE for match verdicts: one matcher, no fabricated decided-miss.
+
+Meaning path (the only one):
+
+    AST tree shadows → temporal rewrite / tree-modification sugar → meaning
+
+``MatchDecided`` is meaning. The sole production mint of a *settled miss*
+(``MatchDecided(False)``) lives in ``authenticated_exception_matching`` —
+``matches_raise_effect`` / ``*_message_verdict`` — after authenticated
+operands have been produced by sugar. Anywhere else that mints
+``MatchDecided(False)`` is a second mechanism: ad-hoc Python deciding miss
+outside the tree→sugar path (cardinality, isinstance kind gates, spelling).
+
+Throwing ``SugarNotWritten`` is honorable: sugar is not written yet. Fabricating
+a decided miss is the sin even when the runtime answer would have been miss.
+
+BLIND SPOT (loud): ``tests/law_of_one_auditor.py`` / ``law_of_one_evidence.py`` /
+``law_of_one_symbol_graph.py`` audit SourceFile construction, privacy, and
+projection closure. They do **not** scan sugar for fabricated ``MatchDecided``
+mints. This file is the instrument that can see this sin class. If it is
+deleted or skipped, the cluster is unguarded again.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_PKG_SRC = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+
+# Sole owner of MatchDecided(False) meaning. Every other production mint is a
+# second mechanism.
+_ONE_MATCHER = _PKG_SRC / "authenticated_exception_matching.py"
+
+# Production roots under this package. Tests and scripts are not meaning owners.
+_PRODUCTION_ROOTS = (
+    _PKG_SRC / "sugar",
+    _PKG_SRC / "effect",
+    _PKG_SRC / "floor",
+    _PKG_SRC / "outcome",
+    _PKG_SRC / "temporal",
+    _PKG_SRC / "operations",
+)
+
+
+def _production_py_files() -> tuple[Path, ...]:
+    files: list[Path] = []
+    for root in _PRODUCTION_ROOTS:
+        if not root.is_dir():
+            continue
+        files.extend(
+            path
+            for path in root.rglob("*.py")
+            if "__pycache__" not in path.parts and path.name != "__init__.py"
+        )
+    # Package-root modules that own routing/matching.
+    for name in (
+        "authenticated_exception_matching.py",
+        "caller_parameter_contract.py",
+        "effect_router.py",
+        "in_flight_effect.py",
+    ):
+        path = _PKG_SRC / name
+        if path.is_file():
+            files.append(path)
+    return tuple(sorted(set(files)))
+
+
+def _is_match_decided_false(node: ast.AST) -> bool:
+    """True when ``node`` is a Call that constructs ``MatchDecided(False)``."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        name = func.id
+    elif isinstance(func, ast.Attribute):
+        name = func.attr
+    else:
+        return False
+    if name != "MatchDecided":
+        return False
+    if not node.args:
+        return False
+    arg0 = node.args[0]
+    return isinstance(arg0, ast.Constant) and arg0.value is False
+
+
+def _fabricated_decided_miss_sites(path: Path) -> list[tuple[Path, int, str]]:
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    sites: list[tuple[Path, int, str]] = []
+    for node in ast.walk(tree):
+        if _is_match_decided_false(node):
+            line = getattr(node, "lineno", 0)
+            sites.append((path, line, ast.get_source_segment(source, node) or "MatchDecided(False)"))
+    return sites
+
+
+def test_one_matcher_is_the_sole_match_decided_false_owner() -> None:
+    """``MatchDecided(False)`` only from authenticated_exception_matching.
+
+    Truthful: the one matcher may settle miss after authenticated operands.
+    Lying: any other production module minting MatchDecided(False) is a
+    fabricated decided-miss (SIN CLUSTER 1).
+    """
+    assert _ONE_MATCHER.is_file(), f"missing one matcher: {_ONE_MATCHER}"
+
+    offenders: list[str] = []
+    matcher_hits = 0
+    for path in _production_py_files():
+        sites = _fabricated_decided_miss_sites(path)
+        if path.resolve() == _ONE_MATCHER.resolve():
+            matcher_hits += len(sites)
+            continue
+        for site_path, line, snippet in sites:
+            rel = site_path.relative_to(_PKG_SRC)
+            offenders.append(f"{rel}:{line}: {snippet}")
+
+    assert matcher_hits >= 1, (
+        "one matcher must still mint MatchDecided(False) for real identity/message "
+        "misses; instrument found zero hits in authenticated_exception_matching.py"
+    )
+    assert not offenders, (
+        "LAW OF ONE / fabricated decided-miss: MatchDecided(False) outside the one "
+        "matcher (authenticated_exception_matching). That is a second mechanism — "
+        "ad-hoc Python deciding miss without tree→sugar meaning. Throw SugarNotWritten "
+        "until the sugar is written; never fabricate MatchDecided.\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_law_of_one_auditor_is_blind_to_fabricated_match_decided() -> None:
+    """LOUD: repository LAW_OF_ONE auditor does not cover this sin class.
+
+    ``tests/law_of_one_auditor.py`` closes SourceFile construction, privacy, and
+    projection. It never walks sugar for MatchDecided mints. This assertion pins
+    that gap so nobody confuses a green LAW_OF_ONE receipt with coverage of
+    fabricated decided-miss.
+    """
+    repo_tests = Path(__file__).resolve().parents[4] / "tests"
+    auditor = repo_tests / "law_of_one_auditor.py"
+    evidence = repo_tests / "law_of_one_evidence.py"
+    assert auditor.is_file(), auditor
+    assert evidence.is_file(), evidence
+    auditor_src = auditor.read_text(encoding="utf-8")
+    # Positive pin: the auditor's documented axes.
+    assert "SourceFile" in auditor_src
+    assert "materialize_module" in auditor_src or "constructed_module" in auditor_src
+    # Negative pin: it does not name this sin class.
+    assert "MatchDecided" not in auditor_src, (
+        "law_of_one_auditor now mentions MatchDecided — either wire fabricated "
+        "decided-miss into its receipt, or update this blindness pin"
+    )
+    assert "fabricated decided" not in auditor_src.lower()
+
+
+def test_planted_fabricated_miss_is_detected() -> None:
+    """Lying twin of the instrument: a foreign MatchDecided(False) is red."""
+    planted = ast.parse(
+        "def route(effect):\n"
+        "    if not isinstance(effect, RaiseEffect):\n"
+        "        return MatchDecided(False)\n"
+        "    return MatchDecided(True)\n"
+    )
+    hits = [
+        node
+        for node in ast.walk(planted)
+        if _is_match_decided_false(node)
+    ]
+    assert len(hits) == 1

--- a/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
@@ -403,9 +403,15 @@ def test_occurrence_lying_twin_matched_binding_is_not_residual_leaf():
 # ---------------------------------------------------------------------------
 
 
-def test_ordinary_try_cannot_consume_grouped_testimony():
-    """Ordinary except ValueError leaves ExceptionGroup intact (not rewritten)."""
-    effect = _grouped_halt(
+def test_ordinary_try_refuses_grouped_raise_effect():
+    """Ordinary except must not decide miss on GroupedRaiseEffect.
+
+    GroupedRaiseEffect is a sibling of RaiseEffect, not a subclass. Returning
+    MatchDecided(False) fabricates a miss on an effect kind ordinary Try
+    cannot read. Mirror TryStarSugar: named SugarNotWritten, membrane stays
+    loud both directions.
+    """
+    with pytest.raises(SugarNotWritten) as excinfo:
         _desugar(
             "def f():\n"
             "    try:\n"
@@ -414,14 +420,21 @@ def test_ordinary_try_cannot_consume_grouped_testimony():
             "        pass\n",
             name="ordinary_try.py",
         )
-    )
-    assert isinstance(effect, GroupedRaiseEffect)
-    assert [leaf.exception_name for leaf in _leaves(effect)] == ["ValueError"]
+    gap = excinfo.value
+    assert gap.owner == "TrySugar._effect_match_verdict"
+    assert gap.observed == "GroupedRaiseEffect"
+    assert "RaiseEffect" in gap.requested
+    assert "except*" in gap.fix
 
 
-def test_ordinary_try_except_exceptiongroup_still_does_not_split():
-    """Even except ExceptionGroup on ordinary Try does not enter TryStar partition."""
-    effect = _grouped_halt(
+def test_ordinary_try_except_exceptiongroup_still_refuses_without_split():
+    """even except ExceptionGroup on ordinary Try does not enter TryStar partition.
+
+    The arm still cannot read GroupedRaiseEffect through RaiseEffect matching;
+    deciding miss would be the same fabricated verdict. Loud until ordinary
+    Try owns grouped routing (it does not).
+    """
+    with pytest.raises(SugarNotWritten) as excinfo:
         _desugar(
             "def f():\n"
             "    try:\n"
@@ -430,8 +443,9 @@ def test_ordinary_try_except_exceptiongroup_still_does_not_split():
             "        pass\n",
             name="ordinary_eg.py",
         )
-    )
-    assert [leaf.exception_name for leaf in _leaves(effect)] == ["ValueError"]
+    gap = excinfo.value
+    assert gap.owner == "TrySugar._effect_match_verdict"
+    assert gap.observed == "GroupedRaiseEffect"
 
 
 def test_trystar_refuses_ordinary_raise_effect():
@@ -447,6 +461,19 @@ def test_trystar_refuses_ordinary_raise_effect():
         )
     assert "TryStarSugar" in str(excinfo.value)
     assert "GroupedRaiseEffect" in str(excinfo.value)
+
+
+def test_truthful_ordinary_try_still_matches_raise_effect():
+    """Truthful twin: ordinary RaiseEffect under ordinary except still routes."""
+    outcome = _desugar(
+        "def f():\n"
+        "    try:\n"
+        "        raise ValueError('alone')\n"
+        "    except ValueError:\n"
+        "        return 1\n",
+        name="ordinary_raise_truthful.py",
+    )
+    assert isinstance(outcome, Complete), outcome
 
 
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
@@ -111,7 +111,8 @@ def _boundary(*entries, expected=None):
         semantics=SEMANTICS,
         contract_ref=SimpleNamespace(import_signature=signature),
         context_manager_edge=None,
-        site=None,
+        # Real blame coordinate: SugarNotWritten refuses blame=None.
+        site="with_effect_boundary_warning:test",
     )
 
 
@@ -140,14 +141,23 @@ def test_lying_warning_observation_fails_the_assertion():
     assert isinstance(face.effect, ExpectationNotMetEffect)
 
 
-def test_matching_warning_plus_extra_warning_fails_the_assertion():
-    routed = _boundary(
-        _warning("FutureWarning"), _warning("DeprecationWarning")
-    ).desugar()
-    assert len(routed.exits) == 1
-    face = routed.exits[0]
-    assert isinstance(face, Halted)
-    assert isinstance(face.effect, ExpectationNotMetEffect)
+def test_multi_authenticated_warning_observations_are_not_a_decided_miss():
+    """Cardinality ≠ 1 is sugar-not-written, never MatchDecided(False).
+
+    pytest.warns is existential. Two authenticated observations are evidence
+    nobody's multi-obs sugar has read yet. Fabricating ExpectationNotMetEffect
+    from len(observations) alone is a decided miss outside the three-valued
+    matcher — the lying twin of this package.
+    """
+    with pytest.raises(SugarNotWritten) as raised:
+        _boundary(
+            _warning("FutureWarning"), _warning("DeprecationWarning")
+        ).desugar()
+    gap = raised.value
+    assert gap.owner == "WithEffectBoundarySugar.warning_observation"
+    assert "2 authenticated warning observations" in gap.observed
+    assert "exactly one" in gap.requested
+    assert "cardinality" in gap.fix
 
 
 def test_unresolved_completed_face_is_undecided_not_false():
@@ -234,7 +244,7 @@ def _no_warning_from_exitset(body_es):
         semantics=SEMANTICS,
         contract_ref=SimpleNamespace(import_signature=signature),
         context_manager_edge=None,
-        site=None,
+        site="with_effect_boundary_warning:no_warning",
     )
 
 


### PR DESCRIPTION
## Summary

SIN CLUSTER 1 — fabricated decided-miss, under **LAW OF ONE**.

There is exactly one meaning path:

```
AST tree shadows → temporal rewrite / tree-modification sugar → meaning
```

`MatchDecided` is meaning. The sole production mint of a settled **miss** (`MatchDecided(False)`) is `authenticated_exception_matching` (`matches_raise_effect` / `*_message_verdict`) after sugar produced authenticated operands. Anywhere else that mints `MatchDecided(False)` is a **second mechanism** — ad-hoc Python deciding miss outside the tree→sugar path (cardinality, isinstance kind gates, spelling).

Throwing is honorable. Fabricating a decided miss is the sin.

### Fixes

1. **`with_effect_boundary_sugar`**: multi authenticated warning observations no longer become `MatchDecided(False)` → `ExpectationNotMetEffect`. `pytest.warns` is existential; multi-obs is sugar-not-written. Verdicts only from `warning_effect_message_verdict` (the one matcher).
2. **`try_sugar`**: non-`RaiseEffect` (including sibling `GroupedRaiseEffect`) no longer returns `MatchDecided(False)`. Named `SugarNotWritten` — same membrane as `TryStarSugar`. Typed arms still call `matches_raise_effect` only.
3. Empty no-warning `ExitSet` SNW carries `blame=site`.

### Instrument (because the repo auditor is blind)

**LOUD: `tests/law_of_one_auditor.py` / `law_of_one_evidence.py` / `law_of_one_symbol_graph.py` cannot see this sin.**

Those close SourceFile construction, privacy, and projection. They never walk sugar for `MatchDecided` mints. A green LAW_OF_ONE receipt is **not** coverage of fabricated decided-miss.

Package instrument: `test_match_decided_one_matcher_law.py`

- scans production under this package for `MatchDecided(False)`
- allows only `authenticated_exception_matching.py`
- planted twin proves the scanner goes red on a foreign mint
- pins auditor blindness so the gap cannot be confused with coverage

## Gate

| Twin | Expected |
|------|----------|
| Truthful single matching warning | `Completed` via one matcher |
| Lying wrong category | `ExpectationNotMetEffect` (one matcher) |
| Lying multi-obs (was fabricated miss) | `SugarNotWritten` — no local MatchDecided |
| Truthful ordinary `RaiseEffect` + `except` | routes / `Complete` |
| Lying ordinary try + `ExceptionGroup` | `SugarNotWritten` (not MatchDecided(False)) |
| One-matcher ownership law | zero foreign `MatchDecided(False)` |
| Auditor blindness pin | LAW_OF_ONE source has no MatchDecided |

## Validation

```bash
PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src \
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest --noconftest \
  implementations/python/sugar-lift-py-tests/tests/test_match_decided_one_matcher_law.py \
  implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py \
  implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py::test_ordinary_try_refuses_grouped_raise_effect \
  implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py::test_truthful_ordinary_try_still_matches_raise_effect \
  -q
# 24 green on last run
```

## Author

T Savo &lt;evilgenius@nefariousplan.com&gt;

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop fabricating `MatchDecided(False)` outside the authenticated matcher
> - `_effect_match_verdict` in [try_sugar.py](https://github.com/TSavo/sugar/pull/6941/files#diff-f5d956a5de18664d828d314bf5537a359cc1f2f40c5a42b52f03bbe5ecaac0ff) now raises `SugarNotWritten` (with site blame) instead of minting `MatchDecided(False)` when the effect is not a `RaiseEffect` or the handler type is unresolved; bare `except` over a real `RaiseEffect` returns `MatchDecided(True)` directly.
> - `_route_warning_boundary` in [with_effect_boundary_sugar.py](https://github.com/TSavo/sugar/pull/6941/files#diff-0d372d766673042627a4eeab5612c75aa23cb49a85e1aa6866cfb0721be30780) raises `SugarNotWritten` (with blame/owner/observed/requested/fix fields) instead of returning `MatchDecided(False)` when authenticated warning observation count ≠ 1.
> - A new test in [test_match_decided_one_matcher_law.py](https://github.com/TSavo/sugar/pull/6941/files#diff-09e1b870a06f29bdd9d08e6866e0ae61b13d0e1892e0fb4e3ff8c21f90961e5c) enforces the LAW OF ONE: only the `authenticated_exception_matching` module may construct `MatchDecided(False)`, verified via AST scanning of all production files.
> - Behavioral Change: ordinary `try/except` over a `GroupedRaiseEffect` (e.g. `ExceptionGroup`) now raises `SugarNotWritten` rather than producing a decided miss, as verified by updated tests in [test_trystar_subgroup_routing.py](https://github.com/TSavo/sugar/pull/6941/files#diff-556a21d45c7b68e3f1b955eb2125256ca76ae87d366521422d319b84ae49e393).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc04957.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->