### PR TITLE
Dispatch isinstance and effect routing on type coordinates, not spelling

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
@@ -217,16 +217,126 @@ def _observed_effect(entry):
     return None
 
 
+def _matcher_raise_identity(matcher: EffectMatcher, *, owner: str, blame):
+    """Builtin exception-type coordinate for an EffectMatcher name.
+
+    The matcher still carries a language-owned type spelling at construction
+    (legacy Suppresses/Expects door). Matching never compares that spelling to
+    ``effect.exception_name`` — it mints the coordinate once and compares
+    identities. Name-less or non-builtin matchers are unwritten work.
+    """
+    from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+    from sugar_source_tree.panic import SugarNotWritten
+
+    name = getattr(matcher, "name", None)
+    if not isinstance(name, str) or not name:
+        raise SugarNotWritten(
+            blame=blame,
+            owner=owner,
+            observed="name-less EffectMatcher",
+            requested="matcher carrying a language-owned exception type spelling",
+            fix=(
+                "construct EffectMatcher with a real exception type, or route "
+                "through AuthenticatedRaiseMatcher / matches_raise_effect"
+            ),
+        )
+    identity, _ = _builtin_exception_identity(name)
+    if identity is None:
+        raise SugarNotWritten(
+            blame=blame,
+            owner=owner,
+            observed=f"matcher name {name!r} has no builtin type coordinate",
+            requested="a language-owned exception type with python:exception_type_identity",
+            fix="use a builtin exception type or AuthenticatedRaiseMatcher",
+        )
+    return identity
+
+
+def _raise_matches_matcher(effect: RaiseEffect, matcher: EffectMatcher) -> bool:
+    """Match a raise by exception_type_coordinate, never exception_name spelling."""
+    from sugar_source_tree.panic import SugarNotWritten
+
+    owner = "effect_router._matching_effect"
+    blame = getattr(effect, "occurrence_id", None) or owner
+    coordinate = getattr(effect, "exception_type_coordinate", None)
+    if coordinate is None:
+        raise SugarNotWritten(
+            blame=blame,
+            owner=owner,
+            observed="raise effect without exception_type_coordinate",
+            requested="authenticated exception_type_coordinate on the halt",
+            fix=(
+                "mint the raise through the ground exit door or an authenticated "
+                "producer; do not match by exception_name spelling"
+            ),
+        )
+    return coordinate == _matcher_raise_identity(matcher, owner=owner, blame=blame)
+
+
+def _warning_matches_matcher(effect, matcher: EffectMatcher) -> bool:
+    """Match a warning by category_identity when present; else refuse spelling."""
+    from sugar_source_tree.panic import SugarNotWritten
+
+    owner = "effect_router._matching_effect"
+    blame = getattr(effect, "blame", None) or owner
+    identity = getattr(effect, "category_identity", None)
+    if identity is None:
+        raise SugarNotWritten(
+            blame=blame,
+            owner=owner,
+            observed="warning effect without category_identity",
+            requested="authenticated category_identity on the warning",
+            fix=(
+                "construct the warning through a producer that mints "
+                "category_identity; do not match by category_name spelling"
+            ),
+        )
+    # Matcher still states a category spelling; mint the same coordinate door
+    # used for raises when the category is a builtins warning type.
+    from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+
+    name = getattr(matcher, "name", None)
+    if not isinstance(name, str) or not name:
+        raise SugarNotWritten(
+            blame=blame,
+            owner=owner,
+            observed="name-less warning EffectMatcher",
+            requested="matcher carrying a warning category type spelling",
+            fix="construct EffectMatcher with a real warning category",
+        )
+    matcher_identity, _ = _builtin_exception_identity(name)
+    if matcher_identity is None:
+        # Non-builtin warning categories: compare identity terms if the
+        # producer used the same ctor shape as the matcher spelling via
+        # category_identity already being the authority — require equality
+        # only when both sides are coordinates. Spelling never participates.
+        raise SugarNotWritten(
+            blame=blame,
+            owner=owner,
+            observed=f"warning matcher name {name!r} has no builtin type coordinate",
+            requested="authenticated warning-category coordinate on the matcher",
+            fix="mint matcher identity or extend the authenticated warning door",
+        )
+    return identity == matcher_identity
+
+
 def _matching_effect(entries: tuple, matcher: EffectMatcher):
-    """First exact kind+name match, or None. Single match authority for route."""
+    """First kind+coordinate match, or None. Single match authority for route.
+
+    Display spellings (exception_name / category_name / matcher.name as string
+    equality) never decide. Missing coordinates throw — unfinished authentication.
+    """
     for index, entry in enumerate(entries):
         observed = _observed_effect(entry)
-        if (
-            observed is not None
-            and observed[0] == matcher.kind
-            and observed[1] == matcher.name
-        ):
-            return index, entry, observed
+        if observed is None or observed[0] != matcher.kind:
+            continue
+        kind, _type_name, _message, effect = observed
+        if kind == "raise":
+            if _raise_matches_matcher(effect, matcher):
+                return index, entry, observed
+        elif kind == "warning":
+            if _warning_matches_matcher(effect, matcher):
+                return index, entry, observed
     return None
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/bytes_value.py
@@ -22,7 +22,10 @@ class BytesValue(FloorValue):
         return True
 
     def python_isinstance(self, type_name: str, type_term, site):
-        del type_term
+        del type_name  # display spelling is not authority
+        from sugar_lift_py_tests.floor.python_type_coordinate import (
+            authenticated_python_type_spelling,
+        )
         from sugar_lift_py_tests.outcome import Complete
         from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
             FalseBoolLiteralSugar,
@@ -31,9 +34,12 @@ class BytesValue(FloorValue):
             TrueBoolLiteralSugar,
         )
 
+        authenticated = authenticated_python_type_spelling(
+            type_term, owner="BytesValue.python_isinstance", site=site
+        )
         return Complete(
             TrueBoolLiteralSugar(site=site)
-            if type_name == "bytes"
+            if authenticated == "bytes"
             else FalseBoolLiteralSugar(site=site)
         )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_value.py
@@ -108,7 +108,9 @@ class ClassValue(FloorValue):
         consulted: under builtin shadowing the same spelling can name a
         foreign type, and deciding False from that string is a wrong answer.
         """
-        from sugar_lift_py_tests.ir import _ConstStr, _Ctor
+        from sugar_lift_py_tests.floor.python_type_coordinate import (
+            authenticated_python_type_spelling,
+        )
         from sugar_lift_py_tests.outcome import Complete
         from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
             FalseBoolLiteralSugar,
@@ -116,26 +118,11 @@ class ClassValue(FloorValue):
         from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
             TrueBoolLiteralSugar,
         )
-        from sugar_source_tree.panic import SugarNotWritten
 
         del type_name  # display spelling is not authority
-        if (
-            type(type_term) is not _Ctor
-            or type_term.name != "python:type"
-            or len(type_term.args) != 1
-            or type(type_term.args[0]) is not _ConstStr
-        ):
-            raise SugarNotWritten(
-                blame=str(site),
-                owner="ClassValue.python_isinstance",
-                observed=f"type_term={type(type_term).__name__!s}",
-                requested='authenticated python:type("…") coordinate',
-                fix=(
-                    "thread the type operand's coordinate; never decide "
-                    "class-object isinstance by type_name spelling"
-                ),
-            )
-        authenticated_name = type_term.args[0].value
+        authenticated_name = authenticated_python_type_spelling(
+            type_term, owner="ClassValue.python_isinstance", site=site
+        )
         if authenticated_name in {"type", "object"}:
             return Complete(TrueBoolLiteralSugar(site=site))
         if authenticated_name in _CLASS_OBJECT_DISJOINT_TYPES:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
@@ -24,7 +24,10 @@ class ComplexValue(FloorValue):
         return True
 
     def python_isinstance(self, type_name: str, type_term, site):
-        del type_term
+        del type_name  # display spelling is not authority
+        from sugar_lift_py_tests.floor.python_type_coordinate import (
+            authenticated_python_type_spelling,
+        )
         from sugar_lift_py_tests.outcome import Complete
         from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
             FalseBoolLiteralSugar,
@@ -33,9 +36,12 @@ class ComplexValue(FloorValue):
             TrueBoolLiteralSugar,
         )
 
+        authenticated = authenticated_python_type_spelling(
+            type_term, owner="ComplexValue.python_isinstance", site=site
+        )
         return Complete(
             TrueBoolLiteralSugar(site=site)
-            if type_name == "complex"
+            if authenticated == "complex"
             else FalseBoolLiteralSugar(site=site)
         )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ellipsis_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ellipsis_value.py
@@ -15,7 +15,10 @@ class EllipsisValue(FloorValue):
     table (``symbolic_value.py``: ``"py.ellipsis": "ellipsis"``)."""
 
     def python_isinstance(self, type_name: str, type_term, site):
-        del type_term
+        del type_name  # display spelling is not authority
+        from sugar_lift_py_tests.floor.python_type_coordinate import (
+            authenticated_python_type_spelling,
+        )
         from sugar_lift_py_tests.outcome import Complete
         from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
             FalseBoolLiteralSugar,
@@ -24,9 +27,12 @@ class EllipsisValue(FloorValue):
             TrueBoolLiteralSugar,
         )
 
+        authenticated = authenticated_python_type_spelling(
+            type_term, owner="EllipsisValue.python_isinstance", site=site
+        )
         return Complete(
             TrueBoolLiteralSugar(site=site)
-            if type_name == "ellipsis"
+            if authenticated == "ellipsis"
             else FalseBoolLiteralSugar(site=site)
         )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/python_type_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/python_type_coordinate.py
@@ -1,0 +1,40 @@
+"""Authenticated ``python:type`` coordinate door for isinstance dispatch.
+
+LAW OF ONE: the type operand's identity is the coordinate the tree carried
+(``python:type("…")``), never the display ``type_name`` string. Under builtin
+shadowing the same spelling can name a foreign type; deciding True/False from
+that string is a second mechanism inventing meaning outside the tree.
+
+Throwing when the coordinate is unreachable is honorable: the producer has not
+written authentication yet.
+"""
+
+from __future__ import annotations
+
+
+def authenticated_python_type_spelling(type_term, *, owner: str, site) -> str:
+    """Return the builtins type spelling from an authenticated ``python:type`` term.
+
+    Display ``type_name`` is never consulted. Wrong-shape or missing coordinate
+    raises ``SugarNotWritten``.
+    """
+    from sugar_lift_py_tests.ir import _ConstStr, _Ctor
+    from sugar_source_tree.panic import SugarNotWritten
+
+    if (
+        type(type_term) is not _Ctor
+        or type_term.name != "python:type"
+        or len(type_term.args) != 1
+        or type(type_term.args[0]) is not _ConstStr
+    ):
+        raise SugarNotWritten(
+            blame=str(site),
+            owner=owner,
+            observed=f"type_term={type(type_term).__name__}",
+            requested='authenticated python:type("…") coordinate',
+            fix=(
+                "thread the type operand's coordinate; never decide "
+                "isinstance by type_name spelling"
+            ),
+        )
+    return type_term.args[0].value

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -26,7 +26,10 @@ class StringValue(GuardStableValue):
         return False
 
     def python_isinstance(self, type_name: str, type_term, site):
-        del type_term
+        del type_name  # display spelling is not authority
+        from sugar_lift_py_tests.floor.python_type_coordinate import (
+            authenticated_python_type_spelling,
+        )
         from sugar_lift_py_tests.outcome import Complete
         from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
             FalseBoolLiteralSugar,
@@ -35,9 +38,12 @@ class StringValue(GuardStableValue):
             TrueBoolLiteralSugar,
         )
 
+        authenticated = authenticated_python_type_spelling(
+            type_term, owner="StringValue.python_isinstance", site=site
+        )
         return Complete(
             TrueBoolLiteralSugar(site=site)
-            if type_name == "str"
+            if authenticated == "str"
             else FalseBoolLiteralSugar(site=site)
         )
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -96,15 +96,23 @@ class SymbolicValue(FloorValue):
             "py.ellipsis": "ellipsis",
             "py.complex": "complex",
         }
+        from sugar_lift_py_tests.floor.python_type_coordinate import (
+            authenticated_python_type_spelling,
+        )
+
+        del type_name  # display spelling is not authority
+        authenticated = authenticated_python_type_spelling(
+            type_term, owner="SymbolicValue.python_isinstance", site=site
+        )
         term = self.term
         if type(term) is _Ctor and term.name in ground_type_names:
-            matches = ground_type_names[term.name] == type_name
+            matches = ground_type_names[term.name] == authenticated
             return Complete(
                 TrueBoolLiteralSugar(site=site)
                 if matches
                 else FalseBoolLiteralSugar(site=site)
             )
-        return super().python_isinstance(type_name, type_term, site)
+        return super().python_isinstance(authenticated, type_term, site)
 
     def test_python_type(self, value, site):
         """Dispatch a vendor type test from an existing ``python:type`` term.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/term_value.py
@@ -43,7 +43,10 @@ class TermValue(FloorValue):
         return super().equals(other, site)
 
     def python_isinstance(self, type_name: str, type_term, site):
-        del type_term
+        del type_name  # display spelling is not authority
+        from sugar_lift_py_tests.floor.python_type_coordinate import (
+            authenticated_python_type_spelling,
+        )
         from sugar_lift_py_tests.outcome import Complete
         from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
             FalseBoolLiteralSugar,
@@ -52,8 +55,11 @@ class TermValue(FloorValue):
             TrueBoolLiteralSugar,
         )
 
-        matches = (type(self.value) is int and type_name == "int") or (
-            type(self.value) is float and type_name == "float"
+        authenticated = authenticated_python_type_spelling(
+            type_term, owner="TermValue.python_isinstance", site=site
+        )
+        matches = (type(self.value) is int and authenticated == "int") or (
+            type(self.value) is float and authenticated == "float"
         )
         return Complete(
             TrueBoolLiteralSugar(site=site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -59,7 +59,14 @@ class TupleValue(FloorValue):
         )
 
     def python_isinstance(self, type_name: str, type_term, site):
-        """A constructed tuple is exactly an instance of ``tuple`` / ``object``."""
+        """A constructed tuple is exactly an instance of ``tuple`` / ``object``.
+
+        Dispatch reads the authenticated ``type_term`` coordinate. Display
+        ``type_name`` is never authority.
+        """
+        from sugar_lift_py_tests.floor.python_type_coordinate import (
+            authenticated_python_type_spelling,
+        )
         from sugar_lift_py_tests.outcome import Complete
         from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
             FalseBoolLiteralSugar,
@@ -68,9 +75,13 @@ class TupleValue(FloorValue):
             TrueBoolLiteralSugar,
         )
 
-        if type_name in {"tuple", "object"}:
+        del type_name
+        authenticated = authenticated_python_type_spelling(
+            type_term, owner="TupleValue.python_isinstance", site=site
+        )
+        if authenticated in {"tuple", "object"}:
             return Complete(TrueBoolLiteralSugar(site=site))
-        if type_name in {
+        if authenticated in {
             "list",
             "dict",
             "set",
@@ -84,7 +95,7 @@ class TupleValue(FloorValue):
             "NoneType",
         }:
             return Complete(FalseBoolLiteralSugar(site=site))
-        return super().python_isinstance(type_name, type_term, site)
+        return super().python_isinstance(authenticated, type_term, site)
 
     def is_identical(self, other, site):
         from sugar_lift_py_tests.floor.none_value import NoneValue

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
@@ -342,8 +342,9 @@ class _Visitor(ast.NodeVisitor):
             return True
 
         # type_name in {…} / type_name in SOME_FROZENSET — builtin shadowing lie.
-        if any(isinstance(op, (ast.In, ast.NotIn)) for op in node.ops):
-            if isinstance(node.left, ast.Name) and node.left.id == "type_name":
+        # type_name == "str" (and friends) — same sin as == rather than `in`.
+        if isinstance(node.left, ast.Name) and node.left.id == "type_name":
+            if any(isinstance(op, (ast.In, ast.NotIn, ast.Eq, ast.NotEq)) for op in node.ops):
                 return True
 
         attr_names = {

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
@@ -165,6 +165,16 @@ def test_instrument_fixed_cluster_five_production_sites_are_zero() -> None:
         "sugar_lift_py_tests/import_binding.py",
         "sugar_lift_py_tests/floor/class_value.py",
         "sugar_lift_py_tests/floor/call_site_value.py",
+        # residual after cluster-5: floor isinstance + effect_router
+        "sugar_lift_py_tests/floor/tuple_value.py",
+        "sugar_lift_py_tests/floor/string_value.py",
+        "sugar_lift_py_tests/floor/bytes_value.py",
+        "sugar_lift_py_tests/floor/complex_value.py",
+        "sugar_lift_py_tests/floor/ellipsis_value.py",
+        "sugar_lift_py_tests/floor/term_value.py",
+        "sugar_lift_py_tests/floor/symbolic_value.py",
+        "sugar_lift_py_tests/floor/python_type_coordinate.py",
+        "sugar_lift_py_tests/effect_router.py",
     }
     hits = [
         row
@@ -174,6 +184,45 @@ def test_instrument_fixed_cluster_five_production_sites_are_zero() -> None:
     assert hits == [], "cluster-5 production sites still gate on spelling:\n" + "\n".join(
         f"{row.path}:{row.line}: {row.observed}" for row in hits
     )
+
+
+def test_instrument_sees_type_name_eq_string_spelling_gate(tmp_path: Path) -> None:
+    """Residual shape after cluster-5: ``type_name == "str"`` must be red."""
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "string_value.py",
+        "def python_isinstance(type_name, type_term):\n"
+        "    return type_name == 'str'\n",
+    )
+    report = collect_builtin_closed_operation_report(tmp_path)
+    gates = [row for row in report.offenders if row.axis == "name_or_vendor_gates"]
+    assert gates, "type_name == 'str' must register as name_or_vendor_gates"
+    assert any("type_name" in row.observed for row in gates)
+
+
+def test_instrument_sees_effect_router_name_equality_spelling_gate(tmp_path: Path) -> None:
+    """Planted ``observed[1] == matcher.name`` style name equality is a gate."""
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "effect_router.py",
+        "def _matching_effect(entries, matcher):\n"
+        "    for entry in entries:\n"
+        "        name = entry.effect.exception_name\n"
+        "        if name == matcher.name:\n"
+        "            return entry\n"
+        "    return None\n",
+    )
+    report = collect_builtin_closed_operation_report(tmp_path)
+    gates = [row for row in report.offenders if row.axis == "name_or_vendor_gates"]
+    assert gates, "exception_name / matcher.name equality must be a name_or_vendor_gate"
 
 
 def test_instrument_lying_twin_name_suppress_shell_is_red(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Residual after sin-cluster-5 / coordinate suppress: **display spelling still decided type and effect identity** outside the fixed ClassValue / ExitSuppression paths.

### Live set drained (not only TupleValue + effect_router)

| Site | Old second mechanism | Replacement |
| --- | --- | --- |
| `TupleValue.python_isinstance` | `type_name in {"tuple",…}` | `authenticated_python_type_spelling(type_term)` |
| `StringValue` / `BytesValue` / `ComplexValue` / `EllipsisValue` | `type_name == "…"` | same door |
| `TermValue` | `type_name == "int"/"float"` | same door |
| `SymbolicValue` | `ground_type_names[ctor] == type_name` | compare to authenticated spelling from `type_term` |
| `ClassValue` | inline coordinate parse | shared door (behavior preserved) |
| `effect_router._matching_effect` | `observed[1] == matcher.name` (exception_name / category_name) | raise: `exception_type_coordinate` vs builtin identity; warning: `category_identity` vs builtin identity; missing → `SugarNotWritten` |

### Shell deleted

- All floor `type_name ==` / `type_name in` isinstance gates above
- Effect-router kind+**name-string** match

### R / Epsilon R

| Axis | Predicted Epsilon R |
| --- | --- |
| `R_name_or_vendor_gates` on floor isinstance + effect_router match | production sites above → **0** (AST instrument on those paths: 0 hits) |

### Floors preserved

- Missing / wrong-shape `type_term` **throws** (not soft False)
- Missing raise/warning coordinate **throws** (not soft miss)
- No tests xfailed; no local/bx measurement this shot (mr_orange owns consolidated remeasure)

### Enforcement ladder

1. **Type?** No — open `str` type_name parameter remains on the API surface.
2. **One door?** Yes — `floor/python_type_coordinate.authenticated_python_type_spelling`.
3. **Panic/throw?** Yes — `SugarNotWritten` when coordinate unreachable.
4. **Instrument** expanded: `type_name == "str"` shape; production zero targets list residual sites. **Lying twins** added (planted type_name eq + name-equality router).

### Not this PR (separate classes)

Instrument still reports `field.name == name` / `binding.name == name` (lexical/attr lookup) and `raise_value` fabrication denylist checks — **not** type-identity spelling gates. Do not “fix” those by deleting name lookup.

## Validation

Structural only (no pytest / no bx — fleet remeasure owner):

- AST instrument: **0** `name_or_vendor_gates` on the listed production paths after the fix
- Planted `type_name == "str"` still detected

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dispatch `isinstance` and effect routing on type coordinates instead of name spelling
> - Replaces string-spelling comparisons (`type_name == 'str'`, etc.) with authenticated coordinate lookups in all `python_isinstance` methods across floor value types (`BytesValue`, `ClassValue`, `ComplexValue`, `EllipsisValue`, `StringValue`, `SymbolicValue`, `TermValue`, `TupleValue`).
> - Introduces [`authenticated_python_type_spelling`](https://github.com/TSavo/sugar/pull/6971/files#diff-18e36ae12ab3651a2c29c6f434362fe8cc4f1e566021c7e28dfbe7c87ab5c227) to validate and extract the spelling from an authenticated `python:type("…")` coordinate term.
> - Updates [`effect_router`](https://github.com/TSavo/sugar/pull/6971/files#diff-4cf76c9fa93d9f06a5ca7d708a3f6f034186b90e4d615a242ff211d0af3652a0) to match `raise` and `warning` effects by `exception_type_coordinate` / `category_identity` rather than name string.
> - Extends the [`builtin_closed_operation_instrument`](https://github.com/TSavo/sugar/pull/6971/files#diff-422b632b0136f3afa27d19e62f1748a574fbbc5726090092d5833c55292d76b0) to detect `type_name ==`/`!=` comparisons as spelling gates.
> - Risk: code paths that previously matched by display name now raise `SugarNotWritten` when the type term is missing, malformed, or not an authenticated coordinate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12fd755.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->