### PR TITLE
Fix SyntaxError and stale auditor references blocking collection on main

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -1357,7 +1357,6 @@ def authenticated_module_exports(
         # every showcase that walks call-contract exports.
         module_is_package=path.name == "__init__.py",
         module_identities={},
-        module_is_package=path.name == "__init__.py",
     )
     rows: list[dict[str, Any]] = []
     for local, reaching in sorted(final_state.items()):

--- a/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
@@ -155,8 +155,8 @@ def test_law_of_one_auditor_cannot_see_render_edge_fabrication() -> None:
     is the signal the stronger substrate arrived and this note can retire.
     There is no hard-coded R=1; the probe is the absence of those markers.
     """
-    auditor = Path(__file__).resolve().parents[4] / "tests" / "law_of_one_auditor.py"
-    evidence = Path(__file__).resolve().parents[4] / "tests" / "law_of_one_evidence.py"
+    auditor = Path(__file__).resolve().parents[4] / "tests" / "sourcefile_construction_door_auditor.py"
+    evidence = Path(__file__).resolve().parents[4] / "tests" / "sourcefile_construction_door_evidence.py"
     assert auditor.is_file(), auditor
     assert evidence.is_file(), evidence
 


### PR DESCRIPTION
First honest remote measurement (mr_orange, battleaxe, tip `42fede699`): `sugar-lift-py-tests` EXIT=2, ~3864 collected, **1128 failed / 2722 passed**, 10 errors. That run surfaced both defects here.

**1. `import_binding.py:1360` — hard SyntaxError.** `module_is_package=` was passed **twice** to `_final_module_state` ("keyword argument repeated"). It blocked collection of every `import_*` module and poisoned unrelated failures, so the 1128 is inflated.

> **The instrument that missed it:** `ast.parse()` *accepts* duplicate keyword arguments — the check is at COMPILE, not parse. Verifying this file with `ast.parse` returns a false green. Use `compile()`/`compileall`. A syntax defect reached main because the cheap check was the wrong instrument — the same false-green class this campaign exists to delete.

**2. `test_render_edge_exceptional_exit_citation.py`** still pointed at `tests/law_of_one_auditor.py` / `law_of_one_evidence.py`, renamed by #6962 to `sourcefile_construction_door_{auditor,evidence}.py`. It asserted `.is_file()` on paths that no longer exist — so a blindness pin meant to fail loudly when the auditor gains a render-edge axis was failing for bookkeeping instead. Repointed; assertions unchanged.

**R axis:** R_collection_errors. **Epsilon R:** unblocks `import_*` collection and the door probe; expect the failure count to fall substantially.
**Shell deleted:** none — both are defects from today's landings, not instruments retiring.
**Floors:** no test deleted, no assertion weakened, no detector softened.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate keyword argument and stale file references blocking test collection
> - Removes a duplicate `module_is_package` kwarg in `authenticated_module_exports` within [import_binding.py](https://github.com/TSavo/sugar/pull/6974/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) that caused a `TypeError` at runtime.
> - Updates auditor and evidence file paths in [test_render_edge_exceptional_exit_citation.py](https://github.com/TSavo/sugar/pull/6974/files#diff-324143e47e1bade3e4b7da5171f26526e0749c13e45bd8127d2c22b67eb456e4) to reference `sourcefile_construction_door_auditor.py` and `sourcefile_construction_door_evidence.py` instead of the removed `law_of_one_*` files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7374c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module export handling by removing an obsolete package-state parameter.
  * Updated exceptional-exit citation checks to use the current source evidence locations.

* **Tests**
  * Refined validation coverage for renamed source evidence, helping maintain reliable diagnostic and citation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->