### PR TITLE
Enroll the heavy-measurement roll call in CI; stop asking gh run list

### DIFF
--- a/.github/workflows/heavy-measurement-attendance.yml
+++ b/.github/workflows/heavy-measurement-attendance.yml
@@ -1,0 +1,108 @@
+name: Heavy measurement attendance (roll call)
+
+# THE DEFECT THIS FIXES
+#
+# tools/heavy_measurement_attendance.py existed, was correct, and was invoked
+# by NOTHING. Its own docstring names the failure it was written to catch:
+#
+#     absent artifact == "no failures reported" == looks like a clean floor
+#     R is not 0, R is UNMEASURED
+#
+# On 2026-08-01 that is exactly what happened. An empty commit was pushed to
+# main to take one clean measurement of the merged tree. Six workflows ran;
+# three went green and three went red, and NOT ONE of them measured the corpus:
+# the sole-construction floors refused under the lease (auth failure, then a
+# zero-claim refusal), the package suite hit an unevictable root-owned shelf
+# cell and emitted no suite-report.json, and the three greens are
+# DISCRIMINATION workflows that prove an instrument can tell a planted offender
+# from a clean one -- they say nothing about pandas. The roll call would have
+# reported R_attendance and named every silent class. It was never called.
+#
+# An instrument nobody runs is not an instrument. Enrollment is existence.
+#
+# WHY workflow_run AND NOT A STEP INSIDE ci.yml
+#
+# The roll call is a question about a COMMIT, not about a run: which enrolled
+# heavy classes spoke about this tip? It can only be answered after the heavy
+# classes settle, so a step inside ci.yml would race them and report a false
+# absence. Triggering on workflow_run completion recomputes the roll call each
+# time a heavy class finishes; the reading converges as they land. A class that
+# never runs never flips to present, so its silence stays loud forever rather
+# than being papered over by a single early reading.
+
+on:
+  workflow_run:
+    workflows:
+      - "Python package suite (authoritative)"
+      - "Python sole-construction floors (R>0 red)"
+      - "NumPy Wall Ratchet"
+      - "Pandas Wall Ratchet"
+      - "Restored Suite Scoreboard"
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit SHA to hold the roll call for"
+        required: true
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  roll-call:
+    name: roll call (R_attendance = 0)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve the commit under roll call
+        id: subject
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          sha="${{ github.event.inputs.commit || github.event.workflow_run.head_sha }}"
+          [ -n "$sha" ] || { echo "no commit to hold a roll call for"; exit 1; }
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "roll call subject: $sha"
+
+      - name: Collect lease receipts for the commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ steps.subject.outputs.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p receipts
+          # Every run for this SHA, from the API. NOT `gh run list` -- that
+          # under-reports: on 2026-08-01 it returned 6 non-completed runs where
+          # the API returned 234, and a bankruptcy sweep was declared complete
+          # on the strength of it.
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&per_page=100" \
+            --paginate --jq '.workflow_runs[]?|.id' > run-ids.txt || true
+          echo "runs for this commit: $(wc -l < run-ids.txt)"
+          while read -r id; do
+            [ -z "$id" ] && continue
+            gh run download "$id" --dir "receipts/$id" 2>/dev/null || true
+          done < run-ids.txt
+          echo "receipt files found: $(find receipts -name '*.json' | wc -l)"
+
+      - name: Roll call
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ steps.subject.outputs.sha }}
+        run: |
+          set -euo pipefail
+          python3 tools/heavy_measurement_attendance.py \
+            --commit "$SHA" \
+            --receipts-dir receipts \
+            --repo "${GITHUB_REPOSITORY}" \
+            | tee attendance.md \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: heavy-measurement-attendance-${{ steps.subject.outputs.sha }}
+          path: attendance.md
+          if-no-files-found: warn

--- a/tools/heavy_measurement_attendance.py
+++ b/tools/heavy_measurement_attendance.py
@@ -76,21 +76,45 @@ def receipts_attendance(receipts_dir):
 
 
 def workflow_runs(commit, repo=None):
-    """Fall back to the run list. `cancelled` here is the eviction signature."""
-    argv = ["gh", "run", "list", "--commit", commit, "--limit", "100",
-            "--json", "name,status,conclusion,databaseId,workflowName"]
-    if repo:
-        argv += ["--repo", repo]
+    """Fall back to the run list. `cancelled` here is the eviction signature.
+
+    THE API, NOT ``gh run list``. On 2026-08-01 ``gh run list --limit 200``
+    reported 6 non-completed runs for this repository while the REST API
+    reported 234 (182 queued + 52 in progress). A CI bankruptcy was declared
+    complete on the strength of that 6, the 228 real runs kept every one of
+    the 25 available runners busy, and the measurement everybody was waiting
+    on never got a slot.
+
+    Under-reporting is the worst possible failure for a ROLL CALL. A missing
+    run reads as "no run at all for this commit", which is indistinguishable
+    from an evicted one -- the precise confusion this module exists to end.
+    So the fallback asks the paginated API and treats an unavailable API as
+    unknown (``None``), never as absence.
+    """
+    slug = repo or "${GITHUB_REPOSITORY}"
+    argv = ["gh", "api", f"repos/{slug}/actions/runs?head_sha={commit}&per_page=100",
+            "--paginate", "--jq",
+            ".workflow_runs[]?|{name,status,conclusion,databaseId:.id,workflowName:.name}"]
     try:
         completed = subprocess.run(argv, capture_output=True, text=True, check=True)
     except (OSError, subprocess.CalledProcessError) as exc:
-        print(f"heavy-measurement-attendance: `gh run list` unavailable: {exc}",
+        print(f"heavy-measurement-attendance: GitHub API unavailable: {exc}",
               file=sys.stderr)
         return None
-    try:
-        return json.loads(completed.stdout)
-    except ValueError:
-        return None
+    runs = []
+    for line in completed.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            runs.append(json.loads(line))
+        except ValueError:
+            # A page we cannot parse is unknown testimony, not absence.
+            print("heavy-measurement-attendance: unparseable run row; "
+                  "treating the run list as unavailable rather than empty",
+                  file=sys.stderr)
+            return None
+    return runs
 
 
 def main(argv=None):


### PR DESCRIPTION
`tools/heavy_measurement_attendance.py` was correct and had **no caller** — no workflow, only its own tests and a doc. Its docstring names the failure it exists to catch, verbatim:

> absent artifact == "no failures reported" == looks like a clean floor. **R is not 0, R is UNMEASURED**

Today that happened. An empty commit fired one clean build against the fully merged tree after a CI bankruptcy. Six workflows ran — three green, three red — and **not one measured the corpus**: the floors refused under the lease, the package suite hit an unevictable root-owned shelf cell and emitted no `suite-report.json`, and the three greens are *discrimination* workflows that prove an instrument can spot a planted offender, not that pandas is clean.

Run against that tip, the roll call says:

```
python-package-suite             NO  completed/failure (#30718401007) — no lease receipt
python-sole-construction-floors  NO  completed/failure (#30718401030) — no lease receipt
numpy-wall / pandas-wall / restored-suite-scoreboard   NO  no run at all
R_attendance = 5
```

**Zero of five heavy classes spoke.** An instrument nobody runs is not an instrument.

**Why `workflow_run`, not a step in ci.yml.** The roll call asks about a *commit*, not a run, and can only be answered once the heavy classes settle — a step in `ci.yml` would race them and report false absence. On `workflow_run` completion it recomputes as each lands, so the reading converges; a class that never runs never flips to present, so its silence stays loud.

**The fallback asked a liar.** It fell back to `gh run list`, which today reported **6** non-completed runs where the API reported **234**. A bankruptcy was declared complete on that 6; the 228 real runs held all 25 runners and starved the measurement everyone was waiting on. For a roll call, under-reporting is fatal — a missing run reads as "no run at all", indistinguishable from an evicted one. Now it asks the paginated API, and an unavailable API returns *unknown*, never absence.

**R axis:** R_unenrolled_instruments 1→0. **Shell deleted:** none — this enrolls an existing instrument; it retires when a type makes an unmeasured axis unrepresentable.
**Floors:** nothing deleted, weakened, or softened.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enroll heavy-measurement roll call in CI and replace `gh run list` with REST API
> - Adds [heavy-measurement-attendance.yml](.github/workflows/heavy-measurement-attendance.yml), a new workflow that triggers on completion of five named workflows (or manually via `workflow_dispatch`) to compute and publish a heavy-measurement attendance report for a given commit.
> - The workflow collects all runs for the subject commit via `gh api .../actions/runs?head_sha=...&per_page=100 --paginate`, downloads their artifacts, runs `tools/heavy_measurement_attendance.py`, and uploads `attendance.md` as a build artifact and step summary.
> - In [`tools/heavy_measurement_attendance.py`](https://github.com/TSavo/sugar/pull/6975/files#diff-488ea1f5082769971d9377e07807b0fef693e2d67727f202b2a8c34ba0963556), the `workflow_runs` function now uses the paginated REST API instead of `gh run list --commit`, parsing line-delimited JSON output; `databaseId` is sourced from `.id` and `workflowName` from `.name`.
> - Behavioral Change: if the API call fails or any line fails to parse, `workflow_runs` now returns `None` instead of an empty list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 485be1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->