### PR TITLE
SIN CLUSTER 8: name vanished rows; fire the dead nameless-face tripwire

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -431,6 +431,7 @@ def _measure_file(
 
     functions_total = 0
     functions_clean = 0
+    functions_enumerated = 0
     families: Counter[str] = Counter()
     construction_seen: set[tuple[str, str, object, object]] = set()
     backend_defects: Counter[str] = Counter()
@@ -463,7 +464,7 @@ def _measure_file(
         families[kind] += 1
 
     def construct():
-        nonlocal functions_total, functions_clean
+        nonlocal functions_total, functions_clean, functions_enumerated
         reporter = CollectingReporter()
         # Fresh context per file so source_derived refs stay file-local; the
         # demand/gap table (contract_refs) may be shared across the census.
@@ -489,8 +490,17 @@ def _measure_file(
         )
         cm_resolutions.update(file_cm_resolutions)
         unrecognized_cm_kinds.update(file_unrecognized_kinds)
-        for function in source_file.functions():
-            functions_total += 1
+        # Materialize the function population BEFORE the per-function walk.
+        # ConstructionPanic is BaseException and escapes this loop; if we
+        # increment functions_total inside the loop, a mid-file panic freezes a
+        # PARTIAL denominator that is later summed into the board, and Clean%
+        # is computed over a silently shrunken set. The full declared count is
+        # the denominator; enumeration progress is a separate measurement.
+        declared_functions = tuple(source_file.functions())
+        functions_total = len(declared_functions)
+        functions_enumerated = 0
+        for function in declared_functions:
+            functions_enumerated += 1
             try:
                 span = function.line_col_span()
                 line: object = span.start_line
@@ -502,7 +512,7 @@ def _measure_file(
             # Announce the function BEFORE constructing it (elapsed=None), so a
             # hang shows the exact function it is stuck on -- not the one before.
             if on_function is not None:
-                on_function(functions_total - 1, functions_clean, fn_name, None)
+                on_function(functions_enumerated - 1, functions_clean, fn_name, None)
             t_fn = time.perf_counter()
             try:
                 sugar = function.sugar()
@@ -518,7 +528,7 @@ def _measure_file(
             # Report completion WITH this function's own construction time, so
             # `last=` is per-function and a slow/blowup function is obvious.
             if on_function is not None:
-                on_function(functions_total, functions_clean, fn_name, fn_s)
+                on_function(functions_enumerated, functions_clean, fn_name, fn_s)
         # Sole construction-gap source: reporter occurrences, site-deduped.
         # BackendDefect is table hygiene — own counter, never construction R.
         for node, panic in reporter.gaps:
@@ -538,6 +548,15 @@ def _measure_file(
         "R_cm_derived_contract": int(cm_resolutions.get("derived-contract", 0)),
         "astSites": dict(_ast_site_prevalence(path)),
     }
+    functions_not_enumerated = max(0, functions_total - functions_enumerated)
+    function_accounting = {
+        "functionsTotal": functions_total,
+        "functionsClean": functions_clean,
+        "functionsEnumerated": functions_enumerated,
+        "functionsNotEnumerated": functions_not_enumerated,
+        "functionsEnumerationComplete": functions_not_enumerated == 0
+        and (panic_row is None or functions_total == functions_enumerated),
+    }
     if panic_row is not None:
         return {
             "category": "construction-panic",
@@ -547,8 +566,7 @@ def _measure_file(
                 "message": panic_row.message,
                 "gap": panic_row.info,
             },
-            "functionsTotal": functions_total,
-            "functionsClean": functions_clean,
+            **function_accounting,
             "families": dict(families),
             "backendDefects": dict(backend_defects),
             "R_backend_defects": sum(backend_defects.values()),
@@ -557,8 +575,7 @@ def _measure_file(
         }
     return {
         "category": "completed",
-        "functionsTotal": functions_total,
-        "functionsClean": functions_clean,
+        **function_accounting,
         "families": dict(families),
         "backendDefects": dict(backend_defects),
         "R_backend_defects": sum(backend_defects.values()),

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/collect_panic_audit.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/collect_panic_audit.py
@@ -304,13 +304,31 @@ def _run_subprocess_with_file_watchdog(
             except subprocess.TimeoutExpired:
                 process.kill()
                 stdout, stderr = process.communicate()
+            # A timeout kills the whole subprocess: every file after the blamed
+            # one was never attempted. Report that shrinkage by name — blaming
+            # one file while half-writing "the rest did not exist" is the sin.
+            attempted = _transport_files_seen(transport_log)
+            expected_total = _expected_audit_file_count(command, cwd)
+            files_attempted = len(attempted)
+            if expected_total is None:
+                never_prose = "files never attempted unknown (target file count unavailable)"
+                population_prose = f"files attempted {files_attempted}"
+            else:
+                files_never_attempted = max(0, expected_total - files_attempted)
+                never_prose = f"files never attempted {files_never_attempted}"
+                population_prose = (
+                    f"files attempted {files_attempted} of {expected_total}; "
+                    f"{never_prose}"
+                )
             timeout_row = (
                 "audit file timed out and panicked "
                 "owner=idd.collect_panic_audit "
                 f"blame={current_file} "
                 "observed=audit-file-timeout "
                 "requested=bounded-file-audit "
-                "fix=optimize or construct a bounded lift for this source"
+                "fix=optimize or construct a bounded lift for this source; "
+                f"the timeout aborted the remaining unattempted files "
+                f"({population_prose})"
             )
             combined_stderr = f"{stderr.rstrip()}\n{timeout_row}\n"
             return CommandResult(124, stdout, combined_stderr)
@@ -329,20 +347,69 @@ def _latest_transport_file(
 
     latest: Optional[str] = None
     for line in lines:
-        try:
-            row = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if row.get("stage") == "lift.workspace.file":
-            file_name = row.get("file")
-        elif row.get("stage") == "enumerate.request":
-            at = row.get("at")
-            file_name = at.get("file") if isinstance(at, dict) else None
-        else:
-            file_name = None
-        if isinstance(file_name, str) and file_name:
+        file_name = _file_name_from_transport_line(line)
+        if file_name is not None:
             latest = file_name
     return latest, new_offset
+
+
+def _file_name_from_transport_line(line: str) -> Optional[str]:
+    try:
+        row = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if row.get("stage") == "lift.workspace.file":
+        file_name = row.get("file")
+    elif row.get("stage") == "enumerate.request":
+        at = row.get("at")
+        file_name = at.get("file") if isinstance(at, dict) else None
+    else:
+        file_name = None
+    if isinstance(file_name, str) and file_name:
+        return file_name
+    return None
+
+
+def _transport_files_seen(transport_log: Path) -> set[str]:
+    seen: set[str] = set()
+    try:
+        with transport_log.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                file_name = _file_name_from_transport_line(line)
+                if file_name is not None:
+                    seen.add(file_name)
+    except OSError:
+        return seen
+    return seen
+
+
+def _expected_audit_file_count(command: List[str], cwd: Path) -> Optional[int]:
+    """Count .py files the lift would walk, so a timeout can name the unattempted set.
+
+    Prefer an explicit path argument that stages a workspace (rightmost directory
+    with ``.sugar`` or any existing directory/file target). Missing targets are
+    ``None`` — never invent a zero that half-writes "nothing was expected".
+    """
+    target: Optional[Path] = None
+    for part in reversed(command[1:]):
+        if not part or str(part).startswith("-"):
+            continue
+        candidate = Path(part)
+        if not candidate.is_absolute():
+            candidate = (cwd / candidate).resolve()
+        if candidate.exists():
+            target = candidate
+            break
+    if target is None:
+        return None
+    if target.is_file():
+        return 1 if target.suffix == ".py" else None
+    count = 0
+    for source in target.rglob("*.py"):
+        if "__pycache__" in source.parts:
+            continue
+        count += 1
+    return count
 
 
 def _hermetic_env_for_sugar_command(command: List[str]) -> dict:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -157,11 +157,24 @@ class AttributionReport:
         )
 
     @property
+    def conservation_shortfall(self) -> int:
+        """Probes that left the population without an attributed outcome arm.
+
+        Every enrolled probe is either attributed (outcome_total) or recorded as
+        an AttributionInvariantError discrepancy. Anything else is a silent
+        erasure and must be loud — not merely printed in render().
+        """
+        enrolled = sum(row.enrolled for row in self.rows())
+        accounted = self.outcome_total + len(self.discrepancies)
+        return enrolled - accounted
+
+    @property
     def loud_failure_count(self) -> int:
         return (
             self.construction_panic_count
             + len(self.discrepancies)
             + len(self.exceptional_exit_identity_discrepancies)
+            + abs(self.conservation_shortfall)
         )
 
     def render(self) -> str:
@@ -221,11 +234,12 @@ class AttributionReport:
                 f"detail={discrepancy.detail}"
             )
         enrolled = sum(row.enrolled for row in self.rows())
-        if self.outcome_total != enrolled:
+        if self.conservation_shortfall != 0 or self.outcome_total != enrolled:
             lines.append(
                 "OUTCOME TOTAL DISCREPANCY "
                 f"enrolled={enrolled} outcomeTotal={self.outcome_total} "
-                f"unaccounted={len(self.discrepancies)}"
+                f"discrepancies={len(self.discrepancies)} "
+                f"conservationShortfall={self.conservation_shortfall}"
             )
         return "\n".join(lines)
 
@@ -270,6 +284,15 @@ def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
         )
     exceptional_effects = _exceptional_exit_effects(outcome)
     if exceptional_effects:
+        # Always carry coordinates — including Nones. Routing None-coordinate
+        # effects to UNDISCHARGED *without* coordinates made the nameless-halted
+        # face scan unreachable; a guard that cannot fire reads as protection
+        # while protecting nothing. Undischarged still excludes nameless faces
+        # from the authenticated-exit tally; the identity tripwire stays live.
+        coordinates = tuple(
+            (effect.exception_type_coordinate, effect.occurrence_id)
+            for effect in exceptional_effects
+        )
         unnamed = tuple(
             effect
             for effect in exceptional_effects
@@ -281,6 +304,7 @@ def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
                 probe.family,
                 AttributionOutcome.UNDISCHARGED,
                 "native-operation exception identity unproven",
+                coordinates,
             )
         owners = {
             effect.producer_node_owner
@@ -297,10 +321,7 @@ def attribute_body_probe(probe: BodyProbe) -> BodyAttribution:
             probe.family,
             AttributionOutcome.AUTHENTICATED_EXIT,
             detail,
-            tuple(
-                (effect.exception_type_coordinate, effect.occurrence_id)
-                for effect in exceptional_effects
-            ),
+            coordinates,
         )
     raise AttributionInvariantError(
         f"{probe.body_id} "
@@ -479,6 +500,14 @@ def pull_shared_demand_table(repo_root: Path, output: Path) -> dict:
     )
 
 
+def _use_site_coordinate(path: Path, corpus_root: Path, use_site: Mapping) -> str:
+    rel = path.relative_to(corpus_root).as_posix()
+    return (
+        f"{rel}:{use_site.get('startLine')}:{use_site.get('startCol')}"
+        f"-{use_site.get('endLine')}:{use_site.get('endCol')}"
+    )
+
+
 def discover_no_call_body_probes(
     payload: dict,
     corpus_root: Path,
@@ -490,6 +519,10 @@ def discover_no_call_body_probes(
     Every resolved context-manager demand participates.  The native body root
     selects the producer family; no manager or vendor spelling selects it or
     grants semantic behavior to a producer.
+
+    A resolved demand that does not enroll is never a bare ``continue``: it is
+    either a named exclusion (out of this instrument's selected root types) or
+    an ``AttributionInvariantError`` that names the coordinate and reason.
     """
     from sugar_lift_py_tests.context_manager_resolution import (
         TreeConstructionContextV1,
@@ -521,7 +554,6 @@ def discover_no_call_body_probes(
         for node_type, family in family_by_type.items()
         if family in selected_families
     }
-    selected_root_types = tuple(family_by_type)
     paths_by_cid = {}
     for path in SourceTree(corpus_root).paths():
         paths_by_cid[blake3_512_of(path.read_bytes())] = path
@@ -540,6 +572,7 @@ def discover_no_call_body_probes(
 
     probes = []
     seen = set()
+    named_exclusions: list[str] = []
     for source_cid, demands in demands_by_source.items():
         path = paths_by_cid.get(source_cid)
         if path is None:
@@ -551,16 +584,15 @@ def discover_no_call_body_probes(
             (source, str(path), source_cid),
             construction_context=TreeConstructionContextV1.for_source_call_construction(),
         )
+        # Index every With by manager span — body-shape filtering happens after
+        # a demand matches, so a resolved demand can never vanish as "no managers"
+        # merely because its body was multi-statement or a Call root.
         managers_by_span: dict[tuple[int, int, int, int], list[With]] = {}
         registered = (
             tree.constructed_module.construction_event_receipt.registered_occurrences
         )
         for node in registered:
             if not isinstance(node, With):
-                continue
-            if len(node.body) != 1 or not isinstance(node.body[0], Expr):
-                continue
-            if not isinstance(node.body[0].value, selected_root_types):
                 continue
             for item in node.items:
                 span = item.context_expr.line_col_span()
@@ -574,6 +606,7 @@ def discover_no_call_body_probes(
                     [],
                 ).append(node)
         for use_site in demands:
+            coordinate = _use_site_coordinate(path, corpus_root, use_site)
             managers = managers_by_span.get(
                 (
                     use_site.get("startLine"),
@@ -584,13 +617,21 @@ def discover_no_call_body_probes(
                 (),
             )
             if not managers:
-                continue
+                raise AttributionInvariantError(
+                    "resolved demand dropped: reason=no-matching-with "
+                    f"coordinate={coordinate} sourceCid={source_cid}"
+                )
             if len(managers) != 1:
                 raise AttributionInvariantError(
-                    f"assertion demand resolves to {len(managers)} With nodes: {use_site!r}"
+                    f"assertion demand resolves to {len(managers)} With nodes: "
+                    f"coordinate={coordinate} useSite={use_site!r}"
                 )
             with_node = managers[0]
             if len(with_node.body) != 1 or not isinstance(with_node.body[0], Expr):
+                # Named disposition: out of the single-expr no-call population.
+                named_exclusions.append(
+                    f"reason=non-single-expr-body coordinate={coordinate}"
+                )
                 continue
             expression = with_node.body[0].value
             family = next(
@@ -602,8 +643,17 @@ def discover_no_call_body_probes(
                 None,
             )
             if family is None:
+                root_name = type(expression).__name__
+                named_exclusions.append(
+                    f"reason=root-outside-selected-families "
+                    f"coordinate={coordinate} root={root_name}"
+                )
                 continue
             if families is not None and family not in families:
+                named_exclusions.append(
+                    f"reason=family-filter coordinate={coordinate} "
+                    f"family={family.value}"
+                )
                 continue
             body_id = (
                 f"{path.relative_to(corpus_root).as_posix()}:"
@@ -621,7 +671,12 @@ def discover_no_call_body_probes(
                     ),
                 )
             )
+    # Surface named exclusions on the function for twin tests (not half-written).
+    discover_no_call_body_probes.last_named_exclusions = tuple(named_exclusions)  # type: ignore[attr-defined]
     return tuple(sorted(probes, key=lambda probe: probe.body_id))
+
+
+discover_no_call_body_probes.last_named_exclusions = ()  # type: ignore[attr-defined]
 
 
 def require_expected_denominators(

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py
@@ -17,22 +17,27 @@ from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
 from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var, str_const
 from sugar_lift_py_tests.outcome.exit_set import Completed, Halted
 from sugar_lift_py_tests.sugar.attribute_sugar import AttributeSugar
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import Attribute
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
 
-class _ValueSugar(Sugar):
+class _ValueSugar(ConstructedTermSugar):
     def __init__(self, value):
-        self.value = value
+        object.__setattr__(self, "value", value)
+        object.__setattr__(self, "site", None)
 
     def desugar(self, ctx=None):
         del ctx
         from sugar_lift_py_tests.outcome import Complete
 
         return Complete(self.value)
+
+    def to_term(self, *, owner: str):
+        del owner
+        return str_const("test-value-sugar")
 
     @classmethod
     def witnesses(cls):
@@ -88,13 +93,21 @@ def test_formal_attribute_completes_or_halts_from_authenticated_actual() -> None
     )
     halted = carrier.discharge({formal.coordinate_cid: NoneValue()})
 
+    from sugar_lift_py_tests.ir import ctor, str_const
+
     assert carrier.demand.operator == "attribute_named"
     assert len(completed.exits) == 1
     assert isinstance(completed.exits[0], Completed)
     assert completed.exits[0].value == TermValue(7)
     assert len(halted.exits) == 1
     assert isinstance(halted.exits[0], Halted)
-    assert halted.exits[0].effect.exception_type_coordinate is not None
+    # Pin the positive identity — `is not None` under an identity-promising
+    # name is a weak tooth; the named AttributeError must be the value.
+    attribute_error = ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("AttributeError")],
+    )
+    assert halted.exits[0].effect.exception_type_coordinate == attribute_error
     assert halted.exits[0].effect.occurrence_id is not None
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_projection.py
@@ -57,13 +57,22 @@ def test_ordinary_function_call_discharge_can_complete() -> None:
 
 
 def test_ordinary_function_call_discharge_can_halt_with_named_identity() -> None:
+    from sugar_lift_py_tests.ir import ctor, str_const
+
     outcome = _call_outcome("None, 2")
 
     assert isinstance(outcome, ExitSet)
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate is not None
+    # Pin the positive identity — `is not None` is a weak tooth under a name
+    # that promises TypeError from None < int.
+    type_error = ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("TypeError")],
+    )
+    assert halted.effect.exception_type_coordinate == type_error
+    assert halted.effect.exception_name == "TypeError"
     assert halted.effect.occurrence_id is not None
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -114,7 +114,12 @@ def test_authenticated_exit_ledger_projects_both_source_coordinates() -> None:
 
 
 def test_nameless_halted_face_stays_loud_in_the_exit_ledger() -> None:
-    """Lying twin: a Halted face cannot borrow authenticated identity."""
+    """Lying twin: a Halted face cannot borrow authenticated identity.
+
+    Undischarged excludes the face from the authenticated-exit tally; the
+    nameless-halted-face tripwire must still fire (coordinates are carried so
+    the scan is reachable). A guard that cannot fire is worse than no guard.
+    """
     report = attribute_body_probes(
         (_probe(ProducerFamily.SUBSCRIPT, _nameless_raise_value),)
     )
@@ -123,9 +128,21 @@ def test_nameless_halted_face_stays_loud_in_the_exit_ledger() -> None:
     assert row.authenticated_exceptional_exits == 0
     assert row.named_refusals == 0
     assert row.undischarged == 1
-    assert report.loud_failure_count == 0
+    assert len(report.exceptional_exit_identity_discrepancies) == 1
+    assert report.exceptional_exit_identity_discrepancies[0].body_id == (
+        "pandas/example.py:1:Subscript"
+    )
+    assert report.exceptional_exit_identity_discrepancies[0].missing == (
+        "exceptionTypeCoordinate",
+        "raiseOccurrence",
+    )
+    assert report.loud_failure_count == 1
     assert "authenticatedExceptionalExit body=" not in report.render()
     assert "undischarged body=pandas/example.py:1:Subscript" in report.render()
+    assert (
+        "NAMELESS HALTED FACE body=pandas/example.py:1:Subscript "
+        "missing=exceptionTypeCoordinate,raiseOccurrence"
+    ) in report.render()
 
 
 def test_corpus_tally_does_not_count_nameless_halted_faces_as_exits() -> None:
@@ -140,7 +157,9 @@ def test_corpus_tally_does_not_count_nameless_halted_faces_as_exits() -> None:
     assert row.undischarged == 503
     assert row.construction_panics == 0
     assert report.outcome_total == 503
-    assert report.loud_failure_count == 0
+    # Each nameless face trips the identity tripwire; exits stay zero.
+    assert len(report.exceptional_exit_identity_discrepancies) == 503
+    assert report.loud_failure_count == 503
 
 
 def test_declared_typed_gap_is_a_named_refusal_not_a_failure() -> None:
@@ -265,9 +284,9 @@ def test_silent_completion_stays_a_separate_loud_discrepancy() -> None:
         "outcomeTotal=0 unaccounted=1" in report.render()
     )
     assert (
-        "OUTCOME TOTAL DISCREPANCY enrolled=1 outcomeTotal=0 unaccounted=1"
-        in report.render()
-    )
+        "OUTCOME TOTAL DISCREPANCY enrolled=1 outcomeTotal=0 discrepancies=1 "
+        "conservationShortfall=0"
+    ) in report.render()
 
 
 def test_construction_panic_keeps_producer_owner_not_probe_family() -> None:
@@ -350,6 +369,85 @@ def test_shared_table_accepts_only_the_canonical_content_manifest() -> None:
         )
 
 
+def test_nameless_tripwire_fires_when_coordinates_are_none() -> None:
+    """Mutation as transaction: None-coordinate effects must trip NAMELESS FACE.
+
+    If the undischarged route dropped coordinates, this scan was dead and a
+    mutation that flipped counts to authenticated exits had nothing catching it.
+    """
+    report = attribute_body_probes(
+        (_probe(ProducerFamily.BINOP, _nameless_raise_value),)
+    )
+
+    assert report.bodies[0].exceptional_exit_coordinates == ((None, None),)
+    assert report.exceptional_exit_identity_discrepancies
+    assert report.loud_failure_count >= 1
+    assert "NAMELESS HALTED FACE body=pandas/example.py:1:BinOp" in report.render()
+
+
+def test_conservation_shortfall_is_a_hard_loud_failure() -> None:
+    """Conservation is asserted, not merely printed.
+
+    A report whose enrolled probes exceed attributed outcomes + discrepancies
+    must exit non-zero via loud_failure_count even without AttributionInvariantError.
+    """
+    from sugar_lift_py_tests.no_call_body_attribution import (
+        AttributionReport,
+        FamilyAttribution,
+    )
+
+    report = AttributionReport(
+        bodies=(),
+        discrepancies=(),
+        exceptional_exit_identity_discrepancies=(),
+        by_family={
+            family: FamilyAttribution(
+                family=family,
+                enrolled=1 if family is ProducerFamily.SUBSCRIPT else 0,
+                authenticated_exceptional_exits=0,
+                named_refusals=0,
+                construction_panics=0,
+                undischarged=0,
+            )
+            for family in ProducerFamily
+        },
+    )
+
+    assert report.conservation_shortfall == 1
+    assert report.loud_failure_count == 1
+    assert "conservationShortfall=1" in report.render()
+
+
+def test_resolved_demand_without_matching_with_is_named_not_silent(
+    tmp_path,
+) -> None:
+    """Lying twin: a resolved demand cannot vanish via bare continue."""
+    from sugar_lift_python_source.canonical import blake3_512_of
+
+    package = tmp_path / "pandas"
+    package.mkdir()
+    path = package / "missing_with.py"
+    source = "def f():\n    return 1\n"
+    path.write_text(source, encoding="utf-8")
+    source_cid = blake3_512_of(source.encode())
+    rows = [
+        {
+            "kind": "context-manager-demand",
+            "gapKind": None,
+            "useSite": {
+                "sourceCid": source_cid,
+                "startLine": 99,
+                "startCol": 0,
+                "endLine": 99,
+                "endCol": 4,
+            },
+        }
+    ]
+
+    with pytest.raises(AttributionInvariantError, match="no-matching-with"):
+        discover_no_call_body_probes({"rows": rows}, package)
+
+
 def test_discovery_classifies_the_body_root_and_excludes_root_calls(
     tmp_path,
 ) -> None:
@@ -412,6 +510,13 @@ def test_discovery_classifies_the_body_root_and_excludes_root_calls(
         (ProducerFamily.BINOP, "binop_body.py:3:BinOp"),
         (ProducerFamily.SUBSCRIPT, "subscript_body.py:3:Subscript"),
     ]
+    # Call root is a named exclusion — never a silent continue that half-writes
+    # "this demand did not exist".
+    exclusions = discover_no_call_body_probes.last_named_exclusions
+    assert any(
+        "root-outside-selected-families" in row and "root=Call" in row
+        for row in exclusions
+    )
 
     binop_only = discover_no_call_body_probes(
         {"rows": rows}, package, families=frozenset({ProducerFamily.BINOP})
@@ -419,6 +524,8 @@ def test_discovery_classifies_the_body_root_and_excludes_root_calls(
     assert [(probe.family, probe.body_id) for probe in binop_only] == [
         (ProducerFamily.BINOP, "binop_body.py:3:BinOp")
     ]
+    subset_exclusions = discover_no_call_body_probes.last_named_exclusions
+    assert any("root-outside-selected-families" in row for row in subset_exclusions)
 
 
 def test_population_selection_never_reads_manager_target_symbol() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_numpy_pandas_panic_audit.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_numpy_pandas_panic_audit.py
@@ -284,6 +284,52 @@ def test_audit_subprocess_times_out_the_current_file_loudly(
     assert records[0].blame == "numpy/slow.py"
 
 
+def test_audit_timeout_names_files_never_attempted(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Lying twin: a timeout must not half-write that later files did not exist.
+
+    Truthful: the blamed file is named AND the unattempted remainder is counted
+    against the target's declared .py population.
+    """
+    monkeypatch.setenv("SUGAR_PANIC_AUDIT_FILE_TIMEOUT_SECS", "0.1")
+    package = tmp_path / "pkg"
+    package.mkdir()
+    (package / "fast.py").write_text("x = 1\n", encoding="utf-8")
+    (package / "slow.py").write_text("x = 2\n", encoding="utf-8")
+    (package / "never.py").write_text("x = 3\n", encoding="utf-8")
+
+    command = [
+        sys.executable,
+        "-c",
+        (
+            "import json, os, time\n"
+            "with open(os.environ['SUGAR_KIT_LOG'], 'a') as handle:\n"
+            "    handle.write(json.dumps({"
+            "'stage': 'enumerate.request', "
+            "'level_name': 'facts', "
+            "'at': {'file': 'pkg/slow.py'}"
+            "}) + '\\n')\n"
+            "time.sleep(30)\n"
+        ),
+        str(package),
+    ]
+
+    result = panic_audit_module._run_subprocess(command, tmp_path)
+
+    assert result.returncode == 124
+    assert "blame=pkg/slow.py" in result.stderr
+    assert "files attempted 1 of 3" in result.stderr
+    assert "files never attempted 2" in result.stderr
+    records = panic_audit_module.extract_panic_records(
+        panic_audit_module.LiftTarget("pkg-all", package),
+        result.stdout,
+        result.stderr,
+    )
+    assert len(records) == 1
+    assert records[0].blame == "pkg/slow.py"
+
+
 def test_cli_exits_red_until_numpy_pandas_have_zero_panics(monkeypatch, capsys) -> None:
     from sugar_lift_py_tests.idd import cli
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -41,9 +41,68 @@ def test_recensus_projects_construction_panic_as_a_loud_counted_gap(
     import sugar_source_tree.tree as tree_mod
 
     monkeypatch.setattr(tree_mod.SourceFile, "__init__", boom)
-    row = module._measure_file(path, relative="fixture.py")
+    row = module._measure_file(path, relative="fixture.py", workspace_root=tmp_path)
     assert row["category"] == "construction-panic"
     assert row["panic"]["type"] == "ConstructionPanic"
+
+
+def test_mid_file_construction_panic_does_not_shrink_function_denominator(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Lying twin: a ConstructionPanic mid-loop must not bank a partial total.
+
+    Truthful: functionsTotal is the declared population, materialized before the
+    walk. A panic that escapes still leaves the full denominator on the row so
+    the board never computes Clean% over a silently shrunken set.
+    """
+    module = _load("control_effect_recensus")
+    path = tmp_path / "multi.py"
+    path.write_text(
+        "def a():\n    return 1\n\ndef b():\n    return 2\n\ndef c():\n    return 3\n",
+        encoding="utf-8",
+    )
+
+    calls = {"n": 0}
+    original_sugar = None
+
+    def flaky_sugar(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise ConstructionPanic(
+                ConstructionGap(
+                    owner="mid-file-panic",
+                    blame="multi.py:b",
+                    observed="second function",
+                    requested="constructed sugar",
+                    fix="keep the panic loud without shrinking the denominator",
+                )
+            )
+        return original_sugar(self, *args, **kwargs)
+
+    # Patch after SourceFile constructs so functions() still lists all three.
+    import sugar_source_tree.nodes as nodes_mod
+
+    # FunctionDef.sugar is the door the recensus calls via function.sugar().
+    target = getattr(nodes_mod, "FunctionDef", None)
+    if target is None:
+        pytest.skip("FunctionDef not importable for patch")
+    original_sugar = target.sugar
+
+    monkeypatch.setattr(target, "sugar", flaky_sugar)
+    # Empty contract_refs avoids provisional demand derivation (unrelated to
+    # the denominator law under test).
+    row = module._measure_file(
+        path,
+        relative="multi.py",
+        workspace_root=tmp_path,
+        contract_refs={},
+    )
+
+    assert row["category"] == "construction-panic"
+    assert row["functionsTotal"] == 3
+    assert row["functionsEnumerated"] == 2
+    assert row["functionsNotEnumerated"] == 1
+    assert row["functionsEnumerationComplete"] is False
 
 
 def test_control_effect_recensus_enumerates_one_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Removes the silent-erasure sins in no-call attribution, control-effect recensus, and panic audit:

- Resolved demand rows no longer vanish via bare `continue` — they enroll, get a named exclusion, or throw with a coordinate.
- `ConstructionPanic` mid-file no longer freezes a partial `functionsTotal` into the board; the declared function population is materialized first.
- Audit timeouts name files never attempted, not only the blamed file.
- Nameless-halted-face tripwire is reachable again (undischarged keeps coordinates) and fires into `loud_failure_count`.
- Conservation shortfall is a hard loud-failure term, not only printed.
- Identity-promising tests pin `TypeError` / `AttributeError` values instead of `is not None`.

## Test plan

- [x] Focused twins: `test_no_call_body_attribution.py` (including tripwire + conservation + named drop)
- [x] Mid-file panic denominator: `test_recensus_panic_collection.py::test_mid_file_construction_panic_does_not_shrink_function_denominator`
- [x] Timeout unattempted files: `test_numpy_pandas_panic_audit.py::test_audit_timeout_names_files_never_attempted`
- [x] Weak-teeth pins: formal projection + attribute native operation demand
- [ ] CI on authenticated cpython-3.12.13 / corpus path

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Name vanished rows and fire the dead nameless-face tripwire in attribution and audit tooling
> - `discover_no_call_body_probes` now raises `AttributionInvariantError` instead of silently skipping a resolved demand that matches no `With` node; named exclusions for filtered-out cases are recorded on a function attribute.
> - `AttributionReport` treats conservation shortfall as a loud failure and includes `conservationShortfall` and discrepancy count in the OUTCOME TOTAL DISCREPANCY render line.
> - `attribute_body_probe` always carries `exceptional_exit_coordinates` (including `None` values) for outcomes with exceptional effects, and returns UNDISCHARGED with coordinates when identity fields are missing.
> - `_measure_file` tracks `functionsEnumerated`/`functionsNotEnumerated`/`functionsEnumerationComplete` separately from the declared total, so a mid-file `ConstructionPanic` no longer shrinks the function denominator.
> - Timeout stderr in `_run_subprocess_with_file_watchdog` now reports how many files were attempted and, when determinable, how many were never attempted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e7c048.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->