### PR TITLE
Drain residual self-sealing teeth (R=2→0); fix parent vector citation

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/law_of_one_vector_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/law_of_one_vector_law.py
@@ -123,6 +123,7 @@ def _cite_self_sealing(repo: Path) -> Citation:
     if err:
         return Citation("instrument", "self_sealing", rel, -1, {}, [err], "missing_owner" if "missing" in err else "collect_error")
     try:
+        # roots default inside scan_roots — never omit via wrong kwargs only.
         findings, errors = mod.scan_roots(repo=repo)
         by = {}
         for f in findings:

--- a/implementations/python/sugar-lift-py-tests/scripts/self_sealing_instrument_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/self_sealing_instrument_law.py
@@ -385,15 +385,21 @@ def _source_files(roots: Iterable[Path]) -> list[Path]:
 
 
 def scan_roots(
-    roots: Iterable[Path], *, repo: Path | None = None
+    roots: Iterable[Path] | None = None, *, repo: Path | None = None
 ) -> tuple[list[Finding], list[str]]:
+    """Scan instrument roots. ``roots`` defaults to ``_default_roots(repo)``.
+
+    Parent vector citations call ``scan_roots(repo=repo)`` — roots must be
+    optional so a missing-arg TypeError cannot silently zero the axis.
+    """
     base = (repo or Path.cwd()).resolve()
+    scan_paths = tuple(roots) if roots is not None else _default_roots(base)
     findings: list[Finding] = []
     errors: list[str] = []
     # Never audit this script as an offender source of examples in docstrings
     # with executable code — docstrings are not AST statements. Fine.
     self_path = Path(__file__).resolve()
-    for path in _source_files(roots):
+    for path in _source_files(scan_paths):
         if path.resolve() == self_path:
             continue
         label = (

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_effect_coordinate_required.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_effect_coordinate_required.py
@@ -1,13 +1,14 @@
 """Constructor law: RaiseEffect refuses nameless authenticated exits.
 
 Shell deleted: presence-only ``assert effect.exception_type_coordinate is not None``
-teeth on successful RaiseEffect paths — the type carries the law now.
+(and mro presence) teeth — the type / for_builtin door carry the law; pin identity.
 """
 
 from __future__ import annotations
 
 import pytest
 
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.effect.raise_effect import (
     RaiseEffect,
     UndeterminedRaiseEffect,
@@ -16,19 +17,39 @@ from sugar_lift_py_tests.effect.raise_effect import (
 
 def test_raise_effect_refuses_none_coordinate() -> None:
     with pytest.raises(TypeError, match="refuses exception_type_coordinate=None"):
-        RaiseEffect(exception_type_coordinate=None, occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_raise_effect_coordinate_required.py:19:0'))  # type: ignore[arg-type]
+        RaiseEffect(  # type: ignore[arg-type]
+            exception_type_coordinate=None,
+            occurrence=AuthenticatedRaiseLocus.of(
+                "implementations/python/sugar-lift-py-tests/tests/"
+                "test_raise_effect_coordinate_required.py:refuses_none"
+            ),
+        )
 
 
 def test_raise_effect_requires_coordinate_argument() -> None:
     with pytest.raises(TypeError):
-        RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_raise_effect_coordinate_required.py:24:0'), exception_name='ValueError')  # type: ignore[call-arg]
+        RaiseEffect(  # type: ignore[call-arg]
+            occurrence=AuthenticatedRaiseLocus.of(
+                "implementations/python/sugar-lift-py-tests/tests/"
+                "test_raise_effect_coordinate_required.py:requires_coord"
+            ),
+            exception_name="ValueError",
+        )
 
 
 def test_for_builtin_mints_authenticated_coordinate() -> None:
-    effect = RaiseEffect.for_builtin('ValueError', blame='t.py:1:0', occurrence='t.py:1:0')
+    """Value pin — not presence. Constructor already forbids None coordinate."""
+    from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
+
+    expected_coord, expected_mro = _builtin_exception_identity("ValueError")
+    effect = RaiseEffect.for_builtin(
+        "ValueError", blame="t.py:1:0", occurrence="t.py:1:0"
+    )
     assert effect.exception_name == "ValueError"
-    assert effect.exception_type_coordinate is not None
-    assert effect.exception_type_mro is not None
+    assert effect.exception_type_coordinate == expected_coord
+    # for_builtin one door always mints MRO with the type coordinate; pin it.
+    assert effect.exception_type_mro == expected_mro
+    assert effect.occurrence.value == "t.py:1:0"
 
 
 def test_undetermined_cannot_impersonate_raise_effect() -> None:
@@ -40,4 +61,10 @@ def test_undetermined_cannot_impersonate_raise_effect() -> None:
 
 def test_for_builtin_unknown_name_throws() -> None:
     with pytest.raises(TypeError, match="no language-owned"):
-        RaiseEffect.for_builtin('NotARealExceptionType123', occurrence='implementations/python/sugar-lift-py-tests/tests/test_raise_effect_coordinate_required.py:43:0')
+        RaiseEffect.for_builtin(
+            "NotARealExceptionType123",
+            occurrence=(
+                "implementations/python/sugar-lift-py-tests/tests/"
+                "test_raise_effect_coordinate_required.py:unknown"
+            ),
+        )


### PR DESCRIPTION
## Summary

**R axis:** `self_sealing_instruments` (#6958 class)
**Live R before:** 2 (instrument on `origin/main` @ 663d61f0f) — not 94
**Predicted Epsilon R:** 2 → 0
**Floors preserved:** no presence tooth deleted without value pin / constructor law; auditor still red on new offenders

### Why not 94

`#6964` + dual RaiseEffect constructors already drained the 93 PRESENCE-ONLY sites. Live `self_sealing_instrument_law.py` reports **R=2**. The stale ~94 reading was a **parent-vector collect_error**: `_cite_self_sealing` called `scan_roots(repo=repo)` while `roots` was required, so the citation failed and the axis was not measured (false silence / wrong vector).

### Partition of the live set (doctrine first)

| Bucket | N | Meaning |
|--------|--:|--------|
| **(a)** constructor / door kills | **2** | tooth must not exist — type/door already carries the law |
| **(b)** missing object, not yet built | **0** | — |
| **(c)** genuinely open membrane | **0** | — |
| **Total** | **2** | same shape as mr_blue's 93: (c)=0 |

Both sites in `test_raise_effect_coordinate_required.py` (the constructor-law test itself):

1. `assert effect.exception_type_coordinate is not None` → **(a)**  
   Object already exists: `RaiseEffect.exception_type_coordinate: Term` (required). Rung: **type**. Shell deleted: presence tooth; pin `== _builtin_exception_identity(...)[0]`.
2. `assert effect.exception_type_mro is not None` → **(a)**  
   Object: `for_builtin` one door always mints MRO with the coordinate. Rung: **one door**. Shell deleted: presence tooth; pin `== expected_mro`. Residual product: field still `tuple \| None` on the dataclass — further climb would make MRO non-optional on authenticated faces; not required to retire this self-sealing tooth.

### Citation fix (measurement integrity)

- `scan_roots(roots=None, *, repo=...)` defaults to `_default_roots(repo)` so parent vector cannot TypeError into collect_error.
- Parent now cites `R_instrument_self_sealing_cited = 0` honestly.

### Shell deleted

Presence-only asserts on coordinate/MRO after constructors land; silent parent-vector collect_error on the self_sealing axis.

## Validation

```
/usr/bin/python3 .../self_sealing_instrument_law.py --repo .
# EXIT=0; R_self_sealing_instruments = 0
```

No local pytest (watchdog). No bx. CI on main-push is the measurement path.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `roots` optional in `scan_roots` and fix parent vector citation
> - Makes `roots` an optional parameter in [`scan_roots`](https://github.com/TSavo/sugar/pull/6981/files#diff-b81899fd79a18842310e1502510f2e1b27e9097d08d0afc7379b556c7fdb7f69), defaulting to `_default_roots(base)` when not provided, eliminating a `TypeError` on bare calls.
> - Adds an inline comment in [`law_of_one_vector_law.py`](https://github.com/TSavo/sugar/pull/6981/files#diff-35f84b4606a8d139e4bd1f14c3c42248a1dd0a1d03ec2184c2279877a63ca6cd) clarifying that `roots` must not be passed as a kwarg since `scan_roots` defaults it internally.
> - Updates tests in [`test_raise_effect_coordinate_required.py`](https://github.com/TSavo/sugar/pull/6981/files#diff-4bdc51251cabf08212d3705400537a08eb02ecb60a74fd5065ec2e797c0cca2c) to construct occurrences via `AuthenticatedRaiseLocus.of` and adds exact equality assertions for the minted exception coordinate and MRO.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 094d662.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->