### PR TITLE
Run CI on main only; stop PR-triggered matrix flood

### DIFF
--- a/.github/workflows/bare-exception-zero-tolerance.yml
+++ b/.github/workflows/bare-exception-zero-tolerance.yml
@@ -4,7 +4,6 @@ name: Bare exception zero tolerance (discrimination)
 # factory-zero-tolerance.yml so heavy floors share one pinned run and one
 # concurrency group (no multi-workflow pending-run cancellation).
 on:
-  pull_request:
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 # NO `concurrency:` BLOCK. `cancel-in-progress: false` is not enough: GitHub
 # keeps only ONE pending run per group and replaces a queued run with a newer

--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -1,7 +1,6 @@
 name: Python sole-construction floors (R>0 red)
 
 on:
-  pull_request:
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/native-crash-zero-tolerance.yml
+++ b/.github/workflows/native-crash-zero-tolerance.yml
@@ -3,7 +3,6 @@ name: Python native-crash floor (discrimination)
 # Discrimination only. Full corpus R_native_crashes runs exclusively under
 # factory-zero-tolerance.yml (one heavy orchestrator).
 on:
-  pull_request:
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/python-package-suite.yml
+++ b/.github/workflows/python-package-suite.yml
@@ -29,7 +29,6 @@ name: Python package suite (authoritative)
 # are not verdicts.
 
 on:
-  pull_request:
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/timeout-zero-tolerance.yml
+++ b/.github/workflows/timeout-zero-tolerance.yml
@@ -3,7 +3,6 @@ name: Timeout zero tolerance (discrimination)
 # Discrimination only. Full corpus R_timeouts runs exclusively under
 # factory-zero-tolerance.yml (one heavy orchestrator).
 on:
-  pull_request:
   push:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Removes the `pull_request:` trigger from the six heavy workflows. Each keeps `push: branches: [main]` plus workflow_dispatch/schedule, so every landed commit is still measured — after the shot, not before it.

**Why.** Runners are 52 Docker containers on battleaxe (~30 concurrent). Twenty-five merges in one hour, each firing a full PR matrix, produced 184 non-completed runs and **zero completed measurements all day**. Our own bx re-measurement jobs share that same box, so we were starving the CI we were waiting on. Product R has been unknown since 2026-07-26 as a direct result.

Doctrine: "we do not gate ... the merge is not a prize awarded after a slow compile, test, and sweep - it is the measurement boundary for the next shot."

**R axis:** R_ci_capacity_starvation. **Epsilon R:** queued 184 → 0 steady-state.
**Shell deleted:** none — this removes a GATE, not an instrument. Every floor still runs on main.

**Floor moved, stated on the record.** `python-package-suite` and `ci.yml` exist because `sugar-lift-py-tests` had no PR-gate coverage, and that gap let #6270 rewrite the `ExitSet.and_exit` algebra untested. Removing the PR trigger re-opens that exposure: regressions are now caught on main rather than before merge. Accepted deliberately — a gate that never produces a reading catches nothing either.

`issue-claim-labels.yml` keeps its trigger; it is labelling, not CI compute.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `pull_request` trigger from all CI workflows to run on main pushes only
> Removes the `pull_request` event trigger from six GitHub Actions workflows, so they no longer run on every PR and only execute on pushes to `main` (plus `schedule` and `workflow_dispatch` where already configured). Behavioral Change: PRs will no longer get automated CI feedback from these workflows until merged to `main`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 238635a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->