### PR TITLE
Criterion 3: instrument refusal naming (R=8→0); axis2 OPEN

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/criterion3_refusal_naming_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/criterion3_refusal_naming_law.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Criterion 3 — refusals must name the artifact they cannot see.
+
+CLASS NAME
+    CRITERION-3 REFUSAL NAMING
+
+DEFINITION (the half we state but never measured)
+    Source-visible behaviour CONSTRUCTS; source-undecidable behaviour is
+    specifically refused, NAMING the artifact it cannot see.
+
+    Two axes:
+
+    1. R_refusals_naming_nothing
+       A refusal (``SugarNotWritten``, ``construction_panic_gap``,
+       ``BackendDefect``, kin) whose ``observed`` uses undecidable-class
+       language without naming a concrete invisible artifact (receiver type,
+       missing field, coordinate, semantics variant, …). Those are unfinished
+       construction wearing a typed label.
+
+    2. R_refusals_over_decidable_source  — OPEN (not measured)
+       A refusal where perfect machinery over source-visible code could still
+       have decided. Final only when perfect source machinery could not.
+       Static AST cannot soundly recover "source was visible at this site"
+       without false greens. Retirement path (names the object that retires
+       this open axis): a construction-required
+       ``RefusalDecidability`` enum on every named refusal:
+
+         - ``MissingMachinery(source_visible: tuple[Artifact, ...])``
+         - ``PerfectSourceStillUndecidable(exhausted: tuple[Artifact, ...])``
+
+       Only the second is a valid final refusal. When that type is required at
+       the one door, delete any auditor that tried to guess from prose.
+
+ENFORCEMENT LADDER
+    Rung: **auditor** (static recognition over product refusal mints).
+
+    Why not higher yet:
+    - Type system: free ``observed: str`` on SourceTreePanic / ConstructionGap
+      admits any prose; cannot require an Artifact noun in a string.
+    - Construction door: no sealed ``NamedRefusal(artifact, decidability)``
+      yet — optional keyword strings remain open Python.
+    - Panic at contact: a green path never re-reads the refusal prose.
+
+    Retirement (axis 1): typed ``observed: Artifact`` (or required non-empty
+    artifact field alongside undecidability) makes nameless undecidable
+    prose unconstructible; delete this auditor.
+
+    Retirement (axis 2): see RefusalDecidability above — open until then.
+
+Not the board. Sole Python corpus scoreboard remains
+scripts/control_effect_recensus.py.
+"""
+
+from __future__ import annotations
+
+# Not the board.
+SCOREBOARD_AUTHORITY = False
+
+import argparse
+import ast
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+NAMING_NOTHING = "REFUSAL-NAMING-NOTHING"
+# Axis 2 is reported as open, never faked as a live count.
+OPEN_AXIS = "REFUSAL-OVER-DECIDABLE-SOURCE-OPEN"
+
+REQUIRED_FIX = {
+    NAMING_NOTHING: (
+        "name the invisible artifact in observed (f-string the receiver/"
+        "key/semantics type, missing field, or coordinate); undecidable-"
+        "class prose alone is unfinished construction wearing a label"
+    ),
+}
+
+# Calls that mint accounted named refusals / construction gaps.
+_REFUSAL_FUNCS = frozenset(
+    {
+        "SugarNotWritten",
+        "VocabularyMissing",
+        "UnattributableRefusal",
+        "BackendDefect",
+        "WithConstructionGap",
+        "ContextManagerResolutionConstructionGap",
+        "OpaqueSourceCallResolutionGap",
+        "RuntimeSelectedContextManager",
+        "SubstituteNotWritten",
+        "ConstructedValueTestimonyNotWritten",
+        "UnsupportedContextManagerSemantics",
+        "UnsupportedWithBindingTarget",
+        "AsyncContextManagerUnsupported",
+        "construction_panic_gap",
+        "vocabulary_missing",
+        "backend_defect",
+        "ConstructionGap",
+    }
+)
+
+_REFUSAL_NAME_MARKERS = (
+    "NotWritten",
+    "Gap",
+    "Refusal",
+    "Missing",
+    "Defect",
+    "Unsupported",
+)
+
+# Undecidable-class language in observed prose.
+_UNDECIDABLE = re.compile(
+    r"undecid|not source-decid|cannot decide|opaque|"
+    r"unknown (?:runtime|type|value|semantics|variant)|"
+    r"runtime-selected|undischarged",
+    re.IGNORECASE,
+)
+
+# Concrete artifact signals inside a constant observed string.
+_CAMEL_TYPE = re.compile(r"\b[A-Z][a-z0-9]+(?:[A-Z][a-zA-Z0-9]+)+\b")
+_PATHISH = re.compile(r"[A-Za-z0-9_./-]+\.py\b|[A-Za-z_]+\.[A-Za-z_]+|:\d+")
+_IDENTITY_FIELD = re.compile(
+    r"\b(?:exception_type_coordinate|exception_type_mro|occurrence_id|"
+    r"occurrence|type_coordinate|coordinate_cid|authenticated_identity|"
+    r"producer_node_owner|demand_cid|member_cid|semantics)\b"
+)
+
+
+@dataclass(frozen=True, order=True)
+class Finding:
+    path: str
+    line: int
+    column: int
+    violation_class: str
+    call_name: str
+    observed: str
+
+    @property
+    def required_fix(self) -> str:
+        return REQUIRED_FIX[self.violation_class]
+
+    def to_value(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "line": self.line,
+            "column": self.column,
+            "class": self.violation_class,
+            "call": self.call_name,
+            "observed": self.observed,
+            "requiredFix": self.required_fix,
+        }
+
+
+def _call_name(func: ast.AST) -> str | None:
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _is_refusal_call_name(name: str | None) -> bool:
+    if name is None:
+        return False
+    if name in _REFUSAL_FUNCS:
+        return True
+    return any(marker in name for marker in _REFUSAL_NAME_MARKERS)
+
+
+def _observed_text_constant_parts(expr: ast.AST) -> str:
+    if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+        return expr.value
+    if isinstance(expr, ast.JoinedStr):
+        parts: list[str] = []
+        for value in expr.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+        return "".join(parts)
+    if isinstance(expr, ast.BinOp) and isinstance(expr.op, ast.Add):
+        return _observed_text_constant_parts(expr.left) + _observed_text_constant_parts(
+            expr.right
+        )
+    return ""
+
+
+def _is_undecidable_class(expr: ast.AST) -> bool:
+    text = _observed_text_constant_parts(expr)
+    if text and _UNDECIDABLE.search(text):
+        return True
+    # Pure non-constant observed with no constant undecidable marker: not this axis.
+    return False
+
+
+def _names_artifact(expr: ast.AST) -> bool:
+    """True when observed names a concrete invisible artifact, not only a class."""
+    if isinstance(expr, ast.JoinedStr):
+        # f-string always interpolates something — that something is the artifact.
+        return any(isinstance(v, ast.FormattedValue) for v in expr.values)
+    if isinstance(expr, ast.Call):
+        return True
+    if isinstance(expr, ast.BinOp) and isinstance(expr.op, ast.Add):
+        return _names_artifact(expr.left) or _names_artifact(expr.right)
+    if isinstance(expr, (ast.Attribute, ast.Name)):
+        return True
+    if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+        s = expr.value
+        if _CAMEL_TYPE.search(s):
+            return True
+        if _PATHISH.search(s):
+            return True
+        if _IDENTITY_FIELD.search(s):
+            return True
+        if "[" in s and "]" in s:
+            return True
+        return False
+    return False
+
+
+def _kw_observed(call: ast.Call) -> ast.AST | None:
+    for kw in call.keywords:
+        if kw.arg == "observed":
+            return kw.value
+    return None
+
+
+class _Visitor(ast.NodeVisitor):
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.findings: list[Finding] = []
+        self._seen: set[tuple[int, int, str]] = set()
+
+    def _consider(self, call: ast.Call) -> None:
+        name = _call_name(call.func)
+        if not _is_refusal_call_name(name):
+            return
+        observed = _kw_observed(call)
+        if observed is None:
+            return
+        if not _is_undecidable_class(observed):
+            return
+        if _names_artifact(observed):
+            return
+        key = (getattr(call, "lineno", 0) or 0, getattr(call, "col_offset", 0) or 0, name or "")
+        if key in self._seen:
+            return
+        self._seen.add(key)
+        text = _observed_text_constant_parts(observed) or ast.dump(observed)
+        self.findings.append(
+            Finding(
+                path=self.path,
+                line=key[0],
+                column=key[1],
+                violation_class=NAMING_NOTHING,
+                call_name=name or "?",
+                observed=text,
+            )
+        )
+
+    def visit_Raise(self, node: ast.Raise) -> None:
+        if isinstance(node.exc, ast.Call):
+            self._consider(node.exc)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        # Direct mint helpers (construction_panic_gap, backend_defect, …)
+        # that do not always appear under raise.
+        name = _call_name(node.func)
+        if name in {
+            "construction_panic_gap",
+            "vocabulary_missing",
+            "backend_defect",
+            "ConstructionGap",
+        }:
+            self._consider(node)
+        self.generic_visit(node)
+
+
+def scan_python_source(source: str, path: str) -> list[Finding]:
+    tree = ast.parse(source, filename=path)
+    visitor = _Visitor(path)
+    visitor.visit(tree)
+    return sorted(set(visitor.findings))
+
+
+def _default_roots(repo: Path) -> tuple[Path, ...]:
+    return (
+        repo / "implementations/python/sugar-lift-py-tests/src",
+        repo / "implementations/python/sugar-source-tree/src",
+        repo / "implementations/python/sugar-lift-python-source/src",
+    )
+
+
+def _source_files(roots: Iterable[Path]) -> list[Path]:
+    files: set[Path] = set()
+    for root in roots:
+        if root.is_file() and root.suffix == ".py":
+            files.add(root)
+        elif root.is_dir():
+            for path in root.rglob("*.py"):
+                if "__pycache__" in path.parts:
+                    continue
+                files.add(path)
+    return sorted(files)
+
+
+def scan_roots(
+    roots: Iterable[Path] | None = None, *, repo: Path | None = None
+) -> tuple[list[Finding], list[str]]:
+    base = (repo or Path.cwd()).resolve()
+    scan_paths = tuple(roots) if roots is not None else _default_roots(base)
+    findings: list[Finding] = []
+    errors: list[str] = []
+    self_path = Path(__file__).resolve()
+    for path in _source_files(scan_paths):
+        if path.resolve() == self_path:
+            continue
+        label = (
+            str(path.resolve().relative_to(base))
+            if path.resolve().is_relative_to(base)
+            else str(path)
+        )
+        try:
+            source = path.read_text(encoding="utf-8")
+            findings.extend(scan_python_source(source, label))
+        except (OSError, UnicodeError, SyntaxError) as exc:
+            errors.append(f"{label}: {type(exc).__name__}: {exc}")
+    return sorted(set(findings)), sorted(errors)
+
+
+def format_report(findings: Iterable[Finding], errors: Iterable[str] = ()) -> str:
+    rows = list(findings)
+    error_rows = list(errors)
+    lines = [
+        "CRITERION-3 REFUSAL NAMING AUDIT",
+        "rung=auditor",
+        "retire_when="
+        "typed observed:Artifact + RefusalDecidability one-door make both axes "
+        "unrepresentable; then delete this auditor",
+        "axis2=OPEN: R_refusals_over_decidable_source not measured "
+        "(static scan cannot soundly recover source-visibility; see module doc)",
+        "",
+    ]
+    for finding in rows:
+        lines.append(
+            f"{finding.path}:{finding.line}:{finding.column}: {finding.violation_class}: "
+            f"{finding.call_name}: {finding.observed!r}; required fix: {finding.required_fix}"
+        )
+    lines.extend(f"AUDITOR-ERROR: {error}" for error in error_rows)
+    lines.append(f"R_refusals_naming_nothing = {len(rows)}")
+    lines.append("R_refusals_over_decidable_source = OPEN")
+    lines.append(f"R_auditor_errors = {len(error_rows)}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("roots", nargs="*", type=Path)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--json", type=Path)
+    args = parser.parse_args()
+    repo = args.repo.resolve()
+    roots = tuple(path.resolve() for path in args.roots) or None
+    findings, errors = scan_roots(roots, repo=repo)
+    print(format_report(findings, errors))
+    if args.json is not None:
+        args.json.write_text(
+            json.dumps(
+                {
+                    "kind": "criterion3-refusal-naming-audit",
+                    "class": "CRITERION-3 REFUSAL NAMING",
+                    "rung": "auditor",
+                    "R_refusals_naming_nothing": len(findings),
+                    "R_refusals_over_decidable_source": "OPEN",
+                    "auditorErrors": errors,
+                    "findings": [finding.to_value() for finding in findings],
+                    "openAxis": {
+                        "name": "R_refusals_over_decidable_source",
+                        "why_open": (
+                            "static AST cannot soundly decide that perfect "
+                            "machinery over source-visible code could have "
+                            "constructed instead of refused"
+                        ),
+                        "retirement": (
+                            "RefusalDecidability::{MissingMachinery, "
+                            "PerfectSourceStillUndecidable} required at the "
+                            "named-refusal door"
+                        ),
+                    },
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    return 1 if findings or errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mapping_object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mapping_object_value.py
@@ -199,7 +199,10 @@ class MappingObjectValue(ObjectValue):
             construction_panic_gap(
                 owner="MappingObjectValue.get",
                 blame=blame,
-                observed="undecidable mapping key equality",
+                observed=(
+                    "undecidable mapping key equality: "
+                    f"key={type(key).__name__} over {type(self).__name__}"
+                ),
                 requested="one source-decided finite mapping key",
                 fix="construct key equality or keep get typed loud",
             )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -1294,7 +1294,11 @@ def outcome_to_exitset(outcome) -> ExitSet:
         construction_panic_gap(
             owner="outcome_to_exitset",
             blame=outcome.demand.source_node,
-            observed="undischarged native operation demand",
+            observed=(
+                "undischarged native operation demand: "
+                f"{type(outcome).__name__} demand="
+                f"{type(outcome.demand).__name__}"
+            ),
             requested=(
                 "an ExitSet projected from authenticated caller actual operands"
             ),

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
@@ -179,7 +179,11 @@ class SubscriptAugAssignSugar(Sugar):
             raise SugarNotWritten(
                 owner="SubscriptAugAssignSugar._store",
                 blame=self.set_site,
-                observed="undischarged augmented subscript store over undecided receiver",
+                observed=(
+                    "undischarged augmented subscript store over undecided receiver: "
+                    f"{type(receiver).__name__}[{type(index).__name__}]="
+                    f"{type(result).__name__}"
+                ),
                 requested=(
                     "NativeOperationExitCarrierV1 n-ary setitem demand over "
                     "receiver, key, and result formal coordinates"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py
@@ -162,7 +162,10 @@ class SubscriptDeleteEffectSugar(Sugar):
             raise SugarNotWritten(
                 owner="SubscriptDeleteEffectSugar._delete",
                 blame=self.site,
-                observed="undischarged subscript delete over runtime-selected receiver",
+                observed=(
+                    "undischarged subscript delete over runtime-selected receiver: "
+                    f"{type(receiver).__name__}[{type(index).__name__}]"
+                ),
                 requested=(
                     "NativeOperationExitCarrierV1 n-ary delitem demand over "
                     "receiver and key formal coordinates"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_result_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_result_sugar.py
@@ -71,7 +71,10 @@ class MappingPopResultSugar(ConstructedTermSugar):
             construction_panic_gap(
                 owner="MappingPopResultSugar",
                 blame=self.site,
-                observed="undecidable mapping key equality",
+                observed=(
+                    "undecidable mapping key equality: "
+                    f"key={type(key).__name__} over {type(receiver).__name__}"
+                ),
                 requested="one source-decided finite mapping key",
                 fix="construct key equality or keep pop typed loud",
             )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_state_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_state_sugar.py
@@ -72,7 +72,10 @@ class MappingPopStateSugar(ConstructedTermSugar):
             construction_panic_gap(
                 owner="MappingPopStateSugar",
                 blame=self.site,
-                observed="undecidable mapping key equality",
+                observed=(
+                    "undecidable mapping key equality: "
+                    f"key={type(key).__name__} over {type(receiver).__name__}"
+                ),
                 requested="one source-decided finite mapping key",
                 fix="construct key equality or keep pop typed loud",
             )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
@@ -234,7 +234,11 @@ class SubscriptStoreEffectSugar(Sugar):
             raise SugarNotWritten(
                 owner="SubscriptStoreEffectSugar._store",
                 blame=self.site,
-                observed="undischarged subscript store over runtime-selected receiver",
+                observed=(
+                    "undischarged subscript store over runtime-selected receiver: "
+                    f"{type(receiver).__name__}[{type(index).__name__}]="
+                    f"{type(value).__name__}"
+                ),
                 requested=(
                     "NativeOperationExitCarrierV1 n-ary setitem demand over "
                     "receiver, key, and value formal coordinates"

--- a/implementations/python/sugar-lift-py-tests/tests/test_criterion3_refusal_naming_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_criterion3_refusal_naming_law.py
@@ -1,0 +1,101 @@
+"""Lying twins for CRITERION-3 REFUSAL NAMING auditor."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+_SCRIPT = (
+    Path(__file__).parents[1] / "scripts" / "criterion3_refusal_naming_law.py"
+)
+_SPEC = importlib.util.spec_from_file_location("criterion3_refusal_naming_law", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+LAW = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = LAW
+_SPEC.loader.exec_module(LAW)
+
+
+def _classes(source: str) -> set[str]:
+    return {
+        finding.violation_class
+        for finding in LAW.scan_python_source(source, "planted.py")
+    }
+
+
+def test_nameless_undecidable_observed_is_recognized() -> None:
+    assert _classes(
+        """
+from sugar_source_tree.panic import SugarNotWritten
+def refuse(site):
+    raise SugarNotWritten(
+        blame=site,
+        owner="plant",
+        observed="undecidable mapping key equality",
+        requested="source-decided key",
+        fix="name the key type",
+    )
+"""
+    ) == {"REFUSAL-NAMING-NOTHING"}
+
+    assert _classes(
+        """
+from sugar_lift_py_tests.gap.panic import construction_panic_gap
+def refuse(site):
+    construction_panic_gap(
+        owner="plant",
+        blame=site,
+        observed="undischarged store over runtime-selected receiver",
+        requested="decided receiver",
+        fix="name the receiver type",
+    )
+"""
+    ) == {"REFUSAL-NAMING-NOTHING"}
+
+
+def test_named_artifact_undecidable_is_silent() -> None:
+    source = """
+from sugar_source_tree.panic import SugarNotWritten
+def refuse(self, index, site):
+    raise SugarNotWritten(
+        blame=site,
+        owner="plant",
+        observed=(
+            "undecided receiver runtime type: "
+            f"{type(self).__name__}[{type(index).__name__}]"
+        ),
+        requested="source-authenticated subscript",
+        fix="carry type testimony",
+    )
+
+def refuse_field(site):
+    raise SugarNotWritten(
+        blame=site,
+        owner="plant",
+        observed=(
+            "undecided binary compare without authenticated "
+            "exception_type_coordinate"
+        ),
+        requested="ground TypeError or named refusal",
+        fix="do not mint nameless RaiseEffect",
+    )
+"""
+    assert LAW.scan_python_source(source, "clean.py") == []
+
+
+def test_report_names_axes_and_open_second() -> None:
+    findings = LAW.scan_python_source(
+        """
+raise SugarNotWritten(
+    blame=s, owner="o",
+    observed="undecidable",
+    requested="r", fix="f",
+)
+""",
+        "weak.py",
+    )
+    rendered = LAW.format_report(findings)
+    assert "R_refusals_naming_nothing = 1" in rendered
+    assert "R_refusals_over_decidable_source = OPEN" in rendered
+    assert "rung=auditor" in rendered
+    assert "retire_when=" in rendered

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -3431,7 +3431,12 @@ def _install_opaque_call_obligation(
         raise BackendDefect(
             blame=call.fragment,
             owner="manager_construction._install_opaque_call_obligation",
-            observed="conflicting opaque-call obligation",
+            observed=(
+                "conflicting opaque-call obligation at "
+                f"coordinate={coordinate!r} "
+                f"existing={type(existing).__name__} "
+                f"new={type(obligation).__name__}"
+            ),
             requested="byte-identical duplicate testimony",
             fix="resolve the conflicting target or authenticated owner",
         )


### PR DESCRIPTION
## Summary

Criterion 3 half we state but never measured:

> Source-visible behaviour CONSTRUCTS; source-undecidable behaviour is specifically refused, **naming the artifact it cannot see**.

### Live instrument (not a checklist)

`implementations/python/sugar-lift-py-tests/scripts/criterion3_refusal_naming_law.py`

Scans product `src` trees for named-refusal mints (`SugarNotWritten`, `construction_panic_gap`, `BackendDefect`, …).

| Axis | Live R | Status |
|------|-------:|--------|
| **R_refusals_naming_nothing** | **8 → 0** | measured; drained |
| **R_refusals_over_decidable_source** | **OPEN** | not faked |

### Why axis 2 is OPEN (not measured)

A refusal is final only when *perfect* machinery over source-visible code still could not decide. Static AST cannot soundly recover "the source was visible here" without inventing false greens (the shape that would have banked 47 sites as progress).

**Retirement object named:** construction-required

```text
RefusalDecidability::
  MissingMachinery(source_visible: tuple[Artifact, ...])
  PerfectSourceStillUndecidable(exhausted: tuple[Artifact, ...])
```

Only the second is a valid final refusal. When that enum is the one door, delete any prose auditor that tried to guess.

### Partition of the live 8 (doctrine first)

| Bucket | N | Meaning |
|--------|--:|--------|
| **(a)** strengthen refusal (name the artifact) | **8** | legitimate refusals, unfinished labels |
| **(b)** missing object | **0** | — |
| **(c)** open membrane | **0** | — |

Not delete-the-tooth: these refusals should exist. Shell deleted is *nameless* undecidable prose.

### Enforcement ladder

- Type? No — free `observed: str`.
- One door? No — not yet `NamedRefusal(artifact, decidability)`.
- Panic at contact? No — green paths never re-read prose.
- **Auditor** — with retirement paths above.

### Shot accounting

- **R axis:** `R_refusals_naming_nothing`
- **Epsilon R:** 8 → 0
- **Floors:** axis2 remains OPEN (honest); instrument red on new nameless prose
- **Shell deleted:** constant undecidable/undischarged `observed` without artifact interpolation (8 sites now f-string types/coordinates)

### Validation

```
/usr/bin/python3 .../criterion3_refusal_naming_law.py --repo .
# EXIT=0; R_refusals_naming_nothing = 0; R_refusals_over_decidable_source = OPEN
```

Planted twins via importlib (no local pytest; no bx).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add criterion-3 refusal naming auditor and fix undecidable-observed messages to include concrete types
> - Adds [criterion3_refusal_naming_law.py](https://github.com/TSavo/sugar/pull/6988/files#diff-e07703e56aaa3c2f933ebd29b6be78b74aa05b38dde3d63eb28604cffa543581), an AST-based auditor that scans Python sources for refusal calls whose `observed` text describes an undecidable condition without naming a concrete artifact (type, path, or identity field).
> - Updates `observed` strings in seven source files across `sugar_lift_py_tests` and `sugar_lift_python_source` to use f-strings that include runtime type names, resolving the 8 pre-existing violations the auditor would flag.
> - Adds unit tests in [test_criterion3_refusal_naming_law.py](https://github.com/TSavo/sugar/pull/6988/files#diff-6eb12a21d2b57b77c1a60c5eced1a06bffa746fb412f698f641fc322355a4187) covering violation detection, silent behavior for compliant code, and report formatting.
> - Behavioral Change: error messages emitted by the updated refusal sites now include concrete runtime type names, changing observable output in logs and exceptions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4a38ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->