### PR TITLE
ExitSuppressionContract: coordinate suppress; delete name shell

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -81,12 +81,24 @@ def _term_cycle_key(term: Term) -> str:
 class ExitSuppressionContract:
     """Static evidence for one context manager's exceptional exit.
 
-    An empty exception set proves propagation.  A non-empty set proves that
-    exactly those named exception classes are suppressed.  Runtime-dependent
-    exits carry no contract at all and therefore remain loud in WithSugar.
+    An empty coordinate set proves propagation. A non-empty set proves that
+    exactly those **authenticated type coordinates** are suppressed. Names
+    enter only through :meth:`suppresses`, which resolves each name to a
+    builtin ``python:exception_type_identity`` once at construction — the
+    one door. Match sites never see a spelling; they compare
+    ``effect.exception_type_coordinate`` against this frozenset.
+
+    Runtime-dependent exits carry no contract at all and therefore remain
+    loud in WithSugar.
+
+    Retirement path for residual name suppress: the deleted
+    ``exception_names`` / ``suppresses_exception(str)`` shell. If a caller
+    needs foreign (non-builtin) types, promote this field to carry
+    source-authenticated coordinates from the tree rather than the builtin
+    table — then the string door can refuse non-empty names entirely.
     """
 
-    exception_names: frozenset[str]
+    exception_type_coordinates: frozenset
 
     @classmethod
     def never_suppresses(cls) -> "ExitSuppressionContract":
@@ -94,12 +106,31 @@ class ExitSuppressionContract:
 
     @classmethod
     def suppresses(cls, exception_names: tuple[str, ...]) -> "ExitSuppressionContract":
+        """ONE door: resolve source-facing names to type coordinates at mint."""
         if not exception_names:
             raise ValueError("a suppressing exit contract must name an exception")
-        return cls(frozenset(exception_names))
+        from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
 
-    def suppresses_exception(self, exception_name: str) -> bool:
-        return exception_name in self.exception_names
+        coordinates = []
+        for name in exception_names:
+            if not isinstance(name, str) or not name:
+                raise ValueError(
+                    "ExitSuppressionContract.suppresses requires non-empty "
+                    f"exception type names; got {name!r}"
+                )
+            identity, _mro = _builtin_exception_identity(name)
+            if identity is None:
+                raise ValueError(
+                    f"matcher name {name!r} has no builtin type coordinate; "
+                    "use a language-owned exception or thread an authenticated "
+                    "coordinate into ExitSuppressionContract"
+                )
+            coordinates.append(identity)
+        return cls(frozenset(coordinates))
+
+    def suppresses_coordinate(self, coordinate) -> bool:
+        """True when ``coordinate`` is one of the contract's type identities."""
+        return coordinate in self.exception_type_coordinates
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
@@ -73,6 +73,16 @@ class _Visitor(ast.NodeVisitor):
         self._side_door_functions: set[int] = set()
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        # Name-keyed suppress API is itself the residual shell (method body may
+        # only mention self.exception_names; the method *name* is the crime).
+        if node.name == "suppresses_exception":
+            self._add(
+                "name_or_vendor_gates",
+                node,
+                f"def {node.name}",
+                "match exception_type_coordinate against ExitSuppressionContract "
+                "coordinates minted at the suppresses() door; never suppress by name",
+            )
         self._function_stack.append(node)
         self.generic_visit(node)
         self._function_stack.pop()
@@ -125,6 +135,23 @@ class _Visitor(ast.NodeVisitor):
                 node,
                 caught,
                 "leave unsupported floor construction loud; never catch its panic",
+            )
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        # Residual after cluster-5 Suppresses fix: ExitSuppressionContract still
+        # decided suppress via suppresses_exception(str) / exception_names.
+        # Those shells are deleted; any reintroduction is a name_or_vendor_gate.
+        # Retirement of this detector arm: when no production Attribute load of
+        # either name remains AND the type system forbids constructing a
+        # name-keyed suppress contract (coordinates-only field), delete this arm.
+        if node.attr in {"suppresses_exception", "exception_names"}:
+            self._add(
+                "name_or_vendor_gates",
+                node,
+                ast.unparse(node),
+                "match exception_type_coordinate against ExitSuppressionContract "
+                "coordinates minted at the suppresses() door; never suppress by name",
             )
         self.generic_visit(node)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
@@ -9,9 +9,9 @@ on its own.
 Authority lives only in typed contracts:
 
 - ``NeverSuppresses`` — never consume a body halt; a completion completes
-- ``ExitSuppressionContract`` — source-proven named suppress set (or empty)
+- ``ExitSuppressionContract`` — source-proven type-coordinate suppress set (or empty)
 - ``RuntimeSelected`` — undecidable; leave the halt open under its guard
-- ``Suppresses(matcher)`` — membrane matcher (exact kind+name)
+- ``Suppresses(matcher)`` — membrane matcher (raise + authenticated type)
 - ``EffectBoundaryDisposition`` — assertion boundary; the only contract that
   can name an effect on the **completed** edge
 
@@ -183,10 +183,7 @@ def _resource_verdict(disposition: object, effect: object) -> str:
         return "restore"
 
     if isinstance(disposition, ExitSuppressionContract):
-        name = getattr(effect, "exception_name", None)
-        if not isinstance(name, str) or not name:
-            return "open"
-        return "suppress" if disposition.suppresses_exception(name) else "restore"
+        return _exit_suppression_contract_verdict(disposition, effect)
 
     if isinstance(disposition, Suppresses):
         return _suppresses_verdict(disposition, effect)
@@ -198,15 +195,54 @@ def _resource_verdict(disposition: object, effect: object) -> str:
     )
 
 
+def _require_exception_type_coordinate(effect, *, owner: str):
+    """Shared door: halt faces suppress only with an authenticated type coordinate."""
+    from sugar_source_tree.panic import SugarNotWritten
+
+    if effect is None:
+        return None
+    coordinate = getattr(effect, "exception_type_coordinate", None)
+    if coordinate is None:
+        raise SugarNotWritten(
+            blame=getattr(effect, "occurrence_id", None) or owner,
+            owner=owner,
+            observed="effect without exception_type_coordinate",
+            requested="authenticated exception_type_coordinate on the halt",
+            fix=(
+                "mint the raise through the ground exit door or an authenticated "
+                "producer; do not suppress by exception_name spelling"
+            ),
+        )
+    return coordinate
+
+
+def _exit_suppression_contract_verdict(disposition, effect) -> str:
+    """Suppress by coordinate membership only — never by exception_name spelling.
+
+    LAW OF ONE with the Suppresses arm: both doors demand
+    ``exception_type_coordinate``. Soft ``open`` on a missing name was the
+    residual second mechanism after sin-cluster-5 Suppresses was fixed.
+    """
+    owner = "exit_disposition.ExitSuppressionContract"
+    if effect is None:
+        return "restore"
+    coordinate = _require_exception_type_coordinate(effect, owner=owner)
+    if not disposition.exception_type_coordinates:
+        return "restore"
+    return (
+        "suppress"
+        if disposition.suppresses_coordinate(coordinate)
+        else "restore"
+    )
+
+
 def _suppresses_verdict(disposition, effect) -> str:
     """Suppress only by authenticated exception type coordinate, never by name.
 
     A name-less matcher and a name-less effect used to compare equal and
-    suppress. Spelling is half-writing the match: the neighbouring
-    ``ExitSuppressionContract`` arm already refused empty names; this arm
-    goes further and demands the effect's ``exception_type_coordinate``
-    against the builtin identity of the matcher's type. Missing coordinate
-    or name-less matcher is unwritten work (throw), not a soft open.
+    suppress. Spelling is half-writing the match. Both this arm and
+    ``ExitSuppressionContract`` demand ``exception_type_coordinate``; missing
+    coordinate or name-less matcher is unwritten work (throw), not a soft open.
     """
     from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
     from sugar_source_tree.panic import SugarNotWritten
@@ -230,18 +266,7 @@ def _suppresses_verdict(disposition, effect) -> str:
         )
     if effect is None:
         return "restore"
-    coordinate = getattr(effect, "exception_type_coordinate", None)
-    if coordinate is None:
-        raise SugarNotWritten(
-            blame=blame,
-            owner=owner,
-            observed="effect without exception_type_coordinate",
-            requested="authenticated exception_type_coordinate on the halt",
-            fix=(
-                "mint the raise through the ground exit door or an authenticated "
-                "producer; do not suppress by exception_name spelling"
-            ),
-        )
+    coordinate = _require_exception_type_coordinate(effect, owner=owner)
     matcher_identity, _ = _builtin_exception_identity(matcher_name)
     if matcher_identity is None:
         raise SugarNotWritten(

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
@@ -101,21 +101,32 @@ def test_instrument_structurally_sees_spelling_gates_of_cluster_five(tmp_path):
         "        return False\n"
         "    return None\n",
     )
+    # Residual shell after Suppresses was fixed: name-keyed ExitSuppressionContract.
+    _write(
+        tmp_path,
+        "call_site_value.py",
+        "class ExitSuppressionContract:\n"
+        "    exception_names = frozenset()\n"
+        "    def suppresses_exception(self, exception_name):\n"
+        "        return exception_name in self.exception_names\n",
+    )
 
     report = collect_builtin_closed_operation_report(tmp_path)
     gates = [row for row in report.offenders if row.axis == "name_or_vendor_gates"]
     observed = {row.observed for row in gates}
 
-    assert report.r["name_or_vendor_gates"] >= 4
+    assert report.r["name_or_vendor_gates"] >= 5
     assert any("exception_name" in text for text in observed)
     assert any("matcher.name" in text for text in observed)
     assert any("importorskip" in text for text in observed)
     assert any("pytest" in text for text in observed)
     assert any("type_name in" in text for text in observed)
+    assert any("suppresses_exception" in text for text in observed)
+    assert any("exception_names" in text for text in observed)
 
 
 def test_instrument_fixed_cluster_five_production_sites_are_zero():
-    """After the coordinate fix, the four named production files have no name gates."""
+    """After the coordinate fix, the named production files have no name gates."""
     from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
         collect_builtin_closed_operation_report,
     )
@@ -127,6 +138,7 @@ def test_instrument_fixed_cluster_five_production_sites_are_zero():
         "sugar_lift_py_tests/outcome/exit_disposition.py",
         "sugar_lift_py_tests/import_binding.py",
         "sugar_lift_py_tests/floor/class_value.py",
+        "sugar_lift_py_tests/floor/call_site_value.py",
     }
     hits = [
         row
@@ -135,4 +147,27 @@ def test_instrument_fixed_cluster_five_production_sites_are_zero():
     ]
     assert hits == [], "cluster-5 production sites still gate on spelling:\n" + "\n".join(
         f"{row.path}:{row.line}: {row.observed}" for row in hits
+    )
+
+
+def test_instrument_lying_twin_name_suppress_shell_is_red(tmp_path):
+    """Planting suppresses_exception / exception_names must be detected (teeth)."""
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "residual.py",
+        "def decide(effect, disposition):\n"
+        "    name = effect.exception_name\n"
+        "    return disposition.suppresses_exception(name)\n",
+    )
+    report = collect_builtin_closed_operation_report(tmp_path)
+    gates = [row for row in report.offenders if row.axis == "name_or_vendor_gates"]
+    assert any("suppresses_exception" in row.observed for row in gates), gates
+    # effect.exception_name attr compare / load in residual decision path
+    assert any(
+        "exception_name" in row.observed or "suppresses_exception" in row.observed
+        for row in gates
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_exit_suppression_contract.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_exit_suppression_contract.py
@@ -1,0 +1,97 @@
+"""ExitSuppressionContract matches by type coordinate, never exception_name.
+
+Sin residual after cluster-5 Suppresses fix: this arm still did
+``getattr(effect, "exception_name")`` + ``suppresses_exception(name)``.
+One door now mints coordinates at construction; match throws without a
+coordinate on the halt.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.floor.call_site_value import ExitSuppressionContract
+from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+from sugar_lift_py_tests.ir import atomic, ctor, str_const
+from sugar_lift_py_tests.outcome.exit_disposition import exit_disposition_effect
+from sugar_lift_py_tests.outcome.exit_set import Halted
+from sugar_source_tree.panic import SugarNotWritten
+
+
+def _guard():
+    return atomic("true", [])
+
+
+def _value_error(*, coordinate=None, mro=None, name="ValueError"):
+    if coordinate is None and mro is None:
+        coordinate, mro = _builtin_exception_identity("ValueError")
+    return RaiseEffect(
+        exception_name=name,
+        exception_type_coordinate=coordinate,
+        exception_type_mro=mro,
+        occurrence="exit_suppression.py:1:0",
+    )
+
+
+def test_truthful_contract_suppresses_matching_coordinate() -> None:
+    effect = _value_error()
+    verdict = exit_disposition_effect(
+        ExitSuppressionContract.suppresses(("ValueError",)),
+        Halted(_guard(), effect, "state"),
+    )
+    assert verdict is None
+
+
+def test_lying_twin_same_spelling_foreign_coordinate_restores() -> None:
+    truthful = _value_error()
+    foreign = ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("KeyError")],
+    )
+    lying = replace(
+        truthful,
+        exception_type_coordinate=foreign,
+        exception_type_mro=(foreign,),
+    )
+    assert lying.exception_name == "ValueError"
+    restored = exit_disposition_effect(
+        ExitSuppressionContract.suppresses(("ValueError",)),
+        Halted(_guard(), lying, "state"),
+    )
+    assert restored is lying
+
+
+def test_missing_effect_coordinate_throws() -> None:
+    effect = RaiseEffect(exception_name="ValueError", occurrence="exit_suppression.py:2:0")
+    with pytest.raises(SugarNotWritten) as caught:
+        exit_disposition_effect(
+            ExitSuppressionContract.suppresses(("ValueError",)),
+            Halted(_guard(), effect, "state"),
+        )
+    assert "exception_type_coordinate" in caught.value.observed
+
+
+def test_never_suppresses_restores_even_with_coordinate() -> None:
+    effect = _value_error()
+    restored = exit_disposition_effect(
+        ExitSuppressionContract.never_suppresses(),
+        Halted(_guard(), effect, "state"),
+    )
+    assert restored is effect
+
+
+def test_contract_door_stores_coordinates_not_names() -> None:
+    contract = ExitSuppressionContract.suppresses(("ValueError",))
+    identity, _ = _builtin_exception_identity("ValueError")
+    assert identity in contract.exception_type_coordinates
+    assert not hasattr(contract, "exception_names")
+    assert not hasattr(contract, "suppresses_exception")
+    assert contract.suppresses_coordinate(identity) is True
+
+
+def test_suppresses_door_rejects_unknown_builtin_name() -> None:
+    with pytest.raises(ValueError, match="no builtin type coordinate"):
+        ExitSuppressionContract.suppresses(("NotARealExceptionType",))

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py
@@ -2,7 +2,8 @@
 
 The old arm compared ``name == matcher.name`` with no None-guard: a
 coordinate-authenticated but name-less effect equaled a name-less matcher and
-was suppressed. Neighbour ExitSuppressionContract already refused empty names.
+was suppressed. ExitSuppressionContract shares the same coordinate door
+(see test_exit_disposition_exit_suppression_contract).
 """
 
 from __future__ import annotations

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
@@ -177,7 +177,15 @@ def test_and_exit_never_suppresses_restores_body_halt():
 
 
 def test_and_exit_proven_contract_consumes_named_halt():
-    body = RaiseEffect(exception_name="ValueError")
+    from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+
+    coordinate, mro = _builtin_exception_identity("ValueError")
+    body = RaiseEffect(
+        exception_name="ValueError",
+        exception_type_coordinate=coordinate,
+        exception_type_mro=mro,
+        occurrence="exit_set.py:2:0",
+    )
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(
         ExitSet.completed(True),
@@ -207,8 +215,16 @@ def test_and_exit_fans_exitset_across_conditional_faces():
 
 
 def test_and_exit_proven_contract_suppresses_only_matching_face():
+    from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+
     condition = _guard("condition")
-    effect = RaiseEffect(exception_name="ValueError")
+    coordinate, mro = _builtin_exception_identity("ValueError")
+    effect = RaiseEffect(
+        exception_name="ValueError",
+        exception_type_coordinate=coordinate,
+        exception_type_mro=mro,
+        occurrence="exit_set.py:3:0",
+    )
     incoming = ExitSet.conditional_halt(condition, effect, "state")
     after = incoming.and_exit(
         ExitSet.completed(True),

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -88,8 +88,18 @@ class _Pass(_FixedSugar):
 
 class _Raise(_FixedSugar):
     def __init__(self, name: str, *, occurrence: str = "t.py:1:0", probe=None):
+        from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+
+        coordinate, mro = _builtin_exception_identity(name)
         super().__init__(
-            Incomplete(RaiseEffect(exception_name=name, occurrence=occurrence)),
+            Incomplete(
+                RaiseEffect(
+                    exception_name=name,
+                    occurrence=occurrence,
+                    exception_type_coordinate=coordinate,
+                    exception_type_mro=mro,
+                )
+            ),
             probe=probe,
         )
 
@@ -651,11 +661,21 @@ def test_lying_the_equivalence_is_specific_to_never_suppresses():
     """
     from sugar_lift_py_tests.outcome.exit_set import ExitSet
 
+    from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+
     exit_es = ExitSet((Completed(true_guard(), _FloorValue("exited")),))
+    coordinate, mro = _builtin_exception_identity("ValueError")
     halted = Halted(
-        true_guard(), RaiseEffect(exception_name="ValueError"), _FloorValue("pre")
+        true_guard(),
+        RaiseEffect(
+            exception_name="ValueError",
+            exception_type_coordinate=coordinate,
+            exception_type_mro=mro,
+            occurrence="equiv.py:1:0",
+        ),
+        _FloorValue("pre"),
     )
-    suppressing = ExitSuppressionContract(frozenset({"ValueError"}))
+    suppressing = ExitSuppressionContract.suppresses(("ValueError",))
 
     through_exit = ExitSet((halted,)).and_exit(exit_es, disposition=suppressing)
     through_finally = ExitSet((halted,)).and_finally(lambda: exit_es)


### PR DESCRIPTION
## Summary

Fix-forward residual from sin cluster 5 (#6945): **ExitSuppressionContract** still suppressed by `exception_name` spelling while Suppresses already used coordinates. LAW OF ONE requires one suppress door.

### Rung climb

| Ladder question | Answer |
|---|---|
| Type system forbid? | **Partial** — contract field is now `exception_type_coordinates: frozenset` (coordinates, not names). Match API is `suppresses_coordinate`. Deleted `exception_names` / `suppresses_exception(str)`. |
| One construction door? | **Yes** — `ExitSuppressionContract.suppresses(...)` resolves names → builtin identities once at mint. |
| Panic at contact? | **Yes** — missing `exception_type_coordinate` on the halt raises `SugarNotWritten` (shared with Suppresses). |
| Auditor only if no? | Instrument extended to flag residual shell reintroduction (`suppresses_exception` / `exception_names`). Retirement note in instrument: delete arm when those Attribute/FunctionDef names are unrepresentable. |

### Shell deleted

- `ExitSuppressionContract.exception_names: frozenset[str]`
- `ExitSuppressionContract.suppresses_exception(str)`
- Soft `"open"` on empty exception_name in the ExitSuppressionContract arm

### Shot accounting

| | |
|---|---|
| **R axis** | `name_or_vendor_gates` on exit suppress paths (`exit_disposition` + `call_site_value`) |
| **Epsilon R** | residual name-suppress shell **1 → 0** (instrument tooth for that shell red→green on production targets) |
| **Floors** | no xfail/skip; no silent swallow; ground exit mint unchanged; Suppresses arm unchanged in meaning |
| **Shell deleted** | `exception_names` + `suppresses_exception` (named above) |

If no further shell is retirable yet: ClassValue still tables ConstStr after `python:type` unwrap; TupleValue still has `type_name in {...}`; effect_router still matches on `exception_name`. Those hatch when floor isinstance/suppress routing carries coordinates only (no string membership arm).

### Stacks on

#6945 (`agent/sin-cluster-5-spelling-instead-of-tree`). Merge after that lands (or restack onto main).

## Validation

```bash
cd implementations/python/sugar-lift-py-tests
PYTHONPATH=src:../:. python -m pytest -q \
  tests/test_exit_disposition_exit_suppression_contract.py \
  tests/test_exit_disposition_suppresses_coordinate.py \
  tests/test_builtin_closed_operation_instrument.py \
  tests/test_exit_set.py::test_and_exit_proven_contract_consumes_named_halt \
  tests/test_exit_set.py::test_and_exit_proven_contract_suppresses_only_matching_face \
  tests/test_exit_set.py::test_and_exit_membrane_suppresses_matcher_authority \
  tests/test_with_resource_sugar.py::test_proven_contract_consumes_matching_body_halt \
  tests/test_with_resource_sugar.py::test_lying_the_equivalence_is_specific_to_never_suppresses \
  tests/test_class_value_isinstance_coordinate.py \
  tests/test_loop_stop_iteration_coordinate.py
# 29 passed; EXIT=0; collection complete
```

## Test plan

- [x] Truthful/lying twins for ExitSuppressionContract coordinate match
- [x] Instrument lying twin for `suppresses_exception` shell
- [x] Production targets zero for name_or_vendor_gates on fixed files
- [ ] CI on PR

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace name-based exception suppression with authenticated type coordinates
> - `ExitSuppressionContract` now stores `exception_type_coordinates` (resolved at construction from builtin exception names) instead of raw string names; `suppresses_exception` is replaced by `suppresses_coordinate`.
> - `_resource_verdict` in [exit_disposition.py](https://github.com/TSavo/sugar/pull/6952/files#diff-76129a966576d0bf8e6154295bc1ae8dc5b58eb63e5dd6e3f562a97d826dfc6c) delegates suppression decisions to coordinate-based helpers; effects missing a coordinate raise `SugarNotWritten` instead of falling back to name matching.
> - Loop exhaustion in [loop_recurrence_sugar.py](https://github.com/TSavo/sugar/pull/6952/files#diff-f2f1e95b345c3c7e0569fbbe5a17e9608d1617fd8decf5507ba13f0d25c59547) and isinstance dispatch in [class_value.py](https://github.com/TSavo/sugar/pull/6952/files#diff-8c39758b3ac4077d066812f197a75b5786878a0cae336b77a3a3785017fd6272) are similarly moved to coordinate-based checks.
> - `pytest.importorskip` detection in [import_binding.py](https://github.com/TSavo/sugar/pull/6952/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) now authenticates the call against import bindings in analysis state rather than matching by string spelling.
> - The static instrument in [builtin_closed_operation_instrument.py](https://github.com/TSavo/sugar/pull/6952/files#diff-422b632b0136f3afa27d19e62f1748a574fbbc5726090092d5833c55292d76b0) is extended to flag `suppresses_exception`, `exception_names`, and broader spelling-gate patterns as offenders.
> - Risk: passing unknown builtin names to `ExitSuppressionContract.suppresses` or omitting `exception_type_coordinate` on a `RaiseEffect` now raises errors where previously no error occurred.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85aa6dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->