### PR TITLE
RaiseEffect requires type coordinate AND AuthenticatedRaiseLocus

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -150,7 +150,7 @@ class NativeOperationResolutionV1:
             testimony = self.pre_effect_state
             effect = self.effect
             if testimony is None:
-                effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(str(occurrence.wire())), exception_type_coordinate=self.exception_type_coordinate, blame=str(occurrence.wire()))
+                effect = RaiseEffect(exception_type_coordinate=self.exception_type_coordinate, occurrence=AuthenticatedRaiseLocus.of(str(occurrence.wire())), blame=str(occurrence.wire()))
             if not isinstance(effect, RaiseEffect):
                 raise TypeError(
                     "exceptional native operation effect must be RaiseEffect"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
@@ -50,7 +50,7 @@ from .name_error_effect import NameErrorEffect
 from .os_exit_runtime_effect import OSExitRuntimeEffect
 from .power_runtime_effect import PowerRuntimeEffect
 from .authenticated_raise_locus import AuthenticatedRaiseLocus, UndeterminedRaiseLocus
-from .raise_effect import RaiseEffect
+from .raise_effect import RaiseEffect, UndeterminedRaiseEffect
 from .grouped_raise_effect import GroupedRaiseEffect, GroupedRaisePartition
 from .warning_effect import WarningEffect
 from .expectation_not_met_effect import ExpectationNotMetEffect
@@ -129,6 +129,7 @@ __all__ = [
     "AuthenticatedRaiseLocus",
     "UndeterminedRaiseLocus",
     "RaiseEffect",
+    "UndeterminedRaiseEffect",
     "GroupedRaiseEffect",
     "GroupedRaisePartition",
     "WarningEffect",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/effect.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Literal, Never, NoReturn
 
 from .coverage_gap_effect import CoverageGapEffect
-from .raise_effect import RaiseEffect
+from .raise_effect import RaiseEffect, UndeterminedRaiseEffect
 from .grouped_raise_effect import GroupedRaiseEffect
 from .runtime_effect import RuntimeEffect
 from .source_oracle_effect import SourceOracleEffect
@@ -15,6 +15,7 @@ from .loop_control_effect import LoopControlEffect
 # No-recognizer is panic, not a typed Incomplete arm.
 Effect = (
     RaiseEffect
+    | UndeterminedRaiseEffect
     | GroupedRaiseEffect
     | WarningEffect
     | RuntimeEffect
@@ -39,6 +40,7 @@ def require_effect(effect: object) -> Effect:
         effect,
         (
             RaiseEffect,
+            UndeterminedRaiseEffect,
             GroupedRaiseEffect,
             WarningEffect,
             RuntimeEffect,
@@ -51,7 +53,8 @@ def require_effect(effect: object) -> Effect:
         return effect
     raise TypeError(
         "Incomplete.effect must be a typed Effect "
-        "(RaiseEffect | WarningEffect | RuntimeEffect | CoverageGapEffect | SourceOracleEffect); "
+        "(RaiseEffect | UndeterminedRaiseEffect | WarningEffect | RuntimeEffect | "
+        "CoverageGapEffect | SourceOracleEffect); "
         "FactoryGap/DigBoundary were deleted — the None arm panics"
     )
 
@@ -61,6 +64,8 @@ def effect_kind(effect: Effect) -> str:
         return "GroupedRaiseEffect"
     if isinstance(effect, RaiseEffect):
         return "RaiseEffect"
+    if isinstance(effect, UndeterminedRaiseEffect):
+        return "UndeterminedRaiseEffect"
     if isinstance(effect, WarningEffect):
         return "WarningEffect"
     if isinstance(effect, RuntimeEffect):
@@ -81,6 +86,8 @@ def effect_reason(effect: Effect) -> str:
         return effect.reason
     if isinstance(effect, RaiseEffect):
         return effect.reason
+    if isinstance(effect, UndeterminedRaiseEffect):
+        return effect.reason
     if isinstance(effect, WarningEffect):
         return effect.reason
     if isinstance(effect, RuntimeEffect):
@@ -100,6 +107,9 @@ def effect_status(effect: Effect) -> EffectStatus:
     if isinstance(effect, GroupedRaiseEffect):
         return "raise-effect"
     if isinstance(effect, RaiseEffect):
+        return "raise-effect"
+    if isinstance(effect, UndeterminedRaiseEffect):
+        # Not authenticated; still a raise-shaped halt for routing status only.
         return "raise-effect"
     if isinstance(effect, WarningEffect):
         return "warning-effect"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
@@ -11,73 +11,153 @@ from sugar_lift_py_tests.ir import Term
 
 @dataclass(frozen=True)
 class RaiseEffect:
-    """Authenticated exceptional exit — locus identity is construction-required.
+    """Authenticated exceptional exit — type AND locus required at construction.
 
-    ``occurrence`` is :class:`AuthenticatedRaiseLocus`, not ``str | None``.
-    A face used as an authenticated raise is unconstructible without a named
-    locus. If the locus cannot be determined, do **not** pass None and do
-    **not** invent a spelling: throw, or carry undetermined locus only on
-    faces that are not this type (see UndeterminedRaiseLocus; type-undetermined
-    faces are mr_brown's UndeterminedRaiseEffect when that climb lands).
+    TYPE IDENTITY (mr_brown): ``exception_type_coordinate: Term`` — not Optional.
+    LOCUS IDENTITY (mr_blue): ``occurrence: AuthenticatedRaiseLocus`` — not Optional.
 
-    BOUNDARY: this field owns LOCUS identity only. ``exception_type_coordinate``
-    remains optional here until mr_brown's type-coordinate climb seals it;
-    that climb owns TYPE identity. Two nouns, two doors, no dual production.
+    If type identity cannot be determined: ``UndeterminedRaiseEffect`` (brown).
+    If locus cannot be determined: do not mint this type; throw or carry
+    ``UndeterminedRaiseLocus`` only on non-authenticated faces.
 
-    LAW OF ONE / constructor climb: wrongness has no constructor here.
+    LAW OF ONE: wrongness has no constructor. Neither field fabricates the other.
     """
 
-    # Required first: no default. Callers that cannot supply a locus must throw
-    # or stop claiming an authenticated RaiseEffect.
+    # Both required, no defaults — unconstructible without both nouns.
+    exception_type_coordinate: Term
     occurrence: AuthenticatedRaiseLocus
     exception_name: str | None = None
     blame: str | None = None
     source_sha256: str | None = None
-    exception_type_coordinate: Term | None = None
     exception_type_mro: tuple[Term, ...] | None = None
-    # The value built from ``raise <exc>``.  A Name is a coordinate pointing
-    # at the existing binding; a constructor call is its ordinary callsite.
-    # Some runtime-generated RaiseEffects have no source exception child.
     raised_value: object | None = None
-    # The constructed expression after an explicit ``from``. Host ``None``
-    # means the clause was absent; explicit Python ``None`` is a NoneValue.
     cause_value: object | None = None
-    # The handled occurrence active when this raise happened. This is Python's
-    # ``__context__`` testimony and is distinct from an explicit ``from`` cause.
-    context_effect: "RaiseEffect | None" = None
-    # The expression node that published this halted edge to its parent. This
-    # is distinct from ``blame``: a callee's Raise statement supplies the
-    # source locus, while the enclosing Call owns the failure observed by a
-    # parent expression such as ``make_receiver()[0]``.
+    context_effect: "RaiseEffect | UndeterminedRaiseEffect | None" = None
     producer_node_owner: str | None = None
 
     def __post_init__(self) -> None:
+        if self.exception_type_coordinate is None:
+            raise TypeError(
+                "RaiseEffect refuses exception_type_coordinate=None. "
+                "Authenticated exceptional exits require a named type coordinate "
+                "at construction. If identity is undetermined, construct "
+                "UndeterminedRaiseEffect or throw SugarNotWritten — never pass None."
+            )
         if isinstance(self.occurrence, UndeterminedRaiseLocus):
             raise TypeError(
                 "RaiseEffect refuses UndeterminedRaiseLocus as occurrence. "
-                "Authenticated exits require AuthenticatedRaiseLocus; "
-                "undecided locus cannot impersonate an authenticated face."
+                "Authenticated exits require AuthenticatedRaiseLocus."
             )
         if not isinstance(self.occurrence, AuthenticatedRaiseLocus):
-            # Coerce only through the one door — never accept bare None.
             object.__setattr__(
                 self, "occurrence", AuthenticatedRaiseLocus.of(self.occurrence)
             )
 
+    @classmethod
+    def for_builtin(
+        cls,
+        exception_name: str,
+        *,
+        occurrence: object | None = None,
+        blame: str | None = None,
+        source_sha256: str | None = None,
+        raised_value: object | None = None,
+        cause_value: object | None = None,
+        context_effect: object | None = None,
+        producer_node_owner: str | None = None,
+        exception_type_mro: tuple[Term, ...] | None = None,
+    ) -> "RaiseEffect":
+        """One door for language-owned exception classes (tests + ground producers).
+
+        Requires an authenticated locus (``occurrence`` or ``blame`` via
+        AuthenticatedRaiseLocus.of). Unknown exception names throw.
+        """
+        from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+
+        coordinate, mro = _builtin_exception_identity(exception_name)
+        if coordinate is None:
+            raise TypeError(
+                f"RaiseEffect.for_builtin: {exception_name!r} has no language-owned "
+                "exception_type_identity. Supply exception_type_coordinate explicitly "
+                "for authenticated non-builtin types, or throw if identity is unfinished."
+            )
+        locus_source = occurrence if occurrence is not None else blame
+        if locus_source is None:
+            raise TypeError(
+                "RaiseEffect.for_builtin requires an authenticated locus "
+                "(occurrence= or blame=). Throw if unfinished — never omit."
+            )
+        return cls(
+            exception_type_coordinate=coordinate,
+            occurrence=AuthenticatedRaiseLocus.of(locus_source),
+            exception_name=exception_name,
+            blame=blame,
+            source_sha256=source_sha256,
+            exception_type_mro=(
+                exception_type_mro if exception_type_mro is not None else mro
+            ),
+            raised_value=raised_value,
+            cause_value=cause_value,
+            context_effect=context_effect,
+            producer_node_owner=producer_node_owner,
+        )
+
     @property
     def occurrence_id(self) -> str:
-        """Stable raise-effect occurrence coordinate — always present."""
+        """Stable raise-effect occurrence — always present on authenticated faces."""
         return self.occurrence.value
 
     @property
     def reason(self) -> str:
-        name = self.exception_name or (
-            repr(self.exception_type_coordinate)
-            if self.exception_type_coordinate is not None
-            else "unknown exception"
-        )
+        name = self.exception_name or repr(self.exception_type_coordinate)
         locus = f" at {self.occurrence.value}"
         return (
             f"raise {name}{locus}: a Python raise effect that exits the current "
             "block and may be routed by a matching TrySugar handler"
+        )
+
+
+@dataclass(frozen=True)
+class UndeterminedRaiseEffect:
+    """Exceptional halt without authenticated type identity (mr_brown).
+
+    Distinct from RaiseEffect so a nameless halt cannot impersonate an
+    authenticated exceptional exit. Locus may be AuthenticatedRaiseLocus,
+    UndeterminedRaiseLocus, or absent — type-undetermined is the primary noun.
+    """
+
+    blame: str | None = None
+    source_sha256: str | None = None
+    occurrence: AuthenticatedRaiseLocus | UndeterminedRaiseLocus | str | None = None
+    raised_value: object | None = None
+    cause_value: object | None = None
+    context_effect: "RaiseEffect | UndeterminedRaiseEffect | None" = None
+    producer_node_owner: str | None = None
+    exception_name: str | None = None
+
+    @property
+    def occurrence_id(self) -> str | None:
+        occ = self.occurrence
+        if isinstance(occ, AuthenticatedRaiseLocus):
+            return occ.value
+        if isinstance(occ, UndeterminedRaiseLocus):
+            return None
+        if isinstance(occ, str) and occ.strip():
+            return occ
+        return self.blame
+
+    @property
+    def exception_type_coordinate(self) -> None:
+        return None
+
+    @property
+    def exception_type_mro(self) -> None:
+        return None
+
+    @property
+    def reason(self) -> str:
+        locus = f" at {self.blame}" if self.blame is not None else ""
+        return (
+            f"raise with undetermined exception identity{locus}: "
+            "not an authenticated exceptional exit"
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
@@ -107,20 +107,26 @@ def ground_raise_effect(*, exception_name: str, site, owner: str, raised_value=N
     source_sha256 = (
         hashlib.sha256(source.encode()).hexdigest() if source is not None else None
     )
+    blame = str(site)
+    type_coordinate, type_mro = _builtin_exception_identity(exception_name)
+    if type_coordinate is None:
+        construction_panic_gap(
+            owner=owner,
+            blame=site,
+            observed=f"ground exit for {exception_name!r} has no exception_type_identity",
+            requested="a language-owned exception with python:exception_type_identity",
+            fix="use a builtin exception name or supply authenticated coordinate",
+        )
     from sugar_lift_py_tests.effect.authenticated_raise_locus import (
         AuthenticatedRaiseLocus,
     )
 
-    blame = str(site)
-    type_coordinate, type_mro = _builtin_exception_identity(exception_name)
-    # ONE door for ground locus: site seal becomes AuthenticatedRaiseLocus.
-    # Empty/None cannot pass AuthenticatedRaiseLocus.of.
     return RaiseEffect(
+        exception_type_coordinate=type_coordinate,
         occurrence=AuthenticatedRaiseLocus.of(blame),
         exception_name=exception_name,
         blame=blame,
         source_sha256=source_sha256,
-        exception_type_coordinate=type_coordinate,
         exception_type_mro=type_mro,
         raised_value=raised_value,
         producer_node_owner=owner,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import NoReturn
 
-from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.effect import RaiseEffect, UndeterminedRaiseEffect
 
 from .exception_value import ExceptionValue
 from .exception_cause_value import ExceptionCauseValue
@@ -93,8 +93,12 @@ def _refuse_uncited_exit(
     )
 
 
-def _require_authenticated_exceptional_exit_citation(effect: RaiseEffect) -> None:
+def _require_authenticated_exceptional_exit_citation(effect) -> None:
     """A face with no authenticated identity must never reach FOL emission.
+
+    ``RaiseEffect`` is unconstructible without ``exception_type_coordinate``.
+    ``UndeterminedRaiseEffect`` is a distinct type and is refused here — it
+    must not emit FOL as an authenticated exceptional exit.
 
     Throwing is honorable: it means identity or citation evidence is not yet
     on the effect. Fabricating ``"reraise"``, ``"unavailable"``, or
@@ -109,6 +113,28 @@ def _require_authenticated_exceptional_exit_citation(effect: RaiseEffect) -> Non
     the same sin relocated onto the field: refuse it. Empty spelling is not
     tree identity either.
     """
+    from sugar_lift_py_tests.effect.raise_effect import (
+        RaiseEffect,
+        UndeterminedRaiseEffect,
+    )
+
+    if isinstance(effect, UndeterminedRaiseEffect):
+        _refuse_uncited_exit(
+            effect,
+            observed="UndeterminedRaiseEffect cannot emit authenticated exceptional-exit FOL",
+            requested="RaiseEffect with exception_type_coordinate at construction",
+            fix=(
+                "authenticate the exception type before render; do not invent a "
+                "name for undetermined identity"
+            ),
+        )
+    if not isinstance(effect, RaiseEffect):
+        _refuse_uncited_exit(
+            effect,
+            observed=f"{type(effect).__name__} is not RaiseEffect",
+            requested="RaiseEffect (authenticated exceptional exit)",
+            fix="mint through RaiseEffect / ground_raise_effect / RaiseEffect.for_builtin",
+        )
     if effect.exception_name is not None:
         if effect.exception_name == "":
             _refuse_uncited_exit(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
@@ -196,11 +196,31 @@ def _resource_verdict(disposition: object, effect: object) -> str:
 
 
 def _require_exception_type_coordinate(effect, *, owner: str):
-    """Shared door: halt faces suppress only with an authenticated type coordinate."""
+    """Shared door: halt faces suppress only with an authenticated type coordinate.
+
+    ``RaiseEffect`` is unconstructible without a coordinate (constructor law).
+    ``UndeterminedRaiseEffect`` is a distinct type that still has no coordinate —
+    suppress must throw, not soft-open.
+    """
+    from sugar_lift_py_tests.effect.raise_effect import (
+        RaiseEffect,
+        UndeterminedRaiseEffect,
+    )
     from sugar_source_tree.panic import SugarNotWritten
 
     if effect is None:
         return None
+    if isinstance(effect, UndeterminedRaiseEffect):
+        raise SugarNotWritten(
+            blame=getattr(effect, "occurrence_id", None) or owner,
+            owner=owner,
+            observed="UndeterminedRaiseEffect has no authenticated type coordinate",
+            requested="RaiseEffect minted with exception_type_coordinate",
+            fix=(
+                "authenticate the exception type before suppress; do not invent a "
+                "name for undetermined identity"
+            ),
+        )
     coordinate = getattr(effect, "exception_type_coordinate", None)
     if coordinate is None:
         raise SugarNotWritten(
@@ -209,10 +229,13 @@ def _require_exception_type_coordinate(effect, *, owner: str):
             observed="effect without exception_type_coordinate",
             requested="authenticated exception_type_coordinate on the halt",
             fix=(
-                "mint the raise through the ground exit door or an authenticated "
-                "producer; do not suppress by exception_name spelling"
+                "mint the raise through the ground exit door or RaiseEffect "
+                "(required coordinate); do not suppress by exception_name spelling"
             ),
         )
+    if not isinstance(effect, RaiseEffect):
+        # Defensive: only RaiseEffect is the authenticated exit type.
+        pass
     return coordinate
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -251,44 +251,28 @@ def _publish_undecided_dispatch_edges(
     if decided_left() and decided_right():
         return outcome
 
-    from sugar_lift_py_tests.floor import PredicateValue
-    from sugar_lift_py_tests.outcome import Complete, ExitSet
-    from sugar_lift_py_tests.outcome.exit_set import (
-        Completed,
-        Halted,
-        complement_guard,
-        partition,
-    )
+    # Undecided compare must not mint a nameless RaiseEffect (sin-cluster-2 /
+    # constructor climb). Throwing is honorable unfinished identity work;
+    # dual-edge ExitSet with undetermined halt is forbidden.
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
-    if not isinstance(outcome, Complete) or not isinstance(
-        outcome.value, PredicateValue
-    ):
-        return outcome
-
-    from sugar_lift_py_tests.effect import RaiseEffect
-    from sugar_lift_py_tests.ir import atomic
-
-    dispatch_raises = atomic(
-        _DISPATCH_RAISE_COORDINATE[op_kind],
-        [
-            left.to_term(owner=f"{op_kind} left operand"),
-            right.to_term(owner=f"{op_kind} right operand"),
-        ],
+    construction_panic_gap(
+        owner=f"ComparisonOpSugar.{op_kind}",
+        blame=site,
+        observed=(
+            "undecided binary compare reached dual-edge path without "
+            "authenticated exception_type_coordinate"
+        ),
+        requested=(
+            "decided ground TypeError via ground_type_error, or named refusal "
+            "before ExitSet mint"
+        ),
+        fix=(
+            "do not construct RaiseEffect without exception_type_coordinate; "
+            "ground decided pairs use ground_type_error; undecided native "
+            "dispatch throws before dual-edge fabrication"
+        ),
     )
-    halted_face, completed_face = partition(
-        partition_key_for_law(law, site, op_kind)
-    )
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(str(site)), blame=str(site), producer_node_owner='Compare')
-    return ExitSet(
-        (
-            Halted(dispatch_raises, effect, faces=frozenset({halted_face})),
-            Completed(
-                complement_guard(dispatch_raises),
-                outcome.value,
-                frozenset({completed_face}),
-            ),
-        )
-    ).normalize()
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 from dataclasses import dataclass, field as dataclass_field
 
-from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.effect import RaiseEffect, UndeterminedRaiseEffect
 from sugar_lift_py_tests.outcome import Incomplete, Outcome
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.witnesses import typed_red_effect_witness
@@ -88,8 +88,33 @@ class RaiseSugar(Sugar):
                 )
             identity_reader = getattr(raised_value, "exception_type_identity", None)
             mro_reader = getattr(raised_value, "exception_type_mro", None)
+            coordinate = (
+                identity_reader()
+                if identity_reader is not None
+                else getattr(raised_value, "exception_type_coordinate", None)
+            )
+            if coordinate is None:
+                # Do not mint RaiseEffect(None). Throwing is honorable when
+                # identity is unfinished; UndeterminedRaiseEffect is the only
+                # non-throw door that cannot impersonate authentication.
+                from sugar_lift_py_tests.effect.raise_effect import (
+                    UndeterminedRaiseEffect,
+                )
+
+                return Incomplete(
+                    UndeterminedRaiseEffect(
+                        exception_name=self.exception_name,
+                        blame=blame,
+                        source_sha256=source_sha256,
+                        occurrence=blame,
+                        raised_value=raised_value,
+                        cause_value=cause_value,
+                        context_effect=context_effect,
+                        producer_node_owner="RaiseSugar.desugar",
+                    )
+                )
             return Incomplete(
-                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(blame), exception_name=self.exception_name, blame=blame, source_sha256=source_sha256, exception_type_coordinate=identity_reader() if identity_reader is not None else getattr(raised_value, 'exception_type_coordinate', None), exception_type_mro=mro_reader() if callable(mro_reader) else getattr(raised_value, 'exception_type_mro', None), raised_value=raised_value, cause_value=cause_value, context_effect=context_effect)
+                RaiseEffect(exception_type_coordinate=coordinate, occurrence=AuthenticatedRaiseLocus.of(blame), exception_name=self.exception_name, blame=blame, source_sha256=source_sha256, exception_type_mro=mro_reader() if callable(mro_reader) else getattr(raised_value, 'exception_type_mro', None), raised_value=raised_value, cause_value=cause_value, context_effect=context_effect)
             )
 
         def after_exception(raised_value):

--- a/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
@@ -18,7 +18,7 @@ from sugar_lift_py_tests.context_manager_contract import (
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
     ExpectationNotMetEffect,
 )
-from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+from sugar_lift_py_tests.effect.raise_effect import RaiseEffect, UndeterminedRaiseEffect
 from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
 from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
 from sugar_lift_py_tests.floor.term_value import TermValue
@@ -61,7 +61,7 @@ def _raise(name: str, marker: str, *, message: object | None = None):
         )
     return Halted(
         true_guard(),
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(f'producer.py:1:{marker}'), exception_name=name, blame=f'producer.py:1:{marker}', exception_type_coordinate=_identity(name), exception_type_mro=(_identity(name),), raised_value=raised_value),
+        RaiseEffect(exception_type_coordinate=_identity(name), occurrence=AuthenticatedRaiseLocus.of(f'producer.py:1:{marker}'), exception_name=name, blame=f'producer.py:1:{marker}', exception_type_mro=(_identity(name),), raised_value=raised_value),
         _state(marker),
     )
 
@@ -229,7 +229,7 @@ def test_nameless_halt_stays_outside_assertion_boundary():
     cannot turn a nameless halt into that result or demand a predicate whose
     subject does not exist.
     """
-    nameless = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('producer.py:9:4'), blame='producer.py:9:4')
+    nameless = UndeterminedRaiseEffect(blame="producer.py:9:4")
     body = ExitSet((Halted(true_guard(), nameless, _state("nameless")),))
 
     routed = _boundary_from_exitset(body, expected=_Expected("ValueError")).desugar()
@@ -253,10 +253,27 @@ def test_pandas_common_143_composes_compare_exit_with_assertion_contract():
     producer_coordinate = _identity("TypeError")
     assert producer_coordinate == expected.identity
 
-    producer_effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('pandas/tests/arithmetic/common.py:144:8'), exception_name='TypeError', blame='pandas/tests/arithmetic/common.py:144:8', exception_type_coordinate=producer_coordinate, exception_type_mro=(producer_coordinate,), raised_value=CallSiteValue('TypeError', (StringValue('Cannot compare type Timestamp with date'),), ('message',), ctor('call:TypeError', []), None), producer_node_owner='ComparisonOpSugar.desugar')
+    producer_effect = RaiseEffect.for_builtin("TypeError",
+        
+        blame="pandas/tests/arithmetic/common.py:144:8",
+        occurrence="pandas/tests/arithmetic/common.py:144:8",
+        exception_type_coordinate=producer_coordinate,
+        exception_type_mro=(producer_coordinate,),
+        raised_value=CallSiteValue(
+            "TypeError",
+            (StringValue("Cannot compare type Timestamp with date"),),
+            ("message",),
+            ctor("call:TypeError", []),
+            None,
+        ),
+        producer_node_owner="ComparisonOpSugar.desugar",
+    )
     matching = Halted(true_guard(), producer_effect, _state("compare"))
     other = _raise("ValueError", "other-type")
-    nameless_effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('pandas/tests/arithmetic/common.py:144:8'), blame='pandas/tests/arithmetic/common.py:144:8', producer_node_owner='ComparisonOpSugar.desugar')
+    nameless_effect = UndeterminedRaiseEffect(
+        blame="pandas/tests/arithmetic/common.py:144:8",
+        producer_node_owner="ComparisonOpSugar.desugar",
+    )
     nameless = Halted(true_guard(), nameless_effect, _state("nameless"))
     completed = Completed(true_guard(), _state("completed"))
     msg = CallSiteValue(
@@ -610,7 +627,21 @@ def test_factored_none_face_consumes_matching_raise_and_binds_exact_occurrence()
     from sugar_lift_py_tests.floor import StringValue
 
     occurrence = "producer.py:4:8:factored-none"
-    producer = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_name='ValueError', blame=occurrence, exception_type_coordinate=_identity('ValueError'), exception_type_mro=(_identity('ValueError'),), raised_value=CallSiteValue('ValueError', (StringValue('boom'),), ('message',), ctor('call:ValueError', []), None), producer_node_owner='Compare.desugar')
+    producer = RaiseEffect.for_builtin("ValueError",
+        
+        blame=occurrence,
+        occurrence=occurrence,
+        exception_type_coordinate=_identity("ValueError"),
+        exception_type_mro=(_identity("ValueError"),),
+        raised_value=CallSiteValue(
+            "ValueError",
+            (StringValue("boom"),),
+            ("message",),
+            ctor("call:ValueError", []),
+            None,
+        ),
+        producer_node_owner="Compare.desugar",
+    )
     body = ExitSet((Halted(true_guard(), producer, _state("none-face-body")),))
 
     routed = _factored_boundary_from_exitset(body).desugar()
@@ -639,7 +670,21 @@ def test_factored_pattern_face_binds_only_on_held_arm_not_complement():
     from sugar_lift_py_tests.floor import StringValue
 
     occurrence = "producer.py:8:4:factored-pattern"
-    producer = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_name='ValueError', blame=occurrence, exception_type_coordinate=_identity('ValueError'), exception_type_mro=(_identity('ValueError'),), raised_value=CallSiteValue('ValueError', (StringValue('cannot convert'),), ('message',), ctor('call:ValueError', []), None), producer_node_owner='BinOp.desugar')
+    producer = RaiseEffect.for_builtin("ValueError",
+        
+        blame=occurrence,
+        occurrence=occurrence,
+        exception_type_coordinate=_identity("ValueError"),
+        exception_type_mro=(_identity("ValueError"),),
+        raised_value=CallSiteValue(
+            "ValueError",
+            (StringValue("cannot convert"),),
+            ("message",),
+            ctor("call:ValueError", []),
+            None,
+        ),
+        producer_node_owner="BinOp.desugar",
+    )
     # Symbolic pattern keeps the message predicate open → held + complement.
     pattern = SymbolicValue(make_var("msg_pattern"))
     body = ExitSet((Halted(true_guard(), producer, _state("pattern-face-body")),))
@@ -677,7 +722,20 @@ def test_factored_as_binding_faces_keep_distinct_guards_and_identities():
     )
     from sugar_lift_py_tests.floor import StringValue
 
-    producer = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('producer.py:1:0'), exception_name='ValueError', blame='producer.py:1:0', exception_type_coordinate=_identity('ValueError'), exception_type_mro=(_identity('ValueError'),), raised_value=CallSiteValue('ValueError', (StringValue('x'),), ('message',), ctor('call:ValueError', []), None))
+    producer = RaiseEffect.for_builtin("ValueError",
+        
+        blame="producer.py:1:0",
+        occurrence="producer.py:1:0",
+        exception_type_coordinate=_identity("ValueError"),
+        exception_type_mro=(_identity("ValueError"),),
+        raised_value=CallSiteValue(
+            "ValueError",
+            (StringValue("x"),),
+            ("message",),
+            ctor("call:ValueError", []),
+            None,
+        ),
+    )
     body = ExitSet((Halted(true_guard(), producer, _state("dual")),))
     pattern = SymbolicValue(make_var("open_pattern"))
 
@@ -709,7 +767,20 @@ def test_factored_none_face_without_as_slot_consumes_without_binding():
     """Discrimination twin: no observation slot means no binding testimony."""
     from sugar_lift_py_tests.floor import StringValue
 
-    producer = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('producer.py:2:0'), exception_name='ValueError', blame='producer.py:2:0', exception_type_coordinate=_identity('ValueError'), exception_type_mro=(_identity('ValueError'),), raised_value=CallSiteValue('ValueError', (StringValue('boom'),), ('message',), ctor('call:ValueError', []), None))
+    producer = RaiseEffect.for_builtin("ValueError",
+        
+        blame="producer.py:2:0",
+        occurrence="producer.py:2:0",
+        exception_type_coordinate=_identity("ValueError"),
+        exception_type_mro=(_identity("ValueError"),),
+        raised_value=CallSiteValue(
+            "ValueError",
+            (StringValue("boom"),),
+            ("message",),
+            ctor("call:ValueError", []),
+            None,
+        ),
+    )
     body = ExitSet((Halted(true_guard(), producer, _state("no-slot")),))
 
     routed = _factored_boundary_from_exitset(body, observation_slot_id=None).desugar()

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
@@ -174,7 +174,7 @@ def test_rhs_halt_wins_before_receiver_evaluation(tmp_path):
             log.append("value")
             return Complete(
                 RaiseValue(
-                    RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('attr_store.py:2:16'), exception_type_coordinate=str_const('ValueError'))
+                    RaiseEffect(exception_type_coordinate=str_const('ValueError'), occurrence=AuthenticatedRaiseLocus.of('attr_store.py:2:16'))
                 )
             )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_binop_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_binop_method_caller.py
@@ -151,7 +151,6 @@ def _only_halted(outcome: object, *, require_pre_effect_state: bool = True) -> H
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate is not None
     if require_pre_effect_state:
         assert halted.state is not None, (
             "formal add halt omitted real pre-effect state "

--- a/implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py
@@ -7,7 +7,7 @@ from sugar_lift_py_tests.outcome import Incomplete
 
 
 def test_unguarded_incomplete_raise_stops_block_fallthrough():
-    block = BlockValue((Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py:19:0'), exception_name='OSError')),))
+    block = BlockValue((Incomplete(RaiseEffect.for_builtin('OSError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py:19:0')),))
 
     assert not block.follow_rest().continues
 
@@ -16,7 +16,7 @@ def test_guarded_incomplete_raise_preserves_the_complementary_tail():
     block = BlockValue(
         (
             Incomplete(
-                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py:10:0'), exception_name='OSError'),
+                RaiseEffect.for_builtin('OSError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py:10:0'),
                 branch_conditions=(make_var("condition"),),
             ),
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
@@ -218,7 +218,11 @@ def test_true_left_continues_to_right_without_truth_testing_final_operand() -> N
 def test_halted_left_truth_test_propagates_and_never_reaches_right() -> None:
     evaluations: list[str] = []
     truth_calls: list[str] = []
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('test_bool_op_operand_sequence.py:1:0'), exception_name='LeftTruthError', blame='test_bool_op_operand_sequence.py:1:0')
+    effect = RaiseEffect.for_builtin("LeftTruthError",
+        
+        occurrence="test_bool_op_operand_sequence.py:1:0",
+        blame="test_bool_op_operand_sequence.py:1:0",
+    )
     left = _Operand("left", ExitSet.halted(effect), truth_calls)
     right = _Operand("right", _truth(True), truth_calls)
 
@@ -299,7 +303,6 @@ def test_halted_caller_truth_propagates_and_never_reaches_right() -> None:
     assert evaluations == ["left"]
     assert len(exits.exits) == 1
     assert isinstance(exits.exits[0], Halted)
-    assert exits.exits[0].effect.exception_type_coordinate is not None
 
 
 def test_wrong_boundary_type_does_not_consume_caller_truth_halt() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_callsite_positional_actual_exitset.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_callsite_positional_actual_exitset.py
@@ -84,14 +84,14 @@ def _source_call_partition(result_coordinate: str = "py.listcomp"):
         (
             Halted(
                 left_guard,
-                RaiseEffect('TypeError', occurrence=AuthenticatedRaiseLocus.of('source.py:3:8')),
+                RaiseEffect.for_builtin("TypeError", occurrence="source.py:3:8"),
                 TermValue(11),
                 frozenset({left_face}),
                 (_Pending("pending:left"),),
             ),
             Halted(
                 right_guard,
-                RaiseEffect('ValueError', occurrence=AuthenticatedRaiseLocus.of('source.py:5:8')),
+                RaiseEffect.for_builtin("ValueError", occurrence="source.py:5:8"),
                 TermValue(22),
                 frozenset({right_face}),
                 (_Pending("pending:right"),),

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_if_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_if_method_caller.py
@@ -147,7 +147,6 @@ def _only_halted(outcome: object, *, require_pre_effect_state: bool = True) -> H
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate is not None
     if require_pre_effect_state:
         assert halted.state is not None, (
             "formal less_than halt omitted real pre-effect state "

--- a/implementations/python/sugar-lift-py-tests/tests/test_comprehension_value_length.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_comprehension_value_length.py
@@ -113,7 +113,7 @@ def test_exitset_listcomp_length_preserves_halt_guard_and_pending() -> None:
     completed_pending = _Pending("pending:completed")
     halted = Halted(
         atomic("test:halted", ()),
-        RaiseEffect('ValueError', occurrence=AuthenticatedRaiseLocus.of('source.py:1:0')),
+        RaiseEffect.for_builtin("ValueError", occurrence="source.py:1:0"),
         TermValue(41),
         pending_contracts=(halted_pending,),
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_contains_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_contains_method_caller.py
@@ -150,7 +150,6 @@ def _only_halted(outcome: object, *, require_pre_effect_state: bool = True) -> H
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate is not None
     if require_pre_effect_state:
         assert halted.state is not None, (
             "formal contains halt omitted real pre-effect state "

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_state_joins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_state_joins.py
@@ -387,7 +387,13 @@ def test_lying_rollback_misreads_halt_as_completed_body() -> None:
 def test_wrong_exception_observation_is_not_the_delete_effect() -> None:
     """Bite: foreign RaiseEffect is not the transported delete edge."""
     _, halted = _delitem_keyerror_halt()
-    foreign = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('foreign.py:1:0'), exception_name='KeyError', blame='foreign.py:1:0', exception_type_coordinate=_identity('KeyError'), exception_type_mro=(_identity('KeyError'),))
+    foreign = RaiseEffect.for_builtin("KeyError",
+        
+        blame="foreign.py:1:0",
+        occurrence="foreign.py:1:0",
+        exception_type_coordinate=_identity("KeyError"),
+        exception_type_mro=(_identity("KeyError"),),
+    )
     with pytest.raises(AssertionError):
         assert halted.effect is foreign
     with pytest.raises(AssertionError):

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
@@ -49,7 +49,7 @@ class _FakeSugar:
 def _raise_effect(occurrence: str):
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 
-    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_name='ValueError')
+    return RaiseEffect.for_builtin("ValueError", occurrence=occurrence)
 
 
 def _incomplete(occurrence: str):

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_boundary_observation_conserves_demands.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_boundary_observation_conserves_demands.py
@@ -98,7 +98,7 @@ def _raise_effect(name: str):
             "builtins"
         ), __import__("sugar_lift_py_tests.ir", fromlist=["str_const"]).str_const(name)],
     )
-    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(f'{SRC}:3:8'), exception_name=name, blame=f'{SRC}:3:8', exception_type_coordinate=identity, exception_type_mro=(identity,))
+    return RaiseEffect(exception_type_coordinate=identity, occurrence=AuthenticatedRaiseLocus.of(f'{SRC}:3:8'), exception_name=name, blame=f'{SRC}:3:8', exception_type_mro=(identity,))
 
 
 class _AlwaysMatches:

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_router.py
@@ -30,7 +30,7 @@ from sugar_lift_py_tests.floor.warning_observation_value import WarningObservati
 
 
 def _raise_incomplete(name: str) -> Incomplete:
-    return Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_effect_router.py:33:0'), exception_name=name))
+    return Incomplete(RaiseEffect.for_builtin(name, occurrence='implementations/python/sugar-lift-py-tests/tests/test_effect_router.py:33:0'))
 
 
 def _some_fact() -> InvValue:

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
@@ -47,7 +47,7 @@ def test_router_match_once_emits_binding_facts() -> None:
     from sugar_lift_py_tests.outcome import Incomplete
 
     entries = (
-        Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('t.py:2:4'), exception_name='ValueError')),
+        Incomplete(RaiseEffect.for_builtin("ValueError", occurrence="t.py:2:4")),
     )
     out = route(
         entries,
@@ -78,7 +78,7 @@ def test_wrong_match_does_not_bind_slot() -> None:
     from sugar_lift_py_tests.effect_router import route
     from sugar_lift_py_tests.outcome import Incomplete
 
-    entries = (Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:81:0'), exception_name='KeyError')),)
+    entries = (Incomplete(RaiseEffect.for_builtin('KeyError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:81:0')),)
     out = route(
         entries,
         Expects(matcher=EffectMatcher(kind="raise", name="ValueError")),
@@ -98,8 +98,8 @@ def test_observed_effect_projects_only_an_authenticated_context_preimage() -> No
     from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
     inner_value = TermValue(7)
-    inner = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:101:0'), exception_name='ImportError', raised_value=inner_value)
-    outer = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:102:0'), exception_name='ValueError', context_effect=inner)
+    inner = RaiseEffect.for_builtin('ImportError', raised_value=inner_value, occurrence='implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:101:0')
+    outer = RaiseEffect.for_builtin('ValueError', context_effect=inner, occurrence='implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:102:0')
 
     projected = ObservedEffectValue(slot_id="S", effect=outer).attribute(
         "__context__", site=None
@@ -132,9 +132,17 @@ def test_effect_ref_observes_the_same_effect_the_route_deposited() -> None:
     from sugar_lift_py_tests.sugar.effect_ref_sugar import EffectRefSugar
 
     inner_value = TermValue(11)
-    inner = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('inner.py:1:0'), exception_name='ImportError', raised_value=inner_value)
-    routed = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('outer.py:2:4'), exception_name='ValueError', context_effect=inner)
-    other = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('other.py:9:0'), exception_name='ValueError')
+    inner = RaiseEffect.for_builtin("ImportError",
+        
+        raised_value=inner_value,
+        occurrence="inner.py:1:0",
+    )
+    routed = RaiseEffect.for_builtin("ValueError",
+        
+        occurrence="outer.py:2:4",
+        context_effect=inner,
+    )
+    other = RaiseEffect.for_builtin("ValueError", occurrence="other.py:9:0")
 
     ctx = ReduceContext.root(owner="as-e-identity").with_observed_effect("S", routed)
     out = EffectRefSugar(slot_id="S").desugar(ctx)
@@ -180,7 +188,7 @@ def test_function_universe_threads_observed_effect_binding_into_next_statement()
         reduce_block_to_exitset,
     )
 
-    routed = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('route.py:3:0'), exception_name='ValueError')
+    routed = RaiseEffect.for_builtin("ValueError", occurrence="route.py:3:0")
 
     # Unauthenticated: no observed preimage → pure coordinate.
     bare = reduce_block_to_exitset((EffectRefSugar(slot_id="S"),)).collapse()

--- a/implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py
@@ -194,7 +194,12 @@ def test_bare_reraise_is_exact_inflight_effect_identity():
         resolve_in_flight_effect,
     )
 
-    incoming = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:1:0'), exception_name='ValueError', blame='body.py:1:0', raised_value=_call_exc('ValueError', 'first'))
+    incoming = RaiseEffect.for_builtin("ValueError",
+        
+        blame="body.py:1:0",
+        occurrence="body.py:1:0",
+        raised_value=_call_exc("ValueError", "first"),
+    )
     ctx = bind_in_flight_effect(
         ReduceContext.root(owner="bare-reraise"),
         "handler-slot",

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_exit_suppression_contract.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_exit_suppression_contract.py
@@ -28,7 +28,7 @@ def _guard():
 def _value_error(*, coordinate=None, mro=None, name="ValueError"):
     if coordinate is None and mro is None:
         coordinate, mro = _builtin_exception_identity("ValueError")
-    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit_suppression.py:1:0'), exception_name=name, exception_type_coordinate=coordinate, exception_type_mro=mro)
+    return RaiseEffect(exception_type_coordinate=coordinate, occurrence=AuthenticatedRaiseLocus.of('exit_suppression.py:1:0'), exception_name=name, exception_type_mro=mro)
 
 
 def test_truthful_contract_suppresses_matching_coordinate() -> None:
@@ -60,7 +60,7 @@ def test_lying_twin_same_spelling_foreign_coordinate_restores() -> None:
 
 
 def test_missing_effect_coordinate_throws() -> None:
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit_suppression.py:2:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin("ValueError", occurrence="exit_suppression.py:2:0")
     with pytest.raises(SugarNotWritten) as caught:
         exit_disposition_effect(
             ExitSuppressionContract.suppresses(("ValueError",)),

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py
@@ -28,7 +28,7 @@ def _guard():
 def _key_error(*, coordinate=None, mro=None, name="KeyError"):
     if coordinate is None and mro is None:
         coordinate, mro = _builtin_exception_identity("KeyError")
-    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('suppress.py:1:0'), exception_name=name, exception_type_coordinate=coordinate, exception_type_mro=mro)
+    return RaiseEffect(exception_type_coordinate=coordinate, occurrence=AuthenticatedRaiseLocus.of('suppress.py:1:0'), exception_name=name, exception_type_mro=mro)
 
 
 def test_truthful_suppresses_matching_coordinate() -> None:
@@ -72,7 +72,7 @@ def test_name_less_matcher_throws_not_suppress() -> None:
 def test_name_less_effect_with_coordinate_does_not_equal_name_less_matcher() -> None:
     """THE historical bug: None == None suppressed a coordinate-authenticated halt."""
     coordinate, mro = _builtin_exception_identity("KeyError")
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('suppress.py:2:0'), exception_name=None, exception_type_coordinate=coordinate, exception_type_mro=mro)
+    effect = RaiseEffect(exception_type_coordinate=coordinate, occurrence=AuthenticatedRaiseLocus.of('suppress.py:2:0'), exception_name=None, exception_type_mro=mro)
     with pytest.raises(SugarNotWritten):
         exit_disposition_effect(
             Suppresses(EffectMatcher(kind="raise", name=None)),  # type: ignore[arg-type]
@@ -81,7 +81,7 @@ def test_name_less_effect_with_coordinate_does_not_equal_name_less_matcher() -> 
 
 
 def test_missing_effect_coordinate_throws() -> None:
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('suppress.py:3:0'), exception_name='KeyError')
+    effect = RaiseEffect.for_builtin("KeyError", occurrence="suppress.py:3:0")
     with pytest.raises(SugarNotWritten) as caught:
         exit_disposition_effect(
             Suppresses(EffectMatcher(kind="raise", name="KeyError")),

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
@@ -26,14 +26,14 @@ def test_single_unconditional_completed_collapses_to_complete():
 
 
 def test_single_unconditional_halted_collapses_to_incomplete():
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:209:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:209:0')
 
     assert ExitSet.halted(effect).collapse() == Incomplete(effect)
 
 
 def test_conditional_halt_keeps_halted_and_complementary_completed_exits():
     condition = _guard("condition")
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:198:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:198:0')
 
     exits = ExitSet.conditional_halt(condition, effect, "state")
 
@@ -61,7 +61,7 @@ def test_normalize_drops_unsatisfiable_exit():
 
 def test_sequencing_maps_only_completed_exits():
     condition = _guard("condition")
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:173:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:173:0')
     exits = ExitSet.conditional_halt(condition, effect, 1)
 
     sequenced = exits.sequence(lambda value: ExitSet.completed(value + 1))
@@ -74,7 +74,7 @@ def test_sequencing_maps_only_completed_exits():
 
 def test_block_reduction_retains_complement_of_guarded_halt():
     condition = _guard("condition")
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:165:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:165:0')
 
     class GuardedHalt:
         def desugar(self, ctx=None):
@@ -96,22 +96,22 @@ def test_and_finally_cleanup_completion_restores_incoming_completed():
 
 
 def test_and_finally_cleanup_completion_restores_incoming_halted():
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:131:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:131:0')
     incoming = ExitSet.halted(effect)
     after = incoming.and_finally(lambda: ExitSet.completed("cleanup-done"))
     assert after.collapse() == Incomplete(effect)
 
 
 def test_and_finally_cleanup_halt_supersedes_incoming():
-    original = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:106:0'), exception_name='ValueError')
-    cleanup = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:166:0'), exception_name='RuntimeError')
+    original = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:106:0')
+    cleanup = RaiseEffect.for_builtin('RuntimeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:166:0')
     incoming = ExitSet.halted(original)
     after = incoming.and_finally(lambda: ExitSet.halted(cleanup))
     assert after.collapse() == Incomplete(cleanup)
 
 
 def test_and_finally_cleanup_halt_supersedes_completed():
-    cleanup = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:158:0'), exception_name='RuntimeError')
+    cleanup = RaiseEffect.for_builtin('RuntimeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:158:0')
     incoming = ExitSet.completed("ok")
     after = incoming.and_finally(lambda: ExitSet.halted(cleanup))
     assert after.collapse() == Incomplete(cleanup)
@@ -128,7 +128,7 @@ def test_and_finally_terminal_cleanup_completion_supersedes():
 
 def test_and_finally_runs_cleanup_on_every_conditional_exit():
     condition = _guard("condition")
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:99:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:99:0')
     incoming = ExitSet.conditional_halt(condition, effect, "state")
     seen = []
 
@@ -155,22 +155,22 @@ def test_and_exit_completion_keeps_body_completed():
 
 
 def test_and_exit_halt_supersedes_body_completed():
-    exit_halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:114:0'), exception_name='RuntimeError')
+    exit_halt = RaiseEffect.for_builtin('RuntimeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:114:0')
     incoming = ExitSet.completed("body")
     after = incoming.and_exit(ExitSet.halted(exit_halt), disposition=NeverSuppresses())
     assert after.collapse() == Incomplete(exit_halt)
 
 
 def test_and_exit_halt_supersedes_body_halted():
-    body = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:77:0'), exception_name='ValueError')
-    exit_halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:107:0'), exception_name='RuntimeError')
+    body = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:77:0')
+    exit_halt = RaiseEffect.for_builtin('RuntimeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:107:0')
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(ExitSet.halted(exit_halt), disposition=NeverSuppresses())
     assert after.collapse() == Incomplete(exit_halt)
 
 
 def test_and_exit_never_suppresses_restores_body_halt():
-    body = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:64:0'), exception_name='ValueError')
+    body = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:64:0')
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(ExitSet.completed(False), disposition=NeverSuppresses())
     assert after.collapse() == Incomplete(body)
@@ -180,7 +180,12 @@ def test_and_exit_proven_contract_consumes_named_halt():
     from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
 
     coordinate, mro = _builtin_exception_identity("ValueError")
-    body = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit_set.py:2:0'), exception_name='ValueError', exception_type_coordinate=coordinate, exception_type_mro=mro)
+    body = RaiseEffect.for_builtin("ValueError",
+        
+        exception_type_coordinate=coordinate,
+        exception_type_mro=mro,
+        occurrence="exit_set.py:2:0",
+    )
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(
         ExitSet.completed(True),
@@ -190,7 +195,7 @@ def test_and_exit_proven_contract_consumes_named_halt():
 
 
 def test_and_exit_runtime_selected_leaves_open_residual_not_guessed():
-    body = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:36:0'), exception_name='ValueError')
+    body = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:36:0')
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(
         ExitSet.completed(True),
@@ -201,7 +206,7 @@ def test_and_exit_runtime_selected_leaves_open_residual_not_guessed():
 
 def test_and_exit_fans_exitset_across_conditional_faces():
     condition = _guard("condition")
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:29:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:29:0')
     incoming = ExitSet.conditional_halt(condition, effect, "state")
     exit_es = ExitSet.completed(False)
     after = incoming.and_exit(exit_es, disposition=NeverSuppresses())
@@ -214,7 +219,12 @@ def test_and_exit_proven_contract_suppresses_only_matching_face():
 
     condition = _guard("condition")
     coordinate, mro = _builtin_exception_identity("ValueError")
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit_set.py:3:0'), exception_name='ValueError', exception_type_coordinate=coordinate, exception_type_mro=mro)
+    effect = RaiseEffect.for_builtin("ValueError",
+        
+        exception_type_coordinate=coordinate,
+        exception_type_mro=mro,
+        occurrence="exit_set.py:3:0",
+    )
     incoming = ExitSet.conditional_halt(condition, effect, "state")
     after = incoming.and_exit(
         ExitSet.completed(True),
@@ -227,7 +237,12 @@ def test_and_exit_membrane_suppresses_matcher_authority():
     from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
 
     coordinate, mro = _builtin_exception_identity("KeyError")
-    body = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit_set.py:1:0'), exception_name='KeyError', exception_type_coordinate=coordinate, exception_type_mro=mro)
+    body = RaiseEffect.for_builtin("KeyError",
+        
+        exception_type_coordinate=coordinate,
+        exception_type_mro=mro,
+        occurrence="exit_set.py:1:0",
+    )
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(
         ExitSet.completed(True),

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py
@@ -46,7 +46,7 @@ def _guard(name: str):
 
 
 def _effect(name: str = "ValueError"):
-    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py:49:0'), exception_name=name)
+    return RaiseEffect.for_builtin(name, occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py:49:0')
 
 
 def _value():

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py
@@ -69,7 +69,7 @@ def _guard(index: int):
 
 
 def _effect(name: str) -> RaiseEffect:
-    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py:72:0'), exception_name=name)
+    return RaiseEffect.for_builtin(name, occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py:72:0')
 
 
 def _random_exits(rng: random.Random, count: int, distinct: int) -> tuple:

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_nested_exit_faces.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_nested_exit_faces.py
@@ -147,7 +147,7 @@ def _raise(
         )
     return Halted(
         _Atomic(f"body-{marker}", ()),
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occ), exception_name=name, blame=occ, exception_type_coordinate=_identity(name), exception_type_mro=(_identity(name),), raised_value=raised_value, producer_node_owner=producer_node_owner or 'NestedBody.desugar'),
+        RaiseEffect(exception_type_coordinate=_identity(name), occurrence=AuthenticatedRaiseLocus.of(occ), exception_name=name, blame=occ, exception_type_mro=(_identity(name),), raised_value=raised_value, producer_node_owner=producer_node_owner or 'NestedBody.desugar'),
         _state(marker),
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_source_resource_stack.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_source_resource_stack.py
@@ -256,7 +256,7 @@ def _raise(name: str, marker: str, *, message=None, occurrence=None):
         )
     return Halted(
         _Atomic(f"body-{marker}", ()),
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occ), exception_name=name, blame=occ, exception_type_coordinate=_identity(name), exception_type_mro=(_identity(name),), raised_value=raised_value, producer_node_owner='StackBody.desugar'),
+        RaiseEffect(exception_type_coordinate=_identity(name), occurrence=AuthenticatedRaiseLocus.of(occ), exception_name=name, blame=occ, exception_type_mro=(_identity(name),), raised_value=raised_value, producer_node_owner='StackBody.desugar'),
         _state(marker),
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_try_finally.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_try_finally.py
@@ -127,7 +127,7 @@ def _raise(
         )
     return Halted(
         _Atomic(f"body-{marker}", ()),
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occ), exception_name=name, blame=occ, exception_type_coordinate=_identity(name), exception_type_mro=(_identity(name),), raised_value=raised_value, producer_node_owner='TryFinallyBody.desugar'),
+        RaiseEffect(exception_type_coordinate=_identity(name), occurrence=AuthenticatedRaiseLocus.of(occ), exception_name=name, blame=occ, exception_type_mro=(_identity(name),), raised_value=raised_value, producer_node_owner='TryFinallyBody.desugar'),
         _state(marker),
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py
@@ -228,7 +228,7 @@ def test_population_outcomes_require_a_positive_authenticated_exceptional_exit()
 
     obligation, entry = _authenticated_obligation_and_entry()
     positive = classify_fixture_resource_outcome(
-        obligation, entry, lambda: Incomplete(RaiseEffect('ValueError', 'site', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py:231:0')))
+        obligation, entry, lambda: Incomplete(RaiseEffect.for_builtin("ValueError", blame="site", occurrence="site"))
     )
     absent = classify_fixture_resource_outcome(
         obligation, entry, lambda: Complete("ordinary completion")

--- a/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
@@ -57,7 +57,6 @@ def _assert_named_halt(outcome) -> None:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate is not None
 
 
 def test_positional_actuals_discharge_through_python_binder() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py
@@ -46,7 +46,7 @@ def test_send_continues_from_the_same_resume_coordinate_to_termination():
 def test_throw_routes_the_exact_incoming_effect_as_a_halted_face():
     api = _api()
     yielded = _machine(api.YieldStepV1(num(7)), api.ReturnStepV1(num(9))).resume()
-    incoming = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body:3'), exception_name='RenamedError')
+    incoming = RaiseEffect.for_builtin("RenamedError", occurrence="body:3")
 
     exits = yielded.machine.throw(incoming)
 
@@ -104,7 +104,7 @@ def test_throw_runs_constructed_finally_and_restores_exact_incoming_effect():
         api.FinallyStepV1((InertSugar(site="cleanup"),)),
         api.ReturnStepV1(),
     ).resume()
-    incoming = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body:8'), exception_name='RenamedError')
+    incoming = RaiseEffect.for_builtin("RenamedError", occurrence="body:8")
 
     exits = yielded.machine.throw(incoming)
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
@@ -433,7 +433,7 @@ def test_guard_halt_retains_exact_pre_halt_formal_floors() -> None:
     floor = TrueBoolLiteralSugar(site=param.fragment)
     machine = _machine(entry=entry, floor=floor)
     halted = machine.throw(
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('guard:halt'), exception_name='HaltProbe')
+        RaiseEffect.for_builtin("HaltProbe", occurrence="guard:halt")
     )
     assert isinstance(halted, ExitSet)
     for exit_ in halted.exits:

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_if_guard_outcome_sequencing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_if_guard_outcome_sequencing.py
@@ -108,7 +108,7 @@ def _halt(name: str, *, pending=()):
     left, _ = partition(("if-guard-halt", name))
     return Halted(
         atomic(f"guard:halted:{name}", []),
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(f'guard:{name}'), exception_name=f'{name}Error'),
+        RaiseEffect.for_builtin(f"{name}Error", occurrence=f"guard:{name}"),
         state=object(),
         faces=frozenset({left}),
         pending_contracts=pending,
@@ -225,7 +225,7 @@ def test_four_face_guard_projects_completed_operands_once_then_transitions(
 def test_guarded_incomplete_arm_becomes_halted_without_running_branch() -> None:
     calls: list[object] = []
     incomplete = Incomplete(
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('guard:inner'), exception_name='InnerError')
+        RaiseEffect.for_builtin("InnerError", occurrence="guard:inner")
     )
     operand = _TruthOperand(incomplete, calls)
     outer = atomic("guard:outer-incomplete", [])

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
@@ -209,7 +209,7 @@ def test_a_partitioned_guard_preserves_halts_and_transitions_completed_faces(
     """Guard evaluation exits are paths, not a reason to discard the branch."""
     halted_guard = atomic("test.guard.halted", [])
     completed_guard = atomic("test.guard.completed", [])
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('guard:site'), exception_name='GuardError')
+    effect = RaiseEffect.for_builtin("GuardError", occurrence="guard:site")
     halted = Halted(halted_guard, effect, state="guard-state")
     guard_outcome = ExitSet(
         (

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_value_exitset_sequencing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_value_exitset_sequencing.py
@@ -119,7 +119,7 @@ def _mixed_faces():
     pending = (_Pending("pending:halted-left"),)
     halted_left = Halted(
         left_guard,
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('value:halted:left'), exception_name='LeftError'),
+        RaiseEffect.for_builtin("LeftError", occurrence="value:halted:left"),
         state=object(),
         faces=frozenset({left_face}),
         pending_contracts=pending,
@@ -132,7 +132,7 @@ def _mixed_faces():
     )
     halted_right = Halted(
         right_guard,
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('value:halted:right'), exception_name='RightError'),
+        RaiseEffect.for_builtin("RightError", occurrence="value:halted:right"),
         state=object(),
         faces=frozenset({right_face}),
         pending_contracts=(),
@@ -276,14 +276,14 @@ def test_synthetic_all_halted_assign_is_unchanged_and_runs_no_continuation(
     arms = (
         Halted(
             membership_guard,
-            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('contains'), exception_name='TypeError'),
+            RaiseEffect.for_builtin("TypeError", occurrence="contains"),
             None,
             frozenset({membership_true}),
             (),
         ),
         Halted(
             and_((not_(membership_guard), equality_guard)),
-            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('equals'), exception_name='TypeError'),
+            RaiseEffect.for_builtin("TypeError", occurrence="equals"),
             None,
             frozenset({membership_false, equality_true}),
             (),
@@ -321,7 +321,7 @@ def test_synthetic_all_halted_assign_is_unchanged_and_runs_no_continuation(
 
 @pytest.mark.parametrize("consumer", ("assign", "return", "yield"))
 def test_incomplete_value_becomes_one_halted_face_without_advancing(consumer: str) -> None:
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('incomplete:value'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin("ValueError", occurrence="incomplete:value")
     reductions: list[str] = []
     value = _OutcomeValue(Incomplete(effect), reductions)
     if consumer == "assign":
@@ -405,7 +405,7 @@ def _carrier(tmp_path, *, mixed: bool = False):
         halted_face, completed_face = partition("carrier-discharge")
         halted = Halted(
             atomic("carrier:halted", []),
-            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('carrier:halted'), exception_name='CarrierError'),
+            RaiseEffect.for_builtin("CarrierError", occurrence="carrier:halted"),
             state=object(),
             faces=frozenset({halted_face}),
             pending_contracts=(_Pending("pending:carrier-halted"),),

--- a/implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py
@@ -20,7 +20,7 @@ def _leaf(identity, occurrence: str, *mro, raised_value=None):
 
     if raised_value is None:
         raised_value = _typed_value(identity, *(tuple(mro) or (identity,)))
-    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_type_coordinate=identity, exception_type_mro=tuple(mro) or (identity,), raised_value=raised_value)
+    return RaiseEffect(exception_type_coordinate=identity, occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_type_mro=tuple(mro) or (identity,), raised_value=raised_value)
 
 
 def test_nested_group_partition_preserves_tree_and_leaf_identities():
@@ -115,7 +115,7 @@ def test_except_star_partition_and_issubclass_share_class_value_floor(monkeypatc
     issubclass.callable_application_with(
         CallableApplication((leaf_class, base_class), (), "issubclass-site"), None
     )
-    leaf = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('leaf:truthful'), exception_type_coordinate=leaf_identity, raised_value=leaf_type)
+    leaf = RaiseEffect(exception_type_coordinate=leaf_identity, occurrence=AuthenticatedRaiseLocus.of('leaf:truthful'), raised_value=leaf_type)
     partition = GroupedRaiseEffect("group:root", "root", (leaf,)).partition(
         base_type, "except-star-site"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_stop_iteration_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_stop_iteration_coordinate.py
@@ -27,13 +27,24 @@ def _stop_identity():
 
 def test_truthful_stop_iteration_coordinate_is_exhaustion() -> None:
     identity, mro = _stop_identity()
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('loop.py:1:0'), exception_name='StopIteration', exception_type_coordinate=identity, exception_type_mro=mro, producer_node_owner='project_next')
+    effect = RaiseEffect.for_builtin("StopIteration",
+        
+        exception_type_coordinate=identity,
+        exception_type_mro=mro,
+        occurrence="loop.py:1:0",
+        producer_node_owner="project_next",
+    )
     assert _is_authenticated_stop_iteration(effect) is True
 
 
 def test_lying_twin_same_spelling_foreign_coordinate_is_not_exhaustion() -> None:
     identity, mro = _stop_identity()
-    truthful = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('loop.py:1:0'), exception_name='StopIteration', exception_type_coordinate=identity, exception_type_mro=mro)
+    truthful = RaiseEffect.for_builtin("StopIteration",
+        
+        exception_type_coordinate=identity,
+        exception_type_mro=mro,
+        occurrence="loop.py:1:0",
+    )
     foreign_type = ctor(
         "python:exception_type_identity",
         [str_const("builtins"), str_const("ValueError")],
@@ -49,7 +60,11 @@ def test_lying_twin_same_spelling_foreign_coordinate_is_not_exhaustion() -> None
 
 
 def test_missing_coordinate_throws_named_not_name_fallback() -> None:
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('loop.py:2:0'), exception_name='StopIteration', exception_type_coordinate=None)
+    effect = RaiseEffect.for_builtin("StopIteration",
+        
+        exception_type_coordinate=None,
+        occurrence="loop.py:2:0",
+    )
     with pytest.raises(SugarNotWritten) as caught:
         _is_authenticated_stop_iteration(effect)
     assert "exception_type_coordinate" in caught.value.observed

--- a/implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py
@@ -281,7 +281,12 @@ class _HaltingGuard(Sugar):
 
     def desugar(self, ctx=None):
         return Incomplete(
-            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(str(self.site)), exception_name='ValueError', blame=str(self.site), producer_node_owner='MatchGuard')
+            RaiseEffect.for_builtin("ValueError",
+                
+                blame=str(self.site),
+                occurrence=str(self.site),
+                producer_node_owner="MatchGuard",
+            )
         )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_method_raise_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_method_raise_transport.py
@@ -389,7 +389,13 @@ def test_wrong_exception_observation_is_not_the_method_effect() -> None:
     """Bite: foreign RaiseEffect is not the transported method edge."""
     source = _raise_body() + "\nRaiser().boom()\n"
     halted = _method_halt(source)
-    foreign = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('foreign.py:1:0'), exception_name='ValueError', blame='foreign.py:1:0', exception_type_coordinate=_identity('ValueError'), exception_type_mro=(_identity('ValueError'),))
+    foreign = RaiseEffect.for_builtin("ValueError",
+        
+        blame="foreign.py:1:0",
+        occurrence="foreign.py:1:0",
+        exception_type_coordinate=_identity("ValueError"),
+        exception_type_mro=(_identity("ValueError"),),
+    )
     with pytest.raises(AssertionError):
         assert halted.effect is foreign
     with pytest.raises(AssertionError):

--- a/implementations/python/sugar-lift-py-tests/tests/test_mutable_global_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_mutable_global_value.py
@@ -44,7 +44,6 @@ def test_mutable_dict_global_lookup_preserves_complementary_value_and_keyerror_f
     completed = next(exit for exit in exits.exits if isinstance(exit, Completed))
     assert halted.effect.exception_name == "KeyError"
     assert halted.effect.occurrence_id == str(site)
-    assert halted.effect.exception_type_coordinate is not None
     assert halted.effect.exception_type_mro is not None
     assert isinstance(completed.value, CallSiteValue)
     assert completed.value.target_name == "py.subscript"

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -21,7 +21,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
-from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.effect import RaiseEffect, UndeterminedRaiseEffect
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
     ExpectationNotMetEffect,
 )
@@ -706,7 +706,7 @@ def test_nameless_halt_stays_outside_matching_boundary_end_to_end():
         (
             Halted(
                 true_guard(),
-                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('operation-origin')),
+                UndeterminedRaiseEffect(occurrence="operation-origin"),
             ),
         )
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_prefix_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_prefix_carrier.py
@@ -14,7 +14,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
-from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.effect import RaiseEffect, UndeterminedRaiseEffect
 from sugar_lift_py_tests.floor import NoneValue, SymbolicValue, TermValue
 from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
@@ -89,7 +89,7 @@ def test_completed_prefix_arms_stay_deferred_and_retain_all_testimony() -> None:
     first_obligation = _Pending("first", (_Demand("first-demand"),))
     second_obligation = _Pending("second", (_Demand("second-demand"),))
     stopped_state = object()
-    stopped_effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('prefix-halt'), blame='prefix-halt')
+    stopped_effect = UndeterminedRaiseEffect(blame="prefix-halt", occurrence="prefix-halt")
     prefix = ExitSet(
         (
             Completed(

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.effect import RaiseEffect, UndeterminedRaiseEffect
 from sugar_lift_py_tests.floor import RaiseValue
 from sugar_lift_py_tests.ir import str_const
 from sugar_lift_py_tests.no_call_body_attribution import (
@@ -39,19 +39,19 @@ def _probe(family: ProducerFamily, evaluator) -> BodyProbe:
 def _raise_value():
     return Complete(
         RaiseValue(
-            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('pandas/example.py:1:4'), exception_type_coordinate=str_const('TypeError'))
+            RaiseEffect(exception_type_coordinate=str_const('TypeError'), occurrence=AuthenticatedRaiseLocus.of('pandas/example.py:1:4'))
         )
     )
 
 
 def _nameless_raise_value():
-    return Complete(RaiseValue(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py:51:0'))))
+    return Complete(RaiseValue(UndeterminedRaiseEffect()))
 
 
 def _call_owned_raise_value():
     return Complete(
         RaiseValue(
-            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('pandas/example.py:1:4'), exception_type_coordinate=str_const('TypeError'), producer_node_owner='Call')
+            RaiseEffect(exception_type_coordinate=str_const('TypeError'), occurrence=AuthenticatedRaiseLocus.of('pandas/example.py:1:4'), producer_node_owner='Call')
         )
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_subscript_caller_gap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_subscript_caller_gap.py
@@ -327,7 +327,6 @@ def test_caller_actuals_can_name_an_exception_at_the_original_subscript() -> Non
     assert len(exits.exits) == 1
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate is not None
     assert halted.effect.occurrence_id == str(carrier.demand.source_node.wire())
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py
@@ -80,7 +80,7 @@ def _partitioning_arm(name: str):
     return ExitSet(
         (
             Completed(condition, f"{name}-value"),
-            Halted(not_(condition), RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py:163:0'), exception_name='ValueError'), None),
+            Halted(not_(condition), RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py:163:0'), None),
         )
     )
 
@@ -160,7 +160,7 @@ def test_the_halted_arm_survives_the_factoring():
     halted = [exit_ for exit_ in exits.exits if isinstance(exit_, Halted)]
 
     assert len(halted) == 1
-    assert halted[0].effect == RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py:83:0'), exception_name='ValueError')
+    assert halted[0].effect == RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py:83:0')
 
 
 def test_both_faces_values_survive_inside_the_guarded_chain():

--- a/implementations/python/sugar-lift-py-tests/tests/test_partition_demand_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_partition_demand_conservation.py
@@ -80,7 +80,7 @@ def test_every_face_of_a_partition_carries_the_demand() -> None:
             Completed(ctor("g_true", []), TermValue(7), (), ()),
             Halted(
                 ctor("g_false", []),
-                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(BLAME), exception_name='ValueError', blame=BLAME),
+                RaiseEffect.for_builtin('ValueError', blame=BLAME, occurrence=BLAME),
                 None,
                 (),
                 (),

--- a/implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py
@@ -81,7 +81,7 @@ def test_partition_join_puts_the_obligation_on_every_face():
     partitioned = ExitSet(
         (
             Completed(_guard("hot"), "then-value"),
-            Halted(_guard("cold"), RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:545:0'))),
+            Halted(_guard("cold"), RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom")),
         )
     )
 
@@ -103,7 +103,7 @@ def test_partition_join_does_not_pick_one_face():
     partitioned = ExitSet(
         (
             Completed(_guard("hot"), "then-value"),
-            Halted(_guard("cold"), RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:524:0'))),
+            Halted(_guard("cold"), RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom")),
         )
     )
 
@@ -181,7 +181,7 @@ def test_exitset_guarded_conserves_what_each_arm_owes():
         (
             Halted(
                 true_guard(),
-                RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:504:0')),
+                RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom"),
                 None,
                 frozenset(),
                 (pending,),
@@ -205,7 +205,7 @@ def test_sequence_carries_the_prefix_obligation_onto_every_tail_exit():
         return ExitSet(
             (
                 Completed(_guard("ok"), "tail"),
-                Halted(_guard("bad"), RaiseEffect('KeyError', 'k', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:208:0'))),
+                Halted(_guard("bad"), RaiseEffect.for_builtin("KeyError", blame="k", occurrence="k")),
             )
         )
 
@@ -307,7 +307,7 @@ def test_collapse_of_a_halted_arm_carries_its_obligations():
     """TRUTHFUL. `Incomplete(effect)` has a field for the debt; using the
     one-argument form here would drop it at the exit of the algebra."""
     pending = _carrier()
-    effect = RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:484:0'))
+    effect = RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom")
     exits = ExitSet((Halted(true_guard(), effect, None, frozenset(), (pending,)),))
 
     collapsed = exits.collapse()
@@ -434,7 +434,7 @@ def test_the_nested_statement_splice_conserves_faces_and_obligations():
             (
                 Halted(
                     _guard("h"),
-                    RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:437:0')),
+                    RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom"),
                     inner,
                     frozenset({face}),
                     (pending,),
@@ -481,7 +481,7 @@ def test_a_stateless_halt_that_owes_stays_loud():
         (
             Halted(
                 true_guard(),
-                RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:310:0')),
+                RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom"),
                 None,
                 frozenset(),
                 (_carrier(),),
@@ -501,7 +501,7 @@ def test_an_arm_owing_nothing_never_reaches_the_refusal():
         _enrol_exit_obligations,
     )
 
-    clean = ExitSet((Halted(true_guard(), RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:184:0')), None),))
+    clean = ExitSet((Halted(true_guard(), RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom"), None),))
 
     assert _enrol_exit_obligations(clean) is clean
 
@@ -521,7 +521,7 @@ def test_a_stateless_halt_that_owes_is_given_the_prefix_record():
     prefix = _ReducedBlock(("earlier-entry",), True, ())
     owing = Halted(
         true_guard(),
-        RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:106:0')),
+        RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom"),
         None,
         frozenset(),
         (_carrier(),),
@@ -542,6 +542,6 @@ def test_a_stateless_halt_that_owes_nothing_keeps_its_state():
         _halt_state,
     )
 
-    clean = Halted(true_guard(), RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:84:0')), None)
+    clean = Halted(true_guard(), RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom"), None)
 
     assert _halt_state(_ReducedBlock(("earlier-entry",), True, ()), clean) is None

--- a/implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py
@@ -15,7 +15,7 @@ from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
 
 def test_terminal_raise_with_prior_state_promotes_to_halt_only():
     marker = object()
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py:39:0'), exception_name='OSError')
+    effect = RaiseEffect.for_builtin('OSError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py:39:0')
     exits = ExitSet(
         (
             Completed(
@@ -36,7 +36,7 @@ def test_terminal_raise_with_prior_state_promotes_to_halt_only():
 def test_guarded_raise_keeps_its_complementary_completed_arm():
     marker = object()
     condition = make_var("condition")
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py:18:0'), exception_name='OSError')
+    effect = RaiseEffect.for_builtin('OSError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py:18:0')
     exits = ExitSet(
         (
             Completed(

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_effect_coordinate_required.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_effect_coordinate_required.py
@@ -1,0 +1,43 @@
+"""Constructor law: RaiseEffect refuses nameless authenticated exits.
+
+Shell deleted: presence-only ``assert effect.exception_type_coordinate is not None``
+teeth on successful RaiseEffect paths — the type carries the law now.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.effect.raise_effect import (
+    RaiseEffect,
+    UndeterminedRaiseEffect,
+)
+
+
+def test_raise_effect_refuses_none_coordinate() -> None:
+    with pytest.raises(TypeError, match="refuses exception_type_coordinate=None"):
+        RaiseEffect(exception_type_coordinate=None, occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_raise_effect_coordinate_required.py:19:0'))  # type: ignore[arg-type]
+
+
+def test_raise_effect_requires_coordinate_argument() -> None:
+    with pytest.raises(TypeError):
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_raise_effect_coordinate_required.py:24:0'), exception_name='ValueError')  # type: ignore[call-arg]
+
+
+def test_for_builtin_mints_authenticated_coordinate() -> None:
+    effect = RaiseEffect.for_builtin('ValueError', blame='t.py:1:0', occurrence='t.py:1:0')
+    assert effect.exception_name == "ValueError"
+    assert effect.exception_type_coordinate is not None
+    assert effect.exception_type_mro is not None
+
+
+def test_undetermined_cannot_impersonate_raise_effect() -> None:
+    undetermined = UndeterminedRaiseEffect(blame="t.py:1:0")
+    assert undetermined.exception_type_coordinate is None
+    assert not isinstance(undetermined, RaiseEffect)
+    assert type(undetermined) is UndeterminedRaiseEffect
+
+
+def test_for_builtin_unknown_name_throws() -> None:
+    with pytest.raises(TypeError, match="no language-owned"):
+        RaiseEffect.for_builtin('NotARealExceptionType123', occurrence='implementations/python/sugar-lift-py-tests/tests/test_raise_effect_coordinate_required.py:43:0')

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_from_try_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_from_try_composition.py
@@ -245,7 +245,12 @@ def test_halt_while_evaluating_cause_prevents_outer_raise():
     """If the cause expression halts, the outer RaiseEffect is never emitted."""
     outer = _call_exception("RuntimeError", "outer")
     cause_halt = Incomplete(
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('unit.py:9:4'), exception_name='KeyError', blame='unit.py:9:4', raised_value=_call_exception('KeyError', 'cause-boom'))
+        RaiseEffect.for_builtin("KeyError",
+            
+            blame="unit.py:9:4",
+            occurrence="unit.py:9:4",
+            raised_value=_call_exception("KeyError", "cause-boom"),
+        )
     )
     sugar = RaiseSugar(
         exception=Fixed(Complete(outer)),

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
@@ -71,7 +71,11 @@ class _TermBearingHandler:
 
 def _valueless_effect() -> RaiseEffect:
     """The measured shape: a raise with no value and no authenticated type."""
-    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(OCCURRENCE), exception_name='NameError', blame=OCCURRENCE)
+    return RaiseEffect.for_builtin("NameError",
+        
+        blame=OCCURRENCE,
+        occurrence=OCCURRENCE,
+    )
 
 
 # -- the refusal is correct output -------------------------------------------
@@ -156,7 +160,12 @@ def test_a_real_value_term_still_retains_the_question() -> None:
     as a refusal. A guard that refused everything would pass every test above
     and destroy the mechanism.
     """
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(OCCURRENCE), exception_name='ValueError', blame=OCCURRENCE, raised_value=TermValue(7))
+    effect = RaiseEffect.for_builtin("ValueError",
+        
+        blame=OCCURRENCE,
+        occurrence=OCCURRENCE,
+        raised_value=TermValue(7),
+    )
     # A handler with NO authenticated identity but WITH a value term: the
     # question is then real and undecidable rather than unstatable.
     handler = _TermBearingHandler()
@@ -171,7 +180,12 @@ def test_matching_halt_without_message_operand_retains_message_obligation() -> N
     """Truthful twin: the raised VALUE exists, but its rendered message is open."""
     identity = TermValue(1).to_term(owner="exception identity")
     raised_value = TermValue(7)
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(OCCURRENCE), exception_name='ValueError', exception_type_coordinate=identity, raised_value=raised_value)
+    effect = RaiseEffect.for_builtin("ValueError",
+        
+        exception_type_coordinate=identity,
+        occurrence=OCCURRENCE,
+        raised_value=raised_value,
+    )
     expected = _AuthenticatedHandler(identity)
 
     verdict = raise_effect_message_verdict(
@@ -189,7 +203,12 @@ def test_matching_halt_without_message_operand_retains_message_obligation() -> N
 def test_valueless_halt_cannot_use_occurrence_as_message_evidence() -> None:
     """Lying twin: a source coordinate is not a rendered-message operand."""
     identity = TermValue(1).to_term(owner="exception identity")
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(OCCURRENCE), exception_name='ValueError', exception_type_coordinate=identity, raised_value=None)
+    effect = RaiseEffect.for_builtin("ValueError",
+        
+        exception_type_coordinate=identity,
+        occurrence=OCCURRENCE,
+        raised_value=None,
+    )
     expected = _AuthenticatedHandler(identity)
 
     with pytest.raises(SugarNotWritten) as raised:
@@ -209,7 +228,12 @@ def _effect_with_message(message: str) -> tuple[RaiseEffect, _AuthenticatedHandl
         None,
     )
     return (
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(OCCURRENCE), exception_name='ValueError', exception_type_coordinate=identity, raised_value=raised_value),
+        RaiseEffect.for_builtin("ValueError",
+            
+            exception_type_coordinate=identity,
+            occurrence=OCCURRENCE,
+            raised_value=raised_value,
+        ),
         _AuthenticatedHandler(identity),
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py
@@ -7,7 +7,7 @@ from sugar_lift_py_tests.sugar import function_universe_sugar
 
 
 def test_reduce_body_retains_one_unconditional_stateful_halt(monkeypatch):
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py:26:0'), exception_name='AttributeError')
+    effect = RaiseEffect.for_builtin('AttributeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py:26:0')
     pre_effect_state = object()
     exits = ExitSet((Halted(true_guard(), effect, pre_effect_state),))
     monkeypatch.setattr(
@@ -23,7 +23,7 @@ def test_reduce_body_retains_one_unconditional_stateful_halt(monkeypatch):
 
 
 def test_reduce_body_still_collapses_one_unconditional_stateless_halt(monkeypatch):
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py:10:0'), exception_name='AttributeError')
+    effect = RaiseEffect.for_builtin('AttributeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py:10:0')
     exits = ExitSet((Halted(true_guard(), effect),))
     monkeypatch.setattr(
         function_universe_sugar,

--- a/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
@@ -24,13 +24,13 @@ Authenticated bare re-raise re-emits the in-flight effect's real identity
 GATE: truthful twin cites under real evidence; lying twins (nameless face,
 fabricated-name face, missing citation) MUST FAIL.
 
-SOURCEFILE_CONSTRUCTION_DOOR AUDITOR BLIND SPOT
+LAW_OF_ONE AUDITOR BLIND SPOT
 =============================
-``tests/sourcefile_construction_door_auditor.py`` + ``sourcefile_construction_door_evidence.py`` audit SourceFile
+``tests/law_of_one_auditor.py`` + ``law_of_one_evidence.py`` audit SourceFile
 owner paths, privacy closure, projection closure, and protocol zero-work.
 They do **not** walk floor render edges, fabricated-meaning literal invention,
 or exceptional-exit FOL emission. This module owns recognition of that class.
-When the SOURCEFILE_CONSTRUCTION_DOOR auditor gains a floor-render / meaning-invention axis that
+When the LAW_OF_ONE auditor gains a floor-render / meaning-invention axis that
 names live offenders of this class, retire the blind-spot probe below.
 
 Retirement path for the production denylist
@@ -46,7 +46,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.effect import RaiseEffect, UndeterminedRaiseEffect
 from sugar_lift_py_tests.floor.raise_value import (
     FABRICATED_EXCEPTIONAL_EXIT_MEANING_LITERALS,
     RaiseValue,
@@ -71,13 +71,12 @@ _RAISE_VALUE_PATH = (
 
 def _named_cited_effect(**overrides) -> RaiseEffect:
     fields = dict(
-        exception_name="ValueError",
         blame=_LOCUS,
         source_sha256=_SHA,
         occurrence=_LOCUS,
     )
     fields.update(overrides)
-    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:95:0'))
+    return RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:79:0')
 
 
 def _coordinate_cited_effect(**overrides) -> RaiseEffect:
@@ -92,7 +91,7 @@ def _coordinate_cited_effect(**overrides) -> RaiseEffect:
         occurrence=_LOCUS,
     )
     fields.update(overrides)
-    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:80:0'))
+    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:94:0'))
 
 
 def _is_fabricated_constant(node: ast.AST) -> str | None:
@@ -144,20 +143,20 @@ or_literal_meaning_offenders = fabricated_meaning_offenders
 
 
 # ---------------------------------------------------------------------------
-# SOURCEFILE_CONSTRUCTION_DOOR auditor cannot see this sin — real probe, no tautological R pin
+# LAW_OF_ONE auditor cannot see this sin — real probe, no tautological R pin
 # ---------------------------------------------------------------------------
 
 
-def test_sourcefile_construction_door_auditor_cannot_see_render_edge_fabrication() -> None:
-    """Probe: the product SOURCEFILE_CONSTRUCTION_DOOR auditor still has no render-edge axis.
+def test_law_of_one_auditor_cannot_see_render_edge_fabrication() -> None:
+    """Probe: the product LAW_OF_ONE auditor still has no render-edge axis.
 
     Fails when auditor/evidence text gains the vocabulary of this class
     (exceptional_exit / reraise / RaiseValue on the evidence types) — that
     is the signal the stronger substrate arrived and this note can retire.
     There is no hard-coded R=1; the probe is the absence of those markers.
     """
-    auditor = Path(__file__).resolve().parents[4] / "tests" / "sourcefile_construction_door_auditor.py"
-    evidence = Path(__file__).resolve().parents[4] / "tests" / "sourcefile_construction_door_evidence.py"
+    auditor = Path(__file__).resolve().parents[4] / "tests" / "law_of_one_auditor.py"
+    evidence = Path(__file__).resolve().parents[4] / "tests" / "law_of_one_evidence.py"
     assert auditor.is_file(), auditor
     assert evidence.is_file(), evidence
 
@@ -166,7 +165,7 @@ def test_sourcefile_construction_door_auditor_cannot_see_render_edge_fabrication
 
     # Strings that would mean the auditor already owns *this* axis.
     assert "reraise" not in auditor_text, (
-        "sourcefile_construction_door_auditor mentions reraise — re-check whether it now owns "
+        "law_of_one_auditor mentions reraise — re-check whether it now owns "
         "render-edge fabrication and retire this module's blind-spot claim"
     )
     assert "exceptional_exit" not in auditor_text
@@ -302,7 +301,7 @@ def test_nameless_face_cannot_reach_fol_emission() -> None:
                           "<unknown raise locus>#source-sha256=unavailable")
     which is indistinguishable from a genuinely cited exit.
     """
-    nameless = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:305:0'))
+    nameless = UndeterminedRaiseEffect()
 
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(nameless)
@@ -318,13 +317,13 @@ def test_nameless_face_cannot_reach_fol_emission() -> None:
 def test_nameless_raise_value_post_contribution_stays_loud() -> None:
     """post_contribution is the same door — nameless cannot soft-emit."""
     with pytest.raises(ConstructionPanic) as raised:
-        RaiseValue(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(_LOCUS), blame=_LOCUS)).post_contribution()
+        RaiseValue(UndeterminedRaiseEffect(blame=_LOCUS)).post_contribution()
     assert raised.value.info.owner == "RaiseValue.exceptional_exit_term"
 
 
 def test_name_without_source_sha_cannot_cite_unavailable() -> None:
     """Placeholder ``#source-sha256=unavailable`` is absent evidence, not a cite."""
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(_LOCUS), exception_name='ValueError', blame=_LOCUS, source_sha256=None)
+    effect = RaiseEffect.for_builtin('ValueError', blame=_LOCUS, source_sha256=None, occurrence=_LOCUS)
 
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
@@ -337,7 +336,7 @@ def test_name_without_source_sha_cannot_cite_unavailable() -> None:
 
 def test_name_without_blame_cannot_cite_unknown_locus() -> None:
     """Placeholder ``<unknown raise locus>`` is not a re-readable citation."""
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(None), exception_name='ValueError', blame=None, source_sha256=_SHA)
+    effect = RaiseEffect.for_builtin('ValueError', blame=None, source_sha256=_SHA, occurrence=None)
 
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
@@ -350,7 +349,7 @@ def test_name_without_blame_cannot_cite_unknown_locus() -> None:
 
 def test_fabricated_reraise_string_is_not_authenticated_bare_raise() -> None:
     """Nameless face with locus+sha (historical path that became 'reraise')."""
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(_LOCUS), blame=_LOCUS, source_sha256=_SHA)
+    effect = UndeterminedRaiseEffect(blame=_LOCUS, source_sha256=_SHA)
 
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
@@ -368,7 +367,7 @@ def test_exception_name_reraise_placeholder_cannot_reach_fol() -> None:
     citable exit after the first refuse-placeholders shot. Fabricated
     identity is not authenticated identity.
     """
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(_LOCUS), exception_name='reraise', blame=_LOCUS, source_sha256=_SHA)
+    effect = RaiseEffect.for_builtin('reraise', blame=_LOCUS, source_sha256=_SHA, occurrence=_LOCUS)
 
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
@@ -394,7 +393,7 @@ def test_every_fabricated_meaning_literal_as_name_is_loud(placeholder: str) -> N
 
 def test_empty_exception_name_cannot_reach_fol() -> None:
     """Empty spelling is not tree-authenticated identity."""
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(_LOCUS), exception_name='', blame=_LOCUS, source_sha256=_SHA)
+    effect = RaiseEffect.for_builtin('', blame=_LOCUS, source_sha256=_SHA, occurrence=_LOCUS)
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
     assert "empty" in raised.value.info.observed

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_method_caller.py
@@ -155,7 +155,6 @@ def _assert_named_halt(outcome, *, require_pre_effect_state: bool = True) -> Hal
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate is not None
     if require_pre_effect_state:
         # #6640: exceptional discharge stamps reducer-owned pre-effect state.
         # Bound-method *call* producer path may stay red until codex-1 lossless

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py
@@ -90,7 +90,6 @@ def _assert_named_halt(outcome) -> Halted:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate is not None
     return halted
 
 
@@ -218,7 +217,6 @@ def test_source_defined_property_without_setter_named_attribute_error() -> None:
     exits = pending.discharge({obj_cid: receiver, value_cid: TermValue(7)})
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate is not None
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
 
 
@@ -355,7 +353,6 @@ def test_positional_caller_completes_field_store_via_setattr() -> None:
 def test_positional_caller_halts_with_named_identity_from_setattr() -> None:
     halted = _assert_named_halt(_call_outcome("obj, value", "1, 2"))
     # Origin is store dispatch, not a fabricated boundary type alone.
-    assert halted.effect.exception_type_coordinate is not None
     # Source call presentation may name the Call producer for the edge; the
     # type coordinate is still from setattr floor discharge, not pytest.raises.
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
@@ -379,7 +376,6 @@ def test_tuple_receiver_store_halts_from_setattr_not_boundary() -> None:
     )
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate is not None
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
     # Direct setattr owner is proven on the incomplete path before carrier
     # re-projects the exceptional resolution.

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_formal_caller.py
@@ -72,7 +72,6 @@ def _assert_named_halt(outcome) -> Halted:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate is not None
     return halted
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_method_caller.py
@@ -140,7 +140,6 @@ def _assert_named_halt(outcome) -> Halted:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate is not None
     # #6640: exceptional discharge stamps the reducer-owned pre-effect state.
     assert halted.state is not None, (
         "NativeOperationResolutionV1.project omitted the formal setitem "

--- a/implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_store_formal_caller.py
@@ -160,7 +160,12 @@ def test_slice_lower_halt_skips_upper_and_step_desugar() -> None:
             del ctx
             log.append(self.label)
             return Incomplete(
-                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(str(self.site)), exception_name='ValueError', blame=str(self.site), producer_node_owner=f'halt:{self.label}')
+                RaiseEffect.for_builtin("ValueError",
+                    
+                    blame=str(self.site),
+                    occurrence=str(self.site),
+                    producer_node_owner=f"halt:{self.label}",
+                )
             )
 
         @classmethod

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py
@@ -6,7 +6,7 @@ from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
 
 def test_source_constructed_exit_retains_suppressed_and_unsuppressed_faces():
-    original = RaiseEffect(TermValue('boom'), None, None, occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py:25:0'))
+    original = RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom")
     incoming = ExitSet.halted(original, state=TermValue("before-exit"))
     result = SymbolicValue(ctor("fixture:exit-result", []))
 
@@ -22,7 +22,7 @@ def test_source_constructed_exit_retains_suppressed_and_unsuppressed_faces():
 
 
 def test_source_constructed_false_exit_restores_original_effect():
-    original = RaiseEffect(TermValue('boom'), None, None, occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py:9:0'))
+    original = RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom")
     incoming = ExitSet.halted(original, state=TermValue("before-exit"))
 
     routed = incoming.and_exit_truthiness(

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py
@@ -396,7 +396,13 @@ def test_wrong_exception_observation_is_not_the_helper_effect() -> None:
         bind=frozenset({"raiser"}),
     )
     halted = _call_halt(tree, "raiser")
-    foreign = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('foreign.py:1:0'), exception_name='ValueError', blame='foreign.py:1:0', exception_type_coordinate=_identity('ValueError'), exception_type_mro=(_identity('ValueError'),))
+    foreign = RaiseEffect.for_builtin("ValueError",
+        
+        blame="foreign.py:1:0",
+        occurrence="foreign.py:1:0",
+        exception_type_coordinate=_identity("ValueError"),
+        exception_type_mro=(_identity("ValueError"),),
+    )
     with pytest.raises(AssertionError):
         assert halted.effect is foreign
     with pytest.raises(AssertionError):

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
@@ -132,12 +132,12 @@ CODEX3_OWNER = (
 @pytest.mark.parametrize(
     "competing_exit",
     (
-        RaiseValue(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:140:0'), exception_name='TypeError')),
+        RaiseValue(RaiseEffect.for_builtin('TypeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:140:0')),
         GuardedRaise(
             (TermValue(True).to_term(owner="guard"),),
-            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:138:0'), exception_name='TypeError'),
+            RaiseEffect.for_builtin('TypeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:138:0'),
         ),
-        Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:135:0'), exception_name='TypeError')),
+        Incomplete(RaiseEffect.for_builtin('TypeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:135:0')),
         LoopControlValue("break", "helper.py:3"),
     ),
 )

--- a/implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py
@@ -69,7 +69,7 @@ class _TwoFacedElement:
         self.index = index
         self.guard = _atom(f"g{index}")
         self.halt_guard = _atom(f"h{index}")
-        self.effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py:72:0'), exception_name=f'E{index}')
+        self.effect = RaiseEffect.for_builtin(f'E{index}', occurrence='implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py:72:0')
 
     def desugar(self, ctx=None):
         del ctx

--- a/implementations/python/sugar-lift-py-tests/tests/test_starred_unpack_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_starred_unpack_projection.py
@@ -149,10 +149,12 @@ def test_too_few_members_named_valueerror(tmp_path: Path) -> None:
     op = _star_op(prefix=("a", "b"), star="rest", blame=site)
     outcome = op.submit(TupleValue((TermValue(1),)), None)
     assert isinstance(outcome, Incomplete)
-    assert outcome.effect.exception_name == "ValueError" or (
-        outcome.effect.exception_type_coordinate is not None
-        and "ValueError" in repr(outcome.effect.exception_type_coordinate)
-    )
+    # RaiseEffect is unconstructible without coordinate; pin identity, not presence.
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    assert isinstance(outcome.effect, RaiseEffect)
+    expected = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_starred_unpack_projection.py:156:0')
+    assert outcome.effect.exception_type_coordinate == expected.exception_type_coordinate
 
 
 def test_too_few_discrimination_is_not_completed_bind(tmp_path: Path) -> None:
@@ -240,9 +242,12 @@ def test_later_store_halt_preserves_earlier_star_bindings(tmp_path: Path) -> Non
     completed = [e for e in outcome.exits if isinstance(e, Completed)]
     assert len(halted) == 1
     assert len(completed) == 0
-    assert halted[0].effect.exception_name == "TypeError" or (
-        halted[0].effect.exception_type_coordinate is not None
-        and "TypeError" in repr(halted[0].effect.exception_type_coordinate)
+    from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
+
+    assert isinstance(halted[0].effect, RaiseEffect)
+    expected = RaiseEffect.for_builtin('TypeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_starred_unpack_projection.py:248:0')
+    assert (
+        halted[0].effect.exception_type_coordinate == expected.exception_type_coordinate
     )
     # No completed return face — store halt blocked later targets.
     assert not any(isinstance(e, Completed) for e in outcome.exits)

--- a/implementations/python/sugar-lift-py-tests/tests/test_state_survival_matrix.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_state_survival_matrix.py
@@ -351,7 +351,13 @@ def test_c_assertion_observation_binds_real_occurrence_effect() -> None:
 def test_c_wrong_occurrence_observation_refuses_twin() -> None:
     """Bite: binding must not claim a foreign occurrence / effect object."""
     _, halted = _unpack_store_halt()
-    foreign = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('foreign.py:1:0'), exception_name='IndexError', blame='foreign.py:1:0', exception_type_coordinate=_identity('IndexError'), exception_type_mro=(_identity('IndexError'),))
+    foreign = RaiseEffect.for_builtin("IndexError",
+        
+        blame="foreign.py:1:0",
+        occurrence="foreign.py:1:0",
+        exception_type_coordinate=_identity("IndexError"),
+        exception_type_mro=(_identity("IndexError"),),
+    )
     routed = _assertion_boundary(
         ExitSet((halted,)),
         expected=_Expected("IndexError"),

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_refusal_preservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_refusal_preservation.py
@@ -65,7 +65,7 @@ def test_partitioned_subscript_preserves_original_typed_refusal(tmp_path, monkey
         (
             Halted(
                 complement_guard(guard),
-                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(str(site)), exception_name='RuntimeError'),
+                RaiseEffect.for_builtin("RuntimeError", occurrence=str(site)),
             ),
             Completed(guard, _RefusingValue(refusal)),
         )
@@ -89,7 +89,7 @@ def test_partitioned_subscript_truth_keeps_value_and_halt_faces(tmp_path, monkey
         (
             Halted(
                 complement_guard(guard),
-                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(str(site)), exception_name='RuntimeError'),
+                RaiseEffect.for_builtin("RuntimeError", occurrence=str(site)),
             ),
             Completed(
                 guard,

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py
@@ -184,7 +184,7 @@ def test_rhs_halt_wins_before_receiver_or_key_evaluation(tmp_path):
             log.append("value")
             return Complete(
                 RaiseValue(
-                    RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('store.py:4:12'), exception_type_coordinate=str_const('ValueError'))
+                    RaiseEffect(exception_type_coordinate=str_const('ValueError'), occurrence=AuthenticatedRaiseLocus.of('store.py:4:12'))
                 )
             )
 
@@ -218,7 +218,7 @@ def test_receiver_halt_wins_before_key_after_rhs_completed(tmp_path):
             log.append("receiver")
             return Complete(
                 RaiseValue(
-                    RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('store.py:4:4'), exception_type_coordinate=str_const('LookupError'))
+                    RaiseEffect(exception_type_coordinate=str_const('LookupError'), occurrence=AuthenticatedRaiseLocus.of('store.py:4:4'))
                 )
             )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_synthetic_caller_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_synthetic_caller_projection.py
@@ -96,7 +96,6 @@ def test_positional_keyword_and_default_callers_reach_the_same_demand() -> None:
     exceptional = (positional, keyword, default)
     halted = tuple(outcome.exits[0] for outcome in exceptional)
     assert all(isinstance(exit_, Halted) for exit_ in halted)
-    assert all(exit_.effect.exception_type_coordinate is not None for exit_ in halted)
     assert {exit_.effect.occurrence_id for exit_ in halted} == {
         str(carrier.demand.source_node.wire())
     }

--- a/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
@@ -570,8 +570,20 @@ def test_second_handler_reads_first_handler_temporal_binding():
     _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
     _te_cls, te_typed, te_id = _synthetic_class("TypeError")
 
-    ve_leaf = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('leaf:ve'), exception_name='ValueError', exception_type_coordinate=ve_id, exception_type_mro=(ve_id,), raised_value=ve_typed)
-    te_leaf = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('leaf:te'), exception_name='TypeError', exception_type_coordinate=te_id, exception_type_mro=(te_id,), raised_value=te_typed)
+    ve_leaf = RaiseEffect.for_builtin("ValueError",
+        
+        occurrence="leaf:ve",
+        exception_type_coordinate=ve_id,
+        exception_type_mro=(ve_id,),
+        raised_value=ve_typed,
+    )
+    te_leaf = RaiseEffect.for_builtin("TypeError",
+        
+        occurrence="leaf:te",
+        exception_type_coordinate=te_id,
+        exception_type_mro=(te_id,),
+        raised_value=te_typed,
+    )
     group = GroupedRaiseEffect(
         "group:root", "g", (ve_leaf, te_leaf), occurrence="group:root"
     )
@@ -615,10 +627,16 @@ def test_second_handler_reads_first_handler_temporal_binding():
             bound = temporal.value_if_bound("x") if temporal is not None else None
             if bound is None:
                 return Incomplete(
-                    RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('read-x-missing'), exception_name='NameError')
+                    RaiseEffect.for_builtin("NameError",
+                        
+                        occurrence="read-x-missing",
+                    )
                 )
             return Incomplete(
-                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('read-x-ok'), exception_name='RuntimeError')
+                RaiseEffect.for_builtin("RuntimeError",
+                    
+                    occurrence="read-x-ok",
+                )
             )
 
         @classmethod
@@ -795,7 +813,13 @@ def test_guarded_handler_faces_conjoin_body_guard():
         unit=SimpleNamespace(source="try-star"),
     )
     _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
-    leaf = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('leaf:ve'), exception_name='ValueError', exception_type_coordinate=ve_id, exception_type_mro=(ve_id,), raised_value=ve_typed)
+    leaf = RaiseEffect.for_builtin("ValueError",
+        
+        occurrence="leaf:ve",
+        exception_type_coordinate=ve_id,
+        exception_type_mro=(ve_id,),
+        raised_value=ve_typed,
+    )
     group = GroupedRaiseEffect("group:root", "g", (leaf,), occurrence="group:root")
     body_atom = atomic("body.guard", [str_const("body")])
     handler_atom = atomic("handler.guard", [str_const("handler")])
@@ -828,7 +852,10 @@ def test_guarded_handler_faces_conjoin_body_guard():
                 (
                     Halted(
                         handler_atom,
-                        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('handler:re'), exception_name='RuntimeError'),
+                        RaiseEffect.for_builtin("RuntimeError",
+                            
+                            occurrence="handler:re",
+                        ),
                         None,
                     ),
                 )
@@ -890,7 +917,13 @@ def test_alternative_exceptional_faces_keep_separate_guards():
         unit=SimpleNamespace(source="try-star"),
     )
     _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
-    leaf = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('leaf:ve'), exception_name='ValueError', exception_type_coordinate=ve_id, exception_type_mro=(ve_id,), raised_value=ve_typed)
+    leaf = RaiseEffect.for_builtin("ValueError",
+        
+        occurrence="leaf:ve",
+        exception_type_coordinate=ve_id,
+        exception_type_mro=(ve_id,),
+        raised_value=ve_typed,
+    )
     group = GroupedRaiseEffect("group:root", "g", (leaf,), occurrence="group:root")
     body_atom = atomic("body.guard", [str_const("body")])
     g1 = atomic("alt.one", [str_const("1")])
@@ -912,12 +945,12 @@ def test_alternative_exceptional_faces_keep_separate_guards():
                 (
                     Halted(
                         g1,
-                        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('a1'), exception_name='KeyError'),
+                        RaiseEffect.for_builtin("KeyError", occurrence="a1"),
                         None,
                     ),
                     Halted(
                         g2,
-                        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('a2'), exception_name='OSError'),
+                        RaiseEffect.for_builtin("OSError", occurrence="a2"),
                         None,
                     ),
                 )

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_not_bool_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_not_bool_law.py
@@ -285,11 +285,9 @@ def test_halted_truth_is_not_negated() -> None:
 
         assert isinstance(face.value, RaiseValue)
         assert face.value.effect.exception_name == "TypeError"
-        assert face.value.effect.exception_type_coordinate is not None
     else:
         assert isinstance(face, Halted)
         assert face.effect.exception_name == "TypeError"
-        assert face.effect.exception_type_coordinate is not None
 
 
 def test_truthful_exceptional_face_carries_floor_type_not_boundary() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_sequencing_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_sequencing_law.py
@@ -350,7 +350,6 @@ def test_list_indexerror_store_halt_originates_in_setitem_not_boundary(
     effect = halted[0].effect
     assert effect.exception_name == "IndexError"
     assert effect.producer_node_owner == "ground_index_error"
-    assert effect.exception_type_coordinate is not None
     # Type name may match a boundary expectation; origin is the store producer.
     assert "pytest" not in (effect.producer_node_owner or "").lower()
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
@@ -267,7 +267,12 @@ def _raise_with_entries(*entries):
         (
             Halted(
                 true_guard(),
-                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:3:4'), exception_name='TypeError', exception_type_coordinate=type_identity, raised_value=raised_value),
+                RaiseEffect.for_builtin("TypeError",
+                    
+                    exception_type_coordinate=type_identity,
+                    occurrence="body.py:3:4",
+                    raised_value=raised_value,
+                ),
                 state,
             ),
         )
@@ -444,7 +449,12 @@ def _raise_after_warning(*, warning_message="deprecated operand"):
         (
             Halted(
                 true_guard(),
-                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('renamed.py:6:8'), exception_name='TypeError', exception_type_coordinate=type_identity, raised_value=raised_value),
+                RaiseEffect.for_builtin("TypeError",
+                    
+                    exception_type_coordinate=type_identity,
+                    occurrence="renamed.py:6:8",
+                    raised_value=raised_value,
+                ),
                 state,
             ),
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -93,7 +93,7 @@ class _Raise(_FixedSugar):
         coordinate, mro = _builtin_exception_identity(name)
         super().__init__(
             Incomplete(
-                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_name=name, exception_type_coordinate=coordinate, exception_type_mro=mro)
+                RaiseEffect(exception_type_coordinate=coordinate, occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_name=name, exception_type_mro=mro)
             ),
             probe=probe,
         )
@@ -191,7 +191,7 @@ def test_runtime_selected_authenticates_completed_face_without_mutation():
 
 
 def test_runtime_selected_authenticates_halted_face_preserving_identity():
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('law.py:1:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin("ValueError", occurrence="law.py:1:0")
     state = object()
     incoming = Halted(true_guard(), effect, state)
 
@@ -215,7 +215,7 @@ def test_none_disposition_refuses_completed_face_without_mutation():
 
 
 def test_none_disposition_refuses_halted_face_without_mutation():
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('law.py:2:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin("ValueError", occurrence="law.py:2:0")
     state = object()
     incoming = Halted(true_guard(), effect, state)
 
@@ -289,7 +289,7 @@ def test_exit_face_binding_applied_per_face_without_rebuilding_exit():
         "X",
         Halted(
             true_guard(),
-            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('k.py:1:0'), exception_name='KeyError'),
+            RaiseEffect.for_builtin("KeyError", occurrence="k.py:1:0"),
         ),
     )
     assert completed.kind == "completed"
@@ -300,7 +300,7 @@ def test_exit_face_binding_applied_per_face_without_rebuilding_exit():
 def test_enter_halt_skips_body_and_exit():
     body_ran = []
     exit_ran = []
-    enter_halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:308:0'), exception_name='OSError')
+    enter_halt = RaiseEffect.for_builtin('OSError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:303:0')
     sugar = _resource(
         enter=_FixedSugar(Incomplete(enter_halt)),
         body=(_Pass(probe=body_ran),),
@@ -336,7 +336,10 @@ def test_completed_body_runs_exit_with_three_explicit_none_coordinates():
 def test_raised_body_routes_exact_face_coordinates_to_exit():
     """Face 3: type/value/traceback coordinates share the exact raised face."""
     face_id = "raised-face-17"
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('source.py:17:8'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin("ValueError",
+        
+        occurrence="source.py:17:8",
+    )
     exit_sugar = _parametric_exit(face_id=face_id)
     type_coord, value_coord, traceback_coord = (
         argument.desugar().value for argument in exit_sugar.args
@@ -363,7 +366,7 @@ def test_falsy_source_exit_preserves_the_exact_original_halt():
     """Face 4: falsity restores the same effect and pre-effect state objects."""
     from sugar_lift_py_tests.outcome.exit_set import ExitSet
 
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:4:2'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin("ValueError", occurrence="body.py:4:2")
     state = ObjectValue("native-resource", (), identity="before-raise")
     incoming = Halted(true_guard(), effect, state)
     routed = ExitSet((incoming,)).and_exit_truthiness(
@@ -380,7 +383,7 @@ def test_truthy_source_exit_suppresses_the_original_raise():
     """Face 5: source-testified truth consumes the raised edge."""
     from sugar_lift_py_tests.outcome.exit_set import ExitSet
 
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:5:2'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin("ValueError", occurrence="body.py:5:2")
     routed = ExitSet((Halted(true_guard(), effect),)).and_exit_truthiness(
         ExitSet.completed(TermValue(True)), site="exit-site"
     )
@@ -391,7 +394,7 @@ def test_undecided_source_exit_keeps_both_faces_factored():
     """Face 6: UNKNOWN truth is neither false nor true; both arms survive."""
     from sugar_lift_py_tests.outcome.exit_set import ExitSet
 
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:6:2'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin("ValueError", occurrence="body.py:6:2")
     routed = ExitSet((Halted(true_guard(), effect),)).and_exit_truthiness(
         ExitSet.completed(SymbolicValue(make_var("exit_result"))), site="exit-site"
     )
@@ -410,7 +413,7 @@ def test_never_suppresses_restores_body_halt():
 
 def test_typed_never_suppresses_preserves_conditional_raise_and_normal_face():
     guard = atomic("with_body_guard", [make_var("state")])
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:4:8'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin("ValueError", occurrence="body.py:4:8")
 
     class _ConditionalRaise(Sugar):
         def desugar(self, ctx=None):
@@ -631,7 +634,7 @@ def test_never_suppresses_needs_no_second_cleanup_algebra():
     faces = (
         Completed(true_guard(), _FloorValue("body")),
         Halted(
-            true_guard(), RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:642:0'), exception_name='ValueError'), _FloorValue("pre")
+            true_guard(), RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:637:0'), _FloorValue("pre")
         ),
     )
     for disposition in (NeverSuppresses(), NeverSuppressesDispositionV1()):
@@ -659,7 +662,12 @@ def test_lying_the_equivalence_is_specific_to_never_suppresses():
     coordinate, mro = _builtin_exception_identity("ValueError")
     halted = Halted(
         true_guard(),
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('equiv.py:1:0'), exception_name='ValueError', exception_type_coordinate=coordinate, exception_type_mro=mro),
+        RaiseEffect.for_builtin("ValueError",
+            
+            exception_type_coordinate=coordinate,
+            exception_type_mro=mro,
+            occurrence="equiv.py:1:0",
+        ),
         _FloorValue("pre"),
     )
     suppressing = ExitSuppressionContract.suppresses(("ValueError",))
@@ -682,7 +690,7 @@ def test_exit_face_binding_completed_is_none_triple():
 
 
 def test_exit_face_binding_raised_is_not_none_triple():
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('src.py:3:4'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin("ValueError", occurrence="src.py:3:4")
     face = Halted(true_guard(), effect)
     binding = ExitFaceBinding.from_body_exit("X", face)
     assert binding.kind == "raised"

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
@@ -144,7 +144,12 @@ def test_summary_suppresses_disposition_consumes_matching_body_halt():
         body=(
             _FixedSugar(
                 Incomplete(
-                    RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('resource.py:4:8'), exception_name='ValueError', exception_type_coordinate=coordinate, exception_type_mro=mro)
+                    RaiseEffect.for_builtin("ValueError",
+                        
+                        occurrence="resource.py:4:8",
+                        exception_type_coordinate=coordinate,
+                        exception_type_mro=mro,
+                    )
                 )
             ),
         ),
@@ -167,7 +172,7 @@ def test_summary_suppresses_disposition_consumes_matching_body_halt():
 
 
 def test_source_true_exit_consumes_the_halted_edge():
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('resource.py:4:8'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin("ValueError", occurrence="resource.py:4:8")
     sugar, protocol = _truthiness_resource(
         exit_value=TermValue(True), body=(_FixedSugar(Incomplete(effect)),)
     )
@@ -180,7 +185,7 @@ def test_source_true_exit_consumes_the_halted_edge():
 
 
 def test_source_false_exit_passes_the_exact_halted_edge_through():
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('resource.py:4:8'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin("ValueError", occurrence="resource.py:4:8")
     sugar, protocol = _truthiness_resource(
         exit_value=TermValue(False), body=(_FixedSugar(Incomplete(effect)),)
     )
@@ -194,7 +199,7 @@ def test_source_false_exit_passes_the_exact_halted_edge_through():
 
 
 def test_source_undecided_exit_keeps_both_suppression_faces():
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('resource.py:4:8'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin("ValueError", occurrence="resource.py:4:8")
     result = SymbolicValue(ctor("fixture:undecided-exit", ()))
     sugar, _ = _truthiness_resource(
         exit_value=result, body=(_FixedSugar(Incomplete(effect)),)
@@ -245,7 +250,9 @@ def test_source_exit_runs_on_early_return_face():
         ),
         (
             Incomplete(
-                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('resource.py:8:8'), exception_name='ValueError')
+                RaiseEffect.for_builtin("ValueError",
+                     occurrence="resource.py:8:8"
+                )
             ),
             TermValue(False),
             Halted,

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -660,7 +660,12 @@ def _project_generator_enter_result(protocol, machine, result):
         refusal = observed_entry_refusal()
         blame = str(machine.instance_coordinate)
         return Incomplete(
-            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(f'generator-entry-refusal:{blame}'), exception_name=refusal.exception_name, blame=blame, raised_value=refusal.message)
+            RaiseEffect.for_builtin(
+                refusal.exception_name,
+                blame=blame,
+                occurrence=f"generator-entry-refusal:{blame}",
+                raised_value=refusal.message,
+            )
         )
     if isinstance(result, GeneratorTransitionGapV1):
         raise SugarNotWritten(

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
@@ -131,7 +131,11 @@ def test_enter_bound_generator_construction_refuses_foreign_frame():
 
 def test_enter_bound_generator_sequences_mixed_yield_and_halt_faces():
     true_face, false_face = partition("mixed-enter-guard")
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('mixed-enter:halt'), exception_name='RenamedError', blame='mixed-enter')
+    effect = RaiseEffect.for_builtin("RenamedError",
+        
+        blame="mixed-enter",
+        occurrence="mixed-enter:halt",
+    )
     state = TermValue("pre-enter-state")
     pending = ()
 

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_manager_renamed_lifecycle.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_manager_renamed_lifecycle.py
@@ -265,7 +265,11 @@ class _Fixed(Sugar):
 
 def _nested_body_faces() -> ExitSet:
     """Completed, Returned, and Halted edges under distinct guards."""
-    raise_effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:10:8:raise'), exception_name='ValueError', blame='body.py:10:8:raise')
+    raise_effect = RaiseEffect.for_builtin("ValueError",
+        
+        occurrence="body.py:10:8:raise",
+        blame="body.py:10:8:raise",
+    )
     return ExitSet(
         (
             Completed(

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_nested_managers.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_nested_managers.py
@@ -181,7 +181,12 @@ def test_nested_cleanup_runs_before_outer_resume_on_halt(tmp_path: Path) -> None
     machine = entered.machine
     assert isinstance(machine.steps[machine.cursor], NestedManagerExitStepV1)
     # Plant a throw at the post-yield suspension (halted body edge).
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body:halt'), exception_name='RuntimeError', blame='body', raised_value='boom')
+    effect = RaiseEffect.for_builtin("RuntimeError",
+        
+        blame="body",
+        occurrence="body:halt",
+        raised_value="boom",
+    )
     halted = machine.throw(effect)
     # Nested exit must have run: NestedEnteredBinding still present but exit was
     # called (one-shot nested protocol refuses double exit).

--- a/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
@@ -740,7 +740,12 @@ def _raise_effect_with_message(message: str):
             return identity
 
     return (
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(f'{message}@match-pattern'), exception_name='ValueError', exception_type_coordinate=identity, raised_value=raised),
+        RaiseEffect.for_builtin("ValueError",
+            
+            exception_type_coordinate=identity,
+            occurrence=f"{message}@match-pattern",
+            raised_value=raised,
+        ),
         _Handler(),
     )
 

--- a/implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py
@@ -62,7 +62,7 @@ def test_source_return_projection_selects_one_unconditional_returned_floor() -> 
         BlockValue(
             (
                 ReturnValue(TermValue("returned")),
-                RaiseValue(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py:91:0'), exception_name='RuntimeError')),
+                RaiseValue(RaiseEffect.for_builtin('RuntimeError', occurrence='implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py:91:0')),
             ),
             can_fall_through=False,
         ),
@@ -88,7 +88,7 @@ def test_source_return_projection_preserves_ambiguous_control_flow(ambiguous) ->
     (
         BlockValue((TermValue("foreign"),)),
         BlockValue(
-            (RaiseValue(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py:65:0'), exception_name='RuntimeError')),),
+            (RaiseValue(RaiseEffect.for_builtin('RuntimeError', occurrence='implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py:65:0')),),
             can_fall_through=False,
         ),
     ),

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -886,7 +886,7 @@ def test_failure_entering_inner_assigned_resource_still_exits_outer():
     (the inner manager was never entered).
     """
     outer_exit, inner_exit = [], []
-    halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('inner.py:1:0'), exception_name='OSError')
+    halt = RaiseEffect.for_builtin("OSError", occurrence="inner.py:1:0")
     inner = _source_resource(
         manager=_FixedSugar(Complete(_FloorValue("inner-mgr"))),
         protocol=_ProbeProtocol(enter=Incomplete(halt), exit_probe=inner_exit),
@@ -921,7 +921,7 @@ def test_failure_entering_inner_assigned_resource_still_exits_outer():
 def test_discrimination_outer_exit_is_not_skipped_on_enter_halt():
     """BITE: completion-only exit would leave the outer exit probe empty."""
     outer_exit, inner_exit = [], []
-    halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('inner.py:1:0'), exception_name='OSError')
+    halt = RaiseEffect.for_builtin("OSError", occurrence="inner.py:1:0")
     inner = _source_resource(
         manager=_FixedSugar(Complete(_FloorValue("inner-mgr"))),
         protocol=_ProbeProtocol(enter=Incomplete(halt), exit_probe=inner_exit),

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1912,7 +1912,7 @@ def test_factored_raise_routing_uses_none_and_pattern_message_faces():
     type_term = ctor("python:exception_type", [str_const("builtins.ValueError")])
     raise_face = Halted(
         true_guard(),
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('t.py:2:8'), exception_name='ValueError', blame='t.py:2:8', exception_type_coordinate=type_term, exception_type_mro=(type_term,), raised_value=StringValue('needle')),
+        RaiseEffect.for_builtin('ValueError', blame='t.py:2:8', exception_type_coordinate=type_term, exception_type_mro=(type_term,), raised_value=StringValue('needle'), occurrence='t.py:2:8'),
         None,
     )
     body = ExitSet((raise_face,))

--- a/implementations/python/sugar-lift-python-source/tests/test_source_resource_nested_exit_faces.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_resource_nested_exit_faces.py
@@ -143,7 +143,10 @@ def _state(marker: str):
 
 def _nested_body_faces():
     """One ExitSet with Completed, Returned, and Halted faces under distinct guards."""
-    raise_effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:10:8:raise'), exception_name='ValueError', blame='body.py:10:8:raise')
+    raise_effect = RaiseEffect.for_builtin("ValueError",
+        occurrence="body.py:10:8:raise",
+        blame="body.py:10:8:raise",
+        )
     return ExitSet(
         (
             Completed(
@@ -291,7 +294,10 @@ def test_truthy_exit_suppresses_only_the_incoming_raise():
 def test_exit_halt_supersedes_every_incoming_body_face():
     """A halted __exit__ supersedes Completed, Returned, and Halted body faces."""
     body, raise_effect = _nested_body_faces()
-    exit_halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit.py:1:0'), exception_name='RuntimeError', blame='exit.py:1:0')
+    exit_halt = RaiseEffect.for_builtin("RuntimeError",
+        occurrence="exit.py:1:0",
+        blame="exit.py:1:0",
+        )
     protocol = _RecordingProtocol(exit_outcome=Incomplete(exit_halt))
     sugar = _source_resource(
         protocol=protocol,
@@ -321,8 +327,14 @@ def test_exit_halt_supersedes_every_incoming_body_face():
 
 def test_face_occurrence_lying_twin_discriminates_exit_bindings():
     """Lying twin: distinct raise occurrences mint distinct ExitFaceBinding rows."""
-    a = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:1:0:A'), exception_name='ValueError', blame='body.py:1:0:A')
-    b = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:2:0:B'), exception_name='ValueError', blame='body.py:2:0:B')
+    a = RaiseEffect.for_builtin("ValueError",
+        occurrence="body.py:1:0:A",
+        blame="body.py:1:0:A",
+        )
+    b = RaiseEffect.for_builtin("ValueError",
+        occurrence="body.py:2:0:B",
+        blame="body.py:2:0:B",
+        )
     bind_a = ExitFaceBinding.from_body_exit(
         "exit-face", Halted(true_guard(), a, _state("a"))
     )

--- a/implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py
@@ -64,7 +64,6 @@ def test_source_property_getter_publishes_authenticated_exceptional_exit(
     effect = halted[0].effect
     assert isinstance(effect, RaiseEffect)
     assert effect.exception_name == "ValueError"
-    assert effect.exception_type_coordinate is not None
     assert effect.producer_node_owner == "Attribute"
 
 
@@ -90,7 +89,6 @@ def test_property_getter_raise_keeps_imported_bare_exception_coordinate(
     halted = next(face for face in outcome.exits if isinstance(face, Halted))
     assert isinstance(halted.effect, RaiseEffect)
     assert halted.effect.exception_name == "CustomError"
-    assert halted.effect.exception_type_coordinate is not None
 
 
 def test_source_property_getter_that_returns_completes_without_a_raise(
@@ -164,5 +162,4 @@ def test_pandas_303_abstract_method_property_is_the_concrete_reproducer() -> Non
     effect = halted.effect
     assert isinstance(effect, RaiseEffect)
     assert effect.exception_name == "AbstractMethodError"
-    assert effect.exception_type_coordinate is not None
     assert effect.producer_node_owner == "Attribute"

--- a/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
+++ b/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
@@ -437,7 +437,7 @@ def _three_deep_manager_halt(exception_name: str):
     original_middle = middle
     original_inner = inner
     middle_exit, inner_enter, inner_exit = [], [], []
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('test_common.py:640'), exception_name=exception_name, exception_type_coordinate=ctor('python:exception_type_identity', [str_const('builtins'), str_const(exception_name)]))
+    effect = RaiseEffect(exception_type_coordinate=ctor('python:exception_type_identity', [str_const('builtins'), str_const(exception_name)]), occurrence=AuthenticatedRaiseLocus.of('test_common.py:640'), exception_name=exception_name)
     inner = replace(
         inner,
         manager=_FixedOutcomeSugar(Incomplete(effect)),
@@ -587,7 +587,7 @@ def _three_deep_level_receipts(exception_name: str):
     outer, middle, inner = _with_routers(
         _built_function(identity, "test_close_on_error", rows)
     )
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('test_common.py:640'), exception_name=exception_name, exception_type_coordinate=ctor('python:exception_type_identity', [str_const('builtins'), str_const(exception_name)]))
+    effect = RaiseEffect(exception_type_coordinate=ctor('python:exception_type_identity', [str_const('builtins'), str_const(exception_name)]), occurrence=AuthenticatedRaiseLocus.of('test_common.py:640'), exception_name=exception_name)
     inner = replace(
         inner,
         manager=_FixedOutcomeSugar(Incomplete(effect)),

--- a/implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py
+++ b/implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py
@@ -272,7 +272,7 @@ def test_the_effect_itself_is_not_altered_by_the_carried_demand():
     """
     from sugar_lift_py_tests.effect import RaiseEffect
 
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:476:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:476:0')
     bare = Incomplete(effect)
     carrying = Incomplete(effect, (), ("sentinel-entry",))
 
@@ -355,7 +355,7 @@ def test_an_effect_face_is_no_longer_the_partition_gap():
 
     joined = rewrap_pending(
         entry,
-        Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:441:0'), exception_name='ValueError')),
+        Incomplete(RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:441:0')),
         owner="test_effect_face",
         blame=entry.source_node,
     )
@@ -382,7 +382,7 @@ def _halted_carrier(guard=None):
 
     out = _out("def f(p):\n return [p[0]]\n")
     (entry,) = _entries(out)
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:385:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:385:0')
     incomplete = Incomplete(effect, (guard,) if guard is not None else (), (entry,))
     exits = outcome_to_exitset(incomplete)
     (arm,) = exits.exits
@@ -438,7 +438,7 @@ def test_halted_arms_owing_different_things_are_different_destinations():
 
     first = _entries(_out("def f(p):\n return [p[0]]\n"))[0]
     second = _entries(_out("def f(q):\n return [q[1]]\n"))[0]
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:358:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:358:0')
 
     merged = ExitSet(
         (
@@ -473,7 +473,7 @@ def test_halted_arms_owing_the_same_thing_still_merge():
     from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
 
     (entry,) = _entries(_out("def f(p):\n return [p[0]]\n"))
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:275:0'), exception_name='ValueError')
+    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:275:0')
 
     merged = ExitSet(
         (

--- a/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
@@ -202,7 +202,7 @@ def test_rhs_constructs_before_halted_receiver_and_store_does_not_continue():
     sugar = assignment.sugar()
     receiver_calls = []
     value_calls = []
-    halt = Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_store_target_effect.py:205:0'), exception_name='ArbitraryError'))
+    halt = Incomplete(RaiseEffect.for_builtin('ArbitraryError', occurrence='implementations/python/sugar-source-tree/tests/test_store_target_effect.py:205:0'))
     rewritten = replace(
         sugar,
         receiver=_OutcomeSugar(halt, receiver_calls),

--- a/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
@@ -386,7 +386,6 @@ def test_bare_reraise_preserves_the_same_effect_occurrence():
     # Occurrence is the original raise site (line of ``raise ValueError``),
     # not a reconstructed site at the bare re-raise.
     assert out.effect.occurrence.endswith(":6:8")
-    assert out.effect.exception_type_coordinate is not None
 
 
 def test_bare_reraise_is_not_a_reconstructed_raise_at_handler_site():

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -240,7 +240,6 @@ def test_bare_reraise_reemits_the_exact_inflight_raise():
     )
     assert isinstance(out, Incomplete)
     assert isinstance(out.effect, RaiseEffect)
-    assert out.effect.exception_type_coordinate is not None
     assert out.effect.exception_name == "ValueError"
     assert out.effect.occurrence.endswith(":6:8")
 
@@ -530,7 +529,6 @@ def test_finally_raise_supersedes_break_instead_of_fabricating_loop_exit():
     )
     assert isinstance(out, Incomplete)
     assert isinstance(out.effect, RaiseEffect)
-    assert out.effect.exception_type_coordinate is not None
     assert out.effect.exception_name == "ArbitraryCleanupFault"
 
 

--- a/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
@@ -362,7 +362,7 @@ def test_failure_entering_second_manager_still_exits_first():
     outgoing edge, not only the completed one.
     """
     outer_exit, inner_exit = [], []
-    halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('b.py:1:0'), exception_name='OSError')
+    halt = RaiseEffect.for_builtin("OSError", occurrence="b.py:1:0")
     sugar = _nested_pair(
         _FixedSugar(Incomplete(halt)),
         outer_exit_probe=outer_exit,
@@ -380,7 +380,7 @@ def test_discrimination_first_exit_is_not_skipped_on_the_halted_edge():
     unran. Assert the wrong expectation and show it fails."""
     outer_exit, inner_exit = [], []
     sugar = _nested_pair(
-        _FixedSugar(Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py:383:0'), exception_name='OSError'))),
+        _FixedSugar(Incomplete(RaiseEffect.for_builtin('OSError', occurrence='implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py:383:0'))),
         outer_exit_probe=outer_exit,
         inner_exit_probe=inner_exit,
     )
@@ -418,7 +418,7 @@ def test_body_halt_inside_nested_managers_runs_both_exits():
     """LAW: a halting BODY still exits B then A; the halt is preserved under
     NeverSuppresses."""
     outer_exit, inner_exit = [], []
-    halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:2:4'), exception_name='ValueError')
+    halt = RaiseEffect.for_builtin("ValueError", occurrence="body.py:2:4")
     inner = _resource(
         body=(_FixedSugar(Incomplete(halt)),), slot="B", exit_probe=inner_exit
     )
@@ -432,7 +432,7 @@ def test_body_halt_inside_nested_managers_runs_both_exits():
 
 def test_discrimination_body_halt_is_not_suppressed_by_never_suppresses():
     outer_exit, inner_exit = [], []
-    halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:2:4'), exception_name='ValueError')
+    halt = RaiseEffect.for_builtin("ValueError", occurrence="body.py:2:4")
     inner = _resource(
         body=(_FixedSugar(Incomplete(halt)),), slot="B", exit_probe=inner_exit
     )

--- a/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
@@ -734,7 +734,7 @@ def test_discrimination_a_matching_halt_does_not_remain_outgoing(tmp_path):
 def test_exit_halt_supersedes_every_incoming_edge(tmp_path):
     resource, _ = _both_arms(tmp_path)
     body_es = _body_exitset(resource.body)
-    cleanup_failure = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit:1:0'), exception_name='OSError')
+    cleanup_failure = RaiseEffect.for_builtin("OSError", occurrence="exit:1:0")
 
     routed = body_es.and_exit(
         ExitSet.halted(cleanup_failure), disposition=resource.disposition


### PR DESCRIPTION
## Linear stack collapsed — settles cycle with #6966/#6968

**Order (final):** `main` → type-coord + locus as **one linear tip** `64ae899ba`.

`RaiseEffect` requires **BOTH**:
- `exception_type_coordinate: Term` (mr_brown type identity)
- `occurrence: AuthenticatedRaiseLocus` (mr_blue locus identity)

`UndeterminedRaiseEffect` = type-undetermined only. Locus undetermined cannot mint authenticated RaiseEffect.

Branches `fix/named-exceptional-exit-required-coordinate` and `agent/authenticated-raise-locus` force-pushed to the **same tip** so merge_dog is not cyclic. Prefer merge this PR; close #6968 as duplicate if empty.

### Shell deleted
- presence-only `exception_type_coordinate is not None` teeth (type)
- presence-only occurrence teeth (locus — via AuthenticatedRaiseLocus)

### Shot accounting
- R: `R_nameless_authenticated_exceptional_exit` + locus presence subset
- Epsilon R: both nameless type and empty locus unconstructible on authenticated RaiseEffect
- Floors: no fabricated names/loci; undetermined types remain third values
- Unsound: no bx remeasure of this tip (await fleet measure)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require type coordinate and authenticated locus on `RaiseEffect` and introduce `UndeterminedRaiseEffect`
> - `RaiseEffect` now requires a non-None `exception_type_coordinate` and an authenticated locus; constructing one without either raises `TypeError` at instantiation time.
> - A new `RaiseEffect.for_builtin(name, occurrence=...)` factory resolves the type coordinate and MRO for known builtin exception names automatically.
> - A new `UndeterminedRaiseEffect` dataclass represents raise-shaped halts that lack an authenticated type identity or locus; it is accepted by `require_effect`, `effect_kind`, `effect_reason`, and `effect_status`.
> - `RaiseSugar.desugar`, `ground_raise_effect`, and `_publish_undecided_dispatch_edges` now emit `UndeterminedRaiseEffect` or trigger `construction_panic_gap` rather than producing a `RaiseEffect` with a `None` coordinate.
> - The `_require_authenticated_exceptional_exit_citation` and `_require_exception_type_coordinate` helpers now explicitly reject `UndeterminedRaiseEffect` with a `SugarNotWritten` error.
> - A broad test sweep migrates direct `RaiseEffect(...)` constructions to `RaiseEffect.for_builtin(...)` or `UndeterminedRaiseEffect`, and removes assertions on `exception_type_coordinate` where the coordinate is no longer guaranteed.
> - Risk: any existing code constructing `RaiseEffect` with `exception_type_coordinate=None` (explicitly or by omission) will now raise `TypeError` at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d875399.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->