### PR TITLE
Make source-audit ledger tooth real; instrument CID-alone presence class

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/source_audit_presence_identity_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/source_audit_presence_identity_law.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""R_source_audit_cid_alone_presence — source-audit status never keys by CID alone.
+
+SIN CLUSTER 7: two producers of the source-audit product keyed presence by
+CID alone while ``MinorityReport`` partitions by
+``(file, line, col, kind, cid)``. Equal source text seals to one CID at
+distinct loci; those seats are distinct obligations. CID-alone status promotes
+every seat that shares a present CID to Blue while ``report.R`` still counts
+the absent seat — ``warranted + R`` can exceed ``source_loci``, and Yellow
+silently becomes Blue.
+
+**THE LAW.** Production code that derives source-audit ``warranted`` /
+``unresolved`` status from a set of present CIDs (or from ``entry.cid in
+present_*`` without the full roll-call coordinate) is an offender. The one
+door is ``source_audit_from_report`` (full-tuple presence).
+
+Rung: **auditor** — the domain is open Python that can re-derive the product
+inline; the type system cannot close free dict construction of wire rows.
+Retirement path: if source-audit totals become fields of a single typed
+partition value whose constructors only accept full-tuple present keys, this
+auditor deletes itself.
+
+No baseline, no threshold, no allowlist. Exit 1 while R > 0.
+
+    python scripts/source_audit_presence_identity_law.py [ROOT ...]
+    python scripts/source_audit_presence_identity_law.py --self-test
+"""
+
+from __future__ import annotations
+
+# Not the board. This module measures its own named denominator.
+SCOREBOARD_AUTHORITY = False
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class Offender:
+    path: str
+    line: int
+    kind: str
+    expression: str
+
+    def to_json(self) -> dict:
+        return {
+            "path": self.path,
+            "line": self.line,
+            "kind": self.kind,
+            "expression": self.expression,
+            "law": "source-audit presence never keys by CID alone",
+            "fix": (
+                "route through source_audit_from_report(report, file_rel); "
+                "key presence by (file, line, col, kind, cid) — the same "
+                "tuple MinorityReport uses"
+            ),
+            "retirement": (
+                "typed partition value whose constructors only accept "
+                "full-tuple present keys makes this auditor deletable"
+            ),
+        }
+
+
+def _expr_text(node: ast.AST, source: str) -> str:
+    try:
+        return ast.get_source_segment(source, node) or ast.dump(node)
+    except Exception:
+        return ast.dump(node)
+
+
+def _is_cid_attr(node: ast.AST) -> bool:
+    return isinstance(node, ast.Attribute) and node.attr == "cid"
+
+
+def _comp_targets_cid_from_present(node: ast.AST) -> bool:
+    """``{e.cid for e in report.present}`` / ``{entry.cid for entry in ...present}``."""
+    if not isinstance(node, (ast.SetComp, ast.ListComp, ast.GeneratorExp)):
+        return False
+    if not _is_cid_attr(node.elt):
+        return False
+    for gen in node.generators:
+        # iter ends with .present (Name.present or Attribute.present)
+        it = gen.iter
+        if isinstance(it, ast.Attribute) and it.attr == "present":
+            return True
+        if isinstance(it, ast.Name) and it.id in {"present", "present_nodes"}:
+            return True
+    return False
+
+
+def _assigns_present_cids(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Assign):
+        return False
+    for target in node.targets:
+        if isinstance(target, ast.Name) and (
+            target.id == "present_cids"
+            or target.id.endswith("_cids")
+            and "present" in target.id
+        ):
+            if _comp_targets_cid_from_present(node.value):
+                return True
+            # set([...]) wrapping a gen
+            if (
+                isinstance(node.value, ast.Call)
+                and isinstance(node.value.func, ast.Name)
+                and node.value.func.id == "set"
+                and node.value.args
+                and _comp_targets_cid_from_present(node.value.args[0])
+            ):
+                return True
+    return False
+
+
+def _status_by_cid_membership(node: ast.AST) -> bool:
+    """``"warranted" if entry.cid in present_cids else "unresolved"`` shapes."""
+    if not isinstance(node, ast.IfExp):
+        return False
+    # body/orelse string constants warranted/unresolved
+    strings: set[str] = set()
+    for arm in (node.body, node.orelse):
+        if isinstance(arm, ast.Constant) and isinstance(arm.value, str):
+            strings.add(arm.value)
+    if not {"warranted", "unresolved"}.issubset(strings):
+        return False
+    test = node.test
+    # entry.cid in something
+    if isinstance(test, ast.Compare) and len(test.ops) == 1 and isinstance(
+        test.ops[0], ast.In
+    ):
+        left = test.left
+        if _is_cid_attr(left):
+            return True
+        # negated: entry.cid not in ...
+    if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+        inner = test.operand
+        if (
+            isinstance(inner, ast.Compare)
+            and len(inner.ops) == 1
+            and isinstance(inner.ops[0], ast.In)
+            and _is_cid_attr(inner.left)
+        ):
+            return True
+    return False
+
+
+def offenders_in_source(text: str, *, path: str) -> list[Offender]:
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        raise
+    found: list[Offender] = []
+    for node in ast.walk(tree):
+        if _assigns_present_cids(node):
+            found.append(
+                Offender(
+                    path=path,
+                    line=getattr(node, "lineno", 0),
+                    kind="present-cids-set",
+                    expression=_expr_text(node, text),
+                )
+            )
+        if _status_by_cid_membership(node):
+            found.append(
+                Offender(
+                    path=path,
+                    line=getattr(node, "lineno", 0),
+                    kind="status-by-cid-membership",
+                    expression=_expr_text(node, text),
+                )
+            )
+        # bare setcomp of .cid from present not only in assign (e.g. inline)
+        if _comp_targets_cid_from_present(node) and not isinstance(
+            getattr(node, "parent", None), ast.Assign
+        ):
+            # avoid double-counting when parent assign already caught
+            parent_is_assign_value = False
+            # walk doesn't give parent; re-check: if this node is value of an
+            # Assign we already emit present-cids-set. Detect via enclosing:
+            # skip if any Assign in walk has this as value — done below by
+            # only emitting setcomp when not under Assign we already flag.
+            pass
+    # Second pass: standalone setcomps of present CIDs used anywhere
+    for node in ast.walk(tree):
+        if not _comp_targets_cid_from_present(node):
+            continue
+        # Skip if this exact node is the value of an Assign we already flagged
+        already = any(
+            o.line == getattr(node, "lineno", 0) and o.kind == "present-cids-set"
+            for o in found
+        )
+        if already:
+            continue
+        # Only flag if this appears as a set() arg or bare setcomp assigned
+        # — covered by assign. For bare setcomp as RHS of Assign of other
+        # names, _assigns_present_cids may miss; catch generic present.cid set:
+        found.append(
+            Offender(
+                path=path,
+                line=getattr(node, "lineno", 0),
+                kind="present-cid-setcomp",
+                expression=_expr_text(node, text),
+            )
+        )
+    # Dedup by (line, kind)
+    uniq: dict[tuple[int, str], Offender] = {}
+    for o in found:
+        uniq[(o.line, o.kind)] = o
+    return sorted(uniq.values(), key=lambda o: (o.line, o.kind))
+
+
+def scan_roots(roots: Iterable[Path]) -> tuple[list[Offender], list[dict]]:
+    """Scan production packages only (src trees), not tests/scripts/docs."""
+    offenders: list[Offender] = []
+    unreadable: list[dict] = []
+    skip_parts = {
+        "tests",
+        "scripts",
+        "measurements",
+        ".git",
+        "__pycache__",
+        "vendor",
+        "site-packages",
+    }
+    for root in roots:
+        root = root.resolve()
+        for path in sorted(root.rglob("*.py")):
+            parts = set(path.parts)
+            if parts & skip_parts:
+                continue
+            # production src only when under a package src/
+            if "src" not in path.parts:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError) as error:
+                unreadable.append({"path": str(path), "reason": str(error)})
+                continue
+            try:
+                offenders.extend(offenders_in_source(text, path=str(path)))
+            except SyntaxError as error:
+                unreadable.append({"path": str(path), "reason": f"syntax: {error}"})
+    return offenders, unreadable
+
+
+# ---------------------------------------------------------------------------
+# Historical twins — the shapes SIN CLUSTER 7 actually shipped
+# ---------------------------------------------------------------------------
+
+HISTORICAL_LIFT_RPC_CID_ALONE = '''
+def _roll_call_audit_leaf(full_path, file_rel):
+    report = discharge(source_file)
+    present_cids = {entry.cid for entry in report.present}
+    loci = [
+        {
+            "status": "warranted" if entry.cid in present_cids else "unresolved",
+            "kind": entry.kind,
+            "source_cid": entry.cid,
+        }
+        for entry in report.roster
+    ]
+    warranted = sum(row["status"] == "warranted" for row in loci)
+    source_audit = {
+        "totals": {
+            "source_loci": len(loci),
+            "source_warranted": warranted,
+            "source_unresolved": report.R,
+        },
+    }
+    return source_audit
+'''
+
+HISTORICAL_TREE_ENUMERATE_CID_ALONE = '''
+def source_audit_from_roll_call(full_path, file_rel):
+    report = discharge(sf)
+    present_cids = {e.cid for e in report.present}
+    loci = []
+    for entry in report.roster:
+        status = "warranted" if entry.cid in present_cids else "unresolved"
+        loci.append({"status": status, "source_cid": entry.cid})
+    warranted = sum(1 for locus in loci if locus["status"] == "warranted")
+    unresolved = len(loci) - warranted
+    return {"loci": loci, "totals": {"source_warranted": warranted, "source_unresolved": unresolved}}
+'''
+
+PRODUCTION_ONE_DOOR = '''
+def source_audit_from_report(report, file_rel):
+    present_keys = {_roll_call_identity(entry) for entry in report.present}
+    loci = []
+    for entry in report.roster:
+        status = (
+            "warranted" if _roll_call_identity(entry) in present_keys else "unresolved"
+        )
+        loci.append({"status": status})
+    return {"loci": loci}
+
+def _roll_call_audit_leaf(full_path, file_rel):
+    report = discharge(source_file)
+    source_audit = source_audit_from_report(report, file_rel)
+    return source_audit
+'''
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def expect(label: str, source: str, *, min_offenders: int) -> None:
+        found = offenders_in_source(source, path=f"<{label}>")
+        if len(found) < min_offenders:
+            failures.append(
+                f"{label}: expected >= {min_offenders} offenders, got "
+                f"{[(o.kind, o.line) for o in found]}"
+            )
+
+    def expect_clean(label: str, source: str) -> None:
+        found = offenders_in_source(source, path=f"<{label}>")
+        if found:
+            failures.append(
+                f"{label}: expected clean, got {[(o.kind, o.line) for o in found]}"
+            )
+
+    expect("historical lift_rpc CID-alone", HISTORICAL_LIFT_RPC_CID_ALONE, min_offenders=2)
+    expect(
+        "historical tree_enumerate CID-alone",
+        HISTORICAL_TREE_ENUMERATE_CID_ALONE,
+        min_offenders=2,
+    )
+    expect_clean("production one door", PRODUCTION_ONE_DOOR)
+
+    for line in failures:
+        print(f"SELF-TEST FAIL {line}")
+    print(f"self-test: {'FAIL' if failures else 'PASS'} ({len(failures)} failures)")
+    return 1 if failures else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("roots", nargs="*", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    default_root = Path(__file__).resolve().parents[1]  # sugar-lift-py-tests
+    roots = args.roots or [default_root]
+    offenders, unreadable = scan_roots(roots)
+    report = {
+        "law": "R_source_audit_cid_alone_presence",
+        "R": len(offenders),
+        "offenders": [o.to_json() for o in offenders],
+        "unreadable": unreadable,
+        "retirement": (
+            "typed partition value whose constructors only accept full-tuple "
+            "present keys"
+        ),
+    }
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"R_source_audit_cid_alone_presence = {len(offenders)}")
+        for o in offenders:
+            print(f"  {o.path}:{o.line} [{o.kind}] {o.expression!r:.120}")
+        for row in unreadable:
+            print(f"  UNREADABLE {row['path']}: {row['reason']}")
+    return 1 if offenders or unreadable else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -432,6 +432,49 @@ def _roll_call_identity(entry) -> tuple:
     return (entry.file, entry.start_line, entry.start_col, entry.kind, entry.cid)
 
 
+def assert_source_audit_ledger(
+    *,
+    warranted: int,
+    unresolved: int,
+    source_loci: int,
+    report_R: int,
+) -> None:
+    """Panic tooth for source-audit ledger conservation.
+
+    The historical dual-producer drift (SIN CLUSTER 7 / lift_rpc path) was:
+    status keyed by CID alone (inflating warranted) while ``source_unresolved``
+    was taken from ``report.R`` (still counting the absent shared-CID seat).
+    Then ``warranted + report.R > source_loci`` and Yellow silently became Blue.
+
+    The tooth that sings is therefore:
+
+        warranted + report_R == source_loci
+        AND unresolved == report_R
+
+    A status-only sum ``warranted + unresolved == source_loci`` is NOT a tooth:
+    when every locus is assigned exactly one of {warranted, unresolved}, that
+    equality is tautological and stays green under the illegal CID-alone map.
+    That decorative shell was deleted; this function is the live replacement.
+
+    Retirement path: if presence status becomes unconstructable except via
+    full-tuple identity (typed present set / closed seat key), this assert
+    remains as contact panic for ledger arithmetic only, or retires if the
+    wire totals become derived fields of a single typed partition value.
+    """
+    if warranted + report_R != source_loci:
+        raise AssertionError(
+            f"source-audit conservation broken: warranted({warranted}) + "
+            f"report.R({report_R}) != source_loci({source_loci}); "
+            "CID-alone presence inflates warranted while R still counts the "
+            "absent seat — key presence by (file, line, col, kind, cid)"
+        )
+    if unresolved != report_R:
+        raise AssertionError(
+            f"source-audit unresolved({unresolved}) != report.R({report_R}); "
+            "presence must use the full roll-call identity, not CID alone"
+        )
+
+
 def source_audit_from_report(report, file_rel: str) -> dict:
     """ONE door: project a ``MinorityReport`` onto the source-audit wire.
 
@@ -441,7 +484,8 @@ def source_audit_from_report(report, file_rel: str) -> dict:
     There is no second producer of ``source_unresolved`` (no independent
     ``report.R`` path, no CID-only set kept "in sync").
 
-    Conservation is a tooth, not a print: ``warranted + unresolved == source_loci``.
+    Conservation is a tooth, not a print: ``warranted + report.R == source_loci``
+    (and ``unresolved == report.R``). See ``assert_source_audit_ledger``.
     """
     present_keys = {_roll_call_identity(entry) for entry in report.present}
     loci = []
@@ -465,16 +509,12 @@ def source_audit_from_report(report, file_rel: str) -> dict:
     warranted = sum(1 for locus in loci if locus["status"] == "warranted")
     unresolved = sum(1 for locus in loci if locus["status"] == "unresolved")
     source_loci = len(loci)
-    if warranted + unresolved != source_loci:
-        raise AssertionError(
-            f"source-audit conservation broken: warranted({warranted}) + "
-            f"unresolved({unresolved}) != source_loci({source_loci})"
-        )
-    if unresolved != report.R:
-        raise AssertionError(
-            f"source-audit unresolved({unresolved}) != report.R({report.R}); "
-            "presence must use the full roll-call identity, not CID alone"
-        )
+    assert_source_audit_ledger(
+        warranted=warranted,
+        unresolved=unresolved,
+        source_loci=source_loci,
+        report_R=report.R,
+    )
     return {
         "role": file_rel,
         "loci": loci,

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_identity_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_identity_law.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""R_source_audit_cid_alone_presence — auditor for SIN CLUSTER 7 residual class.
+
+The product door keys presence by full roll-call identity. This instrument
+keeps the *class* of CID-alone status producers red if it returns: historical
+shapes trip the scanner; the production one-door shape stays clean; live
+``src/`` packages measure R=0.
+
+Ladder note: auditor (not type) because free Python can re-derive the wire
+dict. Retirement: typed partition constructors that only accept full-tuple
+present keys — then delete this file.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_KIT = Path(__file__).resolve().parents[1]
+_SCANNER_PATH = _KIT / "scripts" / "source_audit_presence_identity_law.py"
+_SPEC = importlib.util.spec_from_file_location(
+    "source_audit_presence_identity_law", _SCANNER_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_SCANNER = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _SCANNER
+_SPEC.loader.exec_module(_SCANNER)
+
+
+def _offenders(source: str):
+    return _SCANNER.offenders_in_source(source, path="<twin>")
+
+
+def test_historical_lift_rpc_cid_alone_is_caught() -> None:
+    """Lying twin: the dual-producer shape that inflated warranted."""
+    found = _offenders(_SCANNER.HISTORICAL_LIFT_RPC_CID_ALONE)
+    kinds = {o.kind for o in found}
+    assert "present-cids-set" in kinds or "present-cid-setcomp" in kinds, found
+    assert "status-by-cid-membership" in kinds, found
+
+
+def test_historical_tree_enumerate_cid_alone_is_caught() -> None:
+    found = _offenders(_SCANNER.HISTORICAL_TREE_ENUMERATE_CID_ALONE)
+    kinds = {o.kind for o in found}
+    assert "present-cids-set" in kinds or "present-cid-setcomp" in kinds, found
+    assert "status-by-cid-membership" in kinds, found
+
+
+def test_production_one_door_is_clean() -> None:
+    assert _offenders(_SCANNER.PRODUCTION_ONE_DOOR) == []
+
+
+def test_live_production_src_holds_at_zero() -> None:
+    """Zero is measured, not inferred. Planted historical shape still trips."""
+    offenders, unreadable = _SCANNER.scan_roots([_KIT])
+    assert unreadable == [], unreadable
+    assert offenders == [], [o.to_json() for o in offenders]
+
+
+def test_planted_offender_trips_live_scan(tmp_path: Path) -> None:
+    """Lying twin against the live scan path: insert the historical shape."""
+    src = tmp_path / "src" / "planted_pkg"
+    src.mkdir(parents=True)
+    (src / "bad.py").write_text(
+        _SCANNER.HISTORICAL_LIFT_RPC_CID_ALONE, encoding="utf-8"
+    )
+    offenders, unreadable = _SCANNER.scan_roots([tmp_path])
+    assert unreadable == []
+    assert len(offenders) >= 1, "planted CID-alone producer must be red"
+    assert any(o.kind == "status-by-cid-membership" for o in offenders)
+
+
+def test_scanner_self_test_passes() -> None:
+    assert _SCANNER.self_test() == 0
+
+
+# ---------------------------------------------------------------------------
+# Conservation tooth — plant the illegal ledger; status-only sum stays green
+# ---------------------------------------------------------------------------
+
+
+def test_ledger_tooth_fires_on_historical_mixed_keying() -> None:
+    """THE tooth that must fail under old lift_rpc totals.
+
+    warranted=2 (CID-alone status), report.R=1 (absent seat), source_loci=2.
+    Status-only conservation (warranted + unresolved_from_status) would see
+    unresolved=0 and pass 2+0==2 — decorative. The live tooth uses report.R.
+    """
+    from sugar_lift_py_tests.tree_enumerate import assert_source_audit_ledger
+
+    with pytest.raises(AssertionError, match="report.R"):
+        assert_source_audit_ledger(
+            warranted=2,
+            unresolved=0,
+            source_loci=2,
+            report_R=1,
+        )
+
+
+def test_ledger_tooth_status_only_sum_is_not_sufficient() -> None:
+    """Prove the deleted shell cannot be the instrument: 2+0==2 is green."""
+    warranted, unresolved, source_loci = 2, 0, 2
+    # Decorative form — green under the illegal state:
+    assert warranted + unresolved == source_loci
+    # Live form — red under the same numbers:
+    from sugar_lift_py_tests.tree_enumerate import assert_source_audit_ledger
+
+    with pytest.raises(AssertionError):
+        assert_source_audit_ledger(
+            warranted=warranted,
+            unresolved=unresolved,
+            source_loci=source_loci,
+            report_R=1,
+        )
+
+
+def test_ledger_tooth_quiet_when_partition_honest() -> None:
+    from sugar_lift_py_tests.tree_enumerate import assert_source_audit_ledger
+
+    assert_source_audit_ledger(
+        warranted=1, unresolved=1, source_loci=2, report_R=1
+    )
+    assert_source_audit_ledger(
+        warranted=2, unresolved=0, source_loci=2, report_R=0
+    )
+    assert_source_audit_ledger(
+        warranted=0, unresolved=2, source_loci=2, report_R=2
+    )
+
+
+def test_lift_rpc_calls_the_one_door_not_cid_alone() -> None:
+    """Product path: _roll_call_audit_leaf must not re-derive presence by CID."""
+    import inspect
+
+    from sugar_lift_py_tests import lift_rpc
+
+    src = inspect.getsource(lift_rpc._roll_call_audit_leaf)
+    assert "source_audit_from_report" in src
+    body = src.split('"""', 2)[-1] if '"""' in src else src
+    assert "present_cids" not in body
+    assert "entry.cid in" not in body

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_tuple.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_tuple.py
@@ -95,15 +95,20 @@ def _status_by_line(audit: dict) -> dict[int, str]:
     return {row["locus"]["line"]: row["status"] for row in audit["loci"]}
 
 
-def _assert_conserved(audit: dict) -> None:
+def _assert_conserved(audit: dict, *, report_R: int) -> None:
+    """Live ledger tooth — requires report.R, not status-only sum.
+
+    Status-only ``warranted + unresolved == source_loci`` is tautological when
+    every locus is binary; it stays green under CID-alone partial presence.
+    """
+    from sugar_lift_py_tests.tree_enumerate import assert_source_audit_ledger
+
     totals = audit["totals"]
-    assert (
-        totals["source_warranted"] + totals["source_unresolved"]
-        == totals["source_loci"]
-    ), (
-        f"conservation broken: warranted({totals['source_warranted']}) + "
-        f"unresolved({totals['source_unresolved']}) != "
-        f"source_loci({totals['source_loci']})"
+    assert_source_audit_ledger(
+        warranted=totals["source_warranted"],
+        unresolved=totals["source_unresolved"],
+        source_loci=totals["source_loci"],
+        report_R=report_R,
     )
 
 
@@ -135,7 +140,7 @@ def test_lying_twin_shared_cid_partial_presence_does_not_warrant_both() -> None:
     assert totals["source_warranted"] == 1
     assert totals["source_unresolved"] == 1
     assert totals["source_loci"] == 2
-    _assert_conserved(audit)
+    _assert_conserved(audit, report_R=report.R)
     assert totals["source_unresolved"] == report.R
 
 
@@ -178,7 +183,7 @@ def test_lying_twin_lift_rpc_roll_call_uses_the_one_door(
         1: "warranted",
         2: "unresolved",
     }, f"lift_rpc still keys presence by CID alone: {_status_by_line(audit)}"
-    _assert_conserved(audit)
+    _assert_conserved(audit, report_R=report.R)
     assert audit["totals"]["source_unresolved"] == report.R
 
 
@@ -206,7 +211,7 @@ def test_truthful_twin_both_present_both_warranted() -> None:
         "source_warranted": 2,
         "source_unresolved": 0,
     }
-    _assert_conserved(audit)
+    _assert_conserved(audit, report_R=report.R)
     assert report.R == 0
 
 
@@ -227,7 +232,7 @@ def test_truthful_twin_neither_present_both_unresolved() -> None:
         "source_warranted": 0,
         "source_unresolved": 2,
     }
-    _assert_conserved(audit)
+    _assert_conserved(audit, report_R=report.R)
     assert audit["totals"]["source_unresolved"] == report.R
 
 
@@ -241,10 +246,10 @@ def test_truthful_twin_roll_call_path_conserves_on_real_source(tmp_path: Path) -
     path = tmp_path / "m.py"
     path.write_text("def f():\n    return 1\n", encoding="utf-8")
     audit = source_audit_from_roll_call(path, "m.py")
-    _assert_conserved(audit)
 
     reporter = CollectingReporter()
     report = discharge(SourceFile.from_path(str(path), reporter=reporter))
+    _assert_conserved(audit, report_R=report.R)
     assert audit["totals"]["source_unresolved"] == report.R
     assert audit["totals"]["source_loci"] == len(report.roster)
 


### PR DESCRIPTION
## Rung climb (not a gate review of #6947)

Adversarial review of #6947 found the **status-sum conservation assert was decorative enforcement**: under binary locus status, `warranted + unresolved == source_loci` is tautological and stays green on the historical illegal ledger (`warranted=2`, `report.R=1`, `source_loci=2`). Relabeling is not a tooth. This PR replaces the shell with a plantable instrument and ratchets the offender class.

### Ladder choice

| Question | Answer |
| --- | --- |
| Type system forbid? | No — free Python can re-derive the wire dict |
| One construction door that refuses? | Presence door already exists (`source_audit_from_report`); cannot type-close re-derivation |
| Panic at contact? | **Yes for ledger** — `assert_source_audit_ledger` |
| Else auditor | **Yes for class return** — AST scan for CID-alone status producers |

### Which shell this deletes

- **Deleted shell:** the status-only sum `AssertionError` in `source_audit_from_report` that could not fail under the dual-producer drift shape.
- **Replacement:** `assert_source_audit_ledger(warranted + report.R == source_loci ∧ unresolved == report.R)` with a lying twin that plants `warranted=2, unresolved=0, R=1` and asserts red; proves status-only sum would have stayed green.
- **New ratchet:** `scripts/source_audit_presence_identity_law.py` — `R_source_audit_cid_alone_presence`. Historical lift_rpc / tree_enumerate CID-alone shapes trip; production one-door is clean; live `src/` measures **R=0**.

### R / Epsilon / floors

| Axis | Before | Epsilon R | After (measured) |
| --- | --- | --- | --- |
| `R_source_audit_cid_alone_presence` | uninstrumented (class could return silently) | → 0 | **0** (live scan) |
| `R_decorative_ledger_tooth` | 1 dead assert claiming conservation | → 0 | **deleted**; live tooth with plantable fail |

**Floors preserved:** full-tuple presence door from #6947; shared-CID distinct seats; product lying twin status map; no test skip/xfail/deletion of coverage.

**Retirement path (auditor):** when source-audit totals become fields of a typed partition value whose constructors only accept full-tuple present keys, delete `source_audit_presence_identity_law.py`.

### Test plan

```bash
# self-test + live scan (exit codes captured, not piped)
python implementations/python/sugar-lift-py-tests/scripts/source_audit_presence_identity_law.py --self-test
# SELF_EXIT=0

python implementations/python/sugar-lift-py-tests/scripts/source_audit_presence_identity_law.py implementations/python/sugar-lift-py-tests
# R_source_audit_cid_alone_presence = 0; SCAN_EXIT=0

# collect count before colour
pytest .../test_source_audit_presence_tuple.py .../test_source_audit_presence_identity_law.py --collect-only
# 15 tests collected

pytest .../test_source_audit_presence_tuple.py .../test_source_audit_presence_identity_law.py -q
# 15 passed
```

Stacks on #6947 (`sin-cluster-7-presence-tuple`). Retarget to `main` after that merges if needed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix source-audit ledger to key presence by full roll-call identity instead of CID alone
> - Replaces CID-only presence keying (`entry.cid in present_cids`) with full roll-call identity keying in `source_audit_from_report` and `source_audit_from_roll_call` in [tree_enumerate.py](https://github.com/TSavo/sugar/pull/6950/files#diff-1a883a4eea1b53f1ee91261df4ca5f694dfda233c883ddab24f920fd9610931e), fixing incorrect warranted/unresolved accounting when multiple seats share a CID at distinct loci.
> - Updates [lift_rpc.py](https://github.com/TSavo/sugar/pull/6950/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) to delegate `sourceAudit` construction to `source_audit_from_report` instead of inline CID-only derivation.
> - Adds an AST-based scanner CLI ([source_audit_presence_identity_law.py](https://github.com/TSavo/sugar/pull/6950/files#diff-6e3e908ea41a321b8a7a7e76a782d8ee38658b74290398d954eb1e213b58acde)) that detects CID-alone keying patterns in source-audit producers, with a self-test harness and JSON output.
> - Adds test suites covering: scanner detection of historical offenders, zero offenders in the live repo, conservation ledger assertions on mixed keying, and end-to-end tuple presence with shared CIDs at distinct loci.
> - Behavioral Change: `unresolved` is now counted from per-entry statuses rather than derived as `len(loci) - warranted`, which changes totals when entries share a CID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36870f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->