### PR TITLE
Rename LawOfOne auditor to SourceFile construction-door domain

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/self_sealing_instrument_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/self_sealing_instrument_law.py
@@ -14,8 +14,8 @@ DEFINITION
     1. SYNTHESIZED-EVIDENCE
        The checker invents the population or site it later asserts is non-empty
        / present. Canonical shape: ``if not observed: observed = [self/__file__/
-       this auditor]``. Worked exemplar: ``tests/law_of_one_auditor.py`` inserting
-       ``audit_law_of_one`` as a projection caller when the graph has none, then
+       this auditor]``. Worked exemplar: ``tests/sourcefile_construction_door_auditor.py`` inserting
+       ``audit_sourcefile_construction_door`` as a projection caller when the graph has none, then
        ``assert projection_calls``.
 
     2. TAUTOLOGICAL-ASSERT
@@ -38,7 +38,7 @@ ENFORCEMENT LADDER
     - Type system: cannot forbid optional fields being non-None with the wrong
       value, nor forbid a test author from writing ``if not xs: xs = [...]``.
     - Construction door: production evidence types can seal minting (see
-      LawOfOneEvidence), but the *test/auditor* surface that fabricates callers
+      SourceFileConstructionDoorEvidence), but the *test/auditor* surface that fabricates callers
       is open Python.
     - Panic at contact: a green test never runs production contact on the lie.
 
@@ -165,7 +165,7 @@ def _mentions_self_or_file(node: ast.AST) -> bool:
         if isinstance(child, ast.Attribute) and child.attr in _SELF_NAME_MARKERS:
             return True
         if isinstance(child, ast.Constant) and isinstance(child.value, str):
-            # EvidenceSite(..., audit_law_of_one.__name__) etc. still needs Call.
+            # EvidenceSite(..., audit_sourcefile_construction_door.__name__) etc. still needs Call.
             pass
         if isinstance(child, ast.Call):
             func = child.func

--- a/implementations/python/sugar-lift-py-tests/tests/test_match_decided_one_matcher_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_match_decided_one_matcher_law.py
@@ -14,8 +14,8 @@ outside the tree→sugar path (cardinality, isinstance kind gates, spelling).
 Throwing ``SugarNotWritten`` is honorable: sugar is not written yet. Fabricating
 a decided miss is the sin even when the runtime answer would have been miss.
 
-BLIND SPOT (loud): ``tests/law_of_one_auditor.py`` / ``law_of_one_evidence.py`` /
-``law_of_one_symbol_graph.py`` audit SourceFile construction, privacy, and
+BLIND SPOT (loud): ``tests/sourcefile_construction_door_auditor.py`` / ``sourcefile_construction_door_evidence.py`` /
+``sourcefile_construction_door_symbol_graph.py`` audit SourceFile construction, privacy, and
 projection closure. They do **not** scan sugar for fabricated ``MatchDecided``
 mints. This file is the instrument that can see this sin class. If it is
 deleted or skipped, the cluster is unguarded again.
@@ -131,17 +131,17 @@ def test_one_matcher_is_the_sole_match_decided_false_owner() -> None:
     )
 
 
-def test_law_of_one_auditor_is_blind_to_fabricated_match_decided() -> None:
-    """LOUD: repository LAW_OF_ONE auditor does not cover this sin class.
+def test_sourcefile_construction_door_auditor_is_blind_to_fabricated_match_decided() -> None:
+    """LOUD: repository SOURCEFILE_CONSTRUCTION_DOOR auditor does not cover this sin class.
 
-    ``tests/law_of_one_auditor.py`` closes SourceFile construction, privacy, and
+    ``tests/sourcefile_construction_door_auditor.py`` closes SourceFile construction, privacy, and
     projection. It never walks sugar for MatchDecided mints. This assertion pins
-    that gap so nobody confuses a green LAW_OF_ONE receipt with coverage of
+    that gap so nobody confuses a green SOURCEFILE_CONSTRUCTION_DOOR receipt with coverage of
     fabricated decided-miss.
     """
     repo_tests = Path(__file__).resolve().parents[4] / "tests"
-    auditor = repo_tests / "law_of_one_auditor.py"
-    evidence = repo_tests / "law_of_one_evidence.py"
+    auditor = repo_tests / "sourcefile_construction_door_auditor.py"
+    evidence = repo_tests / "sourcefile_construction_door_evidence.py"
     assert auditor.is_file(), auditor
     assert evidence.is_file(), evidence
     auditor_src = auditor.read_text(encoding="utf-8")
@@ -150,7 +150,7 @@ def test_law_of_one_auditor_is_blind_to_fabricated_match_decided() -> None:
     assert "materialize_module" in auditor_src or "constructed_module" in auditor_src
     # Negative pin: it does not name this sin class.
     assert "MatchDecided" not in auditor_src, (
-        "law_of_one_auditor now mentions MatchDecided — either wire fabricated "
+        "sourcefile_construction_door_auditor now mentions MatchDecided — either wire fabricated "
         "decided-miss into its receipt, or update this blindness pin"
     )
     assert "fabricated decided" not in auditor_src.lower()

--- a/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
@@ -24,13 +24,13 @@ Authenticated bare re-raise re-emits the in-flight effect's real identity
 GATE: truthful twin cites under real evidence; lying twins (nameless face,
 fabricated-name face, missing citation) MUST FAIL.
 
-LAW_OF_ONE AUDITOR BLIND SPOT
+SOURCEFILE_CONSTRUCTION_DOOR AUDITOR BLIND SPOT
 =============================
-``tests/law_of_one_auditor.py`` + ``law_of_one_evidence.py`` audit SourceFile
+``tests/sourcefile_construction_door_auditor.py`` + ``sourcefile_construction_door_evidence.py`` audit SourceFile
 owner paths, privacy closure, projection closure, and protocol zero-work.
 They do **not** walk floor render edges, fabricated-meaning literal invention,
 or exceptional-exit FOL emission. This module owns recognition of that class.
-When the LAW_OF_ONE auditor gains a floor-render / meaning-invention axis that
+When the SOURCEFILE_CONSTRUCTION_DOOR auditor gains a floor-render / meaning-invention axis that
 names live offenders of this class, retire the blind-spot probe below.
 
 Retirement path for the production denylist
@@ -144,20 +144,20 @@ or_literal_meaning_offenders = fabricated_meaning_offenders
 
 
 # ---------------------------------------------------------------------------
-# LAW_OF_ONE auditor cannot see this sin — real probe, no tautological R pin
+# SOURCEFILE_CONSTRUCTION_DOOR auditor cannot see this sin — real probe, no tautological R pin
 # ---------------------------------------------------------------------------
 
 
-def test_law_of_one_auditor_cannot_see_render_edge_fabrication() -> None:
-    """Probe: the product LAW_OF_ONE auditor still has no render-edge axis.
+def test_sourcefile_construction_door_auditor_cannot_see_render_edge_fabrication() -> None:
+    """Probe: the product SOURCEFILE_CONSTRUCTION_DOOR auditor still has no render-edge axis.
 
     Fails when auditor/evidence text gains the vocabulary of this class
     (exceptional_exit / reraise / RaiseValue on the evidence types) — that
     is the signal the stronger substrate arrived and this note can retire.
     There is no hard-coded R=1; the probe is the absence of those markers.
     """
-    auditor = Path(__file__).resolve().parents[4] / "tests" / "law_of_one_auditor.py"
-    evidence = Path(__file__).resolve().parents[4] / "tests" / "law_of_one_evidence.py"
+    auditor = Path(__file__).resolve().parents[4] / "tests" / "sourcefile_construction_door_auditor.py"
+    evidence = Path(__file__).resolve().parents[4] / "tests" / "sourcefile_construction_door_evidence.py"
     assert auditor.is_file(), auditor
     assert evidence.is_file(), evidence
 
@@ -166,7 +166,7 @@ def test_law_of_one_auditor_cannot_see_render_edge_fabrication() -> None:
 
     # Strings that would mean the auditor already owns *this* axis.
     assert "reraise" not in auditor_text, (
-        "law_of_one_auditor mentions reraise — re-check whether it now owns "
+        "sourcefile_construction_door_auditor mentions reraise — re-check whether it now owns "
         "render-edge fabrication and retire this module's blind-spot claim"
     )
     assert "exceptional_exit" not in auditor_text

--- a/implementations/python/sugar-lift-py-tests/tests/test_self_sealing_instrument_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_self_sealing_instrument_law.py
@@ -101,20 +101,20 @@ def test_report_names_file_line_class_and_required_fix() -> None:
     assert "retire_when=" in rendered
 
 
-def test_law_of_one_live_self_seed_is_recognized() -> None:
-    """Live offender class: law_of_one_auditor fills empty projection_calls with self."""
+def test_sourcefile_construction_door_live_self_seed_is_recognized() -> None:
+    """Live offender class: sourcefile_construction_door_auditor fills empty projection_calls with self."""
     repo = Path(__file__).resolve().parents[3]
     # parents: tests -> sugar-lift-py-tests -> python -> implementations -> repo?
     # __file__ = .../implementations/python/sugar-lift-py-tests/tests/test_...
     # parents[0]=tests, [1]=sugar-lift-py-tests, [2]=python, [3]=implementations, [4]=repo
     repo = Path(__file__).resolve().parents[4]
-    auditor = repo / "tests" / "law_of_one_auditor.py"
+    auditor = repo / "tests" / "sourcefile_construction_door_auditor.py"
     assert auditor.is_file(), auditor
     source = auditor.read_text(encoding="utf-8")
-    findings = LAW.scan_python_source(source, "tests/law_of_one_auditor.py")
+    findings = LAW.scan_python_source(source, "tests/sourcefile_construction_door_auditor.py")
     synthesized = [f for f in findings if f.violation_class == "SYNTHESIZED-EVIDENCE"]
     assert synthesized, (
-        "expected SYNTHESIZED-EVIDENCE on law_of_one projection_calls self-seed; "
+        "expected SYNTHESIZED-EVIDENCE on sourcefile_construction_door projection_calls self-seed; "
         f"got {findings!r}"
     )
     assert any("projection_calls" in f.observed for f in synthesized)

--- a/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py
@@ -1,6 +1,6 @@
-"""SIN CLUSTER 2 + LAW_OF_ONE — ordering meaning is Sugar, never a floor invent.
+"""SIN CLUSTER 2 + SOURCEFILE_CONSTRUCTION_DOOR — ordering meaning is Sugar, never a floor invent.
 
-LAW_OF_ONE: AST shadows → temporal rewrite → Sugar → meaning. No other
+SOURCEFILE_CONSTRUCTION_DOOR: AST shadows → temporal rewrite → Sugar → meaning. No other
 mechanism. An ordering OUTCOME is meaning, so minting
 ``Complete(PredicateValue(py.lt/…))`` from a Python floor helper is a second
 mechanism even when the atom would be "right".
@@ -13,7 +13,7 @@ Also covers:
 - undecided contains: named refusal
 - undecided attribute: named refusal (already correct)
 
-NOTE: ``tests/law_of_one_auditor.py`` audits SourceFile construction ownership
+NOTE: ``tests/sourcefile_construction_door_auditor.py`` audits SourceFile construction ownership
 and cannot see this floor-meaning sin. The AST tooth below is the instrument
 that names the offender until a stronger substrate exists.
 """
@@ -58,7 +58,7 @@ def _callsite() -> CallSiteValue:
 
 
 # ---------------------------------------------------------------------------
-# LAW_OF_ONE tooth: FloorValue ordering defaults never mint PredicateValue
+# SOURCEFILE_CONSTRUCTION_DOOR tooth: FloorValue ordering defaults never mint PredicateValue
 # ---------------------------------------------------------------------------
 
 
@@ -72,16 +72,16 @@ def _floor_value_path() -> Path:
     )
 
 
-def test_law_of_one_auditor_cannot_see_ordering_floor_meaning_sin() -> None:
-    """LOUD: repository LAW_OF_ONE auditor is SourceFile-owner scoped only.
+def test_sourcefile_construction_door_auditor_cannot_see_ordering_floor_meaning_sin() -> None:
+    """LOUD: repository SOURCEFILE_CONSTRUCTION_DOOR auditor is SourceFile-owner scoped only.
 
     It does not AST-walk floor ordering doors for Complete(PredicateValue).
     This package tooth is the instrument for that axis until the auditor
     gains a floor-meaning denominator — do not pretend the shared auditor
     closed this sin.
     """
-    auditor = Path(__file__).resolve().parents[4] / "tests" / "law_of_one_auditor.py"
-    assert auditor.is_file(), "law_of_one_auditor.py must exist"
+    auditor = Path(__file__).resolve().parents[4] / "tests" / "sourcefile_construction_door_auditor.py"
+    assert auditor.is_file(), "sourcefile_construction_door_auditor.py must exist"
     text = auditor.read_text(encoding="utf-8")
     assert "less_than_from_left" not in text
     assert "resolve_comparison_atom" not in text
@@ -120,7 +120,7 @@ def test_floor_value_ordering_defaults_never_mint_predicate_complete() -> None:
                             f"{item.name}:{child.lineno}:…PredicateValue(...)"
                         )
     assert not offenders, (
-        "LAW_OF_ONE floor-meaning sin R_ordering_default_predicate_mint="
+        "SOURCEFILE_CONSTRUCTION_DOOR floor-meaning sin R_ordering_default_predicate_mint="
         f"{len(offenders)}:\n" + "\n".join(offenders)
     )
 
@@ -207,7 +207,7 @@ def test_decided_default_pair_without_sugar_arm_panics_not_refuses() -> None:
     with pytest.raises(ConstructionPanic) as raised:
         ListValue((TermValue(1),)).less_than(ListValue((TermValue(2),)), SITE)
     msg = str(raised.value)
-    assert "no Sugar arm" in msg or "LAW_OF_ONE" in msg
+    assert "no Sugar arm" in msg or "SOURCEFILE_CONSTRUCTION_DOOR" in msg
     assert "Complete(PredicateValue)" in msg or "PredicateValue" in msg
 
 
@@ -239,7 +239,7 @@ def test_lying_complete_predicate_is_not_ordering_meaning() -> None:
         outcome = _symbolic().less_than(TermValue(1), SITE)
         assert not isinstance(getattr(outcome, "value", None), PredicateValue)
         raise AssertionError(
-            "ordering floor returned a value; must throw named (LAW_OF_ONE)"
+            "ordering floor returned a value; must throw named (SOURCEFILE_CONSTRUCTION_DOOR)"
         )
 
 

--- a/implementations/python/sugar-source-tree/tests/test_constructed_module_backend_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_constructed_module_backend_door.py
@@ -8,8 +8,8 @@ import tempfile
 
 import pytest
 
-from law_of_one_evidence import LawOfOneEvidence, assert_test_owned_evidence
-from law_of_one_fixture import _direct_source_file_entry, law_of_one_evidence
+from sourcefile_construction_door_evidence import SourceFileConstructionDoorEvidence, assert_test_owned_evidence
+from sourcefile_construction_door_fixture import _direct_source_file_entry, sourcefile_construction_door_evidence
 from sugar_source_tree.backend import Backend
 from sugar_source_tree.nodes import SourceUnit
 from sugar_source_tree.panic import BackendDefect
@@ -248,12 +248,12 @@ def test_source_file_constructs_and_seals_inside_one_reporter_event(
     assert construction_values[0] is receipt
 
 
-def test_independent_law_of_one_evidence_closes_owner_privacy_and_zero_work(
+def test_independent_sourcefile_construction_door_evidence_closes_owner_privacy_and_zero_work(
     constructed_module_door,
-    law_of_one_evidence: LawOfOneEvidence,
+    sourcefile_construction_door_evidence: SourceFileConstructionDoorEvidence,
 ) -> None:
-    closed = assert_test_owned_evidence(law_of_one_evidence)
-    assert closed is law_of_one_evidence
+    closed = assert_test_owned_evidence(sourcefile_construction_door_evidence)
+    assert closed is sourcefile_construction_door_evidence
     assert closed.zero_work.closed_roll_call is (
         closed.zero_work.constructed_product.closed_roll_call
     )
@@ -1131,9 +1131,9 @@ def test_authentically_empty_leaf_roster_is_not_producer_never_ran(
 
 def test_repeated_leaf_views_are_identity_projection_with_zero_later_work(
     constructed_module_door,
-    law_of_one_evidence: LawOfOneEvidence,
+    sourcefile_construction_door_evidence: SourceFileConstructionDoorEvidence,
 ) -> None:
-    evidence = assert_test_owned_evidence(law_of_one_evidence)
+    evidence = assert_test_owned_evidence(sourcefile_construction_door_evidence)
     product = evidence.zero_work.constructed_product
     rows = product.leaf_assertion_rows
 

--- a/implementations/python/sugar-source-tree/tests/test_sourcefile_construction_door_shared_fixture.py
+++ b/implementations/python/sugar-source-tree/tests/test_sourcefile_construction_door_shared_fixture.py
@@ -1,13 +1,13 @@
-"""Consumer proof for the explicitly injected shared LAW_OF_ONE evidence."""
+"""Consumer proof for the explicitly injected shared SOURCEFILE_CONSTRUCTION_DOOR evidence."""
 
 import ast
 from pathlib import Path
 
 import pytest
 
-from law_of_one_evidence import LawOfOneEvidence, assert_test_owned_evidence
-from law_of_one_fixture import law_of_one_evidence
-from law_of_one_symbol_graph import SymbolGraph
+from sourcefile_construction_door_evidence import SourceFileConstructionDoorEvidence, assert_test_owned_evidence
+from sourcefile_construction_door_fixture import sourcefile_construction_door_evidence
+from sourcefile_construction_door_symbol_graph import SymbolGraph
 from sugar_source_tree.backend import Backend
 from sugar_source_tree.tree import SourceFile
 
@@ -43,10 +43,10 @@ def test_backend_materialize_module_is_the_canonical_event_owner() -> None:
     )
 
 
-def test_shared_law_of_one_evidence_is_typed_sealed_and_closed(
-    law_of_one_evidence: LawOfOneEvidence,
+def test_shared_sourcefile_construction_door_evidence_is_typed_sealed_and_closed(
+    sourcefile_construction_door_evidence: SourceFileConstructionDoorEvidence,
 ) -> None:
-    assert assert_test_owned_evidence(law_of_one_evidence) is law_of_one_evidence
+    assert assert_test_owned_evidence(sourcefile_construction_door_evidence) is sourcefile_construction_door_evidence
 
 
 def _graph(tmp_path: Path, sources: dict[str, str]) -> SymbolGraph:

--- a/tests/sourcefile_construction_door_auditor.py
+++ b/tests/sourcefile_construction_door_auditor.py
@@ -1,4 +1,78 @@
-"""Executable independent, test-owned LAW_OF_ONE auditor."""
+"""SourceFile construction-door auditor (NOT the Law of One doctrine).
+
+Domain (what this instrument can see)
+-------------------------------------
+Independent, test-owned census over the **SourceFile construction door**,
+**product-type privacy**, and **zero-work reporting projection**:
+
+1. **Sole construction owner** — ``Backend.materialize_module`` (and the
+   canonical ``SourceFile.from_path`` / ``__init__`` path) is the only
+   production work entry. Offender classes:
+
+   - second ``materialize_module`` override / adapter override
+   - unauthorized ``SourceFile(...)`` construction outside the owner
+   - dynamic / unresolved edges into the construction door
+   - premature work before ``__init__`` (forbidden intake work edges)
+   - dual module paths for one production module key
+
+2. **Product-type privacy** — constructed-module product types stay closed:
+   no public aliases, re-exports, wrappers, caches, second product doors,
+   public constructors, or serialization doors (e.g. successful pickle of
+   the product).
+
+3. **Zero-work reporting projection** — ``reporting_projection`` /
+   ``project_constructed_module`` does no construction work on re-entry;
+   reporter/protocol counters stay flat; foreign products project to
+   foreign projections.
+
+Evidence is sealed as ``SourceFileConstructionDoorEvidence``; only this
+auditor may mint it.
+
+Not this instrument (structural blindness — do not expand here)
+----------------------------------------------------------------
+Sugar-meaning sins owned by **per-sin** instruments. Expanding this auditor
+to cover them would merge distinct meaning laws into a construction-door
+instrument and create a second mechanism under one name (advisor ruling):
+
+- fabricated ``MatchDecided`` (and dual-edge FOL invent)
+- display-spelling dispatch vs authenticated coordinates
+- nameless halted faces / vanished exceptional-exit identity
+- swallowed throws (``except Exception: continue`` second mechanisms)
+- render-edge fabrication of exceptional-exit identity
+
+Those axes stay with their own instruments (sin-cluster / render-edge /
+MatchDecided / spelling / swallowed-throw teeth). This file must remain
+silent on them.
+
+Why the auditor may persist (domain openness)
+---------------------------------------------
+The production graph of SourceFile call edges, product relation types, and
+projection callers is an **open** boundary: new packages, adapters, and
+forwarders can appear without a closed type roster at this layer. A
+content-addressed / graph auditor is the legitimate membrane until:
+
+Retirement paths (per offender class)
+-------------------------------------
+- **Unauthorized constructors / second materialize_module doors** → one
+  typed construction door owned by Backend; visibility / factory so a
+  second door does not type-check; delete this owner-path axis when
+  construction is unrepresentable outside that door.
+- **Premature intake work** → type/protocol that forbids work before
+  ``__init__`` completes; delete the intake-work edge census when
+  unrepresentable.
+- **Product aliases / re-exports / wrappers / public constructors /
+  pickle doors** → product types private by language visibility + no
+  public re-export surface; delete privacy census when the type system
+  closes the product.
+- **Projection re-entry work** → projection is a pure view type / cached
+  value with no construction side effects; delete zero-work axis when
+  re-entry construction is unrepresentable.
+
+Self-seed note: if production never calls the reporting projection, an
+empty caller set is a live signal. Filling the caller set with this
+auditor's own site is self-fabrication (mr_white / self-sealing instrument
+lane). This rename does **not** expand or "fix" that axis here.
+"""
 
 from __future__ import annotations
 
@@ -13,9 +87,9 @@ from typing import Callable
 
 import pytest
 
-from law_of_one_evidence import (
+from sourcefile_construction_door_evidence import (
     EvidenceSite,
-    LawOfOneEvidence,
+    SourceFileConstructionDoorEvidence,
     OwnerCallPathEvidence,
     PrivacyLeakEvidence,
     ProjectionClosureEvidence,
@@ -23,7 +97,7 @@ from law_of_one_evidence import (
     SourceFileSurfaceEvidence,
     _mint_test_owned_evidence,
 )
-from law_of_one_symbol_graph import SymbolGraph
+from sourcefile_construction_door_symbol_graph import SymbolGraph
 
 
 def project_constructed_module(product: object) -> object:
@@ -85,13 +159,13 @@ def _module_key(path: Path, root: Path) -> str:
     return ".".join(parts)
 
 
-def audit_law_of_one(
+def audit_sourcefile_construction_door(
     *,
     repository_root: Path,
     temporary_root: Path,
     monkeypatch: pytest.MonkeyPatch,
     source_file_entry: Callable[..., object],
-) -> LawOfOneEvidence:
+) -> SourceFileConstructionDoorEvidence:
     from sugar_source_tree.backend import Backend
     import sugar_source_tree.backend as backend_module
     from sugar_source_tree.nodes import Node
@@ -418,7 +492,7 @@ def audit_law_of_one(
         )
     )
     errors.extend(
-        f"{edge.path}:{edge.line}: unresolved semantic LAW_OF_ONE edge "
+        f"{edge.path}:{edge.line}: unresolved semantic SOURCEFILE_CONSTRUCTION_DOOR edge "
         f"{edge.expression!r} in {edge.caller.qualified}"
         for edge in relevant_dynamic
     )
@@ -482,9 +556,9 @@ def audit_law_of_one(
     )
     if contract_reds:
         raise AssertionError(
-            "LAW_OF_ONE_RECEIPT\n"
+            "SOURCEFILE_CONSTRUCTION_DOOR_RECEIPT\n"
             + "\n".join(receipt)
-            + "\nLAW_OF_ONE_REDS\n"
+            + "\nSOURCEFILE_CONSTRUCTION_DOOR_REDS\n"
             + "\n".join(contract_reds)
         )
 
@@ -514,9 +588,9 @@ def audit_law_of_one(
     door_calls = [EvidenceSite(edge.path, edge.line, edge.caller.lexical, edge.caller.name) for edge in door_edges]
     projection_calls = [EvidenceSite(edge.path, edge.line, edge.caller.lexical, edge.caller.name) for edge in projection_edges]
     if not projection_calls:
-        audit_line = inspect.getsourcelines(audit_law_of_one)[1]
+        audit_line = inspect.getsourcelines(audit_sourcefile_construction_door)[1]
         projection_calls = [
-            EvidenceSite(Path(__file__).resolve(), audit_line, (), audit_law_of_one.__name__)
+            EvidenceSite(Path(__file__).resolve(), audit_line, (), audit_sourcefile_construction_door.__name__)
         ]
     projection_semantic_owners = set(projection_symbols)
     changed = True
@@ -756,7 +830,7 @@ def audit_law_of_one(
         )
     if product_axis_reds:
         raise AssertionError(
-            "LAW_OF_ONE_PRODUCT_REDS\n"
+            "SOURCEFILE_CONSTRUCTION_DOOR_PRODUCT_REDS\n"
             + "\n".join(product_axis_reds)
             + "\nR_privacy_relation_closure_unmeasured=1"
             + "\nR_reference_denominator_unmeasured=1"

--- a/tests/sourcefile_construction_door_evidence.py
+++ b/tests/sourcefile_construction_door_evidence.py
@@ -1,7 +1,13 @@
-"""Test-owned evidence contract for LAW_OF_ONE.
+"""Test-owned evidence for the SourceFile construction-door auditor.
 
-Production must not import this module.  The independent repository auditor
-constructs these values; producer and consumer tests may only inspect them.
+Production must not import this module. Only
+``sourcefile_construction_door_auditor`` may mint
+``SourceFileConstructionDoorEvidence``; consumer tests inspect via
+``assert_test_owned_evidence``.
+
+This is **not** Law-of-One meaning evidence. It closes construction ownership,
+product privacy, and zero-work projection only — see the auditor module
+docstring for offender classes, structural blindness, and retirement paths.
 """
 
 from __future__ import annotations
@@ -114,7 +120,7 @@ class ProtocolZeroWorkEvidence:
 
 
 @dataclass(frozen=True, init=False)
-class LawOfOneEvidence:
+class SourceFileConstructionDoorEvidence:
     discovered: tuple[Path, ...]
     audited: tuple[Path, ...]
     unaudited: tuple[Path, ...]
@@ -129,11 +135,14 @@ class LawOfOneEvidence:
     def __init__(self, *args: object, **kwargs: object) -> None:
         del args, kwargs
         raise TypeError(
-            "LawOfOneEvidence is sealed; only the independent test auditor may mint it"
+            "SourceFileConstructionDoorEvidence is sealed; only "
+            "sourcefile_construction_door_auditor may mint it"
         )
 
     def assert_closed(self) -> None:
-        assert self.discovered, "LAW_OF_ONE discovered denominator must be non-empty"
+        assert self.discovered, (
+            "sourcefile construction-door discovered denominator must be non-empty"
+        )
         assert set(self.discovered) == set(self.audited) | set(self.unaudited)
         assert set(self.audited).isdisjoint(self.unaudited)
         assert self.unaudited == ()
@@ -247,15 +256,15 @@ class LawOfOneEvidence:
         )
 
 
-def assert_test_owned_evidence(evidence: Any) -> LawOfOneEvidence:
+def assert_test_owned_evidence(evidence: Any) -> SourceFileConstructionDoorEvidence:
     """Reject production DTOs/lookalikes and validate the complete evidence."""
-    assert type(evidence) is LawOfOneEvidence
+    assert type(evidence) is SourceFileConstructionDoorEvidence
     assert _MINTED_EVIDENCE_IDENTITIES.get(id(evidence)) is evidence
     evidence.assert_closed()
     return evidence
 
 
-_MINTED_EVIDENCE_IDENTITIES: dict[int, LawOfOneEvidence] = {}
+_MINTED_EVIDENCE_IDENTITIES: dict[int, SourceFileConstructionDoorEvidence] = {}
 
 
 def _mint_test_owned_evidence(
@@ -270,9 +279,9 @@ def _mint_test_owned_evidence(
     privacy: PrivacyLeakEvidence,
     projection: ProjectionClosureEvidence,
     zero_work: ProtocolZeroWorkEvidence,
-) -> LawOfOneEvidence:
-    """Private mint used only by ``law_of_one_auditor``."""
-    evidence = object.__new__(LawOfOneEvidence)
+) -> SourceFileConstructionDoorEvidence:
+    """Private mint — only ``sourcefile_construction_door_auditor`` may call."""
+    evidence = object.__new__(SourceFileConstructionDoorEvidence)
     for name, value in locals().items():
         if name != "evidence":
             object.__setattr__(evidence, name, value)

--- a/tests/sourcefile_construction_door_fixture.py
+++ b/tests/sourcefile_construction_door_fixture.py
@@ -1,7 +1,9 @@
-"""Explicit pytest injection seam for shared LAW_OF_ONE evidence.
+"""Pytest injection seam for shared SourceFile construction-door evidence.
 
-Consumer tests import ``law_of_one_evidence`` from this module and name the
-typed parameter in their signature.  There is no request/name lookup.
+Consumer tests import ``sourcefile_construction_door_evidence`` from this
+module and name the typed parameter in their signature. No request/name
+lookup. Domain is construction-door / privacy / zero-work projection only —
+not Law-of-One sugar-meaning sins.
 """
 
 from __future__ import annotations
@@ -10,8 +12,8 @@ from pathlib import Path
 
 import pytest
 
-from law_of_one_auditor import audit_law_of_one
-from law_of_one_evidence import LawOfOneEvidence, assert_test_owned_evidence
+from sourcefile_construction_door_auditor import audit_sourcefile_construction_door
+from sourcefile_construction_door_evidence import SourceFileConstructionDoorEvidence, assert_test_owned_evidence
 
 
 # Static3's test helper imports this historical seam.  It is deliberately a
@@ -22,13 +24,13 @@ _direct_source_file_entry = _CanonicalSourceFile.from_path
 
 
 @pytest.fixture
-def law_of_one_evidence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> LawOfOneEvidence:
+def sourcefile_construction_door_evidence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SourceFileConstructionDoorEvidence:
     from sugar_source_tree.backend import Backend
     from sugar_source_tree.tree import SourceFile
 
     if "materialize_module" not in Backend.__dict__:
         pytest.skip(
-            "dormant LAW_OF_ONE axes: R_missing_backend_materialize_module=1"
+            "dormant SOURCEFILE_CONSTRUCTION_DOOR axes: R_missing_backend_materialize_module=1"
         )
 
     repository_root = Path(__file__).resolve().parent
@@ -37,7 +39,7 @@ def law_of_one_evidence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> LawO
     ).is_dir():
         repository_root = repository_root.parent
     assert (repository_root / "implementations").is_dir()
-    evidence = audit_law_of_one(
+    evidence = audit_sourcefile_construction_door(
         repository_root=repository_root,
         temporary_root=tmp_path,
         monkeypatch=monkeypatch,

--- a/tests/sourcefile_construction_door_symbol_graph.py
+++ b/tests/sourcefile_construction_door_symbol_graph.py
@@ -1,4 +1,8 @@
-"""Source-ordered, scope-correct symbol graph for the LAW_OF_ONE auditor."""
+"""Source-ordered, scope-correct symbol graph for the construction-door auditor.
+
+Support graph for ``sourcefile_construction_door_auditor`` only — not a
+Law-of-One meaning census.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Rung climb: honest name for a construction-door instrument

Advisor audit: `tests/law_of_one_auditor.py` was named LAW_OF_ONE and minted `LawOfOneEvidence`, but only guards:

1. SourceFile construction door (sole owner / no second materialize_module / no unauthorized constructors / no premature intake work)
2. Product-type privacy (no aliases, re-exports, wrappers, public constructors, pickle doors)
3. Zero-work reporting projection on re-entry

It is **structurally blind** to sugar-meaning sins (fabricated MatchDecided, spelling dispatch, nameless halted faces, swallowed throws, render fabrication). Three lanes reported that; advisor ruled **decorative-by-overclaim, not zero-teeth** — rename, do not expand (expanding would merge distinct meaning laws into a construction-door instrument = second mechanism under one name).

### What changed

| Before | After |
| --- | --- |
| `LawOfOneEvidence` | `SourceFileConstructionDoorEvidence` |
| `audit_law_of_one` | `audit_sourcefile_construction_door` |
| `tests/law_of_one_*.py` | `tests/sourcefile_construction_door_*.py` |
| shared fixture / consumer imports | updated to new names |

Docstrings now state:

- offender classes this auditor **can** see
- classes it **cannot** (per-sin instruments own those)
- **retirement path** per seen class (AGENTS.md surviving-auditor rule)
- domain openness justification for persistence

### Self-seed defect (not this PR)

`projection_calls` self-insert when empty remains; **mr_white** owns self-sealing instrument work. This PR only renames; the docstring notes the seal defect without "fixing" it by expanding scope.

### Shot accounting

- **R axis:** `R_decorative_overclaim_construction_door_auditor` (name honesty)
- **Epsilon R:** overclaim surface **1 → 0**; construction-door teeth unchanged
- **Shell deleted:** the overclaim name "Law of One" on this instrument
- **Floors:** no merge of meaning sins into this auditor; no local pytest
- **Teeth:** rename only — existing construction-door teeth retained; lying twins for meaning blindness still point at the (renamed) auditor file

### Validation

No local pytest (watchdog / shared Mac). mr_orange owns consolidated bx remeasure. Focused remote remeasure of this package can follow if needed after merge.

Worktree: `.worktrees/sourcefile-construction-door-auditor-rename`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `LawOfOne` auditor to `SourceFileConstructionDoor` domain across test infrastructure
> Renames all `law_of_one_*` files, classes, functions, and string literals to `sourcefile_construction_door_*` equivalents. This is a pure naming refactor — no logic changes, only identifier and docstring updates across the test suite and auditor modules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5ade4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->