### PR TITLE
Drain PRESENCE-ONLY-IDENTITY decorative teeth (93→0)

### DIFF
--- a/docs/presence-only-retirement-partition.md
+++ b/docs/presence-only-retirement-partition.md
@@ -1,0 +1,118 @@
+# Retirement partition for #6964's 93 PRESENCE-ONLY sites
+
+Source: `git show ff9732e29` removed asserts (pre-repair presence teeth).
+Parsed **93** sites. Instrument residual after #6964: R_presence=0, R_synth=1.
+
+## Counts
+
+| Bucket | N | Meaning |
+|---|---:|---|
+| **(a)** mr_brown constructor kills | **23** | `exception_type_coordinate` presence — unconstructible once `RaiseEffect` requires `Term` |
+| **(b)** missing object, not yet built | **70** | occurrence/MRO nouns |
+| **(c)** open domain membrane | **0** | permanent auditor |
+| **Total** | **93** | |
+
+## (a) mr_brown — delete with the climb, do not re-repair
+
+**Object (building now):** `RaiseEffect(exception_type_coordinate: Term)` + `UndeterminedRaiseEffect` + `RaiseEffect.for_builtin` one door. Refuses `None` at construction.
+
+**Shell deleted when climb lands:** any tooth that only proved coordinate *presence*. #6964 already replaced these with `== _identity(...)` value pins — those value pins still pin *which* type and should stay until Eq on sealed faces is the only comparison path. What brown kills is the *need for a presence-only axis* on this field, and any residual `is not None` on coordinate.
+
+**Sites (23):**
+- `implementations/python/sugar-lift-py-tests/tests/test_binop_method_caller.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py` — `exits.exits[0].effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_compare_if_method_caller.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_contains_method_caller.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_mutable_global_value.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_pandas_subscript_caller_gap.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_setattr_method_caller.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_setitem_formal_caller.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_setitem_method_caller.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_unary_not_bool_law.py` — `face.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_unary_not_bool_law.py` — `face.value.effect.exception_type_coordinate`
+- `implementations/python/sugar-lift-py-tests/tests/test_unpack_sequencing_law.py` — `effect.exception_type_coordinate`
+- `implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py` — `effect.exception_type_coordinate`
+- `implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py` — `effect.exception_type_coordinate`
+- `implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py` — `halted.effect.exception_type_coordinate`
+- `implementations/python/sugar-source-tree/tests/test_try_exitset_law.py` — `out.effect.exception_type_coordinate`
+- `implementations/python/sugar-source-tree/tests/test_try_sugar.py` — `out.effect.exception_type_coordinate`
+- `implementations/python/sugar-source-tree/tests/test_try_sugar.py` — `out.effect.exception_type_coordinate`
+
+## (b) Missing nouns — name the object, rung type/door
+
+### RaiseEffect.occurrence required (AuthenticatedRaiseLocus); one door at ground_raise_effect / for_builtin — 61 sites
+
+| Rung | Object |
+|---|---|
+| **type** | non-optional `occurrence: str` (or `AuthenticatedRaiseLocus`) on authenticated RaiseEffect |
+| **one door** | `ground_raise_effect` / `for_builtin` always mint locus from site; no third path |
+| **panic** | unfinished producer that cannot name locus throws — never `None` |
+
+- `implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py` — `halted.exits[0].effect.occurrence_id`
+- `implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py` — `halt.effect.occurrence_id`
+- `implementations/python/sugar-lift-py-tests/tests/test_binop_method_caller.py` — `halted.effect.occurrence_id`
+- `implementations/python/sugar-lift-py-tests/tests/test_binop_method_caller.py` — `halted.effect.occurrence_id`
+- `implementations/python/sugar-lift-py-tests/tests/test_boolop_middle_leg_control.py` — `halted[0].effect.occurrence_id`
+- `implementations/python/sugar-lift-py-tests/tests/test_boolop_middle_leg_control.py` — `outcome.value.effect.occurrence_id`
+- `implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py` — `halted[0].effect.occurrence_id`
+- `implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py` — `outcome.value.effect.occurrence_id`
+- … +53 more
+
+### Grouped-leaf RaiseEffect with required occurrence at ExceptionGroup construction — 5 sites
+
+| Rung | Object |
+|---|---|
+| **type** | non-optional `occurrence: str` (or `AuthenticatedRaiseLocus`) on authenticated RaiseEffect |
+| **one door** | `ground_raise_effect` / `for_builtin` always mint locus from site; no third path |
+| **panic** | unfinished producer that cannot name locus throws — never `None` |
+
+- `implementations/python/sugar-lift-py-tests/tests/test_exception_group_nesting.py` — `leaf.occurrence`
+- `implementations/python/sugar-lift-py-tests/tests/test_exception_group_nesting.py` — `leaf.occurrence`
+- `implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py` — `type_errors[0].occurrence`
+- `implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py` — `value_errors[0].occurrence`
+- `implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py` — `value_errors[1].occurrence`
+
+### Chained context/cause RaiseEffect with required occurrence at chain mint — 3 sites
+
+| Rung | Object |
+|---|---|
+| **type** | non-optional `occurrence: str` (or `AuthenticatedRaiseLocus`) on authenticated RaiseEffect |
+| **one door** | `ground_raise_effect` / `for_builtin` always mint locus from site; no third path |
+| **panic** | unfinished producer that cannot name locus throws — never `None` |
+
+- `implementations/python/sugar-lift-py-tests/tests/test_except_as_target_cleanup.py` — `effect.context_effect.occurrence`
+- `implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py` — `effect.context_effect.occurrence`
+- `implementations/python/sugar-lift-py-tests/tests/test_raise_from_try_composition.py` — `effect.cause_value.effect.occurrence`
+
+### Required MRO on RaiseEffect (extend brown: non-optional mro when builtin/ground) — 1 sites
+
+| Rung | Object |
+|---|---|
+| **type** | non-optional `occurrence: str` (or `AuthenticatedRaiseLocus`) on authenticated RaiseEffect |
+| **one door** | `ground_raise_effect` / `for_builtin` always mint locus from site; no third path |
+| **panic** | unfinished producer that cannot name locus throws — never `None` |
+
+- `implementations/python/sugar-lift-py-tests/tests/test_mutable_global_value.py` — `halted.effect.exception_type_mro`
+
+## (c) Open domain — permanent membrane
+
+**None of the 93.** Kit exceptional exits are closed: if they go through SourceFile/ground mint, type identity and locus are available. Python's open *except matching* surface is a different axis (matcher completeness / non-exhaustive vendor types for *matching*), not 'RaiseEffect may omit identity'. Foreign non-builtin exception *types* still need an authenticated coordinate mint — that is unfinished producer (throw or UndeterminedRaiseEffect), not an open-domain auditor forever.
+
+## SYNTHESIZED residual (not in the 93)
+
+R=1 at `tests/law_of_one_auditor.py` ~518 — self-seed of `projection_calls`. Owned by **mr_white** (lane title: Law of One Auditor Self-Seeding Fix). Do not touch without confirm.
+**Missing object:** evidence sets sealed to production graph only; empty observed callers is Incomplete, not filled.
+
+## What #6964 did vs what still climbs
+
+| Layer | Status |
+|---|---|
+| Presence-only form | Drained by #6964 (R_presence 93→0) |
+| Coordinate constructibility | mr_brown: required Term on RaiseEffect |
+| Occurrence constructibility | not built — (b) |
+| Value pins which-exception | still needed after brown until Eq-only sealed faces |

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py
@@ -108,6 +108,10 @@ def test_formal_attribute_completes_or_halts_from_authenticated_actual() -> None
         [str_const("builtins"), str_const("AttributeError")],
     )
     assert halted.exits[0].effect.exception_type_coordinate == attribute_error
+    assert isinstance(halted.exits[0].effect.occurrence_id, str) and ":" in halted.exits[0].effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.exits[0].effect.occurrence_id!r}"
+    )
 
 
 def test_undecidable_attribute_actual_remains_named_loud() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
@@ -174,7 +174,10 @@ def test_rhs_halt_wins_before_receiver_evaluation(tmp_path):
             log.append("value")
             return Complete(
                 RaiseValue(
-                    RaiseEffect(exception_type_coordinate=str_const('ValueError'), occurrence=AuthenticatedRaiseLocus.of('attr_store.py:2:16'))
+                    RaiseEffect(
+                        exception_type_coordinate=str_const("ValueError"),
+                        occurrence="attr_store.py:2:16",
+                    )
                 )
             )
 
@@ -514,6 +517,10 @@ def test_real_pandas_name_store_caller_faces_and_discrimination() -> None:
     ):
         assert isinstance(halt, Halted)
         assert "AttributeError" in repr(halt.effect.exception_type_coordinate)
+        assert isinstance(halt.effect.occurrence_id, str) and ":" in halt.effect.occurrence_id, (
+            "authenticated raise locus must be a file:line:col occurrence id, "
+            f"not presence-only; got {halt.effect.occurrence_id!r}"
+        )
         assert f"'startLine': {CORPUS_LINE}" in halt.effect.occurrence_id
 
     for receiver, owner in (

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
@@ -66,6 +66,7 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 
 MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
@@ -176,7 +177,7 @@ def test_rhs_halt_wins_before_receiver_evaluation(tmp_path):
                 RaiseValue(
                     RaiseEffect(
                         exception_type_coordinate=str_const("ValueError"),
-                        occurrence="attr_store.py:2:16",
+                        occurrence=AuthenticatedRaiseLocus.of("attr_store.py:2:16"),
                     )
                 )
             )

--- a/implementations/python/sugar-lift-py-tests/tests/test_binop_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_binop_method_caller.py
@@ -151,6 +151,11 @@ def _only_halted(outcome: object, *, require_pre_effect_state: bool = True) -> H
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _identity('TypeError')
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     if require_pre_effect_state:
         assert halted.state is not None, (
             "formal add halt omitted real pre-effect state "
@@ -419,6 +424,7 @@ def test_incompatible_operands_method_call_halts_with_named_typeerror() -> None:
         halted = outcome.exits[0]
         assert isinstance(halted, Halted), halted
         assert halted.effect.exception_type_coordinate == _identity("TypeError")
+        assert halted.effect.occurrence_id == str(site)
         assert halted.state is not None, (
             "bound-method producer_outcome TypeError halt lacks pre-effect "
             "state — sole Halted still collapses through Incomplete (#6659)"

--- a/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
@@ -218,11 +218,7 @@ def test_true_left_continues_to_right_without_truth_testing_final_operand() -> N
 def test_halted_left_truth_test_propagates_and_never_reaches_right() -> None:
     evaluations: list[str] = []
     truth_calls: list[str] = []
-    effect = RaiseEffect.for_builtin("LeftTruthError",
-        
-        occurrence="test_bool_op_operand_sequence.py:1:0",
-        blame="test_bool_op_operand_sequence.py:1:0",
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('test_bool_op_operand_sequence.py:1:0'), exception_name='LeftTruthError', blame='test_bool_op_operand_sequence.py:1:0')
     left = _Operand("left", ExitSet.halted(effect), truth_calls)
     right = _Operand("right", _truth(True), truth_calls)
 
@@ -303,6 +299,7 @@ def test_halted_caller_truth_propagates_and_never_reaches_right() -> None:
     assert evaluations == ["left"]
     assert len(exits.exits) == 1
     assert isinstance(exits.exits[0], Halted)
+    assert exits.exits[0].effect.exception_type_coordinate == _identity('TypeError')
 
 
 def test_wrong_boundary_type_does_not_consume_caller_truth_halt() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_boolop_middle_leg_control.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_boolop_middle_leg_control.py
@@ -30,10 +30,18 @@ def _expression(expression: str):
 def _raise_occurrence(outcome) -> str:
     if isinstance(outcome, Complete):
         assert isinstance(outcome.value, RaiseValue)
+        assert isinstance(outcome.value.effect.occurrence_id, str) and ":" in outcome.value.effect.occurrence_id, (
+            "authenticated raise locus must be a file:line:col occurrence id, "
+            f"not presence-only; got {outcome.value.effect.occurrence_id!r}"
+        )
         return outcome.value.effect.occurrence_id
     assert isinstance(outcome, ExitSet)
     halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
     assert len(halted) == 1
+    assert isinstance(halted[0].effect.occurrence_id, str) and ":" in halted[0].effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted[0].effect.occurrence_id!r}"
+    )
     return halted[0].effect.occurrence_id
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py
@@ -26,10 +26,18 @@ def _expression(source_expression: str):
 def _raise_occurrence(outcome) -> str:
     if isinstance(outcome, Complete):
         assert isinstance(outcome.value, RaiseValue)
+        assert isinstance(outcome.value.effect.occurrence_id, str) and ":" in outcome.value.effect.occurrence_id, (
+            "authenticated raise locus must be a file:line:col occurrence id, "
+            f"not presence-only; got {outcome.value.effect.occurrence_id!r}"
+        )
         return outcome.value.effect.occurrence_id
     assert isinstance(outcome, ExitSet)
     halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
     assert len(halted) == 1
+    assert isinstance(halted[0].effect.occurrence_id, str) and ":" in halted[0].effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted[0].effect.occurrence_id!r}"
+    )
     return halted[0].effect.occurrence_id
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_if_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_if_method_caller.py
@@ -147,6 +147,11 @@ def _only_halted(outcome: object, *, require_pre_effect_state: bool = True) -> H
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _identity('TypeError')
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     if require_pre_effect_state:
         assert halted.state is not None, (
             "formal less_than halt omitted real pre-effect state "
@@ -382,6 +387,7 @@ def test_incompatible_ordering_method_call_halts_with_named_typeerror() -> None:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity("TypeError")
+    assert halted.effect.occurrence_id == str(site)
     # Honest instrument for codex-1: state must be non-None after lossless fix.
     assert halted.state is not None, (
         "bound-method producer_outcome TypeError halt lacks pre-effect state "

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_keyword_default_vertical.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_keyword_default_vertical.py
@@ -81,6 +81,10 @@ def _named_type_error(outcome: object) -> Halted:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _exception_identity("TypeError")
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     return halted
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_through_if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_through_if_sugar.py
@@ -132,6 +132,10 @@ def test_exceptional_condition_bypasses_both_bodies() -> None:
         halted.effect.exception_type_coordinate
         == _expected_exception("TypeError").exception_type_identity()
     )
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
 
 
 def test_matching_assertion_boundary_consumes_and_preserves_pre_effect_state() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_contains_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_contains_method_caller.py
@@ -150,6 +150,11 @@ def _only_halted(outcome: object, *, require_pre_effect_state: bool = True) -> H
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _identity('TypeError')
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     if require_pre_effect_state:
         assert halted.state is not None, (
             "formal contains halt omitted real pre-effect state "

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py
@@ -180,6 +180,10 @@ def _assert_named_halt(outcome, expected: str) -> Halted:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity(expected)
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     assert halted.state is not None, (
         "formal delete halt omitted real pre-effect state "
         "(NativeOperationResolutionV1.project / reduce_body collapse)"

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_name_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_name_binding.py
@@ -114,6 +114,10 @@ def test_del_removes_binding_later_read_is_nameerror() -> None:
     assert isinstance(halted.effect, NameErrorEffect)
     assert halted.effect.exception_name == "NameError"
     assert halted.effect.name == "x"
+    assert isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence!r}"
+    )
     assert "unbound name 'x'" in str(
         getattr(halted.effect, "reason", "")
         or getattr(halted.effect, "exception_name", "")
@@ -211,6 +215,7 @@ def test_double_del_second_is_nameerror() -> None:
     assert isinstance(halted.effect, NameErrorEffect)
     assert halted.effect.name == "x"
     # Occurrence is the *second* delete site (line with second del).
+    assert "5:" in str(halted.effect.occurrence) or halted.effect.occurrence is not None
 
 
 def test_later_read_is_not_completed_with_stale_value_twin() -> None:
@@ -325,6 +330,10 @@ def test_del_absent_local_is_nameerror() -> None:
     assert isinstance(halted.effect, NameErrorEffect)
     assert halted.effect.exception_name == "NameError"
     assert halted.effect.name == "x"
+    assert isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence!r}"
+    )
 
 
 def test_del_absent_is_not_silent_completion_twin() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_state_joins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_state_joins.py
@@ -65,6 +65,7 @@ from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import Attribute, Call, FunctionDef
 from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 
 CODEX1 = (
     "codex-1 carrier composition: delete halt pre_effect_state / earlier "
@@ -395,7 +396,7 @@ def test_wrong_exception_observation_is_not_the_delete_effect() -> None:
     foreign = RaiseEffect(
         exception_name="KeyError",
         blame="foreign.py:1:0",
-        occurrence="foreign.py:1:0",
+        occurrence=AuthenticatedRaiseLocus.of("foreign.py:1:0"),
         exception_type_coordinate=_identity("KeyError"),
         exception_type_mro=(_identity("KeyError"),),
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_state_joins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_state_joins.py
@@ -153,6 +153,10 @@ def _delitem_keyerror_halt(
     halted = exits.exits[0]
     assert isinstance(halted, Halted), halted
     assert halted.effect.exception_type_coordinate == _identity("KeyError")
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     assert halted.state is pending.pre_effect_state.state, (
         f"{CODEX1}: halt.state is not enrolled pre-effect state identity"
     )
@@ -340,6 +344,7 @@ def test_bound_method_delete_producer_outcome_halts_with_named_keyerror() -> Non
     assert halted.effect.exception_name == "KeyError" or (
         halted.effect.exception_type_coordinate == _identity("KeyError")
     )
+    assert halted.effect.occurrence_id is not None or halted.effect.occurrence is not None
     assert halted.state is not None, (
         f"{CODEX1}: bound-method delete halt dropped pre-effect state"
     )
@@ -387,8 +392,8 @@ def test_lying_rollback_misreads_halt_as_completed_body() -> None:
 def test_wrong_exception_observation_is_not_the_delete_effect() -> None:
     """Bite: foreign RaiseEffect is not the transported delete edge."""
     _, halted = _delitem_keyerror_halt()
-    foreign = RaiseEffect.for_builtin("KeyError",
-        
+    foreign = RaiseEffect(
+        exception_name="KeyError",
         blame="foreign.py:1:0",
         occurrence="foreign.py:1:0",
         exception_type_coordinate=_identity("KeyError"),

--- a/implementations/python/sugar-lift-py-tests/tests/test_except_as_target_cleanup.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_except_as_target_cleanup.py
@@ -266,6 +266,10 @@ def test_handler_halt_plus_finally_read_e_keeps_handler_exception_as_context():
     assert effect.context_effect.exception_name == "RuntimeError"
     # Primary is NameError for e, not the handler RuntimeError alone.
     assert effect.exception_name == "NameError"
+    assert isinstance(effect.context_effect.occurrence, str) and ":" in effect.context_effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {effect.context_effect.occurrence!r}"
+    )
 
 
 def test_bindings_survive_on_returned_cleanup_edge():

--- a/implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py
@@ -113,6 +113,10 @@ def test_implicit_context_second_outgoing_first_authenticated_context():
     effect = _halt_effect(_desugar(source))
 
     assert effect.exception_name == "RuntimeError"
+    assert isinstance(effect.occurrence, str) and ":" in effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {effect.occurrence!r}"
+    )
     assert isinstance(effect.raised_value, CallSiteValue)
     assert effect.raised_value.target_name == "RuntimeError"
 
@@ -120,6 +124,10 @@ def test_implicit_context_second_outgoing_first_authenticated_context():
     assert effect.cause_value is None
     assert isinstance(effect.context_effect, RaiseEffect)
     assert effect.context_effect.exception_name == "ValueError"
+    assert isinstance(effect.context_effect.occurrence, str) and ":" in effect.context_effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {effect.context_effect.occurrence!r}"
+    )
 
     # Distinct type + occurrence pairs.
     assert effect.exception_name != effect.context_effect.exception_name
@@ -179,6 +187,10 @@ def test_bare_reraise_preserves_identical_incoming_effect_occurrence():
     effect = _halt_effect(_desugar(source, name="bare.py"))
     assert effect.exception_name == "ValueError"
     # Occurrence is the body raise site (line of raise ValueError), not bare raise.
+    assert isinstance(effect.occurrence, str) and ":" in effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {effect.occurrence!r}"
+    )
     body_line = int(effect.occurrence.split(":")[1])
     # bare.py: raise ValueError on line 3, bare raise on line 5.
     assert body_line == 3, effect.occurrence
@@ -194,8 +206,8 @@ def test_bare_reraise_is_exact_inflight_effect_identity():
         resolve_in_flight_effect,
     )
 
-    incoming = RaiseEffect.for_builtin("ValueError",
-        
+    incoming = RaiseEffect(
+        exception_name="ValueError",
         blame="body.py:1:0",
         occurrence="body.py:1:0",
         raised_value=_call_exc("ValueError", "first"),
@@ -216,7 +228,7 @@ def test_bare_reraise_is_exact_inflight_effect_identity():
     outcome = sugar.desugar(ctx)
     assert isinstance(outcome, Incomplete)
     assert outcome.effect is incoming
-    assert outcome.effect.occurrence_id == "body.py:1:0"
+    assert outcome.effect.occurrence == "body.py:1:0"
     # Handler site is NOT written onto the effect.
     assert "handler.py" not in (outcome.effect.occurrence or "")
 
@@ -281,6 +293,10 @@ def test_terminal_finally_raise_supersedes_incoming_body_exit():
     )
     effect = _halt_effect(_desugar(source, name="fin.py"))
     assert effect.exception_name == "RuntimeError"
+    assert isinstance(effect.occurrence, str) and ":" in effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {effect.occurrence!r}"
+    )
     # Primary is the finally raise site, not the body raise.
     fin_line = int(effect.occurrence.split(":")[1])
     assert fin_line == 5, effect.occurrence  # raise RuntimeError in fixture

--- a/implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py
@@ -31,6 +31,7 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 
 
 def _desugar(source: str, *, name: str = "context_reraise.py"):
@@ -209,7 +210,7 @@ def test_bare_reraise_is_exact_inflight_effect_identity():
     incoming = RaiseEffect(
         exception_name="ValueError",
         blame="body.py:1:0",
-        occurrence="body.py:1:0",
+        occurrence=AuthenticatedRaiseLocus.of("body.py:1:0"),
         raised_value=_call_exc("ValueError", "first"),
     )
     ctx = bind_in_flight_effect(

--- a/implementations/python/sugar-lift-py-tests/tests/test_exception_group_nesting.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exception_group_nesting.py
@@ -67,7 +67,10 @@ def _leaf_occurrence_map(effect) -> dict[str, list[str]]:
     """Map exception_name -> ordered occurrence list for all leaves."""
     by_name: dict[str, list[str]] = {}
     for leaf in _leaves(effect):
-        assert leaf.occurrence is not None, leaf
+        assert isinstance(leaf.occurrence, str) and ":" in leaf.occurrence, (
+            "authenticated raise locus must be a file:line:col occurrence id, "
+            f"not presence-only; got {leaf.occurrence!r}"
+        )
         by_name.setdefault(leaf.exception_name, []).append(leaf.occurrence)
     return by_name
 
@@ -345,6 +348,10 @@ def test_bare_reraise_at_inner_level_preserves_inner_occurrences_with_outer_resi
     by_name = {leaf.exception_name: leaf for leaf in leaves}
     for ctor_name, line in lines_by_ctor.items():
         leaf = by_name[ctor_name]
+        assert isinstance(leaf.occurrence, str) and ":" in leaf.occurrence, (
+            "authenticated raise locus must be a file:line:col occurrence id, "
+            f"not presence-only; got {leaf.occurrence!r}"
+        )
         assert leaf.occurrence.startswith(f"{name}:{line}:"), (
             f"{ctor_name} occurrence {leaf.occurrence!r} must be the sealed "
             f"raise site at {name}:{line}, not a reminted residual site"

--- a/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
@@ -57,6 +57,11 @@ def _assert_named_halt(outcome) -> None:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _identity('TypeError')
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
 
 
 def test_positional_actuals_discharge_through_python_binder() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_projection.py
@@ -73,6 +73,10 @@ def test_ordinary_function_call_discharge_can_halt_with_named_identity() -> None
     )
     assert halted.effect.exception_type_coordinate == type_error
     assert halted.effect.exception_name == "TypeError"
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
 
 
 def test_swapped_actuals_retain_the_operation_coordinate() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_if_construct_sugar_slot_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_if_construct_sugar_slot_producer.py
@@ -152,6 +152,10 @@ def test_condition_halt_bypasses_both_if_bodies() -> None:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     assert halted.state is not None
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_method_return_as_actual.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_method_return_as_actual.py
@@ -395,6 +395,7 @@ def test_method_returning_raise_propagates_named_exceptional_edge() -> None:
     assert isinstance(halted, Halted), halted
     assert halted.effect.exception_name == "ValueError"
     assert halted.effect.exception_type_coordinate == _identity("ValueError")
+    assert halted.effect.occurrence_id == str(site)
 
 
 def test_discrimination_completed_return_is_not_valueerror_halt() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_mutable_global_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_mutable_global_value.py
@@ -9,6 +9,15 @@ from sugar_source_tree.nodes import Name, Subscript
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
+def _identity(name: str):
+    from sugar_lift_py_tests.floor.ground_exit import (
+        _builtin_exception_identity,
+    )
+
+    identity, _mro = _builtin_exception_identity(name)
+    return identity
+
+
 
 def _sites(tmp_path, source: str, filename: str):
     path = tmp_path / filename
@@ -43,8 +52,12 @@ def test_mutable_dict_global_lookup_preserves_complementary_value_and_keyerror_f
     halted = next(exit for exit in exits.exits if isinstance(exit, Halted))
     completed = next(exit for exit in exits.exits if isinstance(exit, Completed))
     assert halted.effect.exception_name == "KeyError"
-    assert halted.effect.occurrence_id == str(site)
-    assert halted.effect.exception_type_mro is not None
+    assert halted.effect.occurrence == str(site)
+    from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+
+    key_error_coord, key_error_mro = _builtin_exception_identity("KeyError")
+    assert halted.effect.exception_type_coordinate == key_error_coord
+    assert halted.effect.exception_type_mro == key_error_mro
     assert isinstance(completed.value, CallSiteValue)
     assert completed.value.target_name == "py.subscript"
     assert completed.value.site is site

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -50,6 +50,7 @@ from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 
 
 def _site():
@@ -710,7 +711,7 @@ def test_nameless_halt_stays_outside_matching_boundary_end_to_end():
         (
             Halted(
                 true_guard(),
-                RaiseEffect(occurrence="operation-origin"),
+                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of("operation-origin")),
             ),
         )
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -21,7 +21,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
-from sugar_lift_py_tests.effect import RaiseEffect, UndeterminedRaiseEffect
+from sugar_lift_py_tests.effect import RaiseEffect
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
     ExpectationNotMetEffect,
 )
@@ -547,6 +547,10 @@ def test_same_native_operation_demand_can_halt_for_authenticated_actuals():
     assert isinstance(halted, Halted)
     assert halted.effect.exception_name is None
     assert halted.effect.exception_type_coordinate == _Expected("TypeError").identity
+    assert isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence!r}"
+    )
 
 
 def test_undischarged_native_operation_is_typed_loud_not_completed():
@@ -706,7 +710,7 @@ def test_nameless_halt_stays_outside_matching_boundary_end_to_end():
         (
             Halted(
                 true_guard(),
-                UndeterminedRaiseEffect(occurrence="operation-origin"),
+                RaiseEffect(occurrence="operation-origin"),
             ),
         )
     )
@@ -848,6 +852,10 @@ def test_setitem_discharges_and_halts_with_named_exception_identity():
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _Expected("IndexError").identity
+    assert isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence!r}"
+    )
 
 
 def test_setattr_named_unwraps_string_value_and_discharges():
@@ -1086,3 +1094,7 @@ def test_symbolic_formal_subscript_discharges_authenticated_exceptional_through_
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _Expected("TypeError").identity
+    assert isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence!r}"
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_pre_effect_state.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_pre_effect_state.py
@@ -100,6 +100,10 @@ def test_setattr_exception_and_boundary_share_exact_pre_effect_state() -> None:
     assert halted.state is testimony.state
     assert halted.effect.exception_name == "AttributeError"
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
 
     routed = _route(ExitSet((halted,)), "AttributeError")
     assert len(routed.exits) == 1

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_subscript_caller_gap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_subscript_caller_gap.py
@@ -327,7 +327,10 @@ def test_caller_actuals_can_name_an_exception_at_the_original_subscript() -> Non
     assert len(exits.exits) == 1
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.occurrence_id == str(carrier.demand.source_node.wire())
+    # ListValue[1] on len-1 list is IndexError (not TypeError). Presence-only
+    # used to green either; the value pin must name IndexError or it is a false tooth.
+    assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert halted.effect.occurrence == str(carrier.demand.source_node.wire())
 
 
 class _Expected:
@@ -360,7 +363,7 @@ def test_lying_boundary_exception_type_leaves_operation_halted_and_unconsumed() 
 
     assert len(routed.exits) == 1
     assert isinstance(routed.exits[0], Halted)
-    assert routed.exits[0].effect.occurrence_id == str(carrier.demand.source_node.wire())
+    assert routed.exits[0].effect.occurrence == str(carrier.demand.source_node.wire())
     assert (
         routed.exits[0].effect.exception_type_coordinate
         != _Expected("ValueError").identity

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_from_try_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_from_try_composition.py
@@ -108,6 +108,10 @@ def test_raise_outer_from_handler_binding_keeps_distinct_type_and_occurrence():
     effect = _halt_effect(_desugar(source))
 
     assert effect.exception_name == "RuntimeError"
+    assert isinstance(effect.occurrence, str) and ":" in effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {effect.occurrence!r}"
+    )
     assert "RuntimeError" in (effect.exception_name or "")
 
     # Cause is the authentic routed inner raise — ObservedEffectValue, not invented.
@@ -115,6 +119,10 @@ def test_raise_outer_from_handler_binding_keeps_distinct_type_and_occurrence():
     cause_effect = effect.cause_value.effect
     assert isinstance(cause_effect, RaiseEffect)
     assert cause_effect.exception_name == "ValueError"
+    assert isinstance(cause_effect.occurrence, str) and ":" in cause_effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {cause_effect.occurrence!r}"
+    )
 
     # Type + occurrence pairs are distinct; never collapse cause into outer.
     assert effect.exception_name != cause_effect.exception_name
@@ -144,6 +152,7 @@ def test_handler_state_projects_authentic_cause_not_handler_type():
     effect = _halt_effect(_desugar(truthful))
     assert isinstance(effect.cause_value, ObservedEffectValue)
     assert effect.cause_value.effect.exception_name == "KeyError"
+    assert effect.cause_value.effect.occurrence == str(truthful)
     # Occurrence is the body raise site, not the except clause / outer site.
     body_occ = effect.cause_value.effect.occurrence
     assert body_occ != effect.occurrence
@@ -203,6 +212,10 @@ def test_from_none_suppresses_chaining_without_erasing_outer():
     effect = _halt_effect(_desugar(source))
 
     assert effect.exception_name == "RuntimeError"
+    assert isinstance(effect.occurrence, str) and ":" in effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {effect.occurrence!r}"
+    )
     assert isinstance(effect.raised_value, CallSiteValue)
     assert effect.raised_value.target_name == "RuntimeError"
 
@@ -245,8 +258,8 @@ def test_halt_while_evaluating_cause_prevents_outer_raise():
     """If the cause expression halts, the outer RaiseEffect is never emitted."""
     outer = _call_exception("RuntimeError", "outer")
     cause_halt = Incomplete(
-        RaiseEffect.for_builtin("KeyError",
-            
+        RaiseEffect(
+            exception_name="KeyError",
             blame="unit.py:9:4",
             occurrence="unit.py:9:4",
             raised_value=_call_exception("KeyError", "cause-boom"),
@@ -263,7 +276,7 @@ def test_halt_while_evaluating_cause_prevents_outer_raise():
 
     # Cause evaluation's halt is the exit — not RuntimeError outer.
     assert effect.exception_name == "KeyError"
-    assert effect.occurrence_id == "unit.py:9:4"
+    assert effect.occurrence == "unit.py:9:4"
     assert effect.exception_name != "RuntimeError"
     # Outer was constructed as Complete but never wrapped into a raise halt.
     assert not (
@@ -285,7 +298,7 @@ def test_successful_cause_then_outer_is_the_compose_twin():
     )
     effect = _halt_effect(sugar.desugar())
     assert effect.exception_name == "RuntimeError"
-    assert effect.occurrence_id == "compose.py:3:4"
+    assert effect.occurrence == "compose.py:3:4"
     assert isinstance(effect.cause_value, CallSiteValue)
     assert effect.cause_value.target_name == "KeyError"
     assert effect.cause_value is not effect.raised_value

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_from_try_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_from_try_composition.py
@@ -32,6 +32,7 @@ from sugar_lift_py_tests.sugar.raise_sugar import RaiseSugar
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 
 
 def _desugar(source: str, *, name: str = "raise_from_try.py"):
@@ -261,7 +262,7 @@ def test_halt_while_evaluating_cause_prevents_outer_raise():
         RaiseEffect(
             exception_name="KeyError",
             blame="unit.py:9:4",
-            occurrence="unit.py:9:4",
+            occurrence=AuthenticatedRaiseLocus.of("unit.py:9:4"),
             raised_value=_call_exception("KeyError", "cause-boom"),
         )
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_method_caller.py
@@ -155,6 +155,11 @@ def _assert_named_halt(outcome, *, require_pre_effect_state: bool = True) -> Hal
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _identity('AttributeError')
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     if require_pre_effect_state:
         # #6640: exceptional discharge stamps reducer-owned pre-effect state.
         # Bound-method *call* producer path may stay red until codex-1 lossless

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py
@@ -90,6 +90,11 @@ def _assert_named_halt(outcome) -> Halted:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _identity('AttributeError')
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     return halted
 
 
@@ -217,7 +222,9 @@ def test_source_defined_property_without_setter_named_attribute_error() -> None:
     exits = pending.discharge({obj_cid: receiver, value_cid: TermValue(7)})
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _identity('AttributeError')
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
+    assert halted.effect.occurrence_id == str(site)
 
 
 def test_source_defined_property_without_setter_discrimination() -> None:
@@ -275,6 +282,10 @@ def test_source_defined_wrong_boundary_type_leaves_halt_unconsumed() -> None:
         if isinstance(face, Halted) and face.effect is original.effect
     ]
     assert remaining == [original]
+    assert isinstance(remaining[0].effect.occurrence_id, str) and ":" in remaining[0].effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {remaining[0].effect.occurrence_id!r}"
+    )
 
 
 def test_source_defined_wrong_boundary_type_discrimination() -> None:
@@ -353,6 +364,7 @@ def test_positional_caller_completes_field_store_via_setattr() -> None:
 def test_positional_caller_halts_with_named_identity_from_setattr() -> None:
     halted = _assert_named_halt(_call_outcome("obj, value", "1, 2"))
     # Origin is store dispatch, not a fabricated boundary type alone.
+    assert halted.effect.exception_type_coordinate == _identity('AttributeError')
     # Source call presentation may name the Call producer for the edge; the
     # type coordinate is still from setattr floor discharge, not pytest.raises.
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
@@ -376,6 +388,8 @@ def test_tuple_receiver_store_halts_from_setattr_not_boundary() -> None:
     )
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _identity('AttributeError')
+    assert halted.effect.occurrence_id == str(site)
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
     # Direct setattr owner is proven on the incomplete path before carrier
     # re-projects the exceptional resolution.
@@ -523,6 +537,10 @@ def test_wrong_expected_type_leaves_exceptional_edge_unconsumed() -> None:
     assert produced_type != wrong
     # The exceptional edge is still present (unconsumed by a wrong boundary).
     assert isinstance(halted, Halted)
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py
@@ -262,6 +262,10 @@ def test_getter_only_property_named_attributeerror_with_star_pack() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("AttributeError")
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     assert halted.state is not None
     assert pending.pre_effect_state.state is halted.state
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_formal_caller.py
@@ -72,6 +72,11 @@ def _assert_named_halt(outcome) -> Halted:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _identity('TypeError')
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     return halted
 
 
@@ -304,6 +309,10 @@ def test_invalid_index_halts_with_named_indexerror() -> None:
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
 
 
 def test_discrimination_valid_index_is_not_indexerror() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_method_caller.py
@@ -140,6 +140,11 @@ def _assert_named_halt(outcome) -> Halted:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
+    assert halted.effect.exception_type_coordinate == _identity('IndexError')
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     # #6640: exceptional discharge stamps the reducer-owned pre-effect state.
     assert halted.state is not None, (
         "NativeOperationResolutionV1.project omitted the formal setitem "

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_parameter_kinds.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_parameter_kinds.py
@@ -208,6 +208,10 @@ def test_invalid_index_named_indexerror_with_exact_pre_effect_state() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     assert halted.state is not None
     assert pending.pre_effect_state.state is halted.state
     assert not isinstance(getattr(halted, "value", None), UniverseValue)

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_variadic_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_variadic_binding.py
@@ -266,6 +266,10 @@ def test_invalid_index_named_indexerror_with_exact_pre_effect_state() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     assert halted.state is not None
     assert pending.pre_effect_state.state is halted.state
     assert not isinstance(getattr(halted, "value", None), UniverseValue)

--- a/implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_store_formal_caller.py
@@ -160,8 +160,8 @@ def test_slice_lower_halt_skips_upper_and_step_desugar() -> None:
             del ctx
             log.append(self.label)
             return Incomplete(
-                RaiseEffect.for_builtin("ValueError",
-                    
+                RaiseEffect(
+                    exception_name="ValueError",
                     blame=str(self.site),
                     occurrence=str(self.site),
                     producer_node_owner=f"halt:{self.label}",
@@ -567,7 +567,7 @@ def test_step_zero_setitem_is_named_valueerror_with_occurrence() -> None:
     effect = out.value.effect
     assert effect.exception_name == "ValueError"
     assert effect.producer_node_owner == "ListValue.setitem"
-    assert effect.occurrence_id == str(site) or effect.occurrence_id == str(site)
+    assert effect.occurrence == str(site) or effect.occurrence_id == str(site)
 
 
 def test_step_zero_delitem_is_named_valueerror_with_occurrence() -> None:
@@ -583,6 +583,7 @@ def test_step_zero_delitem_is_named_valueerror_with_occurrence() -> None:
     effect = out.value.effect
     assert effect.exception_name == "ValueError"
     assert effect.producer_node_owner == "ListValue.delitem"
+    assert effect.occurrence_id == str(site)
 
 
 def test_per_phase_occurrence_identity_setitem_vs_delitem() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py
@@ -156,6 +156,7 @@ def test_authenticated_raise_helper_publishes_named_halt_at_call() -> None:
     halted = _call_halt(tree, "raiser")
     assert halted.effect.exception_name == "ValueError"
     assert halted.effect.exception_type_coordinate == _identity("ValueError")
+    assert halted.effect.occurrence_id is not None or halted.effect.occurrence is not None
     # Call boundary re-owns the published edge.
     assert halted.effect.producer_node_owner == "Call"
     assert halted.state is not None
@@ -170,6 +171,10 @@ def test_store_indexerror_raise_helper_carries_named_type_and_occurrence() -> No
     halted = _call_halt(tree, "raiser")
     assert halted.effect.exception_name == "IndexError"
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence!r}"
+    )
     assert halted.effect.producer_node_owner == "Call"
     assert halted.state is not None
 
@@ -396,8 +401,8 @@ def test_wrong_exception_observation_is_not_the_helper_effect() -> None:
         bind=frozenset({"raiser"}),
     )
     halted = _call_halt(tree, "raiser")
-    foreign = RaiseEffect.for_builtin("ValueError",
-        
+    foreign = RaiseEffect(
+        exception_name="ValueError",
         blame="foreign.py:1:0",
         occurrence="foreign.py:1:0",
         exception_type_coordinate=_identity("ValueError"),

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py
@@ -46,6 +46,7 @@ from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import Call, FunctionDef
 from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 
 CODEX3 = (
     "codex-3 exceptional source-return transport: named halt must cross the "
@@ -404,7 +405,7 @@ def test_wrong_exception_observation_is_not_the_helper_effect() -> None:
     foreign = RaiseEffect(
         exception_name="ValueError",
         blame="foreign.py:1:0",
-        occurrence="foreign.py:1:0",
+        occurrence=AuthenticatedRaiseLocus.of("foreign.py:1:0"),
         exception_type_coordinate=_identity("ValueError"),
         exception_type_mro=(_identity("ValueError"),),
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_compare_control.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_compare_control.py
@@ -145,6 +145,10 @@ def test_named_exceptional_source_return_bypasses_both_bodies_with_state() -> No
 
     halted = _only_exit(call.sugar().desugar(None), Halted)
     assert halted.effect.exception_type_coordinate == _type_error_identity()
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     assert halted.state is not None
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
@@ -43,6 +43,7 @@ from sugar_lift_py_tests.sugar.unpack_projection_targets import (
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import FunctionDef
 from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 
 
 def _tree(source: str, name: str = "star_store.py") -> SourceFile:
@@ -403,7 +404,7 @@ def test_arity_valueerror_wrong_occurrence_is_not_truthful() -> None:
     truthful = _arity_mismatch_effect(sugar.desugar(None))
     foreign = replace(
         truthful,
-        occurrence="pytest.raises:foreign-boundary",
+        occurrence=AuthenticatedRaiseLocus.of("pytest.raises:foreign-boundary"),
         producer_node_owner="pytest.raises",
     )
     assert isinstance(foreign, RaiseEffect)

--- a/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
@@ -377,7 +377,8 @@ def test_exact_arity_valueerror_identity() -> None:
         == "DynamicUnpackStoreAssignSugar.arity_mismatch"
     )
     # Operation occurrence cites the unpack site — not a foreign boundary.
-    assert effect.occurrence_id == str(site) or effect.occurrence_id == str(site)
+    assert effect.occurrence == str(site) or effect.occurrence_id == str(site)
+    assert effect.occurrence_id == str(site)
 
 
 def test_arity_valueerror_wrong_occurrence_is_not_truthful() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_state_survival_matrix.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_state_survival_matrix.py
@@ -149,6 +149,10 @@ def _unpack_store_halt() -> tuple[NativeOperationExitCarrierV1, Halted]:
     assert isinstance(halted, Halted)
     assert halted.state is pending.pre_effect_state.state
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     return pending, halted
 
 
@@ -351,8 +355,8 @@ def test_c_assertion_observation_binds_real_occurrence_effect() -> None:
 def test_c_wrong_occurrence_observation_refuses_twin() -> None:
     """Bite: binding must not claim a foreign occurrence / effect object."""
     _, halted = _unpack_store_halt()
-    foreign = RaiseEffect.for_builtin("IndexError",
-        
+    foreign = RaiseEffect(
+        exception_name="IndexError",
         blame="foreign.py:1:0",
         occurrence="foreign.py:1:0",
         exception_type_coordinate=_identity("IndexError"),

--- a/implementations/python/sugar-lift-py-tests/tests/test_state_survival_matrix.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_state_survival_matrix.py
@@ -97,6 +97,7 @@ from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import (
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import Call, FunctionDef
 from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -358,7 +359,7 @@ def test_c_wrong_occurrence_observation_refuses_twin() -> None:
     foreign = RaiseEffect(
         exception_name="IndexError",
         blame="foreign.py:1:0",
-        occurrence="foreign.py:1:0",
+        occurrence=AuthenticatedRaiseLocus.of("foreign.py:1:0"),
         exception_type_coordinate=_identity("IndexError"),
         exception_type_mro=(_identity("IndexError"),),
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_formal_call_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_formal_call_projection.py
@@ -119,6 +119,10 @@ def test_immutable_receiver_reads_but_formal_store_halts_with_named_type() -> No
 
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity("TypeError")
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     assert "'startLine': 2" in halted.effect.occurrence
     assert "assertion" not in halted.effect.occurrence
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_try_native_store_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_try_native_store_carrier.py
@@ -110,6 +110,10 @@ def test_exitset_consumer_observes_authentic_store_occurrence_and_state() -> Non
     halted = next(exit_ for exit_ in retained.exits if isinstance(exit_, Halted))
     assert pending.pre_effect_state is not None
     assert halted.state is pending.pre_effect_state.state
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     assert observed == [(halted.effect, halted.state)]
     foreign = _helper_outcome("\n" + PLAIN_STORE)
     assert isinstance(foreign, NativeOperationExitCarrierV1)

--- a/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
@@ -334,7 +334,19 @@ def test_leaf_occurrence_identities_survive_partition_and_reraise():
     type_errors = [leaf for leaf in leaves if leaf.exception_name == "TypeError"]
     assert len(value_errors) == 2
     assert len(type_errors) == 1
+    assert isinstance(value_errors[0].occurrence, str) and ":" in value_errors[0].occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {value_errors[0].occurrence!r}"
+    )
+    assert isinstance(value_errors[1].occurrence, str) and ":" in value_errors[1].occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {value_errors[1].occurrence!r}"
+    )
     assert value_errors[0].occurrence != value_errors[1].occurrence
+    assert isinstance(type_errors[0].occurrence, str) and ":" in type_errors[0].occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {type_errors[0].occurrence!r}"
+    )
     assert type_errors[0].occurrence != value_errors[0].occurrence
 
 
@@ -510,6 +522,10 @@ def test_grouped_raise_occurrence_is_sealed_coordinate_not_line_col_spelling():
             name="sealed_occ_a.py",
         )
     )
+    assert isinstance(effect.occurrence, str) and ":" in effect.occurrence, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {effect.occurrence!r}"
+    )
     # Sealed coordinate carries blake3 CIDs; fabricated line-col is "file:N:M".
     assert "blake3" in effect.occurrence
     assert effect.occurrence.count(":") >= 4  # file:start:end:source_cid:cid
@@ -570,15 +586,15 @@ def test_second_handler_reads_first_handler_temporal_binding():
     _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
     _te_cls, te_typed, te_id = _synthetic_class("TypeError")
 
-    ve_leaf = RaiseEffect.for_builtin("ValueError",
-        
+    ve_leaf = RaiseEffect(
+        exception_name="ValueError",
         occurrence="leaf:ve",
         exception_type_coordinate=ve_id,
         exception_type_mro=(ve_id,),
         raised_value=ve_typed,
     )
-    te_leaf = RaiseEffect.for_builtin("TypeError",
-        
+    te_leaf = RaiseEffect(
+        exception_name="TypeError",
         occurrence="leaf:te",
         exception_type_coordinate=te_id,
         exception_type_mro=(te_id,),
@@ -627,14 +643,14 @@ def test_second_handler_reads_first_handler_temporal_binding():
             bound = temporal.value_if_bound("x") if temporal is not None else None
             if bound is None:
                 return Incomplete(
-                    RaiseEffect.for_builtin("NameError",
-                        
+                    RaiseEffect(
+                        exception_name="NameError",
                         occurrence="read-x-missing",
                     )
                 )
             return Incomplete(
-                RaiseEffect.for_builtin("RuntimeError",
-                    
+                RaiseEffect(
+                    exception_name="RuntimeError",
                     occurrence="read-x-ok",
                 )
             )
@@ -813,8 +829,8 @@ def test_guarded_handler_faces_conjoin_body_guard():
         unit=SimpleNamespace(source="try-star"),
     )
     _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
-    leaf = RaiseEffect.for_builtin("ValueError",
-        
+    leaf = RaiseEffect(
+        exception_name="ValueError",
         occurrence="leaf:ve",
         exception_type_coordinate=ve_id,
         exception_type_mro=(ve_id,),
@@ -852,8 +868,8 @@ def test_guarded_handler_faces_conjoin_body_guard():
                 (
                     Halted(
                         handler_atom,
-                        RaiseEffect.for_builtin("RuntimeError",
-                            
+                        RaiseEffect(
+                            exception_name="RuntimeError",
                             occurrence="handler:re",
                         ),
                         None,
@@ -917,8 +933,8 @@ def test_alternative_exceptional_faces_keep_separate_guards():
         unit=SimpleNamespace(source="try-star"),
     )
     _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
-    leaf = RaiseEffect.for_builtin("ValueError",
-        
+    leaf = RaiseEffect(
+        exception_name="ValueError",
         occurrence="leaf:ve",
         exception_type_coordinate=ve_id,
         exception_type_mro=(ve_id,),
@@ -945,12 +961,12 @@ def test_alternative_exceptional_faces_keep_separate_guards():
                 (
                     Halted(
                         g1,
-                        RaiseEffect.for_builtin("KeyError", occurrence="a1"),
+                        RaiseEffect(exception_name="KeyError", occurrence="a1"),
                         None,
                     ),
                     Halted(
                         g2,
-                        RaiseEffect.for_builtin("OSError", occurrence="a2"),
+                        RaiseEffect(exception_name="OSError", occurrence="a2"),
                         None,
                     ),
                 )

--- a/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
@@ -28,6 +28,7 @@ from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 
 
 def _desugar(source: str, *, name: str = "trystar_subgroup.py"):
@@ -588,20 +589,20 @@ def test_second_handler_reads_first_handler_temporal_binding():
 
     ve_leaf = RaiseEffect(
         exception_name="ValueError",
-        occurrence="leaf:ve",
+        occurrence=AuthenticatedRaiseLocus.of("leaf:ve"),
         exception_type_coordinate=ve_id,
         exception_type_mro=(ve_id,),
         raised_value=ve_typed,
     )
     te_leaf = RaiseEffect(
         exception_name="TypeError",
-        occurrence="leaf:te",
+        occurrence=AuthenticatedRaiseLocus.of("leaf:te"),
         exception_type_coordinate=te_id,
         exception_type_mro=(te_id,),
         raised_value=te_typed,
     )
     group = GroupedRaiseEffect(
-        "group:root", "g", (ve_leaf, te_leaf), occurrence="group:root"
+        "group:root", "g", (ve_leaf, te_leaf), occurrence=AuthenticatedRaiseLocus.of("group:root")
     )
 
     class Fixed(Sugar):
@@ -645,13 +646,13 @@ def test_second_handler_reads_first_handler_temporal_binding():
                 return Incomplete(
                     RaiseEffect(
                         exception_name="NameError",
-                        occurrence="read-x-missing",
+                        occurrence=AuthenticatedRaiseLocus.of("read-x-missing"),
                     )
                 )
             return Incomplete(
                 RaiseEffect(
                     exception_name="RuntimeError",
-                    occurrence="read-x-ok",
+                    occurrence=AuthenticatedRaiseLocus.of("read-x-ok"),
                 )
             )
 
@@ -831,12 +832,12 @@ def test_guarded_handler_faces_conjoin_body_guard():
     _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
     leaf = RaiseEffect(
         exception_name="ValueError",
-        occurrence="leaf:ve",
+        occurrence=AuthenticatedRaiseLocus.of("leaf:ve"),
         exception_type_coordinate=ve_id,
         exception_type_mro=(ve_id,),
         raised_value=ve_typed,
     )
-    group = GroupedRaiseEffect("group:root", "g", (leaf,), occurrence="group:root")
+    group = GroupedRaiseEffect("group:root", "g", (leaf,), occurrence=AuthenticatedRaiseLocus.of("group:root"))
     body_atom = atomic("body.guard", [str_const("body")])
     handler_atom = atomic("handler.guard", [str_const("handler")])
 
@@ -870,7 +871,7 @@ def test_guarded_handler_faces_conjoin_body_guard():
                         handler_atom,
                         RaiseEffect(
                             exception_name="RuntimeError",
-                            occurrence="handler:re",
+                            occurrence=AuthenticatedRaiseLocus.of("handler:re"),
                         ),
                         None,
                     ),
@@ -935,12 +936,12 @@ def test_alternative_exceptional_faces_keep_separate_guards():
     _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
     leaf = RaiseEffect(
         exception_name="ValueError",
-        occurrence="leaf:ve",
+        occurrence=AuthenticatedRaiseLocus.of("leaf:ve"),
         exception_type_coordinate=ve_id,
         exception_type_mro=(ve_id,),
         raised_value=ve_typed,
     )
-    group = GroupedRaiseEffect("group:root", "g", (leaf,), occurrence="group:root")
+    group = GroupedRaiseEffect("group:root", "g", (leaf,), occurrence=AuthenticatedRaiseLocus.of("group:root"))
     body_atom = atomic("body.guard", [str_const("body")])
     g1 = atomic("alt.one", [str_const("1")])
     g2 = atomic("alt.two", [str_const("2")])
@@ -961,12 +962,12 @@ def test_alternative_exceptional_faces_keep_separate_guards():
                 (
                     Halted(
                         g1,
-                        RaiseEffect(exception_name="KeyError", occurrence="a1"),
+                        RaiseEffect(exception_name="KeyError", occurrence=AuthenticatedRaiseLocus.of("a1")),
                         None,
                     ),
                     Halted(
                         g2,
-                        RaiseEffect(exception_name="OSError", occurrence="a2"),
+                        RaiseEffect(exception_name="OSError", occurrence=AuthenticatedRaiseLocus.of("a2")),
                         None,
                     ),
                 )

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_not_bool_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_not_bool_law.py
@@ -285,9 +285,11 @@ def test_halted_truth_is_not_negated() -> None:
 
         assert isinstance(face.value, RaiseValue)
         assert face.value.effect.exception_name == "TypeError"
+        assert face.value.effect.exception_type_coordinate == _identity('TypeError')
     else:
         assert isinstance(face, Halted)
         assert face.effect.exception_name == "TypeError"
+        assert face.effect.exception_type_coordinate == _identity('TypeError')
 
 
 def test_truthful_exceptional_face_carries_floor_type_not_boundary() -> None:
@@ -345,6 +347,10 @@ def test_formal_not_halt_bypasses_negate_continuation() -> None:
         [str_const("builtins"), str_const("TypeError")],
     )
     # Occurrence is the operation site, not a fabricated boundary locus.
+    assert isinstance(exits.exits[0].effect.occurrence_id, str) and ":" in exits.exits[0].effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {exits.exits[0].effect.occurrence_id!r}"
+    )
 
 
 def test_undecided_actual_stays_named_refusal_on_discharge() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_sequencing_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_sequencing_law.py
@@ -56,6 +56,15 @@ from sugar_source_tree.nodes import Assign
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
+def _identity(name: str):
+    from sugar_lift_py_tests.floor.ground_exit import (
+        _builtin_exception_identity,
+    )
+
+    identity, _mro = _builtin_exception_identity(name)
+    return identity
+
+
 MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
     "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
@@ -350,6 +359,7 @@ def test_list_indexerror_store_halt_originates_in_setitem_not_boundary(
     effect = halted[0].effect
     assert effect.exception_name == "IndexError"
     assert effect.producer_node_owner == "ground_index_error"
+    assert effect.exception_type_coordinate == _identity('IndexError')
     # Type name may match a boundary expectation; origin is the store producer.
     assert "pytest" not in (effect.producer_node_owner or "").lower()
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_setattr_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_setattr_formal_caller.py
@@ -216,6 +216,7 @@ def test_property_without_setter_named_attribute_error_preserves_x_state() -> No
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("AttributeError")
+    assert halted.effect.occurrence_id == str(site)
     # Authentic earlier-binding pre-effect state (post-#6640 / #6644).
     assert halted.state is not None
     assert pending.pre_effect_state.state is halted.state

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_setitem_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_setitem_formal_caller.py
@@ -233,6 +233,10 @@ def test_invalid_index_named_indexerror_no_statement_completion() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     # Authentic earlier-binding halt state (carrier #6640 / enrollment #6644).
     assert halted.state is not None
     assert pending.pre_effect_state.state is halted.state
@@ -250,6 +254,10 @@ def test_source_caller_invalid_index_named_indexerror() -> None:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     # Caller path also preserves pre-effect state on the halt face.
     assert halted.state is not None
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_variadic_setitem_join.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_variadic_setitem_join.py
@@ -209,6 +209,10 @@ def test_variadic_store_halt_preserves_earlier_name_binding_state() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
     assert halted.state is not None
     assert pending.pre_effect_state.state is halted.state
     assert not isinstance(getattr(halted, "value", None), UniverseValue)

--- a/implementations/python/sugar-lift-py-tests/tests/test_while_assert_condition_occurrence_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_while_assert_condition_occurrence_identity.py
@@ -29,6 +29,10 @@ def _halt_occurrence(compare: Compare) -> str:
     assert isinstance(outcome, ExitSet)
     halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
     assert len(halted) == 1
+    assert isinstance(halted[0].effect.occurrence_id, str) and ":" in halted[0].effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted[0].effect.occurrence_id!r}"
+    )
     return halted[0].effect.occurrence_id
 
 

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_manager.py
@@ -266,7 +266,7 @@ def test_returned_manager_pattern_preserves_message_obligation(tmp_path: Path):
         or getattr(binding.effect, "occurrence", None)
         or getattr(binding.effect, "blame", None)
     )
-    assert occurrence is not None
+    assert occurrence == str(binding)
     assert all(_observed_binding(face) is None for face in exits.exits if isinstance(face, Halted))
 
 

--- a/implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py
@@ -16,6 +16,15 @@ from sugar_source_tree.nodes import Attribute, With
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
+def _identity(name: str):
+    from sugar_lift_py_tests.floor.ground_exit import (
+        _builtin_exception_identity,
+    )
+
+    identity, _mro = _builtin_exception_identity(name)
+    return identity
+
+
 PANDAS_MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
     "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
@@ -64,6 +73,11 @@ def test_source_property_getter_publishes_authenticated_exceptional_exit(
     effect = halted[0].effect
     assert isinstance(effect, RaiseEffect)
     assert effect.exception_name == "ValueError"
+    assert effect.exception_type_coordinate == _identity('ValueError')
+    assert isinstance(effect.occurrence_id, str) and ":" in effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {effect.occurrence_id!r}"
+    )
     assert effect.producer_node_owner == "Attribute"
 
 
@@ -89,6 +103,11 @@ def test_property_getter_raise_keeps_imported_bare_exception_coordinate(
     halted = next(face for face in outcome.exits if isinstance(face, Halted))
     assert isinstance(halted.effect, RaiseEffect)
     assert halted.effect.exception_name == "CustomError"
+    assert halted.effect.exception_type_coordinate == _identity('CustomError')
+    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {halted.effect.occurrence_id!r}"
+    )
 
 
 def test_source_property_getter_that_returns_completes_without_a_raise(
@@ -162,4 +181,9 @@ def test_pandas_303_abstract_method_property_is_the_concrete_reproducer() -> Non
     effect = halted.effect
     assert isinstance(effect, RaiseEffect)
     assert effect.exception_name == "AbstractMethodError"
+    assert effect.exception_type_coordinate == _identity('AbstractMethodError')
+    assert isinstance(effect.occurrence_id, str) and ":" in effect.occurrence_id, (
+        "authenticated raise locus must be a file:line:col occurrence id, "
+        f"not presence-only; got {effect.occurrence_id!r}"
+    )
     assert effect.producer_node_owner == "Attribute"

--- a/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
@@ -70,6 +70,15 @@ import pytest
 from sugar_source_tree.panic import SugarNotWritten
 from with_resolution_fixture import source_file_with_preconstruction
 
+def _identity(name: str):
+    from sugar_lift_py_tests.floor.ground_exit import (
+        _builtin_exception_identity,
+    )
+
+    identity, _mro = _builtin_exception_identity(name)
+    return identity
+
+
 
 def _fn(src: str):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
@@ -386,6 +395,7 @@ def test_bare_reraise_preserves_the_same_effect_occurrence():
     # Occurrence is the original raise site (line of ``raise ValueError``),
     # not a reconstructed site at the bare re-raise.
     assert out.effect.occurrence.endswith(":6:8")
+    assert out.effect.exception_type_coordinate == _identity('ValueError')
 
 
 def test_bare_reraise_is_not_a_reconstructed_raise_at_handler_site():

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -240,6 +240,7 @@ def test_bare_reraise_reemits_the_exact_inflight_raise():
     )
     assert isinstance(out, Incomplete)
     assert isinstance(out.effect, RaiseEffect)
+    assert out.effect.exception_type_coordinate == _identity('ValueError')
     assert out.effect.exception_name == "ValueError"
     assert out.effect.occurrence.endswith(":6:8")
 
@@ -529,6 +530,7 @@ def test_finally_raise_supersedes_break_instead_of_fabricating_loop_exit():
     )
     assert isinstance(out, Incomplete)
     assert isinstance(out.effect, RaiseEffect)
+    assert out.effect.exception_type_coordinate == _identity('ArbitraryCleanupFault')
     assert out.effect.exception_name == "ArbitraryCleanupFault"
 
 


### PR DESCRIPTION
## Summary

Drains the unassigned **PRESENCE-ONLY-IDENTITY** class from #6958's self-sealing instrument.

### Live instrument (authority)

```text
# before (this branch base / #6958 report ~96; main remeasure)
R_self_sealing_instruments = 94
R_synthesized_evidence = 1   # law_of_one_auditor self-seed — owned, not this PR
R_presence_only_identity = 93

# after (same instrument, structural remeasure only)
R_self_sealing_instruments = 1
R_synthesized_evidence = 1
R_presence_only_identity = 0
```

### What changed

| Shape | Replacement | Fails when (reachable) |
| --- | --- | --- |
| `assert effect.exception_type_coordinate is not None` | `== _identity("TypeError")` (or KeyError/…) | forged non-None wrong type; None |
| `assert effect.exception_type_mro is not None` | `== _builtin_exception_identity(name)[1]` | wrong MRO / None |
| `assert effect.occurrence_id is not None` | `== str(site)` when site in scope | wrong locus; None |
| same without site | `isinstance(str) and ":" in value` (locus shape) | None, `""`, non-locus placeholder |

### LOUD: tooth that was about to pin FALSE

`test_pandas_subscript_caller_gap.py::test_caller_actuals_can_name_an_exception_at_the_original_subscript` — `ListValue((7,))[1]` is **IndexError** via `ground_index_error`, not TypeError. Heuristic default almost wrote TypeError. Corrected to `_identity("IndexError")`.

### Rung climb

| Ladder | |
| --- | --- |
| Type forbid? | Not yet — optional identity fields remain. |
| One door? | Prefer sealed non-optional coordinates on RaiseEffect next (would retire many teeth). |
| Panic? | N/A for tests. |
| This PR | Deletes decorative **presence-only** shell on 93 sites; #6958 auditor remains until R=0 (synth residual). |

### Shot accounting

| | |
| --- | --- |
| **R axis** | `R_presence_only_identity` (and total `R_self_sealing_instruments`) |
| **Epsilon R** | **−93** presence-only; total self-sealing **94 → 1** |
| **Floors** | production packages untouched; no xfail; SYNTHESIZED-EVIDENCE still red (law_of_one) |
| **Shell deleted** | presence-only `is not None` on identity-bearing attrs (93). Not deleting #6958 auditor until synth=0. |

### Validation

- Instrument remeasure (stdlib AST only, not pytest): EXIT=1, R_presence_only=0, R_synth=1
- Syntax-checked all 50 modified files via `ast.parse`
- **No pytest / no bx** — mr_orange owns consolidated remote remeasure

## Test plan

- [ ] mr_orange consolidated bx remeasure includes self_sealing_instrument_law + affected packages
- [ ] Confirm IndexError pin on pandas subscript gap under remote

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce authenticated file:line:col occurrence IDs across 93 presence-only raise effect test sites
> - Replaces bare string occurrences and `RaiseEffect.for_builtin` factory calls with `AuthenticatedRaiseLocus.of(...)` throughout tests, eliminating "presence-only" identity placeholders.
> - Adds assertions across ~40 test files requiring `occurrence_id` or `occurrence` to be a colon-delimited `file:line:col` string and `exception_type_coordinate` to match the expected builtin identity.
> - Adds a [presence-only-retirement-partition.md](https://github.com/TSavo/sugar/pull/6964/files#diff-e96ef79d7c9f758824198973f0093b05cf4eaf52baaa3d59420650d0ae9a1d38) document cataloguing the 93 retired sites, their categories, and required changes.
> - Behavioral Change: tests that previously accepted any non-None or raw-string occurrence now require a structured authenticated locus; fabricated foreign `RaiseEffect` objects in inequality tests must also carry authenticated loci.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 367ac25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->