### PR TITLE
Rip out swallowed-throw second mechanisms (sin cluster 4)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2147,10 +2147,12 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     fn = _tree.find_function_by_name(sf, name)
                     if fn is None:
                         continue
-                    try:
-                        def_memento, rows = _tree.function_contract_rows(fn, file_rel)
-                    except Exception:
-                        continue
+                    # function_contract_rows may raise SugarNotWritten /
+                    # ConstructionPanic for unfinished body sugar. That throw is
+                    # honorable. Catching Exception and continuing manufactured
+                    # absence in targetCandidates (candidateCount undercount with
+                    # no named refusal). Let the throw propagate to the RPC edge.
+                    def_memento, rows = _tree.function_contract_rows(fn, file_rel)
                     if rows is None:
                         continue
                     post = rows[0].post

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2147,11 +2147,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     fn = _tree.find_function_by_name(sf, name)
                     if fn is None:
                         continue
-                    # function_contract_rows may raise SugarNotWritten /
-                    # ConstructionPanic for unfinished body sugar. That throw is
-                    # honorable. Catching Exception and continuing manufactured
-                    # absence in targetCandidates (candidateCount undercount with
-                    # no named refusal). Let the throw propagate to the RPC edge.
+                    # No except/continue. Throws from unfinished body sugar rise.
                     def_memento, rows = _tree.function_contract_rows(fn, file_rel)
                     if rows is None:
                         continue

--- a/implementations/python/sugar-lift-py-tests/tests/test_implications_target_candidate_no_swallow.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_implications_target_candidate_no_swallow.py
@@ -1,0 +1,93 @@
+"""Implications target_candidates must not manufacture absence from exceptions.
+
+SIN CLUSTER 4 / coord 3 — ``except Exception: continue`` around
+``function_contract_rows`` dropped a resolved target from target_candidates
+and reported a smaller candidateCount to the RPC client with no named refusal.
+Manufactured absence.
+
+Replacement: let the throw propagate. Incomplete (rows is None) remains a
+typed non-contract arm; Exception is never silence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_source_tree.panic import SugarNotWritten
+
+
+def test_truthful_function_contract_rows_exception_propagates():
+    """Truthful twin: a raise from function_contract_rows is not continue."""
+
+    def function_contract_rows(fn, file_rel):
+        del fn, file_rel
+        raise SugarNotWritten(
+            blame=SimpleNamespace(filename="t.py", line=1, col=0),
+            owner="test.implications.target",
+            observed="body sugar not written",
+            requested="Complete universe with contract rows",
+            fix="write body sugar; do not drop the target from candidates",
+        )
+
+    targets = ["target_fn"]
+    with pytest.raises(SugarNotWritten) as raised:
+        for name in targets:
+            fn = SimpleNamespace(name=name)
+            # Production implications loop after the fix: no try/except swallow.
+            function_contract_rows(fn, "t.py")
+    assert raised.value.owner == "test.implications.target"
+
+
+def test_lying_continue_manufactures_absence():
+    """Lying twin: except Exception continue yields empty candidates silently.
+
+    Under the banned shape, a raising target disappears from candidateCount
+    with no gap row — manufactured absence. The instrument fails if production
+    re-grows that silence (this twin asserts the crime's observable).
+    """
+
+    def function_contract_rows(fn, file_rel):
+        del fn, file_rel
+        raise RuntimeError("body sugar refused")
+
+    targets = ["a", "b"]
+    target_candidates = []
+    silent_drops = 0
+    for name in targets:
+        fn = SimpleNamespace(name=name)
+        try:
+            _def_memento, rows = function_contract_rows(fn, "t.py")
+        except Exception:
+            silent_drops += 1
+            continue
+        if rows is None:
+            continue
+        target_candidates.append(name)
+
+    # The crime:
+    assert silent_drops == 2
+    assert target_candidates == []
+    # Truthful: at least one raise, not a zero-candidate success.
+    with pytest.raises(RuntimeError):
+        function_contract_rows(SimpleNamespace(name="a"), "t.py")
+
+
+def test_production_implications_loop_no_longer_swallows_exception():
+    """Static twin: lift_rpc implications arm does not catch-and-continue."""
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "sugar_lift_py_tests"
+        / "lift_rpc.py"
+    ).read_text(encoding="utf-8")
+    marker = "def_memento, rows = _tree.function_contract_rows(fn, file_rel)"
+    assert marker in source
+    idx = source.index(marker)
+    # Immediately around the call: no try/except Exception swallow.
+    window = source[idx - 120 : idx + 80]
+    assert "try:" not in window
+    assert "except Exception" not in window
+    assert "function_contract_rows refused" not in source  # never soft-named either

--- a/implementations/python/sugar-lift-py-tests/tests/test_implications_target_candidate_no_swallow.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_implications_target_candidate_no_swallow.py
@@ -1,12 +1,10 @@
 """Implications target_candidates must not manufacture absence from exceptions.
 
 SIN CLUSTER 4 / coord 3 — ``except Exception: continue`` around
-``function_contract_rows`` dropped a resolved target from target_candidates
-and reported a smaller candidateCount to the RPC client with no named refusal.
-Manufactured absence.
+``function_contract_rows`` dropped a resolved target from target_candidates.
+Catch-and-continue is a second mechanism for surviving unfinished Sugar.
 
-Replacement: let the throw propagate. Incomplete (rows is None) remains a
-typed non-contract arm; Exception is never silence.
+DELETE the handler. Throws rise. No counter, no named skip list.
 """
 
 from __future__ import annotations
@@ -32,22 +30,14 @@ def test_truthful_function_contract_rows_exception_propagates():
             fix="write body sugar; do not drop the target from candidates",
         )
 
-    targets = ["target_fn"]
     with pytest.raises(SugarNotWritten) as raised:
-        for name in targets:
-            fn = SimpleNamespace(name=name)
-            # Production implications loop after the fix: no try/except swallow.
-            function_contract_rows(fn, "t.py")
+        for name in ["target_fn"]:
+            function_contract_rows(SimpleNamespace(name=name), "t.py")
     assert raised.value.owner == "test.implications.target"
 
 
 def test_lying_continue_manufactures_absence():
-    """Lying twin: except Exception continue yields empty candidates silently.
-
-    Under the banned shape, a raising target disappears from candidateCount
-    with no gap row — manufactured absence. The instrument fails if production
-    re-grows that silence (this twin asserts the crime's observable).
-    """
+    """Lying twin: except Exception continue yields empty candidates silently."""
 
     def function_contract_rows(fn, file_rel):
         del fn, file_rel
@@ -67,16 +57,14 @@ def test_lying_continue_manufactures_absence():
             continue
         target_candidates.append(name)
 
-    # The crime:
     assert silent_drops == 2
     assert target_candidates == []
-    # Truthful: at least one raise, not a zero-candidate success.
     with pytest.raises(RuntimeError):
         function_contract_rows(SimpleNamespace(name="a"), "t.py")
 
 
-def test_production_implications_loop_no_longer_swallows_exception():
-    """Static twin: lift_rpc implications arm does not catch-and-continue."""
+def test_production_implications_loop_has_no_exception_continue():
+    """Static twin: lift_rpc implications arm has no try/except around the call."""
     source = (
         Path(__file__).resolve().parents[1]
         / "src"
@@ -86,8 +74,6 @@ def test_production_implications_loop_no_longer_swallows_exception():
     marker = "def_memento, rows = _tree.function_contract_rows(fn, file_rel)"
     assert marker in source
     idx = source.index(marker)
-    # Immediately around the call: no try/except Exception swallow.
     window = source[idx - 120 : idx + 80]
     assert "try:" not in window
     assert "except Exception" not in window
-    assert "function_contract_rows refused" not in source  # never soft-named either

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -973,37 +973,6 @@ class ManagerConstructionGapV1:
     detail: str
 
 
-def _content_cids_for_factory_prefix(
-    factory_prefix: tuple[FloorValue, ...],
-    *,
-    resolved_cid: str,
-) -> tuple[str, ...] | ManagerConstructionGapV1:
-    """Mint content CIDs for every factory-prefix face — or refuse by name.
-
-    ``factoryPrefixCids`` is sealed inside the manager-construction preimage.
-    Projection is therefore a transaction: every face mints a CID, or the door
-    returns a named residual. Catching ``ConstructionPanic`` and sealing only
-    the survivors would silently mutate identity (structurally different
-    factories could share a construction CID). Silence is not zero.
-    """
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
-
-    cids: list[str] = []
-    for item in factory_prefix:
-        try:
-            cids.append(_term_content_cid(item.to_term(owner=resolved_cid)))
-        except ConstructionPanic as panic:
-            info = getattr(panic, "info", None)
-            owner = getattr(info, "owner", None) or type(item).__name__
-            observed = getattr(info, "observed", None) or str(panic)
-            return ManagerConstructionGapV1(
-                "force-floor",
-                resolved_cid,
-                f"factory-prefix:{type(item).__name__}:{owner}:{observed}",
-            )
-    return tuple(cids)
-
-
 def _factory_return_faces_from_entries(
     entries: tuple,
 ) -> tuple[FloorValue, ...]:
@@ -1680,15 +1649,12 @@ def construct_manager_behavior(
         if helper_fields:
             result = result.with_deferred_helper_fields()
     bindings = frame.runtime_entries
-    # factoryPrefixCids is inside the construction CID preimage. Every prefix
-    # face projects or the door refuses by name — never drop a panic and seal
-    # a shorter survivor list (that mutates identity).
-    sealed_prefix = _content_cids_for_factory_prefix(
-        factory_prefix, resolved_cid=resolved.cid
+    # factoryPrefixCids is inside the construction CID preimage. Project every
+    # face; ConstructionPanic propagates. No catch, no survivor list, no second
+    # mechanism — if a face has no term, the door panics. That is the point.
+    prefix_cids = tuple(
+        _term_content_cid(item.to_term(owner=resolved.cid)) for item in factory_prefix
     )
-    if isinstance(sealed_prefix, ManagerConstructionGapV1):
-        return sealed_prefix
-    prefix_cids = sealed_prefix
     preimage = {
         "kind": "constructed-manager-behavior",
         "schemaVersion": "1",

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -973,6 +973,37 @@ class ManagerConstructionGapV1:
     detail: str
 
 
+def _content_cids_for_factory_prefix(
+    factory_prefix: tuple[FloorValue, ...],
+    *,
+    resolved_cid: str,
+) -> tuple[str, ...] | ManagerConstructionGapV1:
+    """Mint content CIDs for every factory-prefix face — or refuse by name.
+
+    ``factoryPrefixCids`` is sealed inside the manager-construction preimage.
+    Projection is therefore a transaction: every face mints a CID, or the door
+    returns a named residual. Catching ``ConstructionPanic`` and sealing only
+    the survivors would silently mutate identity (structurally different
+    factories could share a construction CID). Silence is not zero.
+    """
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    cids: list[str] = []
+    for item in factory_prefix:
+        try:
+            cids.append(_term_content_cid(item.to_term(owner=resolved_cid)))
+        except ConstructionPanic as panic:
+            info = getattr(panic, "info", None)
+            owner = getattr(info, "owner", None) or type(item).__name__
+            observed = getattr(info, "observed", None) or str(panic)
+            return ManagerConstructionGapV1(
+                "force-floor",
+                resolved_cid,
+                f"factory-prefix:{type(item).__name__}:{owner}:{observed}",
+            )
+    return tuple(cids)
+
+
 def _factory_return_faces_from_entries(
     entries: tuple,
 ) -> tuple[FloorValue, ...]:
@@ -1649,19 +1680,15 @@ def construct_manager_behavior(
         if helper_fields:
             result = result.with_deferred_helper_fields()
     bindings = frame.runtime_entries
-    # BranchResultAuthentication / other control-metadata faces ride in the
-    # linearized if-block but are not term-projectable factory prefix work.
-    # Keep only prefix entries that mint a content CID; never panic the door.
-    prefix_cids_list: list[str] = []
-    kept_prefix: list[FloorValue] = []
-    for item in factory_prefix:
-        try:
-            prefix_cids_list.append(_term_content_cid(item.to_term(owner=resolved.cid)))
-            kept_prefix.append(item)
-        except ConstructionPanic:
-            continue
-    factory_prefix = tuple(kept_prefix)
-    prefix_cids = tuple(prefix_cids_list)
+    # factoryPrefixCids is inside the construction CID preimage. Every prefix
+    # face projects or the door refuses by name — never drop a panic and seal
+    # a shorter survivor list (that mutates identity).
+    sealed_prefix = _content_cids_for_factory_prefix(
+        factory_prefix, resolved_cid=resolved.cid
+    )
+    if isinstance(sealed_prefix, ManagerConstructionGapV1):
+        return sealed_prefix
+    prefix_cids = sealed_prefix
     preimage = {
         "kind": "constructed-manager-behavior",
         "schemaVersion": "1",

--- a/implementations/python/sugar-lift-python-source/tests/test_factory_prefix_cid_seal_transaction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_factory_prefix_cid_seal_transaction.py
@@ -1,28 +1,26 @@
-"""factoryPrefixCids seal is a transaction: every face mints or the door refuses.
+"""factoryPrefixCids: project every face or panic — no second mechanism.
 
 SIN CLUSTER 4 / coord 1 — ``except ConstructionPanic: continue`` under
 ``never panic the door`` dropped unprojectable prefix faces, then sealed the
 survivors into ``factoryPrefixCids`` inside the manager construction preimage.
-A term-projection defect silently mutated identity: structurally different
-factories could share a construction CID.
+A missing Sugar law was replaced by ad-hoc survival; identity mutated.
 
-Replacement: ``_content_cids_for_factory_prefix`` — all faces project, or a
-named ``ManagerConstructionGapV1`` carries the blame. Silence is not zero.
+LAW OF ONE: AST shadows → Sugar → meaning. Catch-and-continue is a second
+mechanism. DELETE the handler. If a face has no term, ConstructionPanic rises.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
 
 from sugar_lift_py_tests.floor.floor_value import FloorValue
 from sugar_lift_py_tests.floor.none_value import NoneValue
 from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import _term_content_cid
-from sugar_lift_python_source.manager_construction import (
-    ManagerConstructionGapV1,
-    _content_cids_for_factory_prefix,
-)
 
 
 @dataclass(frozen=True)
@@ -46,14 +44,19 @@ class _PanickingPrefixFace(FloorValue):
         )
 
 
+def _project_prefix_cids(
+    factory_prefix: tuple[FloorValue, ...], *, resolved_cid: str
+) -> tuple[str, ...]:
+    """Production shape after the fix: no try/except — panics rise."""
+    return tuple(
+        _term_content_cid(item.to_term(owner=resolved_cid)) for item in factory_prefix
+    )
+
+
 def _lying_swallow_cids(
     factory_prefix: tuple[FloorValue, ...], *, resolved_cid: str
 ) -> tuple[str, ...]:
-    """Banned shape: catch ConstructionPanic, keep survivors, seal shorter list.
-
-    This is the old door. Tests keep it only as the LYING twin that must fail
-    the content-address law.
-    """
+    """Banned shape: catch ConstructionPanic, keep survivors, seal shorter list."""
     cids: list[str] = []
     for item in factory_prefix:
         try:
@@ -63,36 +66,31 @@ def _lying_swallow_cids(
     return tuple(cids)
 
 
-def test_truthful_prefix_seal_projects_every_face():
-    """Truthful twin: projectable prefix faces mint one CID each, in order."""
+def test_truthful_prefix_projects_every_face():
+    """Truthful twin: projectable faces mint one CID each, in order."""
     resolved = "blake3-512:" + "a" * 128
     prefix = (NoneValue(), NoneValue())
-    sealed = _content_cids_for_factory_prefix(prefix, resolved_cid=resolved)
-    assert isinstance(sealed, tuple)
+    sealed = _project_prefix_cids(prefix, resolved_cid=resolved)
     assert len(sealed) == 2
     assert sealed[0] == _term_content_cid(NoneValue().to_term(owner=resolved))
     assert sealed[1] == sealed[0]
 
 
-def test_truthful_prefix_seal_refuses_unprojectable_face_by_name():
-    """Truthful twin: ConstructionPanic becomes a named force-floor residual."""
+def test_truthful_unprojectable_face_panics_the_door():
+    """Truthful twin: ConstructionPanic propagates — the door panics."""
     resolved = "blake3-512:" + "b" * 128
     prefix = (NoneValue(), _PanickingPrefixFace("drop-me"))
-    result = _content_cids_for_factory_prefix(prefix, resolved_cid=resolved)
-    assert isinstance(result, ManagerConstructionGapV1)
-    assert result.kind == "force-floor"
-    assert result.resolved_object_cid == resolved
-    assert "factory-prefix" in result.detail
-    assert "_PanickingPrefixFace" in result.detail
-    assert "test.factory-prefix" in result.detail
+    with pytest.raises(ConstructionPanic) as raised:
+        _project_prefix_cids(prefix, resolved_cid=resolved)
+    assert raised.value.info.owner == "test.factory-prefix"
 
 
 def test_lying_swallow_collides_identity_for_structurally_different_prefixes():
-    """Lying twin MUST FAIL the content-address rule.
+    """Lying twin MUST FAIL the content-address rule under the banned swallow.
 
-    Under the banned swallow, a prefix with an unprojectable face seals to the
-    same CID list as the same prefix without that face — identity mutation.
-    The truthful seal refuses the panicking prefix instead.
+    Under catch-and-continue, a prefix with an unprojectable face seals to the
+    same CID list as the same prefix without that face — identity mutation via
+    a second mechanism. Truthful projection raises instead.
     """
     resolved = "blake3-512:" + "c" * 128
     alone = (NoneValue(),)
@@ -100,15 +98,26 @@ def test_lying_swallow_collides_identity_for_structurally_different_prefixes():
 
     lying_alone = _lying_swallow_cids(alone, resolved_cid=resolved)
     lying_with = _lying_swallow_cids(with_panic, resolved_cid=resolved)
-    # The crime: structurally different prefixes mint the same survivor CIDs.
-    assert lying_alone == lying_with
+    assert lying_alone == lying_with  # the crime: collision
 
-    truthful_alone = _content_cids_for_factory_prefix(alone, resolved_cid=resolved)
-    truthful_with = _content_cids_for_factory_prefix(with_panic, resolved_cid=resolved)
+    truthful_alone = _project_prefix_cids(alone, resolved_cid=resolved)
     assert truthful_alone == lying_alone
-    assert isinstance(truthful_with, ManagerConstructionGapV1), (
-        "truthful seal must refuse the unprojectable face; "
-        f"got survivor CIDs {truthful_with!r} that collide with {truthful_alone!r}"
-    )
-    # Transaction: no partial survivor list is returned alongside a success.
-    assert not isinstance(truthful_with, tuple)
+    with pytest.raises(ConstructionPanic):
+        _project_prefix_cids(with_panic, resolved_cid=resolved)
+
+
+def test_production_source_has_no_factory_prefix_catch_continue():
+    """Static twin: the catch-continue and "never panic the door" are gone."""
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "sugar_lift_python_source"
+        / "manager_construction.py"
+    ).read_text(encoding="utf-8")
+    assert "never panic the door" not in source
+    assert "kept_prefix" not in source
+    # The seal is a bare projection loop — no ConstructionPanic handler on it.
+    marker = "_term_content_cid(item.to_term(owner=resolved.cid))"
+    assert marker in source
+    # No _content_cids helper that catches panic into a gap (prior soft fix).
+    assert "_content_cids_for_factory_prefix" not in source

--- a/implementations/python/sugar-lift-python-source/tests/test_factory_prefix_cid_seal_transaction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_factory_prefix_cid_seal_transaction.py
@@ -1,0 +1,114 @@
+"""factoryPrefixCids seal is a transaction: every face mints or the door refuses.
+
+SIN CLUSTER 4 / coord 1 — ``except ConstructionPanic: continue`` under
+``never panic the door`` dropped unprojectable prefix faces, then sealed the
+survivors into ``factoryPrefixCids`` inside the manager construction preimage.
+A term-projection defect silently mutated identity: structurally different
+factories could share a construction CID.
+
+Replacement: ``_content_cids_for_factory_prefix`` — all faces project, or a
+named ``ManagerConstructionGapV1`` carries the blame. Silence is not zero.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sugar_lift_py_tests.floor.floor_value import FloorValue
+from sugar_lift_py_tests.floor.none_value import NoneValue
+from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.ir import _term_content_cid
+from sugar_lift_python_source.manager_construction import (
+    ManagerConstructionGapV1,
+    _content_cids_for_factory_prefix,
+)
+
+
+@dataclass(frozen=True)
+class _PanickingPrefixFace(FloorValue):
+    """Honorable unfinished Floor: to_term raises ConstructionPanic."""
+
+    label: str = "unwritten-prefix-face"
+
+    def to_term(self, *, owner: str):
+        del owner
+        raise ConstructionPanic(
+            ConstructionGap(
+                owner="test.factory-prefix",
+                blame=self.label,
+                observed=type(self).__name__,
+                requested="project this floor value to a term",
+                fix=f"write more Floor: implement {type(self).__name__}.to_term",
+                gap_kind=GapKind.FLOOR,
+                gap_locus=GapLocus.PROJECTION,
+            )
+        )
+
+
+def _lying_swallow_cids(
+    factory_prefix: tuple[FloorValue, ...], *, resolved_cid: str
+) -> tuple[str, ...]:
+    """Banned shape: catch ConstructionPanic, keep survivors, seal shorter list.
+
+    This is the old door. Tests keep it only as the LYING twin that must fail
+    the content-address law.
+    """
+    cids: list[str] = []
+    for item in factory_prefix:
+        try:
+            cids.append(_term_content_cid(item.to_term(owner=resolved_cid)))
+        except ConstructionPanic:
+            continue
+    return tuple(cids)
+
+
+def test_truthful_prefix_seal_projects_every_face():
+    """Truthful twin: projectable prefix faces mint one CID each, in order."""
+    resolved = "blake3-512:" + "a" * 128
+    prefix = (NoneValue(), NoneValue())
+    sealed = _content_cids_for_factory_prefix(prefix, resolved_cid=resolved)
+    assert isinstance(sealed, tuple)
+    assert len(sealed) == 2
+    assert sealed[0] == _term_content_cid(NoneValue().to_term(owner=resolved))
+    assert sealed[1] == sealed[0]
+
+
+def test_truthful_prefix_seal_refuses_unprojectable_face_by_name():
+    """Truthful twin: ConstructionPanic becomes a named force-floor residual."""
+    resolved = "blake3-512:" + "b" * 128
+    prefix = (NoneValue(), _PanickingPrefixFace("drop-me"))
+    result = _content_cids_for_factory_prefix(prefix, resolved_cid=resolved)
+    assert isinstance(result, ManagerConstructionGapV1)
+    assert result.kind == "force-floor"
+    assert result.resolved_object_cid == resolved
+    assert "factory-prefix" in result.detail
+    assert "_PanickingPrefixFace" in result.detail
+    assert "test.factory-prefix" in result.detail
+
+
+def test_lying_swallow_collides_identity_for_structurally_different_prefixes():
+    """Lying twin MUST FAIL the content-address rule.
+
+    Under the banned swallow, a prefix with an unprojectable face seals to the
+    same CID list as the same prefix without that face — identity mutation.
+    The truthful seal refuses the panicking prefix instead.
+    """
+    resolved = "blake3-512:" + "c" * 128
+    alone = (NoneValue(),)
+    with_panic = (NoneValue(), _PanickingPrefixFace("hidden-defect"))
+
+    lying_alone = _lying_swallow_cids(alone, resolved_cid=resolved)
+    lying_with = _lying_swallow_cids(with_panic, resolved_cid=resolved)
+    # The crime: structurally different prefixes mint the same survivor CIDs.
+    assert lying_alone == lying_with
+
+    truthful_alone = _content_cids_for_factory_prefix(alone, resolved_cid=resolved)
+    truthful_with = _content_cids_for_factory_prefix(with_panic, resolved_cid=resolved)
+    assert truthful_alone == lying_alone
+    assert isinstance(truthful_with, ManagerConstructionGapV1), (
+        "truthful seal must refuse the unprojectable face; "
+        f"got survivor CIDs {truthful_with!r} that collide with {truthful_alone!r}"
+    )
+    # Transaction: no partial survivor list is returned alongside a success.
+    assert not isinstance(truthful_with, tuple)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -7251,10 +7251,7 @@ class With(Statement):
                 site=self.fragment,
             )
 
-        # Named SourceTreePanic from the narrow CM door is honorable unfinished
-        # work. Soft dual-mode used to catch Exception and substitute
-        # SoftUnresolvedWithSugar — UNDECIDED rendered as incomplete. Let the
-        # throw propagate; a None return remains the only "not this arm" signal.
+        # SourceTreePanic from the door propagates — no Exception swallow.
         resolved_ref = self._require_narrow_cm_ref(item)
         if resolved_ref is not None:
             from sugar_lift_py_tests.context_manager_contract import (
@@ -7762,10 +7759,7 @@ class With(Statement):
             item = self.items[0]
             if item.optional_vars is None or item.optional_vars.kind != "Name":
                 return None
-            # Soft dual-mode used to catch Exception around the narrow CM door
-            # and treat SourceTreePanic as resolved_ref=None — a named refusal
-            # rendered as "not an effect boundary" (False). Let the throw rise;
-            # None from the door itself remains the only undecided-absent arm.
+            # SourceTreePanic from the door propagates — no Exception swallow.
             resolved_ref = None
             if self._generator_manager_frame(item) is None:
                 resolved_ref = self._require_narrow_cm_ref(item)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -7251,21 +7251,11 @@ class With(Statement):
                 site=self.fragment,
             )
 
-        context = self.unit.construction_context
-        if getattr(context, "frame_projection", False):
-            try:
-                resolved_ref = self._require_narrow_cm_ref(item)
-            except Exception:  # noqa: BLE001 — soft dual-mode factory projection
-                # Nested With only on the function-form branch of dual-mode
-                # EffectBoundary factories (pytest.raises). Leave a soft
-                # incomplete so the CM return path can still project a frame.
-                from sugar_lift_py_tests.sugar.soft_unresolved_with_sugar import (
-                    SoftUnresolvedWithSugar,
-                )
-
-                return SoftUnresolvedWithSugar(site=self.fragment)
-        else:
-            resolved_ref = self._require_narrow_cm_ref(item)
+        # Named SourceTreePanic from the narrow CM door is honorable unfinished
+        # work. Soft dual-mode used to catch Exception and substitute
+        # SoftUnresolvedWithSugar — UNDECIDED rendered as incomplete. Let the
+        # throw propagate; a None return remains the only "not this arm" signal.
+        resolved_ref = self._require_narrow_cm_ref(item)
         if resolved_ref is not None:
             from sugar_lift_py_tests.context_manager_contract import (
                 EffectBoundarySemanticsV1,
@@ -7772,16 +7762,13 @@ class With(Statement):
             item = self.items[0]
             if item.optional_vars is None or item.optional_vars.kind != "Name":
                 return None
+            # Soft dual-mode used to catch Exception around the narrow CM door
+            # and treat SourceTreePanic as resolved_ref=None — a named refusal
+            # rendered as "not an effect boundary" (False). Let the throw rise;
+            # None from the door itself remains the only undecided-absent arm.
             resolved_ref = None
             if self._generator_manager_frame(item) is None:
-                context = self.unit.construction_context
-                if getattr(context, "frame_projection", False):
-                    try:
-                        resolved_ref = self._require_narrow_cm_ref(item)
-                    except Exception:  # noqa: BLE001 — soft dual-mode projection
-                        resolved_ref = None
-                else:
-                    resolved_ref = self._require_narrow_cm_ref(item)
+                resolved_ref = self._require_narrow_cm_ref(item)
             from sugar_lift_py_tests.context_manager_contract import (
                 EffectBoundarySemanticsV1,
             )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/parso_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/parso_adapter.py
@@ -79,7 +79,7 @@ from .backend import (
 )
 from .nodes import SourceUnit
 from .operators import Operator, operator_for
-from .panic import backend_defect, vocabulary_missing
+from .panic import vocabulary_missing
 from .spans import Span
 
 ParsoNode = object  # parso.tree.NodeOrLeaf, kept untyped at the boundary
@@ -365,18 +365,9 @@ def _join_string_pieces(unit: SourceUnit, pieces: Sequence[ParsoNode]) -> Backen
     text = "".join(
         unit.source[_span(unit, p).start : _span(unit, p).end] for p in pieces
     )
-    try:
-        value = _pyast.literal_eval(text)
-    except Exception as exc:
-        # A decode we could not perform must not become Constant.value. Raw
-        # source text is not a literal value — refuse by name with blame.
-        backend_defect(
-            blame=pieces[0],
-            owner="parso_adapter._join_string_pieces",
-            observed=f"literal_eval failed ({type(exc).__name__}: {exc}); text={text!r}",
-            requested="a successfully decoded Python string-literal value",
-            fix="fix the adapter decode or the backend leaf text; never substitute raw source as Constant.value",
-        )
+    # Decode or throw. Never substitute raw source as Constant.value — that is
+    # meaning produced outside Sugar (LAW_OF_ONE).
+    value = _pyast.literal_eval(text)
     return _fixed_constant(span, value)
 
 
@@ -402,21 +393,8 @@ def _constant_leaf(unit: SourceUnit, node: ParsoNode) -> BackendNode:
     if node.type == "string":
         import ast as _pyast
 
-        try:
-            value = _pyast.literal_eval(text)
-        except Exception as exc:
-            # Parse failure is not a value. Downstream trusts Constant.value;
-            # substituting raw source text launders an adapter defect into data.
-            backend_defect(
-                blame=node,
-                owner="parso_adapter._constant_leaf",
-                observed=(
-                    f"literal_eval failed ({type(exc).__name__}: {exc}); "
-                    f"text={text!r}"
-                ),
-                requested="a successfully decoded Python string-literal value",
-                fix="fix the adapter decode or the backend leaf text; never substitute raw source as Constant.value",
-            )
+        # Decode or throw. Never substitute raw source as Constant.value.
+        value = _pyast.literal_eval(text)
         return _fixed_constant(span, value)
     if node.type == "keyword" and node.value in ("None", "True", "False"):
         value = {"None": None, "True": True, "False": False}[node.value]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/parso_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/parso_adapter.py
@@ -79,7 +79,7 @@ from .backend import (
 )
 from .nodes import SourceUnit
 from .operators import Operator, operator_for
-from .panic import vocabulary_missing
+from .panic import backend_defect, vocabulary_missing
 from .spans import Span
 
 ParsoNode = object  # parso.tree.NodeOrLeaf, kept untyped at the boundary
@@ -367,8 +367,16 @@ def _join_string_pieces(unit: SourceUnit, pieces: Sequence[ParsoNode]) -> Backen
     )
     try:
         value = _pyast.literal_eval(text)
-    except Exception:
-        value = unit.source[start:end]
+    except Exception as exc:
+        # A decode we could not perform must not become Constant.value. Raw
+        # source text is not a literal value — refuse by name with blame.
+        backend_defect(
+            blame=pieces[0],
+            owner="parso_adapter._join_string_pieces",
+            observed=f"literal_eval failed ({type(exc).__name__}: {exc}); text={text!r}",
+            requested="a successfully decoded Python string-literal value",
+            fix="fix the adapter decode or the backend leaf text; never substitute raw source as Constant.value",
+        )
     return _fixed_constant(span, value)
 
 
@@ -396,8 +404,19 @@ def _constant_leaf(unit: SourceUnit, node: ParsoNode) -> BackendNode:
 
         try:
             value = _pyast.literal_eval(text)
-        except Exception:
-            value = text
+        except Exception as exc:
+            # Parse failure is not a value. Downstream trusts Constant.value;
+            # substituting raw source text launders an adapter defect into data.
+            backend_defect(
+                blame=node,
+                owner="parso_adapter._constant_leaf",
+                observed=(
+                    f"literal_eval failed ({type(exc).__name__}: {exc}); "
+                    f"text={text!r}"
+                ),
+                requested="a successfully decoded Python string-literal value",
+                fix="fix the adapter decode or the backend leaf text; never substitute raw source as Constant.value",
+            )
         return _fixed_constant(span, value)
     if node.type == "keyword" and node.value in ("None", "True", "False"):
         value = {"None": None, "True": True, "False": False}[node.value]

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree_sitter_python_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree_sitter_python_adapter.py
@@ -73,7 +73,7 @@ from .backend import (
 )
 from .nodes import SourceUnit
 from .operators import Operator, operator_for
-from .panic import vocabulary_missing
+from .panic import backend_defect, vocabulary_missing
 from .spans import Span
 
 TSNode = object  # tree_sitter.Node, kept untyped at the boundary
@@ -308,8 +308,17 @@ def _string_like(unit: SourceUnit, node: TSNode) -> Description:
 
         try:
             value = _pyast.literal_eval(text)
-        except Exception:
-            value = text
+        except Exception as exc:
+            backend_defect(
+                blame=node,
+                owner="tree_sitter_python_adapter._string_like",
+                observed=(
+                    f"literal_eval failed ({type(exc).__name__}: {exc}); "
+                    f"text={text!r}"
+                ),
+                requested="a successfully decoded Python string-literal value",
+                fix="fix the adapter decode or the backend leaf text; never substitute raw source as Constant.value",
+            )
         return _fixed_constant(span, value)
     values: List[BackendNode] = []
     for c in node.children:
@@ -350,8 +359,17 @@ def _concatenated_string(unit: SourceUnit, node: TSNode) -> Description:
         text = "".join(_text(unit, p) for p in pieces)
         try:
             value = _pyast.literal_eval(text)
-        except Exception:
-            value = unit.source[span.start : span.end]
+        except Exception as exc:
+            backend_defect(
+                blame=pieces[0],
+                owner="tree_sitter_python_adapter._concatenated_string",
+                observed=(
+                    f"literal_eval failed ({type(exc).__name__}: {exc}); "
+                    f"text={text!r}"
+                ),
+                requested="a successfully decoded Python string-literal value",
+                fix="fix the adapter decode or the backend leaf text; never substitute raw source as Constant.value",
+            )
         return _fixed_constant(span, value)
     values: List[BackendNode] = []
     for p in pieces:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree_sitter_python_adapter.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree_sitter_python_adapter.py
@@ -73,7 +73,7 @@ from .backend import (
 )
 from .nodes import SourceUnit
 from .operators import Operator, operator_for
-from .panic import backend_defect, vocabulary_missing
+from .panic import vocabulary_missing
 from .spans import Span
 
 TSNode = object  # tree_sitter.Node, kept untyped at the boundary
@@ -306,19 +306,8 @@ def _string_like(unit: SourceUnit, node: TSNode) -> Description:
         text = _text(unit, node)
         import ast as _pyast
 
-        try:
-            value = _pyast.literal_eval(text)
-        except Exception as exc:
-            backend_defect(
-                blame=node,
-                owner="tree_sitter_python_adapter._string_like",
-                observed=(
-                    f"literal_eval failed ({type(exc).__name__}: {exc}); "
-                    f"text={text!r}"
-                ),
-                requested="a successfully decoded Python string-literal value",
-                fix="fix the adapter decode or the backend leaf text; never substitute raw source as Constant.value",
-            )
+        # Decode or throw. Never substitute raw source as Constant.value.
+        value = _pyast.literal_eval(text)
         return _fixed_constant(span, value)
     values: List[BackendNode] = []
     for c in node.children:
@@ -357,19 +346,8 @@ def _concatenated_string(unit: SourceUnit, node: TSNode) -> Description:
         import ast as _pyast
 
         text = "".join(_text(unit, p) for p in pieces)
-        try:
-            value = _pyast.literal_eval(text)
-        except Exception as exc:
-            backend_defect(
-                blame=pieces[0],
-                owner="tree_sitter_python_adapter._concatenated_string",
-                observed=(
-                    f"literal_eval failed ({type(exc).__name__}: {exc}); "
-                    f"text={text!r}"
-                ),
-                requested="a successfully decoded Python string-literal value",
-                fix="fix the adapter decode or the backend leaf text; never substitute raw source as Constant.value",
-            )
+        # Decode or throw. Never substitute raw source as Constant.value.
+        value = _pyast.literal_eval(text)
         return _fixed_constant(span, value)
     values: List[BackendNode] = []
     for p in pieces:

--- a/implementations/python/sugar-source-tree/tests/test_literal_eval_no_raw_substitution.py
+++ b/implementations/python/sugar-source-tree/tests/test_literal_eval_no_raw_substitution.py
@@ -1,0 +1,98 @@
+"""literal_eval failure must refuse — never substitute raw source as value.
+
+SIN CLUSTER 4 / coord 4 — parso_adapter (and the tree-sitter twin) caught
+``literal_eval`` failure and set ``Constant.value`` to the raw source text.
+A parse we could not perform became a value downstream trusts.
+
+Replacement: ``backend_defect`` with owner + blame. No substituted value.
+"""
+
+from __future__ import annotations
+
+import ast
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_source_tree.panic import BackendDefect, backend_defect
+
+
+def test_truthful_backend_defect_refuses_decode_without_value():
+    """Truthful twin: named BackendDefect carries owner/blame; no value minted."""
+    text = r"'\x'"
+    with pytest.raises(BackendDefect) as raised:
+        backend_defect(
+            blame=SimpleNamespace(filename="t.py", line=1, col=0),
+            owner="parso_adapter._constant_leaf",
+            observed=f"literal_eval failed; text={text!r}",
+            requested="a successfully decoded Python string-literal value",
+            fix="never substitute raw source as Constant.value",
+        )
+    assert raised.value.owner == "parso_adapter._constant_leaf"
+    assert "never substitute raw source" in raised.value.fix
+
+
+def test_lying_raw_source_substitution_is_the_crime():
+    """Lying twin: except → value = text launders a parse failure into data.
+
+    Keep the banned shape only as the instrument that must not reappear in
+    production. The truthful path raises instead of returning a Constant.
+    """
+    text = r"'\x'"
+    try:
+        value = ast.literal_eval(text)
+        pytest.fail(f"expected literal_eval to fail, got {value!r}")
+    except Exception:
+        lying_value = text  # the sin: raw source as Constant.value
+
+    assert lying_value == text
+    assert isinstance(lying_value, str)
+    # Truthful refusal: no Constant.value is constructed from the failure.
+    with pytest.raises(BackendDefect):
+        backend_defect(
+            blame=SimpleNamespace(filename="t.py", line=1, col=0),
+            owner="parso_adapter._constant_leaf",
+            observed=f"literal_eval failed; text={text!r}",
+            requested="a successfully decoded Python string-literal value",
+            fix="never substitute raw source as Constant.value",
+        )
+
+
+def test_parso_adapter_source_no_longer_substitutes_raw_on_literal_eval_failure():
+    """Static twin: production source refuses decode failure by backend_defect.
+
+    parso is an OPTIONAL_PROVIDER; this law reads the adapter source so it
+    stays green without installing the provider, while still pinning the
+    illegal ``value = text`` / ``value = unit.source[...]`` shape out.
+    """
+    from pathlib import Path
+
+    adapter = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "sugar_source_tree"
+        / "parso_adapter.py"
+    )
+    source = adapter.read_text(encoding="utf-8")
+    assert "backend_defect" in source
+    assert "never substitute raw source as Constant.value" in source
+    # Banned survivor shapes after a failed literal_eval:
+    assert "value = text" not in source
+    assert "value = unit.source[start:end]" not in source
+    assert "value = unit.source[span.start : span.end]" not in source
+
+
+def test_tree_sitter_adapter_source_no_longer_substitutes_raw_on_literal_eval_failure():
+    """Same law for the tree-sitter twin adapter (same package, same sin)."""
+    from pathlib import Path
+
+    adapter = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "sugar_source_tree"
+        / "tree_sitter_python_adapter.py"
+    )
+    source = adapter.read_text(encoding="utf-8")
+    assert "backend_defect" in source
+    assert "value = text" not in source
+    assert "value = unit.source[span.start : span.end]" not in source

--- a/implementations/python/sugar-source-tree/tests/test_literal_eval_no_raw_substitution.py
+++ b/implementations/python/sugar-source-tree/tests/test_literal_eval_no_raw_substitution.py
@@ -1,43 +1,29 @@
-"""literal_eval failure must refuse — never substitute raw source as value.
+"""literal_eval failure must throw — never substitute raw source as value.
 
 SIN CLUSTER 4 / coord 4 — parso_adapter (and the tree-sitter twin) caught
 ``literal_eval`` failure and set ``Constant.value`` to the raw source text.
-A parse we could not perform became a value downstream trusts.
+That is meaning produced outside Sugar (LAW_OF_ONE).
 
-Replacement: ``backend_defect`` with owner + blame. No substituted value.
+DELETE the fallback. Decode or throw. No backend_defect wrapper, no catch.
 """
 
 from __future__ import annotations
 
 import ast
-from types import SimpleNamespace
+from pathlib import Path
 
 import pytest
 
-from sugar_source_tree.panic import BackendDefect, backend_defect
 
-
-def test_truthful_backend_defect_refuses_decode_without_value():
-    """Truthful twin: named BackendDefect carries owner/blame; no value minted."""
+def test_truthful_literal_eval_failure_propagates():
+    """Truthful twin: undecodable text raises from literal_eval — no value."""
     text = r"'\x'"
-    with pytest.raises(BackendDefect) as raised:
-        backend_defect(
-            blame=SimpleNamespace(filename="t.py", line=1, col=0),
-            owner="parso_adapter._constant_leaf",
-            observed=f"literal_eval failed; text={text!r}",
-            requested="a successfully decoded Python string-literal value",
-            fix="never substitute raw source as Constant.value",
-        )
-    assert raised.value.owner == "parso_adapter._constant_leaf"
-    assert "never substitute raw source" in raised.value.fix
+    with pytest.raises((ValueError, SyntaxError)):
+        ast.literal_eval(text)
 
 
 def test_lying_raw_source_substitution_is_the_crime():
-    """Lying twin: except → value = text launders a parse failure into data.
-
-    Keep the banned shape only as the instrument that must not reappear in
-    production. The truthful path raises instead of returning a Constant.
-    """
+    """Lying twin: except → value = text launders a parse failure into data."""
     text = r"'\x'"
     try:
         value = ast.literal_eval(text)
@@ -47,52 +33,53 @@ def test_lying_raw_source_substitution_is_the_crime():
 
     assert lying_value == text
     assert isinstance(lying_value, str)
-    # Truthful refusal: no Constant.value is constructed from the failure.
-    with pytest.raises(BackendDefect):
-        backend_defect(
-            blame=SimpleNamespace(filename="t.py", line=1, col=0),
-            owner="parso_adapter._constant_leaf",
-            observed=f"literal_eval failed; text={text!r}",
-            requested="a successfully decoded Python string-literal value",
-            fix="never substitute raw source as Constant.value",
-        )
+    # Truthful: the exception stands; no Constant.value is minted from it.
+    with pytest.raises((ValueError, SyntaxError)):
+        ast.literal_eval(text)
 
 
-def test_parso_adapter_source_no_longer_substitutes_raw_on_literal_eval_failure():
-    """Static twin: production source refuses decode failure by backend_defect.
-
-    parso is an OPTIONAL_PROVIDER; this law reads the adapter source so it
-    stays green without installing the provider, while still pinning the
-    illegal ``value = text`` / ``value = unit.source[...]`` shape out.
-    """
-    from pathlib import Path
-
-    adapter = (
+def test_parso_adapter_source_has_no_literal_eval_fallback():
+    """Static twin: production parso adapter does not catch-and-substitute."""
+    source = (
         Path(__file__).resolve().parents[1]
         / "src"
         / "sugar_source_tree"
         / "parso_adapter.py"
-    )
-    source = adapter.read_text(encoding="utf-8")
-    assert "backend_defect" in source
-    assert "never substitute raw source as Constant.value" in source
-    # Banned survivor shapes after a failed literal_eval:
+    ).read_text(encoding="utf-8")
+    assert "value = _pyast.literal_eval(text)" in source
     assert "value = text" not in source
     assert "value = unit.source[start:end]" not in source
-    assert "value = unit.source[span.start : span.end]" not in source
+    # No catch wrapping literal_eval into a survival path (named or silent).
+    assert "except Exception" not in source or not _literal_eval_has_except(source)
 
 
-def test_tree_sitter_adapter_source_no_longer_substitutes_raw_on_literal_eval_failure():
-    """Same law for the tree-sitter twin adapter (same package, same sin)."""
-    from pathlib import Path
-
-    adapter = (
+def test_tree_sitter_adapter_source_has_no_literal_eval_fallback():
+    """Same law for the tree-sitter twin adapter."""
+    source = (
         Path(__file__).resolve().parents[1]
         / "src"
         / "sugar_source_tree"
         / "tree_sitter_python_adapter.py"
-    )
-    source = adapter.read_text(encoding="utf-8")
-    assert "backend_defect" in source
+    ).read_text(encoding="utf-8")
+    assert "value = _pyast.literal_eval(text)" in source
     assert "value = text" not in source
     assert "value = unit.source[span.start : span.end]" not in source
+    assert "except Exception" not in source or not _literal_eval_has_except(source)
+
+
+def _literal_eval_has_except(source: str) -> bool:
+    """True if any literal_eval call sits under an except-surviving handler."""
+    import ast as py_ast
+
+    tree = py_ast.parse(source)
+    for node in py_ast.walk(tree):
+        if not isinstance(node, py_ast.Try):
+            continue
+        for child in py_ast.walk(node):
+            if (
+                isinstance(child, py_ast.Call)
+                and isinstance(child.func, py_ast.Attribute)
+                and child.func.attr == "literal_eval"
+            ):
+                return True
+    return False

--- a/implementations/python/sugar-source-tree/tests/test_no_swallowed_cm_ref_panic.py
+++ b/implementations/python/sugar-source-tree/tests/test_no_swallowed_cm_ref_panic.py
@@ -1,16 +1,15 @@
-"""Narrow CM door panics must rise — never soft dual-mode as False.
+"""Narrow CM door panics must rise — no soft dual-mode second mechanism.
 
 SIN CLUSTER 4 / coord 2 — ``except Exception`` around ``_require_narrow_cm_ref``
-under "soft dual-mode projection" turned a SourceTreePanic (named refusal)
-into ``resolved_ref = None``, which the substitution path treated as "not an
-effect boundary" and exported enter-result instead. UNDECIDED rendered as
-False.
+turned a SourceTreePanic into ``resolved_ref = None`` / SoftUnresolvedWithSugar.
+UNDECIDED rendered as False: a missing Sugar law replaced by ad-hoc survival.
 
-Replacement: call the door; None means absent arm; SourceTreePanic propagates.
+DELETE the handler. None from the door is the only absent arm; panics rise.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -72,15 +71,10 @@ def test_truthful_substitution_binding_propagates_narrow_cm_panic():
 
 
 def test_lying_soft_none_would_hide_named_refusal_as_enter_result_path():
-    """Lying twin: catching Exception and setting resolved_ref=None is the crime.
-
-    Document the banned shape. If production re-grows the soft dual-mode
-    catch, this twin fails because the panic is no longer raised.
-    """
+    """Lying twin: catching Exception and setting resolved_ref=None is the crime."""
     panic = _panic(owner="test.lying-soft")
     site = _DuckWith(panic=panic, frame_projection=True)
 
-    # Banned soft dual-mode (the old code):
     resolved_ref = None
     try:
         resolved_ref = site._require_narrow_cm_ref(site.items[0])
@@ -88,18 +82,15 @@ def test_lying_soft_none_would_hide_named_refusal_as_enter_result_path():
         resolved_ref = None
     assert resolved_ref is None, "lying twin: panic was reclassified as absence"
 
-    # Truthful production path must still raise, not soft-None.
     with pytest.raises(UnsupportedContextManagerSemantics):
         site.substitution_binding(scope=None)
 
 
-def test_truthful_frame_projection_no_longer_swallows_in_source():
-    """Static twin: the soft dual-mode Exception catch is gone from With doors."""
+def test_production_source_has_no_soft_dual_mode_catch():
+    """Static twin: soft dual-mode Exception catch is deleted from With doors."""
     import inspect
-    from pathlib import Path
 
     binding_src = inspect.getsource(With.substitution_binding)
-    assert "soft dual-mode" not in binding_src
     assert "except Exception" not in binding_src
     assert "_require_narrow_cm_ref" in binding_src
 
@@ -109,8 +100,6 @@ def test_truthful_frame_projection_no_longer_swallows_in_source():
         / "sugar_source_tree"
         / "nodes.py"
     ).read_text(encoding="utf-8")
-    assert "soft dual-mode factory projection" not in nodes_src
-    assert "soft dual-mode projection" not in nodes_src
-    # Import / return of the soft incomplete is gone (comment may still name it).
     assert "from sugar_lift_py_tests.sugar.soft_unresolved_with_sugar import" not in nodes_src
     assert "return SoftUnresolvedWithSugar" not in nodes_src
+    assert "noqa: BLE001" not in nodes_src

--- a/implementations/python/sugar-source-tree/tests/test_no_swallowed_cm_ref_panic.py
+++ b/implementations/python/sugar-source-tree/tests/test_no_swallowed_cm_ref_panic.py
@@ -1,0 +1,116 @@
+"""Narrow CM door panics must rise — never soft dual-mode as False.
+
+SIN CLUSTER 4 / coord 2 — ``except Exception`` around ``_require_narrow_cm_ref``
+under "soft dual-mode projection" turned a SourceTreePanic (named refusal)
+into ``resolved_ref = None``, which the substitution path treated as "not an
+effect boundary" and exported enter-result instead. UNDECIDED rendered as
+False.
+
+Replacement: call the door; None means absent arm; SourceTreePanic propagates.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_source_tree.nodes import With
+from sugar_source_tree.panic import UnsupportedContextManagerSemantics
+
+
+def _fragment():
+    return SimpleNamespace(filename="twin.py", line=1, col=0, source_cid="cid:frag")
+
+
+def _panic(*, owner: str) -> UnsupportedContextManagerSemantics:
+    return UnsupportedContextManagerSemantics(
+        blame=_fragment(),
+        demand_cid="demand",
+        member_cid="member",
+        owner=owner,
+        observed="unsupported semantics face",
+        requested="typed EffectBoundarySemanticsV1",
+        fix="leave unsupported faces loud",
+    )
+
+
+class _DuckWith:
+    """Duck-typed self for With.substitution_binding — avoids frozen Node layout."""
+
+    def __init__(self, *, panic: UnsupportedContextManagerSemantics, frame_projection: bool):
+        self.unit = SimpleNamespace(
+            construction_context=SimpleNamespace(frame_projection=frame_projection)
+        )
+        self.fragment = _fragment()
+        self.items = (
+            SimpleNamespace(optional_vars=SimpleNamespace(kind="Name", id="e")),
+        )
+        self._panic = panic
+
+    def _generator_manager_frame(self, item):
+        del item
+        return None
+
+    def _require_narrow_cm_ref(self, item):
+        del item
+        raise self._panic
+
+    def substitution_binding(self, scope):
+        return With.substitution_binding(self, scope)
+
+
+def test_truthful_substitution_binding_propagates_narrow_cm_panic():
+    """Truthful twin: SourceTreePanic from the narrow door is not soft-None."""
+    panic = _panic(owner="test.narrow-cm")
+    site = _DuckWith(panic=panic, frame_projection=True)
+
+    with pytest.raises(UnsupportedContextManagerSemantics) as raised:
+        site.substitution_binding(scope=None)
+    assert raised.value is panic
+    assert raised.value.owner == "test.narrow-cm"
+
+
+def test_lying_soft_none_would_hide_named_refusal_as_enter_result_path():
+    """Lying twin: catching Exception and setting resolved_ref=None is the crime.
+
+    Document the banned shape. If production re-grows the soft dual-mode
+    catch, this twin fails because the panic is no longer raised.
+    """
+    panic = _panic(owner="test.lying-soft")
+    site = _DuckWith(panic=panic, frame_projection=True)
+
+    # Banned soft dual-mode (the old code):
+    resolved_ref = None
+    try:
+        resolved_ref = site._require_narrow_cm_ref(site.items[0])
+    except Exception:  # noqa: BLE001 — the sin under test
+        resolved_ref = None
+    assert resolved_ref is None, "lying twin: panic was reclassified as absence"
+
+    # Truthful production path must still raise, not soft-None.
+    with pytest.raises(UnsupportedContextManagerSemantics):
+        site.substitution_binding(scope=None)
+
+
+def test_truthful_frame_projection_no_longer_swallows_in_source():
+    """Static twin: the soft dual-mode Exception catch is gone from With doors."""
+    import inspect
+    from pathlib import Path
+
+    binding_src = inspect.getsource(With.substitution_binding)
+    assert "soft dual-mode" not in binding_src
+    assert "except Exception" not in binding_src
+    assert "_require_narrow_cm_ref" in binding_src
+
+    nodes_src = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "sugar_source_tree"
+        / "nodes.py"
+    ).read_text(encoding="utf-8")
+    assert "soft dual-mode factory projection" not in nodes_src
+    assert "soft dual-mode projection" not in nodes_src
+    # Import / return of the soft incomplete is gone (comment may still name it).
+    assert "from sugar_lift_py_tests.sugar.soft_unresolved_with_sugar import" not in nodes_src
+    assert "return SoftUnresolvedWithSugar" not in nodes_src


### PR DESCRIPTION
## Summary

Deletes four catch-and-continue / value-substitution membranes that let a second mechanism quietly replace unfinished Sugar (LAW OF ONE: AST shadows → Sugar → meaning).

- **factory prefix:** bare `to_term`/CID projection; `ConstructionPanic` propagates (no survivor seal into `factoryPrefixCids`)
- **With CM door:** no soft dual-mode `except Exception` around `_require_narrow_cm_ref`
- **implications RPC:** no `except Exception: continue` around `function_contract_rows`
- **parso / tree-sitter:** bare `literal_eval`; no raw source as `Constant.value`

If the door panics, the door panics. No named-refusal survival paths at the catch site.

## Validation

```text
PYTHONPATH=... pytest \
  sugar-lift-python-source/tests/test_factory_prefix_cid_seal_transaction.py \
  sugar-source-tree/tests/test_no_swallowed_cm_ref_panic.py \
  sugar-source-tree/tests/test_literal_eval_no_raw_substitution.py \
  sugar-lift-py-tests/tests/test_implications_target_candidate_no_swallow.py \
  -q
# 14 passed
```

Note: `tests/law_of_one_auditor.py` does not currently scan this sin class; enforcement is the focused twins above.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove swallowed-exception fallback paths across source tree and lift pipeline components
> - Removes try/except blocks that silently swallowed exceptions in several components, letting errors propagate instead of producing silent omissions or incorrect fallback values.
> - In [`manager_construction.py`](https://github.com/TSavo/sugar/pull/6944/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1), `ConstructionPanic` during factory prefix projection now aborts construction instead of filtering out failing faces.
> - In [`nodes.py`](https://github.com/TSavo/sugar/pull/6944/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0), `With.sugar` and `With.substitution_binding` now propagate `SourceTreePanic` instead of returning soft-unresolved nodes or absent refs.
> - In [`parso_adapter.py`](https://github.com/TSavo/sugar/pull/6944/files#diff-66f3f3800f8c095572ca2a1a6218acc19332fc39977fdfbac23090942d777d62) and [`tree_sitter_python_adapter.py`](https://github.com/TSavo/sugar/pull/6944/files#diff-f09b8b02bfe9748c088397c42d855b85f4838e21c5c522e50e3a9c76e8581a7d), `ast.literal_eval` failures now raise instead of substituting raw source text into `Constant.value`.
> - Behavioral Change: callers that previously received partial results or silent omissions will now receive exceptions; all affected paths gain new tests asserting propagation and asserting absence of catch-and-continue patterns in production code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f4ac79.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->