### PR TITLE
CommitMeasurement: total only when every axis is Measured

### DIFF
--- a/.github/workflows/heavy-measurement-attendance.yml
+++ b/.github/workflows/heavy-measurement-attendance.yml
@@ -105,9 +105,46 @@ jobs:
             | tee attendance.md \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
+      - name: Compose CommitMeasurement (cite receipts only)
+        env:
+          SHA: ${{ steps.subject.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # One door for READING tip state. Values are field-paths on sealed
+          # bodies; lease alone without suite-report/floor body is Unmeasured.
+          python3 - <<'PY'
+          from pathlib import Path
+          import json
+          import importlib.util
+          spec = importlib.util.spec_from_file_location(
+              "cm", Path("tools/commit_measurement.py")
+          )
+          mod = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(mod)
+          import os
+          sha = os.environ["SHA"]
+          vector = mod.compose_tip_from_receipts_dir(sha, Path("receipts"))
+          Path("commit-measurement.json").write_text(
+              json.dumps(vector.to_json(), indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(vector.to_json(), indent=2, sort_keys=True))
+          PY
+
+      - name: Gate — tip composition required (silence is not clean)
+        run: |
+          set -euo pipefail
+          # REQUIRED not advisory: PartialVector or missing file → red.
+          python3 tools/commit_measurement_gate.py \
+            --composition commit-measurement.json \
+            --require-complete \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: heavy-measurement-attendance-${{ steps.subject.outputs.sha }}
-          path: attendance.md
+          path: |
+            attendance.md
+            commit-measurement.json
           if-no-files-found: warn

--- a/tests/test_commit_measurement.py
+++ b/tests/test_commit_measurement.py
@@ -1,0 +1,134 @@
+"""Construction-door teeth for CommitMeasurement.
+
+No local pytest in agent sessions (watchdog). CI / assigned remote runs these.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location(
+    "commit_measurement", ROOT / "tools" / "commit_measurement.py"
+)
+assert _SPEC is not None and _SPEC.loader is not None
+CM = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(CM)
+
+CommitMeasurementError = CM.CommitMeasurementError
+CompleteVector = CM.CompleteVector
+Measured = CM.Measured
+PartialVector = CM.PartialVector
+Unmeasured = CM.Unmeasured
+commit_measurement = CM.commit_measurement
+measured = CM.measured
+unmeasured = CM.unmeasured
+
+
+def test_measured_refuses_without_receipt_cid() -> None:
+    with pytest.raises(CommitMeasurementError, match="receipt_cid"):
+        Measured(0, "", 10, 0)
+    with pytest.raises(CommitMeasurementError, match="receipt_cid"):
+        measured(0, receipt_cid="  ", collected=1, exit_code=0)
+
+
+def test_measured_requires_value_collected_exit_code_types() -> None:
+    ok = measured(3, receipt_cid="blake3-512:abc", collected=12, exit_code=1)
+    assert ok.value == 3
+    assert ok.receipt_cid == "blake3-512:abc"
+    assert ok.collected == 12
+    assert ok.exit_code == 1
+    with pytest.raises(CommitMeasurementError, match="value"):
+        Measured(-1, "cid", 1, 0)
+    with pytest.raises(CommitMeasurementError, match="collected"):
+        Measured(0, "cid", -1, 0)
+    with pytest.raises(CommitMeasurementError, match="exit_code"):
+        Measured(0, "cid", 1, True)  # type: ignore[arg-type]
+
+
+def test_unmeasured_is_third_value_not_zero() -> None:
+    u = unmeasured("lease not acquired for python-package-suite at tip")
+    assert u.reason
+    assert not u.is_measured()
+    m = measured(0, receipt_cid="cid:zero", collected=5, exit_code=0)
+    assert m.is_measured()
+    assert m.value == 0
+    assert type(u) is not type(m)
+    with pytest.raises(CommitMeasurementError, match="reason"):
+        Unmeasured("")
+
+
+def test_complete_vector_has_total_only_when_all_measured() -> None:
+    v = commit_measurement(
+        "abc123",
+        "roster:tip-v1",
+        {
+            "spelling": measured(32, receipt_cid="r1", collected=100, exit_code=1),
+            "swallowed": measured(79, receipt_cid="r2", collected=100, exit_code=1),
+        },
+    )
+    assert isinstance(v, CompleteVector)
+    assert v.total == 111
+    assert v.is_complete()
+
+
+def test_partial_vector_has_no_total_method() -> None:
+    """R_total drop-as-progress: unwritable — PartialVector has no .total."""
+    v = commit_measurement(
+        "abc123",
+        "roster:tip-v1",
+        {
+            "spelling": measured(32, receipt_cid="r1", collected=100, exit_code=1),
+            "self_sealing": unmeasured("no lease receipt for class at this commit"),
+        },
+    )
+    assert isinstance(v, PartialVector)
+    assert not v.is_complete()
+    assert v.unmeasured_axes() == ("self_sealing",)
+    assert not hasattr(PartialVector, "total")
+    with pytest.raises(AttributeError):
+        _ = v.total  # type: ignore[attr-defined]
+
+
+def test_partial_vector_refuses_all_measured() -> None:
+    with pytest.raises(CommitMeasurementError, match="CompleteVector"):
+        PartialVector(
+            "sha",
+            "roster",
+            {"a": measured(1, receipt_cid="c", collected=1, exit_code=0)},
+        )
+
+
+def test_complete_vector_refuses_unmeasured_axis() -> None:
+    with pytest.raises(CommitMeasurementError, match="Unmeasured"):
+        CompleteVector(
+            "sha",
+            "roster",
+            {
+                "a": measured(1, receipt_cid="c", collected=1, exit_code=0),
+                "b": unmeasured("missing"),  # type: ignore[dict-item]
+            },
+        )
+
+
+def test_one_door_commit_measurement() -> None:
+    partial = commit_measurement(
+        "deadbeef",
+        "roster:x",
+        {"a": unmeasured("never ran")},
+    )
+    complete = commit_measurement(
+        "deadbeef",
+        "roster:x",
+        {"a": measured(0, receipt_cid="lease:a", collected=3, exit_code=0)},
+    )
+    assert isinstance(partial, PartialVector)
+    assert isinstance(complete, CompleteVector)
+    assert complete.total == 0
+
+
+def test_scoreboard_authority_is_false() -> None:
+    assert CM.SCOREBOARD_AUTHORITY is False

--- a/tests/test_commit_measurement.py
+++ b/tests/test_commit_measurement.py
@@ -1,134 +1,230 @@
-"""Construction-door teeth for CommitMeasurement.
-
-No local pytest in agent sessions (watchdog). CI / assigned remote runs these.
-"""
+"""Construction-door teeth for CommitMeasurement (CI path; no local agent pytest)."""
 
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-_SPEC = importlib.util.spec_from_file_location(
-    "commit_measurement", ROOT / "tools" / "commit_measurement.py"
-)
-assert _SPEC is not None and _SPEC.loader is not None
-CM = importlib.util.module_from_spec(_SPEC)
-_SPEC.loader.exec_module(CM)
-
-CommitMeasurementError = CM.CommitMeasurementError
-CompleteVector = CM.CompleteVector
-Measured = CM.Measured
-PartialVector = CM.PartialVector
-Unmeasured = CM.Unmeasured
-commit_measurement = CM.commit_measurement
-measured = CM.measured
-unmeasured = CM.unmeasured
 
 
-def test_measured_refuses_without_receipt_cid() -> None:
-    with pytest.raises(CommitMeasurementError, match="receipt_cid"):
-        Measured(0, "", 10, 0)
-    with pytest.raises(CommitMeasurementError, match="receipt_cid"):
-        measured(0, receipt_cid="  ", collected=1, exit_code=0)
+def _load(name: str, rel: str):
+    spec = importlib.util.spec_from_file_location(name, ROOT / rel)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
-def test_measured_requires_value_collected_exit_code_types() -> None:
-    ok = measured(3, receipt_cid="blake3-512:abc", collected=12, exit_code=1)
-    assert ok.value == 3
-    assert ok.receipt_cid == "blake3-512:abc"
-    assert ok.collected == 12
-    assert ok.exit_code == 1
-    with pytest.raises(CommitMeasurementError, match="value"):
-        Measured(-1, "cid", 1, 0)
-    with pytest.raises(CommitMeasurementError, match="collected"):
-        Measured(0, "cid", -1, 0)
-    with pytest.raises(CommitMeasurementError, match="exit_code"):
-        Measured(0, "cid", 1, True)  # type: ignore[arg-type]
+CM = _load("commit_measurement", "tools/commit_measurement.py")
+GATE = _load("commit_measurement_gate", "tools/commit_measurement_gate.py")
+
+
+def test_scoreboard_authority_false() -> None:
+    assert CM.SCOREBOARD_AUTHORITY is False
+
+
+def test_measured_requires_lease_and_body_cids() -> None:
+    with pytest.raises(CM.CommitMeasurementError, match="receipt_cid"):
+        CM.Measured(0, "", "body", "totals.failed", 1, 0)
+    with pytest.raises(CM.CommitMeasurementError, match="body_artifact_cid"):
+        CM.Measured(0, "lease", "", "totals.failed", 1, 0)
+    with pytest.raises(CM.CommitMeasurementError, match="value_field_path"):
+        CM.Measured(0, "lease", "body", "", 1, 0)
+
+
+def test_measured_from_sealed_pair_unmeasured_without_body_field() -> None:
+    reading = CM.measured_from_sealed_pair(
+        commit_sha="abc",
+        lease_record={"acquired": True, "leaseClass": "python-package-suite"},
+        lease_receipt_cid="lease:1",
+        body={"totals": {}},
+        body_artifact_cid="body:1",
+        value_field_path="totals.failed",
+    )
+    assert isinstance(reading, CM.Unmeasured)
+
+
+def test_measured_from_sealed_pair_unmeasured_when_lease_not_acquired() -> None:
+    reading = CM.measured_from_sealed_pair(
+        commit_sha="abc",
+        lease_record={"acquired": False, "leaseClass": "python-package-suite"},
+        lease_receipt_cid="lease:1",
+        body={"totals": {"failed": 0, "collected": 3}},
+        body_artifact_cid="body:1",
+        value_field_path="totals.failed",
+    )
+    assert isinstance(reading, CM.Unmeasured)
+    assert "not acquired" in reading.reason
+
+
+def test_measured_from_sealed_pair_cites_body_value() -> None:
+    body = {"totals": {"failed": 7, "collected": 40}}
+    reading = CM.measured_from_sealed_pair(
+        commit_sha="abc",
+        lease_record={
+            "acquired": True,
+            "leaseClass": "python-package-suite",
+            "measurementStatus": "completed/findings",
+        },
+        lease_receipt_cid="lease:1",
+        body=body,
+        body_artifact_cid=CM.content_cid(body),
+        value_field_path="totals.failed",
+        collected_field_path="totals.collected",
+    )
+    assert isinstance(reading, CM.Measured)
+    assert reading.value == 7
+    assert reading.collected == 40
+    assert reading.body_artifact_cid.startswith("blake2b-256:")
 
 
 def test_unmeasured_is_third_value_not_zero() -> None:
-    u = unmeasured("lease not acquired for python-package-suite at tip")
-    assert u.reason
-    assert not u.is_measured()
-    m = measured(0, receipt_cid="cid:zero", collected=5, exit_code=0)
-    assert m.is_measured()
-    assert m.value == 0
+    u = CM.unmeasured("never ran")
+    m = CM.measured(
+        0,
+        receipt_cid="l",
+        body_artifact_cid="b",
+        value_field_path="totals.failed",
+        collected=1,
+        exit_code=0,
+    )
     assert type(u) is not type(m)
-    with pytest.raises(CommitMeasurementError, match="reason"):
-        Unmeasured("")
+    assert m.value == 0
+    assert not u.is_measured()
 
 
-def test_complete_vector_has_total_only_when_all_measured() -> None:
-    v = commit_measurement(
-        "abc123",
-        "roster:tip-v1",
+def test_complete_has_total_partial_does_not() -> None:
+    complete = CM.commit_measurement(
+        "sha",
+        "roster:tip",
         {
-            "spelling": measured(32, receipt_cid="r1", collected=100, exit_code=1),
-            "swallowed": measured(79, receipt_cid="r2", collected=100, exit_code=1),
+            "a": CM.measured(
+                1,
+                receipt_cid="l1",
+                body_artifact_cid="b1",
+                value_field_path="totals.failed",
+                collected=2,
+                exit_code=1,
+            ),
+            "b": CM.measured(
+                2,
+                receipt_cid="l2",
+                body_artifact_cid="b2",
+                value_field_path="totals.failed",
+                collected=2,
+                exit_code=1,
+            ),
         },
     )
-    assert isinstance(v, CompleteVector)
-    assert v.total == 111
-    assert v.is_complete()
-
-
-def test_partial_vector_has_no_total_method() -> None:
-    """R_total drop-as-progress: unwritable — PartialVector has no .total."""
-    v = commit_measurement(
-        "abc123",
-        "roster:tip-v1",
+    assert isinstance(complete, CM.CompleteVector)
+    assert complete.total == 3
+    partial = CM.commit_measurement(
+        "sha",
+        "roster:tip",
         {
-            "spelling": measured(32, receipt_cid="r1", collected=100, exit_code=1),
-            "self_sealing": unmeasured("no lease receipt for class at this commit"),
+            "a": CM.measured(
+                1,
+                receipt_cid="l1",
+                body_artifact_cid="b1",
+                value_field_path="totals.failed",
+                collected=2,
+                exit_code=1,
+            ),
+            "b": CM.unmeasured("missing body"),
         },
     )
-    assert isinstance(v, PartialVector)
-    assert not v.is_complete()
-    assert v.unmeasured_axes() == ("self_sealing",)
-    assert not hasattr(PartialVector, "total")
+    assert isinstance(partial, CM.PartialVector)
+    assert not hasattr(CM.PartialVector, "total")
     with pytest.raises(AttributeError):
-        _ = v.total  # type: ignore[attr-defined]
+        _ = partial.total  # type: ignore[attr-defined]
+    assert "total" not in partial.to_json()
 
 
-def test_partial_vector_refuses_all_measured() -> None:
-    with pytest.raises(CommitMeasurementError, match="CompleteVector"):
-        PartialVector(
-            "sha",
-            "roster",
-            {"a": measured(1, receipt_cid="c", collected=1, exit_code=0)},
-        )
-
-
-def test_complete_vector_refuses_unmeasured_axis() -> None:
-    with pytest.raises(CommitMeasurementError, match="Unmeasured"):
-        CompleteVector(
+def test_forbidden_board_axis_names() -> None:
+    with pytest.raises(CM.CommitMeasurementError, match="corpus-board"):
+        CM.commit_measurement(
             "sha",
             "roster",
             {
-                "a": measured(1, receipt_cid="c", collected=1, exit_code=0),
-                "b": unmeasured("missing"),  # type: ignore[dict-item]
+                "R_construction": CM.unmeasured("no"),
             },
         )
 
 
-def test_one_door_commit_measurement() -> None:
-    partial = commit_measurement(
-        "deadbeef",
-        "roster:x",
-        {"a": unmeasured("never ran")},
-    )
-    complete = commit_measurement(
-        "deadbeef",
-        "roster:x",
-        {"a": measured(0, receipt_cid="lease:a", collected=3, exit_code=0)},
-    )
-    assert isinstance(partial, PartialVector)
-    assert isinstance(complete, CompleteVector)
-    assert complete.total == 0
+def test_compose_tip_lease_without_body_is_unmeasured(tmp_path: Path) -> None:
+    lease = {
+        "schemaVersion": 1,
+        "leaseClass": "python-package-suite",
+        "acquired": True,
+        "measurementStatus": "completed/findings",
+        "commit": "deadbeef",
+    }
+    (tmp_path / "lease.json").write_text(json.dumps(lease), encoding="utf-8")
+    v = CM.compose_tip_from_receipts_dir("deadbeef", tmp_path)
+    assert isinstance(v, CM.PartialVector)
+    assert "python-package-suite" in v.unmeasured_axes()
+    assert "body artifact" in v.axes["python-package-suite"].reason
 
 
-def test_scoreboard_authority_is_false() -> None:
-    assert CM.SCOREBOARD_AUTHORITY is False
+def test_compose_tip_lease_plus_body_is_measured(tmp_path: Path) -> None:
+    body = {
+        "totals": {"failed": 4, "collected": 20},
+        "failedNodeIds": ["a", "b", "c", "d"],
+        "gitCommit": "deadbeef",
+    }
+    lease = {
+        "schemaVersion": 1,
+        "leaseClass": "python-package-suite",
+        "acquired": True,
+        "measurementStatus": "completed/findings",
+        "commit": "deadbeef",
+        "leaseRecord": None,
+    }
+    # embed lease + body in one suite-report style object
+    suite = {**body, "leaseRecord": lease}
+    (tmp_path / "suite-report.json").write_text(json.dumps(suite), encoding="utf-8")
+    # floors absent → partial overall, but package suite measured
+    v = CM.compose_tip_from_receipts_dir("deadbeef", tmp_path)
+    assert isinstance(v, CM.PartialVector)
+    assert isinstance(v.axes["python-package-suite"], CM.Measured)
+    assert v.axes["python-package-suite"].value == 4
+    assert isinstance(v.axes["python-sole-construction-floors"], CM.Unmeasured)
+
+
+def test_gate_missing_composition_is_red(tmp_path: Path) -> None:
+    assert GATE.main(["--composition", str(tmp_path / "nope.json"), "--require-complete"]) == 1
+
+
+def test_gate_partial_require_complete_is_red(tmp_path: Path) -> None:
+    v = CM.commit_measurement(
+        "sha",
+        "roster",
+        {"a": CM.unmeasured("gone")},
+    )
+    path = tmp_path / "cm.json"
+    path.write_text(json.dumps(v.to_json()), encoding="utf-8")
+    assert GATE.main(["--composition", str(path), "--require-complete"]) == 1
+
+
+def test_gate_complete_require_complete_is_green(tmp_path: Path) -> None:
+    v = CM.commit_measurement(
+        "sha",
+        "roster",
+        {
+            "a": CM.measured(
+                0,
+                receipt_cid="l",
+                body_artifact_cid="b",
+                value_field_path="totals.failed",
+                collected=1,
+                exit_code=0,
+            )
+        },
+    )
+    path = tmp_path / "cm.json"
+    path.write_text(json.dumps(v.to_json()), encoding="utf-8")
+    assert GATE.main(["--composition", str(path), "--require-complete"]) == 0

--- a/tools/commit_measurement.py
+++ b/tools/commit_measurement.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""CommitMeasurement — one door for READING measurement state of a commit.
+
+THE GAP THIS CLOSES
+===================
+
+We have one door for TAKING a measurement (the heavy lease). We had NO door
+for READING the state. "How are we doing?" was answered with workflow colour,
+``gh run list``, a log tail, a green check — none authoritative. Summing axis
+R when any axis was never measured produces a number that can *drop* when a
+silent unmeasured axis is discovered, and that drop reads as progress.
+
+This module is the composition object. It does not take measurements. It does
+not re-scan product offenders. It makes illegal readings unconstructible.
+
+    CommitMeasurement / CompleteVector / PartialVector
+    AxisReading = Measured(value, receipt_cid, collected, exit_code) | Unmeasured(reason)
+
+THREE CONSTRUCTOR LAWS
+======================
+
+1. An R reading IS a (value, receipt) pair, unconstructible apart.
+   ``Measured`` refuses without a non-empty ``receipt_cid`` that names the
+   lease/artifact receipt proving the class was acquired for that commit,
+   plus ``collected`` (denominator evidence) and ``exit_code`` captured
+   pre-pipe. Precedent: 255 red rows with no grounds (#3540) — a lie with a
+   stack trace; the fix is a type.
+
+2. ``Unmeasured`` is a THIRD VALUE, not zero. Distinct constructor, not
+   coercible to ``Measured(0, ...)``. Absence yields Unmeasured, never blank
+   and never green — the presenter carries the burden.
+
+3. THE TOTAL IS UNCONSTRUCTIBLE when any axis is Unmeasured. Not "total with
+   an asterisk" — no total. ``CompleteVector`` has ``.total``;
+   ``PartialVector`` does not. R_total=208 was a sum; one silently-unmeasured
+   axis makes a sum drop, which reads as progress.
+
+ONE DOOR
+========
+
+``commit_measurement(commit_sha, roster_cid, axes)`` is the only public
+constructor for the vector. It returns ``CompleteVector | PartialVector``.
+There is no way to get a total from a partial vector without first supplying
+a Measured reading for every Unmeasured axis.
+
+Not a scoreboard. SCOREBOARD_AUTHORITY = False. The sole product corpus
+scoreboard remains scripts/control_effect_recensus.py.
+
+Ladder: this is a TYPE (construction closure). It retires the false "sum of
+axis counts from mixed measured/unmeasured surfaces" practice. No auditor
+required for the invariant "total only when complete" — the method does not
+exist on PartialVector.
+"""
+
+from __future__ import annotations
+
+SCOREBOARD_AUTHORITY = False
+
+from dataclasses import dataclass
+from typing import Mapping, Union
+
+
+class CommitMeasurementError(TypeError):
+    """Illegal measurement reading — refused at construction."""
+
+
+def _require_nonempty_str(name: str, value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CommitMeasurementError(
+            f"{name} must be a non-empty str (presenter burden); "
+            f"got {type(value).__name__!r}={value!r}"
+        )
+    return value.strip()
+
+
+def _require_int(name: str, value: object, *, min_value: int | None = None) -> int:
+    if type(value) is not int:  # bool is subclass of int — refuse bool
+        raise CommitMeasurementError(
+            f"{name} must be int (not {type(value).__name__}); "
+            f"exit codes and counts are not booleans or floats"
+        )
+    if min_value is not None and value < min_value:
+        raise CommitMeasurementError(f"{name} must be >= {min_value}; got {value}")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class Measured:
+    """A measured axis reading: value with lease/receipt testimony.
+
+    Unconstructible without receipt_cid, collected count, and pre-pipe exit_code.
+    """
+
+    value: int
+    receipt_cid: str
+    collected: int
+    exit_code: int
+
+    def __post_init__(self) -> None:
+        _require_int("value", self.value, min_value=0)
+        cid = _require_nonempty_str("receipt_cid", self.receipt_cid)
+        object.__setattr__(self, "receipt_cid", cid)
+        _require_int("collected", self.collected, min_value=0)
+        _require_int("exit_code", self.exit_code)
+
+    def is_measured(self) -> bool:
+        return True
+
+
+@dataclass(frozen=True, slots=True)
+class Unmeasured:
+    """Third value: this axis was not measured. Not zero. Not coercible."""
+
+    reason: str
+
+    def __post_init__(self) -> None:
+        reason = _require_nonempty_str("reason", self.reason)
+        object.__setattr__(self, "reason", reason)
+
+    def is_measured(self) -> bool:
+        return False
+
+
+AxisReading = Union[Measured, Unmeasured]
+
+
+def _require_axes_map(axes: object) -> dict[str, AxisReading]:
+    if not isinstance(axes, Mapping) or not axes:
+        raise CommitMeasurementError(
+            "axes must be a non-empty mapping of axis name -> AxisReading"
+        )
+    out: dict[str, AxisReading] = {}
+    for name, reading in axes.items():
+        key = _require_nonempty_str("axis name", name)
+        if not isinstance(reading, (Measured, Unmeasured)):
+            raise CommitMeasurementError(
+                f"axis {key!r}: reading must be Measured or Unmeasured; "
+                f"got {type(reading).__name__} — there is no third construction "
+                f"path and no blank/green default"
+            )
+        out[key] = reading
+    return out
+
+
+@dataclass(frozen=True, slots=True)
+class CompleteVector:
+    """Every axis Measured. The only shape that may report a total."""
+
+    commit_sha: str
+    roster_cid: str
+    axes: Mapping[str, Measured]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "commit_sha", _require_nonempty_str("commit_sha", self.commit_sha)
+        )
+        object.__setattr__(
+            self, "roster_cid", _require_nonempty_str("roster_cid", self.roster_cid)
+        )
+        if not isinstance(self.axes, Mapping) or not self.axes:
+            raise CommitMeasurementError("CompleteVector.axes must be non-empty")
+        sealed: dict[str, Measured] = {}
+        for name, reading in self.axes.items():
+            key = _require_nonempty_str("axis name", name)
+            if not isinstance(reading, Measured):
+                raise CommitMeasurementError(
+                    f"CompleteVector refuses Unmeasured axis {key!r}; "
+                    f"use PartialVector or supply a Measured reading"
+                )
+            sealed[key] = reading
+        object.__setattr__(self, "axes", sealed)
+
+    @property
+    def total(self) -> int:
+        """Sum of measured R values. Exists only when every axis is Measured."""
+        return sum(reading.value for reading in self.axes.values())
+
+    def is_complete(self) -> bool:
+        return True
+
+
+@dataclass(frozen=True, slots=True)
+class PartialVector:
+    """At least one Unmeasured axis. No total — the method does not exist."""
+
+    commit_sha: str
+    roster_cid: str
+    axes: Mapping[str, AxisReading]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "commit_sha", _require_nonempty_str("commit_sha", self.commit_sha)
+        )
+        object.__setattr__(
+            self, "roster_cid", _require_nonempty_str("roster_cid", self.roster_cid)
+        )
+        sealed = _require_axes_map(self.axes)
+        if not any(isinstance(r, Unmeasured) for r in sealed.values()):
+            raise CommitMeasurementError(
+                "PartialVector requires at least one Unmeasured axis; "
+                "all-Measured vectors are CompleteVector (use commit_measurement)"
+            )
+        object.__setattr__(self, "axes", sealed)
+
+    def is_complete(self) -> bool:
+        return False
+
+    def unmeasured_axes(self) -> tuple[str, ...]:
+        return tuple(
+            name
+            for name, reading in self.axes.items()
+            if isinstance(reading, Unmeasured)
+        )
+
+
+# Public alias for the composition: either complete or partial.
+CommitMeasurement = Union[CompleteVector, PartialVector]
+
+
+def commit_measurement(
+    commit_sha: str,
+    roster_cid: str,
+    axes: Mapping[str, AxisReading],
+) -> CommitMeasurement:
+    """ONE DOOR for commit measurement state.
+
+    Returns CompleteVector when every axis is Measured (``.total`` available).
+    Returns PartialVector when any axis is Unmeasured (no total).
+    """
+    sha = _require_nonempty_str("commit_sha", commit_sha)
+    roster = _require_nonempty_str("roster_cid", roster_cid)
+    sealed = _require_axes_map(axes)
+    if any(isinstance(r, Unmeasured) for r in sealed.values()):
+        return PartialVector(sha, roster, sealed)
+    measured = {name: reading for name, reading in sealed.items()}
+    # type narrowed: all Measured
+    return CompleteVector(sha, roster, measured)  # type: ignore[arg-type]
+
+
+def measured(
+    value: int,
+    *,
+    receipt_cid: str,
+    collected: int,
+    exit_code: int,
+) -> Measured:
+    """Named door for Measured (keyword-forced testimony fields)."""
+    return Measured(value, receipt_cid, collected, exit_code)
+
+
+def unmeasured(reason: str) -> Unmeasured:
+    """Named door for Unmeasured — absence with a named reason."""
+    return Unmeasured(reason)

--- a/tools/commit_measurement.py
+++ b/tools/commit_measurement.py
@@ -1,63 +1,50 @@
 #!/usr/bin/env python3
-"""CommitMeasurement — one door for READING measurement state of a commit.
+"""CommitMeasurement — sealed composition of tip measurement testimony.
 
-THE GAP THIS CLOSES
-===================
+Cite-compose only. SCOREBOARD_AUTHORITY = False. Never recompute product R
+(control_effect_recensus owns the corpus board). Never emit board axis names
+as computed residual.
 
-We have one door for TAKING a measurement (the heavy lease). We had NO door
-for READING the state. "How are we doing?" was answered with workflow colour,
-``gh run list``, a log tail, a green check — none authoritative. Summing axis
-R when any axis was never measured produces a number that can *drop* when a
-silent unmeasured axis is discovered, and that drop reads as progress.
+    AxisReading = Measured(...) | Unmeasured(reason)
+    commit_measurement(...) -> CompleteVector | PartialVector
 
-This module is the composition object. It does not take measurements. It does
-not re-scan product offenders. It makes illegal readings unconstructible.
+Measured requires BOTH:
+  - lease receipt CID (proves lease acquired / ran under lease at commit)
+  - body artifact CID + value_field_path (the report that owns the number)
 
-    CommitMeasurement / CompleteVector / PartialVector
-    AxisReading = Measured(value, receipt_cid, collected, exit_code) | Unmeasured(reason)
+A lease without a body is Unmeasured (today's package-suite: ran, no
+suite-report.json). A free-floating value without both digests is unconstructible.
 
-THREE CONSTRUCTOR LAWS
-======================
+CompleteVector has .total. PartialVector has no .total.
+Unmeasured is a third value, not zero.
 
-1. An R reading IS a (value, receipt) pair, unconstructible apart.
-   ``Measured`` refuses without a non-empty ``receipt_cid`` that names the
-   lease/artifact receipt proving the class was acquired for that commit,
-   plus ``collected`` (denominator evidence) and ``exit_code`` captured
-   pre-pipe. Precedent: 255 red rows with no grounds (#3540) — a lie with a
-   stack trace; the fix is a type.
+One door: ``commit_measurement`` / ``compose_tip_from_receipts_dir``.
 
-2. ``Unmeasured`` is a THIRD VALUE, not zero. Distinct constructor, not
-   coercible to ``Measured(0, ...)``. Absence yields Unmeasured, never blank
-   and never green — the presenter carries the burden.
-
-3. THE TOTAL IS UNCONSTRUCTIBLE when any axis is Unmeasured. Not "total with
-   an asterisk" — no total. ``CompleteVector`` has ``.total``;
-   ``PartialVector`` does not. R_total=208 was a sum; one silently-unmeasured
-   axis makes a sum drop, which reads as progress.
-
-ONE DOOR
-========
-
-``commit_measurement(commit_sha, roster_cid, axes)`` is the only public
-constructor for the vector. It returns ``CompleteVector | PartialVector``.
-There is no way to get a total from a partial vector without first supplying
-a Measured reading for every Unmeasured axis.
-
-Not a scoreboard. SCOREBOARD_AUTHORITY = False. The sole product corpus
-scoreboard remains scripts/control_effect_recensus.py.
-
-Ladder: this is a TYPE (construction closure). It retires the false "sum of
-axis counts from mixed measured/unmeasured surfaces" practice. No auditor
-required for the invariant "total only when complete" — the method does not
-exist on PartialVector.
+CI: ``tools/commit_measurement_gate.py --require-complete`` fails closed.
+Enrollment: heavy-measurement-attendance.yml composes + gates after roll call.
 """
 
 from __future__ import annotations
 
 SCOREBOARD_AUTHORITY = False
 
+import hashlib
+import json
 from dataclasses import dataclass
-from typing import Mapping, Union
+from pathlib import Path
+from typing import Any, Mapping, Union
+
+# Board residual keys this composition must never invent as its own axes.
+FORBIDDEN_BOARD_AXIS_NAMES = frozenset(
+    {
+        "R_construction",
+        "R_desugar",
+        "R_construction_gaps",
+        "functionsClean",
+        "functionsTotal",
+        "R_backend_defects",
+    }
+)
 
 
 class CommitMeasurementError(TypeError):
@@ -67,39 +54,77 @@ class CommitMeasurementError(TypeError):
 def _require_nonempty_str(name: str, value: object) -> str:
     if not isinstance(value, str) or not value.strip():
         raise CommitMeasurementError(
-            f"{name} must be a non-empty str (presenter burden); "
-            f"got {type(value).__name__!r}={value!r}"
+            f"{name} must be a non-empty str; got {type(value).__name__!r}={value!r}"
         )
     return value.strip()
 
 
 def _require_int(name: str, value: object, *, min_value: int | None = None) -> int:
-    if type(value) is not int:  # bool is subclass of int — refuse bool
+    if type(value) is not int:
         raise CommitMeasurementError(
-            f"{name} must be int (not {type(value).__name__}); "
-            f"exit codes and counts are not booleans or floats"
+            f"{name} must be int (not {type(value).__name__})"
         )
     if min_value is not None and value < min_value:
         raise CommitMeasurementError(f"{name} must be >= {min_value}; got {value}")
     return value
 
 
+def content_cid(payload: bytes | str | Mapping[str, Any]) -> str:
+    """Content address for sealed artifacts (blake2b hex, schema-local)."""
+    if isinstance(payload, Mapping):
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    elif isinstance(payload, str):
+        raw = payload.encode("utf-8")
+    else:
+        raw = payload
+    digest = hashlib.blake2b(raw, digest_size=32).hexdigest()
+    return f"blake2b-256:{digest}"
+
+
+def _lookup_path(body: Mapping[str, Any], field_path: str) -> Any:
+    """Dot-path lookup; ``summary.failed`` or ``failedNodeIds`` (len if list)."""
+    cur: Any = body
+    for part in field_path.split("."):
+        if part == "len" and isinstance(cur, (list, tuple, set, dict)):
+            return len(cur)
+        if not isinstance(cur, Mapping) or part not in cur:
+            raise KeyError(field_path)
+        cur = cur[part]
+    if isinstance(cur, (list, tuple)):
+        return len(cur)
+    return cur
+
+
 @dataclass(frozen=True, slots=True)
 class Measured:
-    """A measured axis reading: value with lease/receipt testimony.
+    """Measured axis: value cited from a body artifact under a lease receipt.
 
-    Unconstructible without receipt_cid, collected count, and pre-pipe exit_code.
+    Unconstructible without lease receipt_cid AND body_artifact_cid AND
+    value_field_path. Lease alone does not prove the number.
     """
 
     value: int
     receipt_cid: str
+    body_artifact_cid: str
+    value_field_path: str
     collected: int
     exit_code: int
 
     def __post_init__(self) -> None:
         _require_int("value", self.value, min_value=0)
-        cid = _require_nonempty_str("receipt_cid", self.receipt_cid)
-        object.__setattr__(self, "receipt_cid", cid)
+        object.__setattr__(
+            self, "receipt_cid", _require_nonempty_str("receipt_cid", self.receipt_cid)
+        )
+        object.__setattr__(
+            self,
+            "body_artifact_cid",
+            _require_nonempty_str("body_artifact_cid", self.body_artifact_cid),
+        )
+        object.__setattr__(
+            self,
+            "value_field_path",
+            _require_nonempty_str("value_field_path", self.value_field_path),
+        )
         _require_int("collected", self.collected, min_value=0)
         _require_int("exit_code", self.exit_code)
 
@@ -109,19 +134,113 @@ class Measured:
 
 @dataclass(frozen=True, slots=True)
 class Unmeasured:
-    """Third value: this axis was not measured. Not zero. Not coercible."""
+    """Third value: not measured. Not zero. Not coercible to Measured."""
 
     reason: str
 
     def __post_init__(self) -> None:
-        reason = _require_nonempty_str("reason", self.reason)
-        object.__setattr__(self, "reason", reason)
+        object.__setattr__(
+            self, "reason", _require_nonempty_str("reason", self.reason)
+        )
 
     def is_measured(self) -> bool:
         return False
 
 
 AxisReading = Union[Measured, Unmeasured]
+
+
+def measured(
+    value: int,
+    *,
+    receipt_cid: str,
+    body_artifact_cid: str,
+    value_field_path: str,
+    collected: int,
+    exit_code: int,
+) -> Measured:
+    return Measured(
+        value,
+        receipt_cid,
+        body_artifact_cid,
+        value_field_path,
+        collected,
+        exit_code,
+    )
+
+
+def unmeasured(reason: str) -> Unmeasured:
+    return Unmeasured(reason)
+
+
+def measured_from_sealed_pair(
+    *,
+    commit_sha: str,
+    lease_record: Mapping[str, Any],
+    lease_receipt_cid: str,
+    body: Mapping[str, Any],
+    body_artifact_cid: str,
+    value_field_path: str,
+    collected_field_path: str | None = None,
+    exit_code: int | None = None,
+) -> AxisReading:
+    """Cite-compose one axis from lease receipt + body artifact.
+
+    Returns Unmeasured when lease not acquired, commit mismatch, or body
+    lacks the value field — never Measured without both digests.
+    """
+    sha = _require_nonempty_str("commit_sha", commit_sha)
+    _require_nonempty_str("lease_receipt_cid", lease_receipt_cid)
+    _require_nonempty_str("body_artifact_cid", body_artifact_cid)
+    path = _require_nonempty_str("value_field_path", value_field_path)
+
+    if lease_record.get("acquired") is not True:
+        return unmeasured(
+            f"lease not acquired (acquired={lease_record.get('acquired')!r})"
+        )
+    lease_commit = lease_record.get("commit") or lease_record.get("gitCommit")
+    if isinstance(lease_commit, str) and lease_commit and lease_commit != sha:
+        return unmeasured(
+            f"lease commit {lease_commit!r} != composition commit {sha!r}"
+        )
+    try:
+        raw_value = _lookup_path(body, path)
+    except KeyError:
+        return unmeasured(f"body missing value field {path!r}")
+    if type(raw_value) is not int or raw_value < 0:
+        return unmeasured(
+            f"body field {path!r} is not a non-negative int: {raw_value!r}"
+        )
+    collected = 0
+    if collected_field_path:
+        try:
+            c = _lookup_path(body, collected_field_path)
+            if type(c) is int and c >= 0:
+                collected = c
+        except KeyError:
+            return unmeasured(f"body missing collected field {collected_field_path!r}")
+    else:
+        # Prefer suite-report totals.collected when present
+        try:
+            c = _lookup_path(body, "totals.collected")
+            if type(c) is int and c >= 0:
+                collected = c
+        except KeyError:
+            collected = 0
+    code = exit_code
+    if code is None:
+        status = lease_record.get("measurementStatus") or ""
+        code = 0 if status == "completed/zero-findings" else 1
+    if type(code) is not int:
+        return unmeasured(f"exit_code not int: {code!r}")
+    return measured(
+        raw_value,
+        receipt_cid=lease_receipt_cid,
+        body_artifact_cid=body_artifact_cid,
+        value_field_path=path,
+        collected=collected,
+        exit_code=code,
+    )
 
 
 def _require_axes_map(axes: object) -> dict[str, AxisReading]:
@@ -132,11 +251,16 @@ def _require_axes_map(axes: object) -> dict[str, AxisReading]:
     out: dict[str, AxisReading] = {}
     for name, reading in axes.items():
         key = _require_nonempty_str("axis name", name)
+        if key in FORBIDDEN_BOARD_AXIS_NAMES or key.startswith("R_construction"):
+            raise CommitMeasurementError(
+                f"axis {key!r} is a corpus-board residual name; "
+                f"CommitMeasurement is cite-compose only "
+                f"(SCOREBOARD_AUTHORITY=False). Use control_effect_recensus."
+            )
         if not isinstance(reading, (Measured, Unmeasured)):
             raise CommitMeasurementError(
-                f"axis {key!r}: reading must be Measured or Unmeasured; "
-                f"got {type(reading).__name__} — there is no third construction "
-                f"path and no blank/green default"
+                f"axis {key!r}: must be Measured or Unmeasured; "
+                f"got {type(reading).__name__}"
             )
         out[key] = reading
     return out
@@ -144,8 +268,6 @@ def _require_axes_map(axes: object) -> dict[str, AxisReading]:
 
 @dataclass(frozen=True, slots=True)
 class CompleteVector:
-    """Every axis Measured. The only shape that may report a total."""
-
     commit_sha: str
     roster_cid: str
     axes: Mapping[str, Measured]
@@ -162,27 +284,46 @@ class CompleteVector:
         sealed: dict[str, Measured] = {}
         for name, reading in self.axes.items():
             key = _require_nonempty_str("axis name", name)
+            if key in FORBIDDEN_BOARD_AXIS_NAMES:
+                raise CommitMeasurementError(f"forbidden board axis {key!r}")
             if not isinstance(reading, Measured):
                 raise CommitMeasurementError(
-                    f"CompleteVector refuses Unmeasured axis {key!r}; "
-                    f"use PartialVector or supply a Measured reading"
+                    f"CompleteVector refuses Unmeasured axis {key!r}"
                 )
             sealed[key] = reading
         object.__setattr__(self, "axes", sealed)
 
     @property
     def total(self) -> int:
-        """Sum of measured R values. Exists only when every axis is Measured."""
-        return sum(reading.value for reading in self.axes.values())
+        return sum(r.value for r in self.axes.values())
 
     def is_complete(self) -> bool:
         return True
 
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "kind": "commit-measurement",
+            "status": "complete",
+            "commitSha": self.commit_sha,
+            "rosterCid": self.roster_cid,
+            "total": self.total,
+            "axes": {
+                name: {
+                    "status": "measured",
+                    "value": r.value,
+                    "receiptCid": r.receipt_cid,
+                    "bodyArtifactCid": r.body_artifact_cid,
+                    "valueFieldPath": r.value_field_path,
+                    "collected": r.collected,
+                    "exitCode": r.exit_code,
+                }
+                for name, r in self.axes.items()
+            },
+        }
+
 
 @dataclass(frozen=True, slots=True)
 class PartialVector:
-    """At least one Unmeasured axis. No total — the method does not exist."""
-
     commit_sha: str
     roster_cid: str
     axes: Mapping[str, AxisReading]
@@ -197,8 +338,7 @@ class PartialVector:
         sealed = _require_axes_map(self.axes)
         if not any(isinstance(r, Unmeasured) for r in sealed.values()):
             raise CommitMeasurementError(
-                "PartialVector requires at least one Unmeasured axis; "
-                "all-Measured vectors are CompleteVector (use commit_measurement)"
+                "PartialVector requires ≥1 Unmeasured; use CompleteVector"
             )
         object.__setattr__(self, "axes", sealed)
 
@@ -207,13 +347,35 @@ class PartialVector:
 
     def unmeasured_axes(self) -> tuple[str, ...]:
         return tuple(
-            name
-            for name, reading in self.axes.items()
-            if isinstance(reading, Unmeasured)
+            n for n, r in self.axes.items() if isinstance(r, Unmeasured)
         )
 
+    def to_json(self) -> dict[str, Any]:
+        axes_out: dict[str, Any] = {}
+        for name, r in self.axes.items():
+            if isinstance(r, Measured):
+                axes_out[name] = {
+                    "status": "measured",
+                    "value": r.value,
+                    "receiptCid": r.receipt_cid,
+                    "bodyArtifactCid": r.body_artifact_cid,
+                    "valueFieldPath": r.value_field_path,
+                    "collected": r.collected,
+                    "exitCode": r.exit_code,
+                }
+            else:
+                axes_out[name] = {"status": "unmeasured", "reason": r.reason}
+        return {
+            "kind": "commit-measurement",
+            "status": "partial",
+            "commitSha": self.commit_sha,
+            "rosterCid": self.roster_cid,
+            # deliberately no "total" key
+            "unmeasuredAxes": list(self.unmeasured_axes()),
+            "axes": axes_out,
+        }
 
-# Public alias for the composition: either complete or partial.
+
 CommitMeasurement = Union[CompleteVector, PartialVector]
 
 
@@ -222,32 +384,116 @@ def commit_measurement(
     roster_cid: str,
     axes: Mapping[str, AxisReading],
 ) -> CommitMeasurement:
-    """ONE DOOR for commit measurement state.
-
-    Returns CompleteVector when every axis is Measured (``.total`` available).
-    Returns PartialVector when any axis is Unmeasured (no total).
-    """
+    """ONE DOOR: CompleteVector if all Measured, else PartialVector (no total)."""
     sha = _require_nonempty_str("commit_sha", commit_sha)
     roster = _require_nonempty_str("roster_cid", roster_cid)
     sealed = _require_axes_map(axes)
     if any(isinstance(r, Unmeasured) for r in sealed.values()):
         return PartialVector(sha, roster, sealed)
-    measured = {name: reading for name, reading in sealed.items()}
-    # type narrowed: all Measured
-    return CompleteVector(sha, roster, measured)  # type: ignore[arg-type]
+    return CompleteVector(sha, roster, sealed)  # type: ignore[arg-type]
 
 
-def measured(
-    value: int,
+def _load_json(path: Path) -> Mapping[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return payload if isinstance(payload, Mapping) else None
+
+
+def _lease_from_payload(payload: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    if "leaseRecord" in payload and isinstance(payload["leaseRecord"], Mapping):
+        return payload["leaseRecord"]
+    if "leaseClass" in payload or "acquired" in payload:
+        return payload
+    return None
+
+
+# Per-commit tip axes only (nightlies are a different obligation).
+TIP_AXIS_SPECS: tuple[tuple[str, str, str], ...] = (
+    # axis_name, leaseClass, value_field_path on body
+    ("python-package-suite", "python-package-suite", "totals.failed"),
+    (
+        "python-sole-construction-floors",
+        "python-sole-construction-floors",
+        "totals.failed",
+    ),
+)
+
+
+def compose_tip_from_receipts_dir(
+    commit_sha: str,
+    receipts_dir: Path,
     *,
-    receipt_cid: str,
-    collected: int,
-    exit_code: int,
-) -> Measured:
-    """Named door for Measured (keyword-forced testimony fields)."""
-    return Measured(value, receipt_cid, collected, exit_code)
+    roster_cid: str = "heavy-roster:per-commit",
+) -> CommitMeasurement:
+    """Cite-compose tip axes from a directory of downloaded artifacts.
 
+    For each enrolled per-commit class: find a lease-acquired receipt and a
+    body (suite-report style JSON). Missing either → Unmeasured for that axis.
+    Never recomputes product residual; values are field-paths on sealed bodies.
+    """
+    sha = _require_nonempty_str("commit_sha", commit_sha)
+    root = Path(receipts_dir)
+    # Index lease records and body reports by leaseClass / presence
+    leases: dict[str, tuple[Path, Mapping[str, Any]]] = {}
+    bodies: list[tuple[Path, Mapping[str, Any]]] = []
+    if root.is_dir():
+        for path in sorted(root.rglob("*.json")):
+            payload = _load_json(path)
+            if payload is None:
+                continue
+            lease = _lease_from_payload(payload)
+            if lease is not None and lease.get("leaseClass"):
+                cls = str(lease["leaseClass"])
+                # Prefer acquired true if multiple
+                prev = leases.get(cls)
+                if prev is None or lease.get("acquired") is True:
+                    leases[cls] = (path, lease)
+            # Body candidates: have totals or failedNodeIds
+            if "totals" in payload or "failedNodeIds" in payload:
+                bodies.append((path, payload))
 
-def unmeasured(reason: str) -> Unmeasured:
-    """Named door for Unmeasured — absence with a named reason."""
-    return Unmeasured(reason)
+    axes: dict[str, AxisReading] = {}
+    for axis_name, lease_class, value_path in TIP_AXIS_SPECS:
+        if lease_class not in leases:
+            axes[axis_name] = unmeasured(
+                f"no lease receipt for class {lease_class!r} at commit {sha}"
+            )
+            continue
+        lease_path, lease_rec = leases[lease_class]
+        lease_cid = content_cid(lease_rec)
+        # Body: embed on same file, or separate suite-report in same run dir
+        body_path: Path | None = None
+        body: Mapping[str, Any] | None = None
+        full = _load_json(lease_path)
+        if full and ("totals" in full or "failedNodeIds" in full):
+            body_path, body = lease_path, full
+        else:
+            run_dir = lease_path.parent
+            for cand in sorted(run_dir.rglob("*.json")):
+                payload = _load_json(cand)
+                if payload and ("totals" in payload or "failedNodeIds" in payload):
+                    body_path, body = cand, payload
+                    break
+            if body is None:
+                # last resort: any body in tree with matching commit field
+                for bpath, bpay in bodies:
+                    if bpay.get("gitCommit") == sha or bpay.get("commit") == sha:
+                        body_path, body = bpath, bpay
+                        break
+        if body is None or body_path is None:
+            axes[axis_name] = unmeasured(
+                f"lease present for {lease_class!r} but no body artifact "
+                f"(suite-report / floor report) — Measured requires both"
+            )
+            continue
+        axes[axis_name] = measured_from_sealed_pair(
+            commit_sha=sha,
+            lease_record=lease_rec,
+            lease_receipt_cid=lease_cid,
+            body=body,
+            body_artifact_cid=content_cid(body),
+            value_field_path=value_path,
+        )
+    return commit_measurement(sha, roster_cid, axes)

--- a/tools/commit_measurement_gate.py
+++ b/tools/commit_measurement_gate.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Gate: tip measurement composition is required, not advisory.
+
+Exit 1 if:
+  - composition file missing / unreadable (silence ≠ clean)
+  - status is partial (any Unmeasured) when --require-complete
+  - JSON claims a total while status is partial (lie)
+
+Exit 0 only for CompleteVector (--require-complete) or any readable composition
+when --require-complete is omitted (inspect mode).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--composition",
+        type=Path,
+        required=True,
+        help="path to commit-measurement.json from compose_tip_from_receipts_dir",
+    )
+    parser.add_argument(
+        "--require-complete",
+        action="store_true",
+        help="red unless status==complete (every tip axis Measured)",
+    )
+    args = parser.parse_args(argv)
+    path = args.composition
+    if not path.is_file():
+        print(
+            f"commit-measurement-gate RED: composition missing at {path} "
+            f"(silence is not a clean tip — Unmeasured by absence)",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"commit-measurement-gate RED: unreadable {path}: {exc}", file=sys.stderr)
+        return 1
+    if not isinstance(payload, dict) or payload.get("kind") != "commit-measurement":
+        print(
+            f"commit-measurement-gate RED: {path} is not a commit-measurement object",
+            file=sys.stderr,
+        )
+        return 1
+    status = payload.get("status")
+    if status == "partial" and "total" in payload:
+        print(
+            "commit-measurement-gate RED: partial composition claims total "
+            "(total while Unmeasured is a lie)",
+            file=sys.stderr,
+        )
+        return 1
+    if args.require_complete:
+        if status != "complete":
+            unmeasured = payload.get("unmeasuredAxes") or list(
+                (payload.get("axes") or {}).keys()
+            )
+            print(
+                f"commit-measurement-gate RED: require-complete but status={status!r} "
+                f"unmeasuredAxes={unmeasured!r}",
+                file=sys.stderr,
+            )
+            return 1
+        if "total" not in payload:
+            print(
+                "commit-measurement-gate RED: complete composition missing total",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"commit-measurement-gate GREEN: complete total={payload.get('total')} "
+            f"commit={payload.get('commitSha')}"
+        )
+        return 0
+    print(f"commit-measurement-gate OK: status={status} (not require-complete)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Advisor-conditional greenlight — conditions met

1. **Cite-compose only.** `SCOREBOARD_AUTHORITY = False`. Constructor forbids corpus-board axis names (`R_construction`, …). Values are **field-paths on sealed body artifacts**, never recomputed product residual. Not a second `control_effect_recensus`.

2. **Lease + body.** `Measured` requires `receipt_cid` **and** `body_artifact_cid` + `value_field_path`. Lease without suite-report/floor body → `Unmeasured` (today's package-suite: ran, no report).

3. **Required, not advisory.** After roll call, `heavy-measurement-attendance.yml` writes `commit-measurement.json` and runs `commit_measurement_gate.py --require-complete` (missing/partial → red).

## Type

| | |
| --- | --- |
| `Measured` | value + lease CID + body CID + field path + collected + exit_code |
| `Unmeasured` | third value, not zero |
| `CompleteVector` | all Measured → `.total` |
| `PartialVector` | any Unmeasured → **no** `.total` |
| One door | `commit_measurement` / `compose_tip_from_receipts_dir` |

## Shell deleted

Silence / missing report readable as clean tip; lease-only “Measured” without body; total while Unmeasured.

## Shot accounting

| | |
| --- | --- |
| R axis | false tip totals / silence-as-green |
| Epsilon R | class unwritable at type + gate |
| Floors | board authority untouched; lease take-door unchanged |
| Shell deleted | sum-without-measurement; advisory tip status |

## Not redundant with roll call + lease

Roll call: who spoke. Lease gate: zero-claim / acquired. Suite-report: one class body. **Missing noun:** multi-axis tip composition where total is uncallable while any owed axis is Unmeasured.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit `CommitMeasurement` total only when every axis is `Measured`
> - Introduces [commit_measurement.py](https://github.com/TSavo/sugar/pull/6980/files#diff-034ed16ba84c4a527a93fb4c6f2ee50b10a1a08d9cb122bd440105312d686c07) with `Measured`/`Unmeasured` axis readings, `CompleteVector` (all axes measured, exposes `total`) and `PartialVector` (≥1 unmeasured, no `total`), and `compose_tip_from_receipts_dir` which scans a receipts directory and produces the appropriate vector for a given commit SHA.
> - Adds [commit_measurement_gate.py](https://github.com/TSavo/sugar/pull/6980/files#diff-b5a5858eb37eabbca47615ba3529b03368c226cfea4392c0580b83a94477b8fb), a CLI that reads a composition JSON and exits non-zero when the composition is missing, invalid, or incomplete under `--require-complete`.
> - Updates the [heavy-measurement-attendance workflow](https://github.com/TSavo/sugar/pull/6980/files#diff-e038313cc9be78cc03fb254cab8aa7e5cbb1e338f5bc9ce90795d14f0291285f) to compose a `commit-measurement.json` from collected receipts after attendance and run the gate with `--require-complete`, failing the job if the composition is partial or absent.
> - Adds unit tests in [test_commit_measurement.py](https://github.com/TSavo/sugar/pull/6980/files#diff-81137490bc719fa11ba8c7349e84cb97bb1d5af5bf7c7d3e404b8922ef063a32) covering construction validation, `measured_from_sealed_pair` semantics, vector totals, and gate CLI exit codes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 271594c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->