### PR TITLE
Close SIN CLUSTER 6: enumeration that bypasses the construction door

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2142,10 +2142,17 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         caller_post = term_table.formula(formula)
 
                 target_candidates = []
-                targets = _tree.call_target_names(sf, span)
-                for name in targets:
-                    fn = _tree.find_function_by_name(sf, name)
-                    if fn is None:
+                targets = []
+                seen_targets = set()
+                for call in _tree.call_nodes_in_assert(sf, span):
+                    name = call.func.id
+                    if name in seen_targets:
+                        continue
+                    seen_targets.add(name)
+                    targets.append(name)
+                    try:
+                        fn = _tree.resolve_function_for_call(call)
+                    except _tree.FunctionBindingMiss:
                         continue
                     try:
                         def_memento, rows = _tree.function_contract_rows(fn, file_rel)
@@ -2223,6 +2230,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 # call-site cue.
                 from sugar_lift_py_tests import tree_enumerate as _tree
                 from sugar_lift_py_tests.ir import TermTableBuilder
+                from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
                 from sugar_source_tree.panic import SugarNotWritten
 
                 sf = _tree.source_file(full_path)
@@ -2301,7 +2309,13 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         continue
                     seen.add(t)
                     targets.append(t)
-                    fn = _tree.find_function_by_name(sf, t)
+                    # Resolve by binding/coordinate at the call site — not
+                    # first-match-by-spelling. Miss is a named throw; soft skip
+                    # is an explicit catch of FunctionBindingMiss.
+                    try:
+                        fn = _tree.resolve_function_for_call(call)
+                    except _tree.FunctionBindingMiss:
+                        fn = None
                     # A call IS substitution: ground args fill the pre, so the
                     # dig serves the contract AS APPLIED at this call (a concrete
                     # iterable unrolls the callee's loop here; the fold
@@ -2311,17 +2325,19 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     # applied dig is attempted even when the ABSTRACT universe is
                     # a gap: the applied substitution can succeed exactly where
                     # the abstract is still a hole (that is the whole point of
-                    # filling the pre).
-                    if (
-                        fn is not None
-                        and len(call.args) == len(fn.params)
-                        and _tree._args_are_ground(call)
-                    ):
+                    # filling the pre). Arity is the binder's job (vararg packs,
+                    # defaults fill) — never len(args)==len(params).
+                    if fn is not None and _tree._args_are_ground(call):
                         try:
-                            memento, rows = _tree.applied_contract_rows(
-                                fn, tuple(call.args), file_rel
+                            keywords = tuple(
+                                (keyword.arg, keyword.value)
+                                for keyword in call.keywords
+                                if keyword.arg is not None
                             )
-                        except SugarNotWritten:
+                            memento, rows = _tree.applied_contract_rows(
+                                fn, tuple(call.args), file_rel, keywords=keywords
+                            )
+                        except (SugarNotWritten, SourceCallBindingGap):
                             rows = None
                         if rows:
                             cued.append(_node(memento.to_rpc(), rows[0]))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -46,13 +46,63 @@ def find_function(sf: SourceFile, name: Optional[str], span: Optional[dict]):
     return None
 
 
+class FunctionBindingMiss(Exception):
+    """Named refusal: no unique authenticated function binding.
+
+    Absence is a decision. Returning bare ``None`` made a miss
+    indistinguishable from a soft skip; callers that need soft handling must
+    catch this named throw explicitly.
+    """
+
+    def __init__(self, *, name: str, reason: str) -> None:
+        self.name = name
+        self.reason = reason
+        super().__init__(f"FunctionBindingMiss name={name!r} reason={reason}")
+
+
 def find_function_by_name(sf: SourceFile, name: str):
-    """The function definition with this exact name, or None. Direct name
-    resolution -- the callee a cue names is found by that name."""
-    for fn in sf.functions():
-        if fn.name == name:
-            return fn
-    return None
+    """Resolve the unique module-direct function binding for ``name``.
+
+    Authority is ``module_direct_bindings`` (bind-time roster), never
+    first-match-by-spelling over transitive ``functions()`` (class methods and
+    nested defs share spellings). Miss or competing bindings THROW named —
+    they are not soft ``None``.
+    """
+    bindings = (sf.unit.module_direct_bindings or {}).get(name, ())
+    functions = [
+        binding
+        for binding in bindings
+        if isinstance(binding, (FunctionDef, AsyncFunctionDef))
+    ]
+    if len(functions) == 1:
+        return functions[0]
+    if not functions:
+        raise FunctionBindingMiss(
+            name=name, reason="no module-direct function binding"
+        )
+    raise FunctionBindingMiss(
+        name=name,
+        reason=f"{len(functions)} competing module-direct function bindings",
+    )
+
+
+def resolve_function_for_call(call):
+    """Resolve the callee through binding/coordinate at an exact call site.
+
+    Uses ``SourceUnit.source_function_definition_for_call`` — lexical rows and
+    module-direct bindings, not spelling walks. THROW named on a miss.
+    """
+    from sugar_source_tree.nodes import Name
+
+    unit = call.unit
+    definition = unit.source_function_definition_for_call(call)
+    if definition is not None:
+        return definition
+    name = call.func.id if isinstance(call.func, Name) else type(call.func).__name__
+    raise FunctionBindingMiss(
+        name=name,
+        reason="no unique authenticated function binding at call site",
+    )
 
 
 def call_target_names(sf: SourceFile, span: Optional[dict]) -> list:
@@ -294,32 +344,42 @@ def _args_are_ground(call) -> bool:
     return True
 
 
-def applied_contract_rows(fn, arg_nodes: tuple, file_rel: str):
+def applied_contract_rows(fn, arg_nodes: tuple, file_rel: str, keywords: tuple = ()):
     """The callee's contract AS APPLIED at a call: a call IS substitution.
 
-    Substitute the actual argument nodes for the formals into the body -- the
-    same `_substitute_body` that threads a block; a concrete iterable arg makes
-    a symbolic loop unroll here (`_Splice`), a filled name inlines. Then lift
-    the applied body. `A(xs): total=0; for x in xs: total=total+x` dug at
-    `A([1,2,3])` yields post `out == 6` -- the fold coordinate collapsed by the
-    dig, exactly as `c[post]=5` collapses `b[post]`. The DTO keeps the callee's
-    memento and formals (same wire shape; the post simply no longer mentions
-    them). Incomplete -> (memento, None), an effect, as the abstract path."""
+    Binding goes through ``SourceCallFrame.bind_node_actuals`` — the same door
+    that packs positional, keyword, default, positional-only, keyword-only, and
+    variadic formals. An ad-hoc flat param/actual zip binder is forbidden:
+    ``def f(a, *rest)`` called ``f(1, 2)`` must bind ``rest=(2,)``, not
+    ``rest=2``.
+
+    Construction uses the bound frame's already-sugared body and the frame's
+    formal coordinates — not a second bare ``FunctionUniverseSugar`` mint that
+    drifts from ``FunctionDef.sugar()``. Incomplete -> (memento, None), an
+    effect, as the abstract path. Binding gaps propagate as
+    ``SourceCallBindingGap``.
+    """
+    from sugar_lift_py_tests.floor.universe_value import UniverseValue
     from sugar_lift_py_tests.outcome import Complete
-    from sugar_lift_py_tests.sugar.function_universe_sugar import (
-        FunctionUniverseSugar,
-    )
+    from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_body
 
     def_memento = function_def_memento(fn, file_rel)
-    scope = {p.name: a for p, a in zip(fn.params, arg_nodes)}
-    applied_body, _changed = fn._substitute_body(fn.body, scope)
-    sugar = FunctionUniverseSugar(
-        name=fn.name,
-        formals=tuple(p.name for p in fn.params),
-        statements=tuple(stmt.sugar() for stmt in applied_body),
-        site=fn.fragment,
+    frame = fn.source_visible_call_frame()
+    # SourceCallBindingGap propagates loud — no soft gap swallow.
+    bound = frame.bind_node_actuals(tuple(arg_nodes), tuple(keywords))
+    # Statement sugars and formal coordinates come from the construction door
+    # (frame bind + FunctionDef body sugars). Project the universe floor
+    # without a second incomplete FunctionUniverseSugar producer.
+    outcome = reduce_body(bound.body.statements).and_then(
+        lambda record: Complete(
+            UniverseValue(
+                name=fn.name,
+                formals=bound.parameters,
+                record=record,
+                formal_coordinates=bound.formal_coordinates,
+            )
+        )
     )
-    outcome = sugar.desugar(None)
     if not isinstance(outcome, Complete):
         return def_memento, None
     return def_memento, outcome.value.payload_rows(def_memento)

--- a/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_6_enumeration_door.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_6_enumeration_door.py
@@ -1,0 +1,289 @@
+"""SIN CLUSTER 6 — enumeration that bypasses the construction door.
+
+Coordinates under sugar-lift-py-tests:
+
+1. applied_contract_rows binds through SourceCallFrame.bind_node_actuals
+   (not ad-hoc zip of flat params). ``f(a, *rest)`` called ``f(1, 2)`` packs
+   ``rest=(2,)``; a lying twin asserting ``rest=2`` must fail.
+2. No second bare FunctionUniverseSugar mint — formal coordinates come from
+   the frame produced by the construction door.
+3. Function resolution is binding/coordinate, not first-match-by-spelling;
+   a miss THROWS FunctionBindingMiss (named), never soft None.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from sugar_lift_py_tests import tree_enumerate as te
+from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_source_tree.nodes import Call, Constant, FunctionDef, Name
+from sugar_source_tree.tree import SourceFile
+
+
+def _tree(source: str, name: str = "cluster6.py") -> SourceFile:
+    return SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _module_fn(source: str, name: str) -> tuple[SourceFile, FunctionDef]:
+    tree = _tree(source)
+    list(tree.functions())  # force bind-time rosters
+    fn = te.find_function_by_name(tree, name)
+    return tree, fn
+
+
+# --- 1 + 2: bind_node_actuals door; no second bare FunctionUniverseSugar -----
+
+
+def test_variadic_applied_binds_rest_as_tuple_truthful_twin() -> None:
+    """Truthful: ``f(a, *rest)`` called ``f(1, 2)`` binds rest as Tuple(2,)."""
+    source = (
+        "def f(a, *rest):\n"
+        "    return rest\n"
+        "\n"
+        "def test_a():\n"
+        "    assert f(1, 2) == (2,)\n"
+    )
+    tree, fn = _module_fn(source, "f")
+    call = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, Call)
+        and isinstance(node.func, Name)
+        and node.func.id == "f"
+    )
+    frame = fn.source_visible_call_frame()
+    bound = frame.bind_node_actuals(tuple(call.args), ())
+    by_name = {
+        name: entry.state
+        for name, entry in zip(bound.parameters, bound.runtime_entries, strict=True)
+    }
+    rest = by_name["rest"]
+    # Materialized Tuple may be the shadow class (``Tuple_``); kind is authority.
+    assert rest.kind == "Tuple", type(rest).__name__
+    assert len(rest.elts) == 1
+    assert rest.elts[0].kind == "Constant"
+    assert rest.elts[0].value == 2
+
+    # Applied contract path uses the same door and publishes without minting a
+    # coordinate-free FunctionUniverseSugar.
+    _memento, rows = te.applied_contract_rows(fn, tuple(call.args), "cluster6.py")
+    assert rows is not None
+
+
+def test_variadic_applied_lying_twin_rest_is_not_scalar_must_fail() -> None:
+    """Lying twin: asserting rest is the bare scalar 2 must fail.
+
+    The old ad-hoc binder ``zip(params, args)`` published rest=2. That shape
+    is illegal; the twin fails so the regression cannot go silent.
+    """
+    source = (
+        "def f(a, *rest):\n"
+        "    return rest\n"
+        "\n"
+        "def test_a():\n"
+        "    assert f(1, 2) == (2,)\n"
+    )
+    tree, fn = _module_fn(source, "f")
+    call = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, Call)
+        and isinstance(node.func, Name)
+        and node.func.id == "f"
+    )
+    frame = fn.source_visible_call_frame()
+    bound = frame.bind_node_actuals(tuple(call.args), ())
+    rest = dict(
+        zip(bound.parameters, (e.state for e in bound.runtime_entries), strict=True)
+    )["rest"]
+
+    # Truthful: packed Tuple. Lying: bare Constant(2) — must not hold.
+    assert rest.kind == "Tuple"
+    with pytest.raises(AssertionError):
+        assert rest.kind == "Constant" and rest.value == 2
+
+
+def test_applied_contract_rows_does_not_mint_bare_function_universe_sugar() -> None:
+    """Coordinate 2: source must not construct FunctionUniverseSugar inline."""
+    src = inspect.getsource(te.applied_contract_rows)
+    assert "FunctionUniverseSugar(" not in src
+    assert "bind_node_actuals" in src
+    assert "formal_coordinates" in src
+
+
+def test_ad_hoc_zip_binder_is_absent_from_applied_contract_rows() -> None:
+    """Coordinate 1 instrument: the flat param/actual zip binder is gone."""
+    src = inspect.getsource(te.applied_contract_rows)
+    # Executable body only — docstring may name the retired shape.
+    body = src.split('"""', 2)[-1] if '"""' in src else src
+    assert "zip(fn.params" not in body
+    assert "{p.name: a for p, a in zip" not in body
+
+
+def test_bind_actuals_floor_packs_rest_as_tuple_value() -> None:
+    """Floor side of the same door: bind_actuals packs *rest into TupleValue."""
+    from sugar_lift_py_tests.floor import TermValue, TupleValue
+
+    source = "def f(a, *rest):\n    return rest\n"
+    _tree_sf, fn = _module_fn(source, "f")
+    frame = fn.source_visible_call_frame()
+    bound = frame.bind_actuals((TermValue(1), TermValue(2)), ())
+    assert len(bound.actuals) == 2
+    rest = bound.actuals[1]
+    assert rest == TupleValue((TermValue(2),))
+    with pytest.raises(AssertionError):
+        # Lying twin: rest is the bare second actual, not a pack.
+        assert rest == TermValue(2)
+
+
+def test_binding_gap_is_loud_on_arity_mismatch() -> None:
+    """No silent truncate: missing required formal raises SourceCallBindingGap."""
+    source = "def f(a, b):\n    return a\n"
+    _tree_sf, fn = _module_fn(source, "f")
+    frame = fn.source_visible_call_frame()
+    with pytest.raises(SourceCallBindingGap):
+        frame.bind_node_actuals((), ())
+
+
+# --- 3: binding/coordinate resolution; named throw on miss -------------------
+
+
+def test_find_function_by_name_module_binding_truthful_twin() -> None:
+    source = (
+        "class C:\n"
+        "    def f(self):\n"
+        "        return 0\n"
+        "\n"
+        "def f(a, *rest):\n"
+        "    return rest\n"
+    )
+    tree = _tree(source)
+    list(tree.functions())
+    fn = te.find_function_by_name(tree, "f")
+    assert isinstance(fn, FunctionDef)
+    assert fn.name == "f"
+    # Module-level def, not the method: has *rest.
+    assert any(p.param_kind == "vararg" for p in fn.params)
+
+
+def test_find_function_by_name_miss_throws_named() -> None:
+    source = "def g():\n    return 1\n"
+    tree = _tree(source)
+    list(tree.functions())
+    with pytest.raises(te.FunctionBindingMiss) as caught:
+        te.find_function_by_name(tree, "missing")
+    assert caught.value.name == "missing"
+    assert "no module-direct" in caught.value.reason
+
+
+def test_find_function_by_name_does_not_return_none_on_miss() -> None:
+    """Lying twin of soft-None: the miss path must not be a None result."""
+    source = "def g():\n    return 1\n"
+    tree = _tree(source)
+    list(tree.functions())
+    try:
+        result = te.find_function_by_name(tree, "nope")
+    except te.FunctionBindingMiss:
+        return
+    # If we got here without throw, soft None is the SIN.
+    assert result is not None, "miss returned None — absence must THROW named"
+
+
+def test_resolve_function_for_call_by_coordinate() -> None:
+    source = (
+        "def helper(x):\n"
+        "    return x\n"
+        "\n"
+        "def test_a():\n"
+        "    assert helper(3) == 3\n"
+    )
+    tree = _tree(source)
+    list(tree.functions())
+    call = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, Call)
+        and isinstance(node.func, Name)
+        and node.func.id == "helper"
+    )
+    fn = te.resolve_function_for_call(call)
+    assert fn.name == "helper"
+    assert fn is te.find_function_by_name(tree, "helper")
+
+
+def test_resolve_function_for_call_miss_throws_named() -> None:
+    source = (
+        "def test_a():\n"
+        "    assert unknown_callee(1) == 1\n"
+    )
+    tree = _tree(source)
+    list(tree.functions())
+    call = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, Call)
+        and isinstance(node.func, Name)
+        and node.func.id == "unknown_callee"
+    )
+    with pytest.raises(te.FunctionBindingMiss) as caught:
+        te.resolve_function_for_call(call)
+    assert caught.value.name == "unknown_callee"
+
+
+def test_spelling_first_match_over_methods_is_not_authority() -> None:
+    """Class method spelling must not win over the module-direct binding."""
+    source = (
+        "class Holder:\n"
+        "    def pack(self, *items):\n"
+        "        return items\n"
+        "\n"
+        "def pack(a, *rest):\n"
+        "    return (a, rest)\n"
+        "\n"
+        "def test_a():\n"
+        "    assert pack(1, 2) == (1, (2,))\n"
+    )
+    tree = _tree(source)
+    list(tree.functions())
+    fn = te.find_function_by_name(tree, "pack")
+    # Module def has formals (a, *rest); method has (self, *items).
+    assert [p.name for p in fn.params] == ["a", "rest"]
+
+
+def test_applied_contract_ground_list_fold_truthful_twin() -> None:
+    """Unit twin of dig-with-args: ground list folds through bind_node_actuals door."""
+    source = (
+        "def A(xs):\n"
+        "    total = 0\n"
+        "    for x in xs:\n"
+        "        total = total + x\n"
+        "    return total\n"
+        "\n"
+        "def test_a():\n"
+        "    assert A([1, 2, 3]) == 6\n"
+    )
+    tree, fn = _module_fn(source, "A")
+    call = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, Call)
+        and isinstance(node.func, Name)
+        and node.func.id == "A"
+    )
+    _memento, rows = te.applied_contract_rows(fn, tuple(call.args), "fold.py")
+    assert rows is not None
+    post = rows[0].post
+    assert post is not None
+    # out == 6 after the fold collapses under applied actuals.
+    formula = post.ir_formula
+    # Formula is (= out 6) or equivalent tree; walk for the literal 6.
+    text = str(formula)
+    assert "6" in text

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1571,43 +1571,40 @@ def construct_manager_behavior(
         # Typed floor projection failure — not a bare crash, not soft silence.
         # Multi-arm ExitSet is still a factory with Completed return arms: dig
         # the source outcome and project manager returns from those arms.
+        #
+        # ConstructionPanic carries prose in ``info.observed``, not a typed
+        # ExitSet payload. Discriminate by re-reducing the source body and
+        # matching the outcome type. NEVER substring-match panic message text
+        # — control flow driven by error-message prose is a SIN.
         owner = getattr(getattr(panic, "info", None), "owner", None) or "force-floor"
         observed = getattr(getattr(panic, "info", None), "observed", None) or str(panic)
-        if "ExitSet" in str(observed):
-            projected_force_floor_detail = str(observed)
-            from sugar_lift_py_tests.outcome import Complete, ExitSet
+        from sugar_lift_py_tests.outcome import Complete, ExitSet
 
-            outcome = call.reduce_source_outcome(reduce_ctx)
-            if isinstance(outcome, ExitSet):
-                manager_projection_arm_count = len(outcome.exits) - bool(
-                    keyword_actuals
-                )
-                projected_force_floor_detail = (
-                    f"ExitSet with {manager_projection_arm_count} arms"
-                )
-                projected = _project_manager_from_exitset(
-                    outcome,
-                    factory_prefix=factory_prefix,
-                    seen_calls=seen_calls,
-                    resolved_cid=resolved.cid,
-                )
-                if isinstance(projected, ManagerConstructionGapV1):
-                    return projected
-                result, factory_prefix = projected
-            elif isinstance(outcome, Complete):
-                projected = _project_factory_manager(
-                    outcome.value,
-                    factory_prefix=factory_prefix,
-                    seen_calls=seen_calls,
-                    resolved_cid=resolved.cid,
-                )
-                if isinstance(projected, ManagerConstructionGapV1):
-                    return projected
-                result, factory_prefix = projected
-            else:
-                return ManagerConstructionGapV1(
-                    "force-floor", resolved.cid, f"{owner}:{observed}"
-                )
+        outcome = call.reduce_source_outcome(reduce_ctx)
+        if isinstance(outcome, ExitSet):
+            manager_projection_arm_count = len(outcome.exits) - bool(keyword_actuals)
+            projected_force_floor_detail = (
+                f"ExitSet with {manager_projection_arm_count} arms"
+            )
+            projected = _project_manager_from_exitset(
+                outcome,
+                factory_prefix=factory_prefix,
+                seen_calls=seen_calls,
+                resolved_cid=resolved.cid,
+            )
+            if isinstance(projected, ManagerConstructionGapV1):
+                return projected
+            result, factory_prefix = projected
+        elif isinstance(outcome, Complete):
+            projected = _project_factory_manager(
+                outcome.value,
+                factory_prefix=factory_prefix,
+                seen_calls=seen_calls,
+                resolved_cid=resolved.cid,
+            )
+            if isinstance(projected, ManagerConstructionGapV1):
+                return projected
+            result, factory_prefix = projected
         else:
             return ManagerConstructionGapV1(
                 "force-floor", resolved.cid, f"{owner}:{observed}"

--- a/implementations/python/sugar-lift-python-source/tests/test_sin_cluster_6_exitset_typed_discrimination.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sin_cluster_6_exitset_typed_discrimination.py
@@ -1,0 +1,40 @@
+"""SIN CLUSTER 6 coordinate 4 — manager construction ExitSet recovery.
+
+Control flow must not be driven by substring-matching panic message prose
+(``\"ExitSet\" in str(observed)``). Recovery digs ``reduce_source_outcome`` and
+discriminates by exact outcome type. If the type does not carry what is
+needed, the path returns a typed gap — it does not read the message.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import sugar_lift_python_source.manager_construction as manager_construction
+from sugar_lift_python_source.manager_construction import construct_manager_behavior
+
+
+def test_construct_manager_behavior_has_no_panic_message_substring_match() -> None:
+    """Truthful instrument: ExitSet prose substring gate is deleted; typed path remains."""
+    src = inspect.getsource(construct_manager_behavior)
+    assert 'if "ExitSet" in str(observed):' not in src
+    assert "if 'ExitSet' in str(observed):" not in src
+    assert '"ExitSet" in str(' not in src
+    assert "isinstance(outcome, ExitSet)" in src
+    assert "isinstance(outcome, Complete)" in src
+    assert "reduce_source_outcome" in src
+
+
+def test_lying_twin_panic_prose_substring_gate_is_absent() -> None:
+    """Lying twin: reintroducing message-driven control must fail this suite."""
+    module_src = Path(manager_construction.__file__).read_text(encoding="utf-8")
+    forbidden = 'if "ExitSet" in str(observed):'
+    assert forbidden not in module_src
+    # Also refuse the looser form that matches any str(observed) ExitSet probe.
+    assert any(
+        line.strip().startswith("if ")
+        and "ExitSet" in line
+        and "str(observed)" in line
+        for line in module_src.splitlines()
+    ) is False


### PR DESCRIPTION
## Summary

Removes **SIN CLUSTER 6 — enumeration that bypasses the door**: ad-hoc Python reimplementing what the construction door already does.

Under the Law of One (AST tree shadows → temporal rewrite → Sugar meaning), this cluster was a third mechanism:

1. **Ad-hoc binder / dict-as-substitution** — flat `zip(params, args)` published wrong `*rest` binding (`rest=2` instead of `rest=(2,)`). Routed through `SourceCallFrame.bind_node_actuals`.
2. **Second `FunctionUniverseSugar` mint** — coordinate-free producer of one fact. Deleted; project from the bound frame’s body + formal coordinates.
3. **First-match-by-spelling** — `find_function_by_name` over transitive `functions()`, soft `None` on miss. Resolve by module binding / call coordinate; **throw** named `FunctionBindingMiss`.
4. **Panic-prose control flow** — `"ExitSet" in str(observed)`. Typed discrimination via `reduce_source_outcome` + `isinstance(ExitSet|Complete)`.

## Test plan

- [x] `pytest implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_6_enumeration_door.py`
- [x] `pytest implementations/python/sugar-lift-python-source/tests/test_sin_cluster_6_exitset_typed_discrimination.py`
- Truthful/lying twins: `f(a, *rest)` called `f(1,2)` binds `rest=(2,)`; twin asserting `rest=2` fails

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix enumeration to resolve call targets by call-site binding instead of name search
> - Replaces `find_function_by_name` (first-match by name) with `resolve_function_for_call` (call-site binding via coordinate) in the `_handle_enumerate` handler in [lift_rpc.py](https://github.com/TSavo/sugar/pull/6946/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335), closing the bypass path through the construction door.
> - Introduces `FunctionBindingMiss` exception in [tree_enumerate.py](https://github.com/TSavo/sugar/pull/6946/files#diff-1a883a4eea1b53f1ee91261df4ca5f694dfda233c883ddab24f920fd9610931e) so binding misses are named and soft-skipped rather than surfaced as errors.
> - Refactors `applied_contract_rows` to use the function's source-visible call frame for binding (supporting varargs, keywords, defaults) instead of ad-hoc positional zip; removes the strict arity check.
> - Fixes `construct_manager_behavior` in [manager_construction.py](https://github.com/TSavo/sugar/pull/6946/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to branch on typed reduced outcome (`ExitSet` vs `Complete`) instead of panic message substring matching.
> - Behavioral Change: `find_function_by_name` now raises on miss or ambiguity rather than returning `None` or picking the first match; callers relying on the old silent-miss behavior will need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b13b7f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->