### PR TITLE
Process floors measure authenticated pandas, not kit false green

### DIFF
--- a/docs/contributing/python-sole-construction.md
+++ b/docs/contributing/python-sole-construction.md
@@ -38,8 +38,11 @@ Scripts:
   across production package and corpus tooling; only
   `audit_only/collect_construction_gaps.py` is the catch membrane
 - `scripts/vendor_special_case_law.py` → `R_vendor_special_case`
-- `scripts/native_crash_zero_tolerance.py` → `R_native_crashes` across every
-  Python file in the production package and corpus tooling
+- `scripts/native_crash_zero_tolerance.py` → `R_native_crashes` across the
+  **authenticated pandas corpus** (process floors). Paths are required:
+  silent default to kit `production_roots` is forbidden (wrong-population
+  false green). Same population rule for bare-exception and timeout floors
+  in `tools/run_sole_construction_floors.sh`.
 - `scripts/silent_zero_tolerance.py` → `R_silent` across every Python file in
   the production package and corpus tooling
 - `scripts/factory_walk_unclassified_law.py` → `R_factory_walk_unclassified`

--- a/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
@@ -57,6 +57,15 @@ def python_paths(roots: Sequence[Path]) -> list[Path]:
 
 
 def production_roots(repo_root: Path) -> tuple[Path, Path]:
+    """Kit package + corpus tooling only — NOT the pandas/numpy corpus wall.
+
+    Historical trap: native-crash / timeout / bare-exception floors defaulted
+    here when invoked with no path args. That measures Sugar's own sources
+    (~400 files) and reports green while the authenticated pandas corpus
+    (the population those process floors police) stays unmeasured. Use this
+    helper only when the caller *names* kit self-check; never as a silent
+    CLI default for corpus process floors.
+    """
     kit = repo_root / "implementations/python/sugar-lift-py-tests"
     return (kit / "src/sugar_lift_py_tests", kit / "scripts")
 
@@ -66,6 +75,30 @@ def require_python_paths(roots: Sequence[Path]) -> list[Path]:
     if not paths:
         raise ValueError(f"no Python source files found under {list(roots)}")
     return paths
+
+
+def require_explicit_scan_roots(roots: Sequence[Path]) -> list[Path]:
+    """Refuse empty path sets so a floor cannot green on a defaulted population.
+
+    The silent ``production_roots`` argparse default was a false-green door:
+    CI invoked the scanners with no args, they scanned kit src+scripts, and
+    R=0 meant "kit did not crash" while the pandas corpus was never entered.
+
+    Call sites must pass the intended roots (authenticated pandas corpus for
+    process floors). Empty is red, not a fallback.
+
+    Retirement: when these scanners' CLIs no longer admit zero path args
+    (required non-empty roots at the argparse door / typed config), delete
+    this check — empty becomes unrepresentable rather than audited.
+    """
+    if not roots:
+        raise ValueError(
+            "scan roots must be explicit and non-empty; refusing empty or "
+            "defaulted path set (wrong-population false green). Pass the "
+            "authenticated pandas corpus root (or other named population), "
+            "never rely on production_roots as a silent default."
+        )
+    return require_python_paths(roots)
 
 
 def relative_to_root(path: Path, root: Path) -> str:

--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _enum_floor_runtime import (  # noqa: E402
     prepare_floor_io,
     production_roots,
+    require_explicit_scan_roots,
     require_python_paths,
 )
 from _production_lift_child import (  # noqa: E402
@@ -99,7 +100,14 @@ def main() -> int:
     repo_root = Path(__file__).resolve().parents[4]
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "paths", nargs="*", type=Path, default=list(production_roots(repo_root))
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[],
+        help=(
+            "Scan roots (required, non-empty). Process floors police the "
+            "authenticated pandas corpus — never silent kit production_roots."
+        ),
     )
     parser.add_argument("--repo-root", type=Path, default=repo_root)
     parser.add_argument("--file-timeout", type=int, default=30)
@@ -118,10 +126,14 @@ def main() -> int:
         )
         return 2
     try:
-        paths = require_python_paths(args.paths)
+        paths = require_explicit_scan_roots(args.paths)
     except ValueError as error:
         print(f"BARE-EXCEPTION ZERO-TOLERANCE RED: {error}")
         return 1
+    print(
+        "BARE-EXCEPTION POPULATION: "
+        f"roots={[str(p) for p in args.paths]} files={len(paths)}"
+    )
 
     _base, engine_path, progress_path = prepare_floor_io(
         repo_root=args.repo_root,

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -25,6 +25,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _enum_floor_runtime import (  # noqa: E402
     prepare_floor_io,
     production_roots,
+    require_explicit_scan_roots,
     require_python_paths,
 )
 from _production_lift_child import production_lift_bootstrap_error  # noqa: E402
@@ -156,7 +157,11 @@ def main() -> int:
         "paths",
         nargs="*",
         type=Path,
-        default=list(production_roots(repo_root)),
+        default=[],
+        help=(
+            "Scan roots (required, non-empty). Process floors police the "
+            "authenticated pandas corpus — never silent kit production_roots."
+        ),
     )
     parser.add_argument("--repo-root", type=Path, default=repo_root)
     parser.add_argument("--file-timeout", type=int, default=30)
@@ -178,10 +183,14 @@ def main() -> int:
         return 2
 
     try:
-        paths = require_python_paths(args.paths)
+        paths = require_explicit_scan_roots(args.paths)
     except ValueError as error:
         print(f"NATIVE-CRASH ZERO-TOLERANCE RED: {error}")
         return 1
+    print(
+        "NATIVE-CRASH POPULATION: "
+        f"roots={[str(p) for p in args.paths]} files={len(paths)}"
+    )
 
     _base, engine_path, progress_path = prepare_floor_io(
         repo_root=args.repo_root,

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _enum_floor_runtime import (  # noqa: E402
     prepare_floor_io,
     production_roots,
+    require_explicit_scan_roots,
     require_python_paths,
 )
 from _production_lift_child import production_lift_bootstrap_error  # noqa: E402
@@ -98,7 +99,14 @@ def main() -> int:
     repo_root = Path(__file__).resolve().parents[4]
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "paths", nargs="*", type=Path, default=list(production_roots(repo_root))
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[],
+        help=(
+            "Scan roots (required, non-empty). Process floors police the "
+            "authenticated pandas corpus — never silent kit production_roots."
+        ),
     )
     parser.add_argument("--repo-root", type=Path, default=repo_root)
     parser.add_argument("--file-timeout", type=int, default=30)
@@ -119,10 +127,14 @@ def main() -> int:
         )
         return 2
     try:
-        paths = require_python_paths(args.paths)
+        paths = require_explicit_scan_roots(args.paths)
     except ValueError as error:
         print(f"TIMEOUT ZERO-TOLERANCE RED: {error}")
         return 1
+    print(
+        "TIMEOUT POPULATION: "
+        f"roots={[str(p) for p in args.paths]} files={len(paths)}"
+    )
 
     _base, engine_path, progress_path = prepare_floor_io(
         repo_root=args.repo_root,

--- a/implementations/python/sugar-lift-py-tests/tests/test_enum_floor_explicit_population.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enum_floor_explicit_population.py
@@ -1,0 +1,68 @@
+"""Process floors refuse empty/defaulted path sets (wrong-population false green).
+
+Historical bug: native_crash / timeout / bare_exception scanners defaulted
+``paths`` to ``production_roots`` (kit src + scripts, ~444 files). CI invoked
+them with no args; R=0 meant "kit did not crash" while the authenticated
+pandas corpus was never scanned.
+
+Tooth: empty roots raise; non-empty roots still require discoverable *.py.
+Lying twin: calling require_explicit_scan_roots(()) must fail — that is the
+silent-default door reopened.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_RUNTIME_PATH = _SCRIPTS / "_enum_floor_runtime.py"
+_SPEC = importlib.util.spec_from_file_location("_enum_floor_runtime", _RUNTIME_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_RUNTIME = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_RUNTIME)
+
+
+def test_empty_scan_roots_are_loud() -> None:
+    with pytest.raises(ValueError, match="explicit and non-empty"):
+        _RUNTIME.require_explicit_scan_roots(())
+
+
+def test_lying_twin_production_roots_are_not_a_silent_cli_default() -> None:
+    """Scanner CLIs must not default paths to production_roots anymore."""
+    for name in (
+        "native_crash_zero_tolerance.py",
+        "timeout_zero_tolerance.py",
+        "bare_exception_zero_tolerance.py",
+    ):
+        source = (_SCRIPTS / name).read_text(encoding="utf-8")
+        assert "default=list(production_roots" not in source, (
+            f"{name} still silently defaults paths to production_roots"
+        )
+        assert "require_explicit_scan_roots" in source, (
+            f"{name} must refuse empty path sets at the door"
+        )
+
+
+def test_truthful_named_root_discovers_python(tmp_path: Path) -> None:
+    (tmp_path / "mod.py").write_text("x = 1\n", encoding="utf-8")
+    paths = _RUNTIME.require_explicit_scan_roots((tmp_path,))
+    assert paths == [tmp_path / "mod.py"]
+
+
+def test_missing_named_root_still_loud(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="no Python source files"):
+        _RUNTIME.require_explicit_scan_roots((tmp_path / "absent",))
+
+
+def test_production_roots_are_kit_not_pandas(tmp_path: Path) -> None:
+    """Document the wrong population so it cannot be confused with corpus."""
+    roots = _RUNTIME.production_roots(tmp_path)
+    assert roots == (
+        tmp_path / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests",
+        tmp_path / "implementations/python/sugar-lift-py-tests/scripts",
+    )
+    joined = " ".join(str(r) for r in roots)
+    assert "pandas" not in joined

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -68,6 +68,39 @@ def test_binding_job_invokes_every_permanent_axis() -> None:
                 "R_factory_walk_unclassified only runs a fixture/discrimination; "
                 "binding CI must census the checked-in production surface"
             )
+        if axis in {
+            "R_native_crashes = 0",
+            "R_bare_exceptions = 0",
+            "R_timeouts = 0",
+        }:
+            # Process floors must name a population. Bare script invocation
+            # used to default to kit production_roots (~444 files) — false
+            # green while the authenticated pandas corpus went unmeasured.
+            assert "PANDAS_CORPUS" in step or "authenticated_pandas" in step, (
+                f"{axis} must pass an explicit corpus path; silent default "
+                "to kit production_roots is a wrong-population false green"
+            )
+            # Not only the script name: a path argument must follow.
+            assert '"$PANDAS_CORPUS"' in step or "'$PANDAS_CORPUS'" in step, (
+                f"{axis} must pass \"$PANDAS_CORPUS\" as the scan root"
+            )
+
+
+def test_process_floors_resolve_authenticated_pandas_population() -> None:
+    """The floor set must authenticate pandas before the three process axes."""
+    floors = FLOOR_SET.read_text()
+    assert "authenticated_pandas_corpus" in floors, (
+        "process floors must resolve the authenticated pandas corpus root"
+    )
+    assert "PANDAS_CORPUS=" in floors
+    # Order: corpus resolved once, then all three axes use it.
+    corpus_at = floors.find("PANDAS_CORPUS=")
+    native_at = floors.find('axis "R_native_crashes = 0"')
+    bare_at = floors.find('axis "R_bare_exceptions = 0"')
+    timeout_at = floors.find('axis "R_timeouts = 0"')
+    assert 0 <= corpus_at < native_at < bare_at < timeout_at, (
+        "PANDAS_CORPUS must be bound before the process-floor axes"
+    )
 
 
 def test_no_axis_is_skipped_after_an_earlier_honest_red() -> None:

--- a/tools/run_sole_construction_floors.sh
+++ b/tools/run_sole_construction_floors.sh
@@ -48,9 +48,28 @@ axis "R_construction_panic_catches_outside_membrane = 0" \
   python "$SCRIPTS/construction_panic_catch_law.py"
 
 # Heavy supervised enum floors — sequential, inside the one lease interval.
-axis "R_native_crashes = 0" python "$SCRIPTS/native_crash_zero_tolerance.py"
-axis "R_bare_exceptions = 0" python "$SCRIPTS/bare_exception_zero_tolerance.py"
-axis "R_timeouts = 0" python "$SCRIPTS/timeout_zero_tolerance.py"
+# Population: authenticated pandas corpus (NOT kit production_roots).
+# Silent default to sugar-lift-py-tests src+scripts was a false green: R=0 on
+# ~444 kit files while the corpus process floors never entered pandas.
+# Scanners refuse empty path args; this binding must name the corpus root.
+PANDAS_CORPUS="$(
+  python -c 'from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus; print(authenticated_pandas_corpus().root)'
+)" || {
+  echo "::error::cannot authenticate pandas corpus for process floors"
+  exit 1
+}
+echo "process-floor population: authenticated pandas corpus at $PANDAS_CORPUS"
+# --repo-root must be the corpus root (not the Sugar checkout): relative loci
+# and supervised-enum corpus_root are derived from it.
+axis "R_native_crashes = 0" \
+  python "$SCRIPTS/native_crash_zero_tolerance.py" "$PANDAS_CORPUS" \
+  --repo-root "$PANDAS_CORPUS"
+axis "R_bare_exceptions = 0" \
+  python "$SCRIPTS/bare_exception_zero_tolerance.py" "$PANDAS_CORPUS" \
+  --repo-root "$PANDAS_CORPUS"
+axis "R_timeouts = 0" \
+  python "$SCRIPTS/timeout_zero_tolerance.py" "$PANDAS_CORPUS" \
+  --repo-root "$PANDAS_CORPUS"
 
 axis "All permanent axes are bound" \
   python -m pytest tests/test_python_sole_construction_ci.py -q


### PR DESCRIPTION
## Summary

**Bug (verified):** `tools/run_sole_construction_floors.sh` lines 51–53 invoked
`native_crash_zero_tolerance.py`, `bare_exception_zero_tolerance.py`, and
`timeout_zero_tolerance.py` with **no path args**. Each scanner defaulted to
`production_roots` = kit `src/sugar_lift_py_tests` + `scripts` (**N=444**).

That is Sugar's own tree, not the **authenticated pandas corpus** those process
floors are supposed to police (**N=1421** on pandas 3.0.3). R=0 there was a
**false green** — silence about the wrong population.

### What each floor actually measured (before)

| Floor | Invoked as | Population | N (this checkout) |
|---|---|---|---|
| R_native_crashes | no paths | kit production_roots | 444 |
| R_bare_exceptions | no paths | kit production_roots | 444 |
| R_timeouts | no paths | kit production_roots | 444 |

### After

| Floor | Invoked as | Population |
|---|---|---|
| all three | `"$PANDAS_CORPUS" --repo-root "$PANDAS_CORPUS"` | `authenticated_pandas_corpus().root` |

### Rung climb

| Ladder | Answer |
|---|---|
| Type system forbid empty paths? | No (CLI Sequence[Path] remains open). |
| One door that refuses? | **Yes** — `require_explicit_scan_roots`: empty is ValueError/red. Silent `default=list(production_roots(...))` **deleted**. |
| Panic at contact? | Exit 1 with named RED message (not green zero). |
| Auditor | Binding tooth in `test_python_sole_construction_ci.py` + lying twin in `test_enum_floor_explicit_population.py`. Retirement note on `require_explicit_scan_roots`: delete when CLI cannot admit zero path args. |

### Shot accounting

| | |
|---|---|
| **R axis** | Process-floor **population authority** (`R_native_crashes` / `R_timeouts` / `R_bare_exceptions` measured on authenticated pandas, not kit) |
| **Epsilon R** | Retire wrong-population zero (kit N=444). Honest corpus R may be **higher** once CI remeasures 1421 files — that is the point. |
| **Floors preserved** | R>0 still red; empty path set red; no xfail; no baseline raise |
| **Shell deleted** | `default=list(production_roots(repo_root))` on the three process scanners; bare `axis ... script.py` with no path in the floor set |

### Remeasure

- Empty CLI: EXIT=1 with refusal text (all three scanners).
- Population sizes established locally: kit **444** vs pandas **1421**.
- Full 1421-file supervised enum is a **heavy** run (lease / battleaxe / CI
  `python-sole-construction-floors`). Local worker init smoke hit an unrelated
  env refusal; CI under the heavy lease is the honest full remeasure.

## Validation

```bash
PYTHONPATH=implementations/python/sugar-lift-py-tests/src:... \
  python -m pytest -q \
  tests/test_python_sole_construction_ci.py \
  implementations/python/sugar-lift-py-tests/tests/test_enum_floor_explicit_population.py \
  implementations/python/sugar-lift-py-tests/tests/test_native_crash_zero_tolerance.py \
  implementations/python/sugar-lift-py-tests/tests/test_timeout_zero_tolerance.py \
  implementations/python/sugar-lift-py-tests/tests/test_bare_exception_zero_tolerance.py
# 22 passed; EXIT=0
```

## Test plan

- [x] Empty path set is red (lying twin)
- [x] Binding test requires PANDAS_CORPUS on three process axes
- [x] Population size contrast documented (444 vs 1421)
- [ ] CI sole-construction floors full remeasure under lease

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require explicit authenticated pandas corpus paths for process floor scripts
> - The three zero-tolerance floor scripts (`native_crash_zero_tolerance.py`, `bare_exception_zero_tolerance.py`, `timeout_zero_tolerance.py`) now default to an empty path list instead of silently falling back to kit `production_roots`.
> - A new `require_explicit_scan_roots` helper in [_enum_floor_runtime.py](https://github.com/TSavo/sugar/pull/6959/files#diff-722768a8db41f7e5bee7a5b826a61b0ebdc49edb27a8ff262303b2d68fd8c709) raises a `ValueError` on empty roots, causing the CLI to exit with a RED result.
> - [run_sole_construction_floors.sh](https://github.com/TSavo/sugar/pull/6959/files#diff-2425932b3b3850c1dce0e1350ce9dadb9c8d59942a7fb072ba19c29e2f913421) now authenticates the pandas corpus, assigns it to `PANDAS_CORPUS`, and passes it explicitly to all three process floor scripts.
> - Tests in [test_enum_floor_explicit_population.py](https://github.com/TSavo/sugar/pull/6959/files#diff-4f4dd2b97ef2f719145825da840b7178bc82a15f718300db245626ff771fea88) and [test_python_sole_construction_ci.py](https://github.com/TSavo/sugar/pull/6959/files#diff-b94b7a42638a5f3bf792d21deb778da5ee5b7f32e26a112cf32599b545b71fe0) assert explicit population requirements and correct corpus resolution ordering.
> - Behavioral Change: invoking any process floor script without explicit path arguments now fails loudly instead of silently scanning kit production roots.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7d5137.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->