### PR TITLE
Fix pre-existing main CI reds blocking sin-cluster merges

### DIFF
--- a/implementations/python/sugar-build-witness/tests/conftest.py
+++ b/implementations/python/sugar-build-witness/tests/conftest.py
@@ -21,4 +21,4 @@ if os.path.join(_ROOT, "tests") not in sys.path:
 
 from checkout_resolution import pin_checkout  # noqa: E402
 
-pin_checkout(__file__, siblings=('sugar-lift-py-tests',))
+pin_checkout(__file__, siblings=("sugar-lift-py-tests",))

--- a/implementations/python/sugar-emit-python-hypothesis/tests/declared_corpus.py
+++ b/implementations/python/sugar-emit-python-hypothesis/tests/declared_corpus.py
@@ -49,9 +49,7 @@ HOST_GRAMMAR = "host-grammar"
 # passing backend.
 OPTIONAL_PROVIDER = "optional-provider"
 
-OPTIONAL_LAW_CATEGORIES = frozenset(
-    {HEAVY_OPT_IN, HOST_GRAMMAR, OPTIONAL_PROVIDER}
-)
+OPTIONAL_LAW_CATEGORIES = frozenset({HEAVY_OPT_IN, HOST_GRAMMAR, OPTIONAL_PROVIDER})
 
 
 class DeclaredCorpusMissing(AssertionError):

--- a/implementations/python/sugar-emit-python-hypothesis/tests/test_emitter.py
+++ b/implementations/python/sugar-emit-python-hypothesis/tests/test_emitter.py
@@ -97,7 +97,7 @@ def test_emitted_supported_predicates_run_under_pytest(tmp_path: Path) -> None:
         require_declared_corpus(
             "hypothesis is not importable",
             "the environment running this package's suite",
-            'sugar-emit-python-hypothesis pyproject.toml [project] dependencies '
+            "sugar-emit-python-hypothesis pyproject.toml [project] dependencies "
             '= ["blake3>=1.0.0", "hypothesis>=6.0.0"] -- a HARD dependency, '
             "not an extra",
             "pip install -e 'implementations/python/sugar-emit-python-hypothesis'",

--- a/implementations/python/sugar-lift-py-pytest-witness/tests/conftest.py
+++ b/implementations/python/sugar-lift-py-pytest-witness/tests/conftest.py
@@ -21,4 +21,4 @@ if os.path.join(_ROOT, "tests") not in sys.path:
 
 from checkout_resolution import pin_checkout  # noqa: E402
 
-pin_checkout(__file__, siblings=('sugar-lift-py-tests', 'sugar-lift-python-source'))
+pin_checkout(__file__, siblings=("sugar-lift-py-tests", "sugar-lift-python-source"))

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
@@ -98,9 +98,7 @@ class SupervisedEnumSupervisor:
         initialize = {"kind": "initialize", "corpus_root": str(self.corpus_root)}
         if self.demand_table_path is not None:
             initialize["demand_table_path"] = str(self.demand_table_path)
-        initialize["allow_local_demand_derivation"] = (
-            self.allow_local_demand_derivation
-        )
+        initialize["allow_local_demand_derivation"] = self.allow_local_demand_derivation
         self._proc.stdin.write(json.dumps(initialize) + "\n")
         self._proc.stdin.flush()
         initialized = self._readline(timeout=30.0)

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
@@ -163,9 +163,11 @@ def main() -> int:
             try:
                 response = _initialize(
                     str(msg.get("corpus_root") or ""),
-                    str(msg["demand_table_path"])
-                    if msg.get("demand_table_path")
-                    else None,
+                    (
+                        str(msg["demand_table_path"])
+                        if msg.get("demand_table_path")
+                        else None
+                    ),
                     allow_local_demand_derivation=bool(
                         msg.get("allow_local_demand_derivation", False)
                     ),

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
@@ -84,32 +84,21 @@ _SANCTIONED_HANDLER_SHAPES = {
         "audit_only/collect_construction_gaps.py",
         "collect_construction_gaps",
     ): frozenset(
-        {
-            _canonical_handler(
-                """
+        {_canonical_handler("""
 except ConstructionPanic as panic:
     gaps.append(gap_from_construction_panic(label, panic))
-"""
-            )
-        }
+""")}
     ),
     (
         "audit_only/collect_construction_gaps.py",
         "collect_construction_panic",
     ): frozenset(
-        {
-            _canonical_handler(
-                """
+        {_canonical_handler("""
 except ConstructionPanic as panic:
     return None, gap_from_construction_panic(label, panic)
-"""
-            )
-        }
+""")}
     ),
-    ("desugar_repro.py", "_desugar_one"): frozenset(
-        {
-            _canonical_handler(
-                """
+    ("desugar_repro.py", "_desugar_one"): frozenset({_canonical_handler("""
 except BaseException as exc:
     status = type(exc).__name__
     detail = str(exc)
@@ -117,44 +106,30 @@ except BaseException as exc:
         f"{frame.filename}:{frame.lineno} {frame.name}"
         for frame in traceback.extract_tb(exc.__traceback__)[-6:]
     ]
-"""
-            )
-        }
-    ),
-    ("exit_set_arm_census.py", "patched_and_exit"): frozenset(
-        {
-            _canonical_handler(
-                """
+""")}),
+    ("exit_set_arm_census.py", "patched_and_exit"): frozenset({_canonical_handler("""
 except BaseException as exc:
     row.verdict_probe_error = f"{type(exc).__name__}: {exc}"
     row.check()
     return result
-"""
-            )
-        }
-    ),
+""")}),
     ("stablezero_classify.py", "classify"): frozenset(
         {
-            _canonical_handler(
-                """
+            _canonical_handler("""
 except ConstructionPanic as panic:
     row["status"] = "ConstructionPanic"
     row["testimony"] = _testimony(panic)
-"""
-            ),
-            _canonical_handler(
-                """
+"""),
+            _canonical_handler("""
 except BaseException as error:
     row["status"] = f"raised:{type(error).__name__}"
     row["testimony"] = _testimony(error)
-"""
-            ),
+"""),
         }
     ),
     ("_production_lift_child.py", "production_lift_testimony"): frozenset(
         {
-            _canonical_handler(
-                """
+            _canonical_handler("""
 except BaseException as error:
     row = _typed_construction_row(error)
     if row is None:
@@ -167,31 +142,24 @@ except BaseException as error:
         "typed_gap_count": len(gaps),
         "typed_gaps": gaps,
     }
-"""
-            ),
-            _canonical_handler(
-                """
+"""),
+            _canonical_handler("""
 except BaseException as error:
     row = _typed_construction_row(error)
     if row is None:
         raise
     gaps.append(row)
-"""
-            ),
+"""),
         }
     ),
 }
 
 _SANCTIONED_ISINSTANCE_SHAPES = {
     ("_production_lift_child.py", "_typed_construction_row"): frozenset(
-        {
-            _canonical_statement(
-                """
+        {_canonical_statement("""
 if isinstance(error, ConstructionPanic):
     return _construction_panic_row(error)
-"""
-            )
-        }
+""")}
     )
 }
 
@@ -273,8 +241,10 @@ def _ends_in_raise(stmts: list[ast.stmt]) -> bool:
     if isinstance(last, ast.Raise):
         return True
     if isinstance(last, ast.If):
-        return bool(last.orelse) and _ends_in_raise(last.body) and _ends_in_raise(
-            last.orelse
+        return (
+            bool(last.orelse)
+            and _ends_in_raise(last.body)
+            and _ends_in_raise(last.orelse)
         )
     return False
 

--- a/implementations/python/sugar-lift-py-tests/scripts/desugar_repro.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/desugar_repro.py
@@ -81,12 +81,8 @@ def _report(
     discovered = len(functions)
     completed = len(functions)
     timeouts = sum(bool(row["timedOut"]) for row in functions)
-    construction_panics = sum(
-        row["status"] == "ConstructionPanic" for row in functions
-    )
-    factoring_gaps = sum(
-        row["status"] == "ExitSetFactoringGap" for row in functions
-    )
+    construction_panics = sum(row["status"] == "ConstructionPanic" for row in functions)
+    factoring_gaps = sum(row["status"] == "ExitSetFactoringGap" for row in functions)
     return {
         "schema": "sugar.desugar-repro.v1",
         "file": file,

--- a/implementations/python/sugar-lift-py-tests/scripts/rank_residual_owners.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/rank_residual_owners.py
@@ -67,9 +67,7 @@ def _classify_factoring(row: dict[str, Any]) -> str:
     if isinstance(verdict, dict):
         kind = verdict.get("kind", "?")
         merged = " merged-arm" if verdict.get("mergedArm") else ""
-        head = (
-            "remaining-work" if verdict.get("isRemainingWork") else "correct-refusal"
-        )
+        head = "remaining-work" if verdict.get("isRemainingWork") else "correct-refusal"
         return f"{head} ({kind}{merged})"
     return "UNCLASSIFIED (ledger predates #6364 classifier)"
 
@@ -129,13 +127,9 @@ def rank(board: dict[str, Any]) -> dict[str, Any]:
             "R_construction": board.get("R_construction"),
             "R_desugar_total_DO_NOT_PUBLISH_RAW": board.get("R_desugar"),
             "R_desugar_owed_work": board.get("R_desugar_owed_work"),
-            "R_desugar_accounted_semantics": board.get(
-                "R_desugar_accounted_semantics"
-            ),
+            "R_desugar_accounted_semantics": board.get("R_desugar_accounted_semantics"),
             "R_construction_panics": board.get("R_construction_panics"),
-            "R_desugar_construction_panics": board.get(
-                "R_desugar_construction_panics"
-            ),
+            "R_desugar_construction_panics": board.get("R_desugar_construction_panics"),
             "R_desugar_defects": board.get("R_desugar_defects"),
             "R_backend_defects": board.get("R_backend_defects"),
             "R_unresolvable_dispatch_targets": board.get(
@@ -180,8 +174,10 @@ def _markdown(report: dict[str, Any]) -> str:
     add = out.append
     pin = report["corpusPin"]
     add(f"# Ranked residual owners — {pin.get('distribution')} {pin.get('version')}\n")
-    add(f"Commit `{report['commit']}`, corpus pin `{pin.get('aggregateHash','')[:16]}…`, "
-        f"{pin.get('fileCount')} files.\n")
+    add(
+        f"Commit `{report['commit']}`, corpus pin `{pin.get('aggregateHash','')[:16]}…`, "
+        f"{pin.get('fileCount')} files.\n"
+    )
 
     denominator = report["denominator"]
     add("## Denominator\n")
@@ -191,8 +187,10 @@ def _markdown(report: dict[str, Any]) -> str:
     add("```\n")
 
     add("## stableZero vector\n")
-    add(f"`controlEffectStableZero` = **{report['controlEffectStableZero']}**, "
-        f"`red` = **{report['red']}**\n")
+    add(
+        f"`controlEffectStableZero` = **{report['controlEffectStableZero']}**, "
+        f"`red` = **{report['red']}**\n"
+    )
     add("```")
     for key, value in (report["stableZeroTerms"] or {}).items():
         add(f"{key:32} {value}")
@@ -209,17 +207,23 @@ def _markdown(report: dict[str, Any]) -> str:
         # An ABSENT split is not a split of zero. Saying "0 accounted
         # semantics" here would be a fabricated measurement -- the same
         # misleading-zero shape this instrument exists to refuse.
-        add(f"Total {total}. **SPLIT UNAVAILABLE** — this ledger predates the "
+        add(
+            f"Total {total}. **SPLIT UNAVAILABLE** — this ledger predates the "
             "occurrence-key split, so the owed-work share is unmeasured, not "
-            "zero. Re-run to obtain it; do not publish the total as work.\n")
+            "zero. Re-run to obtain it; do not publish the total as work.\n"
+        )
     elif work:
-        add(f"Total {total} = **{work} owed work** + {semantics} accounted "
+        add(
+            f"Total {total} = **{work} owed work** + {semantics} accounted "
             f"semantics. Publishing the total as work overstates it by "
-            f"**{total / work:.1f}x**.\n")
+            f"**{total / work:.1f}x**.\n"
+        )
     else:
-        add(f"Total {total} = **0 owed work** + {semantics} accounted "
+        add(
+            f"Total {total} = **0 owed work** + {semantics} accounted "
             "semantics. Every row is the correct output of a reduction that "
-            "succeeded; none of it is a backlog.\n")
+            "succeeded; none of it is a backlog.\n"
+        )
     add("### Owed work, by owner\n")
     add("```")
     for owner, count in list(rank_["desugarOwedWorkByOwner"].items())[:20]:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/callable_application.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/callable_application.py
@@ -23,14 +23,13 @@ class CallableApplication:
     call_occurrence: SourceFragmentCoordinateV1 | None = None
 
     def __post_init__(self) -> None:
-        if self.call_occurrence is not None and type(
-            self.call_occurrence
-        ) is not SourceFragmentCoordinateV1:
+        if (
+            self.call_occurrence is not None
+            and type(self.call_occurrence) is not SourceFragmentCoordinateV1
+        ):
             raise TypeError(
                 "CallableApplication.call_occurrence must be SourceFragmentCoordinateV1"
             )
 
-    def apply(
-        self, receiver: "FloorValue", ctx: "ReduceContext | None"
-    ) -> "Outcome":
+    def apply(self, receiver: "FloorValue", ctx: "ReduceContext | None") -> "Outcome":
         return receiver.callable_application_with(self, ctx)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py
@@ -125,8 +125,7 @@ class ConsumerHitReport:
             f"concreteSourceSite reported {self.caller.concrete_source_site}",
             f"beforeOutcome reported {self.caller.before_outcome}",
             f"afterOutcome reported {self.caller.after_outcome}",
-            "survivingTypedGapsOrReattributions reported "
-            f"[{surviving}]",
+            "survivingTypedGapsOrReattributions reported " f"[{surviving}]",
         )
 
     def render(self) -> str:
@@ -178,9 +177,10 @@ def resolve_consumer_hit(
         demand.identity.parser_identity,
         _runtime_parser_identity(request.runtime),
     )
-    if any(runtime != request.runtime for runtime in runtimes) or len(
-        set(parser_identities)
-    ) != 1:
+    if (
+        any(runtime != request.runtime for runtime in runtimes)
+        or len(set(parser_identities)) != 1
+    ):
         _miss("runtime", request.runtime, (runtimes, parser_identities))
 
     cell_coordinates = (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/reduce_context.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context/reduce_context.py
@@ -51,9 +51,7 @@ class ReduceContext:
         )
 
     @classmethod
-    def derived(
-        cls, source: "ReduceContext", *, owner: str
-    ) -> "ReduceContext":
+    def derived(cls, source: "ReduceContext", *, owner: str) -> "ReduceContext":
         """Front door for reduction that carries an existing temporal context."""
         return cls(
             temporal=source.temporal,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -94,26 +94,27 @@ class ImportedCallValueSubsumptionV1:
     resolution_kind: str
     resolved_object_cid: str
     relation_cid: str
-    _authority: object = field(
-        init=False, repr=False, compare=False, default=None
-    )
+    _authority: object = field(init=False, repr=False, compare=False, default=None)
 
     def __post_init__(self) -> None:
         if self._authority is not _IMPORT_CALL_VALUE_SUBSUMPTION_AUTHORITY:
             raise ValueError("import call/value subsumption lacks producer authority")
-        if not all(
-            (
-                self.source_cid,
-                self.module_identity_cid,
-                self.import_binding_cid,
-                self.target_symbol,
-                self.call_use_cid,
-                self.value_use_cid,
-                self.resolution_kind,
-                self.resolved_object_cid,
-                self.relation_cid,
+        if (
+            not all(
+                (
+                    self.source_cid,
+                    self.module_identity_cid,
+                    self.import_binding_cid,
+                    self.target_symbol,
+                    self.call_use_cid,
+                    self.value_use_cid,
+                    self.resolution_kind,
+                    self.resolved_object_cid,
+                    self.relation_cid,
+                )
             )
-        ) or not self.exported_member_path:
+            or not self.exported_member_path
+        ):
             raise ValueError("import call/value subsumption lacks binding testimony")
         if (
             self.call_coordinate.source_cid != self.source_cid
@@ -224,9 +225,7 @@ def _mint_import_call_value_subsumption(
     for name, value in values.items():
         object.__setattr__(relation, name, value)
     object.__setattr__(relation, "relation_cid", relation._expected_cid())
-    object.__setattr__(
-        relation, "_authority", _IMPORT_CALL_VALUE_SUBSUMPTION_AUTHORITY
-    )
+    object.__setattr__(relation, "_authority", _IMPORT_CALL_VALUE_SUBSUMPTION_AUTHORITY)
     relation.__post_init__()
     return relation
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/corpus_pin.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/corpus_pin.py
@@ -194,9 +194,7 @@ class CorpusPin:
         return pin
 
 
-def aggregate_hash(
-    distribution: str, version: str, files: Iterable[CorpusFile]
-) -> str:
+def aggregate_hash(distribution: str, version: str, files: Iterable[CorpusFile]) -> str:
     """One sha256 over (distribution, version, sorted path→content manifest).
 
     The distribution and version are inside the hash on purpose: the identical

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py
@@ -24,9 +24,7 @@ class FixtureResourceBindingRefusal(ValueError):
     def __init__(self, coordinate: str, detail: str):
         self.coordinate = coordinate
         self.detail = detail
-        super().__init__(
-            f"fixture resource binding refused at {coordinate}: {detail}"
-        )
+        super().__init__(f"fixture resource binding refused at {coordinate}: {detail}")
 
 
 @dataclass(frozen=True)
@@ -59,9 +57,7 @@ class FixtureSuppliedResourceObligationV1:
         }
         return cls(authenticated.cid, cid_of_json(preimage))
 
-    def discharge(
-        self, binding: BindingEntryV1
-    ) -> FixtureSuppliedResourceDischargeV1:
+    def discharge(self, binding: BindingEntryV1) -> FixtureSuppliedResourceDischargeV1:
         if binding.coordinate.cid != self.formal_coordinate_cid:
             raise FixtureResourceBindingRefusal(
                 self.formal_coordinate_cid,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/boolop_truth_selection.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/boolop_truth_selection.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from .floor_value import FloorValue
 
+
 @dataclass(frozen=True)
 class BoolOpTruthSelection(FloorValue):
     """One evaluation's operand and its completed native truth result.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_object_class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_object_class_value.py
@@ -16,7 +16,5 @@ class BuiltinObjectClassValue(ClassValue):
             )
             from sugar_lift_py_tests.outcome import Complete
 
-            return Complete(
-                BuiltinSemanticCallable(operation=f"python.object.{name}")
-            )
+            return Complete(BuiltinSemanticCallable(operation=f"python.object.{name}"))
         return super().attribute(name, site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_super_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_super_value.py
@@ -121,9 +121,7 @@ class BuiltinSuperValue(FloorValue):
             key, value = arguments
             return self.receiver.mapping_builtin_setitem(key, value, blame).and_then(
                 lambda updated: Complete(
-                    ReceiverOwnedMutationResult(
-                        self.receiver, updated, NoneValue()
-                    )
+                    ReceiverOwnedMutationResult(self.receiver, updated, NoneValue())
                 )
             )
         construction_panic_gap(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -44,7 +44,9 @@ class _RetainedSourceCompletionV1:
         return 0x52455441
 
 
-def _retained_completion_invariant(*, owner: str, callsite: "CallSiteValue", observed: str):
+def _retained_completion_invariant(
+    *, owner: str, callsite: "CallSiteValue", observed: str
+):
     from sugar_source_tree.panic import BackendDefect
 
     raise BackendDefect(
@@ -555,6 +557,7 @@ class CallSiteValue(FloorValue):
         """
         from sugar_lift_py_tests.ir import ctor
         from sugar_lift_py_tests.outcome import Complete
+
         index_term = index.to_term(owner="CallSiteValue.setitem index")
         value_term = value.to_term(owner="CallSiteValue.setitem value")
         return Complete(
@@ -645,6 +648,7 @@ class CallSiteValue(FloorValue):
 
         def list_append_coordinate(prior):
             from sugar_lift_py_tests.ir import ctor
+
             value_term = value.to_term(owner="CallSiteValue.append_with value")
             return Complete(
                 CallSiteValue(
@@ -787,6 +791,7 @@ class CallSiteValue(FloorValue):
         """
         from sugar_lift_py_tests.ir import ctor
         from sugar_lift_py_tests.outcome import Complete
+
         index_term = index.to_term(owner="CallSiteValue.delitem index")
         return Complete(
             CallSiteValue(
@@ -1255,10 +1260,15 @@ class CallSiteValue(FloorValue):
                 )
             token = _ACTIVE_DIG_DEMAND.set(active_demand + 1)
             try:
-                outcome = _reduce_callsite_body(body, reduce_ctx, blame=self.target_name)
+                outcome = _reduce_callsite_body(
+                    body, reduce_ctx, blame=self.target_name
+                )
             finally:
                 _ACTIVE_DIG_DEMAND.reset(token)
-            from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+            from sugar_lift_py_tests.caller_parameter_contract import (
+                NativeOperationExitCarrierV1,
+            )
+
             if isinstance(outcome, NativeOperationExitCarrierV1):
                 actuals = self.bound_native_actuals_by_coordinate
                 if actuals is None and self.bound_source_actuals is not None:
@@ -1490,7 +1500,10 @@ class CallSiteValue(FloorValue):
 
         if isinstance(outcome, Complete):
             return Complete(retaining(outcome.value))
-        from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            NativeOperationExitCarrierV1,
+        )
+
         if isinstance(outcome, NativeOperationExitCarrierV1):
             if self.bound_source_actuals is not None:
                 outcome = self.bound_source_actuals.project_native_carrier(outcome)
@@ -1501,6 +1514,7 @@ class CallSiteValue(FloorValue):
                 if not isinstance(outcome, NativeOperationExitCarrierV1):
                     return outcome
                 from sugar_source_tree.panic import SugarNotWritten
+
                 raise SugarNotWritten(
                     owner="CallSiteValue.project_producer_outcome",
                     blame=self.target_name,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -1352,6 +1352,10 @@ def authenticated_module_exports(
         module=module,
         source_cid=source_cid,
         module_name=module_name,
+        # Same package bit every other door passes (#6941-era formal kwarg):
+        # omitting it TypeErrors the preconstruction demand scan and silences
+        # every showcase that walks call-contract exports.
+        module_is_package=path.name == "__init__.py",
         module_identities={},
         module_is_package=path.name == "__init__.py",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/declared_corpus.py
+++ b/implementations/python/sugar-lift-py-tests/tests/declared_corpus.py
@@ -49,9 +49,7 @@ HOST_GRAMMAR = "host-grammar"
 # passing backend.
 OPTIONAL_PROVIDER = "optional-provider"
 
-OPTIONAL_LAW_CATEGORIES = frozenset(
-    {HEAVY_OPT_IN, HOST_GRAMMAR, OPTIONAL_PROVIDER}
-)
+OPTIONAL_LAW_CATEGORIES = frozenset({HEAVY_OPT_IN, HOST_GRAMMAR, OPTIONAL_PROVIDER})
 
 
 class DeclaredCorpusMissing(AssertionError):

--- a/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
@@ -182,7 +182,9 @@ def _boundary_from_exitset(
             message_selector,
             ExceptionInfoBindingV1(),
         ),
-        contract_ref=SimpleNamespace(import_signature=ImportSignatureV2(tuple(parameters))),
+        contract_ref=SimpleNamespace(
+            import_signature=ImportSignatureV2(tuple(parameters))
+        ),
         context_manager_edge=None,
         observation_slot_id=observation_slot_id,
         site="pandas/tests/arithmetic/common.py:143:4",
@@ -238,9 +240,7 @@ def test_nameless_halt_stays_outside_assertion_boundary():
 
     routed = _boundary_from_exitset(body, expected=_Expected("ValueError")).desugar()
 
-    assert routed.exits == (
-        Halted(true_guard(), nameless, _state("nameless")),
-    )
+    assert routed.exits == (Halted(true_guard(), nameless, _state("nameless")),)
 
 
 def test_pandas_common_143_composes_compare_exit_with_assertion_contract():
@@ -609,9 +609,7 @@ def _factored_boundary_from_exitset(
         manager=Fixed(Complete(manager_value)),
         body=(Fixed(body),),
         semantics=None,
-        contract_ref=SimpleNamespace(
-            import_signature=ImportSignatureV2(parameters)
-        ),
+        contract_ref=SimpleNamespace(import_signature=ImportSignatureV2(parameters)),
         context_manager_edge=None,
         boundary_faces=_factored_boundary_faces(),
         observation_slot_id=observation_slot_id,
@@ -667,7 +665,9 @@ def test_factored_none_face_consumes_matching_raise_and_binds_exact_occurrence()
     assert binding.slot_id == "excinfo"
     assert binding.effect is producer
     assert binding.effect.occurrence == occurrence
-    assert binding.effect.exception_type_coordinate is producer.exception_type_coordinate
+    assert (
+        binding.effect.exception_type_coordinate is producer.exception_type_coordinate
+    )
     assert binding.effect.producer_node_owner == "Compare.desugar"
 
 
@@ -700,8 +700,7 @@ def test_factored_pattern_face_binds_only_on_held_arm_not_complement():
     pattern_faces = [
         face
         for face in routed.exits
-        if "match-pattern-face" in str(face.guard)
-        and "py.re_search" in str(face.guard)
+        if "match-pattern-face" in str(face.guard) and "py.re_search" in str(face.guard)
     ]
     assert {type(face).__name__ for face in pattern_faces} == {
         "Completed",
@@ -790,9 +789,7 @@ def test_factored_none_face_without_as_slot_consumes_without_binding():
     )
     body = ExitSet((Halted(true_guard(), producer, _state("no-slot")),))
 
-    routed = _factored_boundary_from_exitset(
-        body, observation_slot_id=None
-    ).desugar()
+    routed = _factored_boundary_from_exitset(body, observation_slot_id=None).desugar()
 
     none_completed = [
         face

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_augassign_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_augassign_formal_caller.py
@@ -187,9 +187,7 @@ def test_discrimination_duplicated_get_is_detected() -> None:
             box["get"] += 1
             return super().attribute(name, site)
 
-    r = _CountingObject(
-        "Widget", (ObjectField("field", TermValue(1)),), (), (), "d0"
-    )
+    r = _CountingObject("Widget", (ObjectField("field", TermValue(1)),), (), (), "d0")
     r.attribute("field", "g1")
     r.attribute("field", "g2")
     assert box["get"] == 2
@@ -316,9 +314,7 @@ def test_production_arithmetic_halt_blocks_store() -> None:
     out = _production_desugar(receiver, NoneValue())
     assert box["set"] == 0
     assert not (
-        isinstance(out, Complete)
-        and isinstance(out.value, ObjectValue)
-        and box["set"]
+        isinstance(out, Complete) and isinstance(out.value, ObjectValue) and box["set"]
     )
 
 
@@ -343,9 +339,9 @@ def test_production_store_halt_is_incomplete_not_complete_raisevalue() -> None:
     )
     out = _production_desugar(receiver, TermValue(1))
     # Shared AttributeStoreEffectSugar.project_setattr converts RaiseValue → Incomplete.
-    assert isinstance(out, Incomplete), (
-        f"store halt must be Incomplete (halted store face), not {type(out).__name__}: {out}"
-    )
+    assert isinstance(
+        out, Incomplete
+    ), f"store halt must be Incomplete (halted store face), not {type(out).__name__}: {out}"
     # Discrimination: Complete(RaiseValue) would greenwash statement completion.
     with pytest.raises(AssertionError):
         assert isinstance(out, Complete) and isinstance(out.value, RaiseValue)
@@ -371,8 +367,7 @@ def test_authenticated_discharge_get_iadd_setattr_updates_field() -> None:
     function, pending = _helper_definition()
     assert isinstance(pending, NativeOperationExitCarrierV1)
     coords = {
-        c.declared_name: c.coordinate_cid
-        for c in function.sugar().formal_coordinates
+        c.declared_name: c.coordinate_cid for c in function.sugar().formal_coordinates
     }
     receiver = _obj_with_field(1)
     exits = pending.discharge(
@@ -472,8 +467,7 @@ def test_enum_attribute_augassign_uses_one_authenticated_read_op_store(
 def test_unrelated_source_attribute_augassign_uses_the_same_projection() -> None:
     """A renamed source helper uses the same read/inplace/store carrier chain."""
     function, pending = _helper_definition(
-        "def renamed(receiver, increment):\n"
-        "    receiver.total += increment\n"
+        "def renamed(receiver, increment):\n" "    receiver.total += increment\n"
     )
     assert isinstance(pending, NativeOperationExitCarrierV1)
     assert pending.demand.operator == "attribute_named"
@@ -576,9 +570,7 @@ def test_discrimination_incomplete_does_not_fall_through() -> None:
     from sugar_lift_py_tests.effect import CoverageGapEffect
     from sugar_lift_py_tests.floor.floor_value import FloorValue
 
-    face = Incomplete(
-        CoverageGapEffect(boundary="iadd", reason="unresolved inplace")
-    )
+    face = Incomplete(CoverageGapEffect(boundary="iadd", reason="unresolved inplace"))
 
     class _Inc(FloorValue):
         def inplace_binary_operator_with(self, operation, ctx):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -865,9 +865,7 @@ def resolve_import_binding(
                 or nested_module not in graph.modules
                 or (
                     demand_kind == "import-value-use-demand"
-                    and list(
-                        authenticated_use.use.get("exportedMemberPath") or ()
-                    )
+                    and list(authenticated_use.use.get("exportedMemberPath") or ())
                     != suffix
                 )
             ):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -140,9 +140,7 @@ def _resolve_export_uncached(
     if locus is not None and not _prefix_has_completed_fallthrough(
         module, locus, graph=graph, session=session
     ):
-        return _gap(
-            "dynamic-export", binding_cid, graph, module_name, exported_name
-        )
+        return _gap("dynamic-export", binding_cid, graph, module_name, exported_name)
     return _resolve_export_binding(
         graph,
         binding_cid,
@@ -311,9 +309,7 @@ def _resolve_export_binding(
             session=session,
         )
     if binding is not None and binding[0] == "dynamic":
-        call_method = _callable_instance_call_method(
-            body, binding[1], exported_name
-        )
+        call_method = _callable_instance_call_method(body, binding[1], exported_name)
         if call_method is not None:
             definition = _definition(module, call_method)
             return ResolvedPythonObjectV1(
@@ -590,9 +586,7 @@ def _resolve_star_export(
     target_tree = parsed_tree(target.source, target.source_seat)
     published = _target_star_published_names(target_tree.body)
     if exported_name not in published:
-        return _gap(
-            "dynamic-export", binding_cid, graph, module_name, exported_name
-        )
+        return _gap("dynamic-export", binding_cid, graph, module_name, exported_name)
     warrant = ReexportWarrantV1(
         from_module=module_name,
         from_source_cid=module.source_cid,
@@ -792,9 +786,7 @@ def _export_statement_with_locus(statement: ast.stmt, name: str, state):
         return body_state, body_locus
     if isinstance(statement, ast.If):
         body_state, body_locus = _export_block_with_locus(statement.body, name, state)
-        else_state, else_locus = _export_block_with_locus(
-            statement.orelse, name, state
-        )
+        else_state, else_locus = _export_block_with_locus(statement.orelse, name, state)
         joined = _join_export_states((body_state, else_state), statement)
         if joined is body_state and body_state is not state:
             return joined, body_locus
@@ -844,9 +836,7 @@ def _prefix_has_completed_fallthrough(
 
     if graph is None and session is None:
         return prefix_has_completed_fallthrough(module, locus)
-    return prefix_has_completed_fallthrough(
-        module, locus, graph=graph, session=session
-    )
+    return prefix_has_completed_fallthrough(module, locus, graph=graph, session=session)
 
 
 def _absolute_import(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -225,7 +225,9 @@ class _SealedBackendRelation:
                     fix="consume the sole producer product",
                 )
             raise TypeError("backend construction owner")
-        if not isinstance(_owner_token, _PrivateSeal) or _owner_token.owner_type is not type(self):
+        if not isinstance(
+            _owner_token, _PrivateSeal
+        ) or _owner_token.owner_type is not type(self):
             raise TypeError("backend construction owner")
         changed = tuple(
             name
@@ -285,7 +287,9 @@ class _SealedBackendRelation:
 def _close_private(instance: _SealedBackendRelation, **fields: object) -> object:
     for name, value in fields.items():
         object.__setattr__(instance, name, value)
-    object.__setattr__(instance, "_owner_token", _PrivateSeal(type(instance), dict(fields)))
+    object.__setattr__(
+        instance, "_owner_token", _PrivateSeal(type(instance), dict(fields))
+    )
     return instance
 
 
@@ -686,7 +690,9 @@ class Backend:
         # This is the sole completed traversal.  Every roster below is a
         # projection of these exact constructed node objects, never a reread.
         constructed_nodes = tuple(root.walk())
-        positions = {id(node): position for position, node in enumerate(constructed_nodes)}
+        positions = {
+            id(node): position for position, node in enumerate(constructed_nodes)
+        }
         parent_positions: list[int | None] = [None] * len(constructed_nodes)
         for position, node in enumerate(constructed_nodes):
             for field_name in type(node)._child_fields:
@@ -820,7 +826,9 @@ class Backend:
         for node in constructed_nodes:
             if not isinstance(node, Assign) or len(node.targets) != 1:
                 continue
-            if not isinstance(node.targets[0], Name) or not isinstance(node.value, Constant):
+            if not isinstance(node.targets[0], Name) or not isinstance(
+                node.value, Constant
+            ):
                 continue
             value = node.value.value
             if type(value) not in (int, float, str):
@@ -891,7 +899,9 @@ class Backend:
                 construction_event_identity=event_identity,
                 filename=unit.filename,
                 function_occurrence=owning_function,
-                function_locus=(None if owning_function is None else owning_function.line_col_span()),
+                function_locus=(
+                    None if owning_function is None else owning_function.line_col_span()
+                ),
                 assert_occurrence=owning_assert,
                 assert_locus=owning_assert.line_col_span(),
                 call_occurrence=call,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py
@@ -52,10 +52,11 @@ class BindingCoordinateV1:
     def project(self, *path: str | int) -> "BindingCoordinateV1":
         """Derive an authenticated child coordinate from this formal seat."""
         if not path or not all(
-            isinstance(part, (str, int)) and not isinstance(part, bool)
-            for part in path
+            isinstance(part, (str, int)) and not isinstance(part, bool) for part in path
         ):
-            raise BindingProvenanceGap("projected coordinate requires a structural path")
+            raise BindingProvenanceGap(
+                "projected coordinate requires a structural path"
+            )
         projection_path = (*self.projection_path, *path)
         preimage = {
             "kind": "binding-coordinate",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -500,11 +500,8 @@ class ConstructionTestimonyReporterV1:
                 or definition.ref not in self._materialized_by_ref
                 or node.ref not in self._materialized_by_ref
                 or definition.unit.source_cid != node.unit.source_cid
-                or not isinstance(
-                    resolved_definition, (FunctionDef, AsyncFunctionDef)
-                )
-                or resolved_definition.fragment.seal()
-                != definition.fragment.seal()
+                or not isinstance(resolved_definition, (FunctionDef, AsyncFunctionDef))
+                or resolved_definition.fragment.seal() != definition.fragment.seal()
                 or value.call_occurrence != call_occurrence
                 or frame is None
                 or frame.owner.ref is not definition.ref
@@ -1221,13 +1218,9 @@ def _cv2_leaf(value: object) -> Any:
     from sugar_source_tree.backend import _validated_construction_event_receipt_cid
     from sugar_source_tree.nodes import Node, TargetPatternV1
 
-    construction_event_receipt_cid = _validated_construction_event_receipt_cid(
-        value
-    )
+    construction_event_receipt_cid = _validated_construction_event_receipt_cid(value)
     if construction_event_receipt_cid is not None:
-        return {
-            "backendConstructionEventReceiptCid": construction_event_receipt_cid
-        }
+        return {"backendConstructionEventReceiptCid": construction_event_receipt_cid}
 
     if type(value) is TargetPatternV1:
         receipt = value.receipt
@@ -1373,9 +1366,7 @@ def constructed_value_cid_v2(value: object) -> str:
     """
     from sugar_source_tree.backend import _validated_construction_event_receipt_cid
 
-    construction_event_receipt_cid = _validated_construction_event_receipt_cid(
-        value
-    )
+    construction_event_receipt_cid = _validated_construction_event_receipt_cid(value)
     if construction_event_receipt_cid is not None:
         return construction_event_receipt_cid
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -11580,6 +11580,33 @@ class Name(Expression):
             return self
         bound = unwrap_binding_state(bound)
         if isinstance(bound, Node):
+            # Formal / binding-coordinate refs carry identity in ``coordinate``,
+            # not in the Param's declaration span. Replacing every use with the
+            # declaration-span node collapses source order: a chained compare
+            # ``1 <= month`` becomes operands (const@use, formal@decl) with decl
+            # left of the use, so Compare._comparison_leg_site rejects a
+            # well-formed chain (datetime._days_in_month assert; claim-mass
+            # line 160). Both doors that mint formals share this shape:
+            # FunctionDef.substitute → FormalRef, source_visible_call_frame →
+            # BindingCoordinateRef. Re-span to the use site; coordinate CID is
+            # unchanged.
+            if (
+                bound.kind in ("FormalRef", "BindingCoordinateRef")
+                and bound.span != self.span
+                and hasattr(bound, "coordinate")
+            ):
+                from .backend import Leaf, materialize
+                from .shadow import ShadowNode
+
+                return materialize(
+                    self.unit,
+                    ShadowNode(
+                        bound.kind,
+                        self.span,
+                        (("coordinate", Leaf(bound.coordinate)),),
+                    ),
+                    self.reporter,
+                )
             return bound
         span = self.line_col_span()
         if (

--- a/implementations/python/sugar-source-tree/tests/test_formal_ref_use_site_span.py
+++ b/implementations/python/sugar-source-tree/tests/test_formal_ref_use_site_span.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""FormalRef substitution keeps use-site geometry for source-order teeth.
+
+``Name.substitute`` must not replace every formal use with the Param's
+declaration-span FormalRef. Compare chains authenticate the operator by the
+interval between adjacent *operand* spans; a declaration-span formal that sits
+left of a later constant use falsifies a well-formed chain
+(``assert 1 <= month <= 12`` inside a function after formal masking).
+
+Lying twin: declaration-span FormalRef at a use would fail
+``_comparison_leg_site``. Truthful: use-site FormalRef, chain constructs.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Assert, Compare, FunctionDef, Name
+from sugar_source_tree.tree import SourceFile
+
+
+def _tree(source: str) -> SourceFile:
+    return SourceFile((source, "formal_use_site.py", blake3_512_of(source.encode())))
+
+
+def test_formal_ref_at_use_keeps_use_site_span_not_param_span() -> None:
+    source = (
+        "def f(month):\n"
+        "    assert 1 <= month <= 12\n"
+        "    return month\n"
+    )
+    tree = _tree(source)
+    fn = next(n for n in tree.nodes() if isinstance(n, FunctionDef) and n.name == "f")
+    substituted = fn.substitute({})
+    assert_stmt = next(n for n in substituted.body if isinstance(n, Assert))
+    compare = assert_stmt.test
+    assert isinstance(compare, Compare)
+    month = compare.comparators[0]
+    assert month.kind == "FormalRef"
+    # Use site is col of `month` in `1 <= month`, not the param list.
+    use = month.line_col_span()
+    assert use.start_line == 2
+    assert use.start_col > 10  # past "assert 1 <= "
+    param = fn.params[0].line_col_span()
+    assert (use.start_line, use.start_col) != (param.start_line, param.start_col)
+
+
+def test_chained_compare_with_formal_constructs_after_masking() -> None:
+    """THE product twin: function sugar must not refuse a well-formed chain."""
+    source = (
+        "def _days_in_month(year, month):\n"
+        "    assert 1 <= month <= 12, month\n"
+        "    return 30\n"
+    )
+    tree = _tree(source)
+    fn = next(n for n in tree.nodes() if isinstance(n, FunctionDef))
+    # Must not raise SugarNotWritten on Compare._comparison_leg_site
+    sugar = fn.sugar()
+    assert sugar is not None
+
+
+def test_lying_twin_declaration_span_formal_breaks_leg_site() -> None:
+    """Plant declaration-span operands; leg site must reject (tooth can fail)."""
+    source = "def f(month):\n    assert 1 <= month <= 12\n"
+    tree = _tree(source)
+    fn = next(n for n in tree.nodes() if isinstance(n, FunctionDef))
+    assert_stmt = next(n for n in fn.body if isinstance(n, Assert))
+    compare = assert_stmt.test
+    assert isinstance(compare, Compare)
+    # Build operands as if formal kept param span (the old illegal shape).
+    param = fn.params[0]
+    operands = (compare.left, param, compare.comparators[1])
+    from sugar_source_tree.panic import SugarNotWritten
+    import pytest
+
+    with pytest.raises(SugarNotWritten, match="Compare._comparison_leg_site"):
+        compare._comparison_leg_site(0, operands)

--- a/tools/lift_refusal_vocabulary_census.json
+++ b/tools/lift_refusal_vocabulary_census.json
@@ -2,7 +2,7 @@
   "identity": "path + normalized text digest + duplicate ordinal; line is display only",
   "issue": "#3632",
   "law": "REFUSE is the verifier verb; lift outputs are reduced meaning or typed effects.",
-  "lift_output_backlog": 1883,
+  "lift_output_backlog": 2183,
   "occurrences": [
     {
       "key": "implementations/python/sugar-build-witness/src/sugar_build_witness/discharge_cli.py:523c0ad6c899be9b:1",
@@ -275,6 +275,116 @@
       "wire_marker": "not-lift-output"
     },
     {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py:1c984318e43ec4ed:1",
+      "line": 84,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"Where neither exists this refusal is correct output and the \"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py:a29256257ec4d8bc:1",
+      "line": 66,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# deterministic and it makes the refusal disappear. It designates WHERE",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py:c94bd5451e5dba7e:1",
+      "line": 56,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# THIS REFUSAL IS CORRECT OUTPUT, NOT OWED WORK.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py:c9deb69dd2301897:1",
+      "line": 95,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_exception_matching.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "predicate over, and the sole caller turns it into a loud refusal.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py:6d00f42e323dd52e:1",
+      "line": 69,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Refuse execution testimony minted outside the declared runtime.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py:76f002a1c742454d:1",
+      "line": 105,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "f\"site-packages {purelib}; refusing a leaking environment\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py:9ed74bff44bac48b:1",
+      "line": 110,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "f\"interpreter's own site-packages {purelib}; refusing foreign metadata\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py:ae7b4ed98193ab1d:1",
+      "line": 251,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "harmless while editing bytes in place refuses.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py:b42acd18a59455bb:1",
+      "line": 280,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"BATTLEAXE EXECUTION ENVIRONMENT REFUSED: \" + str(error),",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py:0d5ff2985bfc5b5f:1",
+      "line": 421,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "Readability never authorizes deletion: Floor ``delattr`` refuses",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py:26ef7cc2d7b354dc:1",
+      "line": 140,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Project the closed resolution into an ExitSet or a typed refusal.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py:42f8e0fc20bd6e44:1",
       "line": 8,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py",
@@ -295,6 +405,116 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py:12e5fceed212aa43:1",
+      "line": 79,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "AttributionOutcome.NAMED_REFUSAL,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py:a1b2f270229d681b:1",
+      "line": 167,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Resolve one composite hit or refuse at its first differing coordinate.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py:ff133e7e9a4e0ce0:1",
+      "line": 83,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/consumer_resolution_report.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"surviving testimony must be a named refusal or construction panic\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py:2856a4f73f441b0f:1",
+      "line": 290,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refuse.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py:5373c2b6961936fe:1",
+      "line": 617,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "decoder would have refused as ``malformed context-manager resolution gap``.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py:bad1765747939ec7:1",
+      "line": 439,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Authority shared by every face, or refuse when faces disagree.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py:fd70f0ea43937688:1",
+      "line": 363,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"generator resource ref refuses non-generator protocol testimony\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/corpus_pin.py:e955cb08b6c029b4:1",
+      "line": 351,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/corpus_pin.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Refuse to measure against a corpus that is not the pinned one.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py:aa9fae34782a4b03:1",
+      "line": 154,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Refuse artifact consumption under a digest from another preimage.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:04dea0f339d88ee8:1",
+      "line": 25,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "``desugarDesignedGaps`` a DECLARED mechanism refusing on purpose, as its",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:0a7e08e0ba72b318:1",
+      "line": 315,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# designed refusal is reported correct output, not silence.",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:1cdfd99d904e041e:1",
       "line": 11,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
@@ -305,18 +525,38 @@
       "wire_marker": "internal-only"
     },
     {
-      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:5a22a8cc4df81f51:1",
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:4d6dfc932785abc9:1",
+      "line": 348,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# the remaining-work vs correct-refusal split as data on the exception",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:50ddfcb47defb03f:1",
+      "line": 314,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# R_desugar (they are not typed refusals), and never dropped \u2014 a",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:5b6a49ad296497cf:1",
       "line": 330,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
-      "text": "a typed refusal is a measured frontier row, not a broken instrument.\"\"\"",
+      "text": "# ``desugar-call:`` key is a typed refusal (the reduction stopped and",
       "wire_marker": "internal-only"
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:69c525740c848874:1",
-      "line": 286,
+      "line": 417,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -326,7 +566,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:6f37f5208a9cb3dd:1",
-      "line": 253,
+      "line": 384,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -336,7 +576,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:70ab45bc61822f20:1",
-      "line": 334,
+      "line": 494,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -346,7 +586,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:8113597c30466169:1",
-      "line": 287,
+      "line": 418,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -355,13 +595,63 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:8fcd255140305df2:1",
+      "line": 249,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "were that refusal working, every one classifying ``isRemainingWork: False``.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:95968d355e3c72a6:1",
+      "line": 467,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"R_desugar_owed_work\": int(self.categories.get(\"typed-refusal\", 0)),",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:a0b601919607484d:1",
+      "line": 288,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "``None`` when the refusal carries no arms, and an unclassifiable occurrence",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:a397c6ec06cd75da:1",
-      "line": 268,
+      "line": 399,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "return (\"refusal\", gap)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:ba32e4b0782f1679:1",
+      "line": 244,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "A designed gap is a refusal a mechanism raises ON PURPOSE, as its correct",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:cc3031e8034c8c16:1",
+      "line": 246,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "is one: ``factor_completed`` refuses arms it cannot prove exclusive because",
       "wire_marker": "internal-only"
     },
     {
@@ -372,6 +662,876 @@
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "R_desugar typed semantic refusals/effects (door: ``sugar.desugar(None)``)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:d8a3f899b66a652d:1",
+      "line": 485,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "a typed refusal is a measured frontier row, not a broken instrument.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:f3d7104e7e87f773:1",
+      "line": 336,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"typed-refusal\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/warning_effect.py:16e4f550fe8543f6:1",
+      "line": 20,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/warning_effect.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# refuses when the producer did not construct it.",
+      "wire_marker": "wire-protocol:effect-kind"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py:0baa07d8b286f927:1",
+      "line": 116,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "FixtureResourceOutcome.NAMED_REFUSAL,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py:0baa07d8b286f927:2",
+      "line": 128,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "FixtureResourceOutcome.NAMED_REFUSAL,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py:1369a163c8e1a063:1",
+      "line": 21,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "class FixtureResourceBindingRefusal(ValueError):",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py:40d0da2548658559:1",
+      "line": 117,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refusal.detail,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py:4f6b3eb9ce36eac3:1",
+      "line": 27,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "super().__init__(f\"fixture resource binding refused at {coordinate}: {detail}\")",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py:569f312e071c4e89:1",
+      "line": 113,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "except FixtureResourceBindingRefusal as refusal:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py:76026a3e22776cee:1",
+      "line": 115,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refusal.coordinate,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py:91bb2157a05d7710:1",
+      "line": 104,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "body; ordinary or empty completion is a named refusal, never success by",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py:9aa00bc812f9387f:1",
+      "line": 62,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "raise FixtureResourceBindingRefusal(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py:9aa00bc812f9387f:2",
+      "line": 73,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "raise FixtureResourceBindingRefusal(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py:a6cc0eac207fdb75:1",
+      "line": 85,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/fixture_resource_obligation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "NAMED_REFUSAL = \"named-refusal\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py:50d2b69c61a48ed7:1",
+      "line": 106,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "force_floor / field projection can refuse with a stage-keyed residual",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py:f63cbff11fa6b479:1",
+      "line": 195,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "arm the condition stays a bodyless CallSiteValue and ``not`` refuses.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:04768a62b9348346:1",
+      "line": 969,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "def _dig_or_refuse_binop(self, other, site, *, op: str, floor_method: str):",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:0a60b9e9283c560b:1",
+      "line": 929,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return self._dig_or_refuse_binop(other, site, op=\"%\", floor_method=\"modulo\")",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:151e94d813ebdcb4:1",
+      "line": 920,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return self._dig_or_refuse_binop(other, site, op=\"*\", floor_method=\"multiply\")",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:19ecbdcd4fffef36:1",
+      "line": 537,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# result's container type is undecided \u2014 named refusal, never",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:2857960ac46c2d6f:1",
+      "line": 100,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "table \u2014 then the string door can refuse non-empty names entirely.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:3ef2b63bf4085cb7:1",
+      "line": 951,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# retain the named undecided-dispatch refusal.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:47ca32290ca83d0d:1",
+      "line": 926,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return self._dig_or_refuse_binop(other, site, op=\"/\", floor_method=\"divide\")",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:52a4a4cf224c64da:1",
+      "line": 909,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Addition floor via interface dispatch: dig, redispatch, or refuse.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:7e6c839fad846b5f:1",
+      "line": 991,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return refused",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:b4ef46960d398f7a:1",
+      "line": 962,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return self._dig_or_refuse_binop(other, site, op=\"|\", floor_method=\"bitwise_or\")",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:c20dae017f95487e:1",
+      "line": 923,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return self._dig_or_refuse_binop(other, site, op=\"**\", floor_method=\"power\")",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d0f289d1ced31436:1",
+      "line": 932,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return self._dig_or_refuse_binop(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d0f289d1ced31436:2",
+      "line": 937,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return self._dig_or_refuse_binop(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d0f289d1ced31436:3",
+      "line": 945,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return self._dig_or_refuse_binop(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d0f289d1ced31436:4",
+      "line": 952,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return self._dig_or_refuse_binop(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d0f289d1ced31436:5",
+      "line": 957,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return self._dig_or_refuse_binop(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d0f289d1ced31436:6",
+      "line": 965,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return self._dig_or_refuse_binop(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d753c45130bb14e1:1",
+      "line": 990,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "if refused is not None:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:e9e27e8fd5e4ebc8:1",
+      "line": 917,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return self._dig_or_refuse_binop(other, site, op=\"-\", floor_method=\"subtract\")",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:f587884b31c4c7b3:1",
+      "line": 914,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return self._dig_or_refuse_binop(other, site, op=\"+\", floor_method=\"add\")",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:f5d75e57ec717a53:1",
+      "line": 264,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "named producer refusal rather than standing on a ground field law or",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:f90d6079fcab7b08:1",
+      "line": 989,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refused = self._undecided_binary_law(other, site, op)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py:805fa14e9d05a709:1",
+      "line": 88,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Field members that refused entry (overflow) stay loud, not TypeError.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py:16d6773bd54f70f2:1",
+      "line": 222,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/dict_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# hash/eq semantics are not source-decided stays the named refusal.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:014ed6ca2eb38b70:1",
+      "line": 1015,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "if refused is not None:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:014ed6ca2eb38b70:2",
+      "line": 1035,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "if refused is not None:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:014ed6ca2eb38b70:3",
+      "line": 1057,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "if refused is not None:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:097a6f3b9574f919:1",
+      "line": 786,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Refuse membership when container dispatch is not source-decided.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:0c4a488cb49b6fb9:1",
+      "line": 1034,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refused = self._undecided_unary_law(site, \"+\")",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:1f3d5ea80364c8b5:1",
+      "line": 604,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Refuse a lookup whose runtime dispatch is not source-decided.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:222287dae6537994:1",
+      "line": 788,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "Named refusal, not construction panic and not ``Complete(py.in)``.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:223fedce4813d3cd:1",
+      "line": 1033,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Default: no unary-plus floor. TermValue folds; undecided types refuse.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:2be5be2ae1d38edf:1",
+      "line": 760,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "This is an accounted named refusal, not a construction failure. The",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:6f8e1bc8d785f4a8:1",
+      "line": 1138,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "code wearing a typed refusal. Binary floor already panics decided",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:77199514ecd31f4c:1",
+      "line": 1118,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "def _refuse_ordering_meaning(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:79e1af0c73cca3c6:1",
+      "line": 1006,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"from source, or retain this named refusal without inventing an \"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:8400f9d7c8e3699a:1",
+      "line": 1199,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Backward-compatible name: refuse ordering meaning (always throws).\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:8b57d4a8c516d4cb:1",
+      "line": 1016,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return refused",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:8b57d4a8c516d4cb:2",
+      "line": 1036,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return refused",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:8b57d4a8c516d4cb:3",
+      "line": 1058,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return refused",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:9085c0f961c575f9:1",
+      "line": 1013,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# operand type refuses (success versus TypeError is not source-decidable).",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:9ca6e3b40ba1c89b:1",
+      "line": 1210,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "left._refuse_ordering_meaning(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:9f8fb782071e5eff:1",
+      "line": 1014,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refused = self._undecided_unary_law(site, \"-\")",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:b392f5da7c480d6a:1",
+      "line": 1200,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "self._refuse_ordering_meaning(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:b392f5da7c480d6a:2",
+      "line": 1215,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "self._refuse_ordering_meaning(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:b392f5da7c480d6a:3",
+      "line": 1220,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "self._refuse_ordering_meaning(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:b392f5da7c480d6a:4",
+      "line": 1225,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "self._refuse_ordering_meaning(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:bad65eb6fc982e50:1",
+      "line": 984,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "identity. Both stay refused until source-visible type testimony decides.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:bd6f605a6726dc83:1",
+      "line": 1054,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# an untyped symbol refuses because success versus TypeError is not",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:be2d66f5d5448455:1",
+      "line": 1132,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "source-decided): named third-value refusal (``SugarNotWritten``).",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:c5bd1246ec562325:1",
+      "line": 722,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "An actual whose runtime type remains undecided stays a named refusal;",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:d23f6b298ecf0095:1",
+      "line": 1056,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refused = self._undecided_unary_law(site, \"~\")",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:d70314f1281e99b2:1",
+      "line": 606,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "This is accounted named-refusal semantics (``SugarNotWritten``), not a",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:ee82ebb15531dc06:1",
+      "line": 758,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Refuse lookup when source testimony decides neither outgoing edge.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/function_callable.py:1893e7fe573876bf:1",
+      "line": 424,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/function_callable.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# raised ModuleNotFoundError: not a panic, not a refusal, not a family the",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py:27bc6ff1f04b9e29:1",
+      "line": 149,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "completed RaiseValue. Undecided native dispatch stays on the named-refusal",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py:74e7374ba2b4ed31:1",
+      "line": 17,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "producer \u2192 ExitSet \u2192 boundary route refuses matching.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py:42eb148a6b5f23aa:1",
+      "line": 90,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "an arity mismatch on a list: a correct refusal wearing the wrong name.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py:d423c21c1798f93a:1",
+      "line": 126,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# TypeError. Undecided peers refuse named (no FOL invent).",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py:81af5002c3cd7800:1",
+      "line": 275,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"``self.name = value`` via instance-field store or property refusal.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py:90dff086874aba61:1",
+      "line": 297,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"``del self.name`` via instance-field delete or property refusal.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:646e7800f5893f01:1",
+      "line": 109,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "the same sin relocated onto the field: refuse it. Empty spelling is not",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:88101b621c1ba63e:1",
+      "line": 70,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "def _refuse_uncited_exit(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:a7562b951727a20d:1",
+      "line": 219,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# check; refuse it at the same mouth.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:1",
+      "line": 114,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "_refuse_uncited_exit(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:2",
+      "line": 127,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "_refuse_uncited_exit(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:3",
+      "line": 148,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "_refuse_uncited_exit(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:4",
+      "line": 165,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "_refuse_uncited_exit(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:5",
+      "line": 175,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "_refuse_uncited_exit(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:6",
+      "line": 224,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "_refuse_uncited_exit(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:7",
+      "line": 239,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "_refuse_uncited_exit(",
       "wire_marker": "internal-only"
     },
     {
@@ -395,23 +1555,623 @@
       "wire_marker": "internal-only"
     },
     {
-      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py:cae40838c62d8b5b:1",
-      "line": 164,
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py:8bfc1a1c321b37c7:1",
+      "line": 244,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/set_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
-      "text": "# callable, never a member -- two tests pin that refusal deliberately. The",
+      "text": "# a callable, never a member -- two tests pin that refusal deliberately. So",
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py:55fb783f8b4f40db:1",
+      "line": 185,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"obligation a face to be owed on, or refuse the join at the \"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py:02a79529f205debd:1",
+      "line": 868,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# since that module went the panic was an ImportError, not a refusal.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py:c3c41b077992d612:1",
+      "line": 111,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# refuse named (no FOL invent).",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py:c45c1c27b7a6bbe2:1",
+      "line": 158,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# not a named refusal of missing machinery.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:1dca8e80578ea2e3:1",
+      "line": 465,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# testimony. Named refusal, not fabrication.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:651f6d80c8419d84:1",
+      "line": 395,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "if refused is not None:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:7088ff30703d0b15:1",
+      "line": 284,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# TypeError \u2014 that remains the undecided refusal on the base law.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:8cc50d540607ff56:1",
+      "line": 394,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refused = self._undecided_binary_law(other, site, operator)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:9b4d57b0a72a9592:1",
+      "line": 424,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Formal operands: authenticated discharge. Open symbols stay refused.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:c422df5c1b61696b:1",
+      "line": 408,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Formal operands: authenticated discharge. Open symbols stay refused",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:e6caa57577e3416a:1",
+      "line": 57,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "operation reaches the named producer refusal rather than standing on a",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:ebd7d649ff1ee053:1",
+      "line": 396,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return refused",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py:5092d8c266959142:1",
+      "line": 142,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# refuse named (LAW_OF_ONE \u2014 no Complete(PredicateValue) invent).",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/warning_observation_value.py:ccbaf696940473c0:1",
+      "line": 22,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/warning_observation_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# guards is what lets the consuming boundary refuse rather than silently",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py:3425b04fdb7bd5bd:1",
+      "line": 607,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Consumer never fabricates testimony; unsealed entries refuse here.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py:35f3e4ba5d60b6b4:1",
+      "line": 1748,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "_refuse_transition(projected)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py:4daf0549501d8b9c:1",
+      "line": 1660,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "def _refuse_transition(result):",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py:c8e40750987fe993:1",
+      "line": 1714,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "_refuse_transition(transitioned)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py:c8e40750987fe993:2",
+      "line": 1756,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "_refuse_transition(transitioned)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py:fae78461a067e48f:1",
+      "line": 1132,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# refuse: advance and let the NEXT step answer. This is what makes",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_entry_refusal.py:2aded5cf60b12ca3:1",
+      "line": 60,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_entry_refusal.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "def observed_entry_refusal() -> GeneratorEntryRefusalV1:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_entry_refusal.py:2d58e2f20b75cd78:1",
+      "line": 72,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_entry_refusal.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return GeneratorEntryRefusalV1(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_entry_refusal.py:7c7e5b1973679555:1",
+      "line": 39,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_entry_refusal.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "class GeneratorEntryRefusalV1:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_entry_refusal.py:f2845873fd3b882f:1",
+      "line": 40,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_entry_refusal.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"The observed ``__enter__`` refusal for a generator that never yields.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/live_construction_panic_isolation.py:385d8be55ed310d3:1",
+      "line": 56,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/live_construction_panic_isolation.py",
+      "reason": "IDD instrument code names an existing frontier or vocabulary row",
+      "replacement": "keep until the named frontier row is retired by its owning migration",
+      "speaker": "instrument-prose",
+      "text": "This stands in for the deleted name so the break is a NAMED refusal instead",
+      "wire_marker": "not-lift-output"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/live_construction_panic_isolation.py:8870af50dcd4f070:1",
+      "line": 58,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/live_construction_panic_isolation.py",
+      "reason": "IDD instrument code names an existing frontier or vocabulary row",
+      "replacement": "keep until the named frontier row is retired by its owning migration",
+      "speaker": "instrument-prose",
+      "text": "refusal, and not a family the census buckets. It is deliberately not caught",
+      "wire_marker": "not-lift-output"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py:09961c171f1219e0:1",
+      "line": 1297,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Refuse mismatched claims here (same boundary as AuthenticatedImportUseV1);",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py:37dc335fa59b8e9d:1",
+      "line": 1152,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Refuse dual-door identity at the import-use mint boundary.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py:ebd53533a50b1223:1",
+      "line": 124,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# must refuse \u2014 there is no fallthrough third surface.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py:feb63344137bde0c:1",
+      "line": 195,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# cross-surface relabeling refuse at mint \u2014 not by observing output sets.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py:123afe61f95c8711:1",
+      "line": 2138,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Named refuse from the construction door \u2014 gap row, not",
+      "wire_marker": "wire-protocol:rpc-dto"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py:f14d9df53d963944:1",
+      "line": 2151,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# FunctionBindingMiss is named refuse (gap above); unfinished",
+      "wire_marker": "wire-protocol:rpc-dto"
+    },
+    {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py:1d746ca8d1121748:1",
-      "line": 412,
+      "line": 478,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "# correctly refuses to snapshot and reports as a typed gap.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:21668c5aae4e776c:1",
+      "line": 324,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "except UnattributableRefusal:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:28b1af74dd98992f:1",
+      "line": 326,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "except SugarNotWritten as refusal:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:2f185209ee265f8e:1",
+      "line": 201,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "+ row.named_refusals",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:4157ea11475d3e78:1",
+      "line": 330,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "AttributionOutcome.NAMED_REFUSAL,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:4231ea48240f655c:1",
+      "line": 320,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "from sugar_source_tree.panic import SugarNotWritten, UnattributableRefusal",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:474eaf68051fb517:1",
+      "line": 238,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "f\"namedRefusal={row.named_refusals}\",",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:4a34ab47ff622529:1",
+      "line": 261,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "elif body.outcome is AttributionOutcome.NAMED_REFUSAL:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:58546381542848eb:1",
+      "line": 504,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "raise DemandTableRefusal(\"shared demand table carries no row list\")",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:5c447a0e7c2a08d1:1",
+      "line": 153,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "named_refusals: int",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:5c447a0e7c2a08d1:2",
+      "line": 176,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "named_refusals: int",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:65589bf6183e740c:1",
+      "line": 263,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "f\"namedRefusal body={body.body_id} coordinate={body.detail}\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:6639b28578941d83:1",
+      "line": 473,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "raise DemandTableRefusal(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:6639b28578941d83:2",
+      "line": 499,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "raise DemandTableRefusal(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:6639b28578941d83:3",
+      "line": 540,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "raise DemandTableRefusal(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:67f369a675678b25:1",
+      "line": 740,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Refuse a different inventory instead of printing incomparable counts.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:73925aea3274241a:1",
+      "line": 67,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "class DemandTableRefusal(RuntimeError):",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:79ff1c01b71dd967:1",
+      "line": 393,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "body.outcome is AttributionOutcome.NAMED_REFUSAL for body in materialized",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:86d79b609dc0c0f0:1",
+      "line": 377,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"authenticated exceptional exit, named refusal, or construction panic\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:8a47b16e2cf98b70:1",
+      "line": 6,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "``SugarNotWritten`` refusal is accounted semantics, not a failure.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:9b50e33d2874ef62:1",
+      "line": 89,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Refuse construction so the dead-guard shape is unwritable.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:9de429e19b194d6e:1",
+      "line": 392,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "named_refusals=sum(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:9de429e19b194d6e:2",
+      "line": 445,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "named_refusals=sum(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:a488d0d6eba73ac1:1",
+      "line": 331,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refusal.owner,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:b9eb397d2c04434f:1",
+      "line": 761,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Authenticated executable edge. Workstations must refuse before pulling.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:cb136438e080c8fe:1",
+      "line": 59,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "NAMED_REFUSAL = \"named-refusal\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:e26356181b8ea8da:1",
+      "line": 384,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"One closed split; a refusal never leaks into the failure axis.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:fa77b1a6edc382ea:1",
+      "line": 166,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "+ self.named_refusals",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:fc2ca3e0a20aa1e8:1",
+      "line": 446,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "body.outcome is AttributionOutcome.NAMED_REFUSAL for body in selected",
       "wire_marker": "internal-only"
     },
     {
@@ -436,7 +2196,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py:609201548e399168:1",
-      "line": 123,
+      "line": 165,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -446,7 +2206,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:0ccc14caa49a9811:1",
-      "line": 789,
+      "line": 1215,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -455,8 +2215,28 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:1fd0e343568c2ffd:1",
+      "line": 1113,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "``rewrap_pending`` refuses.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:3dc4faaf739ea559:1",
+      "line": 66,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "Carries the two refusing ARMS as well as the prose (#6356). A census that",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:5704e70627417bb5:1",
-      "line": 100,
+      "line": 215,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -465,8 +2245,28 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:637604514bc524a0:1",
+      "line": 253,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "unstamped and its refusal unclosable by any producer.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:74f7df15f1d90137:1",
+      "line": 140,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refusal in ``factor_completed`` exists for exactly the case where no such",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:877c3635ffe0adde:1",
-      "line": 744,
+      "line": 1151,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -476,7 +2276,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:c5b1ad8a560dc1a6:1",
-      "line": 164,
+      "line": 338,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -486,7 +2286,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:d1856b0d998ccf78:1",
-      "line": 344,
+      "line": 609,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -495,8 +2295,318 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py:07f9c82fa57598b6:1",
+      "line": 35,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "This module CHANGES NO BEHAVIOUR. The refusal fires identically in every class.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py:0bebc7535e5ad909:1",
+      "line": 13,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refusals\" plan you need it to define what stops being counted. The split is",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py:398e2bb5fc02f274:1",
+      "line": 36,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "It only reads the arms a refusal already carries.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py:a287187b23f20af5:1",
+      "line": 132,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Classify ONE refusing pair of completed arms. Reads, never decides.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py:c79ad5f58c03a458:1",
+      "line": 7,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "(b) a refusal of arms with no exclusion available -- correct output, and",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py:c8f1a79376aee19c:1",
+      "line": 46,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/factoring_gap_kind.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Why one refusal happened, read off the arms' carried testimony.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py:630ce0604f1447b7:1",
+      "line": 260,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"same members under a substituted occurrence are refused\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_projection.py:77e50a85154dc0c1:1",
+      "line": 41,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/binding_projection.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "partition law exists to refuse.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py:595b05dfbe541829:1",
+      "line": 35,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "stay refused until source-visible type testimony decides.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py:70a93924a849931f:1",
+      "line": 58,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"from source, or retain this named refusal without inventing an \"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py:dc1afd7e976b099a:1",
+      "line": 27,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "def refuse_undecided_boolean_truth(value, site, op_kind: str) -> None:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py:e4576961fe0291db:1",
+      "line": 178,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refuse_undecided_boolean_truth(value, self.site, self.op_kind)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py:893586335d8d74f5:1",
+      "line": 11,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "Compare construction is partitioned by law \u2014 not one monomorphic refusal:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py:ad070fe5a08665b1:1",
+      "line": 181,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refuses at the UnaryOp producer.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py:bea61a3423aa2c50:1",
+      "line": 50,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Undischarged demand awaiting caller actuals \u2014 not a refusal.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py:bea61a3423aa2c50:2",
+      "line": 153,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Undischarged demand awaiting caller actuals \u2014 not a refusal.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py:1497a4d86756f4cb:1",
+      "line": 214,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "reducer omitted the real pre-halt state\" and refuses on it, so supplying a",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py:3708e5e3b3522131:1",
+      "line": 212,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "WHY THIS DOES NOT WEAKEN THE BOUNDARY REFUSAL.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py:3f2b3f2c3d331d19:1",
+      "line": 226,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "`ContractConditionalConstructionV1.and_then` to this module's refusal, which",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py:8503829ae272b604:1",
+      "line": 92,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "supplying a record here would silence that refusal for exactly the arms that",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py:ab05c12463e28cdd:1",
+      "line": 91,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "as \"the reducer omitted the real pre-halt state\" and refuses on it, so",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py:06958c7bfbcfdd26:1",
+      "line": 63,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# vendor conversion (generator_entry_refusal), not a transcribed",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py:1944908e3b71797b:1",
+      "line": 66,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "self._entry_refusal_exit(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py:478e12f739d3faa4:1",
+      "line": 64,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# string and not a SugarNotWritten refusal of a real outcome.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py:531bd92f8b9a06da:1",
+      "line": 129,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "exception_name=refusal.exception_name,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py:686fe51f60356a94:1",
+      "line": 118,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "Observation lives in ``generator_entry_refusal`` (vendor conversion).",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py:7a3ab7ea8b1d8b2b:1",
+      "line": 115,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "def _entry_refusal_exit(manager_exit, termination: GeneratorTerminationV1):",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py:dafb6f6f55e5557e:1",
+      "line": 123,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "from sugar_lift_py_tests.generator_entry_refusal import observed_entry_refusal",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py:e38bfa0234d520b9:1",
+      "line": 126,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refusal = observed_entry_refusal()",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py:e6ec2692427b3ace:1",
+      "line": 131,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "occurrence=f\"generator-entry-refusal:{blame}\",",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py:f38a3e66be29c61e:1",
+      "line": 132,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "raised_value=refusal.message,",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py:26e7d32ef54bfbc2:1",
-      "line": 169,
+      "line": 215,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -506,7 +2616,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py:a54b145fd7e0f683:1",
-      "line": 170,
+      "line": 216,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -516,7 +2626,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py:c5bd5f1b169a0198:1",
-      "line": 190,
+      "line": 236,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -526,7 +2636,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py:cf014ed7bf6d54a0:1",
-      "line": 135,
+      "line": 181,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -536,7 +2646,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py:a13950695d96a694:1",
-      "line": 99,
+      "line": 233,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -545,8 +2655,288 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py:26032a49a0853eb5:1",
+      "line": 224,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Undischarged demand awaiting caller actuals \u2014 not a refusal.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py:cc790522d233713c:1",
+      "line": 186,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# The source-visible completed/exceptional and loud-refusal laws are",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py:2c273edaff275c7c:1",
+      "line": 87,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# completed faces through the receiver floor; a typed refusal remains a",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py:95521f0f92d8e128:1",
+      "line": 130,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# from the receiver floor (named refusal), exact exits Complete.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py:ea69fdb81baa3154:1",
+      "line": 88,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# refusal and must never be converted into an empty outcome.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py:9c2080f840690fe3:1",
+      "line": 204,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "- refuses with ``SugarNotWritten`` when the effect kind is not what ordinary",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py:23b6867a1d19bf8f:1",
+      "line": 96,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"from source, or retain this named refusal without inventing an \"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py:2a89abad7761fbd4:1",
+      "line": 63,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "``bool`` completion. Refusing it here collapses installed-source manager",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py:55a2db06a597a681:1",
+      "line": 57,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "Formals are not refused here: their type arrives at caller discharge on the",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py:5a06b822e1e150d8:1",
+      "line": 47,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "def refuse_undecided_unary_truth(value, site) -> None:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py:c2335d26523fd148:1",
+      "line": 185,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refuse_undecided_unary_truth(value, self.site)",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py:c47c6818c210b70c:1",
+      "line": 5,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "value owns the answer (a number folds; an undecided type refuses rather than",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py:d1e626c77cc550f7:1",
+      "line": 149,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# the body before truth refusal. Opaque CallSiteValue is neither",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py:f0ac04f4b2e74581:1",
+      "line": 79,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Authenticated call coordinates own a lawful truth floor; do not refuse them.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py:f690524871f53cb4:1",
+      "line": 54,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "an exception identity invents the failure. Both stay refused until",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/warning_observation_producer.py:2168b3e01f92e83d:1",
+      "line": 6,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/warning_observation_producer.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "warning boundary therefore reached the \"unresolved warning producers\" refusal",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/warning_observation_producer.py:828cd33ff6b612ea:1",
+      "line": 17,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/warning_observation_producer.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "``Call._import_bound_callee_symbol`` refuses a shadowed, parameter or",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:13b666fe428cc124:1",
+      "line": 436,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refusal = SugarNotWritten(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:13b666fe428cc124:2",
+      "line": 644,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refusal = SugarNotWritten(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:2849c571ed835ff7:1",
+      "line": 327,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "the three shapes the producer deliberately refuses (no explicit category, a",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:3a16ae849bf31836:1",
+      "line": 449,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "raise refusal",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:3a16ae849bf31836:2",
+      "line": 658,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "raise refusal",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:42874e751b4ad31d:1",
+      "line": 612,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# same defect, and the matching-category router above already refuses",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:528baeae4085e7ca:1",
+      "line": 545,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "edge \u2014 the same refusals the matching-category router already names.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:8a5e0a2e722421ff:1",
+      "line": 443,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# The bucket ENUMERATES its members. A refusal that only names a",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:9777334dbe6ea2a9:1",
+      "line": 448,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refusal.unresolved_warning_producers = unresolved_members",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:9777334dbe6ea2a9:2",
+      "line": 657,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refusal.unresolved_warning_producers = unresolved_members",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:a9cbdf3c915862ed:1",
+      "line": 355,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "partition, and missing producer testimony remains a named refusal.",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar_binary.py:7bd867ef70a95cc3:1",
-      "line": 108,
+      "line": 120,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar_binary.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -555,13 +2945,13 @@
       "wire_marker": "internal-only"
     },
     {
-      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py:27906cdedbc646b8:1",
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py:152bb5f896bb02b6:1",
       "line": 125,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/temporal/builtin_name_bindings.py",
       "reason": "AST-declared identity resolves to an exception class in Python's builtin namespace",
       "replacement": "preserve the substrate-owned symbol exactly",
       "speaker": "vendor-language-identifier",
-      "text": "\"ConnectionRefusedError\": ('ConnectionError',),",
+      "text": "\"ConnectionRefusedError\": (\"ConnectionError\",),",
       "wire_marker": "not-lift-output"
     },
     {
@@ -573,6 +2963,16 @@
       "speaker": "vendor-language-identifier",
       "text": "\"ConnectionRefusedError\",",
       "wire_marker": "not-lift-output"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py:732fec15e9e5d51d:1",
+      "line": 50,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Named refusal: no unique authenticated function binding.",
+      "wire_marker": "internal-only"
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py:3feab243bdcc8dd8:1",
@@ -593,6 +2993,66 @@
       "speaker": "verifier-verdict-quote",
       "text": "# `@concept_gap(...)`. REFUSE is the verifier's verb, not the lifter's.",
       "wire_marker": "not-lift-output"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py:c396e5a13b340b87:1",
+      "line": 958,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# remains a duplicate module seat and is refused by the existing intake",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py:b9b6d4181fa5afd5:1",
+      "line": 244,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# traversal. Refuse instead of reconstructing an enclosing suite.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/external_exception_construction.py:5e01a0b0ae787f66:1",
+      "line": 322,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/external_exception_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# refused rather than joined optimistically.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/leaf_assertions.py:65aff1080252b4a2:1",
+      "line": 84,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/leaf_assertions.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "def _construction_refused(kind: str) -> TypeError:",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/leaf_assertions.py:f54a49d05155cf11:1",
+      "line": 181,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/leaf_assertions.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "raise _construction_refused(\"_TranslatedTerm\")",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/leaf_assertions.py:ffe53c4376d92186:1",
+      "line": 100,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/leaf_assertions.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "raise _construction_refused(\"_CallOccurrence\")",
+      "wire_marker": "internal-only"
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/lifter.py:07a1923e8775da07:1",
@@ -1225,8 +3685,38 @@
       "wire_marker": "wire-protocol:lift-report-payload"
     },
     {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:0553a9949395cd41:1",
+      "line": 3315,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# module-wide refusal.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:1673171b377490e8:1",
+      "line": 2158,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# function path. The same source written as a module-level function refused",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:1ea1d4d29dd68d6f:1",
+      "line": 2839,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "temporal is not source-opaque; construction may still refuse at force_floor",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:2a2db2da63a26692:1",
-      "line": 191,
+      "line": 1545,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1235,18 +3725,48 @@
       "wire_marker": "internal-only"
     },
     {
-      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:42f10ab33f901d33:1",
-      "line": 561,
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:338a3d8b39a4fbfd:1",
+      "line": 1635,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
-      "text": "still refuse at force_floor when the builtin is not yet reducible; that is a",
+      "text": "# refuses at unary_operation_exception_floor:CallSiteValue not.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:53eaeb8bde078c42:1",
+      "line": 2099,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "control flow selects which obligation, if any, becomes a refusal.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:9412ef956d9669dc:1",
+      "line": 3078,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "fix=\"refuse dual-door repair; re-mint module via path_source\",",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:a968c2eba845a3c9:1",
+      "line": 3080,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# No ValueError swallow: authenticated mint refuses tamper/mismatch loud.",
       "wire_marker": "internal-only"
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:bc73bee9cb585110:1",
-      "line": 186,
+      "line": 1532,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1255,8 +3775,138 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:bff2cd54205fddf8:1",
+      "line": 3068,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Path-source law: refuse dual-door / mismatched CID loudly at mint.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:e05b4b7d354f48f1:1",
+      "line": 1156,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "nested hops). Returns a gap when multi-manager identities refuse.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:f2bc5070b6d703a6:1",
+      "line": 3326,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# parked Call's refusal. Preserve the authenticated value row",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:1b2ca43f4358ed18:1",
+      "line": 834,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "Refuses when the frame is missing, is not a generator suspension, or when",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:22d56179f72336e5:1",
+      "line": 664,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "exception_name=refusal.exception_name,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:2af518ea5e2321d3:1",
+      "line": 660,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "refusal = observed_entry_refusal()",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:469fa3ea564fc627:1",
+      "line": 667,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "raised_value=refusal.message,",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:4e9a53fbeff54a09:1",
+      "line": 666,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "occurrence=f\"generator-entry-refusal:{blame}\",",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:98f9412071945a43:1",
+      "line": 423,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "protocol construction CID so a wrong-face resume refuses.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:9e4921b6a55ab560:1",
+      "line": 521,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "on yield; typed-loud refusal when the machine cannot enter.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:ab3e2e00b9e65a9a:1",
+      "line": 657,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "from sugar_lift_py_tests.generator_entry_refusal import observed_entry_refusal",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:f17b99e33b4bc636:1",
+      "line": 691,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "- Double exit of the same entry \u2192 refuse.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:ff8d7c67ee7b3ac9:1",
+      "line": 690,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "- Wrong protocol / wrong face \u2192 refuse.",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:06d5ed5f5ae036dd:1",
-      "line": 243,
+      "line": 885,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1265,8 +3915,48 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:0bc688431d63f096:1",
+      "line": 1790,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Return a construction gap when ``construct_generator_backed_protocol`` refused.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:0d9315daa5f1315b:1",
+      "line": 1312,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# frames refuse. No ObjectValue fabrication.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:1946ce2a22d311ed:1",
+      "line": 2517,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "helpers that construct two classes refuse sole-class projection. This is",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:51190fab5a030c33:1",
+      "line": 2487,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "multiple classes refuse \u2014 never first-candidate selection.",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:7f3c1bc287bc4c25:1",
-      "line": 277,
+      "line": 919,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1275,8 +3965,48 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:b1899d1ce1f39bdf:1",
+      "line": 1892,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"nested manager protocol construction refused\",",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:b261411d613f2318:1",
+      "line": 677,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "theorem construction may still refuse on undecided call-coordinate floors",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:b376f4cbc6f0ada9:1",
+      "line": 1417,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "raise UnattributableRefusal(",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:b4610bd089aa39f4:1",
+      "line": 1400,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "from sugar_source_tree.panic import UnattributableRefusal",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:d44ce190644017d9:1",
-      "line": 237,
+      "line": 879,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1285,14 +4015,104 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:ec1d83a741cc15a3:1",
+      "line": 678,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "(``not``, equality, subscript, f-string parts). That refusal is not",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py:2d42b6eda0eba2d6:1",
+      "line": 322,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# A refusal is this file's construction saying why a row is absent. It",
+      "wire_marker": "wire-protocol:lift-report-payload"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py:4a76cc08df28dabe:1",
+      "line": 326,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "for refusal in file_result.refusals",
+      "wire_marker": "wire-protocol:lift-report-payload"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py:7888bb9cddfb6398:1",
+      "line": 325,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "{\"memento\": memento, \"reason\": json.dumps(refusal, sort_keys=True)}",
+      "wire_marker": "wire-protocol:lift-report-payload"
+    },
+    {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py:87bf7a4969182fe1:1",
-      "line": 150,
+      "line": 160,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "\"refusals\": result.refusals,",
       "wire_marker": "wire-protocol:lift-report-payload"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py:9a69e6adb3474d55:1",
+      "line": 235,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "level is a LOUD refusal rather than an empty success: this kit does see",
+      "wire_marker": "wire-protocol:lift-report-payload"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py:403b22ea73dd3c47:1",
+      "line": 244,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py",
+      "reason": "source/witness oracle guards sealed evidence identity, not lifter output",
+      "replacement": "keep only as oracle guard vocabulary unless a future evidence-effect rename owns it",
+      "speaker": "provenance-oracle-guard",
+      "text": "states seats against, or it mints an address the seat law refuses. Deriving",
+      "wire_marker": "not-lift-output"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py:678342b120e4686e:1",
+      "line": 174,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py",
+      "reason": "source/witness oracle guards sealed evidence identity, not lifter output",
+      "replacement": "keep only as oracle guard vocabulary unless a future evidence-effect rename owns it",
+      "speaker": "provenance-oracle-guard",
+      "text": "(`ground_index_error` and its siblings) refuses an absolute locus, because",
+      "wire_marker": "not-lift-output"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py:746de5dac266db2f:1",
+      "line": 222,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py",
+      "reason": "source/witness oracle guards sealed evidence identity, not lifter output",
+      "replacement": "keep only as oracle guard vocabulary unless a future evidence-effect rename owns it",
+      "speaker": "provenance-oracle-guard",
+      "text": "arm never fires -- a refusal is not widened to a population that cannot",
+      "wire_marker": "not-lift-output"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py:b8c70ace9229e6b6:1",
+      "line": 218,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_oracle.py",
+      "reason": "source/witness oracle guards sealed evidence identity, not lifter output",
+      "replacement": "keep only as oracle guard vocabulary unless a future evidence-effect rename owns it",
+      "speaker": "provenance-oracle-guard",
+      "text": "decidable: it must EQUAL that seat, or the door refuses by name.",
+      "wire_marker": "not-lift-output"
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_provenance.py:ca51cbbecb4713d2:1",
@@ -1326,7 +4146,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:0ea9d3db9fed818c:1",
-      "line": 239,
+      "line": 246,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1336,7 +4156,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:a73ac5bc57ddf363:1",
-      "line": 236,
+      "line": 243,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1346,7 +4166,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:c4829d099c3b9db1:1",
-      "line": 449,
+      "line": 456,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1356,7 +4176,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:eae51ec3ab0e5a96:1",
-      "line": 492,
+      "line": 500,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1853,6 +4673,246 @@
       "speaker": "verifier-verdict-quote",
       "text": "except VerifyDialectRefusal as exc:",
       "wire_marker": "not-lift-output"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py:292764d14dfd45d5:1",
+      "line": 295,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_provenance.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "the same-type partition law refuses -- the identical reason",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py:5962e02588c357e8:1",
+      "line": 797,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Prove the seal: a successfully sealed state never delays wire refusal.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py:6e245b1560265270:1",
+      "line": 706,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "CID. Genuinely unavailable content refuses loud.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py:8ca21c4bce69537d:1",
+      "line": 725,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# whose sugar declined \u2014 silent green. Refuse seal loud instead.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py:94ae1f20c0ecb1d4:1",
+      "line": 724,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# CID fallback after refusal would mint sealed testimony for a value",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py:ba6253a3338b129b:1",
+      "line": 757,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "succeeds. Unavailable testimony or value/testimony mismatch refuse here.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py:e8b3c1a5422ae4d5:1",
+      "line": 723,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# SugarNotWritten / SourceTreePanic are refusal, not soft-miss. Shape",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py:09e8084ac43dc487:1",
+      "line": 159,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# the admission rule in `outcome/exit_set.py` exists to refuse.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:0ff90d970709a82f:1",
+      "line": 3407,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# branches refuse the whole If as Opaque (never skip inside).",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:135cda5248ccb50b:1",
+      "line": 3260,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# machine refuse at a statement that asks for nothing and name",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:5ea9ab078e85df21:1",
+      "line": 7159,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "authenticated), and that refusal stays total; injecting a store there",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:61d89ff95e22609b:1",
+      "line": 7158,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "contract refuses an as-binding outright (its projection is not",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:81c4e60ad47fa407:1",
+      "line": 5220,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "at *desugar* time through the store law \u2014 never by refusing the leaf",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:8f560ad01639115f:1",
+      "line": 10567,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# shadowed or ambiguous name -- and it must REFUSE, falling through",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:a5a31fdecf9b5a0e:1",
+      "line": 3650,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "boundary's refusal only surfaced later if the body happened to be",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:acab81ce0a110325:1",
+      "line": 11316,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "when neither is known, the producer refuses instead of inventing a",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:ca5b1d622d4c3c1a:1",
+      "line": 7051,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# must refuse here \u2014 never let face zero speak for the rest.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:d366ffe4568e3075:1",
+      "line": 3586,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# Raise is a step, not a Finally term; refuse pure-term suite.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py:0722d5de92ff249f:1",
+      "line": 204,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# one string and hand the wire decoder a kind it would have REFUSED.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py:116b130b61766434:1",
+      "line": 56,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Common base. Every refusal carries the native coordinate it blames.\"\"\"",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py:6fd8120daf6ceec6:1",
+      "line": 118,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "Unlike an ordinary ``SugarNotWritten``, consuming this refusal as a",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py:8326e56ae05b594d:1",
+      "line": 116,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"A construction refusal that this attribution boundary cannot classify.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py:97d107d5b3fa2542:1",
+      "line": 115,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "class UnattributableRefusal(SugarNotWritten):",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py:b5142fbc575d5c9a:1",
+      "line": 123,
+      "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "_LABEL = \"UNATTRIBUTABLE REFUSAL\"",
+      "wire_marker": "internal-only"
     },
     {
       "key": "implementations/rust/sugar-cli/src/cmd_lift.rs:0f7fb297008cfcc1:1",
@@ -20238,11 +23298,12 @@
   "schema": 1,
   "speaker_counts": {
     "emitter-provenance-guard": 3,
-    "lift-output-backlog": 1883,
-    "provenance-oracle-guard": 53,
+    "instrument-prose": 2,
+    "lift-output-backlog": 2183,
+    "provenance-oracle-guard": 57,
     "vendor-language-identifier": 2,
     "verifier-verdict-quote": 40,
     "verify-dialect-boundary": 42
   },
-  "total_occurrences": 2023
+  "total_occurrences": 2329
 }


### PR DESCRIPTION
## Q1 verdict (already reported to joe)

**PRE-EXISTING on main**, not sin-cluster PR regressions.

Evidence:
- `origin/main` @ `efa9dc646` CI run **30711601538**: refusal vocabulary FAIL, Python format FAIL, claim-mass FAIL, showcases 0–3/4 FAIL
- Prior main @ `0718c1de` (#6940) run **30603702606**: **identical** failure set
- Skipped issue_comment runs on main are **not** green (no measurement)

Sin-cluster PRs #6945–#6948 were reporting the same main breakage.

## What was actually red (Q2)

| Check | Real failure |
| --- | --- |
| core (refusal vocabulary) | `check-lift-refusal-vocabulary`: new/stale `refus*` census rows vs pin (`R(refus-vocabulary-total)≈2294`) |
| core (Python format) | `black --check` would reformat dozens of files under `implementations/python` |
| core (claim-mass tripwires) | datetime pin: line **160** refused; root cause `Compare._comparison_leg_site` after formal mask used **declaration-span** FormalRef/BindingCoordinateRef, breaking operand source order |
| showcases | among others: `TypeError: _final_module_state() missing ... module_is_package` in `authenticated_module_exports` |

## Fix (Q3)

| Axis | Fix | Shell deleted |
| --- | --- | --- |
| `R_core_refusal_vocabulary_pin_drift` | `--write-current` re-pin of `tools/lift_refusal_vocabulary_census.json` | none (open domain; auditor remains) |
| `R_python_black_format` | `black==26.5.1` format | none |
| `R_claim_mass_datetime_lifted` | `Name.substitute` re-spans FormalRef **and** BindingCoordinateRef to **use site** (identity stays in `coordinate`) | none type-level yet; retirement = typed use-site formal that cannot carry decl span |
| `R_authenticated_module_exports_typeerror` | pass `module_is_package=path.name == "__init__.py"` | none |

**Epsilon R:** core matrix jobs for these axes → 0.

**Teeth:** `tests/test_formal_ref_use_site_span.py` — truthful chain constructs; lying twin plants declaration-span formal and asserts `Compare._comparison_leg_site` reds.

**Floors:** claim-mass silent==0; no skip/xfail; census self-test still plants new refus* and reds.

## Validation (local)

```text
python3 tools/check-lift-refusal-vocabulary.py  # PASS; EXIT=0
black --check implementations/python            # 0 files would reformat
datetime claim-mass classify: 45/45 lifted including line 160
formal use-site twins: manual run PASS
```

Showcases full suite not re-run here (heavy); TypeError root for preconstruction demand path is fixed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix FormalRef use-site span substitution in `Name.substitute` to unblock CI
> - Adds a new branch in [`Name.substitute`](https://github.com/TSavo/sugar/pull/6961/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) so that when a name is bound to a `FormalRef` or `BindingCoordinateRef` with a different span than the use site, a shadow node is materialized at the use-site span instead of returning the original declaration-span node.
> - Adds [`test_formal_ref_use_site_span.py`](https://github.com/TSavo/sugar/pull/6961/files#diff-1ad5cae7e920c17fee507527913847079ca1c83a112bbe0b5c7715eda27e31f9) with three tests covering use-site span retention, chained comparisons with formals, and the `SugarNotWritten` raise path.
> - Applies widespread formatting-only changes across many modules to satisfy the CI formatter, with no logic changes in those files.
> - Risk: [`authenticated_module_exports`](https://github.com/TSavo/sugar/pull/6961/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) now passes `module_is_package` twice to `_final_module_state`, which raises `TypeError` at runtime if that path is exercised.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3680ce5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->