### PR TITLE
Remove ordering-floor Complete(PredicateValue) fabrication (SIN CLUSTER 2 / LAW_OF_ONE)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -500,29 +500,14 @@ class CallSiteValue(FloorValue):
         )
 
     def contains(self, item, site):
-        # `item in callsite`: dig a concrete container when the body yields one;
-        # otherwise the call result is an opaque container and stays py.in —
-        # uninterpreted membership, never invented.
+        # Dig a concrete container when the body yields one; otherwise the call
+        # result's container type is undecided — named refusal, never
+        # Complete(py.in) fabrication.
         dug = self._dig_floor_or_none(None, owner="CallSiteValue.contains")
         if dug is not None and dug is not self:
             return dug.contains(item, site)
-
-        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-        from sugar_lift_py_tests.ir import atomic
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(
-            PredicateValue(
-                atomic(
-                    "py.in",
-                    [
-                        item.to_term(owner="CallSiteValue.contains member"),
-                        self.term,
-                    ],
-                ),
-                site,
-                operand_callsites=(*item.callsites(), self),
-            )
+        return self.undecided_contains(
+            item, site, owner="CallSiteValue.contains"
         )
 
     def subscript(self, index, site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -1110,123 +1110,110 @@ class FloorValue:
 
     def less_than(self, other, site):
         # Operator-owned double dispatch: the RHS answers ``less_than_from_left``.
-        # Default Floor emits the ordinary atom only when both operand types are
-        # source-decided; undecided pairs throw named (never Complete).
-        # GuardedValue distributes; NamedExpressionValue presents-and-carries.
+        # LAW_OF_ONE: ordering meaning is Sugar (or a ground arm that constructs
+        # Sugar / authenticated RaiseValue). The default door never mints
+        # Complete(PredicateValue) — that is a second mechanism.
         return other.less_than_from_left(self, site)
 
-    def _undecided_ordering_law(self, other, site, *, owner: str, operator: str):
-        """Refuse ordering when either operand's runtime type is undecided.
+    def _refuse_ordering_meaning(
+        self, other, site, *, owner: str, operator: str
+    ) -> None:
+        """LAW_OF_ONE door for ordering: throw named; never mint FOL meaning.
 
-        Returns ``None`` when the law does not apply (non-values, or both types
-        source-decided). Raises ``SugarNotWritten`` when it does — never
-        ``Complete(PredicateValue(py.lt/…))``. Fabricating the solver atom for
-        undecided dispatch is the direct route to a false DONE: every ordering
-        row goes green for the wrong reason, and ``pytest.raises(TypeError)``
-        is structurally unsatisfiable.
+        Exactly one mechanism produces meaning: AST shadows → temporal rewrite
+        → Sugar. An ordering OUTCOME is meaning. Minting
+        ``Complete(PredicateValue(py.lt/…))`` from a Python helper — even when
+        both types are source-decided and the atom would be "right" — is a
+        second mechanism. Undecided pairs refuse as the third value; decided
+        pairs without a ground arm refuse until that arm is written.
+
+        Does not return. Always raises ``SugarNotWritten``.
         """
-        denotes_self = getattr(self, "denotes_value", None)
-        denotes_other = getattr(other, "denotes_value", None)
-        if not callable(denotes_self) or not callable(denotes_other):
-            return None
-        if not (denotes_self() and denotes_other()):
-            return None
-        decided_self = getattr(self, "runtime_type_is_decided", None)
-        decided_other = getattr(other, "runtime_type_is_decided", None)
-        if not callable(decided_self) or not callable(decided_other):
-            return None
-        if decided_self() and decided_other():
-            return None
-
         from sugar_source_tree.panic import SugarNotWritten
 
+        denotes_self = getattr(self, "denotes_value", None)
+        denotes_other = getattr(other, "denotes_value", None)
+        both_denote = (
+            callable(denotes_self)
+            and callable(denotes_other)
+            and denotes_self()
+            and denotes_other()
+        )
+        decided_self = getattr(self, "runtime_type_is_decided", None)
+        decided_other = getattr(other, "runtime_type_is_decided", None)
+        both_decided = (
+            both_denote
+            and callable(decided_self)
+            and callable(decided_other)
+            and decided_self()
+            and decided_other()
+        )
+        if both_denote and not both_decided:
+            observed = (
+                "undecided ordering operand runtime type: "
+                f"{type(self).__name__} {operator} {type(other).__name__}"
+            )
+            requested = (
+                "source-visible runtime types selecting Sugar-owned ordering "
+                "meaning or an authenticated exceptional exit"
+            )
+            fix = (
+                "do not mint Complete(PredicateValue(py.lt/le/gt/ge)) or invent "
+                "TypeError; resolve both operands' runtime types from source, "
+                "then construct via a ground Sugar arm"
+            )
+        else:
+            observed = (
+                "default ordering floor has no Sugar arm for "
+                f"{type(self).__name__} {operator} {type(other).__name__}"
+            )
+            requested = (
+                "Sugar-owned ordering meaning (TrueBoolLiteralSugar / "
+                "FalseBoolLiteralSugar / authenticated RaiseValue) or a "
+                "named third-value refusal"
+            )
+            fix = (
+                "LAW_OF_ONE: implement a ground pair arm that constructs Sugar; "
+                "never resolve_comparison_atom / Complete(PredicateValue) on "
+                "FloorValue defaults"
+            )
         raise SugarNotWritten(
             blame=site,
             owner=owner,
-            observed=(
-                "undecided ordering operand runtime type: "
-                f"{type(self).__name__} {operator} {type(other).__name__}"
-            ),
-            requested=(
-                "source-visible runtime types selecting an ordering completion "
-                "or an authenticated exceptional exit"
-            ),
-            fix=(
-                "do not emit py.lt/le/gt/ge or invent TypeError; resolve both "
-                "operands' runtime types from source before constructing"
-            ),
+            observed=observed,
+            requested=requested,
+            fix=fix,
+        )
+
+    def _undecided_ordering_law(self, other, site, *, owner: str, operator: str):
+        """Backward-compatible name: refuse ordering meaning (always throws)."""
+        self._refuse_ordering_meaning(
+            other, site, owner=owner, operator=operator
         )
 
     def less_than_from_left(self, left, site):
-        """Default RHS law for ``left < self`` — ordinary comparison atom.
+        """Default RHS law for ``left < self`` — never invents FOL meaning.
 
-        Overrides (GuardedValue, NamedExpressionValue, …) replace this door.
-        Does not call ``left.less_than(self)`` (that would recurse).
-
-        Both operand types must be source-decided before the atom is emitted.
-        Undecided pairs throw named via :meth:`_undecided_ordering_law`.
+        Overrides (TermValue, StringValue, GuardedValue, NamedExpressionValue, …)
+        construct Sugar or distribute. Does not call ``left.less_than(self)``.
         """
-        left._undecided_ordering_law(
+        left._refuse_ordering_meaning(
             self, site, owner="FloorValue.less_than_from_left", operator="<"
-        )
-        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-        from sugar_lift_py_tests.floor.comparison_atom import resolve_comparison_atom
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(
-            PredicateValue(
-                resolve_comparison_atom("lt", left, self, owner=str(site)),
-                site,
-                operand_callsites=(*left.callsites(), *self.callsites()),
-            )
         )
 
     def less_equal(self, other, site):
-        self._undecided_ordering_law(
+        self._refuse_ordering_meaning(
             other, site, owner="FloorValue.less_equal", operator="<="
-        )
-        from sugar_lift_py_tests.floor.comparison_atom import resolve_comparison_atom
-        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(
-            PredicateValue(
-                resolve_comparison_atom("le", self, other, owner=str(site)),
-                site,
-                operand_callsites=(*self.callsites(), *other.callsites()),
-            )
         )
 
     def greater_than(self, other, site):
-        self._undecided_ordering_law(
+        self._refuse_ordering_meaning(
             other, site, owner="FloorValue.greater_than", operator=">"
-        )
-        from sugar_lift_py_tests.floor.comparison_atom import resolve_comparison_atom
-        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(
-            PredicateValue(
-                resolve_comparison_atom("gt", self, other, owner=str(site)),
-                site,
-                operand_callsites=(*self.callsites(), *other.callsites()),
-            )
         )
 
     def greater_equal(self, other, site):
-        self._undecided_ordering_law(
+        self._refuse_ordering_meaning(
             other, site, owner="FloorValue.greater_equal", operator=">="
-        )
-        from sugar_lift_py_tests.floor.comparison_atom import resolve_comparison_atom
-        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(
-            PredicateValue(
-                resolve_comparison_atom("ge", self, other, owner=str(site)),
-                site,
-                operand_callsites=(*self.callsites(), *other.callsites()),
-            )
         )
 
     def denotes_value(self) -> bool:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -760,6 +760,11 @@ class FloorValue:
         This is an accounted named refusal, not a construction failure.  The
         producer knows the native operation and the missing testimony, but it
         cannot choose either the completed or AttributeError edge honestly.
+
+        Distinct from the default :meth:`attribute` construction panic: that
+        door means a decided-type floor arm is missing (OUR defect). This door
+        means the receiver's runtime type is not source-decided, so neither
+        completion nor AttributeError is honest yet.
         """
         from sugar_source_tree.panic import SugarNotWritten
 
@@ -777,10 +782,38 @@ class FloorValue:
             ),
         )
 
+    def undecided_contains(self, item, site, *, owner: str):
+        """Refuse membership when container dispatch is not source-decided.
+
+        Named refusal, not construction panic and not ``Complete(py.in)``.
+        Membership over an undecided receiver is a third value: the producer
+        cannot choose completed membership or TypeError without inventing
+        container-type testimony. Construction panic would miscount that as
+        OUR missing floor arm.
+        """
+        del item
+        from sugar_source_tree.panic import SugarNotWritten
+
+        raise SugarNotWritten(
+            blame=site,
+            owner=owner,
+            observed=(
+                "undecided container runtime type or membership semantics: "
+                f"item in {type(self).__name__}"
+            ),
+            requested="a source-authenticated membership success or exceptional exit",
+            fix=(
+                "carry container-type and membership testimony to the contains "
+                "floor; do not guess TypeError or invent a completed py.in "
+                "coordinate"
+            ),
+        )
+
     def contains(self, item, site):
         # Default: this value does not stand on the membership floor -- it cannot
-        # answer whether it holds `item`. A symbolic container stays the py.in
-        # coordinate; a concrete container folds; absence here is the honest "no".
+        # answer whether it holds `item`. Decided containers override and fold
+        # or TypeError; undecided containers use :meth:`undecided_contains`.
+        # Absence of a decided arm here is the honest construction gap.
         del item
         from sugar_lift_py_tests.gap.panic import construction_panic
         from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
@@ -1077,23 +1110,65 @@ class FloorValue:
 
     def less_than(self, other, site):
         # Operator-owned double dispatch: the RHS answers ``less_than_from_left``.
-        # Default Floor emits the ordinary atom; GuardedValue distributes;
-        # NamedExpressionValue presents-and-carries. No concrete-kind membrane
-        # and no operation-string admission on this surface.
+        # Default Floor emits the ordinary atom only when both operand types are
+        # source-decided; undecided pairs throw named (never Complete).
+        # GuardedValue distributes; NamedExpressionValue presents-and-carries.
         return other.less_than_from_left(self, site)
+
+    def _undecided_ordering_law(self, other, site, *, owner: str, operator: str):
+        """Refuse ordering when either operand's runtime type is undecided.
+
+        Returns ``None`` when the law does not apply (non-values, or both types
+        source-decided). Raises ``SugarNotWritten`` when it does — never
+        ``Complete(PredicateValue(py.lt/…))``. Fabricating the solver atom for
+        undecided dispatch is the direct route to a false DONE: every ordering
+        row goes green for the wrong reason, and ``pytest.raises(TypeError)``
+        is structurally unsatisfiable.
+        """
+        denotes_self = getattr(self, "denotes_value", None)
+        denotes_other = getattr(other, "denotes_value", None)
+        if not callable(denotes_self) or not callable(denotes_other):
+            return None
+        if not (denotes_self() and denotes_other()):
+            return None
+        decided_self = getattr(self, "runtime_type_is_decided", None)
+        decided_other = getattr(other, "runtime_type_is_decided", None)
+        if not callable(decided_self) or not callable(decided_other):
+            return None
+        if decided_self() and decided_other():
+            return None
+
+        from sugar_source_tree.panic import SugarNotWritten
+
+        raise SugarNotWritten(
+            blame=site,
+            owner=owner,
+            observed=(
+                "undecided ordering operand runtime type: "
+                f"{type(self).__name__} {operator} {type(other).__name__}"
+            ),
+            requested=(
+                "source-visible runtime types selecting an ordering completion "
+                "or an authenticated exceptional exit"
+            ),
+            fix=(
+                "do not emit py.lt/le/gt/ge or invent TypeError; resolve both "
+                "operands' runtime types from source before constructing"
+            ),
+        )
 
     def less_than_from_left(self, left, site):
         """Default RHS law for ``left < self`` — ordinary comparison atom.
 
         Overrides (GuardedValue, NamedExpressionValue, …) replace this door.
         Does not call ``left.less_than(self)`` (that would recurse).
+
+        Both operand types must be source-decided before the atom is emitted.
+        Undecided pairs throw named via :meth:`_undecided_ordering_law`.
         """
-        # Default: EMIT an operator-indexed atom. Fold when both sides are
-        # ground (the literal pair overrides); emit when either side stands on
-        # the term floor; panic only inside to_term when a side cannot enter
-        # FOL at all. Vendor `<` is py.lt -- not SMT < -- so the sort universe
-        # adjudicates (same NaN/reflexivity split as py.eq). Operand
-        # CallSiteValues ride as operand_callsites.
+        left._undecided_ordering_law(
+            self, site, owner="FloorValue.less_than_from_left", operator="<"
+        )
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
         from sugar_lift_py_tests.floor.comparison_atom import resolve_comparison_atom
         from sugar_lift_py_tests.outcome import Complete
@@ -1107,6 +1182,9 @@ class FloorValue:
         )
 
     def less_equal(self, other, site):
+        self._undecided_ordering_law(
+            other, site, owner="FloorValue.less_equal", operator="<="
+        )
         from sugar_lift_py_tests.floor.comparison_atom import resolve_comparison_atom
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
         from sugar_lift_py_tests.outcome import Complete
@@ -1120,6 +1198,9 @@ class FloorValue:
         )
 
     def greater_than(self, other, site):
+        self._undecided_ordering_law(
+            other, site, owner="FloorValue.greater_than", operator=">"
+        )
         from sugar_lift_py_tests.floor.comparison_atom import resolve_comparison_atom
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
         from sugar_lift_py_tests.outcome import Complete
@@ -1133,6 +1214,9 @@ class FloorValue:
         )
 
     def greater_equal(self, other, site):
+        self._undecided_ordering_law(
+            other, site, owner="FloorValue.greater_equal", operator=">="
+        )
         from sugar_lift_py_tests.floor.comparison_atom import resolve_comparison_atom
         from sugar_lift_py_tests.floor.predicate_value import PredicateValue
         from sugar_lift_py_tests.outcome import Complete
@@ -1182,10 +1266,12 @@ class FloorValue:
         dispatch for the pair is undecided. That is a third value: the producer
         cannot claim sole completion and cannot invent an exception identity.
 
-        Publish both native-dispatch faces (mirrors Compare #6564): the
-        completed face retains the operator coordinate, and the halted face
-        retains a source-cited raise whose exception identity remains
-        undecided. Sole completion or sole TypeError invention stay forbidden.
+        Throw named (``SugarNotWritten``). Do not emit
+        ``Complete(SymbolicValue(...))`` and do not publish a dual-edge ExitSet
+        whose Halted face carries a nameless ``RaiseEffect`` — a nameless halt
+        is routed outside every TypeError boundary, so
+        ``pytest.raises(TypeError): a - b`` is structurally unsatisfiable while
+        still looking like a producer answer.
 
         Two cases stay outside this door:
 
@@ -1196,49 +1282,33 @@ class FloorValue:
           ground field laws, and absence there is still a gap.
 
         Returns ``None`` when the law does not apply, so the caller falls
-        through to its own pair gap.
+        through to its own pair gap. Raises when it does apply.
         """
         if not (self.denotes_value() and other.denotes_value()):
             return None
         if self.runtime_type_is_decided() and other.runtime_type_is_decided():
             return None
 
-        from sugar_lift_py_tests.effect import RaiseEffect
-        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
-        from sugar_lift_py_tests.ir import atomic, ctor
-        from sugar_lift_py_tests.outcome import ExitSet
-        from sugar_lift_py_tests.outcome.exit_set import (
-            Completed,
-            Halted,
-            complement_guard,
-            partition,
-        )
+        from sugar_source_tree.panic import SugarNotWritten
 
-        left_term = self.to_term(owner=f"binary {operator} left")
-        right_term = other.to_term(owner=f"binary {operator} right")
-        completed_value = SymbolicValue(ctor(operator, [left_term, right_term]))
-        dispatch_raises = atomic(
-            f"python.binop_dispatch_raises[{operator}]",
-            [left_term, right_term],
+        raise SugarNotWritten(
+            blame=site,
+            owner="binary_operation_exception_floor",
+            observed=(
+                "undecided binary operand runtime type: "
+                f"{type(self).__name__} {operator} {type(other).__name__}"
+            ),
+            requested=(
+                "source-visible native binary-operator testimony selecting "
+                "completion or an authenticated exceptional exit"
+            ),
+            fix=(
+                "preserve the undecided third value at binary discharge; "
+                "resolve both operands' runtime types and __op__/__rop__ from "
+                "source before completing or halting — do not mint a nameless "
+                "raise face or a sole symbolic completion"
+            ),
         )
-        halted_face, completed_face = partition(
-            ("binary-native-dispatch", str(site), operator)
-        )
-        effect = RaiseEffect(
-            blame=str(site),
-            occurrence=str(site),
-            producer_node_owner="BinOp",
-        )
-        return ExitSet(
-            (
-                Halted(dispatch_raises, effect, faces=frozenset({halted_face})),
-                Completed(
-                    complement_guard(dispatch_raises),
-                    completed_value,
-                    frozenset({completed_face}),
-                ),
-            )
-        ).normalize()
 
     def _binary_floor_gap(self, other, site, owner, floor):
         """The ONE None arm for every binary-operation floor.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
@@ -123,12 +123,22 @@ class NoneValue(FloorValue):
 
     def less_than(self, other, site):
         # None orders against nothing: any ground comparison is authenticated
-        # TypeError. Symbolic falls to super() emit.
+        # TypeError. Undecided peers refuse named (no FOL invent).
         if self._unorderable_ground_peer(other):
             from sugar_lift_py_tests.floor.ground_exit import ground_type_error
 
             return ground_type_error(site=site, owner="NoneValue.less_than")
         return super().less_than(other, site)
+
+    def less_than_from_left(self, left, site):
+        """``left < None`` — TypeError when left is a decided ground peer."""
+        if self._unorderable_ground_peer(left):
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(
+                site=site, owner="NoneValue.less_than_from_left"
+            )
+        return super().less_than_from_left(left, site)
 
     def _unorderable_ground_peer(self, other) -> bool:
         from sugar_lift_py_tests.floor.list_value import ListValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -106,10 +106,9 @@ class StringValue(GuardStableValue):
         )
 
     def less_than(self, other, site):
-        # A string stands on the ordering floor: two strings order by Python's
-        # lexicographic rule and fold to the True/False literal. Ground
-        # cross-type is authenticated TypeError, not an emit. Symbolic falls
-        # to super() emit.
+        # A string stands on the ordering floor: two strings fold to True/False
+        # Sugar. Ground cross-type is authenticated TypeError. Undecided peers
+        # refuse named (no FOL invent).
         if type(other) is StringValue:
             from sugar_lift_py_tests.outcome import Complete
             from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
@@ -129,6 +128,30 @@ class StringValue(GuardStableValue):
 
             return ground_type_error(site=site, owner="StringValue.less_than")
         return super().less_than(other, site)
+
+    def less_than_from_left(self, left, site):
+        """``left < self`` when the RHS is a string — Sugar fold or TypeError."""
+        if type(left) is StringValue:
+            from sugar_lift_py_tests.outcome import Complete
+            from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+                FalseBoolLiteralSugar,
+            )
+            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                TrueBoolLiteralSugar,
+            )
+
+            return Complete(
+                TrueBoolLiteralSugar(site=site)
+                if left.value < self.value
+                else FalseBoolLiteralSugar(site=site)
+            )
+        if self._unorderable_ground_peer(left):
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(
+                site=site, owner="StringValue.less_than_from_left"
+            )
+        return super().less_than_from_left(left, site)
 
     def length(self, site):
         # A string knows its length: the count of characters.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -388,45 +388,12 @@ class SymbolicValue(FloorValue):
             )
         if isinstance(other, GuardedValue):
             return other.map_from_left(owner, self, site)
-        denotes_other = getattr(other, "denotes_value", None)
-        if callable(denotes_other) and denotes_other():
-            from sugar_lift_py_tests.effect import RaiseEffect
-            from sugar_lift_py_tests.ir import atomic, ctor, str_const
-            from sugar_lift_py_tests.outcome import ExitSet
-            from sugar_lift_py_tests.outcome.exit_set import (
-                Completed,
-                Halted,
-                complement_guard,
-                partition,
-            )
-
-            left_term = self.to_term(owner=f"{operator} left operand")
-            right_term = other.to_term(owner=f"{operator} right operand")
-            dispatch_raises = atomic(
-                "python.binary_dispatch_raises",
-                [str_const(operator), left_term, right_term],
-            )
-            halted_face, completed_face = partition(
-                ("binary-native-dispatch", str(site), operator)
-            )
-            return ExitSet(
-                (
-                    Halted(
-                        dispatch_raises,
-                        RaiseEffect(
-                            blame=str(site),
-                            occurrence=str(site),
-                            producer_node_owner="BinOp",
-                        ),
-                        faces=frozenset({halted_face}),
-                    ),
-                    Completed(
-                        complement_guard(dispatch_raises),
-                        SymbolicValue(ctor(operator, [left_term, right_term])),
-                        frozenset({completed_face}),
-                    ),
-                )
-            ).normalize()
+        # Undecided native dispatch: throw named via the shared law. Never mint
+        # Complete(SymbolicValue) or a nameless dual-edge RaiseEffect — that
+        # half-writes an answer the TypeError boundary cannot match.
+        refused = self._undecided_binary_law(other, site, operator)
+        if refused is not None:
+            return refused
         return self._binary_floor_gap(
             other,
             site,
@@ -493,17 +460,11 @@ class SymbolicValue(FloorValue):
         return self.undecided_attribute(name, site, owner="SymbolicValue.attribute")
 
     def contains(self, item, site):
-        # `item in self`: a symbolic container stays the py.in coordinate, a
-        # boolean-valued opaque predicate (`item in recv`). Membership on an
-        # unknown container is uninterpreted -- decidable only where a later
-        # equality/guard consumes it, never invented.
-        del site
-        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-        from sugar_lift_py_tests.ir import atomic
-        from sugar_lift_py_tests.outcome import Complete
-
-        return Complete(
-            PredicateValue(atomic("py.in", [item.to_term(owner="contains"), self.term]))
+        # Membership on an unknown container is a third value: neither
+        # Complete(py.in) nor TypeError is honest without container-type
+        # testimony. Named refusal, not fabrication.
+        return self.undecided_contains(
+            item, site, owner="SymbolicValue.contains"
         )
 
     def format_data_model(self, spec, site, ctx):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -137,10 +137,9 @@ class TermValue(FloorValue):
         return getattr(super(), owner.rsplit(".", 1)[-1])(other, site)
 
     def less_than(self, other, site):
-        # A number stands on the ordering floor: two numbers are ordered or not, and
-        # it gives back the True or False literal -- the boolean IS the type.
-        # Ground cross-type is authenticated TypeError (Python defines no
-        # ordering). Symbolic falls to emit.
+        # A number stands on the ordering floor: two numbers fold to True/False
+        # Sugar. Ground cross-type is authenticated TypeError. Undecided peers
+        # refuse named (LAW_OF_ONE — no Complete(PredicateValue) invent).
         if type(other) is TermValue:
             from sugar_lift_py_tests.outcome import Complete
             from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
@@ -158,6 +157,28 @@ class TermValue(FloorValue):
         if self._unorderable_ground_peer(other):
             return self._ground_ordering_type_error(site, owner="TermValue.less_than")
         return super().less_than(other, site)
+
+    def less_than_from_left(self, left, site):
+        """``left < self`` when the RHS is a number — Sugar fold or TypeError."""
+        if type(left) is TermValue:
+            from sugar_lift_py_tests.outcome import Complete
+            from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+                FalseBoolLiteralSugar,
+            )
+            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                TrueBoolLiteralSugar,
+            )
+
+            return Complete(
+                TrueBoolLiteralSugar(site=site)
+                if left.value < self.value
+                else FalseBoolLiteralSugar(site=site)
+            )
+        if self._unorderable_ground_peer(left):
+            return self._ground_ordering_type_error(
+                site, owner="TermValue.less_than_from_left"
+            )
+        return super().less_than_from_left(left, site)
 
     def less_equal(self, other, site):
         if type(other) is TermValue:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -108,7 +108,14 @@ def publish_undecided_comparison_edges(left, right, site, op_kind: str, outcome)
 
 
 def publish_undecided_ordering_edges(left, right, site, op_kind: str, outcome):
-    """Ordering law: undecided rich-method dispatch is a two-face partition."""
+    """Ordering law: undecided / default floor throws named (LAW_OF_ONE).
+
+    Ordering meaning is Sugar. Floor defaults must not mint
+    ``Complete(PredicateValue)``; when they refuse, ``outcome`` is never a
+    completed predicate dual-edge. This publisher is a no-op safety net for
+    residual Complete(PredicateValue) fabrications — equality/membership still
+    use the shared dual-edge helper where they have not yet been retired.
+    """
     return _publish_undecided_dispatch_edges(
         left,
         right,

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -18,10 +18,11 @@ from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
 from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import Compare, Subscript
+from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 # Content manifest (relative path + per-file BLAKE3-512). Path-shape
@@ -54,8 +55,9 @@ GETITEM_SITE_SHA256 = "d2940a05aea5aa4c8aea3569fcef114c0564eba844a26a4982263ad3b
 
 
 @dataclass(frozen=True)
-class _ValueSugar(Sugar):
+class _ValueSugar(ConstructedTermSugar):
     value: object
+    site: object = "value-sugar-site"
 
     @classmethod
     def witnesses(cls):
@@ -64,6 +66,20 @@ class _ValueSugar(Sugar):
     def desugar(self, ctx=None):
         del ctx
         return Complete(self.value)
+
+    def to_term(self, *, owner: str):
+        return self.value.to_term(owner=owner)
+
+    def occurrence_term(self, *, owner: str):
+        # Floor carriers used in unit tests have no sealed fragment.
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        del owner
+        return ctor(
+            "python:test-value-sugar-occurrence",
+            (str_const(type(self.value).__name__),),
+            symbol_kind="coordinate",
+        )
 
 
 def _repo_root() -> Path:
@@ -131,6 +147,11 @@ def _formal_coordinate(
 
 
 def _assert_dual_dispatch(outcome, *, atom: str, blame: str) -> None:
+    """Equality dual-edge: completed solver atom beside a nameless Compare halt.
+
+    Ordering and membership no longer dual-edge at the floor — they throw named.
+    Keep this helper for equality law only.
+    """
     from sugar_lift_py_tests.floor import PredicateValue
     from sugar_lift_py_tests.outcome import ExitSet
     from sugar_lift_py_tests.outcome.exit_set import Completed, Halted, complement_guard
@@ -157,7 +178,32 @@ def _assert_dual_dispatch(outcome, *, atom: str, blame: str) -> None:
     assert completed.guard == complement_guard(halted.guard)
 
 
+def _assert_named_ordering_or_membership_refusal(thunk) -> SugarNotWritten:
+    """Ordering/membership undecided dispatch throws named — never Complete."""
+    with pytest.raises(SugarNotWritten) as raised:
+        thunk()
+    observed = (raised.value.observed or "").lower()
+    owner = raised.value.owner or ""
+    assert (
+        "undecided" in observed
+        or "ordering" in observed
+        or "membership" in observed
+        or "contain" in owner.lower()
+        or "less_than" in owner
+        or "greater" in owner
+        or "less_equal" in owner
+        or "contains" in owner
+    )
+    return raised.value
+
+
 def _assert_compare_dual(node, *, atom: str) -> None:
+    """Legacy name: equality still dual-edges; ordering/membership throw named."""
+    if atom in {"py.lt", "py.le", "py.gt", "py.ge", "py.in"}:
+        _assert_named_ordering_or_membership_refusal(
+            lambda: node.sugar().desugar(None)
+        )
+        return
     _assert_dual_dispatch(
         node.sugar().desugar(None), atom=atom, blame=str(node.fragment)
     )
@@ -303,15 +349,20 @@ def test_every_nonidentity_comparison_keeps_undecided_call_dispatch_loud(
         if op_kind == "Eq"
         else ComparisonOpSugar(op_kind, left, right, site)
     )
+    atom = {
+        "Lt": "py.lt",
+        "NotEq": "py.eq",
+        "Eq": "py.eq",
+        "In": "py.in",
+        "NotIn": "py.in",
+    }[op_kind]
+    if op_kind in {"Lt", "In", "NotIn"}:
+        # Ordering / membership: named refusal, never fabricated Complete.
+        _assert_named_ordering_or_membership_refusal(lambda: sugar.desugar(None))
+        return
     _assert_dual_dispatch(
         sugar.desugar(None),
-        atom={
-            "Lt": "py.lt",
-            "NotEq": "py.eq",
-            "Eq": "py.eq",
-            "In": "py.in",
-            "NotIn": "py.in",
-        }[op_kind],
+        atom=atom,
         blame=str(site),
     )
 
@@ -325,15 +376,16 @@ def test_every_nonidentity_comparison_keeps_undecided_call_dispatch_loud(
         ("GtE", ">=", "py.ge"),
     ),
 )
-def test_undecided_symbolic_ordering_emits_completed_and_exceptional_edges(
+def test_undecided_symbolic_ordering_throws_named_never_complete(
     op_kind: str, operator: str, atom: str
 ) -> None:
-    """Ordering keeps its solver atom and the native dispatch halt together."""
+    """Ordering with undecided operands throws named — never Complete(py.lt)."""
+    del atom
     node = _synthetic_compare(f"left {operator} 1")
     left = _ValueSugar(SymbolicValue(make_var("left")))
     right = _ValueSugar(TermValue(1))
-    outcome = ComparisonOpSugar(op_kind, left, right, node.fragment).desugar(None)
-    _assert_dual_dispatch(outcome, atom=atom, blame=str(node.fragment))
+    sugar = ComparisonOpSugar(op_kind, left, right, node.fragment)
+    _assert_named_ordering_or_membership_refusal(lambda: sugar.desugar(None))
 
 
 def test_symbolic_equality_keeps_solver_atom_and_exceptional_edge() -> None:
@@ -385,13 +437,14 @@ def test_membership_law_routes_through_authenticated_contains(
     op_kind: str, expression: str
 ) -> None:
     node = _synthetic_compare(expression)
-    outcome = ComparisonOpSugar(
+    # Undecided container: named refusal at contains (no Complete(py.in)).
+    sugar = ComparisonOpSugar(
         op_kind,
         _ValueSugar(TermValue(1)),
         _ValueSugar(SymbolicValue(make_var("container"))),
         node.fragment,
-    ).desugar(None)
-    _assert_dual_dispatch(outcome, atom="py.in", blame=str(node.fragment))
+    )
+    _assert_named_ordering_or_membership_refusal(lambda: sugar.desugar(None))
 
 
 def test_formal_ordering_survives_until_authenticated_caller_discharge() -> None:
@@ -686,20 +739,15 @@ def test_pandas_series_string_ordering_retains_both_faces() -> None:
 
 
 def test_source_decided_number_string_ordering_emits_type_error() -> None:
-    """Truthful twin of the enrolled ``obj < "a"`` site with decided types.
+    """Truthful twin: decided unorderable pair constructs TypeError RaiseValue.
 
     When both operands are source-visible ground values Python refuses to
     order, Compare constructs an authenticated TypeError RaiseValue — not
-    ``py.lt`` and not a RuntimeEffect.  The enrolled pandas site still
-    refuses because ``obj`` is undecided; this twin isolates the floor law
-    on a workspace-relative locus the ground exit can cite.
+    ``py.lt`` and not a RuntimeEffect.  Undecided ``obj < "a"`` still refuses
+    named at the floor; this twin isolates the decided ground law on a
+    workspace-relative locus the ground exit can cite.
     """
     from sugar_lift_py_tests.floor import RaiseValue, StringValue
-
-    path = _corpus_root() / "tests/arithmetic/test_numeric.py"
-    source = path.read_text(encoding="utf-8")
-    assert source.count('obj < "a"') == 1
-    _compare_at(path, source, line=146)
 
     twin = 'def f():\n    return 1.0 < "a"\n'
     tree = SourceFile(
@@ -766,11 +814,10 @@ def test_pandas_left_right_ordering_faces_retain_both_edges(
 def test_undecided_dispatch_partition_keys_are_law_scoped(
     expression: str, op_kind: str, law_name: str, atom: str
 ) -> None:
-    """Ordering / membership / equality dual edges use distinct partition families.
+    """Equality still dual-edges under a law-scoped key; ordering/membership refuse.
 
-    The dual-edge construction is shared, but the ExitSet partition key names
-    the law so residual measurement cannot collapse three mechanisms into one
-    monomorphic ``comparison-native-dispatch`` coordinate.
+    Partition keys remain law-scoped for equality. Ordering and membership no
+    longer mint dual-edge ExitSets from undecided floors — they throw named.
     """
     from sugar_lift_py_tests.floor import SymbolicValue
     from sugar_lift_py_tests.ir import make_var
@@ -786,22 +833,7 @@ def test_undecided_dispatch_partition_keys_are_law_scoped(
     node = _synthetic_compare(expression)
     left = _ValueSugar(SymbolicValue(make_var("left")))
     right = _ValueSugar(SymbolicValue(make_var("right")))
-    if op_kind == "Eq":
-        outcome = EqualityOpSugar(left, right, node.fragment).desugar(None)
-    elif op_kind == "In":
-        outcome = ComparisonOpSugar(
-            "In",
-            _ValueSugar(SymbolicValue(make_var("needle"))),
-            _ValueSugar(SymbolicValue(make_var("container"))),
-            node.fragment,
-        ).desugar(None)
-    else:
-        outcome = ComparisonOpSugar(op_kind, left, right, node.fragment).desugar(None)
-
-    _assert_dual_dispatch(outcome, atom=atom, blame=str(node.fragment))
     expected_prefix = f"compare.{law_name}.dispatch"
-    # partition() returns face stamps; law is sealed into the key used at mint.
-    # Pin the key factory and that identity never dual-edges.
     assert partition_key_for_law(CompareLaw(law_name), node.fragment, op_kind)[0] == (
         expected_prefix
     )
@@ -810,6 +842,20 @@ def test_undecided_dispatch_partition_keys_are_law_scoped(
         CompareLaw.MEMBERSHIP,
         CompareLaw.EQUALITY,
     )
+    if op_kind == "Eq":
+        outcome = EqualityOpSugar(left, right, node.fragment).desugar(None)
+        _assert_dual_dispatch(outcome, atom=atom, blame=str(node.fragment))
+        return
+    if op_kind == "In":
+        sugar = ComparisonOpSugar(
+            "In",
+            _ValueSugar(SymbolicValue(make_var("needle"))),
+            _ValueSugar(SymbolicValue(make_var("container"))),
+            node.fragment,
+        )
+    else:
+        sugar = ComparisonOpSugar(op_kind, left, right, node.fragment)
+    _assert_named_ordering_or_membership_refusal(lambda: sugar.desugar(None))
 
 
 @pytest.mark.parametrize(("op_kind", "negated"), (("Is", False), ("IsNot", True)))
@@ -835,39 +881,19 @@ def test_identity_law_never_publishes_a_raise_partition(
 
 
 def test_chained_comparison_composes_pair_ordering_laws() -> None:
-    """Chaining law: ``a < b < c`` is And of pair ordering dual edges.
+    """Chaining law: ``a < b < c`` is And of pair ordering sugars.
 
     Construction lives at ``Compare._construct_sugar`` (BoolOpSugar over
-    adjacent ComparisonOpSugar pairs). Residual faces are ordered dual-edge
-    composition under short-circuit And — not a monomorphic chain panic.
+    adjacent ComparisonOpSugar pairs). Undecided free names refuse named at
+    the first ordering floor — not a monomorphic chain panic and not a
+    fabricated dual-edge completion.
     """
-    from sugar_lift_py_tests.ir import and_, atomic, make_var, not_
-    from sugar_lift_py_tests.outcome import ExitSet
-    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
-
     node = _synthetic_compare("a < b < c")
     sugar = node.sugar()
     assert type(sugar).__name__ == "BoolOpSugar"
     assert sugar.op_kind == "And"
     assert len(sugar.values) == 2
-    outcome = sugar.desugar(None)
-    assert isinstance(outcome, ExitSet)
-    halted = [face for face in outcome.exits if isinstance(face, Halted)]
-    completed = [face for face in outcome.exits if isinstance(face, Completed)]
-    assert len(halted) == 2
-    assert halted[0].effect.occurrence_id != halted[1].effect.occurrence_id
-
-    a, b, c = make_var("a"), make_var("b"), make_var("c")
-    first_raises = atomic("python.lt_dispatch_raises", [a, b])
-    first_true = atomic("py.lt", [a, b])
-    second_raises = atomic("python.lt_dispatch_raises", [b, c])
-    assert {face.guard for face in halted} == {
-        first_raises,
-        and_([not_(first_raises), and_([first_true, second_raises])]),
-    }
-    assert any(
-        face.guard == and_([not_(first_raises), not_(first_true)]) for face in completed
-    )
+    _assert_named_ordering_or_membership_refusal(lambda: sugar.desugar(None))
 
 
 def test_chained_compare_leg_sites_follow_operator_occurrences_not_operands() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
@@ -55,24 +55,19 @@ def _line_96_bitand(source: str, path: Path):
 
 
 def _assert_dual_edge_dispatch(node, *, producer: str = "BinOp") -> None:
-    """Undecided native dispatch publishes Halted + Completed faces."""
-    from sugar_lift_py_tests.effect import RaiseEffect
-    from sugar_lift_py_tests.outcome import ExitSet
-    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+    """Undecided native dispatch throws named — never nameless dual-edge halt.
 
-    outcome = node.sugar().desugar(None)
-    assert isinstance(outcome, ExitSet)
-    halted = tuple(face for face in outcome.exits if isinstance(face, Halted))
-    completed = tuple(face for face in outcome.exits if isinstance(face, Completed))
-    assert len(halted) == 1
-    assert len(completed) == 1
-    effect = halted[0].effect
-    assert isinstance(effect, RaiseEffect)
-    assert effect.producer_node_owner == producer
-    assert effect.exception_name is None
-    # Never invent a runtime TypeError / RuntimeEffect for undecided source.
-    assert "TypeError" not in str(outcome)
-    assert "RuntimeEffect" not in str(outcome)
+    Historical name kept so call sites stay stable; the law is now
+    ``SugarNotWritten`` at ``binary_operation_exception_floor``.
+    """
+    del producer
+    from sugar_source_tree.panic import SugarNotWritten
+
+    with pytest.raises(SugarNotWritten) as raised:
+        node.sugar().desugar(None)
+    assert raised.value.owner == "binary_operation_exception_floor"
+    assert "undecided" in raised.value.observed.lower()
+    assert "TypeError" not in (raised.value.observed or "")
 
 
 def _assert_named_refusal(node, *, owner: str, observed: str) -> None:
@@ -127,7 +122,7 @@ def test_pandas_series_nan_bitand_retains_child_gap_and_binary_dispatch_twin() -
     lying = truthful.replace("s_0123 & np.nan", "s_0123 & 0")
     # This focused SourceFile door has no authenticated import table, so it must
     # not pretend that ``np.nan`` resolved. The ground lying twin removes that
-    # child boundary and reaches the BinOp producer's dual-edge partition.
+    # child boundary and reaches the BinOp producer's named undecided refusal.
     _assert_named_refusal(
         _line_96_bitand(truthful, path),
         owner="SymbolicValue.attribute",
@@ -161,7 +156,7 @@ def test_pandas_series_bitand_mixed_rights_publish_both_dispatch_faces(
 
     Each site raises TypeError at CPython on a concrete Series, but the
     producer only sees a SymbolicValue left.  The shared undecided-binary law
-    publishes both dispatch faces without inventing TypeError.
+    throws named without inventing TypeError.
     """
     path = _corpus_file()
     source = path.read_text(encoding="utf-8")
@@ -181,8 +176,8 @@ def test_source_decided_int_float_bitand_emits_type_error() -> None:
     """Truthful twin of ``s_0123 & 3.14`` with both types source-decided.
 
     Enrolled site: ``pandas/tests/series/test_logical_ops.py:98``.  With an
-    undecided Series left the producer retains both dispatch faces; with two
-    TermValues the bitwise floor constructs authenticated TypeError RaiseValue. The twin is
+    undecided Series left the producer throws named; with two TermValues the
+    bitwise floor constructs authenticated TypeError RaiseValue. The twin is
     built on a workspace-relative locus so the ground exit can cite source.
     """
     from dataclasses import dataclass

--- a/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py
@@ -1,18 +1,27 @@
-"""SIN CLUSTER 2 — ordering floor must not fabricate a Complete value.
+"""SIN CLUSTER 2 + LAW_OF_ONE — ordering meaning is Sugar, never a floor invent.
 
-Doctrine: throwing is honorable (code not written yet). Half-writing an answer
-outside the tree is the sin. Where operand types are source-decided, construct.
-Where they are not, throw named — never ``Complete``.
+LAW_OF_ONE: AST shadows → temporal rewrite → Sugar → meaning. No other
+mechanism. An ordering OUTCOME is meaning, so minting
+``Complete(PredicateValue(py.lt/…))`` from a Python floor helper is a second
+mechanism even when the atom would be "right".
+
+Throwing is honorable. Undecided must never become a value. Decided ground
+pairs construct Sugar (TrueBool/FalseBool/RaiseValue) on owned arms only.
 
 Also covers:
-- undecided binary: nameless halt is forbidden (boundary cannot match TypeError)
-- undecided contains: named refusal, not ``Complete(py.in)`` or construction_panic
-- undecided attribute: already named refusal; stays that way (not our defect)
+- undecided binary: nameless halt is forbidden
+- undecided contains: named refusal
+- undecided attribute: named refusal (already correct)
 
-GATE: truthful twin, lying twin that must fail, mutation transaction elsewhere.
+NOTE: ``tests/law_of_one_auditor.py`` audits SourceFile construction ownership
+and cannot see this floor-meaning sin. The AST tooth below is the instrument
+that names the offender until a stronger substrate exists.
 """
 
 from __future__ import annotations
+
+import ast
+from pathlib import Path
 
 import pytest
 
@@ -27,6 +36,18 @@ from sugar_source_tree.panic import SugarNotWritten
 
 SITE = "sin-cluster-2-ordering-site"
 
+_ORDERING_METHODS = frozenset(
+    {
+        "less_than",
+        "less_than_from_left",
+        "less_equal",
+        "greater_than",
+        "greater_equal",
+        "_refuse_ordering_meaning",
+        "_undecided_ordering_law",
+    }
+)
+
 
 def _symbolic() -> SymbolicValue:
     return SymbolicValue(make_var("s"))
@@ -37,7 +58,75 @@ def _callsite() -> CallSiteValue:
 
 
 # ---------------------------------------------------------------------------
-# Ordering floor: undecided → named throw; decided ground → construct
+# LAW_OF_ONE tooth: FloorValue ordering defaults never mint PredicateValue
+# ---------------------------------------------------------------------------
+
+
+def _floor_value_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "sugar_lift_py_tests"
+        / "floor"
+        / "floor_value.py"
+    )
+
+
+def test_law_of_one_auditor_cannot_see_ordering_floor_meaning_sin() -> None:
+    """LOUD: repository LAW_OF_ONE auditor is SourceFile-owner scoped only.
+
+    It does not AST-walk floor ordering doors for Complete(PredicateValue).
+    This package tooth is the instrument for that axis until the auditor
+    gains a floor-meaning denominator — do not pretend the shared auditor
+    closed this sin.
+    """
+    auditor = Path(__file__).resolve().parents[4] / "tests" / "law_of_one_auditor.py"
+    assert auditor.is_file(), "law_of_one_auditor.py must exist"
+    text = auditor.read_text(encoding="utf-8")
+    assert "less_than_from_left" not in text
+    assert "resolve_comparison_atom" not in text
+    assert "PredicateValue" not in text
+    assert "SourceFile" in text
+
+
+def test_floor_value_ordering_defaults_never_mint_predicate_complete() -> None:
+    """AST tooth: FloorValue ordering methods must not call resolve_comparison_atom
+    or construct Complete(PredicateValue(...)).
+    """
+    tree = ast.parse(_floor_value_path().read_text(encoding="utf-8"))
+    offenders: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or node.name != "FloorValue":
+            continue
+        for item in node.body:
+            if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if item.name not in _ORDERING_METHODS:
+                continue
+            for child in ast.walk(item):
+                if isinstance(child, ast.Name) and child.id == "resolve_comparison_atom":
+                    offenders.append(f"{item.name}:{child.lineno}:resolve_comparison_atom")
+                if isinstance(child, ast.Call):
+                    func = child.func
+                    if isinstance(func, ast.Name) and func.id == "Complete":
+                        # Complete(...) inside ordering door is the FOL invent shape
+                        # when its argument is PredicateValue — ban any Complete mint
+                        # on the default doors (ground arms live on subclasses).
+                        offenders.append(f"{item.name}:{child.lineno}:Complete(...)")
+                    if isinstance(func, ast.Name) and func.id == "PredicateValue":
+                        offenders.append(f"{item.name}:{child.lineno}:PredicateValue(...)")
+                    if isinstance(func, ast.Attribute) and func.attr == "PredicateValue":
+                        offenders.append(
+                            f"{item.name}:{child.lineno}:…PredicateValue(...)"
+                        )
+    assert not offenders, (
+        "LAW_OF_ONE floor-meaning sin R_ordering_default_predicate_mint="
+        f"{len(offenders)}:\n" + "\n".join(offenders)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ordering floor: undecided → named throw; decided ground → construct Sugar
 # ---------------------------------------------------------------------------
 
 
@@ -96,8 +185,8 @@ def test_source_decided_number_string_ordering_emits_type_error() -> None:
     assert outcome.value.effect.exception_name == "TypeError"
 
 
-def test_source_decided_int_ordering_constructs_bool() -> None:
-    """Truthful twin: two decided numbers fold to a bool completion."""
+def test_source_decided_int_ordering_constructs_bool_sugar() -> None:
+    """Truthful twin: two decided numbers construct TrueBoolLiteralSugar."""
     from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 
     outcome = TermValue(1).less_than(TermValue(2), SITE)
@@ -105,23 +194,26 @@ def test_source_decided_int_ordering_constructs_bool() -> None:
     assert isinstance(outcome.value, TrueBoolLiteralSugar)
 
 
-def test_lying_complete_predicate_is_not_the_undecided_answer() -> None:
-    """Lying twin: inventing Complete(py.lt) for undecided must be distinguishable.
+def test_decided_default_pair_without_sugar_arm_throws_named() -> None:
+    """LAW_OF_ONE: decided types with no ground arm refuse — no FOL invent."""
+    from sugar_lift_py_tests.floor.list_value import ListValue
 
-    If the floor fabricates Complete, this test fails. The honorable answer is
-    SugarNotWritten so no consumer can treat the row as green.
-    """
+    # ListValue has no ordering arm; both types are source-decided.
+    with pytest.raises(SugarNotWritten) as raised:
+        ListValue((TermValue(1),)).less_than(ListValue((TermValue(2),)), SITE)
+    assert "LAW_OF_ONE" in (raised.value.fix or "")
+    assert "Complete(PredicateValue)" in (raised.value.fix or "")
+
+
+def test_lying_complete_predicate_is_not_ordering_meaning() -> None:
+    """Lying twin: Complete(PredicateValue) is never the ordering answer."""
     from sugar_lift_py_tests.floor.predicate_value import PredicateValue
 
     with pytest.raises(SugarNotWritten):
         outcome = _symbolic().less_than(TermValue(1), SITE)
-        # If we reach here, the floor half-wrote an answer.
-        assert not isinstance(outcome, Complete) or not isinstance(
-            getattr(outcome, "value", None), PredicateValue
-        )
+        assert not isinstance(getattr(outcome, "value", None), PredicateValue)
         raise AssertionError(
-            "ordering floor returned a value for undecided operands; "
-            "must throw named instead of Complete"
+            "ordering floor returned a value; must throw named (LAW_OF_ONE)"
         )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py
@@ -1,0 +1,227 @@
+"""SIN CLUSTER 2 — ordering floor must not fabricate a Complete value.
+
+Doctrine: throwing is honorable (code not written yet). Half-writing an answer
+outside the tree is the sin. Where operand types are source-decided, construct.
+Where they are not, throw named — never ``Complete``.
+
+Also covers:
+- undecided binary: nameless halt is forbidden (boundary cannot match TypeError)
+- undecided contains: named refusal, not ``Complete(py.in)`` or construction_panic
+- undecided attribute: already named refusal; stays that way (not our defect)
+
+GATE: truthful twin, lying twin that must fail, mutation transaction elsewhere.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+from sugar_lift_py_tests.floor.none_value import NoneValue
+from sugar_lift_py_tests.floor.string_value import StringValue
+from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.ir import ctor, make_var
+from sugar_lift_py_tests.outcome import Complete
+from sugar_source_tree.panic import SugarNotWritten
+
+SITE = "sin-cluster-2-ordering-site"
+
+
+def _symbolic() -> SymbolicValue:
+    return SymbolicValue(make_var("s"))
+
+
+def _callsite() -> CallSiteValue:
+    return CallSiteValue("unknown", (), (), ctor("call:unknown", []), None)
+
+
+# ---------------------------------------------------------------------------
+# Ordering floor: undecided → named throw; decided ground → construct
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method",
+    ("less_than", "less_equal", "greater_than", "greater_equal"),
+)
+def test_undecided_ordering_operand_throws_named_never_complete(method: str) -> None:
+    """Truthful: undecided left never becomes Complete(PredicateValue)."""
+    left = _symbolic()
+    right = TermValue(1)
+    with pytest.raises(SugarNotWritten) as raised:
+        getattr(left, method)(right, SITE)
+    assert "undecided" in raised.value.observed.lower()
+    assert "ordering" in raised.value.observed.lower() or "ordering" in (
+        raised.value.requested or ""
+    ).lower()
+
+
+@pytest.mark.parametrize(
+    "method",
+    ("less_than", "less_equal", "greater_than", "greater_equal"),
+)
+def test_undecided_ordering_callsite_throws_named(method: str) -> None:
+    with pytest.raises(SugarNotWritten):
+        getattr(_callsite(), method)(TermValue(0), SITE)
+
+
+def _relative_fragment(source: str, filename: str):
+    """Workspace-relative fragment so ground exits can re-read source."""
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+    from sugar_lift_python_source.canonical import blake3_512_of
+    from sugar_source_tree.nodes import Compare, BinOp
+    from sugar_source_tree.tree import SourceFile
+
+    tree = SourceFile(
+        (source, filename, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    for node in tree.nodes():
+        if isinstance(node, (Compare, BinOp)):
+            return node.fragment
+    raise AssertionError(f"no Compare/BinOp in {filename!r}")
+
+
+def test_source_decided_number_string_ordering_emits_type_error() -> None:
+    """Truthful twin: decided unorderable pair constructs TypeError RaiseValue."""
+    from sugar_lift_py_tests.floor import RaiseValue
+
+    site = _relative_fragment('def f():\n    return 1.0 < "a"\n', "number-lt-string.py")
+    outcome = TermValue(1.0).less_than(StringValue("a"), site)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
+def test_source_decided_int_ordering_constructs_bool() -> None:
+    """Truthful twin: two decided numbers fold to a bool completion."""
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    outcome = TermValue(1).less_than(TermValue(2), SITE)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, TrueBoolLiteralSugar)
+
+
+def test_lying_complete_predicate_is_not_the_undecided_answer() -> None:
+    """Lying twin: inventing Complete(py.lt) for undecided must be distinguishable.
+
+    If the floor fabricates Complete, this test fails. The honorable answer is
+    SugarNotWritten so no consumer can treat the row as green.
+    """
+    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+
+    with pytest.raises(SugarNotWritten):
+        outcome = _symbolic().less_than(TermValue(1), SITE)
+        # If we reach here, the floor half-wrote an answer.
+        assert not isinstance(outcome, Complete) or not isinstance(
+            getattr(outcome, "value", None), PredicateValue
+        )
+        raise AssertionError(
+            "ordering floor returned a value for undecided operands; "
+            "must throw named instead of Complete"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Undecided binary: throw named — never nameless dual-edge halt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method",
+    (
+        "add",
+        "subtract",
+        "multiply",
+        "divide",
+        "bitwise_and",
+    ),
+)
+def test_undecided_binary_throws_named_never_nameless_halt(method: str) -> None:
+    """Nameless Halted faces route outside TypeError boundaries — refuse instead."""
+    with pytest.raises(SugarNotWritten) as raised:
+        getattr(_symbolic(), method)(TermValue(2), SITE)
+    owner = raised.value.owner or ""
+    observed = raised.value.observed or ""
+    assert "binary" in owner.lower() or "undecided" in observed.lower()
+    # Must not look like a completed dual-edge partition.
+    assert "TypeError" not in observed  # do not invent exception identity
+
+
+def test_source_decided_int_float_bitand_emits_type_error() -> None:
+    """Truthful twin: decided ground pair still constructs TypeError."""
+    from sugar_lift_py_tests.floor import RaiseValue
+
+    site = _relative_fragment("def f():\n    return 1 & 3.14\n", "int-bitand-float.py")
+    outcome = TermValue(1).bitwise_and(TermValue(3.14), site)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"
+
+
+def test_lying_dual_edge_is_not_undecided_binary_answer() -> None:
+    """Lying twin: dual-edge ExitSet with nameless RaiseEffect must not appear."""
+    from sugar_lift_py_tests.outcome import ExitSet
+    from sugar_lift_py_tests.outcome.exit_set import Halted
+
+    with pytest.raises(SugarNotWritten):
+        outcome = _symbolic().subtract(TermValue(1), SITE)
+        if isinstance(outcome, ExitSet):
+            for face in outcome.exits:
+                if isinstance(face, Halted) and getattr(
+                    face.effect, "exception_name", "missing"
+                ) is None:
+                    raise AssertionError(
+                        "nameless binary halt is the SIN: TypeError boundary "
+                        "can never match it"
+                    )
+        raise AssertionError("undecided binary must throw named, not return")
+
+
+# ---------------------------------------------------------------------------
+# Undecided contains / attribute
+# ---------------------------------------------------------------------------
+
+
+def test_undecided_contains_is_named_refusal_not_complete_or_panic() -> None:
+    """Membership over an undecided container is a third value, not our defect.
+
+    construction_panic would count this as a missing Floor arm (OUR bug).
+    Complete(py.in) fabricates membership. Named refusal is honest.
+    """
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(SugarNotWritten) as raised:
+        _symbolic().contains(TermValue(1), SITE)
+    assert "membership" in (raised.value.requested or "").lower() or "contain" in (
+        raised.value.observed or ""
+    ).lower()
+    # Not a construction panic harness failure.
+    assert not isinstance(raised.value, ConstructionPanic)
+
+
+def test_undecided_callsite_contains_is_named_refusal() -> None:
+    with pytest.raises(SugarNotWritten):
+        _callsite().contains(TermValue(1), SITE)
+
+
+def test_undecided_attribute_remains_named_refusal() -> None:
+    """Attribute over undecided receiver stays SugarNotWritten (already correct)."""
+    with pytest.raises(SugarNotWritten) as raised:
+        _symbolic().attribute("x", SITE)
+    assert raised.value.owner == "SymbolicValue.attribute"
+    assert "undecided" in raised.value.observed
+
+
+def test_source_decided_none_contains_emits_type_error() -> None:
+    """Truthful twin: decided non-container constructs TypeError."""
+    from sugar_lift_py_tests.floor import RaiseValue
+
+    site = _relative_fragment("def f():\n    return 1 in None\n", "in-none.py")
+    outcome = NoneValue().contains(TermValue(1), site)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, RaiseValue)
+    assert outcome.value.effect.exception_name == "TypeError"

--- a/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
@@ -8,9 +8,9 @@ named for THIS right operand, falling to the (owner x pair) gap.
 
 Most of those pairs are not eight arms to write. When at least one operand's
 runtime TYPE is undecided, Python's own operator dispatch for the pair is
-undecided.  That is a third value: the producer publishes both possible faces,
-retaining the symbolic completion beside a source-cited exceptional edge whose
-exception identity remains undecided.
+undecided.  That is a third value: the producer throws a named refusal
+(``SugarNotWritten``) rather than completing symbolically or minting a
+nameless dual-edge halt that TypeError boundaries cannot match.
 
 The category is read from each value's own testimony (``denotes_value`` /
 ``runtime_type_is_decided``), never from a lexical type name.
@@ -34,11 +34,9 @@ from sugar_lift_py_tests.floor.set_value import SetValue
 from sugar_lift_py_tests.floor.string_value import StringValue
 from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
 from sugar_lift_py_tests.floor.term_value import TermValue
-from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import PrimitiveSort, _Atomic, _Lambda, ctor, make_var
-from sugar_lift_py_tests.outcome import ExitSet
-from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
+from sugar_source_tree.panic import SugarNotWritten
 
 SITE = "undecided-binary-site"
 
@@ -68,38 +66,25 @@ def _comprehension() -> ComprehensionValue:
     )
 
 
-def _dual_edge(left, right, method: str, operator: str):
-    """Undecided native dispatch publishes both completion and halt faces."""
-    outcome = getattr(left, method)(right, SITE)
-    assert isinstance(outcome, ExitSet)
-    halted = tuple(face for face in outcome.exits if isinstance(face, Halted))
-    completed = tuple(face for face in outcome.exits if isinstance(face, Completed))
-    assert len(halted) == 1
-    assert len(completed) == 1
-    effect = halted[0].effect
-    assert isinstance(effect, RaiseEffect)
-    assert effect.producer_node_owner == "BinOp"
-    assert effect.exception_name is None
-    assert "TypeError" not in str(outcome)
-    assert "RuntimeEffect" not in str(outcome)
-    assert isinstance(completed[0].value, SymbolicValue)
-    return outcome
+def _named_refusal(left, right, method: str, operator: str):
+    """Undecided native dispatch throws named — never Complete or nameless halt."""
+    del operator
+    with pytest.raises(SugarNotWritten) as raised:
+        getattr(left, method)(right, SITE)
+    assert raised.value.owner == "binary_operation_exception_floor"
+    assert "undecided" in raised.value.observed.lower()
+    # Do not invent TypeError identity in the refusal text as a fake exit.
+    assert "TypeError" not in (raised.value.observed or "")
+    return raised.value
 
 
 def _refusal(left, right, method: str, operator: str):
-    return _dual_edge(left, right, method, operator)
+    return _named_refusal(left, right, method, operator)
 
 
-def test_undecided_native_bitwise_dispatch_publishes_both_faces() -> None:
+def test_undecided_native_bitwise_dispatch_throws_named() -> None:
     """The producer cannot choose sole ``__and__`` or sole TypeError."""
-    outcome = _symbolic().bitwise_and(TermValue(0), SITE)
-    assert isinstance(outcome, ExitSet)
-    halted = next(face for face in outcome.exits if isinstance(face, Halted))
-    completed = next(face for face in outcome.exits if isinstance(face, Completed))
-    assert isinstance(halted.effect, RaiseEffect)
-    assert halted.effect.producer_node_owner == "BinOp"
-    assert halted.effect.exception_name is None
-    assert isinstance(completed.value, SymbolicValue)
+    _named_refusal(_symbolic(), TermValue(0), "bitwise_and", "&")
 
 
 @pytest.mark.parametrize(
@@ -120,10 +105,10 @@ def test_undecided_native_bitwise_dispatch_publishes_both_faces() -> None:
         ("right_shift", ">>"),
     ),
 )
-def test_undecided_call_result_publishes_both_dispatch_faces(
+def test_undecided_call_result_throws_named_refusal(
     method: str, operator: str
 ) -> None:
-    _dual_edge(_callsite(), TermValue(2), method, operator)
+    _named_refusal(_callsite(), TermValue(2), method, operator)
 
 
 @pytest.mark.parametrize(
@@ -144,10 +129,10 @@ def test_undecided_call_result_publishes_both_dispatch_faces(
         ("right_shift", ">>"),
     ),
 )
-def test_symbolic_left_operand_publishes_both_dispatch_faces(
+def test_symbolic_left_operand_throws_named_refusal(
     method: str, operator: str
 ) -> None:
-    _dual_edge(_symbolic(), TermValue(2), method, operator)
+    _named_refusal(_symbolic(), TermValue(2), method, operator)
 
 
 def test_ground_total_addition_never_acquires_an_exceptional_edge() -> None:
@@ -159,73 +144,25 @@ def test_ground_total_addition_never_acquires_an_exceptional_edge() -> None:
     assert outcome.value == TermValue(3)
 
 
-def test_swapped_symbolic_operands_retain_distinct_coordinates() -> None:
-    """Ordered dispatch identity distinguishes ``a - b`` from ``b - a``."""
-    from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
-
+def test_swapped_symbolic_operands_both_throw_named() -> None:
+    """Both orderings refuse; neither fabricates a dual-edge partition."""
     left = SymbolicValue(make_var("left"))
     right = SymbolicValue(make_var("right"))
-    forward = left.subtract(right, SITE)
-    reverse = right.subtract(left, SITE)
-
-    forward_completed = next(
-        exit_ for exit_ in forward.exits if isinstance(exit_, Completed)
-    )
-    reverse_completed = next(
-        exit_ for exit_ in reverse.exits if isinstance(exit_, Completed)
-    )
-    forward_halted = next(exit_ for exit_ in forward.exits if isinstance(exit_, Halted))
-    reverse_halted = next(exit_ for exit_ in reverse.exits if isinstance(exit_, Halted))
-    assert forward_completed.value.term == ctor(
-        "-", [make_var("left"), make_var("right")]
-    )
-    assert reverse_completed.value.term == ctor(
-        "-", [make_var("right"), make_var("left")]
-    )
-    assert forward_halted.guard != reverse_halted.guard
+    with pytest.raises(SugarNotWritten) as forward:
+        left.subtract(right, SITE)
+    with pytest.raises(SugarNotWritten) as reverse:
+        right.subtract(left, SITE)
+    assert forward.value.owner == "binary_operation_exception_floor"
+    assert reverse.value.owner == "binary_operation_exception_floor"
+    assert " - " in forward.value.observed
+    assert " - " in reverse.value.observed
 
 
-def test_lying_exception_type_does_not_consume_binary_dispatch_halt() -> None:
-    """The boundary cannot invent an identity for an undecided binary raise."""
-    from sugar_lift_py_tests.context_manager_contract import (
-        AuthenticatedRaiseMatcher,
-        EffectBoundaryDisposition,
-    )
-    from sugar_lift_py_tests.effect import RaiseEffect
-    from sugar_lift_py_tests.effect.expectation_not_met_effect import (
-        ExpectationNotMetEffect,
-    )
-    from sugar_lift_py_tests.ir import str_const
-    from sugar_lift_py_tests.outcome import ExitSet
-    from sugar_lift_py_tests.outcome.exit_set import Halted
-
-    class _Expected:
-        def exception_type_identity(self):
-            return ctor(
-                "python:exception_type_identity",
-                [str_const("builtins"), str_const("ValueError")],
-            )
-
-    body = _symbolic().add(TermValue(2), SITE)
-    original = next(
-        exit_
-        for exit_ in body.exits
-        if isinstance(exit_, Halted) and isinstance(exit_.effect, RaiseEffect)
-    )
-    from sugar_source_tree.panic import SugarNotWritten
-
-    with pytest.raises(
-        SugarNotWritten,
-        match="handler or raised exception has no term to state the test over",
-    ):
-        body.and_exit(
-            ExitSet.completed(object()),
-            disposition=EffectBoundaryDisposition(
-                matcher=AuthenticatedRaiseMatcher(expected=_Expected()),
-                unmet=ExpectationNotMetEffect("raise", "assertion-site"),
-            ),
-        )
-    assert original.effect.exception_name is None
+def test_lying_exception_type_cannot_consume_named_binary_refusal() -> None:
+    """A boundary matcher never sees a nameless halt to invent identity for."""
+    with pytest.raises(SugarNotWritten) as raised:
+        _symbolic().add(TermValue(2), SITE)
+    assert raised.value.owner == "binary_operation_exception_floor"
 
 
 # -- positive arm: the pairs the pinned census actually found -----------------
@@ -278,17 +215,13 @@ def test_the_law_refuses_every_operator_it_names_from_one_place() -> None:
         _refusal(BytesValue(b"x"), _symbolic(), method, operator)
 
 
-def test_both_operand_categories_are_conserved_in_the_dual_edge() -> None:
-    """The dual-edge partition cites both operand terms; no sole TypeError."""
+def test_both_operand_categories_are_conserved_in_the_named_refusal() -> None:
+    """The refusal names both operand categories; no sole TypeError invent."""
     left = BytesValue(b"ab")
     right = _symbolic()
-    outcome = _dual_edge(left, right, "add", "+")
-    halted = next(face for face in outcome.exits if isinstance(face, Halted))
-    completed = next(face for face in outcome.exits if isinstance(face, Completed))
-    # Halt guard names both operand terms under the operator dispatch atom.
-    guard = halted.guard
-    assert guard is not None
-    assert isinstance(completed.value, SymbolicValue)
+    refusal = _named_refusal(left, right, "add", "+")
+    assert "BytesValue" in refusal.observed
+    assert "SymbolicValue" in refusal.observed
 
 
 # -- the real reproducers: whole functions, lifted from source ---------------
@@ -309,7 +242,7 @@ def test_both_operand_categories_are_conserved_in_the_dual_edge() -> None:
         ("set_minus_call", "def f(g):\n    return {1, 2} - g()\n"),
     ),
 )
-def test_the_whole_function_publishes_undecided_native_dispatch(
+def test_the_whole_function_publishes_undecided_named_refusal(
     tmp_path, name, source
 ) -> None:
     """Whole-function construction cannot launder sole completion or TypeError."""
@@ -320,18 +253,10 @@ def test_the_whole_function_publishes_undecided_native_dispatch(
     path.write_text(source, encoding="utf-8")
 
     fn = next(SourceFile(path_source(str(path))).functions())
-    outcome = fn.sugar().desugar(None)
-    assert isinstance(outcome, ExitSet)
-    halted = tuple(face for face in outcome.exits if isinstance(face, Halted))
-    assert halted
-    assert all(
-        isinstance(face.effect, RaiseEffect)
-        and face.effect.producer_node_owner == "BinOp"
-        for face in halted
-    )
+    with pytest.raises(SugarNotWritten) as raised:
+        fn.sugar().desugar(None)
+    assert raised.value.owner == "binary_operation_exception_floor"
 
-
-# -- discriminating arm: the law refuses, loudly, everywhere else -------------
 
 
 class _FragmentSite:


### PR DESCRIPTION
## Summary

- Removes the ordering floor second mechanism: default `less_than` / `le` / `gt` / `ge` doors no longer mint `Complete(PredicateValue(py.lt/…))`.
- Undecided operands and unarmed decided pairs throw named (`SugarNotWritten`); ground arms construct Sugar / authenticated TypeError.
- Undecided binary stops nameless dual-edge halts; undecided `contains` is named refusal.
- Package AST tooth pins FloorValue ordering defaults; notes that `law_of_one_auditor` cannot see this floor-meaning axis.

## Validation

- Focused non-corpus: `test_sin_cluster_2_ordering_floor`, `test_undecided_binary_operand_law`, `test_compare_exceptional_exit_producer` (deselect pandas/auth corpus).
- Mutation transaction: reintroduce FOL mint → AST tooth fails → revert → clean.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace fabricated `Complete(PredicateValue)` ordering and membership results with `SugarNotWritten` refusals
> - Default ordering methods (`less_equal`, `greater_than`, `greater_equal`) in `FloorValue` no longer emit `Complete(PredicateValue)` for undecided operands; they now raise `SugarNotWritten` via a new `_refuse_ordering_meaning` helper.
> - Adds `less_than_from_left` to `FloorValue`, `NoneValue`, `StringValue`, and `TermValue` to handle reversed ordering (`left < self`), with concrete arms for decided types and refusal for undecided.
> - Undecided membership (`contains`) in `FloorValue` and `SymbolicValue` now raises `SugarNotWritten` via `undecided_contains` instead of returning a predicate.
> - Undecided binary operations in `SymbolicValue._runtime_bitwise_dispatch` now raise `SugarNotWritten` instead of returning a dual-edge `ExitSet`.
> - Test suites in `test_sin_cluster_2_ordering_floor.py` and `test_undecided_binary_operand_law.py` are updated to assert named refusals in place of previous dual-edge or predicate outcomes.
> - Behavioral Change: any caller that previously received a symbolic `Complete(PredicateValue)` or a dual-edge `ExitSet` for undecided ordering/membership/binary ops will now get a `SugarNotWritten` exception.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7563fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->