### PR TITLE
Instrument swallowed-throw second mechanisms; drain sin cluster 4

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/swallowed_throw_second_mechanism_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/swallowed_throw_second_mechanism_law.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""R_swallowed_throw_second_mechanism — honorable throws must not be half-rewritten.
+
+LAW OF ONE: AST shadows → Sugar → meaning. One mechanism. Catch-and-continue,
+raw-source substitution after ``literal_eval`` failure, and dual-mode
+``SoftUnresolved*Sugar`` survival are second mechanisms for unfinished Sugar:
+they dress a gap as absence, identity mutation, or soft incomplete.
+
+THROWING IS HONORABLE: unfinished work raises. The sin is rewriting the throw
+into silence, a survivor list, a substituted value, or a soft sugar outside the
+AST tower.
+
+Axes (kept separate; never summed into a single threshold):
+
+* ``R_construction_panic_soft_continue`` — ``except ConstructionPanic`` (or
+  bare / BaseException that can hold it) then ``continue`` / survivor filter
+  without pure re-raise.
+* ``R_exception_soft_continue`` — ``except Exception`` then bare ``continue``
+  in a production loop (manufactures absence for the next shot).
+* ``R_soft_unresolved_sugar_return`` — production returns
+  ``SoftUnresolvedWithSugar`` / ``SoftUnresolvedTrySugar`` (UNDECIDED as soft
+  Incomplete).
+* ``R_literal_eval_raw_substitution`` — ``literal_eval`` under ``try``, except
+  assigns raw source text as the decoded value (meaning outside Sugar).
+
+Enforcement ladder note: this auditor is larval. Retirement path:
+
+* Prefer: delete the handler; let the throw rise (panic / SourceTreePanic).
+* Climb: encode "no second mechanism" as unconstructable construction (typed
+  doors that cannot catch) once the language allows; then DELETE this shell.
+* What would hatch the shell: every production package forbids soft handlers
+  by construction (or a compiler/type-level catch ban). Until then the auditor
+  names live offenders and the replacement architecture per row.
+
+Scope: production ``src/`` under sugar-lift-python-source, sugar-source-tree,
+and sugar-lift-py-tests. Tests and measurement scripts are out of domain
+(they may plant the sin as lying twins).
+
+Exit 1 while any axis R > 0 or auditor_errors > 0. No baseline. Silence only
+at stable zero.
+
+Usage::
+
+    python scripts/swallowed_throw_second_mechanism_law.py
+    python scripts/swallowed_throw_second_mechanism_law.py --python-root PATH
+"""
+
+from __future__ import annotations
+
+# Not the board. Named denominator only.
+# See tests/test_one_authoritative_scoreboard.py.
+SCOREBOARD_AUTHORITY = False
+
+import argparse
+import ast
+from pathlib import Path
+import sys
+from typing import NamedTuple
+
+
+class SwallowOffender(NamedTuple):
+    path: str
+    line: int
+    axis: str
+    kind: str
+    note: str
+    fix: str
+
+
+_AXES = (
+    "R_construction_panic_soft_continue",
+    "R_exception_soft_continue",
+    "R_soft_unresolved_sugar_return",
+    "R_literal_eval_raw_substitution",
+)
+
+_SOFT_UNRESOLVED_NAMES = frozenset(
+    {
+        "SoftUnresolvedWithSugar",
+        "SoftUnresolvedTrySugar",
+    }
+)
+
+_PRODUCTION_PACKAGE_SRC = (
+    "sugar-lift-python-source/src",
+    "sugar-source-tree/src",
+    "sugar-lift-py-tests/src",
+)
+
+
+def _handler_type_names(handler: ast.ExceptHandler) -> set[str]:
+    names: set[str] = set()
+    t = handler.type
+    if t is None:
+        names.add("<bare>")
+        return names
+
+    def walk(node: ast.AST) -> None:
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.Tuple):
+            for elt in node.elts:
+                walk(elt)
+
+    walk(t)
+    return names
+
+
+def _body_has_continue(handler: ast.ExceptHandler) -> bool:
+    for node in ast.walk(handler):
+        if isinstance(node, ast.Continue):
+            return True
+    return False
+
+
+def _soft_silence_body(handler: ast.ExceptHandler) -> bool:
+    """Handler only silences: continue, pass, return None, or name = None."""
+    if _body_has_continue(handler):
+        return True
+    body = [
+        n
+        for n in handler.body
+        if not (
+            isinstance(n, ast.Expr)
+            and isinstance(n.value, ast.Constant)
+            and isinstance(n.value.value, str)
+        )
+    ]
+    if not body:
+        return True
+    for stmt in body:
+        if isinstance(stmt, ast.Pass):
+            continue
+        if isinstance(stmt, ast.Continue):
+            continue
+        if isinstance(stmt, ast.Return) and (
+            stmt.value is None
+            or (isinstance(stmt.value, ast.Constant) and stmt.value.value is None)
+        ):
+            continue
+        if isinstance(stmt, ast.Assign) and (
+            isinstance(stmt.value, ast.Constant) and stmt.value.value is None
+        ):
+            continue
+        if isinstance(stmt, ast.AnnAssign) and (
+            isinstance(stmt.value, ast.Constant) and stmt.value.value is None
+        ):
+            continue
+        # any other statement means not pure silence (may still be soft via continue above)
+        return False
+    return True
+
+
+def _pure_reraise(handler: ast.ExceptHandler) -> bool:
+    """Every path ends in raise; no continue/soft survivor assignment."""
+    body = [
+        n
+        for n in handler.body
+        if not (
+            isinstance(n, ast.Expr)
+            and isinstance(n.value, ast.Constant)
+            and isinstance(n.value.value, str)
+        )
+    ]
+    if not body:
+        return False
+    if _body_has_continue(handler):
+        return False
+
+    def ends_raise(stmts: list[ast.stmt]) -> bool:
+        if not stmts:
+            return False
+        last = stmts[-1]
+        if isinstance(last, ast.Raise):
+            return True
+        if isinstance(last, ast.If):
+            return bool(last.orelse) and ends_raise(last.body) and ends_raise(last.orelse)
+        return False
+
+    return ends_raise(body)
+
+
+def _calls_literal_eval(node: ast.AST) -> bool:
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        func = child.func
+        if isinstance(func, ast.Attribute) and func.attr == "literal_eval":
+            return True
+        if isinstance(func, ast.Name) and func.id == "literal_eval":
+            return True
+    return False
+
+
+# Call leaves that, when Exception-silenced, manufacture construction absence.
+_CONSTRUCTION_DOOR_LEAVES = frozenset(
+    {
+        "_require_narrow_cm_ref",
+        "function_contract_rows",
+        "force_floor",
+        "to_term",
+        "require_narrow_cm_ref",
+        "reduce_source_outcome",
+    }
+)
+
+
+def _try_calls_construction_door(try_node: ast.Try) -> bool:
+    for child in ast.walk(try_node):
+        if not isinstance(child, ast.Call):
+            continue
+        func = child.func
+        if isinstance(func, ast.Name) and func.id in _CONSTRUCTION_DOOR_LEAVES:
+            return True
+        if isinstance(func, ast.Attribute) and func.attr in _CONSTRUCTION_DOOR_LEAVES:
+            return True
+    return False
+
+
+def _except_assigns_raw_source(handler: ast.ExceptHandler) -> bool:
+    """True if except body assigns text/source slice to a value-like name."""
+    for stmt in handler.body:
+        if not isinstance(stmt, ast.Assign):
+            continue
+        for target in stmt.targets:
+            if isinstance(target, ast.Name) and target.id in {"value", "decoded", "lit"}:
+                # value = text / value = unit.source[...] / value = source[...]
+                rhs = stmt.value
+                if isinstance(rhs, ast.Name) and rhs.id in {
+                    "text",
+                    "source",
+                    "raw",
+                    "span_text",
+                }:
+                    return True
+                if isinstance(rhs, ast.Subscript):
+                    return True
+                if (
+                    isinstance(rhs, ast.Attribute)
+                    and isinstance(rhs.value, ast.Name)
+                    and rhs.value.id in {"unit", "node"}
+                    and rhs.attr == "source"
+                ):
+                    return True
+    return False
+
+
+def _return_soft_unresolved(node: ast.Return) -> str | None:
+    value = node.value
+    if value is None:
+        return None
+    # return SoftUnresolvedWithSugar(...)
+    if isinstance(value, ast.Call):
+        func = value.func
+        if isinstance(func, ast.Name) and func.id in _SOFT_UNRESOLVED_NAMES:
+            return func.id
+        if isinstance(func, ast.Attribute) and func.attr in _SOFT_UNRESOLVED_NAMES:
+            return func.attr
+    return None
+
+
+def scan_file(path: Path, *, rel: str) -> list[SwallowOffender]:
+    offenders: list[SwallowOffender] = []
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        return [
+            SwallowOffender(
+                rel,
+                0,
+                "auditor_errors",
+                "auditor-read-error",
+                f"could not read source: {error}",
+                "make the production source readable to the auditor",
+            )
+        ]
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as error:
+        return [
+            SwallowOffender(
+                rel,
+                int(error.lineno or 0),
+                "auditor_errors",
+                "auditor-parse-error",
+                f"ast.parse failed: {error.msg}",
+                "fix the production source so the auditor can read it",
+            )
+        ]
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Return):
+            soft = _return_soft_unresolved(node)
+            if soft is not None:
+                offenders.append(
+                    SwallowOffender(
+                        path=rel,
+                        line=node.lineno,
+                        axis="R_soft_unresolved_sugar_return",
+                        kind="soft-unresolved-sugar-return",
+                        note=(
+                            f"return {soft}(...) is dual-mode soft survival — "
+                            "UNDECIDED rendered as Incomplete outside the tower"
+                        ),
+                        fix=(
+                            "delete the soft sugar return; let SourceTreePanic / "
+                            "SugarNotWritten rise, or write the missing Sugar door"
+                        ),
+                    )
+                )
+
+        if not isinstance(node, ast.Try):
+            continue
+
+        try_has_literal_eval = _calls_literal_eval(node)
+        for handler in node.handlers:
+            names = _handler_type_names(handler)
+            has_continue = _body_has_continue(handler)
+            pure = _pure_reraise(handler)
+
+            if try_has_literal_eval and _except_assigns_raw_source(handler):
+                offenders.append(
+                    SwallowOffender(
+                        path=rel,
+                        line=handler.lineno,
+                        axis="R_literal_eval_raw_substitution",
+                        kind="literal-eval-raw-source-substitution",
+                        note=(
+                            "literal_eval failure substituted raw source text as "
+                            "Constant.value — meaning outside Sugar"
+                        ),
+                        fix=(
+                            "delete the except survival; bare literal_eval — "
+                            "decode or throw"
+                        ),
+                    )
+                )
+
+            catches_panic = bool(
+                names & {"ConstructionPanic", "BaseException"}
+            ) or names == {"<bare>"}
+            if catches_panic and has_continue and not pure:
+                offenders.append(
+                    SwallowOffender(
+                        path=rel,
+                        line=handler.lineno,
+                        axis="R_construction_panic_soft_continue",
+                        kind="construction-panic-soft-continue",
+                        note=(
+                            "except ConstructionPanic (or BaseException/bare) "
+                            "then continue — unfinished Floor sealed as absence "
+                            "or survivor identity"
+                        ),
+                        fix=(
+                            "rip the catch; ConstructionPanic must propagate. "
+                            "Write the missing to_term / Floor; never keep survivors"
+                        ),
+                    )
+                )
+
+            # Bare Exception soft-silence is debt when it is a second mechanism
+            # for unfinished construction: either loop-continue, or soft-None /
+            # empty body around a construction door call.
+            if names == {"Exception"} and not pure:
+                door = _try_calls_construction_door(node)
+                if has_continue or (door and _soft_silence_body(handler)):
+                    offenders.append(
+                        SwallowOffender(
+                            path=rel,
+                            line=handler.lineno,
+                            axis="R_exception_soft_continue",
+                            kind="exception-soft-continue",
+                            note=(
+                                "except Exception then soft silence swallows "
+                                "honorable throws"
+                                + (
+                                    " around a construction door"
+                                    if door
+                                    else " (loop continue manufactures absence)"
+                                )
+                            ),
+                            fix=(
+                                "rip the catch; let the throw rise. Named gap "
+                                "enrollment belongs only at a sanctioned membrane "
+                                "with exact AST shape, never bare Exception silence"
+                            ),
+                        )
+                    )
+
+    return sorted(offenders)
+
+
+def production_roots(python_root: Path) -> list[tuple[str, Path]]:
+    roots: list[tuple[str, Path]] = []
+    for rel in _PRODUCTION_PACKAGE_SRC:
+        roots.append((rel, python_root / rel))
+    return roots
+
+
+def scan_python_root(python_root: Path) -> list[SwallowOffender]:
+    offenders: list[SwallowOffender] = []
+    for prefix, root in production_roots(python_root):
+        if not root.is_dir():
+            offenders.append(
+                SwallowOffender(
+                    prefix,
+                    0,
+                    "auditor_errors",
+                    "auditor-root-error",
+                    "scan root is not a directory",
+                    "restore the production package src tree",
+                )
+            )
+            continue
+        try:
+            paths = sorted(root.rglob("*.py"))
+        except OSError as error:
+            offenders.append(
+                SwallowOffender(
+                    prefix,
+                    0,
+                    "auditor_errors",
+                    "auditor-root-error",
+                    f"could not enumerate scan root: {error}",
+                    "restore the production package src tree",
+                )
+            )
+            continue
+        for path in paths:
+            if "__pycache__" in path.parts:
+                continue
+            rel = f"{prefix}/{path.relative_to(root).as_posix()}"
+            offenders.extend(scan_file(path, rel=rel))
+    return sorted(offenders)
+
+
+def axis_counts(offenders: list[SwallowOffender]) -> dict[str, int]:
+    counts = {axis: 0 for axis in _AXES}
+    counts["auditor_errors"] = 0
+    for row in offenders:
+        if row.axis == "auditor_errors" or row.kind.startswith("auditor-"):
+            counts["auditor_errors"] += 1
+        elif row.axis in counts:
+            counts[row.axis] += 1
+    return counts
+
+
+def format_report(offenders: list[SwallowOffender]) -> str:
+    counts = axis_counts(offenders)
+    lines = [
+        "swallowed_throw_second_mechanism_law",
+        *(f"{axis} = {counts[axis]}" for axis in _AXES),
+        f"auditor_errors = {counts['auditor_errors']}",
+        "",
+        "Replacement architecture: rip catch-and-continue; throw or write Sugar/Floor.",
+        "Never substitute raw source as Constant.value. Never SoftUnresolved survival.",
+        "",
+        "Loci:",
+    ]
+    if not offenders:
+        lines.append("(none)")
+    for row in offenders:
+        lines.append(
+            f"{row.path}:{row.line}:{row.kind} [{row.axis}] — {row.note} | FIX: {row.fix}"
+        )
+    return "\n".join(lines)
+
+
+def default_python_root() -> Path:
+    # scripts/ → sugar-lift-py-tests → python/
+    return Path(__file__).resolve().parents[2]
+
+
+def main(argv: list[str] | None = None) -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--python-root",
+        type=Path,
+        default=default_python_root(),
+        help="implementations/python root (contains package dirs)",
+    )
+    args = parser.parse_args(argv)
+    offenders = scan_python_root(args.python_root)
+    counts = axis_counts(offenders)
+    r_total = sum(counts[axis] for axis in _AXES)
+    auditor_errors = counts["auditor_errors"]
+    print(format_report(offenders))
+    if r_total or auditor_errors:
+        print(
+            f"SWALLOWED-THROW LAW RED: R_total={r_total} "
+            f"(axes={ {a: counts[a] for a in _AXES} }) "
+            f"auditor_errors={auditor_errors}",
+            file=sys.stderr,
+        )
+        return 1
+    print("SWALLOWED-THROW LAW GREEN: all axes 0", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/tests/test_swallowed_throw_second_mechanism_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_swallowed_throw_second_mechanism_law.py
@@ -1,0 +1,325 @@
+"""Instrument: swallowed honorable throws as second mechanisms.
+
+Discrimination twins plant the sin class and assert detection. Live production
+scan pins the drained sin-cluster-4 sites absent and reports residual R for
+offenders this shot does not retire. Silence only at stable zero of all axes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_KIT = Path(__file__).resolve().parents[1]
+_SCANNER_PATH = _KIT / "scripts" / "swallowed_throw_second_mechanism_law.py"
+_SPEC = importlib.util.spec_from_file_location(
+    "swallowed_throw_second_mechanism_law", _SCANNER_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_SCANNER = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_SCANNER)
+
+_PYTHON_ROOT = _KIT.parent  # implementations/python
+
+
+def _write_pkg(tmp_path: Path, rel: str, source: str) -> Path:
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def test_lying_construction_panic_continue_is_detected(tmp_path: Path) -> None:
+    """Lying twin: except ConstructionPanic: continue must red."""
+    root = tmp_path / "python"
+    _write_pkg(
+        root,
+        "sugar-lift-python-source/src/sugar_lift_python_source/bad.py",
+        """
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+def seal(prefix):
+    cids = []
+    for item in prefix:
+        try:
+            cids.append(item.to_term(owner="o"))
+        except ConstructionPanic:
+            continue
+    return cids
+""",
+    )
+    for pkg in (
+        "sugar-source-tree/src",
+        "sugar-lift-py-tests/src",
+    ):
+        (root / pkg).mkdir(parents=True, exist_ok=True)
+
+    offenders = _SCANNER.scan_python_root(root)
+    kinds = {(o.kind, o.axis) for o in offenders}
+    assert ("construction-panic-soft-continue", "R_construction_panic_soft_continue") in kinds
+
+
+def test_lying_exception_soft_continue_is_detected(tmp_path: Path) -> None:
+    """Lying twin: except Exception: continue manufactures absence."""
+    root = tmp_path / "python"
+    _write_pkg(
+        root,
+        "sugar-lift-py-tests/src/sugar_lift_py_tests/bad.py",
+        """
+def enumerate_targets(names, rows_of):
+    out = []
+    for name in names:
+        try:
+            rows = rows_of(name)
+        except Exception:
+            continue
+        out.append(rows)
+    return out
+""",
+    )
+    for pkg in (
+        "sugar-source-tree/src",
+        "sugar-lift-python-source/src",
+    ):
+        (root / pkg).mkdir(parents=True, exist_ok=True)
+
+    offenders = _SCANNER.scan_python_root(root)
+    assert any(o.kind == "exception-soft-continue" for o in offenders)
+
+
+def test_lying_exception_soft_none_on_construction_door_is_detected(
+    tmp_path: Path,
+) -> None:
+    """Lying twin: except Exception around _require_narrow_cm_ref → soft-None."""
+    root = tmp_path / "python"
+    _write_pkg(
+        root,
+        "sugar-source-tree/src/sugar_source_tree/bad.py",
+        """
+def door(self, item):
+    try:
+        resolved_ref = self._require_narrow_cm_ref(item)
+    except Exception:
+        resolved_ref = None
+    return resolved_ref
+""",
+    )
+    for pkg in (
+        "sugar-lift-python-source/src",
+        "sugar-lift-py-tests/src",
+    ):
+        (root / pkg).mkdir(parents=True, exist_ok=True)
+
+    offenders = _SCANNER.scan_python_root(root)
+    assert any(o.kind == "exception-soft-continue" for o in offenders)
+
+
+def test_lying_soft_unresolved_return_is_detected(tmp_path: Path) -> None:
+    root = tmp_path / "python"
+    _write_pkg(
+        root,
+        "sugar-source-tree/src/sugar_source_tree/bad.py",
+        """
+from sugar_lift_py_tests.sugar.soft_unresolved_with_sugar import SoftUnresolvedWithSugar
+
+def sugar(self):
+    return SoftUnresolvedWithSugar(site=self.fragment)
+""",
+    )
+    for pkg in (
+        "sugar-lift-python-source/src",
+        "sugar-lift-py-tests/src",
+    ):
+        (root / pkg).mkdir(parents=True, exist_ok=True)
+
+    offenders = _SCANNER.scan_python_root(root)
+    assert any(o.kind == "soft-unresolved-sugar-return" for o in offenders)
+
+
+def test_lying_literal_eval_raw_substitution_is_detected(tmp_path: Path) -> None:
+    root = tmp_path / "python"
+    _write_pkg(
+        root,
+        "sugar-source-tree/src/sugar_source_tree/bad.py",
+        """
+import ast as _pyast
+
+def decode(text):
+    try:
+        value = _pyast.literal_eval(text)
+    except Exception:
+        value = text
+    return value
+""",
+    )
+    for pkg in (
+        "sugar-lift-python-source/src",
+        "sugar-lift-py-tests/src",
+    ):
+        (root / pkg).mkdir(parents=True, exist_ok=True)
+
+    offenders = _SCANNER.scan_python_root(root)
+    assert any(o.kind == "literal-eval-raw-source-substitution" for o in offenders)
+
+
+def test_truthful_bare_projection_and_reraise_are_clean(tmp_path: Path) -> None:
+    """Truthful twin: bare projection / pure re-raise is not the sin class."""
+    root = tmp_path / "python"
+    _write_pkg(
+        root,
+        "sugar-lift-python-source/src/sugar_lift_python_source/ok.py",
+        """
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+def seal(prefix, owner):
+    return tuple(item.to_term(owner=owner) for item in prefix)
+
+def boundary():
+    try:
+        raise ConstructionPanic(None)
+    except ConstructionPanic:
+        raise
+""",
+    )
+    _write_pkg(
+        root,
+        "sugar-source-tree/src/sugar_source_tree/ok.py",
+        """
+import ast as _pyast
+
+def decode(text):
+    value = _pyast.literal_eval(text)
+    return value
+""",
+    )
+    _write_pkg(
+        root,
+        "sugar-lift-py-tests/src/sugar_lift_py_tests/ok.py",
+        """
+def rows_of(name):
+    return name
+""",
+    )
+
+    offenders = _SCANNER.scan_python_root(root)
+    assert offenders == [], _SCANNER.format_report(offenders)
+
+
+def test_drained_sin_cluster_4_sites_are_absent_on_live_tree() -> None:
+    """Fix-forward pin: the four drained membranes must not reappear.
+
+    Residual offenders outside this drain remain measured by the CLI (exit 1
+    until stable zero). This tooth fails if a drained site regrows.
+    """
+    offenders = _SCANNER.scan_python_root(_PYTHON_ROOT)
+
+    # Content pins: drained patterns must be gone from production source text.
+    manager = (
+        _PYTHON_ROOT
+        / "sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py"
+    ).read_text(encoding="utf-8")
+    assert "kept_prefix" not in manager
+    assert "never panic the door" not in manager
+
+    nodes = (
+        _PYTHON_ROOT / "sugar-source-tree/src/sugar_source_tree/nodes.py"
+    ).read_text(encoding="utf-8")
+    assert "return SoftUnresolvedWithSugar" not in nodes
+    assert "from sugar_lift_py_tests.sugar.soft_unresolved_with_sugar import" not in nodes
+
+    parso = (
+        _PYTHON_ROOT / "sugar-source-tree/src/sugar_source_tree/parso_adapter.py"
+    ).read_text(encoding="utf-8")
+    assert "value = text" not in parso
+    assert "value = unit.source[start:end]" not in parso
+
+    ts = (
+        _PYTHON_ROOT
+        / "sugar-source-tree/src/sugar_source_tree/tree_sitter_python_adapter.py"
+    ).read_text(encoding="utf-8")
+    assert "value = text" not in ts
+    assert "value = unit.source[span.start : span.end]" not in ts
+
+    lift = (
+        _PYTHON_ROOT / "sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py"
+    ).read_text(encoding="utf-8")
+    marker = "def_memento, rows = _tree.function_contract_rows(fn, file_rel)"
+    # First implications arm (target_candidates) has no try wrapping the call.
+    idx = lift.index(marker)
+    window = lift[idx - 120 : idx + 80]
+    assert "except Exception" not in window
+
+    # Scanner pins: drained kinds absent at drained loci (Try soft residual may remain).
+    assert not any(
+        o.path.endswith("parso_adapter.py")
+        and o.kind == "literal-eval-raw-source-substitution"
+        for o in offenders
+    ), _SCANNER.format_report(offenders)
+    assert not any(
+        o.path.endswith("tree_sitter_python_adapter.py")
+        and o.kind == "literal-eval-raw-source-substitution"
+        for o in offenders
+    ), _SCANNER.format_report(offenders)
+    assert not any(
+        o.path.endswith("nodes.py")
+        and o.kind == "soft-unresolved-sugar-return"
+        and "With" in o.note
+        for o in offenders
+    ), _SCANNER.format_report(offenders)
+    assert not any(
+        o.path.endswith("manager_construction.py")
+        and o.kind == "construction-panic-soft-continue"
+        and "factoryPrefix" in o.note
+        for o in offenders
+    )
+    # factory-prefix survivor seal gone: no kept_prefix path left (content pin above).
+    # Nested ConstructionPanic continue at force_floor may remain as residual R.
+
+
+def test_live_scan_reports_named_axes_and_residual_is_nonzero_until_drained() -> None:
+    """Live R is measured output: axes named, residual remaining after this drain."""
+    offenders = _SCANNER.scan_python_root(_PYTHON_ROOT)
+    counts = _SCANNER.axis_counts(offenders)
+    for axis in _SCANNER._AXES:
+        assert axis in counts
+    # literal_eval axis must be zero after this drain
+    assert counts["R_literal_eval_raw_substitution"] == 0
+    # SoftUnresolvedWith drained; SoftUnresolvedTry residual may remain
+    soft = [
+        o
+        for o in offenders
+        if o.kind == "soft-unresolved-sugar-return"
+    ]
+    assert all("Try" in o.note or "Try" in o.fix for o in soft) or soft == []
+    # Report must be non-empty text with axis headers
+    report = _SCANNER.format_report(offenders)
+    assert "R_construction_panic_soft_continue" in report
+    assert "R_exception_soft_continue" in report
+
+
+def test_cli_exit_code_tracks_residual(tmp_path: Path) -> None:
+    """CLI exits 1 while any axis > 0; exits 0 on a clean tree."""
+    clean = tmp_path / "clean"
+    for pkg in _SCANNER._PRODUCTION_PACKAGE_SRC:
+        (clean / pkg).mkdir(parents=True, exist_ok=True)
+        (clean / pkg / "empty.py").write_text("# clean\n", encoding="utf-8")
+    assert _SCANNER.main(["--python-root", str(clean)]) == 0
+
+    dirty = tmp_path / "dirty"
+    for pkg in _SCANNER._PRODUCTION_PACKAGE_SRC:
+        (dirty / pkg).mkdir(parents=True, exist_ok=True)
+    (dirty / "sugar-source-tree/src/bad.py").write_text(
+        """
+import ast as _pyast
+def decode(text):
+    try:
+        value = _pyast.literal_eval(text)
+    except Exception:
+        value = text
+    return value
+""",
+        encoding="utf-8",
+    )
+    assert _SCANNER.main(["--python-root", str(dirty)]) == 1


### PR DESCRIPTION
## Summary

Instrument-first fix-forward from the adversarial review of #6944 (not a merge gate — a rung climb).

**Instrument:** `scripts/swallowed_throw_second_mechanism_law.py` scans production `src/` under `sugar-lift-python-source`, `sugar-source-tree`, and `sugar-lift-py-tests` and reports named axes:

| Axis | Meaning |
| --- | --- |
| `R_construction_panic_soft_continue` | `except ConstructionPanic` then `continue` / survivor filter |
| `R_exception_soft_continue` | bare `except Exception` loop-continue, or soft-None around a construction door |
| `R_soft_unresolved_sugar_return` | production `return SoftUnresolved*Sugar(...)` |
| `R_literal_eval_raw_substitution` | `literal_eval` failure → raw source as `Constant.value` |

Discrimination twins plant each sin and assert detection; truthful bare projection stays clean. CLI exits 1 while any axis > 0. No baseline.

**Enforcement ladder:** type system cannot ban catch handlers; one-door construction does not yet forbid soft membranes; panic is the *content* of the fix for unfinished Floor. Auditor is the larval shell. **Retirement path (named in the script):** delete residual soft handlers until stable zero; when construction doors make soft handlers unconstructable, **DELETE this auditor**.

## Shell this PR deletes

The four production catch membranes (sin cluster 4), not the auditor shell:

1. factory-prefix `except ConstructionPanic: continue` survivor seal into `factoryPrefixCids`
2. dual-mode `SoftUnresolvedWithSugar` / soft-None Exception around `_require_narrow_cm_ref`
3. implications `except Exception: continue` around `function_contract_rows`
4. parso + tree-sitter `literal_eval` → raw source substitution

## Shot accounting

| Axis | Before (same instrument on offender class) | After (this PR) | Epsilon R |
| --- | ---: | ---: | ---: |
| `R_literal_eval_raw_substitution` | 4 | **0** | −4 |
| `R_soft_unresolved_sugar_return` | 2 (With+Try) | **1** (Try residual) | −1 |
| `R_construction_panic_soft_continue` | 2 | **1** (nested force_floor residual) | −1 |
| `R_exception_soft_continue` | 6 | **5** (implications site gone) | −1 |
| **R_total** | **14** | **7** | **−7** |

**Floors preserved:** no test deleted/xfailed; construction panic pure re-raise still lawful; audit/transport membranes not reclassified as green by baseline.

**Residual (still red CLI — next shots, not this merge prize):**

- `manager_construction.py` nested `except ConstructionPanic: continue`
- `nodes.py` `SoftUnresolvedTrySugar` dual-mode return
- Exception loop continues in census / collect_panic_audit / lift_rpc dispatch / bind_lifter / bench_backends

## Validation

```text
PYTHONPATH=.../sugar-source-tree/src:.../sugar-lift-python-source/src:.../sugar-lift-py-tests/src \
  python3 -m pytest implementations/python/sugar-lift-py-tests/tests/test_swallowed_throw_second_mechanism_law.py -q
# 9 passed (collected 9)

python3 implementations/python/sugar-lift-py-tests/scripts/swallowed_throw_second_mechanism_law.py
# EXIT=1  R_total=7 (residual; law stays red until stable zero)
```

## Note vs #6944

#6944 rips the same four production sites with package-local twins. This PR **adds the cross-package instrument that #6944 lacked**, so regrowth of the class is measured, and residual siblings outside the four sites stay red. Overlap on production rips is intentional fix-forward; either merge order leaves the instrument as the durable tooth.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add static scanner for exception-swallowing patterns in Python source trees
> - Adds [`swallowed_throw_second_mechanism_law.py`](https://github.com/TSavo/sugar/pull/6954/files#diff-1045456b2cd3109e2e7f757d629f3812152150a9a9c695f190d01b4eab2279e6), a CLI script that walks configured package roots and detects four axes of exception-swallowing: soft-unresolved sugar returns, `literal_eval` raw-source substitution in except handlers, `ConstructionPanic`/`BaseException`/bare-except with `continue`, and bare `Exception` soft-silence around construction door calls.
> - Findings are emitted as `SwallowOffender` records with path, line, axis, kind, note, and suggested fix; the script exits nonzero if any violations or auditor errors are found.
> - Adds [`test_swallowed_throw_second_mechanism_law.py`](https://github.com/TSavo/sugar/pull/6954/files#diff-69a6bd5907b5b75d46cbdbff74b0afac5ba53b2cf01dd4c5258aecc44d58e01a) with tests covering detection of each axis, clean-code false-positive checks, a live-tree regression guard for previously drained sin-cluster-4 sites, and CLI exit-code behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f5c9bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->