### PR TITLE
Type the heavy roster by cadence; stop mixing owed silence with never-asked

### DIFF
--- a/.github/workflows/heavy-measurement-attendance.yml
+++ b/.github/workflows/heavy-measurement-attendance.yml
@@ -93,8 +93,13 @@ jobs:
           SHA: ${{ steps.subject.outputs.sha }}
         run: |
           set -euo pipefail
+          # PER-COMMIT cadence only. The nightly classes (walls, scoreboard)
+          # owe testimony about their last scheduled WINDOW, not about this
+          # tip, and mixing the two floors R_attendance at 3 forever for a
+          # reason that is not a defect. The two axes are never summed.
           python3 tools/heavy_measurement_attendance.py \
             --commit "$SHA" \
+            --cadence per-commit \
             --receipts-dir receipts \
             --repo "${GITHUB_REPOSITORY}" \
             | tee attendance.md \

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -67,6 +67,18 @@ def _text(name):
     return (WORKFLOWS / name).read_text()
 
 
+def _attendance_module():
+    """Load the roll call as a module so its roster and cadence are checkable."""
+    from importlib import util
+
+    spec = util.spec_from_file_location(
+        "heavy_measurement_attendance", ROOT / "tools" / "heavy_measurement_attendance.py"
+    )
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 @pytest.mark.parametrize("workflow", sorted(HEAVY_WORKFLOWS))
 def test_heavy_workflows_declare_no_concurrency_group(workflow):
     """No group means no pending slot means nothing to evict."""
@@ -180,3 +192,55 @@ def test_orchestrator_still_runs_the_corpus_floors():
         "construction_side_door_law.py",
     ):
         assert script in floors, f"the leased floor set must invoke {script}"
+
+
+def test_roster_cadence_matches_each_workflow_trigger():
+    """A class typed PER_COMMIT must actually run on every commit.
+
+    THE DEFECT THIS FIXES. The roll call was enrolled with one untyped roster
+    and asked every class the same question: did you speak about this tip?
+    Three of the five are `workflow_dispatch` + cron only, so they can never
+    answer it -- R_attendance floored at 3 on every commit, forever, for a
+    reason that is not a defect. A permanently red instrument is tuned out,
+    and a tuned-out instrument is decorative.
+
+    The cadence is now declared in HEAVY_CADENCE, and a declaration nobody
+    checks is a comment. This is the check: PER_COMMIT requires
+    `push: branches: [main]`, NIGHTLY_WINDOW requires a `schedule:`. Retyping a
+    class without changing its triggers -- or adding a trigger without
+    retyping -- fails here, at check time, instead of silently producing a
+    number that mixes "owed and silent" with "never asked".
+    """
+    module = _attendance_module()
+    for workflow, lease_class in HEAVY_WORKFLOWS.items():
+        text = _text(workflow)
+        on_block = re.split(r"^[a-zA-Z]", text.split("on:", 1)[1], maxsplit=1)[0]
+        cadence = module.HEAVY_CADENCE[lease_class]
+        if cadence == module.PER_COMMIT:
+            assert "push:" in on_block and "main" in on_block, (
+                f"{lease_class} is typed PER_COMMIT but {workflow} has no "
+                f"push:[main] trigger, so it can never testify about a commit; "
+                f"either give it the trigger or retype it NIGHTLY_WINDOW"
+            )
+        else:
+            assert "schedule:" in on_block, (
+                f"{lease_class} is typed NIGHTLY_WINDOW but {workflow} has no "
+                f"schedule: trigger, so it owes a window it will never be asked "
+                f"about; either give it a schedule or retype it PER_COMMIT"
+            )
+
+
+def test_the_two_cadences_are_never_summed():
+    """R_attendance_commit and R_attendance_nightly are different obligations.
+
+    A single number mixing "did not speak when it owed us" with "was never
+    asked" is not a measurement. The roll call must emit one axis per cadence
+    and must never expose a combined total.
+    """
+    module = _attendance_module()
+    source = Path(module.__file__).read_text()
+    assert "R_attendance_commit" in source and "R_attendance_nightly" in source
+    assert "len(HEAVY_ROSTER)" not in source, (
+        "the minority must be computed over the OWED classes for the cadence "
+        "being asked, never over the whole roster"
+    )

--- a/tools/heavy_measurement_attendance.py
+++ b/tools/heavy_measurement_attendance.py
@@ -47,6 +47,23 @@ from pathlib import Path
 # Adding a heavy workflow without adding it here is how an instrument goes
 # quiet unnoticed, so tests/test_heavy_measurement_concurrency_topology.py
 # checks this roster against the workflows themselves.
+# A roster entry carries its CADENCE, because two different obligations were
+# being asked one question. A PER_COMMIT class owes testimony about THIS TIP.
+# A NIGHTLY class owes testimony about the most recent scheduled WINDOW and is
+# not asked about any particular commit at all.
+#
+# Conflating them made the roll call permanently red for a non-defect: three of
+# the five classes are cron/dispatch-only, so a per-commit R_attendance floored
+# at 3 forever. A permanently red instrument is tuned out, and a tuned-out
+# instrument is decorative -- the death this module exists to prevent.
+#
+# So the minority is computed ONLY over the classes OWED for the question being
+# asked, and the two cadences are NEVER SUMMED. A single number mixing "did not
+# speak when it owed us" with "was never asked" is not a measurement, it is a
+# mood.
+PER_COMMIT = "per-commit"
+NIGHTLY_WINDOW = "nightly-window"
+
 HEAVY_ROSTER = {
     "python-package-suite": "Python package suite (authoritative)",
     "python-sole-construction-floors": "Python sole-construction floors (R>0 red)",
@@ -54,6 +71,23 @@ HEAVY_ROSTER = {
     "pandas-wall": "Pandas Wall Ratchet",
     "restored-suite-scoreboard": "Restored Suite Scoreboard",
 }
+
+# Cadence per class. Verified against each workflow's own triggers by
+# tests/test_heavy_measurement_concurrency_topology.py: a class typed
+# PER_COMMIT whose workflow has no `push: branches: [main]` is a contradiction
+# the roll call cannot detect at runtime, so the test makes it uncompilable.
+HEAVY_CADENCE = {
+    "python-package-suite": PER_COMMIT,
+    "python-sole-construction-floors": PER_COMMIT,
+    "numpy-wall": NIGHTLY_WINDOW,
+    "pandas-wall": NIGHTLY_WINDOW,
+    "restored-suite-scoreboard": NIGHTLY_WINDOW,
+}
+
+
+def owed(cadence):
+    """The classes that owe testimony for the question being asked."""
+    return [c for c in HEAVY_ROSTER if HEAVY_CADENCE[c] == cadence]
 
 
 def receipts_attendance(receipts_dir):
@@ -125,6 +159,12 @@ def main(argv=None):
     parser.add_argument("--repo", default=None)
     parser.add_argument("--advisory", action="store_true",
                         help="report the minority without failing (nightly telemetry mode)")
+    parser.add_argument("--cadence", choices=(PER_COMMIT, NIGHTLY_WINDOW),
+                        default=PER_COMMIT,
+                        help="which obligation the roll call is about. Per-commit "
+                             "classes owe testimony about this tip; nightly classes "
+                             "owe testimony about their last scheduled window. The "
+                             "two are never summed.")
     args = parser.parse_args(argv)
 
     attended, testimony = ({}, [])
@@ -142,13 +182,14 @@ def main(argv=None):
                         f"{run.get('status')}/{run.get('conclusion')} (#{run.get('databaseId')})"
                     )
 
-    minority = [c for c in HEAVY_ROSTER if c not in attended]
+    obliged = owed(args.cadence)
+    minority = [c for c in obliged if c not in attended]
 
-    print(f"### heavy-measurement attendance for `{args.commit}`")
+    print(f"### heavy-measurement attendance ({args.cadence}) for `{args.commit}`")
     print()
     print("| heavy class | spoke | testimony |")
     print("| --- | --- | --- |")
-    for lease_class in HEAVY_ROSTER:
+    for lease_class in obliged:
         if lease_class in attended:
             detail = f"receipt `{attended[lease_class]}`, lease acquired"
             spoke = "yes"
@@ -171,7 +212,13 @@ def main(argv=None):
                   f"That is honest silence, and it is still silence.")
 
     print()
-    print(f"**R_attendance = {len(minority)}**")
+    axis = "R_attendance_commit" if args.cadence == PER_COMMIT else "R_attendance_nightly"
+    print(f"**{axis} = {len(minority)}**")
+    not_asked = [c for c in HEAVY_ROSTER if c not in obliged]
+    if not_asked:
+        print()
+        print("Not asked at this cadence (a different obligation, NOT counted here): "
+              + ", ".join(f"`{c}`" for c in not_asked))
     if minority:
         print()
         print("These instruments did not report. Their silence is NOT a clean floor —")


### PR DESCRIPTION
**My defect, caught by advisor before it rotted.** #6975 enrolled the roll call with one untyped roster and asked every class the same question. Three of five (`numpy-wall`, `pandas-wall`, `restored-suite-scoreboard`) are cron/dispatch-only and can never answer it — so `R_attendance` floored at **3 on every commit, forever**, for a reason that is not a defect. A permanently red instrument is tuned out, and a tuned-out instrument is decorative: I'd enrolled a detector that would have been ignored within a week.

**The shape.** A PER_COMMIT class owes testimony about *this tip*. A NIGHTLY_WINDOW class owes testimony about its *last scheduled window*. The minority is computed only over classes **owed** for the question asked, and **the two cadences are never summed** — a number mixing "did not speak when it owed us" with "was never asked" is not a measurement, it is a mood. Rejected: moving everything to `push:[main]`, which re-saturates the runners we just spent a day unclogging.

At main tip:
```
R_attendance_commit  = 2   package-suite, sole-construction-floors: completed/failure, no lease receipt
R_attendance_nightly = 3   walls, scoreboard: no run in window
```
Each names the classes *not asked* at that cadence, so neither can be mistaken for the other.

**The declaration is checked**, because a declaration nobody checks is a comment. The topology test now verifies `HEAVY_CADENCE` against each workflow's real triggers: PER_COMMIT requires `push:[main]`, NIGHTLY_WINDOW requires `schedule:`. Verified with a lying twin — planting `numpy-wall` as PER_COMMIT is caught. A second tooth pins that the cadences stay unsummed.

**Shell deleted:** none — repairs #6975. **Floors:** nothing deleted or weakened.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope heavy roster attendance by cadence to separate per-commit from nightly metrics
> - Adds `PER_COMMIT` and `NIGHTLY_WINDOW` constants and a `HEAVY_CADENCE` mapping in [`heavy_measurement_attendance.py`](https://github.com/TSavo/sugar/pull/6976/files#diff-488ea1f5082769971d9377e07807b0fef693e2d67727f202b2a8c34ba0963556) to declare each roster class's cadence.
> - Adds an `owed(cadence)` helper and extends the CLI with `--cadence` (default: `per-commit`), scoping attendance checks and the output metric (`R_attendance_commit` or `R_attendance_nightly`) to only the classes obliged at the selected cadence.
> - Updates the [`heavy-measurement-attendance` workflow](https://github.com/TSavo/sugar/pull/6976/files#diff-e038313cc9be78cc03fb254cab8aa7e5cbb1e338f5bc9ce90795d14f0291285f) to pass `--cadence per-commit` explicitly.
> - Adds tests asserting that each workflow's triggers match its roster cadence type, and that per-commit and nightly attendance are never summed into a single metric.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 381f6b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->