### PR TITLE
Repo root by resolve door: stop parents[N] layout arithmetic

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
@@ -14,6 +14,11 @@ from types import ModuleType
 from typing import Iterable, Sequence
 
 from sugar_lift_py_tests.demand_table_identity import corpus_manifest_cid
+from sugar_lift_py_tests.repo_root import (
+    RepoRootUnresolved,
+    resolve_repo_root,
+    sugar_lift_py_tests_package_root,
+)
 
 
 class ExecutionEnvironmentMismatch(RuntimeError):
@@ -55,10 +60,12 @@ def interpreter_identity() -> InterpreterIdentity:
 
 def declared_interpreter_runtime() -> str:
     """Read the one managed Python authority from the build manifest."""
-    repo_root = Path(__file__).resolve().parents[5]
-    manifest = tomllib.loads(
-        (repo_root / "sugar-build.toml").read_text(encoding="utf-8")
-    )
+    try:
+        repo_root = resolve_repo_root()
+    except RepoRootUnresolved as error:
+        raise ExecutionEnvironmentMismatch(str(error)) from error
+    manifest_path = repo_root / "sugar-build.toml"
+    manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
     version = str(manifest["tools"]["python"])
     return f"cpython-{version}"
 
@@ -204,10 +211,14 @@ def authenticate_environment() -> (
     tuple[ImportIdentity, ImportIdentity, ImportIdentity, str]
 ):
     authenticate_interpreter_runtime(interpreter_identity())
-    package_root = Path(__file__).resolve().parents[2]
-    repo_root = Path(__file__).resolve().parents[5]
+    try:
+        repo_root = resolve_repo_root()
+        package_root = sugar_lift_py_tests_package_root(repo_root)
+    except RepoRootUnresolved as error:
+        raise ExecutionEnvironmentMismatch(str(error)) from error
     activate_checkout_import_roots(repo_root, sys.path)
     pins, expected_cid = _declared_corpus(package_root)
+
     purelib = Path(sysconfig.get_paths()["purelib"])
 
     pandas = import_module("pandas")
@@ -254,7 +265,11 @@ def authenticated_pandas_corpus() -> AuthenticatedPandasCorpus:
     from sugar_source_tree.tree import SourceTree
 
     root = pandas_identity.loaded_from.parent
-    _, expected_cid = _declared_corpus(Path(__file__).resolve().parents[2])
+    try:
+        package_root = sugar_lift_py_tests_package_root()
+    except RepoRootUnresolved as error:
+        raise ExecutionEnvironmentMismatch(str(error)) from error
+    _, expected_cid = _declared_corpus(package_root)
     observed_cid, file_count = authenticate_corpus_manifest(
         root, SourceTree(root).paths(), expected_cid
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/repo_root.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/repo_root.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""ONE door: resolve the Sugar monorepo root by asking, never by counting.
+
+``Path(__file__).resolve().parents[N]`` encodes "the root is exactly N levels
+up" as a magic integer. When the package is installed into a venv's
+site-packages that integer is simply wrong — and it does not crash at the
+count; it resolves to a REAL BUT WRONG path (e.g. the python-test-environment
+temp dir). Authentication then FileNotFoundError-s far away wearing the
+costume of a corpus failure.
+
+The missing object is a root that cannot be constructed by layout arithmetic.
+This door RESOLVES by:
+
+1. explicit environment binding (``SUGAR_REPO_ROOT``, then ``GITHUB_WORKSPACE``
+   if it actually contains the marker);
+2. walking up from a known anchor (default: process cwd) until the marker file
+   ``sugar-build.toml`` is found.
+
+It REFUSES LOUDLY, naming the marker and every place it looked, when the root
+cannot be found. Never a silent fallback to a plausible directory.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Mapping, Sequence
+
+MARKER = "sugar-build.toml"
+# Explicit seats first. GITHUB_WORKSPACE is the CI checkout; SUGAR_REPO_ROOT is
+# the general override for non-checkout layouts (site-packages installs).
+_ENV_KEYS: tuple[str, ...] = ("SUGAR_REPO_ROOT", "GITHUB_WORKSPACE")
+
+
+class RepoRootUnresolved(RuntimeError):
+    """The monorepo root could not be resolved; the marker was never found."""
+
+
+def _has_marker(directory: Path) -> bool:
+    return (directory / MARKER).is_file()
+
+
+def _env_candidate(env: Mapping[str, str], key: str) -> Path | None:
+    raw = env.get(key)
+    if raw is None or not str(raw).strip():
+        return None
+    return Path(str(raw)).expanduser().resolve()
+
+
+def resolve_repo_root(
+    *,
+    start: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    extra_starts: Sequence[Path] = (),
+) -> Path:
+    """Resolve the Sugar monorepo root, or refuse naming what was searched.
+
+    Parameters
+    ----------
+    start:
+        First walk anchor. Defaults to the process current working directory.
+    env:
+        Environment map. Defaults to ``os.environ``.
+    extra_starts:
+        Additional walk anchors (e.g. a known file path's parents) tried after
+        ``start``. Each is walked upward independently; none is used as a
+        counted index into a fixed layout.
+    """
+    source = os.environ if env is None else env
+    searched: list[str] = []
+
+    for key in _ENV_KEYS:
+        candidate = _env_candidate(source, key)
+        if candidate is None:
+            searched.append(f"env:{key}=<unset>")
+            continue
+        searched.append(f"env:{key}={candidate}")
+        if candidate.is_dir() and _has_marker(candidate):
+            return candidate
+
+    anchors: list[Path] = []
+    primary = Path.cwd().resolve() if start is None else Path(start).resolve()
+    anchors.append(primary)
+    for extra in extra_starts:
+        resolved = Path(extra).resolve()
+        if resolved not in anchors:
+            anchors.append(resolved)
+
+    for anchor in anchors:
+        current = anchor if anchor.is_dir() else anchor.parent
+        seen: set[Path] = set()
+        while current not in seen:
+            seen.add(current)
+            searched.append(f"walk:{current}")
+            if _has_marker(current):
+                return current
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+
+    raise RepoRootUnresolved(
+        "cannot resolve Sugar monorepo root: "
+        f"looked for {MARKER!r} via explicit env ({', '.join(_ENV_KEYS)}) "
+        f"and by walking up from anchors; searched: {searched}. "
+        f"Set SUGAR_REPO_ROOT to the checkout that contains {MARKER}, "
+        "or run with that checkout as the working directory."
+    )
+
+
+def sugar_lift_py_tests_package_root(repo_root: Path | None = None) -> Path:
+    """The checkout package root for sugar-lift-py-tests (owns pyproject.toml).
+
+    Never derived from site-packages layout. Always under the monorepo root.
+    """
+    root = repo_root if repo_root is not None else resolve_repo_root()
+    package = (root / "implementations" / "python" / "sugar-lift-py-tests").resolve()
+    if not (package / "pyproject.toml").is_file():
+        raise RepoRootUnresolved(
+            "cannot locate sugar-lift-py-tests package root: "
+            f"expected pyproject.toml at {package / 'pyproject.toml'} "
+            f"under resolved monorepo root {root}"
+        )
+    return package

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_provenance.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_provenance.py
@@ -18,16 +18,17 @@ def _git(root: Path, *args: str) -> str | None:
 
 
 def _monorepo_root() -> Path | None:
-    """Locate monorepo root from installed package paths (…/implementations/python/…)."""
-    import sugar_lift_py_tests
+    """Locate monorepo root via the one resolve door (sugar-build.toml).
 
-    here = Path(sugar_lift_py_tests.__file__).resolve()
-    for parent in here.parents:
-        if (parent / "tools" / "sugar_source_stamp.py").is_file() and (
-            parent / "implementations" / "rust" / "Cargo.toml"
-        ).is_file():
-            return parent
-    return None
+    Returns None when the door refuses — callers that need a soft miss keep
+    that shape. Prefer ``resolve_repo_root()`` when absence must be loud.
+    """
+    from sugar_lift_py_tests.repo_root import RepoRootUnresolved, resolve_repo_root
+
+    try:
+        return resolve_repo_root()
+    except RepoRootUnresolved:
+        return None
 
 
 def _content_identity(roots: list[Path]) -> str:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar_binary.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar_binary.py
@@ -6,9 +6,21 @@ import subprocess
 from pathlib import Path
 from typing import Mapping
 
-ROOT = Path(__file__).resolve().parents[5]
-SUGARBIN = ROOT / "bin" / "sugarbin"
-SUGARBIN_WINDOWS = ROOT / "bin" / "sugarbin.ps1"
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+
+def monorepo_root() -> Path:
+    """Monorepo root via the one resolve door — never parents[N]."""
+    return resolve_repo_root()
+
+
+def sugarbin_path() -> Path:
+    return monorepo_root() / "bin" / "sugarbin"
+
+
+def sugarbin_windows_path() -> Path:
+    return monorepo_root() / "bin" / "sugarbin.ps1"
+
 
 subprocess_run = subprocess.run
 
@@ -77,12 +89,12 @@ def resolve_sugar_binary(
             "powershell.exe",
             "-NoProfile",
             "-File",
-            str(SUGARBIN_WINDOWS),
+            str(sugarbin_windows_path()),
             "-Profile",
             profile,
         ]
     elif route == "windows-broker":
-        child_env["SUGAR_WINDOWS_SCRIPT"] = str(SUGARBIN)
+        child_env["SUGAR_WINDOWS_SCRIPT"] = str(sugarbin_path())
         command = [
             "bash.exe",
             "-lc",
@@ -93,12 +105,12 @@ def resolve_sugar_binary(
             profile,
         ]
     else:
-        command = [str(SUGARBIN), "--profile", profile]
+        command = [str(sugarbin_path()), "--profile", profile]
     timeout = resolve_timeout_seconds(child_env)
     try:
         completed = subprocess_run(
             command,
-            cwd=ROOT,
+            cwd=monorepo_root(),
             env=child_env,
             text=True,
             capture_output=True,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/witness_harness.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/witness_harness.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from threading import Lock
 from typing import Literal
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 from sugar_lift_py_tests.sugar_binary import (
     SugarBinaryResolutionError,
     resolve_sugar_binary,
@@ -22,10 +23,21 @@ Verdict = Literal[
     "solver-timeout",
 ]
 
-ROOT = Path(__file__).resolve().parents[5]
-PY_TESTS = ROOT / "implementations" / "python" / "sugar-lift-py-tests"
-PY_SOURCE = ROOT / "implementations" / "python" / "sugar-lift-python-source"
-PY_PYTEST_WITNESS = ROOT / "implementations" / "python" / "sugar-lift-py-pytest-witness"
+
+def _root() -> Path:
+    return resolve_repo_root()
+
+
+def _py_tests() -> Path:
+    return _root() / "implementations" / "python" / "sugar-lift-py-tests"
+
+
+def _py_source() -> Path:
+    return _root() / "implementations" / "python" / "sugar-lift-python-source"
+
+
+def _py_pytest_witness() -> Path:
+    return _root() / "implementations" / "python" / "sugar-lift-py-pytest-witness"
 _SUGAR_BUILD_LOCK = Lock()
 _RESOLVED_SUGAR_BIN: Path | None = None
 
@@ -75,7 +87,8 @@ class WitnessPipelineResult:
 
 def _pythonpath() -> str:
     return os.pathsep.join(
-        str(path / "src") for path in (PY_PYTEST_WITNESS, PY_TESTS, PY_SOURCE)
+        str(path / "src")
+        for path in (_py_pytest_witness(), _py_tests(), _py_source())
     )
 
 
@@ -149,7 +162,7 @@ timeout_seconds = 10
 binary = "lake"
 ir_compiler = "lean"
 timeout_seconds = 10
-lake_project = "{ROOT / 'tools' / 'portfolio' / 'lean-mathlib'}"
+lake_project = "{_root() / 'tools' / 'portfolio' / 'lean-mathlib'}"
 """,
         encoding="utf-8",
     )
@@ -250,7 +263,7 @@ lake_project = "{ROOT / 'tools' / 'portfolio' / 'lean-mathlib'}"
 
 
 def run_lift_rpc(project: Path) -> dict:
-    env = {**os.environ, "PYTHONPATH": str(PY_TESTS / "src")}
+    env = {**os.environ, "PYTHONPATH": str(_py_tests() / "src")}
     request = "\n".join(
         json.dumps(message)
         for message in [

--- a/implementations/python/sugar-lift-py-tests/tests/test_repo_root_door.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_repo_root_door.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Repo-root resolve door: ask for sugar-build.toml, never count parents[N].
+
+THE defect that blocked floors: installed into site-packages, parents[5]
+resolved to the python-test-environment temp dir (a real path that does not
+contain sugar-build.toml). Authentication then FileNotFoundError-ed far away
+as if the corpus authority failed.
+
+Teeth:
+- Truthful: from a checkout cwd, resolve finds sugar-build.toml.
+- Site-packages twin: process "lives" under a venv layout; env/cwd still resolve.
+- Lying twin: missing sugar-build.toml refuses LOUDLY naming the marker
+  (not a FileNotFoundError on a wrong path).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.repo_root import (
+    MARKER,
+    RepoRootUnresolved,
+    resolve_repo_root,
+    sugar_lift_py_tests_package_root,
+)
+
+
+def _write_marker(repo: Path) -> Path:
+    repo.mkdir(parents=True, exist_ok=True)
+    marker = repo / MARKER
+    marker.write_text(
+        textwrap.dedent(
+            """\
+            [tools]
+            python = "3.12.13"
+            """
+        ),
+        encoding="utf-8",
+    )
+    return marker
+
+
+def test_resolves_by_walking_from_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "checkout"
+    _write_marker(repo)
+    nested = repo / "implementations" / "python" / "sugar-lift-py-tests"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+    monkeypatch.delenv("SUGAR_REPO_ROOT", raising=False)
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    assert resolve_repo_root() == repo.resolve()
+
+
+def test_site_packages_layout_resolves_via_github_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """THE CI twin: package under site-packages, checkout only via GITHUB_WORKSPACE.
+
+    Simulates the floors job layout: __file__ would live under
+    sugar-python-test-environment/venv/.../site-packages, while the real
+    sugar-build.toml is under the Actions workspace.
+    """
+    checkout = tmp_path / "actions-workspace" / "sugar"
+    _write_marker(checkout)
+    # Fake venv site-packages tree (no sugar-build.toml here — the old defect).
+    site_pkg = (
+        tmp_path
+        / "sugar-python-test-environment"
+        / "venv"
+        / "lib"
+        / "python3.12"
+        / "site-packages"
+        / "sugar_lift_py_tests"
+    )
+    site_pkg.mkdir(parents=True)
+    (site_pkg / "authenticated_pytest.py").write_text("# fake install\n", encoding="utf-8")
+    # Cwd is the temp env (wrong for parents[N]); env names the checkout.
+    monkeypatch.chdir(tmp_path / "sugar-python-test-environment")
+    monkeypatch.delenv("SUGAR_REPO_ROOT", raising=False)
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(checkout))
+    assert resolve_repo_root() == checkout.resolve()
+
+
+def test_site_packages_layout_resolves_via_sugar_repo_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkout = tmp_path / "repo"
+    _write_marker(checkout)
+    monkeypatch.chdir(tmp_path)  # no marker in cwd
+    monkeypatch.setenv("SUGAR_REPO_ROOT", str(checkout))
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    assert resolve_repo_root() == checkout.resolve()
+
+
+def test_missing_marker_refuses_naming_sugar_build_toml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Lying twin: undischarged root must panic with the marker name, not a wrong path."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SUGAR_REPO_ROOT", raising=False)
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    with pytest.raises(RepoRootUnresolved) as raised:
+        resolve_repo_root(start=tmp_path)
+    message = str(raised.value)
+    assert MARKER in message
+    assert "looked for" in message or "searched" in message
+    # Must not pretend a wrong directory is the root.
+    assert "FileNotFoundError" not in message
+
+
+def test_env_pointing_at_directory_without_marker_is_not_accepted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Plausible path that lacks sugar-build.toml is not a silent root."""
+    decoy = tmp_path / "almost"
+    decoy.mkdir()
+    real = tmp_path / "real"
+    _write_marker(real)
+    monkeypatch.setenv("SUGAR_REPO_ROOT", str(decoy))
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    monkeypatch.chdir(real)
+    # decoy env is skipped; walk from cwd finds real
+    assert resolve_repo_root() == real.resolve()
+
+
+def test_package_root_is_under_resolved_monorepo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "sugar"
+    _write_marker(repo)
+    package = repo / "implementations" / "python" / "sugar-lift-py-tests"
+    package.mkdir(parents=True)
+    (package / "pyproject.toml").write_text(
+        '[project]\nname = "sugar-lift-py-tests"\n', encoding="utf-8"
+    )
+    monkeypatch.setenv("SUGAR_REPO_ROOT", str(repo))
+    monkeypatch.chdir(tmp_path)
+    assert sugar_lift_py_tests_package_root() == package.resolve()
+
+
+def test_declared_interpreter_runtime_uses_door_not_parents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Blocking site: declared_interpreter_runtime reads sugar-build via the door."""
+    repo = tmp_path / "sugar"
+    _write_marker(repo)
+    # Authority version must match what declared_interpreter_runtime reads.
+    (repo / MARKER).write_text(
+        '[tools]\npython = "3.12.13"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SUGAR_REPO_ROOT", str(repo))
+    monkeypatch.chdir(tmp_path)
+    from sugar_lift_py_tests.authenticated_pytest import declared_interpreter_runtime
+
+    assert declared_interpreter_runtime() == "cpython-3.12.13"


### PR DESCRIPTION
## Cause (accepted)

Floors run on main failed corpus auth with:
```
FileNotFoundError: .../sugar-python-test-environment/sugar-build.toml
```
`Path(__file__).resolve().parents[5]` when the package is imported from the
immutable python-test-environment **site-packages** resolves to the temp env
dir (a real path), not the checkout. Authority in `sugar-build.toml` and
pandas pins was never the issue — **environment binding / layout arithmetic**.

## Missing object

A monorepo root that **cannot** be constructed by counting directory levels.
**ONE door** `resolve_repo_root()`:

1. `SUGAR_REPO_ROOT` / `GITHUB_WORKSPACE` if that directory **contains** `sugar-build.toml`
2. Walk up from cwd (or anchors) until the marker is found
3. Else `RepoRootUnresolved` naming the marker and every place searched

Never `parents[N]`. Never silent fallback to a plausible directory.

## What this PR changes

| Site | Before | After |
| --- | --- | --- |
| `authenticated_pytest` (blocking) | `parents[5]` / `parents[2]` | `resolve_repo_root` + `sugar_lift_py_tests_package_root` |
| `sugar_binary` | `ROOT = parents[5]` | `monorepo_root()` door |
| `witness_harness` | `ROOT = parents[5]` | door helpers |
| `source_provenance._monorepo_root` | ad-hoc walk / soft None | door (soft None preserved for callers) |

**Pins not relaxed.**

## R / Epsilon / shell

| | |
| --- | --- |
| **R axis** | `R_repo_root_by_parents_count` |
| **Epsilon R** | Blocking production seats → 0; residual `parents[5]` in package **src** = **2** (`idd/numpy_wall.py`, `idd/pandas_wall.py` argparse defaults) |
| **Shell deleted** | Counted monorepo root (`parents[5]`) in authenticated_pytest / sugar_binary / witness_harness |
| **Floors** | Corpus / `tools.python` authority unchanged |
| **Teeth** | `tests/test_repo_root_door.py`: site-packages+`GITHUB_WORKSPACE` twin; missing-marker refusal names `sugar-build.toml`; `declared_interpreter_runtime` via door |

## Residual (named, not drained today)

- `parents[5]` production: **2** (idd wall CLI defaults)
- Broader `Path(__file__).parents[N]` under `sugar-lift-py-tests` (tests + other src): leave as residual axis for later routing through the door

## Validation

```
bin/bpytest -q tests/test_repo_root_door.py
# 7 passed on bx
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `parents[N]` repo root arithmetic with `resolve_repo_root()` across test harness
> - Introduces [repo_root.py](https://github.com/TSavo/sugar/pull/6978/files#diff-2f1473201c846e2d26271e7299b867c60b0a9a58178d000426da36c12b47fc75) with `resolve_repo_root()`, which checks `SUGAR_REPO_ROOT` and `GITHUB_WORKSPACE` env vars then walks up from cwd until it finds `sugar-build.toml`; raises `RepoRootUnresolved` on failure.
> - Replaces all hardcoded `Path(__file__).resolve().parents[N]` calls in `authenticated_pytest.py`, `sugar_binary.py`, `witness_harness.py`, and `source_provenance.py` with calls to `resolve_repo_root()`.
> - `RepoRootUnresolved` is caught at call sites and re-raised as `ExecutionEnvironmentMismatch` where appropriate.
> - Adds tests in [test_repo_root_door.py](https://github.com/TSavo/sugar/pull/6978/files#diff-5a07aab42a2551c5e5bb12da0d9ef014f1850681d7134e8595d95d36b78a3883) covering env-var paths, directory walking, missing markers, and package root validation.
> - Behavioral Change: root resolution now works in installed/site-packages layouts (e.g. CI via `GITHUB_WORKSPACE`) where fixed parent-index arithmetic would silently produce wrong paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2434ac4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->