### PR TITLE
Key source-audit presence by full roll-call identity (SIN CLUSTER 7: two producers of one fact)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1598,34 +1598,15 @@ def _roll_call_audit_leaf(full_path: Path, file_rel: str) -> dict:
     from sugar_source_tree.roll_call import discharge
     from sugar_source_tree.tree import SourceFile
 
+    from sugar_lift_py_tests.tree_enumerate import source_audit_from_report
+
     reporter = CollectingReporter()
     source_file = SourceFile.from_path(str(full_path), reporter=reporter)
     report = discharge(source_file)
-    present_cids = {entry.cid for entry in report.present}
-    loci = [
-        {
-            "status": "warranted" if entry.cid in present_cids else "unresolved",
-            "kind": entry.kind,
-            "name": entry.name,
-            "source_cid": entry.cid,
-            "locus": {
-                "file": file_rel,
-                "line": entry.start_line,
-                "col": entry.start_col,
-            },
-        }
-        for entry in report.roster
-    ]
-    warranted = sum(row["status"] == "warranted" for row in loci)
-    source_audit = {
-        "role": file_rel,
-        "loci": loci,
-        "totals": {
-            "source_loci": len(loci),
-            "source_warranted": warranted,
-            "source_unresolved": report.R,
-        },
-    }
+    # ONE door: the same full-tuple presence projection as tree_enumerate.
+    # Do not re-derive status by CID alone, and do not mix report.R with a
+    # separately keyed warranted count (that pair already drifted).
+    source_audit = source_audit_from_report(report, file_rel)
 
     demanded_source = f"module:{source_file.unit.source_cid}"
     panics = []

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -363,6 +363,69 @@ def _gap_locus(node, file_rel: str) -> tuple[str, str]:
     return pos, terminal
 
 
+def _roll_call_identity(entry) -> tuple:
+    """The SAME identity ``MinorityReport`` uses for present/minority.
+
+    Equal source text seals to one CID at distinct loci; those seats are
+    distinct obligations. Never key presence by CID alone.
+    """
+    return (entry.file, entry.start_line, entry.start_col, entry.kind, entry.cid)
+
+
+def source_audit_from_report(report, file_rel: str) -> dict:
+    """ONE door: project a ``MinorityReport`` onto the source-audit wire.
+
+    Presence is keyed by the full roll-call identity
+    ``(file, line, col, kind, cid)`` — the same tuple ``MinorityReport`` uses.
+    Status and the three ledger totals are derived once from that partition.
+    There is no second producer of ``source_unresolved`` (no independent
+    ``report.R`` path, no CID-only set kept "in sync").
+
+    Conservation is a tooth, not a print: ``warranted + unresolved == source_loci``.
+    """
+    present_keys = {_roll_call_identity(entry) for entry in report.present}
+    loci = []
+    for entry in report.roster:
+        status = (
+            "warranted" if _roll_call_identity(entry) in present_keys else "unresolved"
+        )
+        loci.append(
+            {
+                "status": status,
+                "kind": entry.kind,
+                "name": entry.name,
+                "source_cid": entry.cid,
+                "locus": {
+                    "file": file_rel,
+                    "line": entry.start_line,
+                    "col": entry.start_col,
+                },
+            }
+        )
+    warranted = sum(1 for locus in loci if locus["status"] == "warranted")
+    unresolved = sum(1 for locus in loci if locus["status"] == "unresolved")
+    source_loci = len(loci)
+    if warranted + unresolved != source_loci:
+        raise AssertionError(
+            f"source-audit conservation broken: warranted({warranted}) + "
+            f"unresolved({unresolved}) != source_loci({source_loci})"
+        )
+    if unresolved != report.R:
+        raise AssertionError(
+            f"source-audit unresolved({unresolved}) != report.R({report.R}); "
+            "presence must use the full roll-call identity, not CID alone"
+        )
+    return {
+        "role": file_rel,
+        "loci": loci,
+        "totals": {
+            "source_loci": source_loci,
+            "source_warranted": warranted,
+            "source_unresolved": unresolved,
+        },
+    }
+
+
 def source_audit_from_roll_call(full_path: Path, file_rel: str) -> dict:
     """The report feed the Rust CLI renders, straight from the reporter's roll
     call. Construction registers every node; the discharge answers present
@@ -380,34 +443,7 @@ def source_audit_from_roll_call(full_path: Path, file_rel: str) -> dict:
     reporter = CollectingReporter()
     sf = SourceFile.from_path(str(full_path), reporter=reporter)
     report = discharge(sf)
-    present_cids = {e.cid for e in report.present}
-    loci = []
-    for entry in report.roster:
-        status = "warranted" if entry.cid in present_cids else "unresolved"
-        loci.append(
-            {
-                "status": status,
-                "kind": entry.kind,
-                "name": entry.name,
-                "source_cid": entry.cid,
-                "locus": {
-                    "file": file_rel,
-                    "line": entry.start_line,
-                    "col": entry.start_col,
-                },
-            }
-        )
-    warranted = sum(1 for locus in loci if locus["status"] == "warranted")
-    unresolved = len(loci) - warranted
-    return {
-        "role": file_rel,
-        "loci": loci,
-        "totals": {
-            "source_loci": len(loci),
-            "source_warranted": warranted,
-            "source_unresolved": unresolved,
-        },
-    }
+    return source_audit_from_report(report, file_rel)
 
 
 def _root_of(full_path: Path, file_rel: str) -> Path:

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_tuple.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_tuple.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""SIN CLUSTER 7: source-audit presence is keyed by the full roll-call identity.
+
+``MinorityReport`` partitions present/minority by
+``(file, line, col, kind, cid)``. Equal source text seals to one CID at
+distinct loci; those seats are distinct obligations. Keying source-audit
+status by CID alone promotes every seat that shares a present CID to Blue
+while ``report.R`` still counts the absent seat — so
+``warranted + unresolved`` can exceed ``source_loci``, and Yellow silently
+becomes Blue.
+
+Truthful twin: full-tuple presence, conservation holds.
+Lying twin: shared CID, present at one locus and absent at the other, must
+NOT mark both warranted — red against the dual CID-only producers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.roll_call import MinorityReport
+
+
+class _Seat:
+    """Minimal node seat: sealed CID + source coordinate + kind."""
+
+    def __init__(
+        self,
+        cid: str,
+        *,
+        line: int,
+        col: int,
+        kind: str = "Name",
+        name: str = "x",
+        file: str = "t.py",
+    ) -> None:
+        self._cid = cid
+        self._line = line
+        self._col = col
+        self.kind = kind
+        self.name = name
+
+        class _Unit:
+            filename = file
+
+        self.unit = _Unit()
+
+    @property
+    def fragment(self):
+        outer = self
+
+        class _Seal:
+            @property
+            def cid(self_):
+                return outer._cid
+
+        class _Frag:
+            def seal(self_):
+                return _Seal()
+
+        return _Frag()
+
+    def line_col_span(self):
+        outer = self
+
+        class _LC:
+            start_line = outer._line
+            start_col = outer._col
+            end_line = outer._line
+            end_col = outer._col + 1
+
+        return _LC()
+
+
+def _split_presence_report() -> MinorityReport:
+    """Same CID at two loci; only the first discharges present."""
+    r = CollectingReporter()
+    a = _Seat("shared-cid", line=1, col=0)
+    b = _Seat("shared-cid", line=2, col=0)
+    r.register(a)
+    r.register(b)
+    r.present_fact(a)
+    report = MinorityReport(reporter=r)
+    assert report.R == 1
+    assert len(report.roster) == 2
+    assert len(report.present) == 1
+    assert len(report.minority) == 1
+    return report
+
+
+def _status_by_line(audit: dict) -> dict[int, str]:
+    return {row["locus"]["line"]: row["status"] for row in audit["loci"]}
+
+
+def _assert_conserved(audit: dict) -> None:
+    totals = audit["totals"]
+    assert (
+        totals["source_warranted"] + totals["source_unresolved"]
+        == totals["source_loci"]
+    ), (
+        f"conservation broken: warranted({totals['source_warranted']}) + "
+        f"unresolved({totals['source_unresolved']}) != "
+        f"source_loci({totals['source_loci']})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lying twin — MUST fail against the CID-alone dual producers
+# ---------------------------------------------------------------------------
+
+
+def test_lying_twin_shared_cid_partial_presence_does_not_warrant_both() -> None:
+    """THE lying twin.
+
+    Present at locus 1, absent at locus 2, same CID. The product must keep
+    locus 2 Yellow. CID-alone keying marks both Blue and (on the lift_rpc
+    producer) lets warranted + R exceed source_loci.
+    """
+    from sugar_lift_py_tests.tree_enumerate import source_audit_from_report
+
+    report = _split_presence_report()
+    audit = source_audit_from_report(report, "t.py")
+
+    assert _status_by_line(audit) == {
+        1: "warranted",
+        2: "unresolved",
+    }, (
+        "shared CID at two loci: present at one must not promote the other; "
+        f"got {_status_by_line(audit)}"
+    )
+    totals = audit["totals"]
+    assert totals["source_warranted"] == 1
+    assert totals["source_unresolved"] == 1
+    assert totals["source_loci"] == 2
+    _assert_conserved(audit)
+    assert totals["source_unresolved"] == report.R
+
+
+def test_lying_twin_lift_rpc_roll_call_uses_the_one_door(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """lift_rpc must not re-derive presence by CID; it uses the one door."""
+    from sugar_lift_py_tests import lift_rpc
+    from sugar_source_tree.tree import SourceFile
+    import sugar_source_tree.roll_call as roll_call
+
+    report = _split_presence_report()
+    seats = list(report.reporter.registered)
+
+    class _Unit:
+        source_cid = "mod"
+
+    class _SF:
+        unit = _Unit()
+        reporter = report.reporter
+
+    class _Reporter:
+        def __init__(self) -> None:
+            self.registered = seats
+            self.gaps: list = []
+            self.present = list(report.reporter.present)
+
+    monkeypatch.setattr(
+        SourceFile, "from_path", classmethod(lambda cls, *a, **k: _SF())
+    )
+    monkeypatch.setattr(roll_call, "discharge", lambda sf: report)
+    monkeypatch.setattr("sugar_source_tree.reporter.CollectingReporter", _Reporter)
+
+    path = tmp_path / "t.py"
+    path.write_text("# seat file\n", encoding="utf-8")
+    leaf = lift_rpc._roll_call_audit_leaf(path, "t.py")
+    audit = leaf["auxiliaryRows"]["sourceAudit"]
+
+    assert _status_by_line(audit) == {
+        1: "warranted",
+        2: "unresolved",
+    }, f"lift_rpc still keys presence by CID alone: {_status_by_line(audit)}"
+    _assert_conserved(audit)
+    assert audit["totals"]["source_unresolved"] == report.R
+
+
+# ---------------------------------------------------------------------------
+# Truthful twin — full-tuple presence and conservation
+# ---------------------------------------------------------------------------
+
+
+def test_truthful_twin_both_present_both_warranted() -> None:
+    from sugar_lift_py_tests.tree_enumerate import source_audit_from_report
+
+    r = CollectingReporter()
+    a = _Seat("shared-cid", line=1, col=0)
+    b = _Seat("shared-cid", line=2, col=0)
+    r.register(a)
+    r.register(b)
+    r.present_fact(a)
+    r.present_fact(b)
+    report = MinorityReport(reporter=r)
+
+    audit = source_audit_from_report(report, "t.py")
+    assert _status_by_line(audit) == {1: "warranted", 2: "warranted"}
+    assert audit["totals"] == {
+        "source_loci": 2,
+        "source_warranted": 2,
+        "source_unresolved": 0,
+    }
+    _assert_conserved(audit)
+    assert report.R == 0
+
+
+def test_truthful_twin_neither_present_both_unresolved() -> None:
+    from sugar_lift_py_tests.tree_enumerate import source_audit_from_report
+
+    r = CollectingReporter()
+    a = _Seat("shared-cid", line=1, col=0)
+    b = _Seat("shared-cid", line=2, col=0)
+    r.register(a)
+    r.register(b)
+    report = MinorityReport(reporter=r)
+
+    audit = source_audit_from_report(report, "t.py")
+    assert _status_by_line(audit) == {1: "unresolved", 2: "unresolved"}
+    assert audit["totals"] == {
+        "source_loci": 2,
+        "source_warranted": 0,
+        "source_unresolved": 2,
+    }
+    _assert_conserved(audit)
+    assert audit["totals"]["source_unresolved"] == report.R
+
+
+def test_truthful_twin_roll_call_path_conserves_on_real_source(tmp_path: Path) -> None:
+    """Live construction path: totals conserve; unresolved matches report.R."""
+    from sugar_lift_py_tests.tree_enumerate import source_audit_from_roll_call
+    from sugar_source_tree.reporter import CollectingReporter
+    from sugar_source_tree.roll_call import discharge
+    from sugar_source_tree.tree import SourceFile
+
+    path = tmp_path / "m.py"
+    path.write_text("def f():\n    return 1\n", encoding="utf-8")
+    audit = source_audit_from_roll_call(path, "m.py")
+    _assert_conserved(audit)
+
+    reporter = CollectingReporter()
+    report = discharge(SourceFile.from_path(str(path), reporter=reporter))
+    assert audit["totals"]["source_unresolved"] == report.R
+    assert audit["totals"]["source_loci"] == len(report.roster)
+


### PR DESCRIPTION
## Summary

- Removes SIN CLUSTER 7: two producers of source-audit presence keyed by CID alone (`lift_rpc` status vs `report.R`; `tree_enumerate` status + `len - warranted`) while `MinorityReport` partitions by the full `(file, line, col, kind, cid)` identity.
- One door: `source_audit_from_report` — full-tuple presence, totals derived once, conservation teeth `warranted + unresolved == source_loci` and `unresolved == report.R` asserted.
- Lying twin (shared CID present at one locus / absent at another) fails against the dual CID-alone path; truthful twins conserve and keep seats distinct.

## Test plan

- [x] `pytest sugar-lift-py-tests/tests/test_source_audit_presence_tuple.py` (lying twin red first, then green)
- [x] Related roll-call / source-audit tests under `test_enumerate_rpc.py`
- [x] `test_shared_cid_at_distinct_loci_stays_distinct_and_located`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Key source-audit presence by full roll-call identity (file, line, col, kind, cid)
> - Introduces `source_audit_from_report` in [`tree_enumerate.py`](https://github.com/TSavo/sugar/pull/6947/files#diff-1a883a4eea1b53f1ee91261df4ca5f694dfda233c883ddab24f920fd9610931e) as the single projection path from a `MinorityReport` to the `sourceAudit` wire format, keying presence by the full `(file, line, col, kind, cid)` tuple instead of CID alone.
> - Refactors `source_audit_from_roll_call` to delegate to `source_audit_from_report`, and updates `_roll_call_audit_leaf` in [`lift_rpc.py`](https://github.com/TSavo/sugar/pull/6947/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) to use it directly, eliminating duplicate presence logic.
> - Enforces two invariants via `AssertionError`: `warranted + unresolved == source_loci` (conservation) and `unresolved == report.R`.
> - Adds tests in [`test_source_audit_presence_tuple.py`](https://github.com/TSavo/sugar/pull/6947/files#diff-869e9123ce91df87b4f6787d815e1423edc57f7f35589fcaefbe8d113eecdc55) covering shared-CID scenarios and the `_roll_call_audit_leaf` delegation path.
> - Risk: seats sharing a CID at different loci that previously collapsed to a single presence entry will now produce distinct entries; violations of the conservation or unresolved invariants raise `AssertionError` at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 644afa2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->