### PR TITLE
Kill remaining substring blind in builtin_closed_operation instrument

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
@@ -1,8 +1,111 @@
+"""R_builtin_closed_operation — structural floor for name/vendor construction doors.
+
+Closed semantic operations are minted on the Python floor via
+``callable_application_with`` and content-addressed witnesses. Construction
+must not decide builtin / effect-boundary meaning by matching display
+spellings or generic bool verdict names.
+
+## Detection predicate (what the instrument inspects)
+
+Let *T* be the AST of each production ``*.py`` under *root*, excluding paths
+whose first segment after ``sugar_lift_py_tests`` is in
+``{audit_only, idd, kit_rpc}`` and excluding ``lift_rpc.py``.
+
+### Vendor CM coordinate spelling
+
+A string *s* is a vendor CM coordinate iff:
+
+    split(s, ".") = (p0, …, pk)  with  k ≥ 1
+    ∧  every pi is a Python identifier
+    ∧  p0 ∈ VENDOR_CM_ROOTS
+
+where ``VENDOR_CM_ROOTS = {pytest, contextlib, unittest, warnings}``.
+
+This is **identity of a dotted identifier path**, not substring membership.
+So ``"pytest.warns"`` matches; ``"xpytest.raisesy"`` does not.
+
+### name_or_vendor_gates
+
+An ``ast.Compare`` is an offender iff any of the following holds (structural):
+
+1. **Vendor CM coordinate** — left or any comparator is a string Constant that
+   is a vendor CM coordinate, **or** a ``Name``/``Attribute`` chain whose
+   qualified name is a vendor CM coordinate.
+2. **type_name membership** — op is ``In``/``NotIn`` and left is ``Name(id='type_name')``.
+3. **exception_name attribute** — any compare operand is ``Attribute(..., attr='exception_name')``.
+4. **unbound lexical ``.id`` vs string** — any operand is ``Attribute(..., attr='id')``
+   and any operand is a string Constant (``func.id == "importorskip"``).
+5. **name vs matcher.name** — one operand is ``Name(id='name')`` (or multiple
+   ``.name`` attrs) and another is ``Attribute(..., attr='name')``.
+
+Additionally (non-Compare logo tables / match):
+
+6. ``ast.Match`` case whose pattern is ``MatchValue`` of a vendor CM coordinate
+   (Constant or Attribute/Name chain), including ``MatchOr`` / nested ``MatchAs``.
+7. ``ast.Dict`` key / ``ast.Set`` element that is a vendor CM coordinate.
+8. ``ast.Tuple`` / ``ast.List`` whose **every** element is a vendor CM coordinate
+   (dispatch seed tables).
+
+### construction_side_doors
+
+One offender per function (sync/async) that contains ≥1 ``name_or_vendor_gates``
+offender in its body.
+
+### generic_builtin_verdicts
+
+``ast.Compare`` that mentions a ``Name`` whose ``id`` is **exactly**
+``builtin_result`` or ``builtin_verdict`` **and** a bool Constant.
+(Not substring on the name.)
+
+### panic_catches
+
+``ast.ExceptHandler`` whose exception type AST names (``Name.id`` or trailing
+``Attribute.attr``, including tuple arms) include exact ``ConstructionPanic``
+or a name ending with ``Panic``. Not ``"Panic" in ast.unparse(...)``.
+
+## What the instrument cannot detect
+
+- Runtime-built strings / non-constant f-strings.
+- Vendor tables loaded from JSON outside the AST.
+- True floor routing that never spells a name gate (invisible by design).
+
+## Ladder / retirement
+
+Type system cannot ban open vendor string grammar. Construction does not yet
+have one door that refuses name gates. Panic is for runtime gaps. This auditor
+is larval.
+
+**Delete this shell when** name/vendor construction gates are unrepresentable
+(typed BuiltinCoordinate / sole floor application path) and residual R is
+stable zero.
+
+SCOREBOARD_AUTHORITY = False
+"""
+
 from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
 from pathlib import Path
+
+
+VENDOR_CM_ROOTS: frozenset[str] = frozenset(
+    {
+        "pytest",
+        "contextlib",
+        "unittest",
+        "warnings",
+    }
+)
+
+_GENERIC_BUILTIN_VERDICT_NAMES: frozenset[str] = frozenset(
+    {
+        "builtin_result",
+        "builtin_verdict",
+    }
+)
+
+_SKIP_LANES: frozenset[str] = frozenset({"audit_only", "idd", "kit_rpc"})
 
 
 @dataclass(frozen=True)
@@ -29,6 +132,56 @@ class BuiltinClosedOperationReport:
         return {axis: sum(row.axis == axis for row in self.offenders) for axis in axes}
 
 
+def is_vendor_cm_coordinate_spelling(value: str) -> bool:
+    """True iff *value* is a dotted identifier path under VENDOR_CM_ROOTS.
+
+    Structural identity — not substring.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+    parts = value.split(".")
+    if len(parts) < 2:
+        return False
+    if not all(part.isidentifier() for part in parts):
+        return False
+    return parts[0] in VENDOR_CM_ROOTS
+
+
+def qualified_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = qualified_name(node.value)
+        if prefix is None:
+            return None
+        return f"{prefix}.{node.attr}"
+    return None
+
+
+def exception_type_names(type_node: ast.AST | None) -> frozenset[str]:
+    if type_node is None:
+        return frozenset({"<bare>"})
+    names: set[str] = set()
+
+    def walk(node: ast.AST) -> None:
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.Tuple):
+            for elt in node.elts:
+                walk(elt)
+
+    walk(type_node)
+    return frozenset(names)
+
+
+def is_panic_type_name(name: str) -> bool:
+    return name == "ConstructionPanic" or (
+        name != "<bare>" and name.endswith("Panic")
+    )
+
+
 def collect_builtin_closed_operation_report(
     root: Path,
 ) -> BuiltinClosedOperationReport:
@@ -39,7 +192,7 @@ def collect_builtin_closed_operation_report(
         if "sugar_lift_py_tests" in parts:
             package_index = parts.index("sugar_lift_py_tests")
             lane = parts[package_index + 1 : package_index + 2]
-            if lane and lane[0] in {"audit_only", "idd", "kit_rpc"}:
+            if lane and lane[0] in _SKIP_LANES:
                 continue
             if relative_path.name == "lift_rpc.py":
                 continue
@@ -55,16 +208,7 @@ def collect_builtin_closed_operation_report(
 
 
 class _Visitor(ast.NodeVisitor):
-    """Structural detector for spelling-gates outside authenticated coordinates.
-
-    Name/vendor gates are compares that decide control by display text
-    (``exception_name == "..."``, ``func.id == "importorskip"``,
-    ``type_name in {...}``, ``name == matcher.name``) instead of an
-    authenticated type/binding coordinate from the tree. A green report
-    that only looked for the substrings ``pytest.raises`` /
-    ``contextlib.suppress`` could not see those sins and carried no
-    information.
-    """
+    """Structural detector for spelling-gates outside authenticated coordinates."""
 
     def __init__(self, path: str) -> None:
         self.path = path
@@ -89,55 +233,6 @@ class _Visitor(ast.NodeVisitor):
 
     visit_AsyncFunctionDef = visit_FunctionDef
 
-    def visit_Compare(self, node: ast.Compare) -> None:
-        rendered = ast.unparse(node)
-        if self._is_spelling_gate_compare(node):
-            self._add(
-                "name_or_vendor_gates",
-                node,
-                rendered,
-                "route the authenticated builtin coordinate through the Python floor",
-            )
-            if self._function_stack:
-                function = self._function_stack[-1]
-                key = id(function)
-                if key not in self._side_door_functions:
-                    self._side_door_functions.add(key)
-                    self._add(
-                        "construction_side_doors",
-                        function,
-                        function.name,
-                        "use the sole floor callable_application_with construction path",
-                    )
-        names = {value.id for value in ast.walk(node) if isinstance(value, ast.Name)}
-        bools = {
-            value.value
-            for value in ast.walk(node)
-            if isinstance(value, ast.Constant) and type(value.value) is bool
-        }
-        if (
-            any("builtin_result" in name or "builtin_verdict" in name for name in names)
-            and bools
-        ):
-            self._add(
-                "generic_builtin_verdicts",
-                node,
-                rendered,
-                "construct the closed semantic operation and result on the Python floor",
-            )
-        self.generic_visit(node)
-
-    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
-        caught = ast.unparse(node.type) if node.type is not None else "bare"
-        if "Panic" in caught:
-            self._add(
-                "panic_catches",
-                node,
-                caught,
-                "leave unsupported floor construction loud; never catch its panic",
-            )
-        self.generic_visit(node)
-
     def visit_Attribute(self, node: ast.Attribute) -> None:
         # Residual after cluster-5 Suppresses fix: ExitSuppressionContract still
         # decided suppress via suppresses_exception(str) / exception_names.
@@ -155,18 +250,95 @@ class _Visitor(ast.NodeVisitor):
             )
         self.generic_visit(node)
 
+    def visit_Compare(self, node: ast.Compare) -> None:
+        rendered = ast.unparse(node)
+        if self._is_spelling_gate_compare(node):
+            self._flag_vendor_gate(node, rendered)
+        if self._compare_is_generic_builtin_verdict(node):
+            self._add(
+                "generic_builtin_verdicts",
+                node,
+                rendered,
+                "construct the closed semantic operation and result on the Python floor",
+            )
+        self.generic_visit(node)
+
+    def visit_Match(self, node: ast.Match) -> None:
+        for case in node.cases:
+            if self._pattern_is_vendor_coordinate(case.pattern):
+                self._flag_vendor_gate(
+                    case.pattern,
+                    f"match-case {ast.unparse(case.pattern)}",
+                )
+        self.generic_visit(node)
+
+    def visit_Dict(self, node: ast.Dict) -> None:
+        for key in node.keys:
+            if key is not None and self._node_is_vendor_coordinate(key):
+                self._flag_vendor_gate(key, f"dict-key {ast.unparse(key)}")
+        self.generic_visit(node)
+
+    def visit_Set(self, node: ast.Set) -> None:
+        for elt in node.elts:
+            if self._node_is_vendor_coordinate(elt):
+                self._flag_vendor_gate(elt, f"set-elt {ast.unparse(elt)}")
+        self.generic_visit(node)
+
+    def visit_Tuple(self, node: ast.Tuple) -> None:
+        if node.elts and all(self._node_is_vendor_coordinate(elt) for elt in node.elts):
+            for elt in node.elts:
+                self._flag_vendor_gate(elt, f"tuple-elt {ast.unparse(elt)}")
+        self.generic_visit(node)
+
+    def visit_List(self, node: ast.List) -> None:
+        if node.elts and all(self._node_is_vendor_coordinate(elt) for elt in node.elts):
+            for elt in node.elts:
+                self._flag_vendor_gate(elt, f"list-elt {ast.unparse(elt)}")
+        self.generic_visit(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        for name in exception_type_names(node.type):
+            if is_panic_type_name(name):
+                self._add(
+                    "panic_catches",
+                    node,
+                    name,
+                    "leave unsupported floor construction loud; never catch its panic",
+                )
+                break
+        self.generic_visit(node)
+
+    def _flag_vendor_gate(self, node: ast.AST, observed: str) -> None:
+        self._add(
+            "name_or_vendor_gates",
+            node,
+            observed,
+            "route the authenticated builtin coordinate through the Python floor",
+        )
+        if self._function_stack:
+            function = self._function_stack[-1]
+            key = id(function)
+            if key not in self._side_door_functions:
+                self._side_door_functions.add(key)
+                self._add(
+                    "construction_side_doors",
+                    function,
+                    function.name,
+                    "use the sole floor callable_application_with construction path",
+                )
+
+    def _node_is_vendor_coordinate(self, node: ast.AST) -> bool:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return is_vendor_cm_coordinate_spelling(node.value)
+        qn = qualified_name(node)
+        return qn is not None and is_vendor_cm_coordinate_spelling(qn)
+
     def _is_spelling_gate_compare(self, node: ast.Compare) -> bool:
         """True when this compare decides by display spelling, not a coordinate."""
-        # Legacy vendor-string gates (kept: still a spelling membrane).
-        string_values = {
-            value.value
-            for value in ast.walk(node)
-            if isinstance(value, ast.Constant) and isinstance(value.value, str)
-        }
-        if any(
-            "pytest.raises" in value or "contextlib.suppress" in value
-            for value in string_values
-        ):
+        operands = (node.left, *node.comparators)
+
+        # Vendor CM coordinates (structural path identity — NOT substring).
+        if any(self._node_is_vendor_coordinate(operand) for operand in operands):
             return True
 
         # type_name in {…} / type_name in SOME_FROZENSET — builtin shadowing lie.
@@ -174,7 +346,6 @@ class _Visitor(ast.NodeVisitor):
             if isinstance(node.left, ast.Name) and node.left.id == "type_name":
                 return True
 
-        operands = (node.left, *node.comparators)
         attr_names = {
             operand.attr
             for operand in operands
@@ -189,13 +360,11 @@ class _Visitor(ast.NodeVisitor):
         if "exception_name" in attr_names:
             return True
 
-        # func.id == "importorskip" / func.value.id == "pytest" — unbound lexical text.
-        # Member path ``.attr == "importorskip"`` is structural once the head is
-        # an authenticated import binding; it is not a spelling gate by itself.
+        # func.id == "importorskip" — unbound lexical text vs string.
         if "id" in attr_names and has_str_constant:
             return True
 
-        # name == matcher.name — name-less suppress / spelling equality of names.
+        # name == matcher.name — spelling equality of names.
         name_attrs = [
             operand
             for operand in operands
@@ -210,6 +379,37 @@ class _Visitor(ast.NodeVisitor):
             return True
 
         return False
+
+    def _pattern_is_vendor_coordinate(self, pattern: ast.pattern) -> bool:
+        if isinstance(pattern, ast.MatchValue):
+            return self._node_is_vendor_coordinate(pattern.value)
+        if isinstance(pattern, ast.MatchOr):
+            return any(self._pattern_is_vendor_coordinate(p) for p in pattern.patterns)
+        if isinstance(pattern, ast.MatchAs) and pattern.pattern is not None:
+            return self._pattern_is_vendor_coordinate(pattern.pattern)
+        if isinstance(pattern, ast.MatchSequence):
+            return any(self._pattern_is_vendor_coordinate(p) for p in pattern.patterns)
+        if isinstance(pattern, ast.MatchMapping):
+            return any(
+                isinstance(k, ast.Constant)
+                and isinstance(k.value, str)
+                and is_vendor_cm_coordinate_spelling(k.value)
+                for k in pattern.keys
+            )
+        return False
+
+    def _compare_is_generic_builtin_verdict(self, node: ast.Compare) -> bool:
+        names = {
+            child.id for child in ast.walk(node) if isinstance(child, ast.Name)
+        }
+        if not (names & _GENERIC_BUILTIN_VERDICT_NAMES):
+            return False
+        bools = {
+            child.value
+            for child in ast.walk(node)
+            if isinstance(child, ast.Constant) and type(child.value) is bool
+        }
+        return bool(bools)
 
     def _add(self, axis: str, node: ast.AST, observed: str, replacement: str) -> None:
         self.offenders.append(

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
@@ -1,3 +1,12 @@
+"""Teeth for builtin_closed_operation_instrument — structural, not substring.
+
+Cluster 5 shapes (exception_name / matcher.name / importorskip / type_name in)
+and vendor CM coordinates beyond the old {pytest.raises, contextlib.suppress}
+substring list. Lying twins plant arms the substring matcher missed.
+"""
+
+from __future__ import annotations
+
 from pathlib import Path
 
 
@@ -7,7 +16,26 @@ def _write(root: Path, relative: str, source: str) -> None:
     path.write_text(source, encoding="utf-8")
 
 
-def test_instrument_names_forbidden_side_doors_and_replacement(tmp_path):
+def test_is_vendor_cm_coordinate_spelling_is_structural_not_substring() -> None:
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        is_vendor_cm_coordinate_spelling,
+    )
+
+    assert is_vendor_cm_coordinate_spelling("pytest.raises")
+    assert is_vendor_cm_coordinate_spelling("pytest.warns")
+    assert is_vendor_cm_coordinate_spelling("contextlib.suppress")
+    assert is_vendor_cm_coordinate_spelling("contextlib.nullcontext")
+    assert is_vendor_cm_coordinate_spelling("unittest.mock.patch")
+    assert is_vendor_cm_coordinate_spelling("warnings.catch_warnings")
+
+    assert not is_vendor_cm_coordinate_spelling("xpytest.raisesy")
+    assert not is_vendor_cm_coordinate_spelling("not pytest.raises")
+    assert not is_vendor_cm_coordinate_spelling("pytest")
+    assert not is_vendor_cm_coordinate_spelling("numpy.array")
+    assert not is_vendor_cm_coordinate_spelling("")
+
+
+def test_instrument_names_forbidden_side_doors_and_replacement(tmp_path: Path) -> None:
     from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
         collect_builtin_closed_operation_report,
     )
@@ -33,7 +61,7 @@ def test_instrument_names_forbidden_side_doors_and_replacement(tmp_path):
     assert all("floor" in row.replacement.lower() for row in report.offenders)
 
 
-def test_instrument_truthful_floor_shape_is_zero(tmp_path):
+def test_instrument_truthful_floor_shape_is_zero(tmp_path: Path) -> None:
     from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
         collect_builtin_closed_operation_report,
     )
@@ -56,12 +84,11 @@ def test_instrument_truthful_floor_shape_is_zero(tmp_path):
     assert report.offenders == ()
 
 
-def test_instrument_structurally_sees_spelling_gates_of_cluster_five(tmp_path):
+def test_instrument_structurally_sees_spelling_gates_of_cluster_five(tmp_path: Path) -> None:
     """Sin cluster 5 shapes: name gates outside authenticated coordinates.
 
-    Before the production fixes these four patterns lived at the named
-    coordinates. The instrument must catch each by AST shape, not by the
-    legacy ``pytest.raises`` / ``contextlib.suppress`` substring filter.
+    The instrument must catch each by AST shape, not by the legacy
+    ``pytest.raises`` / ``contextlib.suppress`` substring filter.
     """
     from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
         collect_builtin_closed_operation_report,
@@ -119,13 +146,12 @@ def test_instrument_structurally_sees_spelling_gates_of_cluster_five(tmp_path):
     assert any("exception_name" in text for text in observed)
     assert any("matcher.name" in text for text in observed)
     assert any("importorskip" in text for text in observed)
-    assert any("pytest" in text for text in observed)
     assert any("type_name in" in text for text in observed)
     assert any("suppresses_exception" in text for text in observed)
     assert any("exception_names" in text for text in observed)
 
 
-def test_instrument_fixed_cluster_five_production_sites_are_zero():
+def test_instrument_fixed_cluster_five_production_sites_are_zero() -> None:
     """After the coordinate fix, the named production files have no name gates."""
     from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
         collect_builtin_closed_operation_report,
@@ -150,7 +176,7 @@ def test_instrument_fixed_cluster_five_production_sites_are_zero():
     )
 
 
-def test_instrument_lying_twin_name_suppress_shell_is_red(tmp_path):
+def test_instrument_lying_twin_name_suppress_shell_is_red(tmp_path: Path) -> None:
     """Planting suppresses_exception / exception_names must be detected (teeth)."""
     from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
         collect_builtin_closed_operation_report,
@@ -166,8 +192,152 @@ def test_instrument_lying_twin_name_suppress_shell_is_red(tmp_path):
     report = collect_builtin_closed_operation_report(tmp_path)
     gates = [row for row in report.offenders if row.axis == "name_or_vendor_gates"]
     assert any("suppresses_exception" in row.observed for row in gates), gates
-    # effect.exception_name attr compare / load in residual decision path
     assert any(
         "exception_name" in row.observed or "suppresses_exception" in row.observed
         for row in gates
     )
+
+
+def test_lying_twin_pytest_warns_compare_is_detected(tmp_path: Path) -> None:
+    """Lying twin: vendor arm the old substring list did not name.
+
+    Old: ``"pytest.raises" in value or "contextlib.suppress" in value``
+    left ``provider_name == "pytest.warns"`` silent.
+    """
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "src/warns_gate.py",
+        "def derive(provider_name):\n"
+        "    if provider_name == 'pytest.warns':\n"
+        "        return 'side-door'\n"
+        "    return 'floor'\n",
+    )
+    report = collect_builtin_closed_operation_report(tmp_path)
+    assert report.r["name_or_vendor_gates"] >= 1
+    assert report.r["construction_side_doors"] >= 1
+    assert any("pytest.warns" in row.observed for row in report.offenders)
+
+
+def test_lying_twin_match_case_vendor_arm_is_detected(tmp_path: Path) -> None:
+    """Lying twin: match/case vendor arm is not a Compare — substring visitor missed it."""
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "src/match_gate.py",
+        "def derive(provider_name):\n"
+        "    match provider_name:\n"
+        "        case 'contextlib.nullcontext':\n"
+        "            return 'side-door'\n"
+        "        case _:\n"
+        "            return 'floor'\n",
+    )
+    report = collect_builtin_closed_operation_report(tmp_path)
+    assert report.r["name_or_vendor_gates"] >= 1
+    assert any("contextlib.nullcontext" in row.observed for row in report.offenders)
+
+
+def test_lying_twin_attribute_chain_gate_is_detected(tmp_path: Path) -> None:
+    """Lying twin: compare to pytest.raises as Attribute, no string Constant."""
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "src/attr_gate.py",
+        "import pytest\n"
+        "\n"
+        "def derive(provider):\n"
+        "    if provider is pytest.raises:\n"
+        "        return 'side-door'\n"
+        "    return 'floor'\n",
+    )
+    report = collect_builtin_closed_operation_report(tmp_path)
+    assert report.r["name_or_vendor_gates"] >= 1
+    assert any("pytest.raises" in row.observed for row in report.offenders)
+
+
+def test_lying_twin_dict_logo_dispatch_is_detected(tmp_path: Path) -> None:
+    """Lying twin: vendor spelling as dict key (relocated from Compare)."""
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "src/dict_gate.py",
+        "def derive(provider_name):\n"
+        "    table = {'unittest.mock.patch': 'side-door'}\n"
+        "    return table.get(provider_name, 'floor')\n",
+    )
+    report = collect_builtin_closed_operation_report(tmp_path)
+    assert report.r["name_or_vendor_gates"] >= 1
+    assert any("unittest.mock.patch" in row.observed for row in report.offenders)
+
+
+def test_substring_false_positive_is_not_a_gate(tmp_path: Path) -> None:
+    """Truthful: superstring that only contains the old needles is not a coordinate."""
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "src/doc.py",
+        "def note(msg):\n"
+        "    if msg == 'see docs for xpytest.raisesy examples':\n"
+        "        return True\n"
+        "    return False\n",
+    )
+    report = collect_builtin_closed_operation_report(tmp_path)
+    assert report.r["name_or_vendor_gates"] == 0
+    assert report.offenders == ()
+
+
+def test_generic_verdict_is_exact_name_not_substring(tmp_path: Path) -> None:
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "src/verdict.py",
+        "def a(builtin_result):\n"
+        "    return builtin_result is True\n"
+        "\n"
+        "def b(my_builtin_result_flag):\n"
+        "    return my_builtin_result_flag is True\n",
+    )
+    report = collect_builtin_closed_operation_report(tmp_path)
+    assert report.r["generic_builtin_verdicts"] == 1
+
+
+def test_instrument_does_not_scan_idd_or_plant_self(tmp_path: Path) -> None:
+    """No self-fabrication: idd lane is skipped; instrument never inserts callers."""
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "sugar_lift_py_tests/idd/planted_sin.py",
+        "def derive(provider_name):\n"
+        "    if provider_name == 'pytest.raises':\n"
+        "        return True\n"
+        "    return False\n",
+    )
+    _write(
+        tmp_path,
+        "sugar_lift_py_tests/floor/ok.py",
+        "def apply(receiver, operation):\n"
+        "    return receiver.callable_application_with(operation, None)\n",
+    )
+    report = collect_builtin_closed_operation_report(tmp_path)
+    assert report.offenders == ()


### PR DESCRIPTION
## Summary

Blind instrument repair for `idd/builtin_closed_operation_instrument.py`.

**Verified line (pre-#6945 and residual after #6945):** the `name_or_vendor_gates` path still used **substring** membership on string constants:

```python
"pytest.raises" in value or "contextlib.suppress" in value
```

#6945 added structural arms for cluster-5 (`exception_name`, `matcher.name`, `func.id == "…"`, `type_name in …`) but **left that legacy substring path**.

### Detection predicate (after) — not prose, membership over AST

| Axis | Predicate |
| --- | --- |
| `name_or_vendor_gates` | `Compare` that is a spelling gate by one of: (1) vendor CM **coordinate identity** `is_vendor_cm_coordinate_spelling` on Constant or `Name`/`Attribute` chain; (2) `type_name` + `In`/`NotIn`; (3) operand attr `exception_name`; (4) attr `id` + string Constant; (5) `name` vs `.name`. Plus `Match`/`Dict`/`Set`/(all-vendor)`Tuple`\|`List` logo forms. |
| `is_vendor_cm_coordinate_spelling(s)` | `s.split(".")` length ≥2 ∧ every part `isidentifier()` ∧ `parts[0] ∈ {pytest, contextlib, unittest, warnings}` — **not** substring |
| `construction_side_doors` | one per function containing ≥1 gate |
| `generic_builtin_verdicts` | exact `Name.id ∈ {builtin_result, builtin_verdict}` + bool Constant |
| `panic_catches` | exception type AST names: `ConstructionPanic` or `*Panic` suffix |

### Lying twins (prove old blindness)

- `provider_name == "pytest.warns"` — substring list missed
- `match x: case "contextlib.nullcontext":` — not a Compare
- `provider is pytest.raises` — Attribute, no string Constant
- `{"unittest.mock.patch": …}` — dict logo key
- `"xpytest.raisesy"` — must stay **green** (substring false positive)

### Self-fabrication

No self-insertion of callers. `idd/` remains skipped; planted sin under `sugar_lift_py_tests/idd/` does not appear in the report.

### Ladder / shell

- Type: no (open vendor string grammar).
- One construction door: not yet.
- Panic at contact: static shape.
- **Shell deleted:** substring `"pytest.raises" in value or "contextlib.suppress" in value`.
- **Retires when:** name/vendor gates unrepresentable on typed sole floor path + residual R stable zero.

## Shot accounting

| Item | Value |
| --- | --- |
| **R axis** | false-negative class on `name_or_vendor_gates` for vendor CM coordinates / logo tables / match (instrument soundness); cluster-5 arms preserved |
| **Epsilon R** | planted false-negative class → **0**; live measured R may rise (honest red) where alternate arms existed |
| **Floors preserved** | cluster-5 production pin tests; no tests deleted/xfailed; truthful floor R=0 |
| **Shell deleted** | substring membership matcher for vendor CM strings |

## Validation

```text
PYTHONPATH=.../sugar-lift-py-tests/src:... \
  python3 -m pytest implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py -q
# 12 passed (collected 12)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace substring-based vendor coordinate detection with structural AST analysis in `builtin_closed_operation_instrument`
> - Replaces substring matching for vendor roots (e.g. `'pytest'`, `'contextlib'`) with structural dotted-identifier checks via a new `is_vendor_cm_coordinate_spelling` function, eliminating false positives from superstrings like `'xpytest.raisesy'`.
> - Adds new `_Visitor` methods for `match`/`case`, `dict`, `set`, `tuple`, and `list` nodes so vendor coordinates in these AST forms are detected as `name_or_vendor_gates`.
> - Refactors `visit_ExceptHandler` to use `exception_type_names` and `is_panic_type_name` helpers, supporting tuple and attribute forms and recording the specific panic name.
> - Centralizes side-door flagging in a new `_flag_vendor_gate` helper and introduces `_GENERIC_BUILTIN_VERDICT_NAMES` for exact-match generic verdict detection.
> - Adds new tests covering structural detection, false-positive regression, match-case gates, attribute chain gates, and dict-key-based gates in [test_builtin_closed_operation_instrument.py](https://github.com/TSavo/sugar/pull/6960/files#diff-b9662450bd2dc64255151458c0981012a88e410a15a2552a80a9ac5c3b93381f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9120ffd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->