### PR TITLE
Prove CommitMeasurement gate RED on empty tip (not decorative)

### DIFF
--- a/.github/workflows/heavy-measurement-attendance.yml
+++ b/.github/workflows/heavy-measurement-attendance.yml
@@ -87,41 +87,41 @@ jobs:
           done < run-ids.txt
           echo "receipt files found: $(find receipts -name '*.json' | wc -l)"
 
-      - name: Roll call
+      - name: Roll call + CommitMeasurement gate (fail closed)
+        id: measure
         env:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ steps.subject.outputs.sha }}
         run: |
-          set -euo pipefail
-          # PER-COMMIT cadence only. The nightly classes (walls, scoreboard)
-          # owe testimony about their last scheduled WINDOW, not about this
-          # tip, and mixing the two floors R_attendance at 3 forever for a
-          # reason that is not a defect. The two axes are never summed.
+          set -uo pipefail
+          # PER-COMMIT cadence only. Nightlies are a different obligation.
+          #
+          # CRITICAL: attendance exit 1 must NOT skip compose/gate. A gate that
+          # only runs when attendance is already green is decorative. Capture
+          # attendance exit, ALWAYS compose, ALWAYS gate, then OR the reds.
+          set +e
           python3 tools/heavy_measurement_attendance.py \
             --commit "$SHA" \
             --cadence per-commit \
             --receipts-dir receipts \
             --repo "${GITHUB_REPOSITORY}" \
-            | tee attendance.md \
-            | tee -a "$GITHUB_STEP_SUMMARY"
+            > attendance.md 2>&1
+          att_exit=$?
+          set -e
+          cat attendance.md | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "attendance_exit=$att_exit"
 
-      - name: Compose CommitMeasurement (cite receipts only)
-        env:
-          SHA: ${{ steps.subject.outputs.sha }}
-        run: |
-          set -euo pipefail
-          # One door for READING tip state. Values are field-paths on sealed
-          # bodies; lease alone without suite-report/floor body is Unmeasured.
+          # Compose even when receipts/ are empty: that is PartialVector, not silence.
           python3 - <<'PY'
           from pathlib import Path
           import json
           import importlib.util
+          import os
           spec = importlib.util.spec_from_file_location(
               "cm", Path("tools/commit_measurement.py")
           )
           mod = importlib.util.module_from_spec(spec)
           spec.loader.exec_module(mod)
-          import os
           sha = os.environ["SHA"]
           vector = mod.compose_tip_from_receipts_dir(sha, Path("receipts"))
           Path("commit-measurement.json").write_text(
@@ -131,14 +131,20 @@ jobs:
           print(json.dumps(vector.to_json(), indent=2, sort_keys=True))
           PY
 
-      - name: Gate — tip composition required (silence is not clean)
-        run: |
-          set -euo pipefail
-          # REQUIRED not advisory: PartialVector or missing file → red.
+          set +e
           python3 tools/commit_measurement_gate.py \
             --composition commit-measurement.json \
             --require-complete \
             | tee -a "$GITHUB_STEP_SUMMARY"
+          gate_exit=$?
+          set -e
+          echo "gate_exit=$gate_exit"
+          # Fail closed: either attendance minority OR incomplete composition.
+          if [ "$att_exit" -ne 0 ] || [ "$gate_exit" -ne 0 ]; then
+            echo "RED: attendance_exit=$att_exit gate_exit=$gate_exit"
+            exit 1
+          fi
+          echo "GREEN: attendance and CommitMeasurement complete"
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/tests/test_commit_measurement.py
+++ b/tests/test_commit_measurement.py
@@ -228,3 +228,55 @@ def test_gate_complete_require_complete_is_green(tmp_path: Path) -> None:
     path = tmp_path / "cm.json"
     path.write_text(json.dumps(v.to_json()), encoding="utf-8")
     assert GATE.main(["--composition", str(path), "--require-complete"]) == 0
+
+
+def test_empty_receipts_tip_produces_partial_and_gate_red(tmp_path: Path) -> None:
+    """LIVE twin: tip with NO receipts → PartialVector → gate exit 1 (not skip).
+
+    This is the case that proves the object is required: silence is Unmeasured
+    on every tip axis, composition exists as partial, and --require-complete
+    is red. A gate that only fires when instruments already succeeded is not
+    a gate.
+    """
+    empty = tmp_path / "receipts"
+    empty.mkdir()
+    vector = CM.compose_tip_from_receipts_dir("tip-with-zero-receipts", empty)
+    assert isinstance(vector, CM.PartialVector), (
+        f"empty receipts must be PartialVector, got {type(vector).__name__}"
+    )
+    assert vector.unmeasured_axes(), "every tip axis should be Unmeasured"
+    assert "total" not in vector.to_json()
+    composition = tmp_path / "commit-measurement.json"
+    composition.write_text(
+        __import__("json").dumps(vector.to_json()), encoding="utf-8"
+    )
+    code = GATE.main(
+        ["--composition", str(composition), "--require-complete"]
+    )
+    assert code == 1, f"gate must RED on empty-receipt tip, got exit {code}"
+
+
+def test_missing_composition_file_gate_red_not_skipped(tmp_path: Path) -> None:
+    """Absent CommitMeasurement artifact is RED, never 'no file = fine'."""
+    code = GATE.main(
+        ["--composition", str(tmp_path / "commit-measurement.json"), "--require-complete"]
+    )
+    assert code == 1
+
+
+def test_workflow_runs_gate_even_when_attendance_would_exit_red() -> None:
+    """Enrollment law: compose+gate must not sit behind set -e on attendance.
+
+    Re-derived from the workflow file (live instrument path), not a hand list.
+    """
+    text = (
+        ROOT / ".github/workflows/heavy-measurement-attendance.yml"
+    ).read_text(encoding="utf-8")
+    assert "commit_measurement_gate.py" in text
+    assert "--require-complete" in text
+    # Must capture attendance exit and still run gate (not set -e abort before compose)
+    assert "gate_exit" in text or "GATE" in text or "att_exit" in text
+    assert "compose_tip_from_receipts_dir" in text or "commit_measurement.py" in text
+    # Decorative pattern: separate gate step after roll call under set -e only
+    # would skip on attendance red. The fixed job uses att_exit/gate_exit OR.
+    assert "att_exit" in text and "gate_exit" in text

--- a/tools/commit_measurement.py
+++ b/tools/commit_measurement.py
@@ -484,8 +484,8 @@ def compose_tip_from_receipts_dir(
                         break
         if body is None or body_path is None:
             axes[axis_name] = unmeasured(
-                f"lease present for {lease_class!r} but no body artifact "
-                f"(suite-report / floor report) — Measured requires both"
+                f"NoReport: lease present for {lease_class!r} but no body artifact "
+                f"(suite-report / floor report)"
             )
             continue
         axes[axis_name] = measured_from_sealed_pair(


### PR DESCRIPTION
## Plain answer

**A tip with no receipts at all produces a RED gate (exit 1), not a skipped job.**

| Case | Result |
| --- | --- |
| Empty `receipts/` | `PartialVector`, both tip axes Unmeasured, no `.total` / no total key |
| Gate `--require-complete` | **exit 1** |
| Missing `commit-measurement.json` | **exit 1** |
| Lease without suite-report body | axis Unmeasured(NoReport), gate **exit 1** |

Demonstrated with `python3.12` running the compose+gate APIs (not local pytest, not bx).

## Shell deleted

Workflow shape where roll call `set -e` exit 1 **skipped** compose/gate when attendance was already red — a gate that only ran when things were already green.

**Fix:** one step captures `att_exit`, always composes, always gates, fails if either red.

## Teeth (CI)

- `test_empty_receipts_tip_produces_partial_and_gate_red`
- `test_missing_composition_file_gate_red_not_skipped`
- `test_workflow_runs_gate_even_when_attendance_would_exit_red`

## Shot accounting

| | |
| --- | --- |
| R axis | decorative tip gate / silence-as-fine |
| Epsilon R | unwritable when enrollment fixed |
| Floors | cite-only composition; no board authority |
| Shell deleted | set -e skip of gate after attendance red |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prove CommitMeasurement gate fails (RED) on empty tip in CI attendance workflow
> - Merges the separate attendance, composition, and gate steps in [heavy-measurement-attendance.yml](.github/workflows/heavy-measurement-attendance.yml) into a single step that always runs the `CommitMeasurement` gate, even when attendance exits non-zero.
> - The step captures `att_exit` and `gate_exit` separately and fails closed (exit 1) if either is non-zero.
> - Composition now runs even when `receipts/` is empty, producing a `PartialVector` with all axes unmeasured.
> - Adds tests covering: empty receipts producing a RED gate, missing `commit-measurement.json` returning exit code 1, and a workflow-structure check asserting the gate is never skipped.
> - Changes the unmeasured reason string in `compose_tip_from_receipts_dir` to start with `NoReport:` when a lease exists but no body artifact is found.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50693e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->