### PR TITLE
Refuse render-edge fabrication of exceptional-exit identity

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import NoReturn
 
 from sugar_lift_py_tests.effect import RaiseEffect
 
@@ -53,16 +54,82 @@ class RaiseValue(FloorValue):
         return (_exceptional_exit_formula(self.effect),)
 
 
-def _exceptional_exit_formula(effect: RaiseEffect, guards: tuple = ()):
-    # Bare ``raise`` (re-raise of the active exception) is a source-cited
-    # exceptional exit: the coordinate is ``reraise``, not a silent drop and
-    # not a fabricated exception class. Explicit ``raise Exc(...)`` keeps its
-    # constructed name. Absence of both would be a construction gap elsewhere.
-    exception_name = (
-        effect.exception_name
-        if effect.exception_name is not None
-        else (None if effect.exception_type_coordinate is not None else "reraise")
+def _refuse_uncited_exit(
+    effect: RaiseEffect, *, observed: str, requested: str, fix: str
+) -> NoReturn:
+    """Render-edge mouth: absent evidence is a named throw, never a placeholder."""
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner="RaiseValue.exceptional_exit_term",
+        blame=effect.blame or effect.occurrence or "nameless raise face",
+        observed=observed,
+        requested=requested,
+        fix=fix,
     )
+
+
+def _require_authenticated_exceptional_exit_citation(effect: RaiseEffect) -> None:
+    """A face with no authenticated identity must never reach FOL emission.
+
+    Throwing is honorable: it means identity or citation evidence is not yet
+    on the effect. Fabricating ``"reraise"``, ``"unavailable"``, or
+    ``"<unknown raise locus>"`` would mint a citable exit indistinguishable
+    from a genuinely authenticated one — the number the project is judged on.
+
+    Legitimate bare ``raise`` re-raise re-emits the in-flight effect's real
+    tree-derived identity (see ``RaiseSugar.desugar``); it does not mint the
+    string ``"reraise"`` at this edge.
+    """
+    has_identity = (
+        effect.exception_name is not None
+        or effect.exception_type_coordinate is not None
+    )
+    if not has_identity:
+        _refuse_uncited_exit(
+            effect,
+            observed=(
+                "raise face has neither exception_name nor "
+                "exception_type_coordinate"
+            ),
+            requested=(
+                "an authenticated exception identity (name or type coordinate) "
+                "derived from the tree"
+            ),
+            fix=(
+                "do not fabricate 'reraise'; keep the nameless face loud until "
+                "identity is authenticated (bare re-raise re-emits the in-flight "
+                "effect)"
+            ),
+        )
+    if effect.blame is None:
+        _refuse_uncited_exit(
+            effect,
+            observed="raise face has no blame locus for exceptional-exit citation",
+            requested="a source-derived blame coordinate on the RaiseEffect",
+            fix=(
+                "do not fabricate '<unknown raise locus>'; thread the construction "
+                "locus that owns the raise"
+            ),
+        )
+    if effect.source_sha256 is None:
+        _refuse_uncited_exit(
+            effect,
+            observed="raise face has no source_sha256 for exceptional-exit citation",
+            requested="the sha256 of the source text the raise lives in",
+            fix=(
+                "do not fabricate '#source-sha256=unavailable'; cite only when "
+                "the unit text hash is present"
+            ),
+        )
+
+
+def _exceptional_exit_formula(effect: RaiseEffect, guards: tuple = ()):
+    # Identity and citation are enforced at the term edge. Explicit
+    # ``raise Exc(...)`` keeps its constructed name; type-coordinate-only
+    # faces pass ``None`` so the term uses the coordinate. Nameless faces
+    # never reach emission (see ``_require_authenticated_exceptional_exit_citation``).
+    exception_name = effect.exception_name
 
     from sugar_lift_py_tests.ir import and_, eq, implies, make_var
 
@@ -77,25 +144,41 @@ def _exceptional_exit_formula(effect: RaiseEffect, guards: tuple = ()):
 
 
 def _exceptional_exit_term(effect: RaiseEffect, *, exception_name: str | None = None):
-    """Project the one source-cited term shared by raise posts and selections."""
+    """Project the one source-cited term shared by raise posts and selections.
+
+    Requires authenticated identity and citation evidence. Never substitutes
+    placeholder strings for absent fields.
+    """
+    _require_authenticated_exceptional_exit_citation(effect)
+
     from sugar_lift_py_tests.ir import ctor, str_const
 
-    if effect.exception_type_coordinate is not None and exception_name is None:
+    resolved_name = (
+        exception_name if exception_name is not None else effect.exception_name
+    )
+    if effect.exception_type_coordinate is not None and resolved_name is None:
         name_term = effect.exception_type_coordinate
     else:
-        name = (
-            exception_name
-            if exception_name is not None
-            else effect.exception_name or "reraise"
-        )
-        name_term = str_const(name)
+        if resolved_name is None:
+            # Identity check already required name or coordinate; coordinate
+            # path taken above. Defensive mouth if both still empty.
+            _refuse_uncited_exit(
+                effect,
+                observed=(
+                    "raise face has neither exception_name nor "
+                    "exception_type_coordinate"
+                ),
+                requested=(
+                    "an authenticated exception identity (name or type coordinate) "
+                    "derived from the tree"
+                ),
+                fix="do not fabricate 'reraise'; keep the nameless face loud",
+            )
+        name_term = str_const(resolved_name)
     return ctor(
         "py.exceptional_exit",
         [
             name_term,
-            str_const(
-                f"{effect.blame or '<unknown raise locus>'}"
-                f"#source-sha256={effect.source_sha256 or 'unavailable'}"
-            ),
+            str_const(f"{effect.blame}#source-sha256={effect.source_sha256}"),
         ],
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py
@@ -57,12 +57,23 @@ class RaiseValue(FloorValue):
 def _refuse_uncited_exit(
     effect: RaiseEffect, *, observed: str, requested: str, fix: str
 ) -> NoReturn:
-    """Render-edge mouth: absent evidence is a named throw, never a placeholder."""
+    """Render-edge mouth: absent evidence is a named throw, never a placeholder.
+
+    Blame for the panic is the effect's own locus when present — never a
+    second-mechanism literal standing in for missing tree testimony.
+    """
     from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
+    if effect.blame is not None:
+        blame: object = effect.blame
+    elif effect.occurrence is not None:
+        blame = effect.occurrence
+    else:
+        # No locus on the face: the gap's observed prose is the coordinate.
+        blame = observed
     construction_panic_gap(
         owner="RaiseValue.exceptional_exit_term",
-        blame=effect.blame or effect.occurrence or "nameless raise face",
+        blame=blame,
         observed=observed,
         requested=requested,
         fix=fix,

--- a/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
@@ -1,12 +1,20 @@
 """Render-edge fabrication law for exceptional-exit FOL emission.
 
-Doctrine: throwing is honorable — it means we have not written the code yet.
-The sin is half-writing an answer outside the tree. At the render edge,
-`RaiseValue` / `_exceptional_exit_term` must never invent:
+LAW OF ONE (governs this cluster)
+=================================
+Exactly one way to do anything:
 
-  - exception identity ``"reraise"`` when name and type coordinate are absent
-  - source citation ``#source-sha256=unavailable`` when the hash is absent
-  - locus ``<unknown raise locus>`` when blame is absent
+  AST TREE SHADOWS  ->  temporal rewrite and tree modification
+  SUGAR             ->  meaning
+
+That is it. NO OTHER MECHANISM.
+
+Exception IDENTITY is meaning. It must come from Sugar / the tree — never
+from a Python ``or`` fallback that substitutes a literal at the boundary.
+``or "reraise"`` and ``or 'unavailable'`` are a second mechanism inventing
+meaning outside the tree. Doctrine: throwing is HONORABLE (code not written
+yet). The SIN is half-writing an answer outside the tree. Fix = throw, never
+substitute a placeholder.
 
 A nameless face must not reach FOL as a citable ``py.exceptional_exit``.
 Authenticated bare re-raise re-emits the in-flight effect's real identity
@@ -14,9 +22,26 @@ Authenticated bare re-raise re-emits the in-flight effect's real identity
 
 GATE: truthful twin cites under real evidence; lying twin (nameless face
 rendered as a cited exit) MUST FAIL.
+
+LAW_OF_ONE AUDITOR BLIND SPOT — SAY THIS LOUDLY
+===============================================
+``tests/law_of_one_auditor.py`` + ``law_of_one_evidence.py`` audit SourceFile
+owner paths, privacy closure, projection closure, and protocol zero-work.
+They do **not** walk floor render edges, BoolOp ``or``-literal meaning
+invention, or exceptional-exit FOL emission.
+
+  R_law_of_one_auditor_cannot_see_render_edge_fabrication = 1
+
+This module is the instrument that can see the sin: a runtime twin for
+nameless emission, plus an AST tooth for the second-mechanism shape
+(``x or "reraise"`` / ``x or 'unavailable'``) on the emission door.
+When the LAW_OF_ONE auditor gains a floor-render axis, retire this note.
 """
 
 from __future__ import annotations
+
+import ast
+from pathlib import Path
 
 import pytest
 
@@ -32,6 +57,24 @@ from sugar_lift_py_tests.ir import ctor, str_const
 
 _SHA = "a" * 64
 _LOCUS = "pkg/mod.py:12:4"
+
+# Literals that invent exceptional-exit meaning at the render edge.
+# Identity / citation evidence must come from the tree, never these strings.
+_FABRICATED_MEANING_LITERALS = frozenset(
+    {
+        "reraise",
+        "unavailable",
+        "<unknown raise locus>",
+    }
+)
+
+_RAISE_VALUE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "sugar_lift_py_tests"
+    / "floor"
+    / "raise_value.py"
+)
 
 
 def _named_cited_effect(**overrides) -> RaiseEffect:
@@ -58,6 +101,117 @@ def _coordinate_cited_effect(**overrides) -> RaiseEffect:
     )
     fields.update(overrides)
     return RaiseEffect(**fields)
+
+
+def or_literal_meaning_offenders(source: str, *, path: str = "<planted>") -> list[str]:
+    """AST tooth: ``or`` with a fabricated-meaning string is a second mechanism.
+
+    LAW OF ONE: meaning comes from Sugar/the tree. A BoolOp ``or`` whose
+    right-hand (or any operand after the first) is a Constant in the
+    fabricated set invents exception identity / citation at the boundary.
+    """
+    tree = ast.parse(source, filename=path)
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.BoolOp) or not isinstance(node.op, ast.Or):
+            continue
+        for operand in node.values:
+            if (
+                isinstance(operand, ast.Constant)
+                and isinstance(operand.value, str)
+                and operand.value in _FABRICATED_MEANING_LITERALS
+            ):
+                offenders.append(
+                    f"{path}:{getattr(node, 'lineno', 0)}: "
+                    f"or {operand.value!r} invents exceptional-exit meaning"
+                )
+    return offenders
+
+
+# ---------------------------------------------------------------------------
+# LAW_OF_ONE auditor cannot see this sin — pin the blind spot
+# ---------------------------------------------------------------------------
+
+
+def test_law_of_one_auditor_cannot_see_render_edge_fabrication() -> None:
+    """LOUD: the independent LAW_OF_ONE product auditor is blind to this axis.
+
+    Its evidence contract (owner path / privacy / projection / zero-work)
+    has no field for floor FOL emission or ``or``-literal meaning invention.
+    This tooth owns that recognition until a stronger substrate exists.
+    """
+    auditor = Path(__file__).resolve().parents[4] / "tests" / "law_of_one_auditor.py"
+    evidence = Path(__file__).resolve().parents[4] / "tests" / "law_of_one_evidence.py"
+    assert auditor.is_file(), auditor
+    assert evidence.is_file(), evidence
+
+    auditor_text = auditor.read_text(encoding="utf-8")
+    evidence_text = evidence.read_text(encoding="utf-8")
+
+    # Strings that would mean the auditor already owns *this* axis.
+    # (Other reds may say "unavailable" about unrelated product gaps.)
+    assert "reraise" not in auditor_text
+    assert "exceptional_exit" not in auditor_text
+    assert "or \"reraise\"" not in auditor_text
+    assert "source-sha256" not in auditor_text
+    # Evidence types are SourceFile-product only — no render-edge axis.
+    assert "RenderEdge" not in evidence_text
+    assert "exceptional_exit" not in evidence_text
+    assert "RaiseValue" not in evidence_text
+
+    # Receipt axis the existing auditor does not measure. R stays 1 until
+    # law_of_one_auditor grows a floor-render / meaning-invention axis.
+    R_law_of_one_auditor_cannot_see_render_edge_fabrication = 1
+    assert R_law_of_one_auditor_cannot_see_render_edge_fabrication == 1, (
+        "LAW_OF_ONE auditor still cannot see render-edge fabrication; "
+        "this module remains the recognizing instrument"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AST tooth: second-mechanism ``or``-literal meaning (Law of One shape)
+# ---------------------------------------------------------------------------
+
+
+def test_ast_tooth_lying_twin_or_reraise_is_visible() -> None:
+    """Planted second mechanism must be recognized — the historical sin shape."""
+    planted = '''
+def _exceptional_exit_term(effect):
+    name = effect.exception_name or "reraise"
+    cite = effect.source_sha256 or "unavailable"
+    locus = effect.blame or "<unknown raise locus>"
+    return name, cite, locus
+'''
+    offenders = or_literal_meaning_offenders(planted, path="planted.py")
+    assert len(offenders) == 3, offenders
+    assert any("reraise" in row for row in offenders)
+    assert any("unavailable" in row for row in offenders)
+    assert any("unknown raise locus" in row for row in offenders)
+
+
+def test_ast_tooth_truthful_raise_value_has_zero_or_literal_meaning() -> None:
+    """Production emission door: R=0 for fabricated-meaning ``or`` literals."""
+    source = _RAISE_VALUE_PATH.read_text(encoding="utf-8")
+    offenders = or_literal_meaning_offenders(
+        source, path=str(_RAISE_VALUE_PATH)
+    )
+    assert offenders == [], (
+        "render-edge emission invents meaning via or-literal; "
+        "Law of One: identity comes from the tree only. Offenders:\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_ast_tooth_does_not_flag_boolean_existence_ors() -> None:
+    """``name is not None or coord is not None`` is existence, not meaning."""
+    clean = '''
+def has_identity(effect):
+    return (
+        effect.exception_name is not None
+        or effect.exception_type_coordinate is not None
+    )
+'''
+    assert or_literal_meaning_offenders(clean) == []
 
 
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
@@ -1,0 +1,181 @@
+"""Render-edge fabrication law for exceptional-exit FOL emission.
+
+Doctrine: throwing is honorable — it means we have not written the code yet.
+The sin is half-writing an answer outside the tree. At the render edge,
+`RaiseValue` / `_exceptional_exit_term` must never invent:
+
+  - exception identity ``"reraise"`` when name and type coordinate are absent
+  - source citation ``#source-sha256=unavailable`` when the hash is absent
+  - locus ``<unknown raise locus>`` when blame is absent
+
+A nameless face must not reach FOL as a citable ``py.exceptional_exit``.
+Authenticated bare re-raise re-emits the in-flight effect's real identity
+(from the tree); it does not mint the string ``"reraise"``.
+
+GATE: truthful twin cites under real evidence; lying twin (nameless face
+rendered as a cited exit) MUST FAIL.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.floor.raise_value import (
+    RaiseValue,
+    _exceptional_exit_formula,
+    _exceptional_exit_term,
+)
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import ctor, str_const
+
+
+_SHA = "a" * 64
+_LOCUS = "pkg/mod.py:12:4"
+
+
+def _named_cited_effect(**overrides) -> RaiseEffect:
+    fields = dict(
+        exception_name="ValueError",
+        blame=_LOCUS,
+        source_sha256=_SHA,
+        occurrence=_LOCUS,
+    )
+    fields.update(overrides)
+    return RaiseEffect(**fields)
+
+
+def _coordinate_cited_effect(**overrides) -> RaiseEffect:
+    identity = ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("TypeError")],
+    )
+    fields = dict(
+        exception_type_coordinate=identity,
+        blame=_LOCUS,
+        source_sha256=_SHA,
+        occurrence=_LOCUS,
+    )
+    fields.update(overrides)
+    return RaiseEffect(**fields)
+
+
+# ---------------------------------------------------------------------------
+# Truthful twin: authenticated identity + citation reach FOL
+# ---------------------------------------------------------------------------
+
+
+def test_truthful_named_face_emits_cited_exceptional_exit() -> None:
+    """Named raise with real locus + source hash is a citable exit."""
+    effect = _named_cited_effect()
+    term = _exceptional_exit_term(effect)
+
+    assert term == ctor(
+        "py.exceptional_exit",
+        [
+            str_const("ValueError"),
+            str_const(f"{_LOCUS}#source-sha256={_SHA}"),
+        ],
+    )
+
+
+def test_truthful_type_coordinate_face_emits_cited_exceptional_exit() -> None:
+    """Type-coordinate identity (no spelling name) is still authenticated."""
+    effect = _coordinate_cited_effect()
+    term = _exceptional_exit_term(effect)
+
+    assert term.args[0] == effect.exception_type_coordinate
+    assert term.args[1] == str_const(f"{_LOCUS}#source-sha256={_SHA}")
+
+
+def test_truthful_raise_value_post_contribution_is_the_cited_formula() -> None:
+    effect = _named_cited_effect()
+    posts = RaiseValue(effect).post_contribution()
+
+    assert len(posts) == 1
+    # Same term path as the direct projector — no second spelling of identity.
+    assert posts[0] == _exceptional_exit_formula(effect)
+
+
+# ---------------------------------------------------------------------------
+# Lying twin: nameless / uncited faces MUST NOT emit a citable exit
+# ---------------------------------------------------------------------------
+
+
+def test_nameless_face_cannot_reach_fol_emission() -> None:
+    """THE GATE: nameless face rendering as a cited exit must FAIL.
+
+    Before the fix this emitted:
+      py.exceptional_exit(str_const("reraise"),
+                          "<unknown raise locus>#source-sha256=unavailable")
+    which is indistinguishable from a genuinely cited exit.
+    """
+    nameless = RaiseEffect()
+
+    with pytest.raises(ConstructionPanic) as raised:
+        _exceptional_exit_term(nameless)
+
+    info = raised.value.info
+    assert "neither" in info.observed or "no authenticated" in info.observed.lower()
+    # Must not have produced a greened FOL term under a made-up name.
+    with pytest.raises(ConstructionPanic):
+        term = _exceptional_exit_term(nameless)
+        assert term.args[0] == str_const("reraise")
+
+
+def test_nameless_raise_value_post_contribution_stays_loud() -> None:
+    """post_contribution is the same door — nameless cannot soft-emit."""
+    with pytest.raises(ConstructionPanic):
+        RaiseValue(RaiseEffect(blame=_LOCUS)).post_contribution()
+
+
+def test_name_without_source_sha_cannot_cite_unavailable() -> None:
+    """Placeholder ``#source-sha256=unavailable`` is absent evidence, not a cite."""
+    effect = RaiseEffect(
+        exception_name="ValueError",
+        blame=_LOCUS,
+        source_sha256=None,
+    )
+
+    with pytest.raises(ConstructionPanic) as raised:
+        _exceptional_exit_term(effect)
+
+    text = str(raised.value)
+    assert "unavailable" not in text or "source" in text.lower()
+    with pytest.raises(ConstructionPanic):
+        term = _exceptional_exit_term(effect)
+        assert "unavailable" in str(term.args[1])
+
+
+def test_name_without_blame_cannot_cite_unknown_locus() -> None:
+    """Placeholder ``<unknown raise locus>`` is not a re-readable citation."""
+    effect = RaiseEffect(
+        exception_name="ValueError",
+        blame=None,
+        source_sha256=_SHA,
+    )
+
+    with pytest.raises(ConstructionPanic) as raised:
+        _exceptional_exit_term(effect)
+
+    with pytest.raises(ConstructionPanic):
+        term = _exceptional_exit_term(effect)
+        assert "unknown raise locus" in str(term.args[1])
+
+
+def test_fabricated_reraise_string_is_not_authenticated_bare_raise() -> None:
+    """Bare re-raise re-emits the in-flight effect; it does not mint 'reraise'.
+
+    A face whose only 'identity' would have been the render-edge default
+    string stays unrepresentable at FOL emission.
+    """
+    # No name, no type coordinate — the historical path that became "reraise".
+    effect = RaiseEffect(blame=_LOCUS, source_sha256=_SHA)
+
+    with pytest.raises(ConstructionPanic) as raised:
+        _exceptional_exit_term(effect)
+
+    info = raised.value.info
+    # Throw carries the blame coordinate — honorable named refusal.
+    assert _LOCUS in info.blame or _LOCUS in str(raised.value)
+    assert info.owner  # named owner, not an AttributeError


### PR DESCRIPTION
## Summary

- Delete render-edge placeholders that greened nameless/uncited raises as citable FOL exits (`or "reraise"`, `or 'unavailable'`, `<unknown raise locus>`).
- A face with no authenticated name or type coordinate throws named at emission; bare re-raise re-emits the in-flight tree effect rather than minting `"reraise"`.
- Law of One: exception identity is meaning from Sugar/the tree only. Pin that `law_of_one_auditor` cannot see this axis (`R_law_of_one_auditor_cannot_see_render_edge_fabrication=1`) and own recognition via runtime twins + AST tooth for `or`-literal second-mechanism shape.

## Validation

```text
pytest tests/test_render_edge_exceptional_exit_citation.py  # 12 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse fabrication of exceptional-exit identity and citation at the render edge
> - Removes all fallback placeholder literals (`'reraise'`, `'<unknown raise locus>'`, `'#source-sha256=unavailable'`) from [`raise_value.py`](https://github.com/TSavo/sugar/pull/6943/files#diff-c8c77cf2fe469ee2d6b840ecb099a360480aaf0a71b51e37e476548ef74dccfc); these were silently invented when `RaiseEffect` lacked authenticated identity or citation data.
> - Adds `_refuse_uncited_exit` and `_require_authenticated_exceptional_exit_citation` helpers that raise `ConstructionPanic` when `exception_name`/`exception_type_coordinate`, `blame`, or `source_sha256` are absent.
> - Adds an AST-based detector in the new test module that scans for `or`-literal meaning invention and asserts zero offenders in the production code.
> - Behavioral Change: any `RaiseEffect` missing authenticated identity, blame, or source SHA now raises `ConstructionPanic` instead of emitting a term with fabricated values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a2088f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->