### PR TITLE
Instrument R_enumeration_binding_soft_skips: no soft dig after binding refuse

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/enumeration_binding_soft_skip_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/enumeration_binding_soft_skip_law.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""R_enumeration_binding_soft_skips — soft catch of authenticated binding refuse.
+
+Offender class (SIN CLUSTER 6 residual after #6946):
+
+``FunctionBindingMiss`` and ``SourceCallBindingGap`` are *named* refusals from
+the construction door. Catching them and soft-continuing (``continue``,
+``fn = None``, ``rows = None`` without a gap row) reopens the pre-#6946 soft-None
+path under a louder exception type. Serving an abstract universe contract from a
+**spelling-keyed** ``by_name[t]`` table after binding refused is the same door
+again: first-match-by-spelling enumeration.
+
+Law:
+
+1. Production may not catch ``FunctionBindingMiss`` solely to soft-skip.
+   Sanctioned membrane (exact AST shape): append a gap naming the miss, then
+   ``continue`` — never assign ``fn = None`` and fall through to a spelling table.
+2. Production may not index abstract universe contracts by callee *spelling*
+   (``by_name[t]``) on the dig path that also calls ``resolve_function_for_call``.
+   Abstract fallback, when allowed, is keyed by authenticated definition identity
+   (``source_cid`` of the resolved def memento).
+3. ``SourceCallBindingGap`` on the applied dig is not a soft silent ``rows=None``
+   without a gap when it shares a handler with soft ``continue`` into spelling
+   fallback. Prefer a named gap row; identity-keyed abstract is separate.
+
+Enforcement ladder retirement path:
+
+- Type: Python cannot forbid ``except FunctionBindingMiss``; no codomain close.
+- One door: resolve + bind_node_actuals already refuse; the dig must not invent
+  a second serve path after refuse.
+- Panic: a process panic on every dig miss would halt audit scans of partial
+  workspaces — too high for open corpus. Loud *gap row* is the honest terminal
+  until enumerate can refuse the whole request typed.
+- This auditor holds the residual until dig has no soft FunctionBindingMiss
+  membrane and no spelling ``by_name`` on the resolve path; then delete this shell.
+
+Exit 1 while R > 0. No baseline.
+"""
+
+from __future__ import annotations
+
+# Not the board. Own denominator; scripts/control_effect_recensus.py is the
+# sole authoritative Python corpus scoreboard.
+SCOREBOARD_AUTHORITY = False
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+class SoftSkipOffender(NamedTuple):
+    path: str
+    line: int
+    kind: str
+    note: str
+
+
+_FUNCTION_BINDING_MISS = frozenset({"FunctionBindingMiss"})
+_SOURCE_CALL_BINDING_GAP = frozenset({"SourceCallBindingGap"})
+
+
+def _handler_type_names(handler: ast.ExceptHandler) -> set[str]:
+    names: set[str] = set()
+    t = handler.type
+    if t is None:
+        return {"<bare>"}
+
+    def walk(node: ast.AST) -> None:
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.Tuple):
+            for elt in node.elts:
+                walk(elt)
+
+    walk(t)
+    return names
+
+
+def _handler_text(handler: ast.ExceptHandler) -> str:
+    return ast.unparse(handler)
+
+
+def _is_gap_append_then_continue(handler: ast.ExceptHandler) -> bool:
+    """Sanctioned: name the miss as a gap row, then continue — no fn=None fallthrough."""
+    text = _handler_text(handler)
+    if "fn = None" in text or "fn=None" in text:
+        return False
+    if "rows = None" in text and "gaps.append" not in text:
+        return False
+    # Must append a gap that names the miss class, then continue.
+    if "gaps.append" not in text and "cue_gaps.append" not in text:
+        return False
+    if "FunctionBindingMiss" not in text and "SourceCallBindingGap" not in text:
+        # reason string may use the exception instance
+        if "miss." not in text and "bind_gap" not in text and "as miss" not in text:
+            if "as " not in text:
+                return False
+    body = [s for s in handler.body if not isinstance(s, ast.Pass)]
+    if not body:
+        return False
+    # Last statement continue, and some append of gaps earlier
+    last = body[-1]
+    if not isinstance(last, ast.Continue):
+        return False
+    return any(
+        "gaps.append" in ast.unparse(stmt) or "cue_gaps.append" in ast.unparse(stmt)
+        for stmt in body[:-1]
+    )
+
+
+def _soft_function_binding_miss(handler: ast.ExceptHandler) -> bool:
+    names = _handler_type_names(handler)
+    if not (names & _FUNCTION_BINDING_MISS):
+        return False
+    if _is_gap_append_then_continue(handler):
+        return False
+    text = _handler_text(handler)
+    # Pure re-raise is allowed (process-terminal).
+    if len(handler.body) == 1 and isinstance(handler.body[0], ast.Raise):
+        return False
+    soft = (
+        "continue" in text
+        or "fn = None" in text
+        or "fn=None" in text
+        or "pass" == text.strip().splitlines()[-1].strip()
+        or "return None" in text
+    )
+    return soft
+
+
+def _soft_binding_gap_with_rows_none(handler: ast.ExceptHandler) -> bool:
+    """SourceCallBindingGap soft-set rows=None without a gap row."""
+    names = _handler_type_names(handler)
+    if not (names & _SOURCE_CALL_BINDING_GAP):
+        return False
+    text = _handler_text(handler)
+    if "rows = None" in text or "rows=None" in text:
+        if "gaps.append" in text or "cue_gaps.append" in text:
+            return False
+        return True
+    return False
+
+
+def _function_contains_resolve_and_spelling_by_name(func: ast.AST) -> list[ast.AST]:
+    """Find ``by_name[t]`` / ``if t in by_name`` on a path that resolves callees."""
+    if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return []
+    text = ast.unparse(func)
+    if "resolve_function_for_call" not in text:
+        return []
+    offenders: list[ast.AST] = []
+    for node in ast.walk(func):
+        # by_name = {name: ...} construction used as spelling index
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "by_name":
+                    offenders.append(node)
+        # if t in by_name
+        if isinstance(node, ast.Compare):
+            if any(isinstance(op, ast.In) for op in node.ops):
+                unparsed = ast.unparse(node)
+                if "by_name" in unparsed and (
+                    "t in by_name" in unparsed or "in by_name" in unparsed
+                ):
+                    offenders.append(node)
+        # by_name[t]
+        if isinstance(node, ast.Subscript):
+            if isinstance(node.value, ast.Name) and node.value.id == "by_name":
+                offenders.append(node)
+    return offenders
+
+
+def scan_sources(paths: list[Path], *, root: Path) -> list[SoftSkipOffender]:
+    offenders: list[SoftSkipOffender] = []
+    for path in paths:
+        try:
+            rel = path.relative_to(root).as_posix()
+        except ValueError:
+            rel = path.as_posix()
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as error:
+            offenders.append(
+                SoftSkipOffender(
+                    rel, 0, "auditor-read-error", f"could not read source: {error}"
+                )
+            )
+            continue
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as error:
+            offenders.append(
+                SoftSkipOffender(
+                    rel,
+                    int(error.lineno or 0),
+                    "auditor-parse-error",
+                    f"ast.parse failed: {error.msg}",
+                )
+            )
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ExceptHandler):
+                if _soft_function_binding_miss(node):
+                    offenders.append(
+                        SoftSkipOffender(
+                            path=rel,
+                            line=node.lineno,
+                            kind="function-binding-miss-soft-skip",
+                            note=(
+                                "except FunctionBindingMiss soft-continues "
+                                "(continue / fn=None / pass) without a gap row. "
+                                "Replacement: append a named gap then continue, "
+                                "or re-raise. Never fall through to spelling by_name."
+                            ),
+                        )
+                    )
+                if _soft_binding_gap_with_rows_none(node):
+                    offenders.append(
+                        SoftSkipOffender(
+                            path=rel,
+                            line=node.lineno,
+                            kind="source-call-binding-gap-soft-rows-none",
+                            note=(
+                                "except SourceCallBindingGap sets rows=None without "
+                                "a gap row, reopening silent applied-dig failure. "
+                                "Replacement: gaps.append naming the bind gap, then "
+                                "identity-keyed abstract only — never spelling by_name."
+                            ),
+                        )
+                    )
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for hit in _function_contains_resolve_and_spelling_by_name(node):
+                    offenders.append(
+                        SoftSkipOffender(
+                            path=rel,
+                            line=getattr(hit, "lineno", node.lineno),
+                            kind="spelling-by-name-after-resolve",
+                            note=(
+                                "universe dig builds or reads by_name on the same "
+                                "path as resolve_function_for_call. Spelling index is "
+                                "the pre-#6946 second door. Replacement: key abstract "
+                                "contracts by resolved def source_cid only."
+                            ),
+                        )
+                    )
+    return offenders
+
+
+def production_scan_roots(kit_root: Path) -> list[Path]:
+    """Production membranes only — tests/scripts are free to plant the sin."""
+    src = kit_root / "src" / "sugar_lift_py_tests"
+    paths: list[Path] = []
+    for name in ("lift_rpc.py", "tree_enumerate.py"):
+        path = src / name
+        if path.is_file():
+            paths.append(path)
+    return paths
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--kit-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="sugar-lift-py-tests package root",
+    )
+    args = parser.parse_args(argv)
+    kit_root = args.kit_root.resolve()
+    paths = production_scan_roots(kit_root)
+    if not paths:
+        print("R_enumeration_binding_soft_skips auditor_errors=1 (no production roots)")
+        return 1
+    offenders = scan_sources(paths, root=kit_root)
+    r = len(offenders)
+    print(f"R_enumeration_binding_soft_skips={r}")
+    for row in offenders:
+        print(f"  {row.path}:{row.line} [{row.kind}] {row.note}")
+    if r:
+        print(
+            "replacement: FunctionBindingMiss → gap row then continue; "
+            "abstract universe by source_cid of resolved def; delete by_name[t]"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -1353,6 +1353,7 @@ def authenticated_module_exports(
         source_cid=source_cid,
         module_name=module_name,
         module_identities={},
+        module_is_package=path.name == "__init__.py",
     )
     rows: list[dict[str, Any]] = []
     for local, reaching in sorted(final_state.items()):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2125,6 +2125,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 target_candidates = []
                 targets = []
                 seen_targets = set()
+                implication_gaps: List[Dict[str, Any]] = []
                 for call in _tree.call_nodes_in_assert(sf, span):
                     name = call.func.id
                     if name in seen_targets:
@@ -2133,9 +2134,22 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     targets.append(name)
                     try:
                         fn = _tree.resolve_function_for_call(call)
-                    except _tree.FunctionBindingMiss:
+                    except _tree.FunctionBindingMiss as miss:
+                        # Named refuse from the construction door — gap row, not
+                        # soft continue that reopens pre-#6946 soft-None.
+                        implication_gaps.append(
+                            {
+                                "memento": at,
+                                "reason": (
+                                    f"FunctionBindingMiss name={miss.name!r} "
+                                    f"reason={miss.reason}"
+                                ),
+                            }
+                        )
                         continue
                     # No except/continue. Throws from unfinished body sugar rise.
+                    # FunctionBindingMiss is named refuse (gap above); unfinished
+                    # body sugar must not be reclassified as empty candidates.
                     def_memento, rows = _tree.function_contract_rows(fn, file_rel)
                     if rows is None:
                         continue
@@ -2191,7 +2205,10 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     "payload": demand,
                 }
                 _send_enumerate_result(
-                    msg_id, [node], [], term_tables=[term_table.nodes]
+                    msg_id,
+                    [node],
+                    implication_gaps,
+                    term_tables=[term_table.nodes],
                 )
                 _log_enumeration_demand(
                     str(level), at, cache="miss", started=demand_started
@@ -2279,8 +2296,14 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     sf, at.get("span") if isinstance(at, dict) else None
                 )
                 targets = []
-                by_name = {name: (m, d) for name, m, d in universes}
+                # Abstract contracts keyed by authenticated def identity
+                # (source_cid), never by callee spelling. Spelling by_name[t]
+                # reopened first-match after FunctionBindingMiss (#6946 residual).
+                by_source_cid = {
+                    m["source_cid"]: (m, d) for _n, m, d in universes
+                }
                 cued = []
+                cue_gaps: List[Dict[str, Any]] = []
                 seen = set()
                 for call in calls:
                     t = call.func.id
@@ -2289,12 +2312,21 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     seen.add(t)
                     targets.append(t)
                     # Resolve by binding/coordinate at the call site — not
-                    # first-match-by-spelling. Miss is a named throw; soft skip
-                    # is an explicit catch of FunctionBindingMiss.
+                    # first-match-by-spelling. Miss is a named throw; the dig
+                    # records a gap and does not fall through to a spelling table.
                     try:
                         fn = _tree.resolve_function_for_call(call)
-                    except _tree.FunctionBindingMiss:
-                        fn = None
+                    except _tree.FunctionBindingMiss as miss:
+                        cue_gaps.append(
+                            {
+                                "memento": at,
+                                "reason": (
+                                    f"FunctionBindingMiss name={miss.name!r} "
+                                    f"reason={miss.reason}"
+                                ),
+                            }
+                        )
+                        continue
                     # A call IS substitution: ground args fill the pre, so the
                     # dig serves the contract AS APPLIED at this call (a concrete
                     # iterable unrolls the callee's loop here; the fold
@@ -2306,7 +2338,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     # the abstract is still a hole (that is the whole point of
                     # filling the pre). Arity is the binder's job (vararg packs,
                     # defaults fill) — never len(args)==len(params).
-                    if fn is not None and _tree._args_are_ground(call):
+                    if _tree._args_are_ground(call):
                         try:
                             keywords = tuple(
                                 (keyword.arg, keyword.value)
@@ -2316,29 +2348,50 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                             memento, rows = _tree.applied_contract_rows(
                                 fn, tuple(call.args), file_rel, keywords=keywords
                             )
-                        except (SugarNotWritten, SourceCallBindingGap):
+                        except SugarNotWritten:
+                            # Typed tree frontier: abstract identity fallback.
+                            rows = None
+                        except SourceCallBindingGap as bind_gap:
+                            cue_gaps.append(
+                                {
+                                    "memento": at,
+                                    "reason": f"SourceCallBindingGap: {bind_gap}",
+                                }
+                            )
                             rows = None
                         if rows:
                             cued.append(_node(memento.to_rpc(), rows[0]))
                             continue
-                    if t in by_name:
-                        cued.append(_node(*by_name[t]))
-                _send_enumerate_result(
-                    msg_id,
-                    cued,
-                    (
-                        []
-                        if cued
-                        else [
+                    # Abstract contract for THIS authenticated definition only.
+                    def_rpc = _tree.function_def_memento(fn, file_rel).to_rpc()
+                    abstract = by_source_cid.get(def_rpc["source_cid"])
+                    if abstract is not None:
+                        cued.append(_node(*abstract))
+                    else:
+                        cue_gaps.append(
                             {
                                 "memento": at,
                                 "reason": (
-                                    "no universe for the callee(s) this call site cues: "
-                                    f"{targets or 'none'}"
+                                    "resolved callee has no abstract universe row "
+                                    f"(name={t!r} source_cid={def_rpc['source_cid']})"
                                 ),
                             }
-                        ]
-                    ),
+                        )
+                dig_gaps = list(cue_gaps)
+                if not cued and not dig_gaps:
+                    dig_gaps.append(
+                        {
+                            "memento": at,
+                            "reason": (
+                                "no universe for the callee(s) this call site cues: "
+                                f"{targets or 'none'}"
+                            ),
+                        }
+                    )
+                _send_enumerate_result(
+                    msg_id,
+                    cued,
+                    dig_gaps,
                     term_tables=[term_table.nodes],
                 )
                 _log_enumeration_demand(

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumeration_binding_soft_skip_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumeration_binding_soft_skip_law.py
@@ -1,0 +1,254 @@
+"""Instrument: soft FunctionBindingMiss / spelling by_name after resolve.
+
+R axis: R_enumeration_binding_soft_skips
+
+Permanent floor until dig cannot soft-skip authenticated binding refuse and
+cannot serve abstract contracts by callee spelling after resolve.
+
+Lying twins plant the illegal shapes; truthful twins require the production
+membrane to stay clean and the dig to emit a named gap (not a wrong contract).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests import lift_rpc
+
+_KIT = Path(__file__).resolve().parents[1]
+_SCANNER_PATH = _KIT / "scripts" / "enumeration_binding_soft_skip_law.py"
+_SPEC = importlib.util.spec_from_file_location(
+    "enumeration_binding_soft_skip_law", _SCANNER_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_SCANNER = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_SCANNER)
+
+
+def _enumerate(level: str, workspace_root: Path, at=None, seek: bool = False):
+    captured = []
+    original_send = lift_rpc._send
+    lift_rpc._send = captured.append
+    try:
+        lift_rpc._dispatch_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "sugar.enumerate",
+                "params": {
+                    "level": level,
+                    "workspace_root": str(workspace_root),
+                    "at": at,
+                    "seek": seek,
+                    "options": {},
+                },
+            },
+        )
+    finally:
+        lift_rpc._send = original_send
+    assert len(captured) == 1, captured
+    response = captured[0]
+    assert "error" not in response, response
+    return response["result"]
+
+
+def test_scanner_flags_soft_function_binding_miss_continue(tmp_path: Path) -> None:
+    """Lying twin: except FunctionBindingMiss: continue is red."""
+    bad = tmp_path / "lift_rpc.py"
+    bad.write_text(
+        textwrap.dedent(
+            """
+            def dig(call):
+                try:
+                    fn = resolve_function_for_call(call)
+                except FunctionBindingMiss:
+                    continue
+            """
+        ),
+        encoding="utf-8",
+    )
+    offenders = _SCANNER.scan_sources([bad], root=tmp_path)
+    kinds = {o.kind for o in offenders}
+    assert "function-binding-miss-soft-skip" in kinds, offenders
+
+
+def test_scanner_flags_fn_none_soft_skip(tmp_path: Path) -> None:
+    """Lying twin: except FunctionBindingMiss: fn = None reopens soft-None."""
+    bad = tmp_path / "lift_rpc.py"
+    bad.write_text(
+        textwrap.dedent(
+            """
+            def dig(call):
+                try:
+                    fn = resolve_function_for_call(call)
+                except FunctionBindingMiss:
+                    fn = None
+            """
+        ),
+        encoding="utf-8",
+    )
+    offenders = _SCANNER.scan_sources([bad], root=tmp_path)
+    assert any(o.kind == "function-binding-miss-soft-skip" for o in offenders), offenders
+
+
+def test_scanner_flags_spelling_by_name_with_resolve(tmp_path: Path) -> None:
+    """Lying twin: by_name[t] on resolve path is the spelling second door."""
+    bad = tmp_path / "lift_rpc.py"
+    bad.write_text(
+        textwrap.dedent(
+            """
+            def dig(calls, universes):
+                by_name = {name: (m, d) for name, m, d in universes}
+                for call in calls:
+                    fn = resolve_function_for_call(call)
+                    t = call.func.id
+                    if t in by_name:
+                        cued.append(by_name[t])
+            """
+        ),
+        encoding="utf-8",
+    )
+    offenders = _SCANNER.scan_sources([bad], root=tmp_path)
+    assert any(o.kind == "spelling-by-name-after-resolve" for o in offenders), offenders
+
+
+def test_scanner_allows_gap_append_then_continue(tmp_path: Path) -> None:
+    """Truthful membrane: named gap then continue is not soft silence."""
+    ok = tmp_path / "lift_rpc.py"
+    ok.write_text(
+        textwrap.dedent(
+            """
+            def dig(call, at, gaps):
+                try:
+                    fn = resolve_function_for_call(call)
+                except FunctionBindingMiss as miss:
+                    gaps.append({
+                        "memento": at,
+                        "reason": f"FunctionBindingMiss name={miss.name!r} reason={miss.reason}",
+                    })
+                    continue
+            """
+        ),
+        encoding="utf-8",
+    )
+    offenders = _SCANNER.scan_sources([ok], root=tmp_path)
+    soft = [o for o in offenders if o.kind == "function-binding-miss-soft-skip"]
+    assert soft == [], soft
+
+
+def test_production_membrane_has_zero_soft_skips() -> None:
+    """Live offender census: production lift_rpc / tree_enumerate stay at R=0."""
+    paths = _SCANNER.production_scan_roots(_KIT)
+    assert paths, "production roots must exist"
+    offenders = _SCANNER.scan_sources(paths, root=_KIT)
+    assert offenders == [], (
+        "R_enumeration_binding_soft_skips>0 — soft binding skip or spelling "
+        f"by_name still live:\n"
+        + "\n".join(f"  {o.path}:{o.line} [{o.kind}] {o.note}" for o in offenders)
+    )
+
+
+def _call_site_memento(tmp_path: Path, test_function_name: str) -> dict:
+    """Walk source_files → functions → call_sites to the assertion cue memento."""
+    file_key = _enumerate("source_files", tmp_path)["nodes"][0]["memento"]
+    functions = {
+        n["memento"].get("function_name")
+        or n["memento"].get("source_function_name"): n["memento"]
+        for n in _enumerate("functions", tmp_path, at=file_key)["nodes"]
+    }
+    assert test_function_name in functions, sorted(functions)
+    sites = _enumerate("call_sites", tmp_path, at=functions[test_function_name])[
+        "nodes"
+    ]
+    assert sites, "expected a call-site / assertion memento"
+    return sites[0]["memento"]
+
+
+def test_universe_dig_binding_miss_emits_gap_not_spelling_contract(
+    tmp_path: Path,
+) -> None:
+    """Behavioral twin: unknown callee dig is a named gap, not a wrong contract.
+
+    Plant: module has def pack; call site names unknown_callee. Resolve must
+    refuse. Dig must not invent a universe from spelling. Gap reason names
+    FunctionBindingMiss.
+    """
+    (tmp_path / "mod.py").write_text(
+        textwrap.dedent(
+            """
+            def pack(a, *rest):
+                return (a, rest)
+
+            def test_a():
+                assert unknown_callee(1) == 1
+            """
+        ),
+        encoding="utf-8",
+    )
+    call_at = _call_site_memento(tmp_path, "test_a")
+    result = _enumerate("universe", tmp_path, at=call_at, seek=True)
+    # Must not serve pack (or any) contract under unknown_callee spelling.
+    for node in result["nodes"]:
+        name = (node.get("memento") or {}).get("source_function_name") or (
+            node.get("memento") or {}
+        ).get("function_name")
+        assert name != "pack", (
+            f"spelling fallback served pack after binding miss: {node}"
+        )
+    gap_text = " ".join(str(g.get("reason", "")) for g in result["gaps"])
+    assert "FunctionBindingMiss" in gap_text, (
+        f"expected FunctionBindingMiss gap, got nodes={result['nodes']!r} "
+        f"gaps={result['gaps']!r}"
+    )
+    assert result["nodes"] == [], result["nodes"]
+
+
+def test_universe_dig_prefers_module_binding_not_method_spelling(
+    tmp_path: Path,
+) -> None:
+    """Method and module share spelling ``pack``; dig must serve module def.
+
+    Old first-match / by_name last-wins could serve the method. Resolve +
+    identity abstract must serve module ``pack(a, *rest)``.
+    """
+    (tmp_path / "mod.py").write_text(
+        textwrap.dedent(
+            """
+            class Holder:
+                def pack(self, *items):
+                    return items
+
+            def pack(a, *rest):
+                return (a, rest)
+
+            def test_a():
+                assert pack(1, 2) == (1, (2,))
+            """
+        ),
+        encoding="utf-8",
+    )
+    call_at = _call_site_memento(tmp_path, "test_a")
+    result = _enumerate("universe", tmp_path, at=call_at, seek=True)
+    assert result["nodes"], result
+    miss_gaps = [
+        g
+        for g in result["gaps"]
+        if "FunctionBindingMiss" in str(g.get("reason", ""))
+    ]
+    assert miss_gaps == [], result["gaps"]
+    mementos = [n.get("memento") or {} for n in result["nodes"]]
+    assert any(
+        m.get("source_function_name") == "pack" or m.get("function_name") == "pack"
+        for m in mementos
+    ), mementos
+    # Must not sole-serve the method (self, *items) under module call spelling.
+    # Module pack's def memento is the module-level function name "pack".
+    assert all(
+        "Holder" not in str(m.get("function_name", ""))
+        and "Holder" not in str(m.get("source_function_name", ""))
+        for m in mementos
+    ), mementos


### PR DESCRIPTION
## Rung climb (not a review gate)

Review of #6946 found the construction door closed at `tree_enumerate` but **reopened** at the production dig membrane: `except FunctionBindingMiss: continue` / `fn = None` plus spelling `by_name[t]` after refuse.

### Ladder (asked in order)

1. **Type system?** Python cannot forbid `except FunctionBindingMiss`. No codomain close.
2. **One door that refuses?** Yes — `resolve_function_for_call` / `bind_node_actuals` already refuse. Dig must not invent a second serve path after refuse.
3. **Panic at contact?** Process panic on every dig miss would halt partial-workspace audit scans. Loud **gap row** is the honest terminal until enumerate can refuse the whole request as a typed outcome.
4. **Auditor (this PR)** holds the residual until soft catch + spelling `by_name` on the resolve path are gone forever; retirement note is in the law script.

### What changed

| Piece | Role |
| --- | --- |
| `scripts/enumeration_binding_soft_skip_law.py` | Permanent floor: AST census of soft `FunctionBindingMiss`, soft `SourceCallBindingGap`→`rows=None`, and spelling `by_name` co-located with `resolve_function_for_call` |
| `tests/test_enumeration_binding_soft_skip_law.py` | Lying twins plant the sin; live production roots at R=0; behavioral dig twins |
| `lift_rpc.py` dig | Miss → named gap then continue; abstract keyed by resolved def `source_cid`; no `by_name[t]` |
| `import_binding.py` | Floor repair: `authenticated_module_exports` passes `module_is_package` (was TypeError on enumerate) |

### Shot accounting

- **R axis lowered:** `R_enumeration_binding_soft_skips`
- **Predicted Epsilon R:** live production roots **2+ → 0** (soft miss handlers + spelling by_name)
- **Floors preserved:** no secrets, no deleted tests, `SugarNotWritten` applied-dig frontier membrane retained (typed tree gap, not binding refuse)
- **Shell deleted:** soft `FunctionBindingMiss → fn=None/continue` without gap, and spelling `by_name` abstract serve after resolve. **Auditor shell remains** until those shapes are unrepresentable; retirement path is named in the law module docstring.

### Validation (focused, this Mac)

```
PYTHONPATH=… pytest …/test_enumeration_binding_soft_skip_law.py \
  …/test_sin_cluster_6_enumeration_door.py \
  …/test_sin_cluster_6_exitset_typed_discrimination.py \
  …/test_enumerate_rpc.py::test_universe_cue_rewrites_temporal_callee_alias
# 23 passed; 7 tests collected in soft-skip file (not smaller)
python3 …/scripts/enumeration_binding_soft_skip_law.py
# R_enumeration_binding_soft_skips=0
```

Worktree: `.worktrees/sin6-instrument-forward` (repo-local; shared tree not touched).

Fixes forward residual of #6946; does not block #6946 merge.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace spelling-based binding fallback with source_cid lookup and record gaps on binding failures in `_handle_enumerate`
> - The `_handle_enumerate` RPC handler in [lift_rpc.py](https://github.com/TSavo/sugar/pull/6955/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) no longer silently continues or falls back to a `by_name` spelling index on `FunctionBindingMiss` or `SourceCallBindingGap`; instead it records explicit gap reasons and passes them to `_send_enumerate_result`.
> - Universe resolution now uses `source_cid` (authenticated definition identity) to select abstract contracts instead of the previous spelling-keyed `by_name` dict.
> - A new static auditor script [enumeration_binding_soft_skip_law.py](https://github.com/TSavo/sugar/pull/6955/files#diff-2721b8449654be765cda0f51c005fda39555415f0f14dbd9f956197657abbd9f) scans production membranes for soft-skip patterns (silent `continue`, `fn=None`, `rows=None` without gap append, or `by_name` usage on resolve paths) and fails with exit code 1 if any offenders are found.
> - A test module [test_enumeration_binding_soft_skip_law.py](https://github.com/TSavo/sugar/pull/6955/files#diff-b6108a7b40aa219ba2be4a6c39799bcdb74ab9474d70b6fcbe9dec190de76e87) asserts zero offenders in production and exercises the gap-producing enumerate behavior.
> - Behavioral Change: `FunctionBindingMiss` during universe/implication enumeration now always produces a gap entry in the response rather than being silently swallowed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 902877b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->