### PR TITLE
Enroll the authoritative scoreboard; it was never scheduled at all

### DIFF
--- a/.github/workflows/control-effect-recensus.yml
+++ b/.github/workflows/control-effect-recensus.yml
@@ -1,0 +1,120 @@
+name: Control-effect recensus (authoritative scoreboard)
+
+# THE DEFECT THIS FIXES
+#
+# scripts/control_effect_recensus.py declares SCOREBOARD_AUTHORITY = True. It
+# is THE authoritative scoreboard -- every other instrument in the kit declares
+# False, and tests/test_one_authoritative_scoreboard.py pins that there is
+# exactly one. It is the sole producer of R_construction_panics and of the
+# desugar board that every drain is ranked against.
+#
+# It appeared in NO WORKFLOW. Searching the repo for it returns docs, ledgers,
+# and two tests -- nothing that runs it. It was a hand-run tool.
+#
+# That is why the product R for this project was last measured on 2026-07-26:
+# somebody ran it by hand that day, and every board cited since
+# (9a78828ee, 43d994888) is that artifact. On 2026-08-01 a campaign of ~35 PRs
+# landed and could not be evaluated, because the tip has no board and nothing
+# schedules one. The roll call added in #6975 could not catch it either: the
+# authority was not on the roster, so its silence was not even a question
+# anybody asked.
+#
+# The authority being unenrolled is the enrollment law broken at the one place
+# it matters most. Enrollment is existence.
+#
+# WHY NIGHTLY AND NOT push:[main]
+#
+# This is a full-corpus recensus over pandas -- a heavy class. Putting it on
+# every push re-saturates the runner pool we just spent a day unclogging (184
+# queued runs against a max of 25). So it takes the same cadence as the walls
+# and the scoreboard sweep, and the roll call enforces the WINDOW rather than
+# the commit: tools/heavy_measurement_attendance.py --cadence nightly-window
+# reports it missing if it did not speak for its window. workflow_dispatch is
+# provided so a tip board can be demanded on purpose, which is exactly what a
+# drain campaign needs before and after it lands.
+
+on:
+  schedule:
+    # After the walls (37/53 past 10) so the heavy lease is not contended at
+    # the moment three classes wake up together.
+    - cron: "23 11 * * *"
+  workflow_dispatch:
+    inputs:
+      corpus_subtree:
+        description: "Optional subtree inside the corpus for a bounded run"
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  recensus:
+    name: control-effect recensus (R_construction_panics)
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare immutable Python test environment
+        uses: ./.github/actions/python-test-environment
+
+      - name: Recensus, under the machine-wide heavy lease
+        shell: bash
+        run: |
+          set -uo pipefail
+          # The corpus is resolved by the SAME authenticated door the process
+          # floors use. Never a path guessed here -- an unauthenticated corpus
+          # is a board about the wrong population, which reads as progress.
+          PANDAS_CORPUS="$(
+            python -c 'from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus; print(authenticated_pandas_corpus().root)'
+          )" || {
+            echo "::error::cannot authenticate pandas corpus for the recensus"
+            exit 1
+          }
+          echo "recensus population: authenticated pandas corpus at $PANDAS_CORPUS"
+          set +e
+          python3 tools/heavy_measurement_lease.py \
+            --class control-effect-recensus \
+            --record "$GITHUB_WORKSPACE/lease-record.json" \
+            -- python implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py \
+                 "${{ github.event.inputs.corpus_subtree || '' }}$PANDAS_CORPUS" \
+                 --corpus-root "$PANDAS_CORPUS" \
+                 --repo "$GITHUB_WORKSPACE" \
+                 --commit "$GITHUB_SHA" \
+                 --out-dir "$GITHUB_WORKSPACE/.sugar/pandas-control-effect"
+          leased_exit=$?
+          set -e
+          # 75 is the lease REFUSING. A board that did not run is UNMEASURED,
+          # never R=0 -- the confusion this whole family exists to end.
+          if [ "$leased_exit" = "75" ]; then
+            echo "::error::heavy-measurement lease not acquired; the recensus did NOT run. R is UNMEASURED, not 0."
+            exit 75
+          fi
+          exit "$leased_exit"
+
+      - name: Lease gate (R_lease = 0)
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/heavy_measurement_lease_gate.py \
+            --record "$GITHUB_WORKSPACE/lease-record.json" \
+            --require-commit "$GITHUB_SHA" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # The receipt distinguishes "ran and found nothing" from "never ran".
+      - name: Upload the recensus lease receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: control-effect-recensus-lease
+          path: lease-record.json
+          if-no-files-found: error
+
+      - name: Upload the board
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: control-effect-recensus-board
+          path: .sugar/pandas-control-effect/**
+          if-no-files-found: warn

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -50,6 +50,7 @@ HEAVY_WORKFLOWS = {
     "numpy-wall.yml": "numpy-wall",
     "pandas-wall.yml": "pandas-wall",
     "restored-suite-scoreboard.yml": "restored-suite-scoreboard",
+    "control-effect-recensus.yml": "control-effect-recensus",
 }
 
 # The dead group. Nothing may claim it again.
@@ -244,3 +245,28 @@ def test_the_two_cadences_are_never_summed():
         "the minority must be computed over the OWED classes for the cadence "
         "being asked, never over the whole roster"
     )
+
+
+def test_the_authoritative_scoreboard_is_on_the_roster():
+    """The one instrument with SCOREBOARD_AUTHORITY must owe testimony.
+
+    control_effect_recensus.py declares SCOREBOARD_AUTHORITY = True and is the
+    sole producer of R_construction_panics. It was in no workflow and on no
+    roster: a hand-run tool. So the last product R for this project was taken
+    on 2026-07-26 by somebody running it manually, ~35 PRs landed on
+    2026-08-01 with no board to evaluate them against, and the roll call could
+    not report the gap because the authority was not a class it asked about.
+
+    An unenrolled authority is the enrollment law broken where it matters most.
+    """
+    module = _attendance_module()
+    authority = ROOT / "implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py"
+    assert "SCOREBOARD_AUTHORITY = True" in authority.read_text(), (
+        "control_effect_recensus is no longer the authority; find who is and "
+        "put THAT class on the roster"
+    )
+    assert "control-effect-recensus" in module.HEAVY_ROSTER, (
+        "the authoritative scoreboard is not on the heavy roster, so the roll "
+        "call cannot notice when it goes quiet"
+    )
+    assert module.HEAVY_CADENCE["control-effect-recensus"] == module.NIGHTLY_WINDOW

--- a/tools/heavy_measurement_attendance.py
+++ b/tools/heavy_measurement_attendance.py
@@ -70,6 +70,7 @@ HEAVY_ROSTER = {
     "numpy-wall": "NumPy Wall Ratchet",
     "pandas-wall": "Pandas Wall Ratchet",
     "restored-suite-scoreboard": "Restored Suite Scoreboard",
+    "control-effect-recensus": "Control-effect recensus (authoritative scoreboard)",
 }
 
 # Cadence per class. Verified against each workflow's own triggers by
@@ -82,6 +83,12 @@ HEAVY_CADENCE = {
     "numpy-wall": NIGHTLY_WINDOW,
     "pandas-wall": NIGHTLY_WINDOW,
     "restored-suite-scoreboard": NIGHTLY_WINDOW,
+    # THE AUTHORITY ITSELF. control_effect_recensus.py declares
+    # SCOREBOARD_AUTHORITY = True and is the sole producer of
+    # R_construction_panics, yet it was in no workflow and on no roster -- a
+    # hand-run tool, which is why product R was last measured 2026-07-26. Its
+    # silence was not even a question anybody asked.
+    "control-effect-recensus": NIGHTLY_WINDOW,
 }
 
 


### PR DESCRIPTION
**Root cause of the campaign flying blind.**

`scripts/control_effect_recensus.py` declares `SCOREBOARD_AUTHORITY = True`. It is *the* authoritative scoreboard — every other instrument declares `False`, and `test_one_authoritative_scoreboard.py` pins that there is exactly one. It is the sole producer of `R_construction_panics`.

**It appeared in no workflow.** Searching the repo returns docs, ledgers, and two tests — nothing runs it. A hand-run tool.

So product R was last measured **2026-07-26**, because somebody ran it by hand that day; every board cited since (`9a78828ee`, `43d994888`) is that one artifact. Today ~35 PRs landed with no board to evaluate them against, and a worker sent to re-derive the `and_then` mass at tip came back **blocked** for exactly this reason.

The roll call (#6975) could not catch it: the authority wasn't on the roster, so its silence was never a question anybody asked. **An unenrolled authority is the enrollment law broken where it matters most.**

**Nightly, not push:[main]** — a full-corpus pandas recensus on every push re-saturates the pool we just unclogged (184 queued vs max 25). It takes the walls' cadence; the roll call enforces the *window*. `workflow_dispatch` lets a tip board be demanded on purpose, which is what a drain campaign needs before and after it lands.

Corpus resolved through the **same authenticated door** the process floors use — never a path guessed in the workflow, since an unauthenticated corpus is a board about the wrong population and that reads as progress. Lease-wrapped, exit 75 reported as UNMEASURED not R=0, gate on the receipt, board + receipt uploaded.

**Teeth:** `test_the_authoritative_scoreboard_is_on_the_roster` asserts the file still declares the authority *and* that the class is enrolled with a cadence — so relocating the authority without enrolling its new owner fails here instead of going quiet for another five weeks.

`R_attendance_nightly` is now **4**, not 3.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enroll control-effect recensus in the nightly CI schedule and heavy-measurement roster
> - Adds [control-effect-recensus.yml](https://github.com/TSavo/sugar/pull/6984/files#diff-7e202e700aa9f13d566241432324fdcbab9681d436e4227693482c2c51b3acd0), a GitHub Actions workflow that runs nightly (cron `23 11 * * *`) and supports `workflow_dispatch`, executing `scripts/control_effect_recensus.py` under a machine-wide heavy-measurement lease and uploading the lease receipt and board artifacts.
> - Registers `control-effect-recensus` in the `HEAVY_ROSTER` and `HEAVY_CADENCE` mappings in [tools/heavy_measurement_attendance.py](https://github.com/TSavo/sugar/pull/6984/files#diff-488ea1f5082769971d9377e07807b0fef693e2d67727f202b2a8c34ba0963556) with a `NIGHTLY_WINDOW` cadence.
> - Adds a test in [tests/test_heavy_measurement_concurrency_topology.py](https://github.com/TSavo/sugar/pull/6984/files#diff-e61292725586469f033b307bcad2ed1f9d02cca5a16e90e770e6c8b4d1353c79) asserting that `control_effect_recensus.py` sets `SCOREBOARD_AUTHORITY = True`, that its class is on the heavy roster, and that its cadence is `NIGHTLY_WINDOW`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 382263a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->