### PR TITLE
Remove spelling-gate meaning (sin cluster 5): dispatch on authenticated coordinates

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
@@ -102,7 +102,13 @@ class ClassValue(FloorValue):
         is True. Without this ground answer, RaisesExc's
         ``if isinstance(expected_exception, tuple):`` face stays undecided and
         the ``expected_exceptions`` field never floors to a TupleValue.
+
+        Dispatch reads the authenticated ``type_term`` coordinate
+        (``python:type("…")``). The display ``type_name`` string is never
+        consulted: under builtin shadowing the same spelling can name a
+        foreign type, and deciding False from that string is a wrong answer.
         """
+        from sugar_lift_py_tests.ir import _ConstStr, _Ctor
         from sugar_lift_py_tests.outcome import Complete
         from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
             FalseBoolLiteralSugar,
@@ -110,12 +116,31 @@ class ClassValue(FloorValue):
         from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
             TrueBoolLiteralSugar,
         )
+        from sugar_source_tree.panic import SugarNotWritten
 
-        if type_name in {"type", "object"}:
+        del type_name  # display spelling is not authority
+        if (
+            type(type_term) is not _Ctor
+            or type_term.name != "python:type"
+            or len(type_term.args) != 1
+            or type(type_term.args[0]) is not _ConstStr
+        ):
+            raise SugarNotWritten(
+                blame=str(site),
+                owner="ClassValue.python_isinstance",
+                observed=f"type_term={type(type_term).__name__!s}",
+                requested='authenticated python:type("…") coordinate',
+                fix=(
+                    "thread the type operand's coordinate; never decide "
+                    "class-object isinstance by type_name spelling"
+                ),
+            )
+        authenticated_name = type_term.args[0].value
+        if authenticated_name in {"type", "object"}:
             return Complete(TrueBoolLiteralSugar(site=site))
-        if type_name in _CLASS_OBJECT_DISJOINT_TYPES:
+        if authenticated_name in _CLASS_OBJECT_DISJOINT_TYPES:
             return Complete(FalseBoolLiteralSugar(site=site))
-        return super().python_isinstance(type_name, type_term, site)
+        return super().python_isinstance(authenticated_name, type_term, site)
 
     def test_python_subtype(self, supertype, site):
         from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
@@ -55,6 +55,17 @@ def collect_builtin_closed_operation_report(
 
 
 class _Visitor(ast.NodeVisitor):
+    """Structural detector for spelling-gates outside authenticated coordinates.
+
+    Name/vendor gates are compares that decide control by display text
+    (``exception_name == "..."``, ``func.id == "importorskip"``,
+    ``type_name in {...}``, ``name == matcher.name``) instead of an
+    authenticated type/binding coordinate from the tree. A green report
+    that only looked for the substrings ``pytest.raises`` /
+    ``contextlib.suppress`` could not see those sins and carried no
+    information.
+    """
+
     def __init__(self, path: str) -> None:
         self.path = path
         self.offenders: list[BuiltinClosedOperationOffender] = []
@@ -70,15 +81,7 @@ class _Visitor(ast.NodeVisitor):
 
     def visit_Compare(self, node: ast.Compare) -> None:
         rendered = ast.unparse(node)
-        string_values = {
-            value.value
-            for value in ast.walk(node)
-            if isinstance(value, ast.Constant) and isinstance(value.value, str)
-        }
-        if any(
-            "pytest.raises" in value or "contextlib.suppress" in value
-            for value in string_values
-        ):
+        if self._is_spelling_gate_compare(node):
             self._add(
                 "name_or_vendor_gates",
                 node,
@@ -124,6 +127,62 @@ class _Visitor(ast.NodeVisitor):
                 "leave unsupported floor construction loud; never catch its panic",
             )
         self.generic_visit(node)
+
+    def _is_spelling_gate_compare(self, node: ast.Compare) -> bool:
+        """True when this compare decides by display spelling, not a coordinate."""
+        # Legacy vendor-string gates (kept: still a spelling membrane).
+        string_values = {
+            value.value
+            for value in ast.walk(node)
+            if isinstance(value, ast.Constant) and isinstance(value.value, str)
+        }
+        if any(
+            "pytest.raises" in value or "contextlib.suppress" in value
+            for value in string_values
+        ):
+            return True
+
+        # type_name in {…} / type_name in SOME_FROZENSET — builtin shadowing lie.
+        if any(isinstance(op, (ast.In, ast.NotIn)) for op in node.ops):
+            if isinstance(node.left, ast.Name) and node.left.id == "type_name":
+                return True
+
+        operands = (node.left, *node.comparators)
+        attr_names = {
+            operand.attr
+            for operand in operands
+            if isinstance(operand, ast.Attribute)
+        }
+        has_str_constant = any(
+            isinstance(operand, ast.Constant) and isinstance(operand.value, str)
+            for operand in operands
+        )
+
+        # effect.exception_name == "StopIteration" (and any == on that attr).
+        if "exception_name" in attr_names:
+            return True
+
+        # func.id == "importorskip" / func.value.id == "pytest" — unbound lexical text.
+        # Member path ``.attr == "importorskip"`` is structural once the head is
+        # an authenticated import binding; it is not a spelling gate by itself.
+        if "id" in attr_names and has_str_constant:
+            return True
+
+        # name == matcher.name — name-less suppress / spelling equality of names.
+        name_attrs = [
+            operand
+            for operand in operands
+            if isinstance(operand, ast.Attribute) and operand.attr == "name"
+        ]
+        name_names = [
+            operand
+            for operand in operands
+            if isinstance(operand, ast.Name) and operand.id == "name"
+        ]
+        if name_attrs and (name_names or len(name_attrs) >= 2):
+            return True
+
+        return False
 
     def _add(self, axis: str, node: ast.AST, observed: str, replacement: str) -> None:
         self.offenders.append(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -400,12 +400,30 @@ def _import_from_module(
     return ".".join(base) or None
 
 
-def _importorskip_module(value: Node | None) -> str | None:
-    """Module name of ``pytest.importorskip("mod")`` / ``importorskip("mod")``.
+def _unique_import_def_from_state(
+    state: "State | None", local_name: str
+) -> "_ImportDef | None":
+    """The sole import definition reaching ``local_name``, or None."""
+    if state is None:
+        return None
+    reaching = state.get(local_name, frozenset({_UNBOUND}))
+    imports = {value for value in reaching if isinstance(value, _ImportDef)}
+    if len(imports) != 1:
+        return None
+    rest = reaching - imports
+    if rest:
+        return None
+    return next(iter(imports))
 
-    Source-visible only: Attribute or Name head, one positional string
-    Constant, no keywords/stars.  Spelling of the module is the Constant's
-    own value, never a vendor table.
+
+def _importorskip_module(value: Node | None, state: "State | None") -> str | None:
+    """Module name of authenticated ``pytest.importorskip("mod")``.
+
+    Head must be a reaching import binding — ``python:pytest.importorskip``
+    for a bare name, or ``python:pytest`` for an attribute head whose member
+    path is ``importorskip``. Unbound lexical text (``func.id ==
+    "importorskip"``, ``func.value.id == "pytest"``) never mints a module
+    availability fact: the analyzer's own ``state`` is the authority.
     """
     if value is None or value.kind != "Call":
         return None
@@ -417,15 +435,16 @@ def _importorskip_module(value: Node | None) -> str | None:
     if not isinstance(module, str) or not module:
         return None
     func = value.func
-    if func.kind == "Name" and func.id == "importorskip":
-        return module
-    if (
-        func.kind == "Attribute"
-        and func.attr == "importorskip"
-        and func.value.kind == "Name"
-        and func.value.id == "pytest"
-    ):
-        return module
+    if func.kind == "Name":
+        binding = _unique_import_def_from_state(state, func.id)
+        if binding is not None and binding.target_symbol == "python:pytest.importorskip":
+            return module
+        return None
+    if func.kind == "Attribute" and func.attr == "importorskip" and func.value.kind == "Name":
+        binding = _unique_import_def_from_state(state, func.value.id)
+        if binding is not None and binding.target_symbol == "python:pytest":
+            return module
+        return None
     return None
 
 
@@ -824,7 +843,7 @@ class _Pass:
             self.expression(value, state, scope)
             targets = node.targets if node.kind == "Assign" else [node.target]
             importorskip = (
-                _importorskip_module(value)
+                _importorskip_module(value, state)
                 if node.kind == "Assign" and len(targets) == 1
                 else None
             )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
@@ -189,16 +189,66 @@ def _resource_verdict(disposition: object, effect: object) -> str:
         return "suppress" if disposition.suppresses_exception(name) else "restore"
 
     if isinstance(disposition, Suppresses):
-        matcher = disposition.matcher
-        if getattr(matcher, "kind", None) != "raise":
-            return "open"
-        name = getattr(effect, "exception_name", None)
-        if name == matcher.name:
-            return "suppress"
-        return "restore"
+        return _suppresses_verdict(disposition, effect)
 
     raise TypeError(
         "exit disposition must be NeverSuppresses, ExitSuppressionContract, "
         "RuntimeSelected, Suppresses, or EffectBoundaryDisposition; "
         f"got {type(disposition).__name__}"
     )
+
+
+def _suppresses_verdict(disposition, effect) -> str:
+    """Suppress only by authenticated exception type coordinate, never by name.
+
+    A name-less matcher and a name-less effect used to compare equal and
+    suppress. Spelling is half-writing the match: the neighbouring
+    ``ExitSuppressionContract`` arm already refused empty names; this arm
+    goes further and demands the effect's ``exception_type_coordinate``
+    against the builtin identity of the matcher's type. Missing coordinate
+    or name-less matcher is unwritten work (throw), not a soft open.
+    """
+    from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+    from sugar_source_tree.panic import SugarNotWritten
+
+    matcher = disposition.matcher
+    if getattr(matcher, "kind", None) != "raise":
+        return "open"
+    owner = "exit_disposition.Suppresses"
+    blame = getattr(effect, "occurrence_id", None) or owner
+    matcher_name = getattr(matcher, "name", None)
+    if not isinstance(matcher_name, str) or not matcher_name:
+        raise SugarNotWritten(
+            blame=blame,
+            owner=owner,
+            observed="name-less Suppresses matcher",
+            requested="matcher carrying an exception type name with a builtin identity",
+            fix=(
+                "construct Suppresses with a real exception type; never let "
+                "None == None suppress a coordinate-authenticated effect"
+            ),
+        )
+    if effect is None:
+        return "restore"
+    coordinate = getattr(effect, "exception_type_coordinate", None)
+    if coordinate is None:
+        raise SugarNotWritten(
+            blame=blame,
+            owner=owner,
+            observed="effect without exception_type_coordinate",
+            requested="authenticated exception_type_coordinate on the halt",
+            fix=(
+                "mint the raise through the ground exit door or an authenticated "
+                "producer; do not suppress by exception_name spelling"
+            ),
+        )
+    matcher_identity, _ = _builtin_exception_identity(matcher_name)
+    if matcher_identity is None:
+        raise SugarNotWritten(
+            blame=blame,
+            owner=owner,
+            observed=f"matcher name {matcher_name!r} has no builtin type coordinate",
+            requested="a language-owned exception type with python:exception_type_identity",
+            fix="use a builtin exception type or an AuthenticatedRaiseMatcher coordinate path",
+        )
+    return "suppress" if coordinate == matcher_identity else "restore"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
@@ -8,6 +8,34 @@ from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
 
+def _is_authenticated_stop_iteration(effect) -> bool:
+    """Iterator exhaustion only by authenticated ``StopIteration`` type coordinate.
+
+    The kit's ``next`` producer mints ``exception_type_coordinate``. Display
+    spelling of ``exception_name`` is never consulted: a foreign coordinate
+    wearing the same name is not exhaustion, and a RaiseEffect that omitted
+    its coordinate is unwritten work (throw), not a name-based guess.
+    """
+    from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+    from sugar_source_tree.panic import SugarNotWritten
+
+    owner = "LoopRecurrenceSugar._advance_iterator"
+    stop_identity, _ = _builtin_exception_identity("StopIteration")
+    coordinate = getattr(effect, "exception_type_coordinate", None)
+    if coordinate is None:
+        raise SugarNotWritten(
+            blame=getattr(effect, "occurrence_id", None) or owner,
+            owner=owner,
+            observed="RaiseEffect without exception_type_coordinate",
+            requested="authenticated StopIteration type coordinate from next producer",
+            fix=(
+                "mint the halt through ground_exceptional_exit / the iterator "
+                "floor; never decide exhaustion by exception_name spelling"
+            ),
+        )
+    return coordinate == stop_identity
+
+
 @dataclass(frozen=True)
 class LoopBindingRefSugar(ConstructedTermSugar):
     target_cid: str
@@ -244,7 +272,9 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
         )
         if isinstance(outcome, Incomplete):
             effect = outcome.effect
-            if isinstance(effect, RaiseEffect) and effect.exception_name == "StopIteration":
+            if isinstance(effect, RaiseEffect) and _is_authenticated_stop_iteration(
+                effect
+            ):
                 return self._finish_iterator(runtime, ctx, entries=entries)
             return outcome
         if not isinstance(outcome, Complete) or not isinstance(outcome.value, NextResult):

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
@@ -54,3 +54,85 @@ def test_instrument_truthful_floor_shape_is_zero(tmp_path):
         "panic_catches": 0,
     }
     assert report.offenders == ()
+
+
+def test_instrument_structurally_sees_spelling_gates_of_cluster_five(tmp_path):
+    """Sin cluster 5 shapes: name gates outside authenticated coordinates.
+
+    Before the production fixes these four patterns lived at the named
+    coordinates. The instrument must catch each by AST shape, not by the
+    legacy ``pytest.raises`` / ``contextlib.suppress`` substring filter.
+    """
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "loop_recurrence_sugar.py",
+        "def _advance(effect):\n"
+        "    if effect.exception_name == 'StopIteration':\n"
+        "        return 'finish'\n"
+        "    return effect\n",
+    )
+    _write(
+        tmp_path,
+        "exit_disposition.py",
+        "def _resource_verdict(name, matcher):\n"
+        "    if name == matcher.name:\n"
+        "        return 'suppress'\n"
+        "    return 'restore'\n",
+    )
+    _write(
+        tmp_path,
+        "import_binding.py",
+        "def _importorskip_module(func):\n"
+        "    if func.id == 'importorskip':\n"
+        "        return 'mod'\n"
+        "    if func.value.id == 'pytest':\n"
+        "        return 'mod'\n"
+        "    return None\n",
+    )
+    _write(
+        tmp_path,
+        "class_value.py",
+        "def python_isinstance(type_name):\n"
+        "    if type_name in {'tuple', 'list', 'dict'}:\n"
+        "        return False\n"
+        "    return None\n",
+    )
+
+    report = collect_builtin_closed_operation_report(tmp_path)
+    gates = [row for row in report.offenders if row.axis == "name_or_vendor_gates"]
+    observed = {row.observed for row in gates}
+
+    assert report.r["name_or_vendor_gates"] >= 4
+    assert any("exception_name" in text for text in observed)
+    assert any("matcher.name" in text for text in observed)
+    assert any("importorskip" in text for text in observed)
+    assert any("pytest" in text for text in observed)
+    assert any("type_name in" in text for text in observed)
+
+
+def test_instrument_fixed_cluster_five_production_sites_are_zero():
+    """After the coordinate fix, the four named production files have no name gates."""
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    root = Path(__file__).resolve().parents[1] / "src"
+    report = collect_builtin_closed_operation_report(root)
+    targets = {
+        "sugar_lift_py_tests/sugar/loop_recurrence_sugar.py",
+        "sugar_lift_py_tests/outcome/exit_disposition.py",
+        "sugar_lift_py_tests/import_binding.py",
+        "sugar_lift_py_tests/floor/class_value.py",
+    }
+    hits = [
+        row
+        for row in report.offenders
+        if row.path in targets and row.axis == "name_or_vendor_gates"
+    ]
+    assert hits == [], "cluster-5 production sites still gate on spelling:\n" + "\n".join(
+        f"{row.path}:{row.line}: {row.observed}" for row in hits
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_class_value_isinstance_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_class_value_isinstance_coordinate.py
@@ -1,0 +1,60 @@
+"""ClassValue.python_isinstance dispatches on type_term, not type_name spelling.
+
+Truthful: authenticated ``python:type("tuple")`` decides False for a class object.
+Lying: type_name spelling ``tuple`` with a foreign type_term must not decide False.
+Missing type_term coordinate throws — never falls back to the display string.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.floor.block_value import BlockValue
+from sugar_lift_py_tests.floor.class_value import ClassValue
+from sugar_lift_py_tests.ir import ctor, str_const
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_source_tree.panic import SugarNotWritten
+
+
+def _class():
+    return ClassValue("Exception", (), BlockValue(()))
+
+
+def _type_term(name: str):
+    return ctor("python:type", [str_const(name)])
+
+
+def test_truthful_type_coordinate_is_true() -> None:
+    outcome = _class().python_isinstance("type", _type_term("type"), "site")
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, TrueBoolLiteralSugar)
+
+
+def test_truthful_tuple_coordinate_is_false() -> None:
+    outcome = _class().python_isinstance("tuple", _type_term("tuple"), "site")
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, FalseBoolLiteralSugar)
+
+
+def test_lying_twin_spelling_tuple_foreign_coordinate_throws() -> None:
+    """Builtin shadowing: display says tuple, coordinate is not python:type."""
+    foreign = ctor("python:shadowed_type", [str_const("tuple")])
+    with pytest.raises(SugarNotWritten) as caught:
+        _class().python_isinstance("tuple", foreign, "site")
+    assert "python:type" in caught.value.requested
+    assert "type_name" in caught.value.fix
+
+
+def test_lying_twin_spelling_does_not_override_authenticated_type() -> None:
+    """If coordinate says type, spelling 'tuple' must not force False."""
+    outcome = _class().python_isinstance("tuple", _type_term("type"), "site")
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, TrueBoolLiteralSugar)
+
+
+def test_missing_type_term_throws() -> None:
+    with pytest.raises(SugarNotWritten) as caught:
+        _class().python_isinstance("tuple", None, "site")
+    assert "type_term" in caught.value.observed or "python:type" in caught.value.requested

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py
@@ -1,0 +1,99 @@
+"""Suppresses arm matches by exception_type_coordinate, never name equality.
+
+The old arm compared ``name == matcher.name`` with no None-guard: a
+coordinate-authenticated but name-less effect equaled a name-less matcher and
+was suppressed. Neighbour ExitSuppressionContract already refused empty names.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_contract import EffectMatcher, Suppresses
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+from sugar_lift_py_tests.ir import atomic, ctor, str_const
+from sugar_lift_py_tests.outcome.exit_disposition import exit_disposition_effect
+from sugar_lift_py_tests.outcome.exit_set import Halted
+from sugar_source_tree.panic import SugarNotWritten
+
+
+def _guard():
+    return atomic("true", [])
+
+
+def _key_error(*, coordinate=None, mro=None, name="KeyError"):
+    if coordinate is None and mro is None:
+        coordinate, mro = _builtin_exception_identity("KeyError")
+    return RaiseEffect(
+        exception_name=name,
+        exception_type_coordinate=coordinate,
+        exception_type_mro=mro,
+        occurrence="suppress.py:1:0",
+    )
+
+
+def test_truthful_suppresses_matching_coordinate() -> None:
+    effect = _key_error()
+    verdict = exit_disposition_effect(
+        Suppresses(EffectMatcher(kind="raise", name="KeyError")),
+        Halted(_guard(), effect, "state"),
+    )
+    assert verdict is None  # consumed
+
+
+def test_lying_twin_same_spelling_foreign_coordinate_restores() -> None:
+    truthful = _key_error()
+    foreign = ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("ValueError")],
+    )
+    lying = replace(
+        truthful,
+        exception_type_coordinate=foreign,
+        exception_type_mro=(foreign,),
+    )
+    assert lying.exception_name == "KeyError"
+    restored = exit_disposition_effect(
+        Suppresses(EffectMatcher(kind="raise", name="KeyError")),
+        Halted(_guard(), lying, "state"),
+    )
+    assert restored is lying
+
+
+def test_name_less_matcher_throws_not_suppress() -> None:
+    effect = _key_error()
+    with pytest.raises(SugarNotWritten) as caught:
+        exit_disposition_effect(
+            Suppresses(EffectMatcher(kind="raise", name=None)),  # type: ignore[arg-type]
+            Halted(_guard(), effect, "state"),
+        )
+    assert "name-less" in caught.value.observed
+
+
+def test_name_less_effect_with_coordinate_does_not_equal_name_less_matcher() -> None:
+    """THE historical bug: None == None suppressed a coordinate-authenticated halt."""
+    coordinate, mro = _builtin_exception_identity("KeyError")
+    effect = RaiseEffect(
+        exception_name=None,
+        exception_type_coordinate=coordinate,
+        exception_type_mro=mro,
+        occurrence="suppress.py:2:0",
+    )
+    with pytest.raises(SugarNotWritten):
+        exit_disposition_effect(
+            Suppresses(EffectMatcher(kind="raise", name=None)),  # type: ignore[arg-type]
+            Halted(_guard(), effect, "state"),
+        )
+
+
+def test_missing_effect_coordinate_throws() -> None:
+    effect = RaiseEffect(exception_name="KeyError", occurrence="suppress.py:3:0")
+    with pytest.raises(SugarNotWritten) as caught:
+        exit_disposition_effect(
+            Suppresses(EffectMatcher(kind="raise", name="KeyError")),
+            Halted(_guard(), effect, "state"),
+        )
+    assert "exception_type_coordinate" in caught.value.observed

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
@@ -218,7 +218,15 @@ def test_and_exit_proven_contract_suppresses_only_matching_face():
 
 
 def test_and_exit_membrane_suppresses_matcher_authority():
-    body = RaiseEffect(exception_name="KeyError")
+    from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+
+    coordinate, mro = _builtin_exception_identity("KeyError")
+    body = RaiseEffect(
+        exception_name="KeyError",
+        exception_type_coordinate=coordinate,
+        exception_type_mro=mro,
+        occurrence="exit_set.py:1:0",
+    )
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(
         ExitSet.completed(True),

--- a/implementations/python/sugar-lift-py-tests/tests/test_importorskip_binding_state.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_importorskip_binding_state.py
@@ -1,0 +1,89 @@
+"""importorskip module facts require authenticated import bindings in state.
+
+Truthful: ``import pytest`` / ``from pytest import importorskip`` mints the
+module availability binding. Lying: same call spelling bound to a local def,
+``pytest = object()``, or ``import not_pytest as pytest`` must not mint.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_py_tests.import_binding import _ImportDef, _Pass, _NON_IMPORT
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.tree import SourceFile
+
+
+def _final_state(tmp_path: Path, text: str) -> dict[str, list]:
+    path = tmp_path / "module.py"
+    path.write_text(text, encoding="utf-8")
+    source, _, source_cid = path_source(str(path))
+    module = SourceFile((source, str(path), source_cid)).root
+    runner = _Pass(
+        source_cid=source_cid,
+        module_name="module",
+        module_is_package=False,
+        module_identities={},
+    )
+    state = runner.statements(module.body, {}, module)
+    out: dict[str, list] = {}
+    for name, reaching in state.items():
+        items = []
+        for value in reaching:
+            if isinstance(value, _ImportDef):
+                items.append(("import", value.target_symbol))
+            else:
+                items.append(value)
+        out[name] = items
+    return out
+
+
+def test_truthful_pytest_attribute_importorskip_mints_module(tmp_path: Path) -> None:
+    state = _final_state(
+        tmp_path,
+        'import pytest\nnp = pytest.importorskip("numpy")\n',
+    )
+    assert state["pytest"] == [("import", "python:pytest")]
+    assert state["np"] == [("import", "python:numpy")]
+
+
+def test_truthful_from_import_importorskip_mints_module(tmp_path: Path) -> None:
+    state = _final_state(
+        tmp_path,
+        'from pytest import importorskip\nnp = importorskip("numpy")\n',
+    )
+    assert state["importorskip"] == [("import", "python:pytest.importorskip")]
+    assert state["np"] == [("import", "python:numpy")]
+
+
+def test_lying_local_def_importorskip_does_not_mint(tmp_path: Path) -> None:
+    state = _final_state(
+        tmp_path,
+        "def importorskip(m):\n"
+        "    return m\n"
+        'np = importorskip("numpy")\n',
+    )
+    assert state["np"] == [_NON_IMPORT]
+    assert not any(
+        isinstance(item, tuple) and item[0] == "import" and item[1] == "python:numpy"
+        for item in state["np"]
+    )
+
+
+def test_lying_pytest_object_shadow_does_not_mint(tmp_path: Path) -> None:
+    state = _final_state(
+        tmp_path,
+        'pytest = object()\nnp = pytest.importorskip("numpy")\n',
+    )
+    assert state["pytest"] == [_NON_IMPORT]
+    assert state["np"] == [_NON_IMPORT]
+
+
+def test_lying_aliased_foreign_module_does_not_mint(tmp_path: Path) -> None:
+    """Same local spelling ``pytest``, bound to ``not_pytest`` — not admitted."""
+    state = _final_state(
+        tmp_path,
+        'import not_pytest as pytest\nnp = pytest.importorskip("numpy")\n',
+    )
+    assert state["pytest"] == [("import", "python:not_pytest")]
+    assert state["np"] == [_NON_IMPORT]

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_stop_iteration_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_stop_iteration_coordinate.py
@@ -1,0 +1,71 @@
+"""Loop exhaustion dispatches on authenticated StopIteration coordinate.
+
+Truthful twin: kit-minted StopIteration type identity finishes the iterator.
+Lying twin: same ``exception_name`` spelling under a foreign coordinate is not
+exhaustion. Missing coordinate is SugarNotWritten — never a name fallback.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+from sugar_lift_py_tests.ir import ctor, str_const
+from sugar_lift_py_tests.sugar.loop_recurrence_sugar import (
+    _is_authenticated_stop_iteration,
+)
+from sugar_source_tree.panic import SugarNotWritten
+
+
+def _stop_identity():
+    identity, mro = _builtin_exception_identity("StopIteration")
+    return identity, mro
+
+
+def test_truthful_stop_iteration_coordinate_is_exhaustion() -> None:
+    identity, mro = _stop_identity()
+    effect = RaiseEffect(
+        exception_name="StopIteration",
+        exception_type_coordinate=identity,
+        exception_type_mro=mro,
+        occurrence="loop.py:1:0",
+        producer_node_owner="project_next",
+    )
+    assert _is_authenticated_stop_iteration(effect) is True
+
+
+def test_lying_twin_same_spelling_foreign_coordinate_is_not_exhaustion() -> None:
+    identity, mro = _stop_identity()
+    truthful = RaiseEffect(
+        exception_name="StopIteration",
+        exception_type_coordinate=identity,
+        exception_type_mro=mro,
+        occurrence="loop.py:1:0",
+    )
+    foreign_type = ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("ValueError")],
+    )
+    lying = replace(
+        truthful,
+        exception_type_coordinate=foreign_type,
+        exception_type_mro=(foreign_type,),
+    )
+    assert lying.exception_name == "StopIteration"
+    assert lying.exception_type_coordinate != identity
+    assert _is_authenticated_stop_iteration(lying) is False
+
+
+def test_missing_coordinate_throws_named_not_name_fallback() -> None:
+    effect = RaiseEffect(
+        exception_name="StopIteration",
+        exception_type_coordinate=None,
+        occurrence="loop.py:2:0",
+    )
+    with pytest.raises(SugarNotWritten) as caught:
+        _is_authenticated_stop_iteration(effect)
+    assert "exception_type_coordinate" in caught.value.observed
+    assert "exception_name" in caught.value.fix

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
@@ -129,11 +129,14 @@ def _truthiness_resource(*, exit_value, body, enter_value=TermValue(2), slot=Non
 
 
 def test_summary_suppresses_disposition_consumes_matching_body_halt():
+    from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+
     disposition = Suppresses(EffectMatcher(kind="raise", name="ValueError"))
     summary = SimpleNamespace(
         semantics=SimpleNamespace(exit=SimpleNamespace(disposition=disposition))
     )
     protocol = _CompletedProtocol()
+    coordinate, mro = _builtin_exception_identity("ValueError")
     sugar = _source_resource(
         manager=_FixedSugar(Complete(TermValue(1))),
         protocol=protocol,
@@ -142,7 +145,10 @@ def test_summary_suppresses_disposition_consumes_matching_body_halt():
             _FixedSugar(
                 Incomplete(
                     RaiseEffect(
-                        exception_name="ValueError", occurrence="resource.py:4:8"
+                        exception_name="ValueError",
+                        occurrence="resource.py:4:8",
+                        exception_type_coordinate=coordinate,
+                        exception_type_mro=mro,
                     )
                 )
             ),


### PR DESCRIPTION
## Summary

Sin cluster 5 removed **deciding meaning from display spelling** while the tree already carried an authenticated coordinate. LAW OF ONE: AST tree shadows → temporal rewrite / sugar → meaning. A name compare is a second mechanism.

- **LoopRecurrenceSugar**: finish only on authenticated `StopIteration` type coordinate; missing coordinate throws.
- **Suppresses**: match via builtin `exception_type_coordinate`; name-less matcher / missing coordinate throws (kills `None == None` suppress).
- **importorskip**: consult reaching import binding `state`, not unbound `func.id` / `pytest` text.
- **ClassValue.python_isinstance**: read `python:type` from `type_term`; discard `type_name` spelling.
- **builtin_closed_operation instrument**: structural name-gate detector (sees items 1–4; old substring filter did not).

## LAW_OF_ONE auditor is blind to these spelling gates

The existing `tests/law_of_one_auditor.py` / `law_of_one_evidence.py` / `law_of_one_symbol_graph.py` suite pins SourceFile construction exclusivity and product privacy. It does **not** recognize name-compare meaning gates (`exception_name == "StopIteration"`, `func.id == "importorskip"`, `type_name in …`, `name == matcher.name`). Green from that auditor carries no information about this sin class. The structural `builtin_closed_operation` instrument is what sees these shapes.

## Validation

- Instrument pointed at the four production sites: **red** before fix (7 name gates), **zero** on those paths after.
- Focused truthful/lying twin tests for each package (31 passed).

## Test plan

- [x] Focused twin tests for loop, Suppresses, importorskip, ClassValue, instrument
- [ ] CI on PR

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dispatch on authenticated coordinates instead of spelling for type, exception, and import checks
> - Replaces name/spelling-based gating with coordinate-based authentication across several subsystems, so that shadowed, aliased, or foreign-but-same-named values are no longer treated as equivalent to authentic ones.
> - [`ClassValue.python_isinstance`](https://github.com/TSavo/sugar/pull/6945/files#diff-8c39758b3ac4077d066812f197a75b5786878a0cae336b77a3a3785017fd6272) now requires `type_term` to be a `ctor("python:type", [ConstStr])` coordinate and raises `SugarNotWritten` otherwise.
> - [`outcome._suppresses_verdict`](https://github.com/TSavo/sugar/pull/6945/files#diff-76129a966576d0bf8e6154295bc1ae8dc5b58eb63e5dd6e3f562a97d826dfc6c) and [`LoopRecurrenceSugar._advance_iterator`](https://github.com/TSavo/sugar/pull/6945/files#diff-f2f1e95b345c3c7e0569fbbe5a17e9608d1617fd8decf5507ba13f0d25c59547) authenticate exception identity via `exception_type_coordinate` rather than `exception_name` string equality.
> - [`import_binding._importorskip_module`](https://github.com/TSavo/sugar/pull/6945/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) now requires the call head to resolve to an authenticated `python:pytest.importorskip` binding; lexically matching but unbound or shadowed names no longer mint module availability.
> - Risk: code paths that previously matched by name now raise `SugarNotWritten` when coordinates are missing or foreign, changing error behavior for callers that relied on spelling-based dispatch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e145a86.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->