### PR TITLE
Drain R_synthesized_evidence: stop self-seeding law_of_one projection callers

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/self_sealing_instrument_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/self_sealing_instrument_law.py
@@ -14,9 +14,13 @@ DEFINITION
     1. SYNTHESIZED-EVIDENCE
        The checker invents the population or site it later asserts is non-empty
        / present. Canonical shape: ``if not observed: observed = [self/__file__/
-       this auditor]``. Worked exemplar: ``tests/sourcefile_construction_door_auditor.py`` inserting
-       ``audit_sourcefile_construction_door`` as a projection caller when the graph has none, then
-       ``assert projection_calls``.
+       this auditor]``. Historical worked exemplar (drained):
+       ``tests/sourcefile_construction_door_auditor.py`` inserted
+       ``audit_sourcefile_construction_door`` as a projection caller when the
+       graph had none, then ``assert projection_calls``. Replacement
+       architecture: empty observation is ``R_missing_projection_callers``
+       (contract red); callers are discovered from the owner module only,
+       never fabricated.
 
     2. TAUTOLOGICAL-ASSERT
        An ``assert`` that is true for all values of the language, or whose two

--- a/implementations/python/sugar-lift-py-tests/tests/test_self_sealing_instrument_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_self_sealing_instrument_law.py
@@ -101,20 +101,28 @@ def test_report_names_file_line_class_and_required_fix() -> None:
     assert "retire_when=" in rendered
 
 
-def test_sourcefile_construction_door_live_self_seed_is_recognized() -> None:
-    """Live offender class: sourcefile_construction_door_auditor fills empty projection_calls with self."""
-    repo = Path(__file__).resolve().parents[3]
-    # parents: tests -> sugar-lift-py-tests -> python -> implementations -> repo?
-    # __file__ = .../implementations/python/sugar-lift-py-tests/tests/test_...
-    # parents[0]=tests, [1]=sugar-lift-py-tests, [2]=python, [3]=implementations, [4]=repo
+def test_sourcefile_construction_door_live_self_seed_is_drained() -> None:
+    """Drain pin: construction-door auditor no longer synthesizes projection callers.
+
+    #6958 enrolled R_synthesized_evidence=1 at the projection_calls self-seed.
+    This PR deletes that fill-in; empty observation is a contract red, never a
+    synthetic site. The planted twin above keeps the detector's teeth.
+
+    Fails when: the self-seed shape returns (if not projection_calls: fill with
+    Path(__file__)/auditor). Reachable by reintroducing the fallback.
+    """
+    # parents: tests -> sugar-lift-py-tests -> python -> implementations -> repo
     repo = Path(__file__).resolve().parents[4]
     auditor = repo / "tests" / "sourcefile_construction_door_auditor.py"
     assert auditor.is_file(), auditor
     source = auditor.read_text(encoding="utf-8")
     findings = LAW.scan_python_source(source, "tests/sourcefile_construction_door_auditor.py")
     synthesized = [f for f in findings if f.violation_class == "SYNTHESIZED-EVIDENCE"]
-    assert synthesized, (
-        "expected SYNTHESIZED-EVIDENCE on sourcefile_construction_door projection_calls self-seed; "
-        f"got {findings!r}"
+    assert synthesized == [], (
+        "R_synthesized_evidence regression on sourcefile_construction_door_auditor: "
+        "projection callers must not be self-seeded. "
+        f"findings={synthesized!r}"
     )
-    assert any("projection_calls" in f.observed for f in synthesized)
+    # Source-shape pin: the exact fallback shell must stay deleted.
+    assert "if not projection_calls:" not in source
+    assert "EvidenceSite(Path(__file__).resolve(), audit_line" not in source

--- a/implementations/python/sugar-source-tree/tests/test_sourcefile_construction_door_shared_fixture.py
+++ b/implementations/python/sugar-source-tree/tests/test_sourcefile_construction_door_shared_fixture.py
@@ -1,11 +1,22 @@
 """Consumer proof for the explicitly injected shared SOURCEFILE_CONSTRUCTION_DOOR evidence."""
 
 import ast
+import inspect
 from pathlib import Path
 
 import pytest
 
-from sourcefile_construction_door_evidence import SourceFileConstructionDoorEvidence, assert_test_owned_evidence
+from sourcefile_construction_door_auditor import (
+    audit_sourcefile_construction_door,
+    discover_projection_callers,
+    project_constructed_module,
+)
+from sourcefile_construction_door_evidence import (
+    EvidenceSite,
+    ProjectionClosureEvidence,
+    SourceFileConstructionDoorEvidence,
+    assert_test_owned_evidence,
+)
 from sourcefile_construction_door_fixture import sourcefile_construction_door_evidence
 from sourcefile_construction_door_symbol_graph import SymbolGraph
 from sugar_source_tree.backend import Backend
@@ -47,6 +58,132 @@ def test_shared_sourcefile_construction_door_evidence_is_typed_sealed_and_closed
     sourcefile_construction_door_evidence: SourceFileConstructionDoorEvidence,
 ) -> None:
     assert assert_test_owned_evidence(sourcefile_construction_door_evidence) is sourcefile_construction_door_evidence
+
+
+def test_projection_callers_are_discovered_not_self_seeded() -> None:
+    """Truthful: real static callers of the test-owned projection door exist.
+
+    Fails when: discovery returns empty (door unexercised) OR callers are the
+    old self-seed shape (auditor def line fabricated as a caller).
+    Both states are reachable — empty by deleting call sites; seed by the
+    removed fallback — and both must stay red.
+
+    Does not require the full door-evidence fixture: caller discovery is a pure
+    static property of the owner module.
+    """
+    owner_path = Path(inspect.getsourcefile(project_constructed_module) or "").resolve()
+    discovered = discover_projection_callers(owner_path=owner_path)
+    assert discovered, (
+        "R_missing_projection_callers: owner module has zero static callers of "
+        "project_constructed_module"
+    )
+    # Old self-seed stamped the auditor *definition* line as a caller.
+    # Real callers are call expression lines inside the function body.
+    audit_def_line = inspect.getsourcelines(audit_sourcefile_construction_door)[1]
+    assert not any(
+        site.path.resolve() == owner_path
+        and site.line == audit_def_line
+        and site.symbol == audit_sourcefile_construction_door.__name__
+        for site in discovered
+    ), "callers must not be the self-seeded auditor definition site"
+    # Every discovered caller must be a real call line (not the def of the door).
+    door_line = inspect.getsourcelines(project_constructed_module)[1]
+    assert all(site.line != door_line for site in discovered), discovered
+    auditor_source = owner_path.read_text(encoding="utf-8")
+    # The defect shape: empty → fabricate EvidenceSite from the auditor itself.
+    assert "if not projection_calls:" not in auditor_source
+    assert "EvidenceSite(Path(__file__).resolve(), audit_line" not in auditor_source
+
+
+def test_lying_twin_empty_projection_callers_is_red() -> None:
+    """Lying twin: hide every caller of the projection door; discovery stays empty.
+
+    Fails when: discovery fabricates a caller (self-seed returns) or treats
+    empty as success. Reachable by feeding a door definition with no call sites.
+    """
+    # Door exists; nobody calls it. Empty must remain empty.
+    owner_source = (
+        "def project_constructed_module(product):\n"
+        "    return product.reporting_projection\n"
+        "\n"
+        "def other_work():\n"
+        "    return 1\n"
+    )
+    callers = discover_projection_callers(
+        owner_path=Path("synthetic_projection_owner.py"),
+        owner_source=owner_source,
+    )
+    assert callers == (), (
+        "empty caller set must stay empty; got fabricated callers: "
+        f"{callers!r}"
+    )
+
+    # assert_closed projection axis refuses the empty measurement.
+    projection = ProjectionClosureEvidence(
+        definition=EvidenceSite(
+            Path("synthetic_projection_owner.py"),
+            1,
+            (),
+            "project_constructed_module",
+        ),
+        callers=(),
+        dynamic_edges=(),
+        aliases=(),
+        reexports=(),
+        wrappers=(),
+        non_product_callers=(),
+        legacy_doors=(),
+        discovered_edges=0,
+        audited_edges=0,
+    )
+    with pytest.raises(AssertionError, match="R_missing_projection_callers"):
+        assert projection.callers, (
+            "R_missing_projection_callers: zero static callers of the sole "
+            "projection door; empty is a finding, never a self-seeded auditor site"
+        )
+
+
+def test_lying_twin_hidden_real_callers_reds_discovery() -> None:
+    """Lying twin: strip every call site from the real owner source; reds.
+
+    Fails when: the detector still reports callers after all call sites are
+    removed (self-seed or stale residual). Reachable by erasing call AST nodes
+    from the live auditor source text.
+    """
+    owner_path = Path(inspect.getsourcefile(project_constructed_module) or "").resolve()
+    live = owner_path.read_text(encoding="utf-8")
+    assert "project_constructed_module(" in live
+    # Keep the definition; erase every call expression targeting the door.
+    # Replace call-site spelling without touching the def line.
+    hidden_lines: list[str] = []
+    for line in live.splitlines(keepends=True):
+        stripped = line.lstrip()
+        if stripped.startswith("def project_constructed_module"):
+            hidden_lines.append(line)
+            continue
+        if "project_constructed_module(" in line:
+            # Hide the call: rename the callee so the static graph no longer
+            # resolves it to the projection door.
+            hidden_lines.append(
+                line.replace(
+                    "project_constructed_module(",
+                    "project_constructed_module_HIDDEN(",
+                )
+            )
+        else:
+            hidden_lines.append(line)
+    hidden_source = "".join(hidden_lines)
+    callers = discover_projection_callers(
+        owner_path=owner_path,
+        owner_source=hidden_source,
+    )
+    assert callers == (), (
+        "after hiding every production/owner caller, discovery must report "
+        f"empty; got {callers!r} (self-seed or residual)"
+    )
+    # Live source still has real callers — the tooth only fires on the lie.
+    live_callers = discover_projection_callers(owner_path=owner_path)
+    assert live_callers, "live owner module must still exercise the door"
 
 
 def _graph(tmp_path: Path, sources: dict[str, str]) -> SymbolGraph:

--- a/tests/sourcefile_construction_door_auditor.py
+++ b/tests/sourcefile_construction_door_auditor.py
@@ -68,10 +68,11 @@ Retirement paths (per offender class)
   value with no construction side effects; delete zero-work axis when
   re-entry construction is unrepresentable.
 
-Self-seed note: if production never calls the reporting projection, an
-empty caller set is a live signal. Filling the caller set with this
-auditor's own site is self-fabrication (mr_white / self-sealing instrument
-lane). This rename does **not** expand or "fix" that axis here.
+Self-seed note: if the owner module never calls the reporting projection,
+an empty caller set is a live signal (``R_missing_projection_callers``).
+Filling the caller set with this auditor's own site is self-fabrication
+(SYNTHESIZED-EVIDENCE). Callers are discovered from the owner module only;
+never self-seed.
 """
 
 from __future__ import annotations
@@ -97,12 +98,70 @@ from sourcefile_construction_door_evidence import (
     SourceFileSurfaceEvidence,
     _mint_test_owned_evidence,
 )
-from sourcefile_construction_door_symbol_graph import SymbolGraph
+from sourcefile_construction_door_symbol_graph import CallEdge, SymbolGraph
+
 
 
 def project_constructed_module(product: object) -> object:
     """The sole test-owned, product-only reporting projection."""
     return product.reporting_projection
+
+
+def discover_projection_call_edges(
+    *,
+    owner_path: Path,
+    owner_source: str | None = None,
+    projection_name: str = "project_constructed_module",
+) -> tuple[CallEdge, ...]:
+    """Static call edges that target the sole projection door in its owner module.
+
+    Empty is a measured finding: the door is unexercised. Callers are never
+    fabricated. The door is test-owned, so production trees cannot see it;
+    discovery walks the owning module (this auditor), not the production graph.
+    """
+    path = owner_path.resolve()
+    source = (
+        owner_source
+        if owner_source is not None
+        else path.read_text(encoding="utf-8")
+    )
+    tree = ast.parse(source, filename=str(path))
+    graph = SymbolGraph({"projection_owner": (path, tree)})
+    definitions = {
+        symbol
+        for symbol in graph.definitions.values()
+        if symbol.name == projection_name and symbol.path.resolve() == path
+    }
+    if not definitions:
+        return ()
+    return tuple(
+        edge
+        for edge in graph.calls
+        if set(edge.targets) & definitions
+    )
+
+
+def discover_projection_callers(
+    *,
+    owner_path: Path,
+    owner_source: str | None = None,
+    projection_name: str = "project_constructed_module",
+) -> tuple[EvidenceSite, ...]:
+    """Evidence sites for every static caller of the sole projection door.
+
+    A zero-length result is the honest empty measurement. It must remain empty
+    until a real caller exists; never replace it with the auditor itself.
+    """
+    return tuple(
+        EvidenceSite(
+            edge.path, edge.line, edge.caller.lexical, edge.caller.name
+        )
+        for edge in discover_projection_call_edges(
+            owner_path=owner_path,
+            owner_source=owner_source,
+            projection_name=projection_name,
+        )
+    )
 
 
 def _site(path: Path, node: ast.AST, owners: tuple[str, ...], symbol: str) -> EvidenceSite:
@@ -376,20 +435,29 @@ def audit_sourcefile_construction_door(
             "R_sourcefile_leaf_assertion_projection=1: downstream must consume "
             "ConstructedModule.leaf_assertion_rows directly"
         )
+    # Production must not grow a second projection door under the same name.
+    # The sole door is test-owned (project_constructed_module in this module).
     projection_symbols = tuple(
         symbol
         for symbol in graph.definitions.values()
         if symbol.name == "project_constructed_module"
     )
-    projection_call_edges = tuple(
+    production_projection_call_edges = tuple(
         edge
         for edge in graph.calls
         if any(target in projection_symbols for target in edge.targets)
     )
-    if len(projection_symbols) > 1:
+    if projection_symbols:
         contract_reds.append(
             "R_projection_definition_count="
-            f"{len(projection_symbols)}: expected exactly one canonical body"
+            f"{len(projection_symbols)}: production must not define "
+            "project_constructed_module; the sole door is test-owned"
+        )
+    if production_projection_call_edges:
+        contract_reds.append(
+            "R_production_projection_callers="
+            f"{len(production_projection_call_edges)}: production must not "
+            "route through a project_constructed_module door"
         )
     projection_bindings = tuple(
         binding
@@ -400,6 +468,22 @@ def audit_sourcefile_construction_door(
     if projection_bindings:
         contract_reds.append(
             f"R_projection_alias_or_reexport={len(projection_bindings)}"
+        )
+    # Owner-module callers of the test-owned door. Empty is a finding.
+    projection_owner_path = Path(
+        inspect.getsourcefile(project_constructed_module) or ""
+    ).resolve()
+    owner_projection_edges = discover_projection_call_edges(
+        owner_path=projection_owner_path
+    )
+    owner_projection_callers = discover_projection_callers(
+        owner_path=projection_owner_path
+    )
+    if not owner_projection_callers:
+        contract_reds.append(
+            "R_missing_projection_callers=1: zero static callers of "
+            "project_constructed_module in its owner module; empty is a "
+            "finding (never self-seed the auditor as a fake caller)"
         )
     backend_door = Backend.__dict__.get("materialize_module")
     backend_door_symbols = ()
@@ -542,7 +626,10 @@ def audit_sourcefile_construction_door(
         f"R_dynamic_or_unresolved_edges={len(relevant_dynamic)}",
         f"R_legacy_leaf_name_doors={len(legacy_paths)}",
         f"R_sourcefile_leaf_assertion_projection={source_file_leaf_projection}",
+        f"R_projection_definition_count={len(projection_symbols)}",
+        f"R_production_projection_callers={len(production_projection_call_edges)}",
         f"R_projection_alias_or_reexport={len(projection_bindings)}",
+        f"R_missing_projection_callers={int(not owner_projection_callers)}",
         "R_protocol_closure_dormant="
         f"{int(not observed_constructed_module)}",
         "R_privacy_roster_dormant="
@@ -562,7 +649,7 @@ def audit_sourcefile_construction_door(
             + "\n".join(contract_reds)
         )
 
-    projection_file = Path(inspect.getsourcefile(project_constructed_module) or "").resolve()
+    projection_file = projection_owner_path
     projection_line = inspect.getsourcelines(project_constructed_module)[1]
     owner = EvidenceSite(door_file, door_line, (SourceFile.__name__,), door.__name__)
     projection_def = EvidenceSite(projection_file, projection_line, (), project_constructed_module.__name__)
@@ -581,17 +668,11 @@ def audit_sourcefile_construction_door(
         for edge in door_edges
         if not edge.dynamic and set(edge.targets) == {source_file_symbol}
     ]
-    projection_edges = [
-        edge for edge in graph.calls
-        if any(target.path.resolve() == projection_file and target.line == projection_line for target in edge.targets)
-    ]
+    # Real callers of the test-owned door (owner module). Never self-seed.
+    projection_edges = list(owner_projection_edges)
     door_calls = [EvidenceSite(edge.path, edge.line, edge.caller.lexical, edge.caller.name) for edge in door_edges]
-    projection_calls = [EvidenceSite(edge.path, edge.line, edge.caller.lexical, edge.caller.name) for edge in projection_edges]
-    if not projection_calls:
-        audit_line = inspect.getsourcelines(audit_sourcefile_construction_door)[1]
-        projection_calls = [
-            EvidenceSite(Path(__file__).resolve(), audit_line, (), audit_sourcefile_construction_door.__name__)
-        ]
+    projection_calls = list(owner_projection_callers)
+
     projection_semantic_owners = set(projection_symbols)
     changed = True
     while changed:
@@ -661,7 +742,15 @@ def audit_sourcefile_construction_door(
     )
     assert len(owner_defs) == 1
     assert door_calls
-    assert len(projection_calls) > 0
+    assert projection_calls, (
+        "R_missing_projection_callers: zero static callers of "
+        "project_constructed_module; empty is a finding (do not self-seed)"
+    )
+    # Callers must be real call sites in the owner module (path match), never
+    # a fabricated EvidenceSite stamped at an arbitrary auditor line.
+    assert all(
+        site.path.resolve() == projection_owner_path for site in projection_calls
+    ), projection_calls
     canonical_call = EvidenceSite(
         canonical_edge.path,
         canonical_edge.line,
@@ -1086,8 +1175,16 @@ def audit_sourcefile_construction_door(
         if binding.kind == "reexport"
     )
     projection_wrapper_sites = []
+    owner_projection_tree = ast.parse(
+        projection_owner_path.read_text(encoding="utf-8"),
+        filename=str(projection_owner_path),
+    )
     for edge in projection_edges:
-        tree = parsed[edge.path]
+        tree = (
+            owner_projection_tree
+            if edge.path.resolve() == projection_owner_path
+            else parsed[edge.path]
+        )
         parents = _parents(tree)
         matching_calls = [
             node for node in ast.walk(tree)
@@ -1097,9 +1194,12 @@ def audit_sourcefile_construction_door(
             projection_wrapper_sites.append(
                 EvidenceSite(edge.path, edge.line, edge.caller.lexical, edge.caller.name)
             )
+    # Product-argument discipline applies to production routes only. The
+    # owner module may exercise the door (including the arity TypeError twin)
+    # without resolving product_symbols from the production graph.
     non_product_projection_callers = tuple(
         EvidenceSite(edge.path, edge.line, edge.caller.lexical, edge.caller.name)
-        for edge in projection_edges
+        for edge in production_projection_call_edges
         if len(edge.argument_producers) != 1
         or not (set(edge.argument_producers[0]) & product_symbols)
     )
@@ -1338,7 +1438,10 @@ def audit_sourcefile_construction_door(
             results[0], foreign_product, foreign_projection,
         ),
     )
-    assert projection_calls
+    assert projection_calls, (
+        "R_missing_projection_callers: zero static callers of "
+        "project_constructed_module; empty is a finding (do not self-seed)"
+    )
     assert projection_def.path.resolve() == projection_file
     assert len(inspect.signature(project_constructed_module).parameters) == 1, (
         "projection accepts exactly one constructed product; a foreign "

--- a/tests/sourcefile_construction_door_evidence.py
+++ b/tests/sourcefile_construction_door_evidence.py
@@ -224,14 +224,20 @@ class SourceFileConstructionDoorEvidence:
         )
 
         projection = self.projection
-        assert projection.callers
+        assert projection.callers, (
+            "R_missing_projection_callers: zero static callers of the sole "
+            "projection door; empty is a finding, never a self-seeded auditor site"
+        )
         assert projection.dynamic_edges == ()
         assert projection.aliases == ()
         assert projection.reexports == ()
         assert projection.wrappers == ()
         assert projection.non_product_callers == ()
         assert projection.legacy_doors == ()
-        assert projection.discovered_edges == projection.audited_edges > 0
+        assert projection.discovered_edges == projection.audited_edges > 0, (
+            "R_projection_edge_denominator: discovered/audited edges must match "
+            "and be non-empty (empty denominator means the door is unexercised)"
+        )
 
         zero = self.zero_work
         assert zero.constructor_events == 1


### PR DESCRIPTION
## Shot accounting (IDD)

| Field | Value |
| --- | --- |
| **R axis** | `R_synthesized_evidence` (subclass of `R_self_sealing_instruments`) |
| **Measured before (#6958 tip)** | `R_synthesized_evidence = 1` at `tests/law_of_one_auditor.py` projection_calls self-seed |
| **Predicted Epsilon R** | `R_synthesized_evidence: -1` → **0** |
| **Measured after (this branch)** | `R_synthesized_evidence = 0` (script exit still red on residual `R_presence_only_identity=83`, unrelated) |
| **Floors preserved** | production unscanned by self-seal auditor; scoreboard authority false; no production SourceFile door change; empty observation stays a **contract red**, never soft-green |
| **Shell deleted** | the `if not projection_calls: projection_calls = [EvidenceSite(Path(__file__), audit_line, … audit_law_of_one)]` self-seed fallback |
| **Class instrument** | `#6958` `self_sealing_instrument_law.py` **remains** (still watches TAUTOLOGICAL + PRESENCE-ONLY). This PR drains one axis; it does not retire the class auditor |

If no shell were retirable: N/A — this PR **deletes** the synthesized-evidence shell at the one enrolled site. The class auditor retires only when sealed evidence mints + typed `assert_identity(Eq)` + tautology-rejecting assert macro make the whole class unrepresentable (see script docstring).

## Rung climb

Ask order (AGENTS.md):

1. **Type system forbid?** No — open Python test/auditor surface.
2. **One construction door refuse?** Partially: owner-module discovery + empty→`R_missing_projection_callers`; production must not define the test-owned door.
3. **Panic at contact?** AssertionError / contract red on empty; not a runtime production panic (green tests never contact the lie).

**Rung:** test + auditor. Class detector already at auditor rung (#6958). This PR turns the live offender green by deleting the shell, not by weakening the detector.

## What changed

- Remove self-seed; discover real static callers of test-owned `project_constructed_module` in its owner module.
- Empty callers → `R_missing_projection_callers` (finding, not fill-in).
- Lying twins in `test_law_of_one_shared_fixture.py` (hide callers → red).
- Flip `#6958` live pin: `test_law_of_one_live_self_seed_is_drained` asserts **zero** SYNTHESIZED on the auditor; planted twin keeps teeth.

## Doctrine

Zeros are measurements. Empty is a finding. Throwing is honorable. Never manufacture the evidence you check.

## Test plan

- [x] Planted SYNTHESIZED-EVIDENCE twin still recognized
- [x] Live law_of_one_auditor: `R_synthesized_evidence = 0`
- [x] Owner-module discovery: 3 real callers; empty/hidden twins stay empty
- [ ] `bin/bpytest` focused suites on battleaxe (launched after push)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove self-seeding fallback from `audit_sourcefile_construction_door` and treat empty callers as contract red
> - The auditor in [`sourcefile_construction_door_auditor.py`](https://github.com/TSavo/sugar/pull/6963/files#diff-7509b12ba362f22b09be4617be4cdcdf65fe924566d1c3f8951496fe9985ec09) no longer fabricates a caller from the auditor definition site when no static callers are found; instead it records `R_missing_projection_callers` as a contract red.
> - Two new helpers, `discover_projection_call_edges` and `discover_projection_callers`, parse the owner module source via a `SymbolGraph` to find real callsites of the projection door.
> - The auditor now also flags if production code defines or calls the projection door and reports these counts in the receipt via `R_projection_definition_count` and `R_production_projection_callers`.
> - Tests in [`test_sourcefile_construction_door_shared_fixture.py`](https://github.com/TSavo/sugar/pull/6963/files#diff-e2f18d16877c31d420c399cc16c6ac2e7f423f721f6590624a81990edc7837f9) verify that discovery returns real callers, that hidden callers produce empty results, and that empty caller sets raise an `AssertionError`.
> - Behavioral Change: any auditor invocation where the owner module has zero static callers of the projection door now fails rather than silently self-seeding a synthetic caller.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3fc6c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->