### PR TITLE
DiscoveryDisposition one door; delete last_named_exclusions shell

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -83,6 +83,20 @@ class BodyAttribution:
     detail: str
     exceptional_exit_coordinates: tuple[tuple[object | None, object | None], ...] = ()
 
+    def __post_init__(self) -> None:
+        # Construction door: UNDISCHARGED with empty coordinates re-kills the
+        # nameless-face tripwire (scan walks exceptional_exit_coordinates only).
+        # Refuse construction so the dead-guard shape is unwritable.
+        if (
+            self.outcome is AttributionOutcome.UNDISCHARGED
+            and not self.exceptional_exit_coordinates
+        ):
+            raise AttributionInvariantError(
+                f"{self.body_id}: UNDISCHARGED requires exceptional_exit_coordinates "
+                "so the nameless-face tripwire can fire; empty coordinates are the "
+                "dead-guard sin (pass (None, None) faces when identity is unproven)"
+            )
+
 
 @dataclass(frozen=True)
 class AttributionDiscrepancy:
@@ -95,6 +109,40 @@ class AttributionDiscrepancy:
 class ExceptionalExitIdentityDiscrepancy:
     body_id: str
     missing: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class NamedDemandExclusion:
+    """A resolved demand accounted outside the enrolled no-call population.
+
+    One of three lawful dispositions for a resolved demand (enroll | exclude | throw).
+    Never a bare continue and never a function-attribute side channel.
+    """
+
+    reason: str
+    coordinate: str
+    root: str | None = None
+    family: str | None = None
+
+    def render(self) -> str:
+        parts = [f"reason={self.reason}", f"coordinate={self.coordinate}"]
+        if self.root is not None:
+            parts.append(f"root={self.root}")
+        if self.family is not None:
+            parts.append(f"family={self.family}")
+        return " ".join(parts)
+
+
+@dataclass(frozen=True)
+class DiscoveryDisposition:
+    """One door for discovery: enrolled probes plus named exclusions.
+
+    Return value of ``discover_no_call_body_probes``. Callers read ``.probes`` and
+    ``.named_exclusions`` — there is no ``last_named_exclusions`` attribute.
+    """
+
+    probes: tuple[BodyProbe, ...]
+    named_exclusions: tuple[NamedDemandExclusion, ...]
 
 
 @dataclass(frozen=True)
@@ -513,16 +561,17 @@ def discover_no_call_body_probes(
     corpus_root: Path,
     *,
     families: frozenset[ProducerFamily] | None = None,
-) -> tuple[BodyProbe, ...]:
+) -> DiscoveryDisposition:
     """Project authenticated assertion demands to their native body producer.
 
     Every resolved context-manager demand participates.  The native body root
     selects the producer family; no manager or vendor spelling selects it or
     grants semantic behavior to a producer.
 
-    A resolved demand that does not enroll is never a bare ``continue``: it is
-    either a named exclusion (out of this instrument's selected root types) or
-    an ``AttributionInvariantError`` that names the coordinate and reason.
+    One door: return ``DiscoveryDisposition(probes, named_exclusions)``. A resolved
+    demand that does not enroll is either a ``NamedDemandExclusion`` on that
+    object or an ``AttributionInvariantError`` that names the coordinate and
+    reason. There is no function-attribute side channel.
     """
     from sugar_lift_py_tests.context_manager_resolution import (
         TreeConstructionContextV1,
@@ -540,6 +589,8 @@ def discover_no_call_body_probes(
     )
     from sugar_source_tree.tree import SourceFile, SourceTree
 
+    # Full recognition map — family filter is a post-recognition disposition,
+    # never a pre-filter that collapses family-filter into root-outside.
     family_by_type = {
         Subscript: ProducerFamily.SUBSCRIPT,
         BinOp: ProducerFamily.BINOP,
@@ -548,12 +599,7 @@ def discover_no_call_body_probes(
         UnaryOp: ProducerFamily.UNARYOP,
         BoolOp: ProducerFamily.BOOLOP,
     }
-    selected_families = families or frozenset(ProducerFamily)
-    family_by_type = {
-        node_type: family
-        for node_type, family in family_by_type.items()
-        if family in selected_families
-    }
+    selected_families = families if families is not None else frozenset(ProducerFamily)
     paths_by_cid = {}
     for path in SourceTree(corpus_root).paths():
         paths_by_cid[blake3_512_of(path.read_bytes())] = path
@@ -572,7 +618,7 @@ def discover_no_call_body_probes(
 
     probes = []
     seen = set()
-    named_exclusions: list[str] = []
+    named_exclusions: list[NamedDemandExclusion] = []
     for source_cid, demands in demands_by_source.items():
         path = paths_by_cid.get(source_cid)
         if path is None:
@@ -628,9 +674,11 @@ def discover_no_call_body_probes(
                 )
             with_node = managers[0]
             if len(with_node.body) != 1 or not isinstance(with_node.body[0], Expr):
-                # Named disposition: out of the single-expr no-call population.
                 named_exclusions.append(
-                    f"reason=non-single-expr-body coordinate={coordinate}"
+                    NamedDemandExclusion(
+                        reason="non-single-expr-body",
+                        coordinate=coordinate,
+                    )
                 )
                 continue
             expression = with_node.body[0].value
@@ -643,16 +691,22 @@ def discover_no_call_body_probes(
                 None,
             )
             if family is None:
-                root_name = type(expression).__name__
                 named_exclusions.append(
-                    f"reason=root-outside-selected-families "
-                    f"coordinate={coordinate} root={root_name}"
+                    NamedDemandExclusion(
+                        reason="root-outside-selected-families",
+                        coordinate=coordinate,
+                        root=type(expression).__name__,
+                    )
                 )
                 continue
-            if families is not None and family not in families:
+            if family not in selected_families:
                 named_exclusions.append(
-                    f"reason=family-filter coordinate={coordinate} "
-                    f"family={family.value}"
+                    NamedDemandExclusion(
+                        reason="family-filter",
+                        coordinate=coordinate,
+                        family=family.value,
+                        root=type(expression).__name__,
+                    )
                 )
                 continue
             body_id = (
@@ -671,12 +725,11 @@ def discover_no_call_body_probes(
                     ),
                 )
             )
-    # Surface named exclusions on the function for twin tests (not half-written).
-    discover_no_call_body_probes.last_named_exclusions = tuple(named_exclusions)  # type: ignore[attr-defined]
-    return tuple(sorted(probes, key=lambda probe: probe.body_id))
+    return DiscoveryDisposition(
+        probes=tuple(sorted(probes, key=lambda probe: probe.body_id)),
+        named_exclusions=tuple(named_exclusions),
+    )
 
-
-discover_no_call_body_probes.last_named_exclusions = ()  # type: ignore[attr-defined]
 
 
 def require_expected_denominators(
@@ -723,8 +776,11 @@ def run_authenticated_attribution(
         payload = pull_shared_demand_table(
             repo_root, Path(scratch) / "python-demand-table.json"
         )
+    disposition = discover_no_call_body_probes(
+        payload, corpus.root, families=families
+    )
     probes = require_expected_denominators(
-        discover_no_call_body_probes(payload, corpus.root, families=families),
+        disposition.probes,
         families=families,
     )
     return attribute_body_probes(probes)

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_completion_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_completion_conservation.py
@@ -96,7 +96,7 @@ def test_all_34_compare_completions_publish_authenticated_compare_exits(
             payload,
             corpus.root,
             families=frozenset({ProducerFamily.COMPARE}),
-        ),
+        ).probes,
         families=frozenset({ProducerFamily.COMPARE}),
     )
     probes = tuple(

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -14,6 +14,8 @@ from sugar_lift_py_tests.no_call_body_attribution import (
     BodyAttribution,
     BodyProbe,
     DemandTableRefusal,
+    DiscoveryDisposition,
+    NamedDemandExclusion,
     ProducerFamily,
     attribute_body_probe,
     attribute_body_probes,
@@ -504,28 +506,38 @@ def test_discovery_classifies_the_body_root_and_excludes_root_calls(
             }
         )
 
-    probes = discover_no_call_body_probes({"rows": rows}, package)
+    disposition = discover_no_call_body_probes({"rows": rows}, package)
+    assert isinstance(disposition, DiscoveryDisposition)
+    probes = disposition.probes
 
     assert [(probe.family, probe.body_id) for probe in probes] == [
         (ProducerFamily.BINOP, "binop_body.py:3:BinOp"),
         (ProducerFamily.SUBSCRIPT, "subscript_body.py:3:Subscript"),
     ]
-    # Call root is a named exclusion — never a silent continue that half-writes
-    # "this demand did not exist".
-    exclusions = discover_no_call_body_probes.last_named_exclusions
+    # Call root is a named exclusion on the disposition object — never a
+    # function-attribute side channel and never a silent continue.
     assert any(
-        "root-outside-selected-families" in row and "root=Call" in row
-        for row in exclusions
+        exclusion.reason == "root-outside-selected-families"
+        and exclusion.root == "Call"
+        for exclusion in disposition.named_exclusions
     )
 
     binop_only = discover_no_call_body_probes(
         {"rows": rows}, package, families=frozenset({ProducerFamily.BINOP})
     )
-    assert [(probe.family, probe.body_id) for probe in binop_only] == [
+    assert [(probe.family, probe.body_id) for probe in binop_only.probes] == [
         (ProducerFamily.BINOP, "binop_body.py:3:BinOp")
     ]
-    subset_exclusions = discover_no_call_body_probes.last_named_exclusions
-    assert any("root-outside-selected-families" in row for row in subset_exclusions)
+    # Family filter is a post-recognition disposition (not root-outside).
+    assert any(
+        exclusion.reason == "family-filter" and exclusion.family == "Subscript"
+        for exclusion in binop_only.named_exclusions
+    )
+    assert any(
+        exclusion.reason == "root-outside-selected-families"
+        and exclusion.root == "Call"
+        for exclusion in binop_only.named_exclusions
+    )
 
 
 def test_population_selection_never_reads_manager_target_symbol() -> None:
@@ -598,7 +610,7 @@ def test_discovery_projects_one_family_through_one_typed_construction_per_source
     monkeypatch.setattr(SourceFile, "nodes", refuse_second_traversal)
     probes = discover_no_call_body_probes(
         {"rows": rows}, package, families=frozenset({ProducerFamily.ATTRIBUTE})
-    )
+    ).probes
 
     assert [probe.body_id for probe in probes] == ["attribute_body.py:3:Attribute"]
     assert constructed_source_cids == [rows[0]["useSite"]["sourceCid"], subscript_cid]
@@ -651,7 +663,7 @@ def test_discovery_carries_source_property_binding_to_attribute_exit(tmp_path) -
         },
         package,
         families=frozenset({ProducerFamily.ATTRIBUTE}),
-    )
+    ).probes
 
     report = attribute_body_probes(probes)
 
@@ -682,3 +694,46 @@ def test_selected_family_denominator_remains_fixed() -> None:
 
 def test_attribute_family_denominator_is_native_root_inventory() -> None:
     assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] == 53
+
+def test_discovery_has_no_last_named_exclusions_side_channel() -> None:
+    """Lying twin: the side-channel shell must not reappear.
+
+    Exclusions live on DiscoveryDisposition.named_exclusions — the one door.
+    A function attribute that tests alone read was half-writing production
+    accounting: disposition that production never saw.
+    """
+    assert not hasattr(discover_no_call_body_probes, "last_named_exclusions")
+    assert discover_no_call_body_probes.__annotations__.get("return") in (
+        DiscoveryDisposition,
+        "DiscoveryDisposition",
+    )
+
+
+def test_undischarged_without_coordinates_refuses_construction() -> None:
+    """Construction door: empty coordinates on UNDISCHARGED are unwritable.
+
+    Retirement path already climbed one rung (carry coordinates). This door
+    deletes the residual shell where a future path could return UNDISCHARGED
+    with coordinates=() and re-kill the nameless-face scan.
+    """
+    with pytest.raises(AttributionInvariantError, match="dead-guard sin"):
+        BodyAttribution(
+            "pandas/example.py:1:Subscript",
+            ProducerFamily.SUBSCRIPT,
+            AttributionOutcome.UNDISCHARGED,
+            "native-operation exception identity unproven",
+            # empty coordinates — illegal
+        )
+
+
+def test_undischarged_with_none_coordinates_is_constructible() -> None:
+    """Truthful twin: (None, None) faces keep the tripwire live."""
+    body = BodyAttribution(
+        "pandas/example.py:1:Subscript",
+        ProducerFamily.SUBSCRIPT,
+        AttributionOutcome.UNDISCHARGED,
+        "native-operation exception identity unproven",
+        ((None, None),),
+    )
+    assert body.exceptional_exit_coordinates == ((None, None),)
+

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -83,9 +83,8 @@ def test_mid_file_construction_panic_does_not_shrink_function_denominator(
     import sugar_source_tree.nodes as nodes_mod
 
     # FunctionDef.sugar is the door the recensus calls via function.sugar().
-    target = getattr(nodes_mod, "FunctionDef", None)
-    if target is None:
-        pytest.skip("FunctionDef not importable for patch")
+    # No skip hatch: if FunctionDef is missing the tooth must fail, not vanish.
+    target = nodes_mod.FunctionDef
     original_sugar = target.sugar
 
     monkeypatch.setattr(target, "sugar", flaky_sugar)

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
@@ -224,7 +224,7 @@ def test_authenticated_subscript_family_owns_no_construction_panics(
             payload,
             corpus.root,
             families=frozenset({ProducerFamily.SUBSCRIPT}),
-        ),
+        ).probes,
         families=frozenset({ProducerFamily.SUBSCRIPT}),
     )
     probes = tuple(


### PR DESCRIPTION
## Rung climb (fix-forward from #6948 review)

Adversarial review of #6948 found remaining shells, not a merge gate. This PR climbs them.

### Shell deleted

**`discover_no_call_body_probes.last_named_exclusions`** — function-attribute side channel that only twin tests read. Production returned probes alone; named exclusions were half-written disposition.

### What replaced it (enforcement ladder)

| Defect | Ladder ask | Climb |
| --- | --- | --- |
| Side-channel exclusions | type / one door? | **`DiscoveryDisposition(probes, named_exclusions)`** is the sole return. Callers use `.probes`. |
| Dead `family-filter` branch after pre-filtering `family_by_type` | one door recognition? | Full recognition map; **family-filter is post-recognition** again. |
| UNDISCHARGED with empty coordinates re-kills nameless-face scan | construction door? | **`BodyAttribution.__post_init__` refuses** empty coordinates on UNDISCHARGED. |
| `pytest.skip` if FunctionDef missing | tooth must fail | **Skip hatch deleted** — import/patch must exist. |

Type system cannot yet forbid continue-arms inside discovery (open AST roots) — closed reason enum is the next retirement path for `NamedDemandExclusion.reason` strings.

### Shot accounting

| Axis | Epsilon R | Notes |
| --- | --- | --- |
| `R_discovery_side_channel` | **−1 → 0** | shell deleted |
| `R_dead_family_filter` | **−1 → 0** | live family-filter disposition |
| `R_undischarged_empty_coords` | **unwritable** | construction door |
| `R_recensus_skip_hatch` | **−1 → 0** | skip removed |

**Floors preserved:** no-matching-with still throws; nameless-face tripwire still fires on `(None, None)` coordinates; `FAMILY_DENOMINATORS` unchanged; ConstructionPanic still propagates.

**If no further shell yet:** when discovery disposition is a closed enum `Enrolled | Excluded | Thrown` with no `continue` arms, delete string `reason=` field for a closed reason type.

### Instruments (lying twins)

- `test_discovery_has_no_last_named_exclusions_side_channel` — reintroducing the attribute fails
- `test_undischarged_without_coordinates_refuses_construction` — empty coords unwritable
- `test_undischarged_with_none_coordinates_is_constructible` — truthful twin
- Discovery BINOP-only path asserts **`family-filter` for Subscript** and **root-outside for Call**

### Validation

```text
collect: 28 tests in test_no_call_body_attribution.py
run: 29 passed (attribution file + mid-file recensus tooth)
PYTHONPATH=src:../sugar-source-tree/src:../sugar-lift-python-source/src
EXIT captured without pipe
```

Stacks on #6948 (`sin-cluster-8-vanish-tripwire`). Merge #6948 first, then this; or restack onto main after #6948 lands.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Introduce `DiscoveryDisposition` to return named exclusions from `discover_no_call_body_probes`
> - `discover_no_call_body_probes` now returns a `DiscoveryDisposition` dataclass containing both discovered probes and a list of `NamedDemandExclusion` records, replacing silent skipping with explicit exclusion reasons (`non-single-expr-body`, `root-outside-selected-families`, `family-filter`).
> - `AttributionReport` gains a `conservation_shortfall` property; shortfalls are counted as loud failures and included in the rendered discrepancy summary.
> - `BodyAttribution.__post_init__` enforces that `UNDISCHARGED` attributions must carry `exceptional_exit_coordinates`, raising `AttributionInvariantError` otherwise.
> - `_measure_file` in [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/6951/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) now materializes the full function list upfront so a mid-file `ConstructionPanic` does not shrink `functionsTotal`; progress is tracked separately via `functionsEnumerated`.
> - Timeout diagnostics in [collect_panic_audit.py](https://github.com/TSavo/sugar/pull/6951/files#diff-c8118d1d840a142b817faa7fa20f0068b5eea762d8907f6bca5552c9b93bf5d4) now report how many files were attempted and how many were never attempted before the watchdog killed the subprocess.
> - Behavioral Change: call sites of `discover_no_call_body_probes` must now access `.probes` on the returned disposition; resolved demands with no matching `With` manager now raise `AttributionInvariantError` instead of silently continuing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b436c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->