### PR TITLE
Partition spelling-dispatch: climb residual vs permanent membranes

### DIFF
--- a/docs/spelling-dispatch-partition.md
+++ b/docs/spelling-dispatch-partition.md
@@ -1,0 +1,105 @@
+# Spelling-dispatch partition (parent face `spelling_unauth_dispatch`)
+
+Source instrument: `builtin_closed_operation_instrument.py` over
+`production_python_scan_roots` (kit + sugar-source-tree + sugar-lift-python-source).
+
+Advisor ruling: **spelling-dispatch is partly an honest permanent membrane**
+because `ast.Compare` over display text is open domain no local type can close.
+This document is the **partition**, not a blanket drain.
+
+Measured on main tip after #6971 isinstance coordinate climb (this worktree).
+
+## Summary counts (multi-root)
+
+| Axis | R | Stance |
+| --- | ---: | --- |
+| `name_or_vendor_gates` (identity-spelling / vendor CM) | **1** | climb residual or thin membrane |
+| `open_lexical_ast_id` (`func.id` / `Name.id` vs string) | **19** | **permanent membrane** |
+| `open_lexical_attr_name` (`field.name == name`, …) | **33** | **permanent membrane** |
+| `exception_name_fabrication_denylist` | **5** | different product law (#6943/#6949) |
+| `construction_side_doors` (functions containing climb gates) | **1** | follows name_or_vendor |
+
+Pre-partition kit-only `name_or_vendor_gates` was **26**, almost all
+**instrument conflation** of lexical Name projection with type-identity spelling.
+That conflation is the shell this PR deletes from the measurement, not from
+Python's name surface.
+
+## (A) Climb — type identity / vendor CM (must not be free spelling)
+
+| Kind | What | Product status |
+| --- | --- | --- |
+| `type_name_gate` | `type_name ==` / `in` | **Drained** in #6971 → `authenticated_python_type_spelling` |
+| `exception_name_identity_eq` | `exception_name == "ValueError"` as identity | **Drained** in effect_router / exit suppress; residual empty |
+| `matcher_name_eq` | `matcher.name` equality | **Drained** at match door (coordinate mint) |
+| `vendor_cm` | pytest/contextlib/… coordinates | **R=1 live**: `lifter.py` set-elt `warnings.deprecated` |
+| `name_keyed_suppress_api` | `suppresses_exception` reintroduction | **R=0** (detector still watches) |
+
+### Live climb residual (1)
+
+- `sugar_lift_python_source/lifter.py:2837` — set element `'warnings.deprecated'`
+  - **Object that should exist:** a closed vendor-CM coordinate table type (not a free `set` of strings) owned by one door.
+  - Until that type exists, this single row stays a **named** vendor-CM membrane cell, not a silent isinstance gate.
+
+## (B) Permanent membranes — open domain (no local type closes)
+
+### B1. `open_lexical_ast_id` (R=19)
+
+**Offender class:** dispatch or recognition by `Name.id` / `func.id` string
+(`range`, `super`, `len`, `__all__`, `sugar`, `__slots__`, `Final`, …).
+
+**Why open:** Python's grammar leaves `Name` as free spelling; shadowing is
+source-real. No local type forbids writing `func.id == "range"`.
+
+**Retirement path (when hatch):** every such Call/Name is reduced only through
+authenticated binding coordinates (TemporalContext / module_direct_bindings);
+AST id is never read for dispatch. Then delete this axis.
+
+**Not a false green:** `_calls_shadowed_range` and similar still exist; membrane
+must stay loud when reintroduced patterns grow.
+
+### B2. `open_lexical_attr_name` (R=33)
+
+**Offender class:** `field.name == name`, `method.name == name`,
+`binding.name == name`, `statement.name == name`, handler/pattern name match.
+
+**Why open:** Python attribute and binding projection is **name-keyed by the
+language**. Replacing every method/field with content-addressed handles is not
+the current ontology.
+
+**Retirement path:** only if floor methods/fields become handles without string
+names (not planned). Membrane earns keep forever under current design.
+
+Sites include: `object_value.py`, `temporal_context.py`, `class_definition_value.py`,
+`source_call_frame.py`, `tree_enumerate.find_function` name filter, AST
+statement name equality in nodes/adapters.
+
+### B3. `exception_name_fabrication_denylist` (R=5)
+
+**Not spelling-unauth isinstance.** Owned by render-edge exceptional-exit law:
+refuse empty / `reraise` / placeholders. Instrument mis-bucketed these under
+`name_or_vendor_gates` before this partition.
+
+**Retirement:** when `RaiseEffect.exception_name` is not a free optional string
+(typed spelling or coordinate-only faces).
+
+## (C) Explicit non-goals this PR
+
+- No rewrite of every `range`/`super` recognizer to binding coordinates (large
+  product surface; membrane B1 until binding-total recognition exists).
+- No deletion of TemporalContext name lookup (geometry of Python Name).
+- No local/bx test run (CI main-push is measurement path).
+
+## Ladder answers (for this instrument)
+
+1. **Type forbid open Name.id / attr.name?** No — open domain.
+2. **One door for type identity?** Yes for isinstance (#6971);
+   vendor-CM table still free strings (1 residual).
+3. **Panic?** Runtime missing coordinate already throws on climbed paths.
+4. **Auditor retained:** partitioned membrane axes with retirement notes above.
+
+## Shell this PR deletes
+
+Instrument **conflation** that counted lexical Name/attr projection and
+fabrication denylist as `name_or_vendor_gates`, inflating the parent spelling
+face and inviting false “drain everything” work. After: climb residual is the
+honest **1** vendor-CM cell; membranes are named separately.

--- a/implementations/python/sugar-lift-py-tests/scripts/law_of_one_vector_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/law_of_one_vector_law.py
@@ -268,27 +268,29 @@ def _cite_builtin_name_vendor_gates(repo: Path) -> Citation:
         sys.path.insert(0, str(repo / "implementations/python/sugar-lift-py-tests/src"))
         from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (  # type: ignore
             collect_builtin_closed_operation_report,
+            production_python_scan_roots,
         )
 
-        roots = [
-            repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests",
-            repo / "implementations/python/sugar-source-tree/src",
-            repo / "implementations/python/sugar-lift-python-source/src",
-        ]
+        roots = production_python_scan_roots(repo)
         report = collect_builtin_closed_operation_report(roots)
-        counts = report.counts() if hasattr(report, "counts") else {}
-        # Prefer name_or_vendor_gates axis if present; else total offenders
-        if isinstance(counts, dict) and "name_or_vendor_gates" in counts:
-            r = int(counts["name_or_vendor_gates"])
-            detail = {"by_axis": counts, "source": "builtin_closed_operation_instrument.collect"}
-        else:
-            r = len(report.offenders)
-            by: dict[str, int] = {}
-            for o in report.offenders:
-                ax = getattr(o, "axis", "unknown")
-                by[ax] = by.get(ax, 0) + 1
-            r = by.get("name_or_vendor_gates", r)
-            detail = {"by_axis": by, "source": "builtin_closed_operation_instrument.collect"}
+        by: dict[str, int] = {}
+        by_kind: dict[str, int] = {}
+        for o in report.offenders:
+            ax = getattr(o, "axis", "unknown")
+            by[ax] = by.get(ax, 0) + 1
+            k = getattr(o, "kind", "unclassified")
+            by_kind[k] = by_kind.get(k, 0) + 1
+        # Climb residual only — permanent membranes are separate axes (partition doc).
+        r = int(by.get("name_or_vendor_gates", 0))
+        detail = {
+            "by_axis": by,
+            "by_kind": by_kind,
+            "source": "builtin_closed_operation_instrument.collect multi-root",
+            "partition": "docs/spelling-dispatch-partition.md",
+            "membrane_open_lexical_ast_id": by.get("open_lexical_ast_id", 0),
+            "membrane_open_lexical_attr_name": by.get("open_lexical_attr_name", 0),
+            "fabrication_denylist_axis": by.get("exception_name_fabrication_denylist", 0),
+        }
         return Citation("product", "builtin_name_or_vendor_gates", rel, r, detail)
     except Exception as exc:  # noqa: BLE001
         return Citation("product", "builtin_name_or_vendor_gates", rel, -1, {}, [f"{type(exc).__name__}: {exc}"], "collect_error")
@@ -320,8 +322,16 @@ MEMBRANE_HONEST = (
     {
         "face": "spelling_unauth_dispatch",
         "stance": "membrane",
-        "owner_axis": "builtin_name_or_vendor_gates + enumeration_binding_soft_skip",
-        "why": "Open grammar/vendor spelling; type cannot close ast.Compare on display text.",
+        "owner_axis": (
+            "builtin_name_or_vendor_gates (climb residual) + "
+            "open_lexical_ast_id + open_lexical_attr_name (permanent) + "
+            "enumeration_binding_soft_skip; see docs/spelling-dispatch-partition.md"
+        ),
+        "why": (
+            "Open grammar/vendor Name.id and attr.name projection; type cannot close "
+            "ast.Compare on display text. Climb residual is vendor-CM / type-identity "
+            "only; lexical membranes are permanent under current ontology."
+        ),
     },
     {
         "face": "swallowed_throws_soft_handlers",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
@@ -115,6 +115,10 @@ class BuiltinClosedOperationOffender:
     line: int
     observed: str
     replacement: str
+    # Partition tag (see docs/spelling-dispatch-partition.md).
+    # name_or_vendor_gates only counts climbable identity-spelling kinds;
+    # permanent open-domain membranes use their own axes.
+    kind: str = "unclassified"
 
 
 @dataclass(frozen=True)
@@ -127,6 +131,9 @@ class BuiltinClosedOperationReport:
             "construction_side_doors",
             "generic_builtin_verdicts",
             "name_or_vendor_gates",
+            "open_lexical_ast_id",
+            "open_lexical_attr_name",
+            "exception_name_fabrication_denylist",
             "panic_catches",
         )
         return {axis: sum(row.axis == axis for row in self.offenders) for axis in axes}
@@ -182,28 +189,42 @@ def is_panic_type_name(name: str) -> bool:
     )
 
 
+def production_python_scan_roots(repo: Path) -> list[Path]:
+    """Production roots the parent vector cites for spelling-unauth face."""
+    return [
+        repo / "implementations/python/sugar-lift-py-tests/src",
+        repo / "implementations/python/sugar-source-tree/src",
+        repo / "implementations/python/sugar-lift-python-source/src",
+    ]
+
+
 def collect_builtin_closed_operation_report(
-    root: Path,
+    root: Path | list[Path] | tuple[Path, ...],
 ) -> BuiltinClosedOperationReport:
+    """Scan one root or several. Prefer ``production_python_scan_roots(repo)``."""
+    roots = [root] if isinstance(root, Path) else list(root)
     offenders: list[BuiltinClosedOperationOffender] = []
-    for path in sorted(root.rglob("*.py")):
-        relative_path = path.relative_to(root)
-        parts = relative_path.parts
-        if "sugar_lift_py_tests" in parts:
-            package_index = parts.index("sugar_lift_py_tests")
-            lane = parts[package_index + 1 : package_index + 2]
-            if lane and lane[0] in _SKIP_LANES:
-                continue
-            if relative_path.name == "lift_rpc.py":
-                continue
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        except (OSError, SyntaxError):
+    for one in roots:
+        if not one.is_dir():
             continue
-        relative = str(relative_path)
-        visitor = _Visitor(relative)
-        visitor.visit(tree)
-        offenders.extend(visitor.offenders)
+        for path in sorted(one.rglob("*.py")):
+            relative_path = path.relative_to(one)
+            parts = relative_path.parts
+            if "sugar_lift_py_tests" in parts:
+                package_index = parts.index("sugar_lift_py_tests")
+                lane = parts[package_index + 1 : package_index + 2]
+                if lane and lane[0] in _SKIP_LANES:
+                    continue
+                if relative_path.name == "lift_rpc.py":
+                    continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            except (OSError, SyntaxError):
+                continue
+            relative = str(relative_path)
+            visitor = _Visitor(relative)
+            visitor.visit(tree)
+            offenders.extend(visitor.offenders)
     return BuiltinClosedOperationReport(tuple(offenders))
 
 
@@ -226,6 +247,7 @@ class _Visitor(ast.NodeVisitor):
                 f"def {node.name}",
                 "match exception_type_coordinate against ExitSuppressionContract "
                 "coordinates minted at the suppresses() door; never suppress by name",
+                kind="name_keyed_suppress_api",
             )
         self._function_stack.append(node)
         self.generic_visit(node)
@@ -247,19 +269,48 @@ class _Visitor(ast.NodeVisitor):
                 ast.unparse(node),
                 "match exception_type_coordinate against ExitSuppressionContract "
                 "coordinates minted at the suppresses() door; never suppress by name",
+                kind="name_keyed_suppress_api",
             )
         self.generic_visit(node)
 
     def visit_Compare(self, node: ast.Compare) -> None:
         rendered = ast.unparse(node)
-        if self._is_spelling_gate_compare(node):
-            self._flag_vendor_gate(node, rendered)
+        kind = self._spelling_gate_kind(node)
+        if kind is not None:
+            if kind == "vendor_cm":
+                self._flag_vendor_gate(node, rendered)
+            else:
+                self._add(
+                    "name_or_vendor_gates",
+                    node,
+                    rendered,
+                    "route the authenticated type/exception coordinate; never display spelling",
+                    kind=kind,
+                )
+                if self._function_stack:
+                    function = self._function_stack[-1]
+                    key = id(function)
+                    if key not in self._side_door_functions:
+                        self._side_door_functions.add(key)
+                        self._add(
+                            "construction_side_doors",
+                            function,
+                            function.name,
+                            "use the sole floor callable_application_with construction path",
+                            kind="construction_side_door",
+                        )
+        else:
+            open_hit = self._classify_open_domain_compare(node)
+            if open_hit is not None:
+                axis, open_kind, fix = open_hit
+                self._add(axis, node, rendered, fix, kind=open_kind)
         if self._compare_is_generic_builtin_verdict(node):
             self._add(
                 "generic_builtin_verdicts",
                 node,
                 rendered,
                 "construct the closed semantic operation and result on the Python floor",
+                kind="generic_builtin_verdict",
             )
         self.generic_visit(node)
 
@@ -304,6 +355,7 @@ class _Visitor(ast.NodeVisitor):
                     node,
                     name,
                     "leave unsupported floor construction loud; never catch its panic",
+                    kind="panic_catch",
                 )
                 break
         self.generic_visit(node)
@@ -314,6 +366,7 @@ class _Visitor(ast.NodeVisitor):
             node,
             observed,
             "route the authenticated builtin coordinate through the Python floor",
+            kind="vendor_cm",
         )
         if self._function_stack:
             function = self._function_stack[-1]
@@ -325,6 +378,7 @@ class _Visitor(ast.NodeVisitor):
                     function,
                     function.name,
                     "use the sole floor callable_application_with construction path",
+                    kind="construction_side_door",
                 )
 
     def _node_is_vendor_coordinate(self, node: ast.AST) -> bool:
@@ -334,18 +388,22 @@ class _Visitor(ast.NodeVisitor):
         return qn is not None and is_vendor_cm_coordinate_spelling(qn)
 
     def _is_spelling_gate_compare(self, node: ast.Compare) -> bool:
-        """True when this compare decides by display spelling, not a coordinate."""
+        """True when compare is a type-identity / vendor spelling gate (climbable class).
+
+        Permanent open-domain membranes are classified separately in
+        ``_classify_open_domain_compare`` and do not inflate this axis.
+        """
+        return self._spelling_gate_kind(node) is not None
+
+    def _spelling_gate_kind(self, node: ast.Compare) -> str | None:
         operands = (node.left, *node.comparators)
 
-        # Vendor CM coordinates (structural path identity — NOT substring).
         if any(self._node_is_vendor_coordinate(operand) for operand in operands):
-            return True
+            return "vendor_cm"
 
-        # type_name in {…} / type_name in SOME_FROZENSET — builtin shadowing lie.
-        # type_name == "str" (and friends) — same sin as == rather than `in`.
         if isinstance(node.left, ast.Name) and node.left.id == "type_name":
             if any(isinstance(op, (ast.In, ast.NotIn, ast.Eq, ast.NotEq)) for op in node.ops):
-                return True
+                return "type_name_gate"
 
         attr_names = {
             operand.attr
@@ -356,16 +414,67 @@ class _Visitor(ast.NodeVisitor):
             isinstance(operand, ast.Constant) and isinstance(operand.value, str)
             for operand in operands
         )
+        eq_ops = any(isinstance(op, (ast.Eq, ast.NotEq)) for op in node.ops)
 
-        # effect.exception_name == "StopIteration" (and any == on that attr).
-        if "exception_name" in attr_names:
-            return True
+        # Identity-by-spelling: exception_name == "StopIteration" (real class).
+        # Empty string / denylist placeholders belong on fabrication axis.
+        if "exception_name" in attr_names and has_str_constant and eq_ops:
+            fabricated = {"", "reraise", "unavailable", "<unknown raise locus>"}
+            for operand in operands:
+                if (
+                    isinstance(operand, ast.Constant)
+                    and isinstance(operand.value, str)
+                    and operand.value in fabricated
+                ):
+                    return None  # open-domain / fabrication classifier owns it
+            return "exception_name_identity_eq"
 
-        # func.id == "importorskip" — unbound lexical text vs string.
+        # matcher.name equality (not field.name / binding.name lookups).
+        for operand in operands:
+            if (
+                isinstance(operand, ast.Attribute)
+                and operand.attr == "name"
+                and isinstance(operand.value, ast.Name)
+                and operand.value.id == "matcher"
+            ):
+                return "matcher_name_eq"
+
+        return None
+
+    def _classify_open_domain_compare(
+        self, node: ast.Compare
+    ) -> tuple[str, str, str] | None:
+        """Permanent membranes: open Python Name / attr projection domain.
+
+        Returns (axis, kind, replacement) or None.
+        """
+        operands = (node.left, *node.comparators)
+        attr_names = {
+            operand.attr
+            for operand in operands
+            if isinstance(operand, ast.Attribute)
+        }
+        has_str_constant = any(
+            isinstance(operand, ast.Constant) and isinstance(operand.value, str)
+            for operand in operands
+        )
+
+        # Unbound lexical AST id vs string (range/super/len/importorskip/__all__).
+        # Domain open: no local type closes every Name.id in vendor grammar.
+        # Retirement: Name resolves only through authenticated binding coordinates
+        # and Call.func never carries a free spelling id for dispatch.
         if "id" in attr_names and has_str_constant:
-            return True
+            return (
+                "open_lexical_ast_id",
+                "func_id_lexical",
+                "resolve Name through binding coordinates; never dispatch on func.id spelling. "
+                "Membrane until Call sites carry authenticated builtin coordinates.",
+            )
 
-        # name == matcher.name — spelling equality of names.
+        # field.name / binding.name / method.name / statement.name == name
+        # Python attribute and binding projection is name-keyed by the language.
+        # Retirement: only if methods/fields become content-addressed handles
+        # without string names at the floor surface (not planned).
         name_attrs = [
             operand
             for operand in operands
@@ -377,9 +486,33 @@ class _Visitor(ast.NodeVisitor):
             if isinstance(operand, ast.Name) and operand.id == "name"
         ]
         if name_attrs and (name_names or len(name_attrs) >= 2):
-            return True
+            # Exclude matcher.name (handled as climbable spelling gate).
+            if any(
+                isinstance(op, ast.Attribute)
+                and op.attr == "name"
+                and isinstance(op.value, ast.Name)
+                and op.value.id == "matcher"
+                for op in name_attrs
+            ):
+                return None
+            return (
+                "open_lexical_attr_name",
+                "lexical_attr_name",
+                "attribute/binding projection is name-keyed in Python; "
+                "membrane forever unless handles replace names at the floor.",
+            )
 
-        return False
+        # exception_name presence / fabrication denylist — different product law
+        # (#6949 render-edge), not unauth isinstance dispatch.
+        if "exception_name" in attr_names:
+            return (
+                "exception_name_fabrication_denylist",
+                "exception_name_presence_or_denylist",
+                "owned by render-edge fabrication door; not a type-identity spelling gate. "
+                "Retires when exception_name is not a constructible free string on RaiseEffect.",
+            )
+
+        return None
 
     def _pattern_is_vendor_coordinate(self, pattern: ast.pattern) -> bool:
         if isinstance(pattern, ast.MatchValue):
@@ -412,7 +545,15 @@ class _Visitor(ast.NodeVisitor):
         }
         return bool(bools)
 
-    def _add(self, axis: str, node: ast.AST, observed: str, replacement: str) -> None:
+    def _add(
+        self,
+        axis: str,
+        node: ast.AST,
+        observed: str,
+        replacement: str,
+        *,
+        kind: str = "unclassified",
+    ) -> None:
         self.offenders.append(
             BuiltinClosedOperationOffender(
                 axis=axis,
@@ -420,5 +561,6 @@ class _Visitor(ast.NodeVisitor):
                 line=getattr(node, "lineno", 0),
                 observed=observed,
                 replacement=replacement,
+                kind=kind,
             )
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
@@ -390,3 +390,41 @@ def test_instrument_does_not_scan_idd_or_plant_self(tmp_path: Path) -> None:
     )
     report = collect_builtin_closed_operation_report(tmp_path)
     assert report.offenders == ()
+
+
+def test_partition_does_not_count_lexical_attr_name_as_identity_gate(tmp_path: Path) -> None:
+    """field.name == name is open-domain membrane, not name_or_vendor_gates."""
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "object_value.py",
+        "def attribute(self, name):\n"
+        "    for field in self.fields:\n"
+        "        if field.name == name:\n"
+        "            return field.value\n",
+    )
+    report = collect_builtin_closed_operation_report(tmp_path)
+    assert report.r["name_or_vendor_gates"] == 0
+    assert report.r["open_lexical_attr_name"] >= 1
+
+
+def test_partition_func_id_string_is_open_lexical_not_type_identity(tmp_path: Path) -> None:
+    """func.id == \"range\" is permanent open-domain membrane."""
+    from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
+        collect_builtin_closed_operation_report,
+    )
+
+    _write(
+        tmp_path,
+        "nodes.py",
+        "def _concrete(iterable):\n"
+        "    if iterable.func.id == \"range\":\n"
+        "        return True\n"
+        "    return False\n",
+    )
+    report = collect_builtin_closed_operation_report(tmp_path)
+    assert report.r["name_or_vendor_gates"] == 0
+    assert report.r["open_lexical_ast_id"] >= 1


### PR DESCRIPTION
## Summary

Parent vector **spelling** face was reading a **conflated** instrument: kit
`name_or_vendor_gates≈26` after #6971, mostly `field.name == name` /
`binding.name == name` / fabrication denylist — **not** type-identity
spelling left undrained.

Advisor: spelling-dispatch **is partly a permanent membrane** (open
`ast.Compare` / `Name.id`). Deliverable is a **partition**, not a blanket drain.

### Partition (multi-root: kit + source-tree + lift-python-source)

| Axis | R | Stance |
| --- | ---: | --- |
| `name_or_vendor_gates` | **1** | climb residual (`warnings.deprecated` set-elt in lifter) |
| `open_lexical_ast_id` | **19** | permanent membrane (`range`/`super`/`len`/`__all__`/…) |
| `open_lexical_attr_name` | **33** | permanent membrane (attr/binding projection) |
| `exception_name_fabrication_denylist` | **5** | other law (#6943/#6949) |

Full table + retirement paths: `docs/spelling-dispatch-partition.md`.

### Shell deleted

Instrument **conflation** that filed lexical Name geometry under the climb
axis (inflating “spelling=32” with objects that are not undrained isinstance
gates). #6971 product climb of `type_name` / effect match is preserved.

### R / Epsilon R

| Axis | Predicted Epsilon R |
| --- | --- |
| `name_or_vendor_gates` (climb) | false kit mass off axis → **R=1** true vendor residual |
| membrane axes | **named**, not zeroed by pretending they climbed |

### Floors

- No soft silence; membranes name offender class + retirement path
- No local pytest / no bx (CI main-push measurement path)
- Lying twins: lexical attr and `func.id == "range"` must **not** count as climb gates

### Ladder

1. Type forbid open Name.id / attr.name? **No**
2. One door for type identity? **Yes** (#6971); vendor CM table still free string **R=1**
3. Panic? climbed paths already throw on missing coordinate
4. Auditor retained as **partitioned membrane** with retirement notes — not ceremony for isinstance

### Object missing (climb residual)

Closed vendor-CM coordinate table type (not free `set` of strings) for the
remaining `warnings.deprecated` seed — until then the row is a named membrane cell.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Partition spelling-dispatch detections into climbable identity gates vs permanent lexical membranes
> - Introduces `_spelling_gate_kind` to classify climbable spelling gates (vendor CM, type name, exception identity, matcher name) and `_classify_open_domain_compare` to classify permanent membrane cases (`open_lexical_ast_id`, `open_lexical_attr_name`, `exception_name_fabrication_denylist`) in [builtin_closed_operation_instrument.py](https://github.com/TSavo/sugar/pull/6985/files#diff-422b632b0136f3afa27d19e62f1748a574fbbc5726090092d5833c55292d76b0).
> - Previously, all compare-based detections were counted under `name_or_vendor_gates`; now only climbable identity/vendor gates count there, and open-domain lexical cases are recorded under their own axes.
> - Adds `production_python_scan_roots` as a shared helper for scan root resolution, and updates the collector to accept multiple roots in a single call.
> - Adds `kind` metadata to each `BuiltinClosedOperationOffender` for downstream aggregation, and updates `BuiltinClosedOperationReport.r` to include the new membrane axes.
> - Adds two tests and a [partition doc](https://github.com/TSavo/sugar/pull/6985/files#diff-22647098009f385c838b3ddc5f472ea9876ea639b52ef616a39d8cc63b84dfab) documenting the axis split and retirement paths.
> - Behavioral Change: `report.r` and Citation detail now reflect only `name_or_vendor_gates` count (excluding lexical membrane cases), which previously were included in that count.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d13409c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->