### PR TITLE
Drive R_repo_root_by_parents_count package-src to 0

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/numpy_wall.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/numpy_wall.py
@@ -9,6 +9,8 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Literal, Mapping, Optional, Sequence
 
+from sugar_lift_py_tests.repo_root import RepoRootUnresolved, resolve_repo_root
+
 from .collect_panic_audit import (
     _prepare_audit_workspace,
     _resolve_installed_package_path,
@@ -305,8 +307,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument(
         "--root",
         type=Path,
-        default=Path(__file__).resolve().parents[5],
-        help="repository root",
+        default=None,
+        help="repository root (default: resolve via sugar-build.toml door)",
     )
     parser.add_argument(
         "--output-dir",
@@ -328,7 +330,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    root = args.root.resolve()
+    try:
+        root = (
+            args.root.resolve()
+            if args.root is not None
+            else resolve_repo_root()
+        )
+    except RepoRootUnresolved as error:
+        parser.error(str(error))
     output_dir = args.output_dir or (root / ".sugar" / "numpy-wall")
     floors_path = args.floors or (root / "tools" / "numpy-wall-floors.json")
     result = build_numpy_wall(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/pandas_wall.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/pandas_wall.py
@@ -9,6 +9,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Callable, Literal, Mapping, Optional, Sequence
 
+from sugar_lift_py_tests.repo_root import RepoRootUnresolved, resolve_repo_root
+
 from .collect_panic_audit import (
     _cached_audit_workspace,
     _prepare_audit_workspace,
@@ -524,8 +526,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument(
         "--root",
         type=Path,
-        default=Path(__file__).resolve().parents[5],
-        help="repository root",
+        default=None,
+        help="repository root (default: resolve via sugar-build.toml door)",
     )
     parser.add_argument(
         "--output-dir",
@@ -547,7 +549,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    root = args.root.resolve()
+    try:
+        root = (
+            args.root.resolve()
+            if args.root is not None
+            else resolve_repo_root()
+        )
+    except RepoRootUnresolved as error:
+        parser.error(str(error))
     output_dir = args.output_dir or (root / ".sugar" / "pandas-wall")
     floors_path = args.floors or (root / "tools" / "pandas-wall-floors.json")
     result = build_pandas_wall(

--- a/implementations/python/sugar-lift-py-tests/tests/test_repo_root_door.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_repo_root_door.py
@@ -157,3 +157,15 @@ def test_declared_interpreter_runtime_uses_door_not_parents(
     from sugar_lift_py_tests.authenticated_pytest import declared_interpreter_runtime
 
     assert declared_interpreter_runtime() == "cpython-3.12.13"
+
+
+def test_idd_wall_mains_do_not_count_parents_for_repo_root() -> None:
+    """Residual parents[5] seats routed: wall CLIs use the resolve door."""
+    import inspect
+
+    from sugar_lift_py_tests.idd import numpy_wall, pandas_wall
+
+    for mod in (numpy_wall, pandas_wall):
+        src = inspect.getsource(mod.main)
+        assert "parents[5]" not in src, mod.__name__
+        assert "resolve_repo_root" in src, mod.__name__


### PR DESCRIPTION
## Finish the axis from #6978

Residual after the resolve door: **2** `parents[5]` seats in package **src**:
- `idd/numpy_wall.py` argparse `--root` default
- `idd/pandas_wall.py` argparse `--root` default

Both now use `resolve_repo_root()` (default `None`, resolve after parse;
`RepoRootUnresolved` → `parser.error`).

## R / Epsilon / shell

| | |
| --- | --- |
| **R axis** | `R_repo_root_by_parents_count` (package src monorepo `parents[5]`) |
| **Epsilon R** | **2 → 0** |
| **Shell deleted** | `Path(__file__).parents[5]` wall CLI defaults |
| **Floors** | Door marker `sugar-build.toml`; corpus pins untouched |
| **Teeth** | `test_idd_wall_mains_do_not_count_parents_for_repo_root` |

Ladder: type cannot forbid free Path arithmetic → **one door that refuses** (`resolve_repo_root`) → used here. No new auditor.

## Named residual (measured, not drained)

`Path(__file__).parents[N]` **outside package src** (executable lines, not docs):

| Bucket | Count |
| --- | --- |
| `sugar-lift-py-tests/tests/` | 111 |
| `sugar-lift-py-tests/scripts/` | 21 |
| repo `tests/` | 11 |
| `tools/` | 12 |
| **TOTAL outside package src** | **155** |

`parents[5]` monorepo magic: **0** remaining under kit+repo tests+tools.

Package **src** still has **3** non-`[5]` layout seats in `lift_rpc.py` (`parents[1]`/`parents[3]` package-relative paths) — **not** this monorepo-root axis; name if promoted later.

CI on main-push is the measurement path (no local pytest, no bx from this PR).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace hardcoded `parents[5]` repo root resolution with `resolve_repo_root()` in wall CLIs
> - `numpy_wall` and `pandas_wall` CLIs no longer derive the repo root via `Path(__file__).resolve().parents[5]`; they now call `resolve_repo_root()` when `--root` is not provided.
> - If repo root resolution fails, the CLI exits with a `parser.error` using the `RepoRootUnresolved` exception message.
> - A regression test in [test_repo_root_door.py](https://github.com/TSavo/sugar/pull/6979/files#diff-5a07aab42a2551c5e5bb12da0d9ef014f1850681d7134e8595d95d36b78a3883) asserts that `parents[5]` is absent and `resolve_repo_root` is present in both `main` functions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92ddc7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->