### PR TITLE
Ordering rung climb: panic decided gaps; string le/gt/ge Sugar; kill residual dual-edge

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -1118,19 +1118,28 @@ class FloorValue:
     def _refuse_ordering_meaning(
         self, other, site, *, owner: str, operator: str
     ) -> None:
-        """LAW_OF_ONE door for ordering: throw named; never mint FOL meaning.
+        """LAW_OF_ONE door for ordering: never mint FOL meaning.
 
         Exactly one mechanism produces meaning: AST shadows → temporal rewrite
         → Sugar. An ordering OUTCOME is meaning. Minting
         ``Complete(PredicateValue(py.lt/…))`` from a Python helper — even when
         both types are source-decided and the atom would be "right" — is a
-        second mechanism. Undecided pairs refuse as the third value; decided
-        pairs without a ground arm refuse until that arm is written.
+        second mechanism.
 
-        Does not return. Always raises ``SugarNotWritten``.
+        Two exits only:
+
+        * **Undecided** (operands denote values but runtime type is not
+          source-decided): named third-value refusal (``SugarNotWritten``).
+          Perfect machinery over source could not yet choose Sugar fold or
+          authenticated TypeError.
+        * **Decided (or non-undecided) with no ground arm**: construction
+          panic. That is OUR missing Floor/Sugar arm, not source
+          undecidability. Mislabeling it as ``SugarNotWritten`` is unwritten
+          code wearing a typed refusal. Binary floor already panics decided
+          missing pairs via ``_binary_floor_gap``; ordering matches that law.
+
+        Does not return.
         """
-        from sugar_source_tree.panic import SugarNotWritten
-
         denotes_self = getattr(self, "denotes_value", None)
         denotes_other = getattr(other, "denotes_value", None)
         both_denote = (
@@ -1148,41 +1157,42 @@ class FloorValue:
             and decided_self()
             and decided_other()
         )
+        pair = f"{type(self).__name__} {operator} {type(other).__name__}"
         if both_denote and not both_decided:
-            observed = (
-                "undecided ordering operand runtime type: "
-                f"{type(self).__name__} {operator} {type(other).__name__}"
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                blame=site,
+                owner=owner,
+                observed=f"undecided ordering operand runtime type: {pair}",
+                requested=(
+                    "source-visible runtime types selecting Sugar-owned ordering "
+                    "meaning or an authenticated exceptional exit"
+                ),
+                fix=(
+                    "do not mint Complete(PredicateValue(py.lt/le/gt/ge)) or invent "
+                    "TypeError; resolve both operands' runtime types from source, "
+                    "then construct via a ground Sugar arm"
+                ),
             )
-            requested = (
-                "source-visible runtime types selecting Sugar-owned ordering "
-                "meaning or an authenticated exceptional exit"
-            )
-            fix = (
-                "do not mint Complete(PredicateValue(py.lt/le/gt/ge)) or invent "
-                "TypeError; resolve both operands' runtime types from source, "
-                "then construct via a ground Sugar arm"
-            )
-        else:
-            observed = (
-                "default ordering floor has no Sugar arm for "
-                f"{type(self).__name__} {operator} {type(other).__name__}"
-            )
-            requested = (
-                "Sugar-owned ordering meaning (TrueBoolLiteralSugar / "
-                "FalseBoolLiteralSugar / authenticated RaiseValue) or a "
-                "named third-value refusal"
-            )
-            fix = (
-                "LAW_OF_ONE: implement a ground pair arm that constructs Sugar; "
-                "never resolve_comparison_atom / Complete(PredicateValue) on "
-                "FloorValue defaults"
-            )
-        raise SugarNotWritten(
-            blame=site,
+
+        # Decided pair with no arm — or non-denoting pair on this door: OUR gap.
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
             owner=owner,
-            observed=observed,
-            requested=requested,
-            fix=fix,
+            blame=site,
+            observed=f"default ordering floor has no Sugar arm for {pair}",
+            requested=(
+                "Sugar-owned ordering meaning (TrueBoolLiteralSugar / "
+                "FalseBoolLiteralSugar / authenticated RaiseValue)"
+            ),
+            fix=(
+                "LAW_OF_ONE / PANIC=GAP: implement a ground pair arm that "
+                "constructs Sugar; never resolve_comparison_atom / "
+                "Complete(PredicateValue) on FloorValue defaults; never label "
+                "a decided missing arm as SugarNotWritten"
+            ),
         )
 
     def _undecided_ordering_law(self, other, site, *, owner: str, operator: str):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -153,6 +153,71 @@ class StringValue(GuardStableValue):
             )
         return super().less_than_from_left(left, site)
 
+    def less_equal(self, other, site):
+        # Source-decided str lexicographic order is Sugar, not FOL invent and
+        # not a named refusal of missing machinery.
+        if type(other) is StringValue:
+            from sugar_lift_py_tests.outcome import Complete
+            from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+                FalseBoolLiteralSugar,
+            )
+            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                TrueBoolLiteralSugar,
+            )
+
+            return Complete(
+                TrueBoolLiteralSugar(site=site)
+                if self.value <= other.value
+                else FalseBoolLiteralSugar(site=site)
+            )
+        if self._unorderable_ground_peer(other):
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="StringValue.less_equal")
+        return super().less_equal(other, site)
+
+    def greater_than(self, other, site):
+        if type(other) is StringValue:
+            from sugar_lift_py_tests.outcome import Complete
+            from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+                FalseBoolLiteralSugar,
+            )
+            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                TrueBoolLiteralSugar,
+            )
+
+            return Complete(
+                TrueBoolLiteralSugar(site=site)
+                if self.value > other.value
+                else FalseBoolLiteralSugar(site=site)
+            )
+        if self._unorderable_ground_peer(other):
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="StringValue.greater_than")
+        return super().greater_than(other, site)
+
+    def greater_equal(self, other, site):
+        if type(other) is StringValue:
+            from sugar_lift_py_tests.outcome import Complete
+            from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+                FalseBoolLiteralSugar,
+            )
+            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+                TrueBoolLiteralSugar,
+            )
+
+            return Complete(
+                TrueBoolLiteralSugar(site=site)
+                if self.value >= other.value
+                else FalseBoolLiteralSugar(site=site)
+            )
+        if self._unorderable_ground_peer(other):
+            from sugar_lift_py_tests.floor.ground_exit import ground_type_error
+
+            return ground_type_error(site=site, owner="StringValue.greater_equal")
+        return super().greater_equal(other, site)
+
     def length(self, site):
         # A string knows its length: the count of characters.
         del site

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -108,21 +108,43 @@ def publish_undecided_comparison_edges(left, right, site, op_kind: str, outcome)
 
 
 def publish_undecided_ordering_edges(left, right, site, op_kind: str, outcome):
-    """Ordering law: undecided / default floor throws named (LAW_OF_ONE).
+    """Ordering law: never dual-edge residual FOL invent (LAW_OF_ONE).
 
-    Ordering meaning is Sugar. Floor defaults must not mint
-    ``Complete(PredicateValue)``; when they refuse, ``outcome`` is never a
-    completed predicate dual-edge. This publisher is a no-op safety net for
-    residual Complete(PredicateValue) fabrications — equality/membership still
-    use the shared dual-edge helper where they have not yet been retired.
+    Floor undecided doors throw named; ground doors construct Sugar or
+    authenticated RaiseValue. A residual ``Complete(PredicateValue)`` is OUR
+    fabrication second door — construction panic, not a nameless dual-edge
+    ExitSet. Equality still dual-edges via the shared helper; membership uses
+    :func:`publish_undecided_membership_edges`.
+
+    Retirement path: when no path can mint ordering PredicateValue, this
+    membrane only passes through and may shrink to ``return outcome``.
     """
-    return _publish_undecided_dispatch_edges(
-        left,
-        right,
-        site,
-        op_kind,
-        outcome,
-        law=CompareLaw.ORDERING,
+    del left, right
+    from sugar_lift_py_tests.floor import PredicateValue
+    from sugar_lift_py_tests.outcome import Complete
+
+    if not isinstance(outcome, Complete) or not isinstance(
+        outcome.value, PredicateValue
+    ):
+        return outcome
+
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner="publish_undecided_ordering_edges",
+        blame=site,
+        observed=(
+            f"residual Complete(PredicateValue) on ordering desugar ({op_kind})"
+        ),
+        requested=(
+            "named SugarNotWritten for undecided operands, or Sugar-owned "
+            "TrueBool/FalseBool/RaiseValue for decided ground"
+        ),
+        fix=(
+            "LAW_OF_ONE: never dual-edge or sole-complete FOL invent for "
+            "ordering; construct Sugar on ground arms; throw named when "
+            "runtime types are undecided"
+        ),
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -179,20 +179,32 @@ def _assert_dual_dispatch(outcome, *, atom: str, blame: str) -> None:
 
 
 def _assert_named_ordering_or_membership_refusal(thunk) -> SugarNotWritten:
-    """Ordering/membership undecided dispatch throws named — never Complete."""
+    """Ordering/membership undecided dispatch throws named — never Complete.
+
+    Tooth requires ``undecided`` in observed (third-value testimony). Soft OR
+    on owner alone would green a decided-missing-arm mislabel as refusal.
+    """
     with pytest.raises(SugarNotWritten) as raised:
         thunk()
     observed = (raised.value.observed or "").lower()
-    owner = raised.value.owner or ""
+    owner = (raised.value.owner or "").lower()
+    assert "undecided" in observed, (
+        "undecided refusal must name undecidability in observed; "
+        f"got owner={raised.value.owner!r} observed={raised.value.observed!r}"
+    )
     assert (
-        "undecided" in observed
-        or "ordering" in observed
+        "ordering" in observed
         or "membership" in observed
-        or "contain" in owner.lower()
+        or "contain" in observed
+        or "contain" in owner
         or "less_than" in owner
         or "greater" in owner
         or "less_equal" in owner
         or "contains" in owner
+        or "binary" in owner
+    ), (
+        f"refusal must name ordering/membership owner or observed; "
+        f"got owner={raised.value.owner!r} observed={raised.value.observed!r}"
     )
     return raised.value
 
@@ -936,11 +948,13 @@ def test_decided_false_first_leg_emits_no_second_leg_occurrence() -> None:
     assert all(effect.occurrence_id != second_occurrence for effect in effects)
 
 
-def test_subscript_root_preserves_nested_compare_owned_halt() -> None:
-    """The concrete 128th row keeps the Compare halt through Subscript."""
-    from sugar_lift_py_tests.outcome import ExitSet
-    from sugar_lift_py_tests.outcome.exit_set import Halted
+def test_subscript_root_preserves_nested_compare_owned_refusal() -> None:
+    """Enrolled getitem row: nested Compare undecided ordering throws named.
 
+    Law change from nameless dual-edge Halted(Compare): undecided operands
+    refuse at the ordering floor (SugarNotWritten). Subscript must not swallow
+    that refusal into a fabricated ExitSet or sole Complete.
+    """
     path = _corpus_root() / "tests/series/indexing/test_getitem.py"
     source = path.read_text(encoding="utf-8")
     assert hashlib.sha256(source.encode()).hexdigest() == GETITEM_SITE_SHA256
@@ -959,12 +973,9 @@ def test_subscript_root_preserves_nested_compare_owned_halt() -> None:
         if isinstance(node, Compare) and node.line_col_span().start_line == 595
     )
 
-    outcome = subscript.sugar().desugar(None)
-    assert isinstance(outcome, ExitSet)
-    compare_halt = next(
-        face
-        for face in outcome.exits
-        if isinstance(face, Halted) and face.effect.producer_node_owner == "Compare"
-    )
-    assert compare_halt.effect.exception_name is None
-    assert compare_halt.effect.blame == str(comparison.fragment)
+    with pytest.raises(SugarNotWritten) as raised:
+        subscript.sugar().desugar(None)
+    assert "undecided" in (raised.value.observed or "").lower()
+    # Blame still cites the Compare locus (not a silent swallow at Subscript).
+    blame = str(raised.value.blame)
+    assert str(comparison.fragment) in blame or "test_getitem" in blame

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -11,8 +12,39 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_source_tree.nodes import BinOp
 from sugar_source_tree.tree import SourceFile
+
+
+@dataclass(frozen=True)
+class _ValueSugar(ConstructedTermSugar):
+    """Floor carrier for ground TypeError twins — must be ConstructedTermSugar."""
+
+    value: object
+    site: object = "pandas-binary-value-sugar-site"
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(self.value)
+
+    def to_term(self, *, owner: str):
+        return self.value.to_term(owner=owner)
+
+    def occurrence_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        del owner
+        return ctor(
+            "python:test-value-sugar-occurrence",
+            (str_const(type(self.value).__name__),),
+            symbol_kind="coordinate",
+        )
 
 # Content manifest (relative path + per-file BLAKE3-512). Path-shape
 # sha256:a223… is historical negative testimony only — never identity.
@@ -180,14 +212,11 @@ def test_source_decided_int_float_bitand_emits_type_error() -> None:
     bitwise floor constructs authenticated TypeError RaiseValue. The twin is
     built on a workspace-relative locus so the ground exit can cite source.
     """
-    from dataclasses import dataclass
-
     from sugar_lift_py_tests.context_manager_resolution import (
         TreeConstructionContextV1,
     )
     from sugar_lift_py_tests.floor import RaiseValue, TermValue
     from sugar_lift_py_tests.outcome import Complete
-    from sugar_lift_py_tests.sugar.sugar_base import Sugar
     from sugar_lift_python_source.canonical import blake3_512_of
     from sugar_source_tree.nodes import BinOp
     from sugar_source_tree.tree import SourceFile
@@ -204,18 +233,6 @@ def test_source_decided_int_float_bitand_emits_type_error() -> None:
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
     )
     node = next(n for n in tree.nodes() if isinstance(n, BinOp))
-
-    @dataclass(frozen=True)
-    class _ValueSugar(Sugar):
-        value: object
-
-        @classmethod
-        def witnesses(cls):
-            return ()
-
-        def desugar(self, ctx=None):
-            del ctx
-            return Complete(self.value)
 
     operation = type(node.sugar())(
         "BitAnd",
@@ -235,14 +252,11 @@ def test_source_decided_int_plus_str_emits_type_error() -> None:
     Enrolled shapes like ``"foo_" + ser`` refuse on undecided right; the
     dual ``TermValue + StringValue`` publishes RaiseValue.
     """
-    from dataclasses import dataclass
-
     from sugar_lift_py_tests.context_manager_resolution import (
         TreeConstructionContextV1,
     )
     from sugar_lift_py_tests.floor import RaiseValue, StringValue, TermValue
     from sugar_lift_py_tests.outcome import Complete
-    from sugar_lift_py_tests.sugar.sugar_base import Sugar
     from sugar_lift_python_source.canonical import blake3_512_of
     from sugar_source_tree.nodes import BinOp
     from sugar_source_tree.tree import SourceFile
@@ -253,18 +267,6 @@ def test_source_decided_int_plus_str_emits_type_error() -> None:
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
     )
     node = next(n for n in tree.nodes() if isinstance(n, BinOp))
-
-    @dataclass(frozen=True)
-    class _ValueSugar(Sugar):
-        value: object
-
-        @classmethod
-        def witnesses(cls):
-            return ()
-
-        def desugar(self, ctx=None):
-            del ctx
-            return Complete(self.value)
 
     operation = type(node.sugar())(
         "Add",
@@ -283,14 +285,11 @@ def test_source_decided_int_mod_list_emits_type_error() -> None:
 
     ``TermValue % ListValue`` is Python TypeError when both sides are decided.
     """
-    from dataclasses import dataclass
-
     from sugar_lift_py_tests.context_manager_resolution import (
         TreeConstructionContextV1,
     )
     from sugar_lift_py_tests.floor import ListValue, RaiseValue, TermValue
     from sugar_lift_py_tests.outcome import Complete
-    from sugar_lift_py_tests.sugar.sugar_base import Sugar
     from sugar_lift_python_source.canonical import blake3_512_of
     from sugar_source_tree.nodes import BinOp
     from sugar_source_tree.tree import SourceFile
@@ -301,18 +300,6 @@ def test_source_decided_int_mod_list_emits_type_error() -> None:
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
     )
     node = next(n for n in tree.nodes() if isinstance(n, BinOp))
-
-    @dataclass(frozen=True)
-    class _ValueSugar(Sugar):
-        value: object
-
-        @classmethod
-        def witnesses(cls):
-            return ()
-
-        def desugar(self, ctx=None):
-            del ctx
-            return Complete(self.value)
 
     operation = type(node.sugar())(
         "Mod",
@@ -333,11 +320,8 @@ def test_source_decided_list_plus_int_emits_type_error() -> None:
     constructed ListValue and the right a TermValue, BinOp publishes
     RaiseValue rather than panicking or inventing a concat coordinate.
     """
-    from dataclasses import dataclass
-
     from sugar_lift_py_tests.floor import ListValue, RaiseValue, TermValue
     from sugar_lift_py_tests.outcome import Complete
-    from sugar_lift_py_tests.sugar.sugar_base import Sugar
     from sugar_lift_python_source.canonical import blake3_512_of
     from sugar_source_tree.tree import SourceFile
     from sugar_lift_py_tests.context_manager_resolution import (
@@ -351,18 +335,6 @@ def test_source_decided_list_plus_int_emits_type_error() -> None:
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
     )
     node = next(n for n in tree.nodes() if isinstance(n, BinOp))
-
-    @dataclass(frozen=True)
-    class _ValueSugar(Sugar):
-        value: object
-
-        @classmethod
-        def witnesses(cls):
-            return ()
-
-        def desugar(self, ctx=None):
-            del ctx
-            return Complete(self.value)
 
     operation = type(node.sugar())(
         "Add",

--- a/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py
@@ -194,15 +194,41 @@ def test_source_decided_int_ordering_constructs_bool_sugar() -> None:
     assert isinstance(outcome.value, TrueBoolLiteralSugar)
 
 
-def test_decided_default_pair_without_sugar_arm_throws_named() -> None:
-    """LAW_OF_ONE: decided types with no ground arm refuse — no FOL invent."""
+def test_decided_default_pair_without_sugar_arm_panics_not_refuses() -> None:
+    """PANIC=GAP: decided types with no ground arm are OUR defect, not refusal.
+
+    Mislabeling this as SugarNotWritten is unwritten code wearing a typed
+    refusal. Binary floor panics decided missing pairs; ordering matches.
+    """
     from sugar_lift_py_tests.floor.list_value import ListValue
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
     # ListValue has no ordering arm; both types are source-decided.
-    with pytest.raises(SugarNotWritten) as raised:
+    with pytest.raises(ConstructionPanic) as raised:
         ListValue((TermValue(1),)).less_than(ListValue((TermValue(2),)), SITE)
-    assert "LAW_OF_ONE" in (raised.value.fix or "")
-    assert "Complete(PredicateValue)" in (raised.value.fix or "")
+    msg = str(raised.value)
+    assert "no Sugar arm" in msg or "LAW_OF_ONE" in msg
+    assert "Complete(PredicateValue)" in msg or "PredicateValue" in msg
+
+
+def test_decided_string_le_gt_ge_construct_bool_sugar() -> None:
+    """Truthful: source-decided str ordering folds to True/False Sugar for all ops."""
+    from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+
+    a, b = StringValue("a"), StringValue("b")
+    le = a.less_equal(b, SITE)
+    assert isinstance(le, Complete)
+    assert isinstance(le.value, TrueBoolLiteralSugar)
+    gt = b.greater_than(a, SITE)
+    assert isinstance(gt, Complete)
+    assert isinstance(gt.value, TrueBoolLiteralSugar)
+    ge = a.greater_equal(a, SITE)
+    assert isinstance(ge, Complete)
+    assert isinstance(ge.value, TrueBoolLiteralSugar)
+    # False face still Sugar, never PredicateValue invent.
+    le_false = b.less_equal(a, SITE)
+    assert isinstance(le_false.value, FalseBoolLiteralSugar)
 
 
 def test_lying_complete_predicate_is_not_ordering_meaning() -> None:
@@ -215,6 +241,49 @@ def test_lying_complete_predicate_is_not_ordering_meaning() -> None:
         raise AssertionError(
             "ordering floor returned a value; must throw named (LAW_OF_ONE)"
         )
+
+
+def test_lying_residual_ordering_predicate_mint_panics_at_publisher() -> None:
+    """Lying twin: residual Complete(PredicateValue) cannot dual-edge at Sugar.
+
+    Plants the old FOL invent outcome into publish_undecided_ordering_edges.
+    Must ConstructionPanic — never ExitSet with nameless Compare halt.
+    """
+    from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.ir import atomic
+    from sugar_lift_py_tests.outcome import ExitSet
+    from sugar_lift_py_tests.sugar.comparison_op_sugar import (
+        publish_undecided_ordering_edges,
+    )
+
+    left = _symbolic()
+    right = TermValue(1)
+    forged = Complete(
+        PredicateValue(
+            atomic(
+                "py.lt",
+                [
+                    left.to_term(owner="lying residual left"),
+                    right.to_term(owner="lying residual right"),
+                ],
+            ),
+            SITE,
+        )
+    )
+    with pytest.raises(ConstructionPanic) as raised:
+        outcome = publish_undecided_ordering_edges(
+            left, right, SITE, "Lt", forged
+        )
+        if isinstance(outcome, ExitSet):
+            raise AssertionError(
+                "residual ordering PredicateValue dual-edged — SIN reintroduced"
+            )
+        raise AssertionError(
+            "residual ordering PredicateValue passed through; must panic"
+        )
+    assert "PredicateValue" in str(raised.value)
+    assert "ordering" in str(raised.value).lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fix-forward for #6942 review defects (not a gate — instruments + green)

Adversarial review of PR #6942 found the floor FOL invent was partially ripped, then **substituted**: decided missing arms and decided string `<=`/`>`/`>=` became `SugarNotWritten`, and residual `Complete(PredicateValue)` could still dual-edge at the Sugar publisher. This PR climbs those defects.

### R axes / Epsilon R

| Axis | Before | Epsilon R | After |
| --- | --- | --- | --- |
| `R_decided_ordering_refusal_mislabel` | decided missing arm → `SugarNotWritten` | −class | `construction_panic` (PANIC=GAP) |
| `R_string_ordering_sugar_arms` | StringValue only folds `<` | −4 ops | `<=`/`>`/`>=` construct True/False Sugar |
| `R_ordering_residual_dual_edge` | residual PredicateValue dual-edged nameless | −door | construction panic at `publish_undecided_ordering_edges` |
| `R_soft_refusal_helper` | owner-substring OR greened mislabels | −soft tooth | requires `undecided` in observed |
| enrolled getitem pin | expected nameless Compare `ExitSet` halt | law update | named refusal through Subscript |

**Floors preserved:** FloorValue defaults never mint `Complete(PredicateValue)`; undecided operands still `SugarNotWritten` (third value).

### Shells deleted

1. **`test_decided_default_pair_without_sugar_arm_throws_named`** — pinned refuse-as-green for decided ListValue. Replaced by `…_panics_not_refuses`.
2. **ORDERING residual dual-edge “safety net”** in `publish_undecided_ordering_edges` — second mechanism that dual-edged FOL invent with nameless `RaiseEffect`. Now panics.
3. Soft OR helper that greened decided-mislabel as “refusal” without `undecided` in observed.
4. Bare `Sugar` `_ValueSugar` twins (ConstructedTermSugar door red).

### Rung climb (AGENTS.md ladder)

- Type system: open floor hierarchy — cannot forbid yet.
- One door: `_refuse_ordering_meaning` splits undecided refuse vs decided panic.
- Panic at contact: decided missing arm + residual PredicateValue publisher.
- Auditor: residual ordering membrane has retirement note in docstring (shrink to `return outcome` when no mint path remains).

### Instruments (lying + truthful)

- `test_decided_default_pair_without_sugar_arm_panics_not_refuses`
- `test_decided_string_le_gt_ge_construct_bool_sugar`
- `test_lying_residual_ordering_predicate_mint_panics_at_publisher` (plants residual invent)
- AST tooth for FloorValue defaults retained
- Enrolled getitem pin → named refusal

### Validation

```bash
PYTHONPATH=.../sugar-lift-py-tests/src:.../sugar-source-tree/src:.../sugar-lift-python-source/src
/usr/local/opt/python@3.12/bin/python3.12 -m pytest \
  implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py \
  implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py \
  implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py \
  implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py \
  -q --tb=line > /tmp/out.log 2>&1; echo "EXIT=$?"; tail -5 /tmp/out.log
# EXIT=0; 156 passed
```

### What remains (not zero, honest worklist)

- `ListValue` (and other decided containers) ordering still panics until Sugar arms written — that panic **is** the instrument / worklist, not debt to pin.
- Equality still dual-edges undecided `Complete(PredicateValue)` — separate axis, not claimed zero here.
- Membership residual dual-edge door still exists if residual invent returns; only ORDERING publisher was closed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace symbolic predicate emission with named `SugarNotWritten` refusals for ordering and membership on undecided values
> - `FloorValue` ordering methods (`less_equal`, `greater_than`, `greater_equal`) and `_undecided_binary_law` no longer construct `Complete(PredicateValue)` or dual-face `ExitSet` results; they now raise `SugarNotWritten` for undecided operands or call `construction_panic_gap` when a decided pair lacks a Sugar arm.
> - `StringValue` gains `less_equal`, `greater_than`, `greater_equal`, and `less_than_from_left` methods that fold to Bool Sugar for string pairs, return a ground `TypeError` for unorderable ground peers, and delegate to the updated superclass otherwise.
> - `SymbolicValue` and `CallSiteValue` membership (`contains`) now delegate to `undecided_contains`, raising `SugarNotWritten` instead of returning a predicate `Complete`.
> - `publish_undecided_ordering_edges` in [comparison_op_sugar.py](https://github.com/TSavo/sugar/pull/6956/files#diff-e0df8a37726533db4efcdfaffdc4afc7190958f424ccaac6c06eb132f85de773) panics via `construction_panic_gap` if a residual `Complete(PredicateValue)` reaches the publisher.
> - Tests across ordering, binary operand, and membership suites are updated to assert `SugarNotWritten` rather than dual-edge `ExitSet` outcomes.
> - Behavioral Change: any call site that previously received a dual-face `ExitSet` or symbolic predicate for undecided ordering/membership will now get a raised `SugarNotWritten` refusal instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 467692a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->