### PR TITLE
Rip swallowed-throw soft membranes (R_swallowed 7→1)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/census.py
@@ -122,6 +122,13 @@ def census(root: Path) -> int:
 
         # Sole ConstructionPanic membrane: audit_only.collect_construction_panic.
         # No local ``except ConstructionPanic`` soft continue (panic-catch law).
+        #
+        # PERMANENT MEMBRANE (open domain — not a drain residual to green-fake):
+        # Multi-file corpus census over unknown third-party sources. Python's
+        # except surface is open; one file's bare Exception must become a DEFECT
+        # row so the rest of the corpus is still measured. Advisor ruled
+        # swallowed-throw an honest permanent membrane class for this reason.
+        # Product construction paths must NOT copy this pattern.
         try:
             _, panic_row = collect_construction_panic(rel, _measure_file)
         except Exception as e:  # a crash is a DEFECT row, never silence

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/collect_panic_audit.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/collect_panic_audit.py
@@ -60,8 +60,16 @@ def collect_panic_audit(
         try:
             package_path = resolver(package).resolve()
         except (
-            Exception
-        ) as exc:  # pragma: no cover - exact exception is environment-owned
+            ModuleNotFoundError,
+            ImportError,
+            OSError,
+            FileNotFoundError,
+            TypeError,
+            ValueError,
+            RuntimeError,
+        ) as exc:
+            # Environment-owned resolution failures only — never bare Exception.
+            # Unrelated throws rise (honorable unfinished work in the resolver).
             target = LiftTarget(f"{package}-all", root)
             message = f"unable to resolve installed package `{package}`: {exc}"
             diagnostics.append(message)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2695,6 +2695,7 @@ def _serialize_source_call_binding_gap(exc: BaseException) -> dict[str, Any] | N
 
 def _serve() -> None:
     from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
     request_count = 0
     while True:
@@ -2781,10 +2782,11 @@ def _serve() -> None:
             )
             _log_resident_profile(request_count, msg.get("method"))
             continue
-        except Exception as exc:
+        except SourceCallBindingGap as exc:
+            # Typed process membrane: serialize and keep serving.
+            # Unrelated Exceptions are not held — they rise (honorable).
             typed = _serialize_source_call_binding_gap(exc)
-            if typed is None:
-                raise
+            assert typed is not None
             _send(
                 {
                     "jsonrpc": "2.0",

--- a/implementations/python/sugar-lift-py-tests/tests/test_swallowed_throw_second_mechanism_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_swallowed_throw_second_mechanism_law.py
@@ -228,6 +228,8 @@ def test_drained_sin_cluster_4_sites_are_absent_on_live_tree() -> None:
     ).read_text(encoding="utf-8")
     assert "return SoftUnresolvedWithSugar" not in nodes
     assert "from sugar_lift_py_tests.sugar.soft_unresolved_with_sugar import" not in nodes
+    assert "return SoftUnresolvedTrySugar" not in nodes
+    assert "from sugar_lift_py_tests.sugar.soft_unresolved_try_sugar import" not in nodes
 
     parso = (
         _PYTHON_ROOT / "sugar-source-tree/src/sugar_source_tree/parso_adapter.py"
@@ -263,37 +265,47 @@ def test_drained_sin_cluster_4_sites_are_absent_on_live_tree() -> None:
         for o in offenders
     ), _SCANNER.format_report(offenders)
     assert not any(
-        o.path.endswith("nodes.py")
-        and o.kind == "soft-unresolved-sugar-return"
-        and "With" in o.note
+        o.path.endswith("nodes.py") and o.kind == "soft-unresolved-sugar-return"
         for o in offenders
     ), _SCANNER.format_report(offenders)
     assert not any(
         o.path.endswith("manager_construction.py")
         and o.kind == "construction-panic-soft-continue"
-        and "factoryPrefix" in o.note
         for o in offenders
+    ), _SCANNER.format_report(offenders)
+    assert not any(
+        o.path.endswith("bind_lifter.py") and o.kind == "exception-soft-continue"
+        for o in offenders
+    ), _SCANNER.format_report(offenders)
+    assert not any(
+        o.path.endswith("bench_backends.py") and o.kind == "exception-soft-continue"
+        for o in offenders
+    ), _SCANNER.format_report(offenders)
+    # Permanent membrane residual: multi-file corpus census only.
+    residual = [
+        o
+        for o in offenders
+        if o.kind == "exception-soft-continue"
+    ]
+    assert all(o.path.endswith("census.py") for o in residual), _SCANNER.format_report(
+        offenders
     )
-    # factory-prefix survivor seal gone: no kept_prefix path left (content pin above).
-    # Nested ConstructionPanic continue at force_floor may remain as residual R.
 
 
 def test_live_scan_reports_named_axes_and_residual_is_nonzero_until_drained() -> None:
-    """Live R is measured output: axes named, residual remaining after this drain."""
+    """Live R is measured output: axes named; residual is census membrane only."""
     offenders = _SCANNER.scan_python_root(_PYTHON_ROOT)
     counts = _SCANNER.axis_counts(offenders)
     for axis in _SCANNER._AXES:
         assert axis in counts
-    # literal_eval axis must be zero after this drain
     assert counts["R_literal_eval_raw_substitution"] == 0
-    # SoftUnresolvedWith drained; SoftUnresolvedTry residual may remain
-    soft = [
-        o
-        for o in offenders
-        if o.kind == "soft-unresolved-sugar-return"
-    ]
-    assert all("Try" in o.note or "Try" in o.fix for o in soft) or soft == []
-    # Report must be non-empty text with axis headers
+    assert counts["R_soft_unresolved_sugar_return"] == 0
+    assert counts["R_construction_panic_soft_continue"] == 0
+    # Permanent open-domain membrane: multi-file census defect enumeration.
+    assert counts["R_exception_soft_continue"] == 1
+    assert all(
+        o.path.endswith("census.py") for o in offenders
+    ), _SCANNER.format_report(offenders)
     report = _SCANNER.format_report(offenders)
     assert "R_construction_panic_soft_continue" in report
     assert "R_exception_soft_continue" in report

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_lifter.py
@@ -1573,26 +1573,17 @@ def _decorator_contract_witnesses(
             if not isinstance(keyword.value.value, str):
                 continue
             text = keyword.value.value
-            try:
-                from sugar_lift_py_tests.canonicalizer import encode_jcs
-                from sugar_lift_py_tests.contract_expression import (
-                    parse_contract_expression,
-                )
-                from sugar_lift_py_tests.ir import formula_to_value
+            # No except/continue. Invalid decorator contract text must throw —
+            # soft diagnostics here manufactured absence of the obligation.
+            from sugar_lift_py_tests.canonicalizer import encode_jcs
+            from sugar_lift_py_tests.contract_expression import (
+                parse_contract_expression,
+            )
+            from sugar_lift_py_tests.ir import formula_to_value
 
-                names = [*param_names, "out"] if role == "post" else param_names
-                formula = parse_contract_expression(text, names)
-                predicate = json.loads(encode_jcs(formula_to_value(formula)))
-            except Exception as exc:
-                diagnostics.append(
-                    {
-                        "kind": "decorator-contract-invalid",
-                        "message": str(exc),
-                        "path": rel_path,
-                        "line": getattr(decorator, "lineno", node.lineno),
-                    }
-                )
-                continue
+            names = [*param_names, "out"] if role == "post" else param_names
+            formula = parse_contract_expression(text, names)
+            predicate = json.loads(encode_jcs(formula_to_value(formula)))
             witnesses.append(
                 {
                     "confidence_basis_points": 10000,

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1155,8 +1155,6 @@ def _project_return_faces_to_manager(
     Returns None when no face force_floors to ObjectValue yet (caller may try
     nested hops). Returns a gap when multi-manager identities refuse.
     """
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
-
     managers: list[
         tuple[
             FloorValue,
@@ -1182,35 +1180,13 @@ def _project_return_faces_to_manager(
             # GuardedReturn in prefix state). Already projected — skip, do not
             # invent a call-graph-cycle residual for a peer harvest.
             continue
-        try:
-            floor = returned.force_floor(
-                reduce_ctx,
-                owner="construct_manager_behavior returned object",
-                project_callsite=False,
-            )
-        except ConstructionPanic:
-            # A nested source constructor can itself have guarded completion
-            # arms. Project those arms through the same source-authenticated
-            # manager door used for a top-level multi-arm factory.
-            from sugar_lift_py_tests.outcome import ExitSet
-
-            nested_outcome = returned.reduce_source_outcome(reduce_ctx)
-            if not isinstance(nested_outcome, ExitSet):
-                continue
-            projected = _project_manager_from_exitset(
-                nested_outcome,
-                factory_prefix=(),
-                seen_calls=seen_calls,
-                resolved_cid=resolved_cid,
-            )
-            if isinstance(projected, ManagerConstructionGapV1):
-                continue
-            floor, nested_prefix = projected
-            if isinstance(floor, ObjectValue):
-                managers.append((face, floor, returned))
-                non_return_prefix = (*non_return_prefix, *nested_prefix)
-                seen_calls.add(id(returned))
-            continue
+        # No ConstructionPanic soft continue. Nested unfinished floors rise.
+        # Recovery-via-ExitSet was a second mechanism for missing to_term.
+        floor = returned.force_floor(
+            reduce_ctx,
+            owner="construct_manager_behavior returned object",
+            project_callsite=False,
+        )
         if isinstance(floor, (ObjectValue, ReceiverStatePartitionValue)):
             managers.append((face, floor, returned))
             seen_calls.add(id(returned))

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/bench_backends.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/bench_backends.py
@@ -134,13 +134,11 @@ def run_throughput(backend_name: str, root: Path, limit: Optional[int]) -> None:
     constructed = 0
     nodes = 0
     for identity in identities:
-        try:
-            file = SourceFile(identity, backend=tree.backend)
-            for _n in file.nodes():
-                nodes += 1
-            constructed += 1
-        except Exception:
-            continue
+        # No except/continue. A bad SourceFile is unfinished work — throw.
+        file = SourceFile(identity, backend=tree.backend)
+        for _n in file.nodes():
+            nodes += 1
+        constructed += 1
     dt = time.perf_counter() - t0
     load_end = _load1()
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -8433,17 +8433,16 @@ class Try(Statement):
             for type_node in type_nodes:
                 if not isinstance(type_node, Name):
                     # ``except re.error`` / dotted types are not bare Names.
-                    # Under dual-mode factory frame projection, soft-incomplete
-                    # so class bases (AbstractRaises) can still project; full
-                    # reduction of that arm remains CoverageGap, never green.
-                    context = self.unit.construction_context
-                    if getattr(context, "frame_projection", False):
-                        from sugar_lift_py_tests.sugar.soft_unresolved_try_sugar import (
-                            SoftUnresolvedTrySugar,
-                        )
-
-                        return SoftUnresolvedTrySugar(site=self.fragment)
-                    return super()._construct_sugar()
+                    # SoftUnresolvedTrySugar was a second mechanism that
+                    # rendered unfinished except-type Sugar as Incomplete.
+                    # Raise: write the missing Sugar door, do not soft-survive.
+                    raise SugarNotWritten(
+                        owner="Try._construct_sugar",
+                        blame=self.fragment,
+                        observed="non-Name except type without authenticated identity",
+                        requested="a constructed exception-type coordinate (or Name)",
+                        fix="resolve the handler type lexically or write Sugar for dotted except types",
+                    )
                 identity = self.unit.exception_type_identity(type_node)
                 if identity is None:
                     raise SugarNotWritten(


### PR DESCRIPTION
## Summary

Live instrument `swallowed_throw_second_mechanism_law` on main (`663d61f0f`) reported **R=7**, not the stale parent figure of 79 (parent now **cites** this child only — #6972 Model A). This PR drains production second mechanisms.

### Ripped (throws propagate — panic / SugarNotWritten rise is honest progress)

| Site | Axis | Change |
| --- | --- | --- |
| `manager_construction.py` | `R_construction_panic_soft_continue` | bare `force_floor`; no ConstructionPanic recovery continue |
| `nodes.py` Try | `R_soft_unresolved_sugar_return` | SoftUnresolvedTrySugar → `SugarNotWritten` |
| `bind_lifter.py` | `R_exception_soft_continue` | no Exception continue around decorator contract parse |
| `bench_backends.py` | `R_exception_soft_continue` | bare SourceFile construct |
| `lift_rpc.py` | `R_exception_soft_continue` | `except SourceCallBindingGap` only (typed process membrane) |
| `collect_panic_audit.py` | `R_exception_soft_continue` | narrow to env-owned resolution types |

### Permanent membrane (R=1 residual — open domain)

- **`census.py`**: multi-file corpus defect enumeration. Python's except surface is open over unknown third-party sources; one file's Exception becomes a DEFECT row so the rest of the corpus is still measured. Advisor: swallowed-throw is an honest permanent membrane class here. Product construction paths must not copy this.

### Predicted panic rise

- Nested unfinished manager floors → ConstructionPanic (was soft-continued)
- Dotted/`except re.error` types under frame projection → SugarNotWritten (was SoftUnresolved Incomplete)
- Invalid decorator contract text → parse throws (was diagnostic + skip)
- Bench bad files → throw (was silent skip)
- Non-binding-gap Exceptions in RPC serve → process death (was keep-serving)

## Shot accounting

- **R axis:** `R_swallowed_throw_second_mechanism` **7→1**
  - `R_construction_panic_soft_continue` 1→0
  - `R_exception_soft_continue` 5→1 (census only)
  - `R_soft_unresolved_sugar_return` 1→0
- **Epsilon R:** −6 (instrument)
- **Floors:** no baseline, no xfail, no local pytest, no bx
- **Shell deleted:** SoftUnresolvedTrySugar production return; ConstructionPanic soft continue at manager force_floor; bare Exception soft-continue at five production sites. Instrument shell retained (open except membrane).

## Validation

```text
python3 -c '…scan_python_root…'
# R_construction_panic_soft_continue = 0
# R_exception_soft_continue = 1   # census.py only
# R_soft_unresolved_sugar_return = 0
# R_literal_eval_raw_substitution = 0
# TOTAL 1
```

No local pytest (watchdog). No bx. CI on main-push is the measurement path.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace broad exception handlers with specific catches to propagate unhandled throws
> - Narrows exception handling in `collect_panic_audit` to only catch known package-resolution failures (`ModuleNotFoundError`, `ImportError`, `OSError`, etc.); unrelated exceptions now propagate.
> - Replaces `except Exception` in `_serve` with `except SourceCallBindingGap`, so only binding gaps are serialized as JSON-RPC error -32001; other dispatch exceptions propagate.
> - Removes try/except in `_decorator_contract_witnesses` so invalid decorator contract expressions now raise instead of emitting a diagnostic and continuing.
> - Removes `ConstructionPanic` recovery in `_project_return_faces_to_manager`; unfinished floors during manager projection now raise instead of falling back to an `ExitSet` projection.
> - Removes broad catch in `bench_backends.run_throughput` so a problematic file aborts the benchmark instead of being silently skipped.
> - Risk: all affected call sites previously swallowing exceptions will now surface raises; callers may need to handle new failure modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78339bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->