### PR TITLE
AuthenticatedRaiseLocus: seal raise occurrence at construction

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -150,11 +150,7 @@ class NativeOperationResolutionV1:
             testimony = self.pre_effect_state
             effect = self.effect
             if testimony is None:
-                effect = RaiseEffect(
-                    exception_type_coordinate=self.exception_type_coordinate,
-                    occurrence=str(occurrence.wire()),
-                    blame=str(occurrence.wire()),
-                )
+                effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(str(occurrence.wire())), exception_type_coordinate=self.exception_type_coordinate, blame=str(occurrence.wire()))
             if not isinstance(effect, RaiseEffect):
                 raise TypeError(
                     "exceptional native operation effect must be RaiseEffect"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
@@ -49,6 +49,7 @@ from .modulo_by_zero_runtime_effect import ModuloByZeroRuntimeEffect
 from .name_error_effect import NameErrorEffect
 from .os_exit_runtime_effect import OSExitRuntimeEffect
 from .power_runtime_effect import PowerRuntimeEffect
+from .authenticated_raise_locus import AuthenticatedRaiseLocus, UndeterminedRaiseLocus
 from .raise_effect import RaiseEffect
 from .grouped_raise_effect import GroupedRaiseEffect, GroupedRaisePartition
 from .warning_effect import WarningEffect
@@ -125,6 +126,8 @@ __all__ = [
     "NameErrorEffect",
     "OSExitRuntimeEffect",
     "PowerRuntimeEffect",
+    "AuthenticatedRaiseLocus",
+    "UndeterminedRaiseLocus",
     "RaiseEffect",
     "GroupedRaiseEffect",
     "GroupedRaisePartition",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/authenticated_raise_locus.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/authenticated_raise_locus.py
@@ -1,0 +1,119 @@
+"""Authenticated raise locus — the missing noun behind occurrence teeth.
+
+CLASS
+    AuthenticatedRaiseLocus / UndeterminedRaiseLocus
+
+WHY THIS OBJECT
+    Presence-only teeth on ``effect.occurrence`` / ``occurrence_id`` existed
+    because ``RaiseEffect.occurrence: str | None`` accepted a face with no
+    locus. An auditor that only checks non-None is a confession that this
+    constructor did not exist yet (T / AGENTS.md).
+
+LAW OF ONE
+    One door: :meth:`AuthenticatedRaiseLocus.of`. Empty string, None, and
+    ``UndeterminedRaiseLocus`` cannot construct an authenticated locus.
+    Undecided is a third value with its own type — never None on the
+    authenticated type, never a fabricated placeholder string.
+
+BOUNDARY (with mr_brown)
+    This module owns LOCUS identity only. Type identity
+    (``exception_type_coordinate``) is owned by the RaiseEffect type-coord
+    climb (mr_brown). Neither fabricates the other.
+
+RETIREMENT
+    When every authenticated RaiseEffect carries ``AuthenticatedRaiseLocus``
+    and undecided faces use ``UndeterminedRaiseLocus`` (or
+    ``UndeterminedRaiseEffect`` for type-undetermined), delete presence-only
+    and locus-shape teeth on occurrence / occurrence_id. The type carries
+    the law.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AuthenticatedRaiseLocus:
+    """Source-authenticated raise locus — unconstructible empty or undetermined.
+
+    ``value`` is the stable occurrence string (typically file:line:col or an
+    equivalent site seal). Equality is string equality of the sealed value.
+    """
+
+    value: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str):
+            raise TypeError(
+                "AuthenticatedRaiseLocus refuses non-str value "
+                f"({type(self.value).__name__}). Pass a locus string or use "
+                "AuthenticatedRaiseLocus.of(site)."
+            )
+        if not self.value.strip():
+            raise TypeError(
+                "AuthenticatedRaiseLocus refuses empty locus. If the locus is "
+                "unknown, construct UndeterminedRaiseLocus or throw — never "
+                "pass None or '' through this door."
+            )
+
+    @classmethod
+    def of(cls, source: object) -> "AuthenticatedRaiseLocus":
+        """ONE door for authenticated loci.
+
+        Accepts an existing locus, a non-empty str, or any object whose
+        ``str(...)`` is a non-empty locus (e.g. SourceFragment). Refuses None,
+        empty strings, and UndeterminedRaiseLocus (cannot impersonate).
+        """
+        if isinstance(source, AuthenticatedRaiseLocus):
+            return source
+        if isinstance(source, UndeterminedRaiseLocus):
+            raise TypeError(
+                "AuthenticatedRaiseLocus.of refuses UndeterminedRaiseLocus. "
+                "Undecided locus is a third value — carry UndeterminedRaiseLocus "
+                "explicitly, or throw if the producer is unfinished."
+            )
+        if source is None:
+            raise TypeError(
+                "AuthenticatedRaiseLocus.of refuses None. Throw (honorable "
+                "unfinished producer) or construct UndeterminedRaiseLocus — "
+                "never pass None."
+            )
+        text = str(source).strip()
+        if not text:
+            raise TypeError(
+                "AuthenticatedRaiseLocus.of refuses empty locus text from "
+                f"{type(source).__name__}. Thread a real site/fragment or "
+                "construct UndeterminedRaiseLocus."
+            )
+        return cls(text)
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclass(frozen=True)
+class UndeterminedRaiseLocus:
+    """Third value: locus could not be determined.
+
+    Structurally distinct from :class:`AuthenticatedRaiseLocus` so a nameless
+    halt cannot wear authenticated clothes. Suppress/render/matchers that
+    require an authenticated locus refuse this type.
+    """
+
+    reason: str = "raise locus undetermined"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.reason, str) or not self.reason.strip():
+            raise TypeError(
+                "UndeterminedRaiseLocus.reason must be a non-empty str naming "
+                "why the locus is undetermined"
+            )
+
+    @property
+    def value(self) -> None:
+        """Always None — undetermined has no authenticated occurrence string."""
+        return None
+
+    def __str__(self) -> str:
+        return f"<undetermined-raise-locus: {self.reason}>"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/raise_effect.py
@@ -2,20 +2,39 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from sugar_lift_py_tests.effect.authenticated_raise_locus import (
+    AuthenticatedRaiseLocus,
+    UndeterminedRaiseLocus,
+)
 from sugar_lift_py_tests.ir import Term
 
 
 @dataclass(frozen=True)
 class RaiseEffect:
+    """Authenticated exceptional exit — locus identity is construction-required.
+
+    ``occurrence`` is :class:`AuthenticatedRaiseLocus`, not ``str | None``.
+    A face used as an authenticated raise is unconstructible without a named
+    locus. If the locus cannot be determined, do **not** pass None and do
+    **not** invent a spelling: throw, or carry undetermined locus only on
+    faces that are not this type (see UndeterminedRaiseLocus; type-undetermined
+    faces are mr_brown's UndeterminedRaiseEffect when that climb lands).
+
+    BOUNDARY: this field owns LOCUS identity only. ``exception_type_coordinate``
+    remains optional here until mr_brown's type-coordinate climb seals it;
+    that climb owns TYPE identity. Two nouns, two doors, no dual production.
+
+    LAW OF ONE / constructor climb: wrongness has no constructor here.
+    """
+
+    # Required first: no default. Callers that cannot supply a locus must throw
+    # or stop claiming an authenticated RaiseEffect.
+    occurrence: AuthenticatedRaiseLocus
     exception_name: str | None = None
     blame: str | None = None
     source_sha256: str | None = None
     exception_type_coordinate: Term | None = None
     exception_type_mro: tuple[Term, ...] | None = None
-    # Deterministic occurrence of THIS raise site (file:line:col). Distinct from
-    # type name: two raise ValueError at different loci have different
-    # occurrences. Never used as a fabricated "instance identity" from type alone.
-    occurrence: str | None = None
     # The value built from ``raise <exc>``.  A Name is a coordinate pointing
     # at the existing binding; a constructor call is its ordinary callsite.
     # Some runtime-generated RaiseEffects have no source exception child.
@@ -32,10 +51,23 @@ class RaiseEffect:
     # parent expression such as ``make_receiver()[0]``.
     producer_node_owner: str | None = None
 
+    def __post_init__(self) -> None:
+        if isinstance(self.occurrence, UndeterminedRaiseLocus):
+            raise TypeError(
+                "RaiseEffect refuses UndeterminedRaiseLocus as occurrence. "
+                "Authenticated exits require AuthenticatedRaiseLocus; "
+                "undecided locus cannot impersonate an authenticated face."
+            )
+        if not isinstance(self.occurrence, AuthenticatedRaiseLocus):
+            # Coerce only through the one door — never accept bare None.
+            object.__setattr__(
+                self, "occurrence", AuthenticatedRaiseLocus.of(self.occurrence)
+            )
+
     @property
-    def occurrence_id(self) -> str | None:
-        """Stable raise-effect occurrence coordinate, if known."""
-        return self.occurrence if self.occurrence is not None else self.blame
+    def occurrence_id(self) -> str:
+        """Stable raise-effect occurrence coordinate — always present."""
+        return self.occurrence.value
 
     @property
     def reason(self) -> str:
@@ -44,7 +76,7 @@ class RaiseEffect:
             if self.exception_type_coordinate is not None
             else "unknown exception"
         )
-        locus = f" at {self.blame}" if self.blame is not None else ""
+        locus = f" at {self.occurrence.value}"
         return (
             f"raise {name}{locus}: a Python raise effect that exits the current "
             "block and may be routed by a matching TrySugar handler"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
@@ -107,13 +107,19 @@ def ground_raise_effect(*, exception_name: str, site, owner: str, raised_value=N
     source_sha256 = (
         hashlib.sha256(source.encode()).hexdigest() if source is not None else None
     )
+    from sugar_lift_py_tests.effect.authenticated_raise_locus import (
+        AuthenticatedRaiseLocus,
+    )
+
     blame = str(site)
     type_coordinate, type_mro = _builtin_exception_identity(exception_name)
+    # ONE door for ground locus: site seal becomes AuthenticatedRaiseLocus.
+    # Empty/None cannot pass AuthenticatedRaiseLocus.of.
     return RaiseEffect(
+        occurrence=AuthenticatedRaiseLocus.of(blame),
         exception_name=exception_name,
         blame=blame,
         source_sha256=source_sha256,
-        occurrence=blame,
         exception_type_coordinate=type_coordinate,
         exception_type_mro=type_mro,
         raised_value=raised_value,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -1478,7 +1478,7 @@ class GeneratorConstructionV1:
             if (
                 isinstance(effect, RaiseEffect)
                 and effect.exception_type_coordinate == stop_identity
-                and effect.occurrence == str(step.occurrence)
+                and effect.occurrence_id == str(step.occurrence)
             ):
                 machine = replace(self, cursor=self.cursor + 1)
                 return machine._transition(requested)
@@ -1526,7 +1526,7 @@ class GeneratorConstructionV1:
             if (
                 isinstance(effect, RaiseEffect)
                 and effect.exception_type_coordinate == stop_identity
-                and effect.occurrence == str(step.occurrence)
+                and effect.occurrence_id == str(step.occurrence)
             ):
                 machine = replace(self, cursor=self.cursor + 1)
                 return machine._transition(requested)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -278,11 +278,7 @@ def _publish_undecided_dispatch_edges(
     halted_face, completed_face = partition(
         partition_key_for_law(law, site, op_kind)
     )
-    effect = RaiseEffect(
-        blame=str(site),
-        occurrence=str(site),
-        producer_node_owner="Compare",
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(str(site)), blame=str(site), producer_node_owner='Compare')
     return ExitSet(
         (
             Halted(dispatch_raises, effect, faces=frozenset({halted_face})),

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py
@@ -125,12 +125,7 @@ class GeneratorWithSugar(Sugar):
 
         refusal = observed_entry_refusal()
         blame = str(manager_exit.value.instance_coordinate)
-        effect = RaiseEffect(
-            exception_name=refusal.exception_name,
-            blame=blame,
-            occurrence=f"generator-entry-refusal:{blame}",
-            raised_value=refusal.message,
-        )
+        effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(f'generator-entry-refusal:{blame}'), exception_name=refusal.exception_name, blame=blame, raised_value=refusal.message)
         return ExitSet(
             (
                 Halted(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py
@@ -89,26 +89,7 @@ class RaiseSugar(Sugar):
             identity_reader = getattr(raised_value, "exception_type_identity", None)
             mro_reader = getattr(raised_value, "exception_type_mro", None)
             return Incomplete(
-                RaiseEffect(
-                    exception_name=self.exception_name,
-                    blame=blame,
-                    source_sha256=source_sha256,
-                    # Occurrence is the raise site — not a type-level identity.
-                    occurrence=blame,
-                    exception_type_coordinate=(
-                        identity_reader()
-                        if identity_reader is not None
-                        else getattr(raised_value, "exception_type_coordinate", None)
-                    ),
-                    exception_type_mro=(
-                        mro_reader()
-                        if callable(mro_reader)
-                        else getattr(raised_value, "exception_type_mro", None)
-                    ),
-                    raised_value=raised_value,
-                    cause_value=cause_value,
-                    context_effect=context_effect,
-                )
+                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(blame), exception_name=self.exception_name, blame=blame, source_sha256=source_sha256, exception_type_coordinate=identity_reader() if identity_reader is not None else getattr(raised_value, 'exception_type_coordinate', None), exception_type_mro=mro_reader() if callable(mro_reader) else getattr(raised_value, 'exception_type_mro', None), raised_value=raised_value, cause_value=cause_value, context_effect=context_effect)
             )
 
         def after_exception(raised_value):

--- a/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
@@ -61,13 +61,7 @@ def _raise(name: str, marker: str, *, message: object | None = None):
         )
     return Halted(
         true_guard(),
-        RaiseEffect(
-            exception_name=name,
-            blame=f"producer.py:1:{marker}",
-            exception_type_coordinate=_identity(name),
-            exception_type_mro=(_identity(name),),
-            raised_value=raised_value,
-        ),
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(f'producer.py:1:{marker}'), exception_name=name, blame=f'producer.py:1:{marker}', exception_type_coordinate=_identity(name), exception_type_mro=(_identity(name),), raised_value=raised_value),
         _state(marker),
     )
 
@@ -235,7 +229,7 @@ def test_nameless_halt_stays_outside_assertion_boundary():
     cannot turn a nameless halt into that result or demand a predicate whose
     subject does not exist.
     """
-    nameless = RaiseEffect(blame="producer.py:9:4")
+    nameless = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('producer.py:9:4'), blame='producer.py:9:4')
     body = ExitSet((Halted(true_guard(), nameless, _state("nameless")),))
 
     routed = _boundary_from_exitset(body, expected=_Expected("ValueError")).desugar()
@@ -259,27 +253,10 @@ def test_pandas_common_143_composes_compare_exit_with_assertion_contract():
     producer_coordinate = _identity("TypeError")
     assert producer_coordinate == expected.identity
 
-    producer_effect = RaiseEffect(
-        exception_name="TypeError",
-        blame="pandas/tests/arithmetic/common.py:144:8",
-        occurrence="pandas/tests/arithmetic/common.py:144:8",
-        exception_type_coordinate=producer_coordinate,
-        exception_type_mro=(producer_coordinate,),
-        raised_value=CallSiteValue(
-            "TypeError",
-            (StringValue("Cannot compare type Timestamp with date"),),
-            ("message",),
-            ctor("call:TypeError", []),
-            None,
-        ),
-        producer_node_owner="ComparisonOpSugar.desugar",
-    )
+    producer_effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('pandas/tests/arithmetic/common.py:144:8'), exception_name='TypeError', blame='pandas/tests/arithmetic/common.py:144:8', exception_type_coordinate=producer_coordinate, exception_type_mro=(producer_coordinate,), raised_value=CallSiteValue('TypeError', (StringValue('Cannot compare type Timestamp with date'),), ('message',), ctor('call:TypeError', []), None), producer_node_owner='ComparisonOpSugar.desugar')
     matching = Halted(true_guard(), producer_effect, _state("compare"))
     other = _raise("ValueError", "other-type")
-    nameless_effect = RaiseEffect(
-        blame="pandas/tests/arithmetic/common.py:144:8",
-        producer_node_owner="ComparisonOpSugar.desugar",
-    )
+    nameless_effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('pandas/tests/arithmetic/common.py:144:8'), blame='pandas/tests/arithmetic/common.py:144:8', producer_node_owner='ComparisonOpSugar.desugar')
     nameless = Halted(true_guard(), nameless_effect, _state("nameless"))
     completed = Completed(true_guard(), _state("completed"))
     msg = CallSiteValue(
@@ -328,7 +305,7 @@ def test_pandas_common_143_composes_compare_exit_with_assertion_contract():
     assert binding.effect.exception_type_coordinate is producer_coordinate
     assert binding.effect.exception_type_coordinate is not expected.identity
     assert binding.effect.producer_node_owner == "ComparisonOpSugar.desugar"
-    assert binding.effect.occurrence == "pandas/tests/arithmetic/common.py:144:8"
+    assert binding.effect.occurrence_id == "pandas/tests/arithmetic/common.py:144:8"
     assert failed_message.effect is producer_effect
 
     by_marker = {
@@ -633,21 +610,7 @@ def test_factored_none_face_consumes_matching_raise_and_binds_exact_occurrence()
     from sugar_lift_py_tests.floor import StringValue
 
     occurrence = "producer.py:4:8:factored-none"
-    producer = RaiseEffect(
-        exception_name="ValueError",
-        blame=occurrence,
-        occurrence=occurrence,
-        exception_type_coordinate=_identity("ValueError"),
-        exception_type_mro=(_identity("ValueError"),),
-        raised_value=CallSiteValue(
-            "ValueError",
-            (StringValue("boom"),),
-            ("message",),
-            ctor("call:ValueError", []),
-            None,
-        ),
-        producer_node_owner="Compare.desugar",
-    )
+    producer = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_name='ValueError', blame=occurrence, exception_type_coordinate=_identity('ValueError'), exception_type_mro=(_identity('ValueError'),), raised_value=CallSiteValue('ValueError', (StringValue('boom'),), ('message',), ctor('call:ValueError', []), None), producer_node_owner='Compare.desugar')
     body = ExitSet((Halted(true_guard(), producer, _state("none-face-body")),))
 
     routed = _factored_boundary_from_exitset(body).desugar()
@@ -676,21 +639,7 @@ def test_factored_pattern_face_binds_only_on_held_arm_not_complement():
     from sugar_lift_py_tests.floor import StringValue
 
     occurrence = "producer.py:8:4:factored-pattern"
-    producer = RaiseEffect(
-        exception_name="ValueError",
-        blame=occurrence,
-        occurrence=occurrence,
-        exception_type_coordinate=_identity("ValueError"),
-        exception_type_mro=(_identity("ValueError"),),
-        raised_value=CallSiteValue(
-            "ValueError",
-            (StringValue("cannot convert"),),
-            ("message",),
-            ctor("call:ValueError", []),
-            None,
-        ),
-        producer_node_owner="BinOp.desugar",
-    )
+    producer = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_name='ValueError', blame=occurrence, exception_type_coordinate=_identity('ValueError'), exception_type_mro=(_identity('ValueError'),), raised_value=CallSiteValue('ValueError', (StringValue('cannot convert'),), ('message',), ctor('call:ValueError', []), None), producer_node_owner='BinOp.desugar')
     # Symbolic pattern keeps the message predicate open → held + complement.
     pattern = SymbolicValue(make_var("msg_pattern"))
     body = ExitSet((Halted(true_guard(), producer, _state("pattern-face-body")),))
@@ -728,20 +677,7 @@ def test_factored_as_binding_faces_keep_distinct_guards_and_identities():
     )
     from sugar_lift_py_tests.floor import StringValue
 
-    producer = RaiseEffect(
-        exception_name="ValueError",
-        blame="producer.py:1:0",
-        occurrence="producer.py:1:0",
-        exception_type_coordinate=_identity("ValueError"),
-        exception_type_mro=(_identity("ValueError"),),
-        raised_value=CallSiteValue(
-            "ValueError",
-            (StringValue("x"),),
-            ("message",),
-            ctor("call:ValueError", []),
-            None,
-        ),
-    )
+    producer = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('producer.py:1:0'), exception_name='ValueError', blame='producer.py:1:0', exception_type_coordinate=_identity('ValueError'), exception_type_mro=(_identity('ValueError'),), raised_value=CallSiteValue('ValueError', (StringValue('x'),), ('message',), ctor('call:ValueError', []), None))
     body = ExitSet((Halted(true_guard(), producer, _state("dual")),))
     pattern = SymbolicValue(make_var("open_pattern"))
 
@@ -773,20 +709,7 @@ def test_factored_none_face_without_as_slot_consumes_without_binding():
     """Discrimination twin: no observation slot means no binding testimony."""
     from sugar_lift_py_tests.floor import StringValue
 
-    producer = RaiseEffect(
-        exception_name="ValueError",
-        blame="producer.py:2:0",
-        occurrence="producer.py:2:0",
-        exception_type_coordinate=_identity("ValueError"),
-        exception_type_mro=(_identity("ValueError"),),
-        raised_value=CallSiteValue(
-            "ValueError",
-            (StringValue("boom"),),
-            ("message",),
-            ctor("call:ValueError", []),
-            None,
-        ),
-    )
+    producer = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('producer.py:2:0'), exception_name='ValueError', blame='producer.py:2:0', exception_type_coordinate=_identity('ValueError'), exception_type_mro=(_identity('ValueError'),), raised_value=CallSiteValue('ValueError', (StringValue('boom'),), ('message',), ctor('call:ValueError', []), None))
     body = ExitSet((Halted(true_guard(), producer, _state("no-slot")),))
 
     routed = _factored_boundary_from_exitset(body, observation_slot_id=None).desugar()

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py
@@ -108,7 +108,6 @@ def test_formal_attribute_completes_or_halts_from_authenticated_actual() -> None
         [str_const("builtins"), str_const("AttributeError")],
     )
     assert halted.exits[0].effect.exception_type_coordinate == attribute_error
-    assert halted.exits[0].effect.occurrence_id is not None
 
 
 def test_undecidable_attribute_actual_remains_named_loud() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
@@ -174,10 +174,7 @@ def test_rhs_halt_wins_before_receiver_evaluation(tmp_path):
             log.append("value")
             return Complete(
                 RaiseValue(
-                    RaiseEffect(
-                        exception_type_coordinate=str_const("ValueError"),
-                        occurrence="attr_store.py:2:16",
-                    )
+                    RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('attr_store.py:2:16'), exception_type_coordinate=str_const('ValueError'))
                 )
             )
 
@@ -517,7 +514,6 @@ def test_real_pandas_name_store_caller_faces_and_discrimination() -> None:
     ):
         assert isinstance(halt, Halted)
         assert "AttributeError" in repr(halt.effect.exception_type_coordinate)
-        assert halt.effect.occurrence_id is not None
         assert f"'startLine': {CORPUS_LINE}" in halt.effect.occurrence_id
 
     for receiver, owner in (

--- a/implementations/python/sugar-lift-py-tests/tests/test_binop_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_binop_method_caller.py
@@ -152,7 +152,6 @@ def _only_halted(outcome: object, *, require_pre_effect_state: bool = True) -> H
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate is not None
-    assert halted.effect.occurrence_id is not None
     if require_pre_effect_state:
         assert halted.state is not None, (
             "formal add halt omitted real pre-effect state "
@@ -421,7 +420,6 @@ def test_incompatible_operands_method_call_halts_with_named_typeerror() -> None:
         halted = outcome.exits[0]
         assert isinstance(halted, Halted), halted
         assert halted.effect.exception_type_coordinate == _identity("TypeError")
-        assert halted.effect.occurrence_id is not None
         assert halted.state is not None, (
             "bound-method producer_outcome TypeError halt lacks pre-effect "
             "state — sole Halted still collapses through Incomplete (#6659)"

--- a/implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py
@@ -7,7 +7,7 @@ from sugar_lift_py_tests.outcome import Incomplete
 
 
 def test_unguarded_incomplete_raise_stops_block_fallthrough():
-    block = BlockValue((Incomplete(RaiseEffect(exception_name="OSError")),))
+    block = BlockValue((Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py:19:0'), exception_name='OSError')),))
 
     assert not block.follow_rest().continues
 
@@ -16,7 +16,7 @@ def test_guarded_incomplete_raise_preserves_the_complementary_tail():
     block = BlockValue(
         (
             Incomplete(
-                RaiseEffect(exception_name="OSError"),
+                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py:10:0'), exception_name='OSError'),
                 branch_conditions=(make_var("condition"),),
             ),
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
@@ -218,11 +218,7 @@ def test_true_left_continues_to_right_without_truth_testing_final_operand() -> N
 def test_halted_left_truth_test_propagates_and_never_reaches_right() -> None:
     evaluations: list[str] = []
     truth_calls: list[str] = []
-    effect = RaiseEffect(
-        exception_name="LeftTruthError",
-        occurrence="test_bool_op_operand_sequence.py:1:0",
-        blame="test_bool_op_operand_sequence.py:1:0",
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('test_bool_op_operand_sequence.py:1:0'), exception_name='LeftTruthError', blame='test_bool_op_operand_sequence.py:1:0')
     left = _Operand("left", ExitSet.halted(effect), truth_calls)
     right = _Operand("right", _truth(True), truth_calls)
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_boolop_middle_leg_control.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_boolop_middle_leg_control.py
@@ -30,12 +30,10 @@ def _expression(expression: str):
 def _raise_occurrence(outcome) -> str:
     if isinstance(outcome, Complete):
         assert isinstance(outcome.value, RaiseValue)
-        assert outcome.value.effect.occurrence_id is not None
         return outcome.value.effect.occurrence_id
     assert isinstance(outcome, ExitSet)
     halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
     assert len(halted) == 1
-    assert halted[0].effect.occurrence_id is not None
     return halted[0].effect.occurrence_id
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py
@@ -26,12 +26,10 @@ def _expression(source_expression: str):
 def _raise_occurrence(outcome) -> str:
     if isinstance(outcome, Complete):
         assert isinstance(outcome.value, RaiseValue)
-        assert outcome.value.effect.occurrence_id is not None
         return outcome.value.effect.occurrence_id
     assert isinstance(outcome, ExitSet)
     halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
     assert len(halted) == 1
-    assert halted[0].effect.occurrence_id is not None
     return halted[0].effect.occurrence_id
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_callsite_positional_actual_exitset.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_callsite_positional_actual_exitset.py
@@ -84,14 +84,14 @@ def _source_call_partition(result_coordinate: str = "py.listcomp"):
         (
             Halted(
                 left_guard,
-                RaiseEffect("TypeError", occurrence="source.py:3:8"),
+                RaiseEffect('TypeError', occurrence=AuthenticatedRaiseLocus.of('source.py:3:8')),
                 TermValue(11),
                 frozenset({left_face}),
                 (_Pending("pending:left"),),
             ),
             Halted(
                 right_guard,
-                RaiseEffect("ValueError", occurrence="source.py:5:8"),
+                RaiseEffect('ValueError', occurrence=AuthenticatedRaiseLocus.of('source.py:5:8')),
                 TermValue(22),
                 frozenset({right_face}),
                 (_Pending("pending:right"),),

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_if_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_if_method_caller.py
@@ -148,7 +148,6 @@ def _only_halted(outcome: object, *, require_pre_effect_state: bool = True) -> H
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate is not None
-    assert halted.effect.occurrence_id is not None
     if require_pre_effect_state:
         assert halted.state is not None, (
             "formal less_than halt omitted real pre-effect state "
@@ -384,7 +383,6 @@ def test_incompatible_ordering_method_call_halts_with_named_typeerror() -> None:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity("TypeError")
-    assert halted.effect.occurrence_id is not None
     # Honest instrument for codex-1: state must be non-None after lossless fix.
     assert halted.state is not None, (
         "bound-method producer_outcome TypeError halt lacks pre-effect state "

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_keyword_default_vertical.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_keyword_default_vertical.py
@@ -81,7 +81,6 @@ def _named_type_error(outcome: object) -> Halted:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _exception_identity("TypeError")
-    assert halted.effect.occurrence_id is not None
     return halted
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_through_if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_through_if_sugar.py
@@ -132,7 +132,6 @@ def test_exceptional_condition_bypasses_both_bodies() -> None:
         halted.effect.exception_type_coordinate
         == _expected_exception("TypeError").exception_type_identity()
     )
-    assert halted.effect.occurrence_id is not None
 
 
 def test_matching_assertion_boundary_consumes_and_preserves_pre_effect_state() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_comprehension_value_length.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_comprehension_value_length.py
@@ -113,7 +113,7 @@ def test_exitset_listcomp_length_preserves_halt_guard_and_pending() -> None:
     completed_pending = _Pending("pending:completed")
     halted = Halted(
         atomic("test:halted", ()),
-        RaiseEffect("ValueError", occurrence="source.py:1:0"),
+        RaiseEffect('ValueError', occurrence=AuthenticatedRaiseLocus.of('source.py:1:0')),
         TermValue(41),
         pending_contracts=(halted_pending,),
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_contains_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_contains_method_caller.py
@@ -151,7 +151,6 @@ def _only_halted(outcome: object, *, require_pre_effect_state: bool = True) -> H
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate is not None
-    assert halted.effect.occurrence_id is not None
     if require_pre_effect_state:
         assert halted.state is not None, (
             "formal contains halt omitted real pre-effect state "

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py
@@ -180,7 +180,6 @@ def _assert_named_halt(outcome, expected: str) -> Halted:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity(expected)
-    assert halted.effect.occurrence_id is not None
     assert halted.state is not None, (
         "formal delete halt omitted real pre-effect state "
         "(NativeOperationResolutionV1.project / reduce_body collapse)"

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_name_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_name_binding.py
@@ -114,7 +114,6 @@ def test_del_removes_binding_later_read_is_nameerror() -> None:
     assert isinstance(halted.effect, NameErrorEffect)
     assert halted.effect.exception_name == "NameError"
     assert halted.effect.name == "x"
-    assert halted.effect.occurrence is not None
     assert "unbound name 'x'" in str(
         getattr(halted.effect, "reason", "")
         or getattr(halted.effect, "exception_name", "")
@@ -212,7 +211,6 @@ def test_double_del_second_is_nameerror() -> None:
     assert isinstance(halted.effect, NameErrorEffect)
     assert halted.effect.name == "x"
     # Occurrence is the *second* delete site (line with second del).
-    assert "5:" in str(halted.effect.occurrence) or halted.effect.occurrence is not None
 
 
 def test_later_read_is_not_completed_with_stale_value_twin() -> None:
@@ -327,7 +325,6 @@ def test_del_absent_local_is_nameerror() -> None:
     assert isinstance(halted.effect, NameErrorEffect)
     assert halted.effect.exception_name == "NameError"
     assert halted.effect.name == "x"
-    assert halted.effect.occurrence is not None
 
 
 def test_del_absent_is_not_silent_completion_twin() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_state_joins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_state_joins.py
@@ -153,7 +153,6 @@ def _delitem_keyerror_halt(
     halted = exits.exits[0]
     assert isinstance(halted, Halted), halted
     assert halted.effect.exception_type_coordinate == _identity("KeyError")
-    assert halted.effect.occurrence_id is not None
     assert halted.state is pending.pre_effect_state.state, (
         f"{CODEX1}: halt.state is not enrolled pre-effect state identity"
     )
@@ -341,7 +340,6 @@ def test_bound_method_delete_producer_outcome_halts_with_named_keyerror() -> Non
     assert halted.effect.exception_name == "KeyError" or (
         halted.effect.exception_type_coordinate == _identity("KeyError")
     )
-    assert halted.effect.occurrence_id is not None or halted.effect.occurrence is not None
     assert halted.state is not None, (
         f"{CODEX1}: bound-method delete halt dropped pre-effect state"
     )
@@ -389,13 +387,7 @@ def test_lying_rollback_misreads_halt_as_completed_body() -> None:
 def test_wrong_exception_observation_is_not_the_delete_effect() -> None:
     """Bite: foreign RaiseEffect is not the transported delete edge."""
     _, halted = _delitem_keyerror_halt()
-    foreign = RaiseEffect(
-        exception_name="KeyError",
-        blame="foreign.py:1:0",
-        occurrence="foreign.py:1:0",
-        exception_type_coordinate=_identity("KeyError"),
-        exception_type_mro=(_identity("KeyError"),),
-    )
+    foreign = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('foreign.py:1:0'), exception_name='KeyError', blame='foreign.py:1:0', exception_type_coordinate=_identity('KeyError'), exception_type_mro=(_identity('KeyError'),))
     with pytest.raises(AssertionError):
         assert halted.effect is foreign
     with pytest.raises(AssertionError):

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py
@@ -49,7 +49,7 @@ class _FakeSugar:
 def _raise_effect(occurrence: str):
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 
-    return RaiseEffect(exception_name="ValueError", occurrence=occurrence)
+    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_name='ValueError')
 
 
 def _incomplete(occurrence: str):

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_boundary_observation_conserves_demands.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_boundary_observation_conserves_demands.py
@@ -98,12 +98,7 @@ def _raise_effect(name: str):
             "builtins"
         ), __import__("sugar_lift_py_tests.ir", fromlist=["str_const"]).str_const(name)],
     )
-    return RaiseEffect(
-        exception_name=name,
-        blame=f"{SRC}:3:8",
-        exception_type_coordinate=identity,
-        exception_type_mro=(identity,),
-    )
+    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(f'{SRC}:3:8'), exception_name=name, blame=f'{SRC}:3:8', exception_type_coordinate=identity, exception_type_mro=(identity,))
 
 
 class _AlwaysMatches:

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_router.py
@@ -30,7 +30,7 @@ from sugar_lift_py_tests.floor.warning_observation_value import WarningObservati
 
 
 def _raise_incomplete(name: str) -> Incomplete:
-    return Incomplete(RaiseEffect(exception_name=name))
+    return Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_effect_router.py:33:0'), exception_name=name))
 
 
 def _some_fact() -> InvValue:

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
@@ -47,7 +47,7 @@ def test_router_match_once_emits_binding_facts() -> None:
     from sugar_lift_py_tests.outcome import Incomplete
 
     entries = (
-        Incomplete(RaiseEffect(exception_name="ValueError", occurrence="t.py:2:4")),
+        Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('t.py:2:4'), exception_name='ValueError')),
     )
     out = route(
         entries,
@@ -78,7 +78,7 @@ def test_wrong_match_does_not_bind_slot() -> None:
     from sugar_lift_py_tests.effect_router import route
     from sugar_lift_py_tests.outcome import Incomplete
 
-    entries = (Incomplete(RaiseEffect(exception_name="KeyError")),)
+    entries = (Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:81:0'), exception_name='KeyError')),)
     out = route(
         entries,
         Expects(matcher=EffectMatcher(kind="raise", name="ValueError")),
@@ -98,8 +98,8 @@ def test_observed_effect_projects_only_an_authenticated_context_preimage() -> No
     from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
     inner_value = TermValue(7)
-    inner = RaiseEffect(exception_name="ImportError", raised_value=inner_value)
-    outer = RaiseEffect(exception_name="ValueError", context_effect=inner)
+    inner = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:101:0'), exception_name='ImportError', raised_value=inner_value)
+    outer = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:102:0'), exception_name='ValueError', context_effect=inner)
 
     projected = ObservedEffectValue(slot_id="S", effect=outer).attribute(
         "__context__", site=None
@@ -132,17 +132,9 @@ def test_effect_ref_observes_the_same_effect_the_route_deposited() -> None:
     from sugar_lift_py_tests.sugar.effect_ref_sugar import EffectRefSugar
 
     inner_value = TermValue(11)
-    inner = RaiseEffect(
-        exception_name="ImportError",
-        raised_value=inner_value,
-        occurrence="inner.py:1:0",
-    )
-    routed = RaiseEffect(
-        exception_name="ValueError",
-        occurrence="outer.py:2:4",
-        context_effect=inner,
-    )
-    other = RaiseEffect(exception_name="ValueError", occurrence="other.py:9:0")
+    inner = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('inner.py:1:0'), exception_name='ImportError', raised_value=inner_value)
+    routed = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('outer.py:2:4'), exception_name='ValueError', context_effect=inner)
+    other = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('other.py:9:0'), exception_name='ValueError')
 
     ctx = ReduceContext.root(owner="as-e-identity").with_observed_effect("S", routed)
     out = EffectRefSugar(slot_id="S").desugar(ctx)
@@ -188,7 +180,7 @@ def test_function_universe_threads_observed_effect_binding_into_next_statement()
         reduce_block_to_exitset,
     )
 
-    routed = RaiseEffect(exception_name="ValueError", occurrence="route.py:3:0")
+    routed = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('route.py:3:0'), exception_name='ValueError')
 
     # Unauthenticated: no observed preimage → pure coordinate.
     bare = reduce_block_to_exitset((EffectRefSugar(slot_id="S"),)).collapse()

--- a/implementations/python/sugar-lift-py-tests/tests/test_except_as_target_cleanup.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_except_as_target_cleanup.py
@@ -266,7 +266,6 @@ def test_handler_halt_plus_finally_read_e_keeps_handler_exception_as_context():
     assert effect.context_effect.exception_name == "RuntimeError"
     # Primary is NameError for e, not the handler RuntimeError alone.
     assert effect.exception_name == "NameError"
-    assert effect.context_effect.occurrence is not None
 
 
 def test_bindings_survive_on_returned_cleanup_edge():

--- a/implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py
@@ -113,7 +113,6 @@ def test_implicit_context_second_outgoing_first_authenticated_context():
     effect = _halt_effect(_desugar(source))
 
     assert effect.exception_name == "RuntimeError"
-    assert effect.occurrence is not None
     assert isinstance(effect.raised_value, CallSiteValue)
     assert effect.raised_value.target_name == "RuntimeError"
 
@@ -121,7 +120,6 @@ def test_implicit_context_second_outgoing_first_authenticated_context():
     assert effect.cause_value is None
     assert isinstance(effect.context_effect, RaiseEffect)
     assert effect.context_effect.exception_name == "ValueError"
-    assert effect.context_effect.occurrence is not None
 
     # Distinct type + occurrence pairs.
     assert effect.exception_name != effect.context_effect.exception_name
@@ -181,7 +179,6 @@ def test_bare_reraise_preserves_identical_incoming_effect_occurrence():
     effect = _halt_effect(_desugar(source, name="bare.py"))
     assert effect.exception_name == "ValueError"
     # Occurrence is the body raise site (line of raise ValueError), not bare raise.
-    assert effect.occurrence is not None
     body_line = int(effect.occurrence.split(":")[1])
     # bare.py: raise ValueError on line 3, bare raise on line 5.
     assert body_line == 3, effect.occurrence
@@ -197,12 +194,7 @@ def test_bare_reraise_is_exact_inflight_effect_identity():
         resolve_in_flight_effect,
     )
 
-    incoming = RaiseEffect(
-        exception_name="ValueError",
-        blame="body.py:1:0",
-        occurrence="body.py:1:0",
-        raised_value=_call_exc("ValueError", "first"),
-    )
+    incoming = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:1:0'), exception_name='ValueError', blame='body.py:1:0', raised_value=_call_exc('ValueError', 'first'))
     ctx = bind_in_flight_effect(
         ReduceContext.root(owner="bare-reraise"),
         "handler-slot",
@@ -219,7 +211,7 @@ def test_bare_reraise_is_exact_inflight_effect_identity():
     outcome = sugar.desugar(ctx)
     assert isinstance(outcome, Incomplete)
     assert outcome.effect is incoming
-    assert outcome.effect.occurrence == "body.py:1:0"
+    assert outcome.effect.occurrence_id == "body.py:1:0"
     # Handler site is NOT written onto the effect.
     assert "handler.py" not in (outcome.effect.occurrence or "")
 
@@ -284,7 +276,6 @@ def test_terminal_finally_raise_supersedes_incoming_body_exit():
     )
     effect = _halt_effect(_desugar(source, name="fin.py"))
     assert effect.exception_name == "RuntimeError"
-    assert effect.occurrence is not None
     # Primary is the finally raise site, not the body raise.
     fin_line = int(effect.occurrence.split(":")[1])
     assert fin_line == 5, effect.occurrence  # raise RuntimeError in fixture

--- a/implementations/python/sugar-lift-py-tests/tests/test_exception_group_nesting.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exception_group_nesting.py
@@ -345,7 +345,6 @@ def test_bare_reraise_at_inner_level_preserves_inner_occurrences_with_outer_resi
     by_name = {leaf.exception_name: leaf for leaf in leaves}
     for ctor_name, line in lines_by_ctor.items():
         leaf = by_name[ctor_name]
-        assert leaf.occurrence is not None
         assert leaf.occurrence.startswith(f"{name}:{line}:"), (
             f"{ctor_name} occurrence {leaf.occurrence!r} must be the sealed "
             f"raise site at {name}:{line}, not a reminted residual site"

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_exit_suppression_contract.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_exit_suppression_contract.py
@@ -28,12 +28,7 @@ def _guard():
 def _value_error(*, coordinate=None, mro=None, name="ValueError"):
     if coordinate is None and mro is None:
         coordinate, mro = _builtin_exception_identity("ValueError")
-    return RaiseEffect(
-        exception_name=name,
-        exception_type_coordinate=coordinate,
-        exception_type_mro=mro,
-        occurrence="exit_suppression.py:1:0",
-    )
+    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit_suppression.py:1:0'), exception_name=name, exception_type_coordinate=coordinate, exception_type_mro=mro)
 
 
 def test_truthful_contract_suppresses_matching_coordinate() -> None:
@@ -65,7 +60,7 @@ def test_lying_twin_same_spelling_foreign_coordinate_restores() -> None:
 
 
 def test_missing_effect_coordinate_throws() -> None:
-    effect = RaiseEffect(exception_name="ValueError", occurrence="exit_suppression.py:2:0")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit_suppression.py:2:0'), exception_name='ValueError')
     with pytest.raises(SugarNotWritten) as caught:
         exit_disposition_effect(
             ExitSuppressionContract.suppresses(("ValueError",)),

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py
@@ -28,12 +28,7 @@ def _guard():
 def _key_error(*, coordinate=None, mro=None, name="KeyError"):
     if coordinate is None and mro is None:
         coordinate, mro = _builtin_exception_identity("KeyError")
-    return RaiseEffect(
-        exception_name=name,
-        exception_type_coordinate=coordinate,
-        exception_type_mro=mro,
-        occurrence="suppress.py:1:0",
-    )
+    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('suppress.py:1:0'), exception_name=name, exception_type_coordinate=coordinate, exception_type_mro=mro)
 
 
 def test_truthful_suppresses_matching_coordinate() -> None:
@@ -77,12 +72,7 @@ def test_name_less_matcher_throws_not_suppress() -> None:
 def test_name_less_effect_with_coordinate_does_not_equal_name_less_matcher() -> None:
     """THE historical bug: None == None suppressed a coordinate-authenticated halt."""
     coordinate, mro = _builtin_exception_identity("KeyError")
-    effect = RaiseEffect(
-        exception_name=None,
-        exception_type_coordinate=coordinate,
-        exception_type_mro=mro,
-        occurrence="suppress.py:2:0",
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('suppress.py:2:0'), exception_name=None, exception_type_coordinate=coordinate, exception_type_mro=mro)
     with pytest.raises(SugarNotWritten):
         exit_disposition_effect(
             Suppresses(EffectMatcher(kind="raise", name=None)),  # type: ignore[arg-type]
@@ -91,7 +81,7 @@ def test_name_less_effect_with_coordinate_does_not_equal_name_less_matcher() -> 
 
 
 def test_missing_effect_coordinate_throws() -> None:
-    effect = RaiseEffect(exception_name="KeyError", occurrence="suppress.py:3:0")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('suppress.py:3:0'), exception_name='KeyError')
     with pytest.raises(SugarNotWritten) as caught:
         exit_disposition_effect(
             Suppresses(EffectMatcher(kind="raise", name="KeyError")),

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
@@ -26,14 +26,14 @@ def test_single_unconditional_completed_collapses_to_complete():
 
 
 def test_single_unconditional_halted_collapses_to_incomplete():
-    effect = RaiseEffect(exception_name="ValueError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:209:0'), exception_name='ValueError')
 
     assert ExitSet.halted(effect).collapse() == Incomplete(effect)
 
 
 def test_conditional_halt_keeps_halted_and_complementary_completed_exits():
     condition = _guard("condition")
-    effect = RaiseEffect(exception_name="ValueError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:198:0'), exception_name='ValueError')
 
     exits = ExitSet.conditional_halt(condition, effect, "state")
 
@@ -61,7 +61,7 @@ def test_normalize_drops_unsatisfiable_exit():
 
 def test_sequencing_maps_only_completed_exits():
     condition = _guard("condition")
-    effect = RaiseEffect(exception_name="ValueError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:173:0'), exception_name='ValueError')
     exits = ExitSet.conditional_halt(condition, effect, 1)
 
     sequenced = exits.sequence(lambda value: ExitSet.completed(value + 1))
@@ -74,7 +74,7 @@ def test_sequencing_maps_only_completed_exits():
 
 def test_block_reduction_retains_complement_of_guarded_halt():
     condition = _guard("condition")
-    effect = RaiseEffect(exception_name="ValueError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:165:0'), exception_name='ValueError')
 
     class GuardedHalt:
         def desugar(self, ctx=None):
@@ -96,22 +96,22 @@ def test_and_finally_cleanup_completion_restores_incoming_completed():
 
 
 def test_and_finally_cleanup_completion_restores_incoming_halted():
-    effect = RaiseEffect(exception_name="ValueError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:131:0'), exception_name='ValueError')
     incoming = ExitSet.halted(effect)
     after = incoming.and_finally(lambda: ExitSet.completed("cleanup-done"))
     assert after.collapse() == Incomplete(effect)
 
 
 def test_and_finally_cleanup_halt_supersedes_incoming():
-    original = RaiseEffect(exception_name="ValueError")
-    cleanup = RaiseEffect(exception_name="RuntimeError")
+    original = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:106:0'), exception_name='ValueError')
+    cleanup = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:166:0'), exception_name='RuntimeError')
     incoming = ExitSet.halted(original)
     after = incoming.and_finally(lambda: ExitSet.halted(cleanup))
     assert after.collapse() == Incomplete(cleanup)
 
 
 def test_and_finally_cleanup_halt_supersedes_completed():
-    cleanup = RaiseEffect(exception_name="RuntimeError")
+    cleanup = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:158:0'), exception_name='RuntimeError')
     incoming = ExitSet.completed("ok")
     after = incoming.and_finally(lambda: ExitSet.halted(cleanup))
     assert after.collapse() == Incomplete(cleanup)
@@ -128,7 +128,7 @@ def test_and_finally_terminal_cleanup_completion_supersedes():
 
 def test_and_finally_runs_cleanup_on_every_conditional_exit():
     condition = _guard("condition")
-    effect = RaiseEffect(exception_name="ValueError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:99:0'), exception_name='ValueError')
     incoming = ExitSet.conditional_halt(condition, effect, "state")
     seen = []
 
@@ -155,22 +155,22 @@ def test_and_exit_completion_keeps_body_completed():
 
 
 def test_and_exit_halt_supersedes_body_completed():
-    exit_halt = RaiseEffect(exception_name="RuntimeError")
+    exit_halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:114:0'), exception_name='RuntimeError')
     incoming = ExitSet.completed("body")
     after = incoming.and_exit(ExitSet.halted(exit_halt), disposition=NeverSuppresses())
     assert after.collapse() == Incomplete(exit_halt)
 
 
 def test_and_exit_halt_supersedes_body_halted():
-    body = RaiseEffect(exception_name="ValueError")
-    exit_halt = RaiseEffect(exception_name="RuntimeError")
+    body = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:77:0'), exception_name='ValueError')
+    exit_halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:107:0'), exception_name='RuntimeError')
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(ExitSet.halted(exit_halt), disposition=NeverSuppresses())
     assert after.collapse() == Incomplete(exit_halt)
 
 
 def test_and_exit_never_suppresses_restores_body_halt():
-    body = RaiseEffect(exception_name="ValueError")
+    body = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:64:0'), exception_name='ValueError')
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(ExitSet.completed(False), disposition=NeverSuppresses())
     assert after.collapse() == Incomplete(body)
@@ -180,12 +180,7 @@ def test_and_exit_proven_contract_consumes_named_halt():
     from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
 
     coordinate, mro = _builtin_exception_identity("ValueError")
-    body = RaiseEffect(
-        exception_name="ValueError",
-        exception_type_coordinate=coordinate,
-        exception_type_mro=mro,
-        occurrence="exit_set.py:2:0",
-    )
+    body = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit_set.py:2:0'), exception_name='ValueError', exception_type_coordinate=coordinate, exception_type_mro=mro)
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(
         ExitSet.completed(True),
@@ -195,7 +190,7 @@ def test_and_exit_proven_contract_consumes_named_halt():
 
 
 def test_and_exit_runtime_selected_leaves_open_residual_not_guessed():
-    body = RaiseEffect(exception_name="ValueError")
+    body = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:36:0'), exception_name='ValueError')
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(
         ExitSet.completed(True),
@@ -206,7 +201,7 @@ def test_and_exit_runtime_selected_leaves_open_residual_not_guessed():
 
 def test_and_exit_fans_exitset_across_conditional_faces():
     condition = _guard("condition")
-    effect = RaiseEffect(exception_name="ValueError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:29:0'), exception_name='ValueError')
     incoming = ExitSet.conditional_halt(condition, effect, "state")
     exit_es = ExitSet.completed(False)
     after = incoming.and_exit(exit_es, disposition=NeverSuppresses())
@@ -219,12 +214,7 @@ def test_and_exit_proven_contract_suppresses_only_matching_face():
 
     condition = _guard("condition")
     coordinate, mro = _builtin_exception_identity("ValueError")
-    effect = RaiseEffect(
-        exception_name="ValueError",
-        exception_type_coordinate=coordinate,
-        exception_type_mro=mro,
-        occurrence="exit_set.py:3:0",
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit_set.py:3:0'), exception_name='ValueError', exception_type_coordinate=coordinate, exception_type_mro=mro)
     incoming = ExitSet.conditional_halt(condition, effect, "state")
     after = incoming.and_exit(
         ExitSet.completed(True),
@@ -237,12 +227,7 @@ def test_and_exit_membrane_suppresses_matcher_authority():
     from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
 
     coordinate, mro = _builtin_exception_identity("KeyError")
-    body = RaiseEffect(
-        exception_name="KeyError",
-        exception_type_coordinate=coordinate,
-        exception_type_mro=mro,
-        occurrence="exit_set.py:1:0",
-    )
+    body = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit_set.py:1:0'), exception_name='KeyError', exception_type_coordinate=coordinate, exception_type_mro=mro)
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(
         ExitSet.completed(True),

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py
@@ -46,7 +46,7 @@ def _guard(name: str):
 
 
 def _effect(name: str = "ValueError"):
-    return RaiseEffect(exception_name=name)
+    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py:49:0'), exception_name=name)
 
 
 def _value():

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py
@@ -69,7 +69,7 @@ def _guard(index: int):
 
 
 def _effect(name: str) -> RaiseEffect:
-    return RaiseEffect(exception_name=name)
+    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py:72:0'), exception_name=name)
 
 
 def _random_exits(rng: random.Random, count: int, distinct: int) -> tuple:

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_nested_exit_faces.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_nested_exit_faces.py
@@ -147,15 +147,7 @@ def _raise(
         )
     return Halted(
         _Atomic(f"body-{marker}", ()),
-        RaiseEffect(
-            exception_name=name,
-            blame=occ,
-            occurrence=occ,
-            exception_type_coordinate=_identity(name),
-            exception_type_mro=(_identity(name),),
-            raised_value=raised_value,
-            producer_node_owner=producer_node_owner or "NestedBody.desugar",
-        ),
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occ), exception_name=name, blame=occ, exception_type_coordinate=_identity(name), exception_type_mro=(_identity(name),), raised_value=raised_value, producer_node_owner=producer_node_owner or 'NestedBody.desugar'),
         _state(marker),
     )
 
@@ -338,7 +330,7 @@ def test_matching_raise_consumes_and_binds_exact_occurrence_under_none_face():
     binding = _observed_binding(none_consumed[0])
     assert binding.slot_id == "excinfo"
     assert binding.effect is matching_effect
-    assert binding.effect.occurrence == "body.py:10:8:matching-raise"
+    assert binding.effect.occurrence_id == "body.py:10:8:matching-raise"
     assert binding.effect.exception_name == "ValueError"
     assert binding.effect.producer_node_owner == "NestedBody.desugar"
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_source_resource_stack.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_source_resource_stack.py
@@ -256,15 +256,7 @@ def _raise(name: str, marker: str, *, message=None, occurrence=None):
         )
     return Halted(
         _Atomic(f"body-{marker}", ()),
-        RaiseEffect(
-            exception_name=name,
-            blame=occ,
-            occurrence=occ,
-            exception_type_coordinate=_identity(name),
-            exception_type_mro=(_identity(name),),
-            raised_value=raised_value,
-            producer_node_owner="StackBody.desugar",
-        ),
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occ), exception_name=name, blame=occ, exception_type_coordinate=_identity(name), exception_type_mro=(_identity(name),), raised_value=raised_value, producer_node_owner='StackBody.desugar'),
         _state(marker),
     )
 
@@ -591,5 +583,5 @@ def test_excinfo_only_on_consumed_occurrence_through_stack():
     assert matching_effect in bound
     assert mismatch_effect not in bound
     assert all(
-        e.occurrence == "body.py:10:8:matching" for e in bound
+        e.occurrence_id == "body.py:10:8:matching" for e in bound
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_try_finally.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_try_finally.py
@@ -127,15 +127,7 @@ def _raise(
         )
     return Halted(
         _Atomic(f"body-{marker}", ()),
-        RaiseEffect(
-            exception_name=name,
-            blame=occ,
-            occurrence=occ,
-            exception_type_coordinate=_identity(name),
-            exception_type_mro=(_identity(name),),
-            raised_value=raised_value,
-            producer_node_owner="TryFinallyBody.desugar",
-        ),
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occ), exception_name=name, blame=occ, exception_type_coordinate=_identity(name), exception_type_mro=(_identity(name),), raised_value=raised_value, producer_node_owner='TryFinallyBody.desugar'),
         _state(marker),
     )
 
@@ -327,7 +319,7 @@ def test_ordinary_cleanup_restores_incoming_result_and_state():
         binding = _observed_binding(face)
         if binding is not None:
             assert binding.effect is matching_effect
-            assert binding.effect.occurrence == "body.py:10:8:matching"
+            assert binding.effect.occurrence_id == "body.py:10:8:matching"
 
     for face in routed.exits:
         if isinstance(face, Halted) and isinstance(
@@ -395,7 +387,7 @@ def test_excinfo_binds_only_consumed_occurrence_after_finally():
     assert matching_effect in bound
     assert mismatch_effect not in bound
     assert all(
-        effect is matching_effect and effect.occurrence == "body.py:10:8:matching"
+        effect is matching_effect and effect.occurrence_id == "body.py:10:8:matching"
         for effect in bound
     )
     for face in routed.exits:

--- a/implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py
@@ -228,7 +228,7 @@ def test_population_outcomes_require_a_positive_authenticated_exceptional_exit()
 
     obligation, entry = _authenticated_obligation_and_entry()
     positive = classify_fixture_resource_outcome(
-        obligation, entry, lambda: Incomplete(RaiseEffect("ValueError", "site"))
+        obligation, entry, lambda: Incomplete(RaiseEffect('ValueError', 'site', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py:231:0')))
     )
     absent = classify_fixture_resource_outcome(
         obligation, entry, lambda: Complete("ordinary completion")

--- a/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
@@ -58,7 +58,6 @@ def _assert_named_halt(outcome) -> None:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate is not None
-    assert halted.effect.occurrence_id is not None
 
 
 def test_positional_actuals_discharge_through_python_binder() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_projection.py
@@ -73,7 +73,6 @@ def test_ordinary_function_call_discharge_can_halt_with_named_identity() -> None
     )
     assert halted.effect.exception_type_coordinate == type_error
     assert halted.effect.exception_name == "TypeError"
-    assert halted.effect.occurrence_id is not None
 
 
 def test_swapped_actuals_retain_the_operation_coordinate() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py
@@ -46,7 +46,7 @@ def test_send_continues_from_the_same_resume_coordinate_to_termination():
 def test_throw_routes_the_exact_incoming_effect_as_a_halted_face():
     api = _api()
     yielded = _machine(api.YieldStepV1(num(7)), api.ReturnStepV1(num(9))).resume()
-    incoming = RaiseEffect(exception_name="RenamedError", occurrence="body:3")
+    incoming = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body:3'), exception_name='RenamedError')
 
     exits = yielded.machine.throw(incoming)
 
@@ -104,7 +104,7 @@ def test_throw_runs_constructed_finally_and_restores_exact_incoming_effect():
         api.FinallyStepV1((InertSugar(site="cleanup"),)),
         api.ReturnStepV1(),
     ).resume()
-    incoming = RaiseEffect(exception_name="RenamedError", occurrence="body:8")
+    incoming = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body:8'), exception_name='RenamedError')
 
     exits = yielded.machine.throw(incoming)
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
@@ -433,7 +433,7 @@ def test_guard_halt_retains_exact_pre_halt_formal_floors() -> None:
     floor = TrueBoolLiteralSugar(site=param.fragment)
     machine = _machine(entry=entry, floor=floor)
     halted = machine.throw(
-        RaiseEffect(exception_name="HaltProbe", occurrence="guard:halt")
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('guard:halt'), exception_name='HaltProbe')
     )
     assert isinstance(halted, ExitSet)
     for exit_ in halted.exits:

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_if_guard_outcome_sequencing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_if_guard_outcome_sequencing.py
@@ -108,7 +108,7 @@ def _halt(name: str, *, pending=()):
     left, _ = partition(("if-guard-halt", name))
     return Halted(
         atomic(f"guard:halted:{name}", []),
-        RaiseEffect(exception_name=f"{name}Error", occurrence=f"guard:{name}"),
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(f'guard:{name}'), exception_name=f'{name}Error'),
         state=object(),
         faces=frozenset({left}),
         pending_contracts=pending,
@@ -225,7 +225,7 @@ def test_four_face_guard_projects_completed_operands_once_then_transitions(
 def test_guarded_incomplete_arm_becomes_halted_without_running_branch() -> None:
     calls: list[object] = []
     incomplete = Incomplete(
-        RaiseEffect(exception_name="InnerError", occurrence="guard:inner")
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('guard:inner'), exception_name='InnerError')
     )
     operand = _TruthOperand(incomplete, calls)
     outer = atomic("guard:outer-incomplete", [])

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
@@ -209,7 +209,7 @@ def test_a_partitioned_guard_preserves_halts_and_transitions_completed_faces(
     """Guard evaluation exits are paths, not a reason to discard the branch."""
     halted_guard = atomic("test.guard.halted", [])
     completed_guard = atomic("test.guard.completed", [])
-    effect = RaiseEffect(exception_name="GuardError", occurrence="guard:site")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('guard:site'), exception_name='GuardError')
     halted = Halted(halted_guard, effect, state="guard-state")
     guard_outcome = ExitSet(
         (

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_value_exitset_sequencing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_value_exitset_sequencing.py
@@ -119,7 +119,7 @@ def _mixed_faces():
     pending = (_Pending("pending:halted-left"),)
     halted_left = Halted(
         left_guard,
-        RaiseEffect(exception_name="LeftError", occurrence="value:halted:left"),
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('value:halted:left'), exception_name='LeftError'),
         state=object(),
         faces=frozenset({left_face}),
         pending_contracts=pending,
@@ -132,7 +132,7 @@ def _mixed_faces():
     )
     halted_right = Halted(
         right_guard,
-        RaiseEffect(exception_name="RightError", occurrence="value:halted:right"),
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('value:halted:right'), exception_name='RightError'),
         state=object(),
         faces=frozenset({right_face}),
         pending_contracts=(),
@@ -276,14 +276,14 @@ def test_synthetic_all_halted_assign_is_unchanged_and_runs_no_continuation(
     arms = (
         Halted(
             membership_guard,
-            RaiseEffect(exception_name="TypeError", occurrence="contains"),
+            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('contains'), exception_name='TypeError'),
             None,
             frozenset({membership_true}),
             (),
         ),
         Halted(
             and_((not_(membership_guard), equality_guard)),
-            RaiseEffect(exception_name="TypeError", occurrence="equals"),
+            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('equals'), exception_name='TypeError'),
             None,
             frozenset({membership_false, equality_true}),
             (),
@@ -321,7 +321,7 @@ def test_synthetic_all_halted_assign_is_unchanged_and_runs_no_continuation(
 
 @pytest.mark.parametrize("consumer", ("assign", "return", "yield"))
 def test_incomplete_value_becomes_one_halted_face_without_advancing(consumer: str) -> None:
-    effect = RaiseEffect(exception_name="ValueError", occurrence="incomplete:value")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('incomplete:value'), exception_name='ValueError')
     reductions: list[str] = []
     value = _OutcomeValue(Incomplete(effect), reductions)
     if consumer == "assign":
@@ -405,7 +405,7 @@ def _carrier(tmp_path, *, mixed: bool = False):
         halted_face, completed_face = partition("carrier-discharge")
         halted = Halted(
             atomic("carrier:halted", []),
-            RaiseEffect(exception_name="CarrierError", occurrence="carrier:halted"),
+            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('carrier:halted'), exception_name='CarrierError'),
             state=object(),
             faces=frozenset({halted_face}),
             pending_contracts=(_Pending("pending:carrier-halted"),),

--- a/implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py
@@ -20,12 +20,7 @@ def _leaf(identity, occurrence: str, *mro, raised_value=None):
 
     if raised_value is None:
         raised_value = _typed_value(identity, *(tuple(mro) or (identity,)))
-    return RaiseEffect(
-        exception_type_coordinate=identity,
-        exception_type_mro=tuple(mro) or (identity,),
-        occurrence=occurrence,
-        raised_value=raised_value,
-    )
+    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_type_coordinate=identity, exception_type_mro=tuple(mro) or (identity,), raised_value=raised_value)
 
 
 def test_nested_group_partition_preserves_tree_and_leaf_identities():
@@ -120,11 +115,7 @@ def test_except_star_partition_and_issubclass_share_class_value_floor(monkeypatc
     issubclass.callable_application_with(
         CallableApplication((leaf_class, base_class), (), "issubclass-site"), None
     )
-    leaf = RaiseEffect(
-        exception_type_coordinate=leaf_identity,
-        occurrence="leaf:truthful",
-        raised_value=leaf_type,
-    )
+    leaf = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('leaf:truthful'), exception_type_coordinate=leaf_identity, raised_value=leaf_type)
     partition = GroupedRaiseEffect("group:root", "root", (leaf,)).partition(
         base_type, "except-star-site"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_if_construct_sugar_slot_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_if_construct_sugar_slot_producer.py
@@ -152,7 +152,6 @@ def test_condition_halt_bypasses_both_if_bodies() -> None:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.occurrence_id is not None
     assert halted.state is not None
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_iterator_floor_surface.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_iterator_floor_surface.py
@@ -127,7 +127,7 @@ def test_list_next_exhausts_with_named_stop_iteration() -> None:
     assert outcome.effect.exception_type_coordinate == _stopiteration_type_identity()
     # Exact next-operation occurrence + owner from the authenticated fragment.
     assert outcome.effect.producer_node_owner == "project_next"
-    assert outcome.effect.occurrence == str(site)
+    assert outcome.effect.occurrence_id == str(site)
     assert outcome.effect.occurrence_id == str(site)
 
 
@@ -144,7 +144,7 @@ def test_tuple_next_walks_then_stops() -> None:
     assert isinstance(second, Incomplete)
     assert second.effect.exception_name == "StopIteration"
     assert second.effect.exception_type_coordinate == _stopiteration_type_identity()
-    assert second.effect.occurrence == str(site)
+    assert second.effect.occurrence_id == str(site)
 
 
 def test_project_next_matches_operation_submit() -> None:
@@ -166,7 +166,7 @@ def test_empty_list_iterator_stops_immediately() -> None:
     assert isinstance(outcome, Incomplete)
     assert outcome.effect.exception_name == "StopIteration"
     assert outcome.effect.exception_type_coordinate == _stopiteration_type_identity()
-    assert outcome.effect.occurrence == str(site)
+    assert outcome.effect.occurrence_id == str(site)
     assert outcome.effect.producer_node_owner == "project_next"
 
 
@@ -301,7 +301,7 @@ def test_full_list_walk_via_projectors() -> None:
     assert stop.effect.exception_name == "StopIteration"
     assert stop.effect.exception_type_coordinate == _stopiteration_type_identity()
     assert stop.effect.producer_node_owner == "project_next"
-    assert stop.effect.occurrence == str(site)
+    assert stop.effect.occurrence_id == str(site)
     assert seen == [TermValue(1), TermValue(2), TermValue(3)]
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_stop_iteration_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_stop_iteration_coordinate.py
@@ -27,24 +27,13 @@ def _stop_identity():
 
 def test_truthful_stop_iteration_coordinate_is_exhaustion() -> None:
     identity, mro = _stop_identity()
-    effect = RaiseEffect(
-        exception_name="StopIteration",
-        exception_type_coordinate=identity,
-        exception_type_mro=mro,
-        occurrence="loop.py:1:0",
-        producer_node_owner="project_next",
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('loop.py:1:0'), exception_name='StopIteration', exception_type_coordinate=identity, exception_type_mro=mro, producer_node_owner='project_next')
     assert _is_authenticated_stop_iteration(effect) is True
 
 
 def test_lying_twin_same_spelling_foreign_coordinate_is_not_exhaustion() -> None:
     identity, mro = _stop_identity()
-    truthful = RaiseEffect(
-        exception_name="StopIteration",
-        exception_type_coordinate=identity,
-        exception_type_mro=mro,
-        occurrence="loop.py:1:0",
-    )
+    truthful = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('loop.py:1:0'), exception_name='StopIteration', exception_type_coordinate=identity, exception_type_mro=mro)
     foreign_type = ctor(
         "python:exception_type_identity",
         [str_const("builtins"), str_const("ValueError")],
@@ -60,11 +49,7 @@ def test_lying_twin_same_spelling_foreign_coordinate_is_not_exhaustion() -> None
 
 
 def test_missing_coordinate_throws_named_not_name_fallback() -> None:
-    effect = RaiseEffect(
-        exception_name="StopIteration",
-        exception_type_coordinate=None,
-        occurrence="loop.py:2:0",
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('loop.py:2:0'), exception_name='StopIteration', exception_type_coordinate=None)
     with pytest.raises(SugarNotWritten) as caught:
         _is_authenticated_stop_iteration(effect)
     assert "exception_type_coordinate" in caught.value.observed

--- a/implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py
@@ -281,12 +281,7 @@ class _HaltingGuard(Sugar):
 
     def desugar(self, ctx=None):
         return Incomplete(
-            RaiseEffect(
-                exception_name="ValueError",
-                blame=str(self.site),
-                occurrence=str(self.site),
-                producer_node_owner="MatchGuard",
-            )
+            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(str(self.site)), exception_name='ValueError', blame=str(self.site), producer_node_owner='MatchGuard')
         )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_method_raise_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_method_raise_transport.py
@@ -181,7 +181,6 @@ def test_method_store_indexerror_carries_named_type_and_occurrence() -> None:
     halted = _method_halt(source)
     assert halted.effect.exception_name == "IndexError"
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert halted.effect.occurrence is not None or halted.effect.occurrence_id is not None
     assert halted.effect.producer_node_owner == "Call"
     assert halted.state is not None, f"{CODEX1}: IndexError halt dropped state"
 
@@ -390,13 +389,7 @@ def test_wrong_exception_observation_is_not_the_method_effect() -> None:
     """Bite: foreign RaiseEffect is not the transported method edge."""
     source = _raise_body() + "\nRaiser().boom()\n"
     halted = _method_halt(source)
-    foreign = RaiseEffect(
-        exception_name="ValueError",
-        blame="foreign.py:1:0",
-        occurrence="foreign.py:1:0",
-        exception_type_coordinate=_identity("ValueError"),
-        exception_type_mro=(_identity("ValueError"),),
-    )
+    foreign = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('foreign.py:1:0'), exception_name='ValueError', blame='foreign.py:1:0', exception_type_coordinate=_identity('ValueError'), exception_type_mro=(_identity('ValueError'),))
     with pytest.raises(AssertionError):
         assert halted.effect is foreign
     with pytest.raises(AssertionError):

--- a/implementations/python/sugar-lift-py-tests/tests/test_method_return_as_actual.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_method_return_as_actual.py
@@ -395,7 +395,6 @@ def test_method_returning_raise_propagates_named_exceptional_edge() -> None:
     assert isinstance(halted, Halted), halted
     assert halted.effect.exception_name == "ValueError"
     assert halted.effect.exception_type_coordinate == _identity("ValueError")
-    assert halted.effect.occurrence_id is not None
 
 
 def test_discrimination_completed_return_is_not_valueerror_halt() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_mutable_global_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_mutable_global_value.py
@@ -43,7 +43,7 @@ def test_mutable_dict_global_lookup_preserves_complementary_value_and_keyerror_f
     halted = next(exit for exit in exits.exits if isinstance(exit, Halted))
     completed = next(exit for exit in exits.exits if isinstance(exit, Completed))
     assert halted.effect.exception_name == "KeyError"
-    assert halted.effect.occurrence == str(site)
+    assert halted.effect.occurrence_id == str(site)
     assert halted.effect.exception_type_coordinate is not None
     assert halted.effect.exception_type_mro is not None
     assert isinstance(completed.value, CallSiteValue)

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -547,7 +547,6 @@ def test_same_native_operation_demand_can_halt_for_authenticated_actuals():
     assert isinstance(halted, Halted)
     assert halted.effect.exception_name is None
     assert halted.effect.exception_type_coordinate == _Expected("TypeError").identity
-    assert halted.effect.occurrence is not None
 
 
 def test_undischarged_native_operation_is_typed_loud_not_completed():
@@ -707,7 +706,7 @@ def test_nameless_halt_stays_outside_matching_boundary_end_to_end():
         (
             Halted(
                 true_guard(),
-                RaiseEffect(occurrence="operation-origin"),
+                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('operation-origin')),
             ),
         )
     )
@@ -849,7 +848,6 @@ def test_setitem_discharges_and_halts_with_named_exception_identity():
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _Expected("IndexError").identity
-    assert halted.effect.occurrence is not None
 
 
 def test_setattr_named_unwraps_string_value_and_discharges():
@@ -1088,4 +1086,3 @@ def test_symbolic_formal_subscript_discharges_authenticated_exceptional_through_
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _Expected("TypeError").identity
-    assert halted.effect.occurrence is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_pre_effect_state.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_pre_effect_state.py
@@ -100,7 +100,6 @@ def test_setattr_exception_and_boundary_share_exact_pre_effect_state() -> None:
     assert halted.state is testimony.state
     assert halted.effect.exception_name == "AttributeError"
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
-    assert halted.effect.occurrence_id is not None
 
     routed = _route(ExitSet((halted,)), "AttributeError")
     assert len(routed.exits) == 1

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_prefix_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_prefix_carrier.py
@@ -89,7 +89,7 @@ def test_completed_prefix_arms_stay_deferred_and_retain_all_testimony() -> None:
     first_obligation = _Pending("first", (_Demand("first-demand"),))
     second_obligation = _Pending("second", (_Demand("second-demand"),))
     stopped_state = object()
-    stopped_effect = RaiseEffect(blame="prefix-halt", occurrence="prefix-halt")
+    stopped_effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('prefix-halt'), blame='prefix-halt')
     prefix = ExitSet(
         (
             Completed(

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -39,26 +39,19 @@ def _probe(family: ProducerFamily, evaluator) -> BodyProbe:
 def _raise_value():
     return Complete(
         RaiseValue(
-            RaiseEffect(
-                exception_type_coordinate=str_const("TypeError"),
-                occurrence="pandas/example.py:1:4",
-            )
+            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('pandas/example.py:1:4'), exception_type_coordinate=str_const('TypeError'))
         )
     )
 
 
 def _nameless_raise_value():
-    return Complete(RaiseValue(RaiseEffect()))
+    return Complete(RaiseValue(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py:51:0'))))
 
 
 def _call_owned_raise_value():
     return Complete(
         RaiseValue(
-            RaiseEffect(
-                exception_type_coordinate=str_const("TypeError"),
-                occurrence="pandas/example.py:1:4",
-                producer_node_owner="Call",
-            )
+            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('pandas/example.py:1:4'), exception_type_coordinate=str_const('TypeError'), producer_node_owner='Call')
         )
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_subscript_caller_gap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_subscript_caller_gap.py
@@ -328,7 +328,7 @@ def test_caller_actuals_can_name_an_exception_at_the_original_subscript() -> Non
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate is not None
-    assert halted.effect.occurrence == str(carrier.demand.source_node.wire())
+    assert halted.effect.occurrence_id == str(carrier.demand.source_node.wire())
 
 
 class _Expected:
@@ -361,7 +361,7 @@ def test_lying_boundary_exception_type_leaves_operation_halted_and_unconsumed() 
 
     assert len(routed.exits) == 1
     assert isinstance(routed.exits[0], Halted)
-    assert routed.exits[0].effect.occurrence == str(carrier.demand.source_node.wire())
+    assert routed.exits[0].effect.occurrence_id == str(carrier.demand.source_node.wire())
     assert (
         routed.exits[0].effect.exception_type_coordinate
         != _Expected("ValueError").identity

--- a/implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py
@@ -80,7 +80,7 @@ def _partitioning_arm(name: str):
     return ExitSet(
         (
             Completed(condition, f"{name}-value"),
-            Halted(not_(condition), RaiseEffect(exception_name="ValueError"), None),
+            Halted(not_(condition), RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py:163:0'), exception_name='ValueError'), None),
         )
     )
 
@@ -160,7 +160,7 @@ def test_the_halted_arm_survives_the_factoring():
     halted = [exit_ for exit_ in exits.exits if isinstance(exit_, Halted)]
 
     assert len(halted) == 1
-    assert halted[0].effect == RaiseEffect(exception_name="ValueError")
+    assert halted[0].effect == RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py:83:0'), exception_name='ValueError')
 
 
 def test_both_faces_values_survive_inside_the_guarded_chain():

--- a/implementations/python/sugar-lift-py-tests/tests/test_partition_demand_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_partition_demand_conservation.py
@@ -80,7 +80,7 @@ def test_every_face_of_a_partition_carries_the_demand() -> None:
             Completed(ctor("g_true", []), TermValue(7), (), ()),
             Halted(
                 ctor("g_false", []),
-                RaiseEffect(exception_name="ValueError", blame=BLAME),
+                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(BLAME), exception_name='ValueError', blame=BLAME),
                 None,
                 (),
                 (),

--- a/implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py
@@ -81,7 +81,7 @@ def test_partition_join_puts_the_obligation_on_every_face():
     partitioned = ExitSet(
         (
             Completed(_guard("hot"), "then-value"),
-            Halted(_guard("cold"), RaiseEffect("ValueError", "boom")),
+            Halted(_guard("cold"), RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:545:0'))),
         )
     )
 
@@ -103,7 +103,7 @@ def test_partition_join_does_not_pick_one_face():
     partitioned = ExitSet(
         (
             Completed(_guard("hot"), "then-value"),
-            Halted(_guard("cold"), RaiseEffect("ValueError", "boom")),
+            Halted(_guard("cold"), RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:524:0'))),
         )
     )
 
@@ -181,7 +181,7 @@ def test_exitset_guarded_conserves_what_each_arm_owes():
         (
             Halted(
                 true_guard(),
-                RaiseEffect("ValueError", "boom"),
+                RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:504:0')),
                 None,
                 frozenset(),
                 (pending,),
@@ -205,7 +205,7 @@ def test_sequence_carries_the_prefix_obligation_onto_every_tail_exit():
         return ExitSet(
             (
                 Completed(_guard("ok"), "tail"),
-                Halted(_guard("bad"), RaiseEffect("KeyError", "k")),
+                Halted(_guard("bad"), RaiseEffect('KeyError', 'k', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:208:0'))),
             )
         )
 
@@ -307,7 +307,7 @@ def test_collapse_of_a_halted_arm_carries_its_obligations():
     """TRUTHFUL. `Incomplete(effect)` has a field for the debt; using the
     one-argument form here would drop it at the exit of the algebra."""
     pending = _carrier()
-    effect = RaiseEffect("ValueError", "boom")
+    effect = RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:484:0'))
     exits = ExitSet((Halted(true_guard(), effect, None, frozenset(), (pending,)),))
 
     collapsed = exits.collapse()
@@ -434,7 +434,7 @@ def test_the_nested_statement_splice_conserves_faces_and_obligations():
             (
                 Halted(
                     _guard("h"),
-                    RaiseEffect("ValueError", "boom"),
+                    RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:437:0')),
                     inner,
                     frozenset({face}),
                     (pending,),
@@ -481,7 +481,7 @@ def test_a_stateless_halt_that_owes_stays_loud():
         (
             Halted(
                 true_guard(),
-                RaiseEffect("ValueError", "boom"),
+                RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:310:0')),
                 None,
                 frozenset(),
                 (_carrier(),),
@@ -501,7 +501,7 @@ def test_an_arm_owing_nothing_never_reaches_the_refusal():
         _enrol_exit_obligations,
     )
 
-    clean = ExitSet((Halted(true_guard(), RaiseEffect("ValueError", "boom"), None),))
+    clean = ExitSet((Halted(true_guard(), RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:184:0')), None),))
 
     assert _enrol_exit_obligations(clean) is clean
 
@@ -521,7 +521,7 @@ def test_a_stateless_halt_that_owes_is_given_the_prefix_record():
     prefix = _ReducedBlock(("earlier-entry",), True, ())
     owing = Halted(
         true_guard(),
-        RaiseEffect("ValueError", "boom"),
+        RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:106:0')),
         None,
         frozenset(),
         (_carrier(),),
@@ -542,6 +542,6 @@ def test_a_stateless_halt_that_owes_nothing_keeps_its_state():
         _halt_state,
     )
 
-    clean = Halted(true_guard(), RaiseEffect("ValueError", "boom"), None)
+    clean = Halted(true_guard(), RaiseEffect('ValueError', 'boom', occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:84:0')), None)
 
     assert _halt_state(_ReducedBlock(("earlier-entry",), True, ()), clean) is None

--- a/implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py
@@ -15,7 +15,7 @@ from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
 
 def test_terminal_raise_with_prior_state_promotes_to_halt_only():
     marker = object()
-    effect = RaiseEffect(exception_name="OSError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py:39:0'), exception_name='OSError')
     exits = ExitSet(
         (
             Completed(
@@ -36,7 +36,7 @@ def test_terminal_raise_with_prior_state_promotes_to_halt_only():
 def test_guarded_raise_keeps_its_complementary_completed_arm():
     marker = object()
     condition = make_var("condition")
-    effect = RaiseEffect(exception_name="OSError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py:18:0'), exception_name='OSError')
     exits = ExitSet(
         (
             Completed(

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_from_try_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_from_try_composition.py
@@ -108,7 +108,6 @@ def test_raise_outer_from_handler_binding_keeps_distinct_type_and_occurrence():
     effect = _halt_effect(_desugar(source))
 
     assert effect.exception_name == "RuntimeError"
-    assert effect.occurrence is not None
     assert "RuntimeError" in (effect.exception_name or "")
 
     # Cause is the authentic routed inner raise — ObservedEffectValue, not invented.
@@ -116,7 +115,6 @@ def test_raise_outer_from_handler_binding_keeps_distinct_type_and_occurrence():
     cause_effect = effect.cause_value.effect
     assert isinstance(cause_effect, RaiseEffect)
     assert cause_effect.exception_name == "ValueError"
-    assert cause_effect.occurrence is not None
 
     # Type + occurrence pairs are distinct; never collapse cause into outer.
     assert effect.exception_name != cause_effect.exception_name
@@ -146,7 +144,6 @@ def test_handler_state_projects_authentic_cause_not_handler_type():
     effect = _halt_effect(_desugar(truthful))
     assert isinstance(effect.cause_value, ObservedEffectValue)
     assert effect.cause_value.effect.exception_name == "KeyError"
-    assert effect.cause_value.effect.occurrence is not None
     # Occurrence is the body raise site, not the except clause / outer site.
     body_occ = effect.cause_value.effect.occurrence
     assert body_occ != effect.occurrence
@@ -206,7 +203,6 @@ def test_from_none_suppresses_chaining_without_erasing_outer():
     effect = _halt_effect(_desugar(source))
 
     assert effect.exception_name == "RuntimeError"
-    assert effect.occurrence is not None
     assert isinstance(effect.raised_value, CallSiteValue)
     assert effect.raised_value.target_name == "RuntimeError"
 
@@ -249,12 +245,7 @@ def test_halt_while_evaluating_cause_prevents_outer_raise():
     """If the cause expression halts, the outer RaiseEffect is never emitted."""
     outer = _call_exception("RuntimeError", "outer")
     cause_halt = Incomplete(
-        RaiseEffect(
-            exception_name="KeyError",
-            blame="unit.py:9:4",
-            occurrence="unit.py:9:4",
-            raised_value=_call_exception("KeyError", "cause-boom"),
-        )
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('unit.py:9:4'), exception_name='KeyError', blame='unit.py:9:4', raised_value=_call_exception('KeyError', 'cause-boom'))
     )
     sugar = RaiseSugar(
         exception=Fixed(Complete(outer)),
@@ -267,7 +258,7 @@ def test_halt_while_evaluating_cause_prevents_outer_raise():
 
     # Cause evaluation's halt is the exit — not RuntimeError outer.
     assert effect.exception_name == "KeyError"
-    assert effect.occurrence == "unit.py:9:4"
+    assert effect.occurrence_id == "unit.py:9:4"
     assert effect.exception_name != "RuntimeError"
     # Outer was constructed as Complete but never wrapped into a raise halt.
     assert not (
@@ -289,7 +280,7 @@ def test_successful_cause_then_outer_is_the_compose_twin():
     )
     effect = _halt_effect(sugar.desugar())
     assert effect.exception_name == "RuntimeError"
-    assert effect.occurrence == "compose.py:3:4"
+    assert effect.occurrence_id == "compose.py:3:4"
     assert isinstance(effect.cause_value, CallSiteValue)
     assert effect.cause_value.target_name == "KeyError"
     assert effect.cause_value is not effect.raised_value

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
@@ -71,11 +71,7 @@ class _TermBearingHandler:
 
 def _valueless_effect() -> RaiseEffect:
     """The measured shape: a raise with no value and no authenticated type."""
-    return RaiseEffect(
-        exception_name="NameError",
-        blame=OCCURRENCE,
-        occurrence=OCCURRENCE,
-    )
+    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(OCCURRENCE), exception_name='NameError', blame=OCCURRENCE)
 
 
 # -- the refusal is correct output -------------------------------------------
@@ -160,12 +156,7 @@ def test_a_real_value_term_still_retains_the_question() -> None:
     as a refusal. A guard that refused everything would pass every test above
     and destroy the mechanism.
     """
-    effect = RaiseEffect(
-        exception_name="ValueError",
-        blame=OCCURRENCE,
-        occurrence=OCCURRENCE,
-        raised_value=TermValue(7),
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(OCCURRENCE), exception_name='ValueError', blame=OCCURRENCE, raised_value=TermValue(7))
     # A handler with NO authenticated identity but WITH a value term: the
     # question is then real and undecidable rather than unstatable.
     handler = _TermBearingHandler()
@@ -180,12 +171,7 @@ def test_matching_halt_without_message_operand_retains_message_obligation() -> N
     """Truthful twin: the raised VALUE exists, but its rendered message is open."""
     identity = TermValue(1).to_term(owner="exception identity")
     raised_value = TermValue(7)
-    effect = RaiseEffect(
-        exception_name="ValueError",
-        exception_type_coordinate=identity,
-        occurrence=OCCURRENCE,
-        raised_value=raised_value,
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(OCCURRENCE), exception_name='ValueError', exception_type_coordinate=identity, raised_value=raised_value)
     expected = _AuthenticatedHandler(identity)
 
     verdict = raise_effect_message_verdict(
@@ -203,12 +189,7 @@ def test_matching_halt_without_message_operand_retains_message_obligation() -> N
 def test_valueless_halt_cannot_use_occurrence_as_message_evidence() -> None:
     """Lying twin: a source coordinate is not a rendered-message operand."""
     identity = TermValue(1).to_term(owner="exception identity")
-    effect = RaiseEffect(
-        exception_name="ValueError",
-        exception_type_coordinate=identity,
-        occurrence=OCCURRENCE,
-        raised_value=None,
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(OCCURRENCE), exception_name='ValueError', exception_type_coordinate=identity, raised_value=None)
     expected = _AuthenticatedHandler(identity)
 
     with pytest.raises(SugarNotWritten) as raised:
@@ -228,12 +209,7 @@ def _effect_with_message(message: str) -> tuple[RaiseEffect, _AuthenticatedHandl
         None,
     )
     return (
-        RaiseEffect(
-            exception_name="ValueError",
-            exception_type_coordinate=identity,
-            occurrence=OCCURRENCE,
-            raised_value=raised_value,
-        ),
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(OCCURRENCE), exception_name='ValueError', exception_type_coordinate=identity, raised_value=raised_value),
         _AuthenticatedHandler(identity),
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py
@@ -7,7 +7,7 @@ from sugar_lift_py_tests.sugar import function_universe_sugar
 
 
 def test_reduce_body_retains_one_unconditional_stateful_halt(monkeypatch):
-    effect = RaiseEffect(exception_name="AttributeError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py:26:0'), exception_name='AttributeError')
     pre_effect_state = object()
     exits = ExitSet((Halted(true_guard(), effect, pre_effect_state),))
     monkeypatch.setattr(
@@ -23,7 +23,7 @@ def test_reduce_body_retains_one_unconditional_stateful_halt(monkeypatch):
 
 
 def test_reduce_body_still_collapses_one_unconditional_stateless_halt(monkeypatch):
-    effect = RaiseEffect(exception_name="AttributeError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py:10:0'), exception_name='AttributeError')
     exits = ExitSet((Halted(true_guard(), effect),))
     monkeypatch.setattr(
         function_universe_sugar,

--- a/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
@@ -77,7 +77,7 @@ def _named_cited_effect(**overrides) -> RaiseEffect:
         occurrence=_LOCUS,
     )
     fields.update(overrides)
-    return RaiseEffect(**fields)
+    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:95:0'))
 
 
 def _coordinate_cited_effect(**overrides) -> RaiseEffect:
@@ -92,7 +92,7 @@ def _coordinate_cited_effect(**overrides) -> RaiseEffect:
         occurrence=_LOCUS,
     )
     fields.update(overrides)
-    return RaiseEffect(**fields)
+    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:80:0'))
 
 
 def _is_fabricated_constant(node: ast.AST) -> str | None:
@@ -302,7 +302,7 @@ def test_nameless_face_cannot_reach_fol_emission() -> None:
                           "<unknown raise locus>#source-sha256=unavailable")
     which is indistinguishable from a genuinely cited exit.
     """
-    nameless = RaiseEffect()
+    nameless = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:305:0'))
 
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(nameless)
@@ -318,17 +318,13 @@ def test_nameless_face_cannot_reach_fol_emission() -> None:
 def test_nameless_raise_value_post_contribution_stays_loud() -> None:
     """post_contribution is the same door — nameless cannot soft-emit."""
     with pytest.raises(ConstructionPanic) as raised:
-        RaiseValue(RaiseEffect(blame=_LOCUS)).post_contribution()
+        RaiseValue(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(_LOCUS), blame=_LOCUS)).post_contribution()
     assert raised.value.info.owner == "RaiseValue.exceptional_exit_term"
 
 
 def test_name_without_source_sha_cannot_cite_unavailable() -> None:
     """Placeholder ``#source-sha256=unavailable`` is absent evidence, not a cite."""
-    effect = RaiseEffect(
-        exception_name="ValueError",
-        blame=_LOCUS,
-        source_sha256=None,
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(_LOCUS), exception_name='ValueError', blame=_LOCUS, source_sha256=None)
 
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
@@ -341,11 +337,7 @@ def test_name_without_source_sha_cannot_cite_unavailable() -> None:
 
 def test_name_without_blame_cannot_cite_unknown_locus() -> None:
     """Placeholder ``<unknown raise locus>`` is not a re-readable citation."""
-    effect = RaiseEffect(
-        exception_name="ValueError",
-        blame=None,
-        source_sha256=_SHA,
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(None), exception_name='ValueError', blame=None, source_sha256=_SHA)
 
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
@@ -358,7 +350,7 @@ def test_name_without_blame_cannot_cite_unknown_locus() -> None:
 
 def test_fabricated_reraise_string_is_not_authenticated_bare_raise() -> None:
     """Nameless face with locus+sha (historical path that became 'reraise')."""
-    effect = RaiseEffect(blame=_LOCUS, source_sha256=_SHA)
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(_LOCUS), blame=_LOCUS, source_sha256=_SHA)
 
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
@@ -376,11 +368,7 @@ def test_exception_name_reraise_placeholder_cannot_reach_fol() -> None:
     citable exit after the first refuse-placeholders shot. Fabricated
     identity is not authenticated identity.
     """
-    effect = RaiseEffect(
-        exception_name="reraise",
-        blame=_LOCUS,
-        source_sha256=_SHA,
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(_LOCUS), exception_name='reraise', blame=_LOCUS, source_sha256=_SHA)
 
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
@@ -397,11 +385,7 @@ def test_exception_name_reraise_placeholder_cannot_reach_fol() -> None:
 )
 def test_every_fabricated_meaning_literal_as_name_is_loud(placeholder: str) -> None:
     """Every denylist member as exception_name is an offender class, not a name."""
-    effect = RaiseEffect(
-        exception_name=placeholder,
-        blame=_LOCUS,
-        source_sha256=_SHA,
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(_LOCUS), exception_name=placeholder, blame=_LOCUS, source_sha256=_SHA)
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
     assert placeholder in raised.value.info.observed
@@ -410,11 +394,7 @@ def test_every_fabricated_meaning_literal_as_name_is_loud(placeholder: str) -> N
 
 def test_empty_exception_name_cannot_reach_fol() -> None:
     """Empty spelling is not tree-authenticated identity."""
-    effect = RaiseEffect(
-        exception_name="",
-        blame=_LOCUS,
-        source_sha256=_SHA,
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(_LOCUS), exception_name='', blame=_LOCUS, source_sha256=_SHA)
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
     assert "empty" in raised.value.info.observed

--- a/implementations/python/sugar-lift-py-tests/tests/test_self_sealing_instrument_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_self_sealing_instrument_law.py
@@ -53,7 +53,6 @@ def test_halt_identity():
     assert _classes(
         """
 def test_occurrence():
-    assert face.occurrence_id is not None
 """
     ) == {"PRESENCE-ONLY-IDENTITY"}
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_method_caller.py
@@ -156,7 +156,6 @@ def _assert_named_halt(outcome, *, require_pre_effect_state: bool = True) -> Hal
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate is not None
-    assert halted.effect.occurrence_id is not None
     if require_pre_effect_state:
         # #6640: exceptional discharge stamps reducer-owned pre-effect state.
         # Bound-method *call* producer path may stay red until codex-1 lossless

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py
@@ -91,7 +91,6 @@ def _assert_named_halt(outcome) -> Halted:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate is not None
-    assert halted.effect.occurrence_id is not None
     return halted
 
 
@@ -221,7 +220,6 @@ def test_source_defined_property_without_setter_named_attribute_error() -> None:
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate is not None
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
-    assert halted.effect.occurrence_id is not None
 
 
 def test_source_defined_property_without_setter_discrimination() -> None:
@@ -279,7 +277,6 @@ def test_source_defined_wrong_boundary_type_leaves_halt_unconsumed() -> None:
         if isinstance(face, Halted) and face.effect is original.effect
     ]
     assert remaining == [original]
-    assert remaining[0].effect.occurrence_id is not None
 
 
 def test_source_defined_wrong_boundary_type_discrimination() -> None:
@@ -383,7 +380,6 @@ def test_tuple_receiver_store_halts_from_setattr_not_boundary() -> None:
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate is not None
-    assert halted.effect.occurrence_id is not None
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
     # Direct setattr owner is proven on the incomplete path before carrier
     # re-projects the exceptional resolution.
@@ -531,7 +527,6 @@ def test_wrong_expected_type_leaves_exceptional_edge_unconsumed() -> None:
     assert produced_type != wrong
     # The exceptional edge is still present (unconsumed by a wrong boundary).
     assert isinstance(halted, Halted)
-    assert halted.effect.occurrence_id is not None
 
 
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py
@@ -262,7 +262,6 @@ def test_getter_only_property_named_attributeerror_with_star_pack() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("AttributeError")
-    assert halted.effect.occurrence_id is not None
     assert halted.state is not None
     assert pending.pre_effect_state.state is halted.state
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_formal_caller.py
@@ -73,7 +73,6 @@ def _assert_named_halt(outcome) -> Halted:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate is not None
-    assert halted.effect.occurrence_id is not None
     return halted
 
 
@@ -306,7 +305,6 @@ def test_invalid_index_halts_with_named_indexerror() -> None:
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert halted.effect.occurrence_id is not None
 
 
 def test_discrimination_valid_index_is_not_indexerror() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_method_caller.py
@@ -141,7 +141,6 @@ def _assert_named_halt(outcome) -> Halted:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate is not None
-    assert halted.effect.occurrence_id is not None
     # #6640: exceptional discharge stamps the reducer-owned pre-effect state.
     assert halted.state is not None, (
         "NativeOperationResolutionV1.project omitted the formal setitem "

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_parameter_kinds.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_parameter_kinds.py
@@ -208,7 +208,6 @@ def test_invalid_index_named_indexerror_with_exact_pre_effect_state() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert halted.effect.occurrence_id is not None
     assert halted.state is not None
     assert pending.pre_effect_state.state is halted.state
     assert not isinstance(getattr(halted, "value", None), UniverseValue)

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_variadic_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_variadic_binding.py
@@ -266,7 +266,6 @@ def test_invalid_index_named_indexerror_with_exact_pre_effect_state() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert halted.effect.occurrence_id is not None
     assert halted.state is not None
     assert pending.pre_effect_state.state is halted.state
     assert not isinstance(getattr(halted, "value", None), UniverseValue)

--- a/implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_store_formal_caller.py
@@ -160,12 +160,7 @@ def test_slice_lower_halt_skips_upper_and_step_desugar() -> None:
             del ctx
             log.append(self.label)
             return Incomplete(
-                RaiseEffect(
-                    exception_name="ValueError",
-                    blame=str(self.site),
-                    occurrence=str(self.site),
-                    producer_node_owner=f"halt:{self.label}",
-                )
+                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(str(self.site)), exception_name='ValueError', blame=str(self.site), producer_node_owner=f'halt:{self.label}')
             )
 
         @classmethod
@@ -567,7 +562,7 @@ def test_step_zero_setitem_is_named_valueerror_with_occurrence() -> None:
     effect = out.value.effect
     assert effect.exception_name == "ValueError"
     assert effect.producer_node_owner == "ListValue.setitem"
-    assert effect.occurrence == str(site) or effect.occurrence_id == str(site)
+    assert effect.occurrence_id == str(site) or effect.occurrence_id == str(site)
 
 
 def test_step_zero_delitem_is_named_valueerror_with_occurrence() -> None:
@@ -583,7 +578,6 @@ def test_step_zero_delitem_is_named_valueerror_with_occurrence() -> None:
     effect = out.value.effect
     assert effect.exception_name == "ValueError"
     assert effect.producer_node_owner == "ListValue.delitem"
-    assert effect.occurrence_id is not None
 
 
 def test_per_phase_occurrence_identity_setitem_vs_delitem() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py
@@ -6,7 +6,7 @@ from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
 
 def test_source_constructed_exit_retains_suppressed_and_unsuppressed_faces():
-    original = RaiseEffect(TermValue("boom"), None, None)
+    original = RaiseEffect(TermValue('boom'), None, None, occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py:25:0'))
     incoming = ExitSet.halted(original, state=TermValue("before-exit"))
     result = SymbolicValue(ctor("fixture:exit-result", []))
 
@@ -22,7 +22,7 @@ def test_source_constructed_exit_retains_suppressed_and_unsuppressed_faces():
 
 
 def test_source_constructed_false_exit_restores_original_effect():
-    original = RaiseEffect(TermValue("boom"), None, None)
+    original = RaiseEffect(TermValue('boom'), None, None, occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py:9:0'))
     incoming = ExitSet.halted(original, state=TermValue("before-exit"))
 
     routed = incoming.and_exit_truthiness(

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py
@@ -156,7 +156,6 @@ def test_authenticated_raise_helper_publishes_named_halt_at_call() -> None:
     halted = _call_halt(tree, "raiser")
     assert halted.effect.exception_name == "ValueError"
     assert halted.effect.exception_type_coordinate == _identity("ValueError")
-    assert halted.effect.occurrence_id is not None or halted.effect.occurrence is not None
     # Call boundary re-owns the published edge.
     assert halted.effect.producer_node_owner == "Call"
     assert halted.state is not None
@@ -171,7 +170,6 @@ def test_store_indexerror_raise_helper_carries_named_type_and_occurrence() -> No
     halted = _call_halt(tree, "raiser")
     assert halted.effect.exception_name == "IndexError"
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert halted.effect.occurrence is not None
     assert halted.effect.producer_node_owner == "Call"
     assert halted.state is not None
 
@@ -398,13 +396,7 @@ def test_wrong_exception_observation_is_not_the_helper_effect() -> None:
         bind=frozenset({"raiser"}),
     )
     halted = _call_halt(tree, "raiser")
-    foreign = RaiseEffect(
-        exception_name="ValueError",
-        blame="foreign.py:1:0",
-        occurrence="foreign.py:1:0",
-        exception_type_coordinate=_identity("ValueError"),
-        exception_type_mro=(_identity("ValueError"),),
-    )
+    foreign = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('foreign.py:1:0'), exception_name='ValueError', blame='foreign.py:1:0', exception_type_coordinate=_identity('ValueError'), exception_type_mro=(_identity('ValueError'),))
     with pytest.raises(AssertionError):
         assert halted.effect is foreign
     with pytest.raises(AssertionError):

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_compare_control.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_compare_control.py
@@ -145,7 +145,6 @@ def test_named_exceptional_source_return_bypasses_both_bodies_with_state() -> No
 
     halted = _only_exit(call.sugar().desugar(None), Halted)
     assert halted.effect.exception_type_coordinate == _type_error_identity()
-    assert halted.effect.occurrence_id is not None
     assert halted.state is not None
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
@@ -132,12 +132,12 @@ CODEX3_OWNER = (
 @pytest.mark.parametrize(
     "competing_exit",
     (
-        RaiseValue(RaiseEffect(exception_name="TypeError")),
+        RaiseValue(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:140:0'), exception_name='TypeError')),
         GuardedRaise(
             (TermValue(True).to_term(owner="guard"),),
-            RaiseEffect(exception_name="TypeError"),
+            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:138:0'), exception_name='TypeError'),
         ),
-        Incomplete(RaiseEffect(exception_name="TypeError")),
+        Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:135:0'), exception_name='TypeError')),
         LoopControlValue("break", "helper.py:3"),
     ),
 )

--- a/implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py
@@ -69,7 +69,7 @@ class _TwoFacedElement:
         self.index = index
         self.guard = _atom(f"g{index}")
         self.halt_guard = _atom(f"h{index}")
-        self.effect = RaiseEffect(exception_name=f"E{index}")
+        self.effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py:72:0'), exception_name=f'E{index}')
 
     def desugar(self, ctx=None):
         del ctx

--- a/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
@@ -377,8 +377,7 @@ def test_exact_arity_valueerror_identity() -> None:
         == "DynamicUnpackStoreAssignSugar.arity_mismatch"
     )
     # Operation occurrence cites the unpack site — not a foreign boundary.
-    assert effect.occurrence == str(site) or effect.occurrence_id == str(site)
-    assert effect.occurrence_id is not None
+    assert effect.occurrence_id == str(site) or effect.occurrence_id == str(site)
 
 
 def test_arity_valueerror_wrong_occurrence_is_not_truthful() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_state_survival_matrix.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_state_survival_matrix.py
@@ -149,7 +149,6 @@ def _unpack_store_halt() -> tuple[NativeOperationExitCarrierV1, Halted]:
     assert isinstance(halted, Halted)
     assert halted.state is pending.pre_effect_state.state
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert halted.effect.occurrence_id is not None
     return pending, halted
 
 
@@ -352,13 +351,7 @@ def test_c_assertion_observation_binds_real_occurrence_effect() -> None:
 def test_c_wrong_occurrence_observation_refuses_twin() -> None:
     """Bite: binding must not claim a foreign occurrence / effect object."""
     _, halted = _unpack_store_halt()
-    foreign = RaiseEffect(
-        exception_name="IndexError",
-        blame="foreign.py:1:0",
-        occurrence="foreign.py:1:0",
-        exception_type_coordinate=_identity("IndexError"),
-        exception_type_mro=(_identity("IndexError"),),
-    )
+    foreign = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('foreign.py:1:0'), exception_name='IndexError', blame='foreign.py:1:0', exception_type_coordinate=_identity('IndexError'), exception_type_mro=(_identity('IndexError'),))
     routed = _assertion_boundary(
         ExitSet((halted,)),
         expected=_Expected("IndexError"),

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_refusal_preservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_refusal_preservation.py
@@ -65,7 +65,7 @@ def test_partitioned_subscript_preserves_original_typed_refusal(tmp_path, monkey
         (
             Halted(
                 complement_guard(guard),
-                RaiseEffect(exception_name="RuntimeError", occurrence=str(site)),
+                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(str(site)), exception_name='RuntimeError'),
             ),
             Completed(guard, _RefusingValue(refusal)),
         )
@@ -89,7 +89,7 @@ def test_partitioned_subscript_truth_keeps_value_and_halt_faces(tmp_path, monkey
         (
             Halted(
                 complement_guard(guard),
-                RaiseEffect(exception_name="RuntimeError", occurrence=str(site)),
+                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(str(site)), exception_name='RuntimeError'),
             ),
             Completed(
                 guard,

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py
@@ -184,10 +184,7 @@ def test_rhs_halt_wins_before_receiver_or_key_evaluation(tmp_path):
             log.append("value")
             return Complete(
                 RaiseValue(
-                    RaiseEffect(
-                        exception_type_coordinate=str_const("ValueError"),
-                        occurrence="store.py:4:12",
-                    )
+                    RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('store.py:4:12'), exception_type_coordinate=str_const('ValueError'))
                 )
             )
 
@@ -221,10 +218,7 @@ def test_receiver_halt_wins_before_key_after_rhs_completed(tmp_path):
             log.append("receiver")
             return Complete(
                 RaiseValue(
-                    RaiseEffect(
-                        exception_type_coordinate=str_const("LookupError"),
-                        occurrence="store.py:4:4",
-                    )
+                    RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('store.py:4:4'), exception_type_coordinate=str_const('LookupError'))
                 )
             )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_formal_call_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_formal_call_projection.py
@@ -119,7 +119,6 @@ def test_immutable_receiver_reads_but_formal_store_halts_with_named_type() -> No
 
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity("TypeError")
-    assert halted.effect.occurrence_id is not None
     assert "'startLine': 2" in halted.effect.occurrence
     assert "assertion" not in halted.effect.occurrence
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_try_native_store_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_try_native_store_carrier.py
@@ -110,7 +110,6 @@ def test_exitset_consumer_observes_authentic_store_occurrence_and_state() -> Non
     halted = next(exit_ for exit_ in retained.exits if isinstance(exit_, Halted))
     assert pending.pre_effect_state is not None
     assert halted.state is pending.pre_effect_state.state
-    assert halted.effect.occurrence_id is not None
     assert observed == [(halted.effect, halted.state)]
     foreign = _helper_outcome("\n" + PLAIN_STORE)
     assert isinstance(foreign, NativeOperationExitCarrierV1)

--- a/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
@@ -334,10 +334,7 @@ def test_leaf_occurrence_identities_survive_partition_and_reraise():
     type_errors = [leaf for leaf in leaves if leaf.exception_name == "TypeError"]
     assert len(value_errors) == 2
     assert len(type_errors) == 1
-    assert value_errors[0].occurrence is not None
-    assert value_errors[1].occurrence is not None
     assert value_errors[0].occurrence != value_errors[1].occurrence
-    assert type_errors[0].occurrence is not None
     assert type_errors[0].occurrence != value_errors[0].occurrence
 
 
@@ -513,7 +510,6 @@ def test_grouped_raise_occurrence_is_sealed_coordinate_not_line_col_spelling():
             name="sealed_occ_a.py",
         )
     )
-    assert effect.occurrence is not None
     # Sealed coordinate carries blake3 CIDs; fabricated line-col is "file:N:M".
     assert "blake3" in effect.occurrence
     assert effect.occurrence.count(":") >= 4  # file:start:end:source_cid:cid
@@ -574,20 +570,8 @@ def test_second_handler_reads_first_handler_temporal_binding():
     _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
     _te_cls, te_typed, te_id = _synthetic_class("TypeError")
 
-    ve_leaf = RaiseEffect(
-        exception_name="ValueError",
-        occurrence="leaf:ve",
-        exception_type_coordinate=ve_id,
-        exception_type_mro=(ve_id,),
-        raised_value=ve_typed,
-    )
-    te_leaf = RaiseEffect(
-        exception_name="TypeError",
-        occurrence="leaf:te",
-        exception_type_coordinate=te_id,
-        exception_type_mro=(te_id,),
-        raised_value=te_typed,
-    )
+    ve_leaf = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('leaf:ve'), exception_name='ValueError', exception_type_coordinate=ve_id, exception_type_mro=(ve_id,), raised_value=ve_typed)
+    te_leaf = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('leaf:te'), exception_name='TypeError', exception_type_coordinate=te_id, exception_type_mro=(te_id,), raised_value=te_typed)
     group = GroupedRaiseEffect(
         "group:root", "g", (ve_leaf, te_leaf), occurrence="group:root"
     )
@@ -631,16 +615,10 @@ def test_second_handler_reads_first_handler_temporal_binding():
             bound = temporal.value_if_bound("x") if temporal is not None else None
             if bound is None:
                 return Incomplete(
-                    RaiseEffect(
-                        exception_name="NameError",
-                        occurrence="read-x-missing",
-                    )
+                    RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('read-x-missing'), exception_name='NameError')
                 )
             return Incomplete(
-                RaiseEffect(
-                    exception_name="RuntimeError",
-                    occurrence="read-x-ok",
-                )
+                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('read-x-ok'), exception_name='RuntimeError')
             )
 
         @classmethod
@@ -817,13 +795,7 @@ def test_guarded_handler_faces_conjoin_body_guard():
         unit=SimpleNamespace(source="try-star"),
     )
     _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
-    leaf = RaiseEffect(
-        exception_name="ValueError",
-        occurrence="leaf:ve",
-        exception_type_coordinate=ve_id,
-        exception_type_mro=(ve_id,),
-        raised_value=ve_typed,
-    )
+    leaf = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('leaf:ve'), exception_name='ValueError', exception_type_coordinate=ve_id, exception_type_mro=(ve_id,), raised_value=ve_typed)
     group = GroupedRaiseEffect("group:root", "g", (leaf,), occurrence="group:root")
     body_atom = atomic("body.guard", [str_const("body")])
     handler_atom = atomic("handler.guard", [str_const("handler")])
@@ -856,10 +828,7 @@ def test_guarded_handler_faces_conjoin_body_guard():
                 (
                     Halted(
                         handler_atom,
-                        RaiseEffect(
-                            exception_name="RuntimeError",
-                            occurrence="handler:re",
-                        ),
+                        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('handler:re'), exception_name='RuntimeError'),
                         None,
                     ),
                 )
@@ -921,13 +890,7 @@ def test_alternative_exceptional_faces_keep_separate_guards():
         unit=SimpleNamespace(source="try-star"),
     )
     _ve_cls, ve_typed, ve_id = _synthetic_class("ValueError")
-    leaf = RaiseEffect(
-        exception_name="ValueError",
-        occurrence="leaf:ve",
-        exception_type_coordinate=ve_id,
-        exception_type_mro=(ve_id,),
-        raised_value=ve_typed,
-    )
+    leaf = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('leaf:ve'), exception_name='ValueError', exception_type_coordinate=ve_id, exception_type_mro=(ve_id,), raised_value=ve_typed)
     group = GroupedRaiseEffect("group:root", "g", (leaf,), occurrence="group:root")
     body_atom = atomic("body.guard", [str_const("body")])
     g1 = atomic("alt.one", [str_const("1")])
@@ -949,12 +912,12 @@ def test_alternative_exceptional_faces_keep_separate_guards():
                 (
                     Halted(
                         g1,
-                        RaiseEffect(exception_name="KeyError", occurrence="a1"),
+                        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('a1'), exception_name='KeyError'),
                         None,
                     ),
                     Halted(
                         g2,
-                        RaiseEffect(exception_name="OSError", occurrence="a2"),
+                        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('a2'), exception_name='OSError'),
                         None,
                     ),
                 )

--- a/implementations/python/sugar-lift-py-tests/tests/test_tuple_value_slice_subscript.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_tuple_value_slice_subscript.py
@@ -83,7 +83,7 @@ def test_source_tuple_zero_slice_step_is_exact_value_error(
     assert isinstance(outcome.value, RaiseValue)
     assert outcome.value.effect.exception_name == "ValueError"
     assert outcome.value.effect.producer_node_owner == "TupleValue.subscript"
-    assert outcome.value.effect.occurrence == str(site)
+    assert outcome.value.effect.occurrence_id == str(site)
 
 
 def test_source_tuple_symbolic_slice_bound_stays_typed_loud(

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_not_bool_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_not_bool_law.py
@@ -347,7 +347,6 @@ def test_formal_not_halt_bypasses_negate_continuation() -> None:
         [str_const("builtins"), str_const("TypeError")],
     )
     # Occurrence is the operation site, not a fabricated boundary locus.
-    assert exits.exits[0].effect.occurrence_id is not None
 
 
 def test_undecided_actual_stays_named_refusal_on_discharge() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_setattr_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_setattr_formal_caller.py
@@ -216,7 +216,6 @@ def test_property_without_setter_named_attribute_error_preserves_x_state() -> No
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("AttributeError")
-    assert halted.effect.occurrence_id is not None
     # Authentic earlier-binding pre-effect state (post-#6640 / #6644).
     assert halted.state is not None
     assert pending.pre_effect_state.state is halted.state

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_setitem_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_setitem_formal_caller.py
@@ -233,7 +233,6 @@ def test_invalid_index_named_indexerror_no_statement_completion() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert halted.effect.occurrence_id is not None
     # Authentic earlier-binding halt state (carrier #6640 / enrollment #6644).
     assert halted.state is not None
     assert pending.pre_effect_state.state is halted.state
@@ -251,7 +250,6 @@ def test_source_caller_invalid_index_named_indexerror() -> None:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert halted.effect.occurrence_id is not None
     # Caller path also preserves pre-effect state on the halt face.
     assert halted.state is not None
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_variadic_setitem_join.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_variadic_setitem_join.py
@@ -209,7 +209,6 @@ def test_variadic_store_halt_preserves_earlier_name_binding_state() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert halted.effect.occurrence_id is not None
     assert halted.state is not None
     assert pending.pre_effect_state.state is halted.state
     assert not isinstance(getattr(halted, "value", None), UniverseValue)

--- a/implementations/python/sugar-lift-py-tests/tests/test_while_assert_condition_occurrence_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_while_assert_condition_occurrence_identity.py
@@ -29,7 +29,6 @@ def _halt_occurrence(compare: Compare) -> str:
     assert isinstance(outcome, ExitSet)
     halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
     assert len(halted) == 1
-    assert halted[0].effect.occurrence_id is not None
     return halted[0].effect.occurrence_id
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
@@ -267,12 +267,7 @@ def _raise_with_entries(*entries):
         (
             Halted(
                 true_guard(),
-                RaiseEffect(
-                    exception_name="TypeError",
-                    exception_type_coordinate=type_identity,
-                    occurrence="body.py:3:4",
-                    raised_value=raised_value,
-                ),
+                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:3:4'), exception_name='TypeError', exception_type_coordinate=type_identity, raised_value=raised_value),
                 state,
             ),
         )
@@ -449,12 +444,7 @@ def _raise_after_warning(*, warning_message="deprecated operand"):
         (
             Halted(
                 true_guard(),
-                RaiseEffect(
-                    exception_name="TypeError",
-                    exception_type_coordinate=type_identity,
-                    occurrence="renamed.py:6:8",
-                    raised_value=raised_value,
-                ),
+                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('renamed.py:6:8'), exception_name='TypeError', exception_type_coordinate=type_identity, raised_value=raised_value),
                 state,
             ),
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -93,12 +93,7 @@ class _Raise(_FixedSugar):
         coordinate, mro = _builtin_exception_identity(name)
         super().__init__(
             Incomplete(
-                RaiseEffect(
-                    exception_name=name,
-                    occurrence=occurrence,
-                    exception_type_coordinate=coordinate,
-                    exception_type_mro=mro,
-                )
+                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_name=name, exception_type_coordinate=coordinate, exception_type_mro=mro)
             ),
             probe=probe,
         )
@@ -196,7 +191,7 @@ def test_runtime_selected_authenticates_completed_face_without_mutation():
 
 
 def test_runtime_selected_authenticates_halted_face_preserving_identity():
-    effect = RaiseEffect(exception_name="ValueError", occurrence="law.py:1:0")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('law.py:1:0'), exception_name='ValueError')
     state = object()
     incoming = Halted(true_guard(), effect, state)
 
@@ -220,7 +215,7 @@ def test_none_disposition_refuses_completed_face_without_mutation():
 
 
 def test_none_disposition_refuses_halted_face_without_mutation():
-    effect = RaiseEffect(exception_name="ValueError", occurrence="law.py:2:0")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('law.py:2:0'), exception_name='ValueError')
     state = object()
     incoming = Halted(true_guard(), effect, state)
 
@@ -294,7 +289,7 @@ def test_exit_face_binding_applied_per_face_without_rebuilding_exit():
         "X",
         Halted(
             true_guard(),
-            RaiseEffect(exception_name="KeyError", occurrence="k.py:1:0"),
+            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('k.py:1:0'), exception_name='KeyError'),
         ),
     )
     assert completed.kind == "completed"
@@ -305,7 +300,7 @@ def test_exit_face_binding_applied_per_face_without_rebuilding_exit():
 def test_enter_halt_skips_body_and_exit():
     body_ran = []
     exit_ran = []
-    enter_halt = RaiseEffect(exception_name="OSError")
+    enter_halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:308:0'), exception_name='OSError')
     sugar = _resource(
         enter=_FixedSugar(Incomplete(enter_halt)),
         body=(_Pass(probe=body_ran),),
@@ -341,10 +336,7 @@ def test_completed_body_runs_exit_with_three_explicit_none_coordinates():
 def test_raised_body_routes_exact_face_coordinates_to_exit():
     """Face 3: type/value/traceback coordinates share the exact raised face."""
     face_id = "raised-face-17"
-    effect = RaiseEffect(
-        exception_name="ValueError",
-        occurrence="source.py:17:8",
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('source.py:17:8'), exception_name='ValueError')
     exit_sugar = _parametric_exit(face_id=face_id)
     type_coord, value_coord, traceback_coord = (
         argument.desugar().value for argument in exit_sugar.args
@@ -371,7 +363,7 @@ def test_falsy_source_exit_preserves_the_exact_original_halt():
     """Face 4: falsity restores the same effect and pre-effect state objects."""
     from sugar_lift_py_tests.outcome.exit_set import ExitSet
 
-    effect = RaiseEffect(exception_name="ValueError", occurrence="body.py:4:2")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:4:2'), exception_name='ValueError')
     state = ObjectValue("native-resource", (), identity="before-raise")
     incoming = Halted(true_guard(), effect, state)
     routed = ExitSet((incoming,)).and_exit_truthiness(
@@ -388,7 +380,7 @@ def test_truthy_source_exit_suppresses_the_original_raise():
     """Face 5: source-testified truth consumes the raised edge."""
     from sugar_lift_py_tests.outcome.exit_set import ExitSet
 
-    effect = RaiseEffect(exception_name="ValueError", occurrence="body.py:5:2")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:5:2'), exception_name='ValueError')
     routed = ExitSet((Halted(true_guard(), effect),)).and_exit_truthiness(
         ExitSet.completed(TermValue(True)), site="exit-site"
     )
@@ -399,7 +391,7 @@ def test_undecided_source_exit_keeps_both_faces_factored():
     """Face 6: UNKNOWN truth is neither false nor true; both arms survive."""
     from sugar_lift_py_tests.outcome.exit_set import ExitSet
 
-    effect = RaiseEffect(exception_name="ValueError", occurrence="body.py:6:2")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:6:2'), exception_name='ValueError')
     routed = ExitSet((Halted(true_guard(), effect),)).and_exit_truthiness(
         ExitSet.completed(SymbolicValue(make_var("exit_result"))), site="exit-site"
     )
@@ -418,7 +410,7 @@ def test_never_suppresses_restores_body_halt():
 
 def test_typed_never_suppresses_preserves_conditional_raise_and_normal_face():
     guard = atomic("with_body_guard", [make_var("state")])
-    effect = RaiseEffect(exception_name="ValueError", occurrence="body.py:4:8")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:4:8'), exception_name='ValueError')
 
     class _ConditionalRaise(Sugar):
         def desugar(self, ctx=None):
@@ -639,7 +631,7 @@ def test_never_suppresses_needs_no_second_cleanup_algebra():
     faces = (
         Completed(true_guard(), _FloorValue("body")),
         Halted(
-            true_guard(), RaiseEffect(exception_name="ValueError"), _FloorValue("pre")
+            true_guard(), RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:642:0'), exception_name='ValueError'), _FloorValue("pre")
         ),
     )
     for disposition in (NeverSuppresses(), NeverSuppressesDispositionV1()):
@@ -667,12 +659,7 @@ def test_lying_the_equivalence_is_specific_to_never_suppresses():
     coordinate, mro = _builtin_exception_identity("ValueError")
     halted = Halted(
         true_guard(),
-        RaiseEffect(
-            exception_name="ValueError",
-            exception_type_coordinate=coordinate,
-            exception_type_mro=mro,
-            occurrence="equiv.py:1:0",
-        ),
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('equiv.py:1:0'), exception_name='ValueError', exception_type_coordinate=coordinate, exception_type_mro=mro),
         _FloorValue("pre"),
     )
     suppressing = ExitSuppressionContract.suppresses(("ValueError",))
@@ -695,7 +682,7 @@ def test_exit_face_binding_completed_is_none_triple():
 
 
 def test_exit_face_binding_raised_is_not_none_triple():
-    effect = RaiseEffect(exception_name="ValueError", occurrence="src.py:3:4")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('src.py:3:4'), exception_name='ValueError')
     face = Halted(true_guard(), effect)
     binding = ExitFaceBinding.from_body_exit("X", face)
     assert binding.kind == "raised"

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
@@ -144,12 +144,7 @@ def test_summary_suppresses_disposition_consumes_matching_body_halt():
         body=(
             _FixedSugar(
                 Incomplete(
-                    RaiseEffect(
-                        exception_name="ValueError",
-                        occurrence="resource.py:4:8",
-                        exception_type_coordinate=coordinate,
-                        exception_type_mro=mro,
-                    )
+                    RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('resource.py:4:8'), exception_name='ValueError', exception_type_coordinate=coordinate, exception_type_mro=mro)
                 )
             ),
         ),
@@ -172,7 +167,7 @@ def test_summary_suppresses_disposition_consumes_matching_body_halt():
 
 
 def test_source_true_exit_consumes_the_halted_edge():
-    effect = RaiseEffect(exception_name="ValueError", occurrence="resource.py:4:8")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('resource.py:4:8'), exception_name='ValueError')
     sugar, protocol = _truthiness_resource(
         exit_value=TermValue(True), body=(_FixedSugar(Incomplete(effect)),)
     )
@@ -185,7 +180,7 @@ def test_source_true_exit_consumes_the_halted_edge():
 
 
 def test_source_false_exit_passes_the_exact_halted_edge_through():
-    effect = RaiseEffect(exception_name="ValueError", occurrence="resource.py:4:8")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('resource.py:4:8'), exception_name='ValueError')
     sugar, protocol = _truthiness_resource(
         exit_value=TermValue(False), body=(_FixedSugar(Incomplete(effect)),)
     )
@@ -199,7 +194,7 @@ def test_source_false_exit_passes_the_exact_halted_edge_through():
 
 
 def test_source_undecided_exit_keeps_both_suppression_faces():
-    effect = RaiseEffect(exception_name="ValueError", occurrence="resource.py:4:8")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('resource.py:4:8'), exception_name='ValueError')
     result = SymbolicValue(ctor("fixture:undecided-exit", ()))
     sugar, _ = _truthiness_resource(
         exit_value=result, body=(_FixedSugar(Incomplete(effect)),)
@@ -250,9 +245,7 @@ def test_source_exit_runs_on_early_return_face():
         ),
         (
             Incomplete(
-                RaiseEffect(
-                    exception_name="ValueError", occurrence="resource.py:8:8"
-                )
+                RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('resource.py:8:8'), exception_name='ValueError')
             ),
             TermValue(False),
             Halted,

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -660,12 +660,7 @@ def _project_generator_enter_result(protocol, machine, result):
         refusal = observed_entry_refusal()
         blame = str(machine.instance_coordinate)
         return Incomplete(
-            RaiseEffect(
-                exception_name=refusal.exception_name,
-                blame=blame,
-                occurrence=f"generator-entry-refusal:{blame}",
-                raised_value=refusal.message,
-            )
+            RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(f'generator-entry-refusal:{blame}'), exception_name=refusal.exception_name, blame=blame, raised_value=refusal.message)
         )
     if isinstance(result, GeneratorTransitionGapV1):
         raise SugarNotWritten(

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
@@ -131,11 +131,7 @@ def test_enter_bound_generator_construction_refuses_foreign_frame():
 
 def test_enter_bound_generator_sequences_mixed_yield_and_halt_faces():
     true_face, false_face = partition("mixed-enter-guard")
-    effect = RaiseEffect(
-        exception_name="RenamedError",
-        blame="mixed-enter",
-        occurrence="mixed-enter:halt",
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('mixed-enter:halt'), exception_name='RenamedError', blame='mixed-enter')
     state = TermValue("pre-enter-state")
     pending = ()
 

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_manager_renamed_lifecycle.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_manager_renamed_lifecycle.py
@@ -265,11 +265,7 @@ class _Fixed(Sugar):
 
 def _nested_body_faces() -> ExitSet:
     """Completed, Returned, and Halted edges under distinct guards."""
-    raise_effect = RaiseEffect(
-        exception_name="ValueError",
-        occurrence="body.py:10:8:raise",
-        blame="body.py:10:8:raise",
-    )
+    raise_effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:10:8:raise'), exception_name='ValueError', blame='body.py:10:8:raise')
     return ExitSet(
         (
             Completed(

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_nested_managers.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_nested_managers.py
@@ -181,12 +181,7 @@ def test_nested_cleanup_runs_before_outer_resume_on_halt(tmp_path: Path) -> None
     machine = entered.machine
     assert isinstance(machine.steps[machine.cursor], NestedManagerExitStepV1)
     # Plant a throw at the post-yield suspension (halted body edge).
-    effect = RaiseEffect(
-        exception_name="RuntimeError",
-        blame="body",
-        occurrence="body:halt",
-        raised_value="boom",
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body:halt'), exception_name='RuntimeError', blame='body', raised_value='boom')
     halted = machine.throw(effect)
     # Nested exit must have run: NestedEnteredBinding still present but exit was
     # called (one-shot nested protocol refuses double exit).

--- a/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
@@ -740,12 +740,7 @@ def _raise_effect_with_message(message: str):
             return identity
 
     return (
-        RaiseEffect(
-            exception_name="ValueError",
-            exception_type_coordinate=identity,
-            occurrence=f"{message}@match-pattern",
-            raised_value=raised,
-        ),
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(f'{message}@match-pattern'), exception_name='ValueError', exception_type_coordinate=identity, raised_value=raised),
         _Handler(),
     )
 

--- a/implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py
@@ -62,7 +62,7 @@ def test_source_return_projection_selects_one_unconditional_returned_floor() -> 
         BlockValue(
             (
                 ReturnValue(TermValue("returned")),
-                RaiseValue(RaiseEffect(exception_name="RuntimeError")),
+                RaiseValue(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py:91:0'), exception_name='RuntimeError')),
             ),
             can_fall_through=False,
         ),
@@ -88,7 +88,7 @@ def test_source_return_projection_preserves_ambiguous_control_flow(ambiguous) ->
     (
         BlockValue((TermValue("foreign"),)),
         BlockValue(
-            (RaiseValue(RaiseEffect(exception_name="RuntimeError")),),
+            (RaiseValue(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py:65:0'), exception_name='RuntimeError')),),
             can_fall_through=False,
         ),
     ),

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -886,7 +886,7 @@ def test_failure_entering_inner_assigned_resource_still_exits_outer():
     (the inner manager was never entered).
     """
     outer_exit, inner_exit = [], []
-    halt = RaiseEffect(exception_name="OSError", occurrence="inner.py:1:0")
+    halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('inner.py:1:0'), exception_name='OSError')
     inner = _source_resource(
         manager=_FixedSugar(Complete(_FloorValue("inner-mgr"))),
         protocol=_ProbeProtocol(enter=Incomplete(halt), exit_probe=inner_exit),
@@ -921,7 +921,7 @@ def test_failure_entering_inner_assigned_resource_still_exits_outer():
 def test_discrimination_outer_exit_is_not_skipped_on_enter_halt():
     """BITE: completion-only exit would leave the outer exit probe empty."""
     outer_exit, inner_exit = [], []
-    halt = RaiseEffect(exception_name="OSError", occurrence="inner.py:1:0")
+    halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('inner.py:1:0'), exception_name='OSError')
     inner = _source_resource(
         manager=_FixedSugar(Complete(_FloorValue("inner-mgr"))),
         protocol=_ProbeProtocol(enter=Incomplete(halt), exit_probe=inner_exit),

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1912,13 +1912,7 @@ def test_factored_raise_routing_uses_none_and_pattern_message_faces():
     type_term = ctor("python:exception_type", [str_const("builtins.ValueError")])
     raise_face = Halted(
         true_guard(),
-        RaiseEffect(
-            exception_name="ValueError",
-            blame="t.py:2:8",
-            exception_type_coordinate=type_term,
-            exception_type_mro=(type_term,),
-            raised_value=StringValue("needle"),
-        ),
+        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('t.py:2:8'), exception_name='ValueError', blame='t.py:2:8', exception_type_coordinate=type_term, exception_type_mro=(type_term,), raised_value=StringValue('needle')),
         None,
     )
     body = ExitSet((raise_face,))

--- a/implementations/python/sugar-lift-python-source/tests/test_source_resource_nested_exit_faces.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_resource_nested_exit_faces.py
@@ -143,11 +143,7 @@ def _state(marker: str):
 
 def _nested_body_faces():
     """One ExitSet with Completed, Returned, and Halted faces under distinct guards."""
-    raise_effect = RaiseEffect(
-        exception_name="ValueError",
-        occurrence="body.py:10:8:raise",
-        blame="body.py:10:8:raise",
-    )
+    raise_effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:10:8:raise'), exception_name='ValueError', blame='body.py:10:8:raise')
     return ExitSet(
         (
             Completed(
@@ -228,7 +224,7 @@ def test_one_enter_and_exit_per_nested_body_face():
     assert returned_binding.kind == "completed"
     assert halted_binding.kind == "raised"
     assert halted_binding.exception_name == "ValueError"
-    assert halted_binding.occurrence == "body.py:10:8:raise"
+    assert halted_binding.occurrence_id == "body.py:10:8:raise"
 
 
 def test_false_exit_preserves_return_halt_and_temporal_state():
@@ -295,11 +291,7 @@ def test_truthy_exit_suppresses_only_the_incoming_raise():
 def test_exit_halt_supersedes_every_incoming_body_face():
     """A halted __exit__ supersedes Completed, Returned, and Halted body faces."""
     body, raise_effect = _nested_body_faces()
-    exit_halt = RaiseEffect(
-        exception_name="RuntimeError",
-        occurrence="exit.py:1:0",
-        blame="exit.py:1:0",
-    )
+    exit_halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit.py:1:0'), exception_name='RuntimeError', blame='exit.py:1:0')
     protocol = _RecordingProtocol(exit_outcome=Incomplete(exit_halt))
     sugar = _source_resource(
         protocol=protocol,
@@ -329,16 +321,8 @@ def test_exit_halt_supersedes_every_incoming_body_face():
 
 def test_face_occurrence_lying_twin_discriminates_exit_bindings():
     """Lying twin: distinct raise occurrences mint distinct ExitFaceBinding rows."""
-    a = RaiseEffect(
-        exception_name="ValueError",
-        occurrence="body.py:1:0:A",
-        blame="body.py:1:0:A",
-    )
-    b = RaiseEffect(
-        exception_name="ValueError",
-        occurrence="body.py:2:0:B",
-        blame="body.py:2:0:B",
-    )
+    a = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:1:0:A'), exception_name='ValueError', blame='body.py:1:0:A')
+    b = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:2:0:B'), exception_name='ValueError', blame='body.py:2:0:B')
     bind_a = ExitFaceBinding.from_body_exit(
         "exit-face", Halted(true_guard(), a, _state("a"))
     )
@@ -348,8 +332,8 @@ def test_face_occurrence_lying_twin_discriminates_exit_bindings():
     assert bind_a.kind == bind_b.kind == "raised"
     assert bind_a.exception_name == bind_b.exception_name == "ValueError"
     assert bind_a.occurrence != bind_b.occurrence
-    assert bind_a.occurrence == "body.py:1:0:A"
-    assert bind_b.occurrence == "body.py:2:0:B"
+    assert bind_a.occurrence_id == "body.py:1:0:A"
+    assert bind_b.occurrence_id == "body.py:2:0:B"
 
     # Completions never borrow a raise occurrence.
     completed = ExitFaceBinding.from_body_exit(

--- a/implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py
@@ -65,7 +65,6 @@ def test_source_property_getter_publishes_authenticated_exceptional_exit(
     assert isinstance(effect, RaiseEffect)
     assert effect.exception_name == "ValueError"
     assert effect.exception_type_coordinate is not None
-    assert effect.occurrence_id is not None
     assert effect.producer_node_owner == "Attribute"
 
 
@@ -92,7 +91,6 @@ def test_property_getter_raise_keeps_imported_bare_exception_coordinate(
     assert isinstance(halted.effect, RaiseEffect)
     assert halted.effect.exception_name == "CustomError"
     assert halted.effect.exception_type_coordinate is not None
-    assert halted.effect.occurrence_id is not None
 
 
 def test_source_property_getter_that_returns_completes_without_a_raise(
@@ -167,5 +165,4 @@ def test_pandas_303_abstract_method_property_is_the_concrete_reproducer() -> Non
     assert isinstance(effect, RaiseEffect)
     assert effect.exception_name == "AbstractMethodError"
     assert effect.exception_type_coordinate is not None
-    assert effect.occurrence_id is not None
     assert effect.producer_node_owner == "Attribute"

--- a/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
+++ b/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
@@ -437,14 +437,7 @@ def _three_deep_manager_halt(exception_name: str):
     original_middle = middle
     original_inner = inner
     middle_exit, inner_enter, inner_exit = [], [], []
-    effect = RaiseEffect(
-        exception_name=exception_name,
-        exception_type_coordinate=ctor(
-            "python:exception_type_identity",
-            [str_const("builtins"), str_const(exception_name)],
-        ),
-        occurrence="test_common.py:640",
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('test_common.py:640'), exception_name=exception_name, exception_type_coordinate=ctor('python:exception_type_identity', [str_const('builtins'), str_const(exception_name)]))
     inner = replace(
         inner,
         manager=_FixedOutcomeSugar(Incomplete(effect)),
@@ -594,14 +587,7 @@ def _three_deep_level_receipts(exception_name: str):
     outer, middle, inner = _with_routers(
         _built_function(identity, "test_close_on_error", rows)
     )
-    effect = RaiseEffect(
-        exception_name=exception_name,
-        exception_type_coordinate=ctor(
-            "python:exception_type_identity",
-            [str_const("builtins"), str_const(exception_name)],
-        ),
-        occurrence="test_common.py:640",
-    )
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('test_common.py:640'), exception_name=exception_name, exception_type_coordinate=ctor('python:exception_type_identity', [str_const('builtins'), str_const(exception_name)]))
     inner = replace(
         inner,
         manager=_FixedOutcomeSugar(Incomplete(effect)),

--- a/implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py
+++ b/implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py
@@ -272,7 +272,7 @@ def test_the_effect_itself_is_not_altered_by_the_carried_demand():
     """
     from sugar_lift_py_tests.effect import RaiseEffect
 
-    effect = RaiseEffect(exception_name="ValueError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:476:0'), exception_name='ValueError')
     bare = Incomplete(effect)
     carrying = Incomplete(effect, (), ("sentinel-entry",))
 
@@ -355,7 +355,7 @@ def test_an_effect_face_is_no_longer_the_partition_gap():
 
     joined = rewrap_pending(
         entry,
-        Incomplete(RaiseEffect(exception_name="ValueError")),
+        Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:441:0'), exception_name='ValueError')),
         owner="test_effect_face",
         blame=entry.source_node,
     )
@@ -382,7 +382,7 @@ def _halted_carrier(guard=None):
 
     out = _out("def f(p):\n return [p[0]]\n")
     (entry,) = _entries(out)
-    effect = RaiseEffect(exception_name="ValueError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:385:0'), exception_name='ValueError')
     incomplete = Incomplete(effect, (guard,) if guard is not None else (), (entry,))
     exits = outcome_to_exitset(incomplete)
     (arm,) = exits.exits
@@ -438,7 +438,7 @@ def test_halted_arms_owing_different_things_are_different_destinations():
 
     first = _entries(_out("def f(p):\n return [p[0]]\n"))[0]
     second = _entries(_out("def f(q):\n return [q[1]]\n"))[0]
-    effect = RaiseEffect(exception_name="ValueError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:358:0'), exception_name='ValueError')
 
     merged = ExitSet(
         (
@@ -473,7 +473,7 @@ def test_halted_arms_owing_the_same_thing_still_merge():
     from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
 
     (entry,) = _entries(_out("def f(p):\n return [p[0]]\n"))
-    effect = RaiseEffect(exception_name="ValueError")
+    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:275:0'), exception_name='ValueError')
 
     merged = ExitSet(
         (

--- a/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
@@ -202,7 +202,7 @@ def test_rhs_constructs_before_halted_receiver_and_store_does_not_continue():
     sugar = assignment.sugar()
     receiver_calls = []
     value_calls = []
-    halt = Incomplete(RaiseEffect(exception_name="ArbitraryError"))
+    halt = Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_store_target_effect.py:205:0'), exception_name='ArbitraryError'))
     rewritten = replace(
         sugar,
         receiver=_OutcomeSugar(halt, receiver_calls),

--- a/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
@@ -362,7 +362,7 @@ def test_failure_entering_second_manager_still_exits_first():
     outgoing edge, not only the completed one.
     """
     outer_exit, inner_exit = [], []
-    halt = RaiseEffect(exception_name="OSError", occurrence="b.py:1:0")
+    halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('b.py:1:0'), exception_name='OSError')
     sugar = _nested_pair(
         _FixedSugar(Incomplete(halt)),
         outer_exit_probe=outer_exit,
@@ -380,7 +380,7 @@ def test_discrimination_first_exit_is_not_skipped_on_the_halted_edge():
     unran. Assert the wrong expectation and show it fails."""
     outer_exit, inner_exit = [], []
     sugar = _nested_pair(
-        _FixedSugar(Incomplete(RaiseEffect(exception_name="OSError"))),
+        _FixedSugar(Incomplete(RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py:383:0'), exception_name='OSError'))),
         outer_exit_probe=outer_exit,
         inner_exit_probe=inner_exit,
     )
@@ -418,7 +418,7 @@ def test_body_halt_inside_nested_managers_runs_both_exits():
     """LAW: a halting BODY still exits B then A; the halt is preserved under
     NeverSuppresses."""
     outer_exit, inner_exit = [], []
-    halt = RaiseEffect(exception_name="ValueError", occurrence="body.py:2:4")
+    halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:2:4'), exception_name='ValueError')
     inner = _resource(
         body=(_FixedSugar(Incomplete(halt)),), slot="B", exit_probe=inner_exit
     )
@@ -432,7 +432,7 @@ def test_body_halt_inside_nested_managers_runs_both_exits():
 
 def test_discrimination_body_halt_is_not_suppressed_by_never_suppresses():
     outer_exit, inner_exit = [], []
-    halt = RaiseEffect(exception_name="ValueError", occurrence="body.py:2:4")
+    halt = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('body.py:2:4'), exception_name='ValueError')
     inner = _resource(
         body=(_FixedSugar(Incomplete(halt)),), slot="B", exit_probe=inner_exit
     )

--- a/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
@@ -734,7 +734,7 @@ def test_discrimination_a_matching_halt_does_not_remain_outgoing(tmp_path):
 def test_exit_halt_supersedes_every_incoming_edge(tmp_path):
     resource, _ = _both_arms(tmp_path)
     body_es = _body_exitset(resource.body)
-    cleanup_failure = RaiseEffect(exception_name="OSError", occurrence="exit:1:0")
+    cleanup_failure = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('exit:1:0'), exception_name='OSError')
 
     routed = body_es.and_exit(
         ExitSet.halted(cleanup_failure), disposition=resource.disposition


### PR DESCRIPTION
## Summary

**Land first** of boundary Z with #6965 (mr_brown type-coord stack).

`AuthenticatedRaiseLocus` / `UndeterminedRaiseLocus`; `RaiseEffect.occurrence` required.

### Boundary Z

| Owner | Noun | PR |
| --- | --- | --- |
| mr_blue | LOCUS | this (#6966 successor if closed) |
| mr_brown | TYPE | #6965 stacked on this tip `9f8675d24` |

Merge: **this then #6965**. Dual RaiseEffect lives on brown tip after stack.

### Shot accounting

- **R axis:** occurrence presence / locus ontology  
- **Epsilon R:** −69 occurrence presence sites  
- **Shell deleted:** optional `occurrence: str | None` + presence teeth  
- **Floors:** UndeterminedRaiseLocus third value; throw when unfinished  

Tip: `9f8675d24`. Restored after a mistaken dual-restack onto older #6965.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require `AuthenticatedRaiseLocus` at `RaiseEffect` construction time
> - Introduces [`AuthenticatedRaiseLocus`](https://github.com/TSavo/sugar/pull/6968/files#diff-c59b04c9f36a4b79666cdaf389f5d1544e4703cb2dd7913944ef809a8075fa35) and `UndeterminedRaiseLocus` dataclasses; `AuthenticatedRaiseLocus.of` coerces and validates locus strings, rejecting `None`, empty text, and `UndeterminedRaiseLocus`.
> - Updates [`RaiseEffect`](https://github.com/TSavo/sugar/pull/6968/files#diff-86ac0341e1b0150cd2cc92629cac9a1229955bf3a2a82f6eef18f61cba4037a6) so `occurrence` is a required `AuthenticatedRaiseLocus` field, making `occurrence_id` always return a non-empty string.
> - Updates all call sites across production helpers and test fixtures to pass `occurrence=AuthenticatedRaiseLocus.of(...)` instead of raw strings or omitting the field.
> - Switches occurrence identity assertions in tests from `effect.occurrence` to `effect.occurrence_id` to align with the new accessor.
> - Risk: any `RaiseEffect` constructed without a valid locus string now raises `TypeError` at construction time instead of silently producing a `None` `occurrence_id`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5ac926.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->