### PR TITLE
Drain R_repo_root_by_parents_count outside package src to 0

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
@@ -34,10 +34,12 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Iterator, Sequence, TextIO, TypeVar
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 T = TypeVar("T")
 
 # Repo tools/ is not always on path when floors run as scripts/.
-_TOOLS = Path(__file__).resolve().parents[4] / "tools"
+_TOOLS = resolve_repo_root() / "tools"
 if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
 
@@ -174,7 +176,7 @@ def apply_lpt_file_shard(
         raise ValueError(
             f"shard_index {shard_index} out of range for shard_count {shard_count}"
         )
-    tools = Path(__file__).resolve().parents[4] / "tools"
+    tools = resolve_repo_root() / "tools"
     if tools.is_dir() and str(tools) not in sys.path:
         sys.path.insert(0, str(tools))
     from lpt_file_shards import filter_paths_for_shard

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
@@ -25,6 +25,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator, Mapping, Sequence
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 _WORKER = Path(__file__).resolve().parent / "_supervised_enum_worker.py"
 
 # Context init walks the full corpus for provisional demand rows when no
@@ -45,7 +47,7 @@ _SMALL_POP_INIT_CAP_S = 60.0
 _DEFAULT_CONTEXT_INIT_TIMEOUT = _CORPUS_CONTEXT_INIT_TIMEOUT
 
 # tools/job_log_heartbeat.py — job log, not file, ≤30s silence.
-_TOOLS = Path(__file__).resolve().parents[4] / "tools"
+_TOOLS = resolve_repo_root() / "tools"
 if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
 
@@ -703,7 +705,7 @@ class SupervisedEnumSupervisor:
                     # Content-addressed LPT prior write-through (next run packs
                     # by measured cost; cold equal-count seeds the shelf).
                     try:
-                        _tools = Path(__file__).resolve().parents[4] / "tools"
+                        _tools = resolve_repo_root() / "tools"
                         if _tools.is_dir() and str(_tools) not in sys.path:
                             sys.path.insert(0, str(_tools))
                         from lpt_file_shards import ContentAddressedCostPrior

--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -103,7 +106,7 @@ def main() -> int:
             stream.reconfigure(encoding="utf-8", errors="backslashreplace")
         except (AttributeError, ValueError):
             pass
-    repo_root = Path(__file__).resolve().parents[4]
+    repo_root = resolve_repo_root()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "paths",

--- a/implementations/python/sugar-lift-py-tests/scripts/compatibility_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compatibility_door_law.py
@@ -80,6 +80,8 @@ import tempfile
 from pathlib import Path
 from typing import NamedTuple, Sequence
 
+from sugar_lift_py_tests.repo_root import python_implementations_root
+
 
 class CompatibilityDoorOffender(NamedTuple):
     path: str
@@ -522,8 +524,7 @@ def project_wire(row):
 
 
 def default_python_root() -> Path:
-    # scripts/ → sugar-lift-py-tests → python/
-    return Path(__file__).resolve().parents[2]
+    return python_implementations_root()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -24,6 +24,11 @@ from collections import Counter
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from sugar_lift_py_tests.repo_root import (
+    resolve_repo_root,
+    sugar_lift_py_tests_package_root,
+)
+
 # Sole True declaration for the kit (test_one_authoritative_scoreboard).
 SCOREBOARD_AUTHORITY = True
 
@@ -62,12 +67,12 @@ _PANDAS_3_0_3_MANIFEST_SHAPE_CID = (
     "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
 )
 
-_TOOLS = Path(__file__).resolve().parents[4] / "tools"
+_TOOLS = resolve_repo_root() / "tools"
 if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
 
 # Package root for sealed board function facts (C4 Step 1).
-_PKG_SRC = Path(__file__).resolve().parents[1] / "src"
+_PKG_SRC = sugar_lift_py_tests_package_root() / "src"
 if _PKG_SRC.is_dir() and str(_PKG_SRC) not in sys.path:
     sys.path.insert(0, str(_PKG_SRC))
 

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_context_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_context_door_law.py
@@ -61,6 +61,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 BARE_DOOR = "from_path"
 BARE_DOOR_OWNER = "SourceFile"
 CONSTRUCTION_DRIVER = "sugar"
@@ -259,7 +262,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.self_test:
         return self_test()
 
-    roots = args.roots or [Path(__file__).resolve().parents[3]]
+    roots = args.roots or [(resolve_repo_root() / "implementations")]
     offenders, unreadable = scan_roots(roots)
     report = {
         "law": "R_bare_construction_door",

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
@@ -35,6 +35,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -648,7 +651,7 @@ def main() -> int:
     parser.add_argument(
         "--kit-root",
         type=Path,
-        default=Path(__file__).resolve().parents[1],
+        default=sugar_lift_py_tests_package_root(),
     )
     args = parser.parse_args()
     offenders = scan_repository(args.kit_root)

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_side_door_law.py
@@ -47,6 +47,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -531,7 +534,7 @@ def sole_path_roots(repo: Path | None = None) -> list[Path]:
 
     R on these roots must stay 0: meaning is tree + prebound refs only.
     """
-    kit = Path(__file__).resolve().parents[1]
+    kit = sugar_lift_py_tests_package_root()
     py = kit.parent
     if repo is not None:
         py = (repo / "implementations" / "python").resolve()
@@ -548,7 +551,7 @@ def default_production_roots(repo: Path | None = None) -> list[Path]:
     Includes sugar-lift-python-source while that package still feeds lift_rpc /
     production construction so every foreign-ast import there is named.
     """
-    kit = Path(__file__).resolve().parents[1]
+    kit = sugar_lift_py_tests_package_root()
     py = kit.parent
     # kit = .../sugar-lift-py-tests; py = .../python
     if repo is not None:

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -107,6 +107,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, TextIO
 
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
 # CI-visible narration: default print buffering makes a live process look dead.
 # Every RECENSUS line uses flush=True; prefer PYTHONUNBUFFERED=1 in the workflow.
@@ -114,7 +115,7 @@ _PROGRESS_EVERY_N = max(1, int(os.environ.get("RECENSUS_PROGRESS_EVERY_N", "1"))
 # Doctrine: never more than 30s of job-log silence on a long path.
 _JOB_LOG_MAX_SILENCE_S = float(os.environ.get("JOB_LOG_MAX_SILENCE_S", "30"))
 
-_TOOLS = Path(__file__).resolve().parents[4] / "tools"
+_TOOLS = resolve_repo_root() / "tools"
 if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
 
@@ -1128,7 +1129,7 @@ def main() -> int:
 
     def publish_demand_table(table, path: Path) -> None:
         """Publish the derived payload through the authenticated CAS door."""
-        repo_root = Path(__file__).resolve().parents[4]
+        repo_root = resolve_repo_root()
         completed = subprocess.run(
             [
                 str(repo_root / "bin" / "sugarbin"),

--- a/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -247,7 +250,7 @@ def _run_parent(args: argparse.Namespace) -> int:
     workspace_root = Path(os.path.commonpath([str(root) for root in corpus_roots]))
     demand_scratch = tempfile.TemporaryDirectory(prefix="fatal-triage-demand-")
     demand_table_path = Path(demand_scratch.name) / "python-demand-table.json"
-    pull_shared_demand_table(Path(__file__).resolve().parents[4], demand_table_path)
+    pull_shared_demand_table(resolve_repo_root(), demand_table_path)
     supervisor = SupervisedEnumSupervisor(
         file_timeout=float(args.file_timeout),
         corpus_root=workspace_root,

--- a/implementations/python/sugar-lift-py-tests/scripts/enumeration_binding_soft_skip_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/enumeration_binding_soft_skip_law.py
@@ -41,6 +41,9 @@ from __future__ import annotations
 
 # Not the board. Own denominator; scripts/control_effect_recensus.py is the
 # sole authoritative Python corpus scoreboard.
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -266,7 +269,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--kit-root",
         type=Path,
-        default=Path(__file__).resolve().parents[1],
+        default=sugar_lift_py_tests_package_root(),
         help="sugar-lift-py-tests package root",
     )
     args = parser.parse_args(argv)

--- a/implementations/python/sugar-lift-py-tests/scripts/factory_ownership_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/factory_ownership_law.py
@@ -25,6 +25,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -329,7 +332,7 @@ def main() -> int:
         "--sugar-root",
         type=Path,
         default=(
-            Path(__file__).resolve().parents[1]
+            sugar_lift_py_tests_package_root()
             / "src"
             / "sugar_lift_py_tests"
             / "sugar"

--- a/implementations/python/sugar-lift-py-tests/scripts/factory_walk_unclassified_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/factory_walk_unclassified_law.py
@@ -26,6 +26,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -445,7 +448,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 stream.reconfigure(encoding="utf-8", errors="backslashreplace")
             except (AttributeError, ValueError):
                 pass
-    repo_root = Path(__file__).resolve().parents[4]
+    repo_root = resolve_repo_root()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--from-json",

--- a/implementations/python/sugar-lift-py-tests/scripts/factory_walk_unclassified_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/factory_walk_unclassified_law.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from typing import Any
 
 # Repo tools/ for job-log heartbeats (≤30s doctrine — run 30731778056: 88s silence).
-_TOOLS = Path(__file__).resolve().parents[4] / "tools"
+_TOOLS = resolve_repo_root() / "tools"
 if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
 

--- a/implementations/python/sugar-lift-py-tests/scripts/finite_cap_opaque_completion_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/finite_cap_opaque_completion_law.py
@@ -15,6 +15,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -351,7 +354,7 @@ def r_auditor_errors(rows: Sequence[FiniteCapOpaqueCompletion]) -> int:
 
 
 def _default_root() -> Path:
-    return Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+    return sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests"
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/implementations/python/sugar-lift-py-tests/scripts/finite_unfold_compact_projection_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/finite_unfold_compact_projection_law.py
@@ -30,6 +30,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -219,7 +222,7 @@ def r_auditor_errors(rows: Sequence[FiniteUnfoldCompactGap]) -> int:
 
 
 def _default_root() -> Path:
-    return Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+    return sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests"
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/implementations/python/sugar-lift-py-tests/scripts/generator_construction_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/generator_construction_law.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -67,7 +70,7 @@ def scan(repository: Path) -> tuple[int, list[GeneratorConstructionOffender]]:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--repository", type=Path, default=Path(__file__).parents[4])
+    parser.add_argument("--repository", type=Path, default=resolve_repo_root())
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args()
     discovered, offenders = scan(args.repository.resolve())

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -163,7 +166,7 @@ def main() -> int:
             stream.reconfigure(encoding="utf-8", errors="backslashreplace")
         except (AttributeError, ValueError):
             pass
-    repo_root = Path(__file__).resolve().parents[4]
+    repo_root = resolve_repo_root()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "paths",

--- a/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/no_call_body_attribution.py
@@ -17,10 +17,13 @@ import sys
 from pathlib import Path
 
 from sugar_lift_py_tests.no_call_body_attribution import (
+
     ProducerFamily,
     run_authenticated_attribution,
 )
 
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
 def main() -> int:
     parser = argparse.ArgumentParser()
@@ -36,7 +39,7 @@ def main() -> int:
         if args.family
         else None
     )
-    repo_root = Path(__file__).resolve().parents[4]
+    repo_root = resolve_repo_root()
     from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 
     import numpy

--- a/implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/no_sugar_in_desugar_law.py
@@ -17,6 +17,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -269,7 +272,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(json.dumps({"instrument": "R_no_sugar_in_desugar", "self_test": ok}))
             return 0 if ok else 1
         roots = args.roots or [
-            Path(__file__).resolve().parents[1]
+            sugar_lift_py_tests_package_root()
             / "src"
             / "sugar_lift_py_tests"
             / "sugar"

--- a/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
@@ -9,7 +9,9 @@ from collections import Counter
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-_PACKAGE_SRC = Path(__file__).resolve().parents[1] / "src"
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_PACKAGE_SRC = sugar_lift_py_tests_package_root() / "src"
 if str(_PACKAGE_SRC) not in sys.path:
     sys.path.insert(0, str(_PACKAGE_SRC))
 

--- a/implementations/python/sugar-lift-py-tests/scripts/self_sealing_instrument_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/self_sealing_instrument_law.py
@@ -71,6 +71,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 SYNTHESIZED = "SYNTHESIZED-EVIDENCE"
 TAUTOLOGICAL = "TAUTOLOGICAL-ASSERT"
 PRESENCE_ONLY = "PRESENCE-ONLY-IDENTITY"
@@ -414,7 +416,7 @@ def _load_scan_scope():
         import importlib.util
 
         path = (
-            Path(__file__).resolve().parents[1]
+            sugar_lift_py_tests_package_root()
             / "src"
             / "sugar_lift_py_tests"
             / "idd"

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -66,6 +66,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -387,7 +390,7 @@ def main() -> int:
             stream.reconfigure(encoding="utf-8", errors="backslashreplace")
         except (AttributeError, ValueError):
             pass
-    repo_root = Path(__file__).resolve().parents[4]
+    repo_root = resolve_repo_root()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "paths",

--- a/implementations/python/sugar-lift-py-tests/scripts/source_audit_presence_identity_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/source_audit_presence_identity_law.py
@@ -29,6 +29,9 @@ No baseline, no threshold, no allowlist. Exit 1 while R > 0.
 from __future__ import annotations
 
 # Not the board. This module measures its own named denominator.
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -351,7 +354,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.self_test:
         return self_test()
 
-    default_root = Path(__file__).resolve().parents[1]  # sugar-lift-py-tests
+    default_root = sugar_lift_py_tests_package_root()  # sugar-lift-py-tests
     roots = args.roots or [default_root]
     offenders, unreadable = scan_roots(roots)
     report = {

--- a/implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/source_via_execution_law.py
@@ -32,6 +32,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -454,7 +457,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             stream.reconfigure(encoding="utf-8", errors="backslashreplace")
         except (AttributeError, ValueError):
             pass
-    package = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+    package = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests"
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "roots",

--- a/implementations/python/sugar-lift-py-tests/scripts/swallowed_throw_second_mechanism_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/swallowed_throw_second_mechanism_law.py
@@ -50,7 +50,10 @@ from __future__ import annotations
 # Not the board. Named denominator only.
 # See tests/test_one_authoritative_scoreboard.py.
 
-from sugar_lift_py_tests.repo_root import python_implementations_root
+from sugar_lift_py_tests.repo_root import (
+    python_implementations_root,
+    sugar_lift_py_tests_package_root,
+)
 
 SCOREBOARD_AUTHORITY = False
 
@@ -416,7 +419,7 @@ def _swallowed_scan_scope(python_root: Path):
         import importlib.util
 
         path = (
-            Path(__file__).resolve().parents[1]
+            sugar_lift_py_tests_package_root()
             / "src"
             / "sugar_lift_py_tests"
             / "idd"

--- a/implementations/python/sugar-lift-py-tests/scripts/swallowed_throw_second_mechanism_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/swallowed_throw_second_mechanism_law.py
@@ -49,6 +49,9 @@ from __future__ import annotations
 
 # Not the board. Named denominator only.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import python_implementations_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -512,7 +515,7 @@ def format_report(offenders: list[SwallowOffender]) -> str:
 
 def default_python_root() -> Path:
     # scripts/ → sugar-lift-py-tests → python/
-    return Path(__file__).resolve().parents[2]
+    return python_implementations_root()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -107,7 +110,7 @@ def main() -> int:
             stream.reconfigure(encoding="utf-8", errors="backslashreplace")
         except (AttributeError, ValueError):
             pass
-    repo_root = Path(__file__).resolve().parents[4]
+    repo_root = resolve_repo_root()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "paths",

--- a/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
@@ -28,6 +28,9 @@ from __future__ import annotations
 # Not the board. This module measures its own named denominator; the sole
 # authoritative Python corpus scoreboard is scripts/control_effect_recensus.py.
 # See tests/test_one_authoritative_scoreboard.py.
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 SCOREBOARD_AUTHORITY = False
 
 import argparse
@@ -571,7 +574,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             stream.reconfigure(encoding="utf-8", errors="backslashreplace")
         except (AttributeError, ValueError):
             pass
-    package = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+    package = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests"
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "roots",

--- a/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
@@ -51,7 +51,7 @@ try:
     )
 except ImportError:  # script-path invocation without package on PYTHONPATH
     _IDD = (
-        Path(__file__).resolve().parents[1]
+        sugar_lift_py_tests_package_root()
         / "src"
         / "sugar_lift_py_tests"
         / "idd"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/repo_root.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/repo_root.py
@@ -122,3 +122,14 @@ def sugar_lift_py_tests_package_root(repo_root: Path | None = None) -> Path:
             f"under resolved monorepo root {root}"
         )
     return package
+
+
+def python_implementations_root(repo_root: Path | None = None) -> Path:
+    """``implementations/python`` under the monorepo — never parents[2] from tests."""
+    root = repo_root if repo_root is not None else resolve_repo_root()
+    path = (root / "implementations" / "python").resolve()
+    if not path.is_dir():
+        raise RepoRootUnresolved(
+            f"cannot locate implementations/python under monorepo root {root}"
+        )
+    return path

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_exceptional_exit_producer.py
@@ -21,6 +21,9 @@ from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.nodes import Attribute
 from sugar_source_tree.tree import SourceFile
 
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 SITE_SHA256 = "4d2599448c6b329af3822dbc2295fafe142d9ce84e49821c435d9b1c11fea793"
 SOURCE_CID = (
     "blake3-512:43cdd8a4f204ef75c77996a7e7a98b84bcd174de708cfe1e9e430415bbd636e2"
@@ -37,7 +40,7 @@ DEMAND_TABLE_KEY = (
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[4]
+    return resolve_repo_root()
 
 
 def _site_attribute(source: str, site: Path) -> Attribute:

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py
@@ -7,6 +7,7 @@ import pytest
 from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.floor import (
+
     NoneValue,
     ObjectField,
     ObjectValue,
@@ -23,6 +24,8 @@ from sugar_source_tree.nodes import Attribute
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
+
+from sugar_lift_py_tests.repo_root import python_implementations_root, resolve_repo_root, sugar_lift_py_tests_package_root
 
 class _ValueSugar(ConstructedTermSugar):
     def __init__(self, value):
@@ -178,7 +181,7 @@ def test_authenticated_attribute_family_has_a_closed_nonzero_exit_split() -> Non
         run_authenticated_attribution,
     )
 
-    repo_root = Path(__file__).resolve().parents[4]
+    repo_root = resolve_repo_root()
     report = run_authenticated_attribution(
         repo_root, families=frozenset({ProducerFamily.ATTRIBUTE})
     )
@@ -193,8 +196,8 @@ def test_authenticated_attribute_family_has_a_closed_nonzero_exit_split() -> Non
 
 
 def test_attribute_construction_has_no_vendor_exception_name_arm() -> None:
-    production = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
-    source_tree = Path(__file__).resolve().parents[2] / "sugar-source-tree" / "src"
+    production = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests"
+    source_tree = python_implementations_root() / "sugar-source-tree" / "src"
     text = "\n".join(
         path.read_text(encoding="utf-8")
         for path in (

--- a/implementations/python/sugar-lift-py-tests/tests/test_audit_status_construction_authority.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_audit_status_construction_authority.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 _SEMANTIC_ROOTS = ("floor", "temporal", "proofir", "audit_only")
 _FACTORY_AUDIT_NAMES = ("ConstructionAuditStatus", "ConstructionAuditRow")
 
 
 def test_construction_semantics_do_not_import_or_reconstruct_factory_audit_objects():
     """R_semantic_factory_audit_authority stays red until the clean slice is zero."""
-    package = Path(__file__).parents[1] / "src" / "sugar_lift_py_tests"
+    package = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests"
     offenders: list[str] = []
     for root_name in _SEMANTIC_ROOTS:
         for path in sorted((package / root_name).rglob("*.py")):

--- a/implementations/python/sugar-lift-py-tests/tests/test_bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bare_exception_zero_tolerance.py
@@ -10,7 +10,10 @@ import sys
 
 import pytest
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "bare_exception_zero_tolerance.py"
 _SPEC = importlib.util.spec_from_file_location(
     "bare_exception_zero_tolerance", _SCANNER_PATH

--- a/implementations/python/sugar-lift-py-tests/tests/test_binary_handoff_policy.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_binary_handoff_policy.py
@@ -14,7 +14,10 @@ import pytest
 
 from sugar_lift_py_tests.filename import cid_filename_stem
 
-ROOT = Path(__file__).resolve().parents[4]
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 SUGARBIN = ROOT / "bin" / "sugarbin"
 PY_KIT_ROOTS = (
     ROOT / "implementations" / "python" / "sugar-lift-py-tests",

--- a/implementations/python/sugar-lift-py-tests/tests/test_black_format_gate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_black_format_gate.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[4]
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 
 
 def test_black_format_check_is_installed_and_required_by_ci() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 _SCRIPT = (
-    Path(__file__).resolve().parents[1] / "scripts" / "compose_control_effect_board.py"
+    sugar_lift_py_tests_package_root()
+    / "scripts"
+    / "compose_control_effect_board.py"
 )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 from pathlib import Path
 
 
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 def _write(root: Path, relative: str, source: str) -> None:
     path = root / relative
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -159,7 +162,7 @@ def test_instrument_fixed_cluster_five_production_sites_are_zero() -> None:
         collect_builtin_closed_operation_report,
     )
 
-    root = Path(__file__).resolve().parents[1] / "src"
+    root = sugar_lift_py_tests_package_root() / "src"
     report = collect_builtin_closed_operation_report(root)
     targets = {
         "sugar_lift_py_tests/sugar/loop_recurrence_sugar.py",

--- a/implementations/python/sugar-lift-py-tests/tests/test_cid_parser_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_cid_parser_census.py
@@ -22,7 +22,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[2]  # implementations/python
+
+from sugar_lift_py_tests.repo_root import python_implementations_root
+
+ROOT = python_implementations_root()  # implementations/python
 
 # Modules allowed to own CID/filename format knowledge. Everything else is a
 # consumer and must route through them.

--- a/implementations/python/sugar-lift-py-tests/tests/test_classify_loud_timeouts.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_classify_loud_timeouts.py
@@ -9,7 +9,10 @@ from typing import Any
 
 import pytest
 
-SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import classify_loud_timeouts as mod  # noqa: E402

--- a/implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_cm_construction_boundary.py
@@ -5,6 +5,9 @@ import pytest
 from sugar_lift_py_tests.cm_boundary_detector import scan_construction_boundary
 
 
+
+from sugar_lift_py_tests.repo_root import python_implementations_root
+
 def _write(root: Path, relative: str, source: str) -> None:
     path = root / relative
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -56,7 +59,7 @@ def test_planted_boundary_violations_each_raise_r(files, tmp_path):
 
 
 def test_complete_real_roots_have_stable_zero_boundary_residue():
-    python_root = Path(__file__).resolve().parents[2]
+    python_root = python_implementations_root()
     report = scan_construction_boundary(
         sugar_root=python_root / "sugar-lift-py-tests/src/sugar_lift_py_tests/sugar",
         source_tree_root=python_root / "sugar-source-tree/src/sugar_source_tree",

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_completion_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_completion_conservation.py
@@ -9,6 +9,7 @@ import pytest
 
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.no_call_body_attribution import (
+
     AttributionInvariantError,
     AttributionOutcome,
     BodyProbe,
@@ -20,6 +21,8 @@ from sugar_lift_py_tests.no_call_body_attribution import (
     require_expected_denominators,
 )
 from sugar_lift_py_tests.outcome import Complete
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
 PREVIOUSLY_UNACCOUNTED = frozenset(
     {
@@ -89,7 +92,7 @@ def test_all_34_compare_completions_publish_authenticated_compare_exits(
     tmp_path: Path,
 ) -> None:
     corpus = authenticated_pandas_corpus()
-    repo_root = Path(__file__).resolve().parents[4]
+    repo_root = resolve_repo_root()
     payload = pull_shared_demand_table(repo_root, tmp_path / "demand-table.json")
     compare_inventory = require_expected_denominators(
         discover_no_call_body_probes(

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -33,6 +33,9 @@ from sugar_source_tree.tree import SourceFile
 
 # Content manifest (relative path + per-file BLAKE3-512). Path-shape
 # sha256:a223… is historical negative testimony only — never identity.
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
     "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
@@ -106,7 +109,7 @@ class _OperationReceiverProjectionProbe(FloorValue):
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[4]
+    return resolve_repo_root()
 
 
 def _corpus_root() -> Path:

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_family_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_family_attribution.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from sugar_lift_py_tests.context_manager_resolution import (
+
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
@@ -17,6 +18,8 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import Call, Compare, FunctionDef, Name
 from sugar_source_tree.tree import SourceFile
 
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
 def _coordinate(node: Call) -> SourceFragmentCoordinateV1:
     span = node.line_col_span()
@@ -74,7 +77,7 @@ def test_call_operand_raise_is_owned_by_call_not_compare_root() -> None:
 
 
 def test_authenticated_compare_population_has_closed_three_outcome_split() -> None:
-    repo_root = Path(__file__).resolve().parents[4]
+    repo_root = resolve_repo_root()
     report = run_authenticated_attribution(
         repo_root, families=frozenset({ProducerFamily.COMPARE})
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_compatibility_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compatibility_door_law.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-_KIT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "compatibility_door_law.py"
 _SPEC = importlib.util.spec_from_file_location("compatibility_door_law", _SCANNER_PATH)
 assert _SPEC is not None and _SPEC.loader is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_object_place_is_term.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_object_place_is_term.py
@@ -25,7 +25,9 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-_KIT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _PLACE = (
     _KIT / "src" / "sugar_lift_py_tests" / "sugar" / "constructed_object_place_sugar.py"
 )

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_spread_literal_roster.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_spread_literal_roster.py
@@ -29,11 +29,12 @@ from sugar_lift_py_tests.sugar.spread_sugar import (
     SpreadCollectionSugar,
     SpreadDictSugar,
 )
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_source_tree.nodes import BinOp, Call, Constant, List, Subscript
 from sugar_source_tree.tree import SourceFile
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
@@ -119,7 +120,6 @@ def test_multi_function_file_with_star_call_enumerates_full_roster() -> None:
     """
     from recensus_enumerate_consumer import measure_file_via_enumerate
 
-    root = Path(__file__).resolve().parents[0]  # unused; use tmp via SourceTree walk
     # Build a tiny workspace on disk for enumerate (path_source / SourceTree).
     import tempfile
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_consumer_codomain_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_consumer_codomain_law.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-_KIT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "construction_consumer_codomain_law.py"
 _SPEC = importlib.util.spec_from_file_location(
     "construction_consumer_codomain_law", _SCANNER_PATH

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_context_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_context_door_law.py
@@ -22,7 +22,10 @@ import importlib.util
 import sys
 from pathlib import Path
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "construction_context_door_law.py"
 _SPEC = importlib.util.spec_from_file_location(
     "construction_context_door_law", _SCANNER_PATH

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_invariant_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_invariant_law.py
@@ -5,7 +5,10 @@ from pathlib import Path
 import subprocess
 import sys
 
-_SCRIPT = Path(__file__).parents[1] / "scripts" / "construction_invariant_law.py"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPT = sugar_lift_py_tests_package_root() / "scripts" / "construction_invariant_law.py"
 _SPEC = importlib.util.spec_from_file_location("construction_invariant_law", _SCRIPT)
 assert _SPEC is not None and _SPEC.loader is not None
 LAW = importlib.util.module_from_spec(_SPEC)

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_law_gate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_law_gate.py
@@ -33,7 +33,10 @@ import ast
 import re
 from pathlib import Path
 
-_KIT_SRC = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT_SRC = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests"
 _LINTED_DIRS = ("sugar", "floor")
 _SIDE_DOOR_LIFTERS = ("array_map_lifter.py", "literal_call_lifter.py")
 _SIDE_DOOR_CALLS = {"lift_array_map_assertions", "lift_literal_call_assertions"}

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_law_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_law_instrument.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from sugar_lift_py_tests.idd.proofir_vocab_instruments import (
+
     collect_naked_formula_boundary_crossings,
     collect_proofir_vocabulary_frontier,
     count_unknown_sort_equality_seats,
@@ -18,7 +19,9 @@ from sugar_lift_py_tests.proofir import (
     UnknownSort,
 )
 
-ROOT = Path(__file__).resolve().parents[4]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 
 
 def test_construction_law_scanner_reads_the_live_repo() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "construction_panic_catch_law.py"
 _SPEC = importlib.util.spec_from_file_location(
     "construction_panic_catch_law", _SCANNER_PATH

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_side_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_side_door_law.py
@@ -13,7 +13,10 @@ import importlib.util
 import json
 from pathlib import Path
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "construction_side_door_law.py"
 _SPEC = importlib.util.spec_from_file_location(
     "construction_side_door_law", _SCANNER_PATH

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_sink_protocols.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_sink_protocols.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 from sugar_lift_py_tests.context import (
+
     AuditSink,
     ExternalBridgeSink,
     OperationRecorder,
@@ -14,7 +15,9 @@ from sugar_lift_py_tests.context import (
 )
 from sugar_lift_py_tests.context import ReduceContext
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+ROOT = sugar_lift_py_tests_package_root()
 
 
 def test_reduce_context_sink_fields_are_typed_protocols() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_corpus_enrollment_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_corpus_enrollment_law.py
@@ -10,7 +10,9 @@ import importlib.util
 import json
 from pathlib import Path
 
-_KIT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "corpus_enrollment_law.py"
 _SPEC = importlib.util.spec_from_file_location("corpus_enrollment_law", _SCANNER_PATH)
 assert _SPEC is not None and _SPEC.loader is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_corpus_fatal_triage.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_corpus_fatal_triage.py
@@ -5,7 +5,10 @@ from pathlib import Path
 import json
 import subprocess
 
-SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import corpus_fatal_triage  # noqa: E402

--- a/implementations/python/sugar-lift-py-tests/tests/test_corpus_manifest_identity_roles.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_corpus_manifest_identity_roles.py
@@ -6,8 +6,11 @@ import ast
 from pathlib import Path
 import re
 
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 _PRIMARY_MANIFEST_COORDINATE = re.compile(r"blake3-512:[0-9a-f]{128}\Z")
-_PYTHON_IMPLEMENTATIONS = Path(__file__).resolve().parents[4] / "implementations/python"
+_PYTHON_IMPLEMENTATIONS = resolve_repo_root() / "implementations/python"
 
 
 def _manifest_identity_slot_violations(source: str, label: str) -> tuple[str, ...]:

--- a/implementations/python/sugar-lift-py-tests/tests/test_dangling_floor_terms_residue.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dangling_floor_terms_residue.py
@@ -16,9 +16,10 @@ import pytest
 from sugar_lift_py_tests.floor import CallSiteValue, SymbolicValue, TermValue
 from sugar_lift_py_tests.ir import _Ctor, make_var
 from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 from sugar_source_tree.tree import SourceFile
 
-ROOT = Path(__file__).parents[1] / "src" / "sugar_lift_py_tests" / "floor"
+ROOT = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests" / "floor"
 TARGETS = (
     ROOT / "call_site_value.py",
     ROOT / "symbolic_value.py",

--- a/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_demand_table_identity.py
@@ -24,13 +24,16 @@ import shutil
 import pytest
 
 from sugar_lift_py_tests.demand_table_identity import (
+
     CorpusManifestIdentityMismatch,
     corpus_manifest_digest_aliases,
     demand_table_identity,
     require_corpus_manifest_alias,
 )
 
-_SOURCE_ROOT = pathlib.Path(__file__).resolve().parents[1] / "src"
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SOURCE_ROOT = sugar_lift_py_tests_package_root() / "src"
 
 
 _PRODUCER_FUNCTIONS = (

--- a/implementations/python/sugar-lift-py-tests/tests/test_demand_table_interpreter_twin.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_demand_table_interpreter_twin.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 from sugar_lift_py_tests.authenticated_pytest import (
+
     authenticate_environment,
     authenticated_pandas_corpus,
     declared_interpreter_runtime,
@@ -17,6 +18,8 @@ from sugar_source_tree.tree import SourceTree
 from sugar_lift_py_tests.lift_rpc import _preconstruction_demand_rows
 from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
 from sugar_source_tree.cpython_adapter import CPythonAstBackend
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
 _SOURCE = """\
 from contextlib import nullcontext
@@ -59,7 +62,7 @@ def test_runtime_derived_testimony_names_only_the_declared_authority() -> None:
 
 def test_pinned_corpus_table_key_is_minted_under_declared_parser() -> None:
     corpus = authenticated_pandas_corpus()
-    source_root = Path(__file__).resolve().parents[1] / "src"
+    source_root = sugar_lift_py_tests_package_root() / "src"
     identity = demand_table_identity(
         corpus.root,
         SourceTree(corpus.root).paths(),

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_repro.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_repro.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 from sugar_lift_py_tests.gap.info import ConstructionGap
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
-_SCRIPT = Path(__file__).parents[1] / "scripts" / "desugar_repro.py"
+_SCRIPT = sugar_lift_py_tests_package_root() / "scripts" / "desugar_repro.py"
 _SPEC = importlib.util.spec_from_file_location("desugar_repro", _SCRIPT)
 assert _SPEC is not None and _SPEC.loader is not None
 _MOD = importlib.util.module_from_spec(_SPEC)

--- a/implementations/python/sugar-lift-py-tests/tests/test_dig_conditional_effect_witnesses.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dig_conditional_effect_witnesses.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+ROOT = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests"
 
 
 def test_datetime_dig_conditional_effects_have_explicit_witnesses() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_dispatch_targets_resolve.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dispatch_targets_resolve.py
@@ -29,7 +29,10 @@ import importlib
 import importlib.util
 from pathlib import Path
 
-SRC = Path(__file__).resolve().parents[1] / "src"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+SRC = sugar_lift_py_tests_package_root() / "src"
 
 
 def _function_local_imports(tree: ast.AST) -> list[tuple[str, str, int]]:

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
@@ -7,7 +7,10 @@ from pathlib import Path
 
 import pytest
 
-_ROOT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import python_implementations_root, sugar_lift_py_tests_package_root
+
+_ROOT = sugar_lift_py_tests_package_root()
 _SRC = _ROOT / "src" / "sugar_lift_py_tests"
 
 
@@ -250,7 +253,7 @@ def test_no_process_identity_in_slot_fallback() -> None:
     import re
 
     text = (
-        Path(__file__).resolve().parents[2]
+        python_implementations_root()
         / "sugar-source-tree"
         / "src"
         / "sugar_source_tree"

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_witness_sites_01_10.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_witness_sites_01_10.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests" / "floor"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+ROOT = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests" / "floor"
 
 
 def test_first_ten_effect_sites_have_explicit_witnesses() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_enum_floor_explicit_population.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enum_floor_explicit_population.py
@@ -17,7 +17,10 @@ from pathlib import Path
 
 import pytest
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 _RUNTIME_PATH = _SCRIPTS / "_enum_floor_runtime.py"
 _SPEC = importlib.util.spec_from_file_location("_enum_floor_runtime", _RUNTIME_PATH)
 assert _SPEC is not None and _SPEC.loader is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_function_contract_rows_no_swallow.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_function_contract_rows_no_swallow.py
@@ -25,10 +25,14 @@ from types import SimpleNamespace
 
 import pytest
 
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 from sugar_source_tree.panic import SugarNotWritten
 
 _LIFT_RPC = (
-    Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests" / "lift_rpc.py"
+    sugar_lift_py_tests_package_root()
+    / "src"
+    / "sugar_lift_py_tests"
+    / "lift_rpc.py"
 )
 
 _CONTRACT_ROWS_CALL = "function_contract_rows"

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumeration_binding_soft_skip_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumeration_binding_soft_skip_law.py
@@ -19,7 +19,10 @@ import pytest
 
 from sugar_lift_py_tests import lift_rpc
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "enumeration_binding_soft_skip_law.py"
 _SPEC = importlib.util.spec_from_file_location(
     "enumeration_binding_soft_skip_law", _SCANNER_PATH

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_proof.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_proof.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-PYTHON_ROOT = Path(__file__).resolve().parents[2]
+
+from sugar_lift_py_tests.repo_root import python_implementations_root
+
+PYTHON_ROOT = python_implementations_root()
 PROOF_MODULE = (
     PYTHON_ROOT
     / "sugar-lift-py-tests"

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import pytest
 
 from sugar_lift_py_tests.context_manager_contract import (
+
     EffectBoundaryDisposition,
     EffectMatcher,
     NeverSuppresses,
@@ -34,7 +35,9 @@ from sugar_lift_py_tests.floor import TermValue
 from sugar_lift_py_tests.ir import atomic, make_var
 from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+sys.path.insert(0, str(sugar_lift_py_tests_package_root() / "scripts"))
 
 from exit_set_arm_census import SITES, arm_census, totals  # noqa: E402
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_factory_ownership_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factory_ownership_law.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "factory_ownership_law.py"
 _SPEC = importlib.util.spec_from_file_location("factory_ownership_law", _SCANNER_PATH)
 assert _SPEC is not None and _SPEC.loader is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_factory_value_construction_side_doors.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factory_value_construction_side_doors.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 FACTORY_CONSTRUCTORS = (
-    Path(__file__).parents[1]
+    sugar_lift_py_tests_package_root()
     / "src"
     / "sugar_lift_py_tests"
     / "factory"
     / "sugar_constructors.py"
 )
 STATEMENT_FUNCTION_DEF_SUGAR = (
-    Path(__file__).parents[1]
+    sugar_lift_py_tests_package_root()
     / "src"
     / "sugar_lift_py_tests"
     / "sugar"

--- a/implementations/python/sugar-lift-py-tests/tests/test_factory_walk_row_dto.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factory_walk_row_dto.py
@@ -9,12 +9,15 @@ from pathlib import Path
 import pytest
 
 from sugar_lift_py_tests.kit_rpc.factory_walk_row_dto import (
+
     FactoryWalkCompleteRowDto,
     FactoryWalkRedRowDto,
     FactoryWalkStatus,
 )
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+ROOT = sugar_lift_py_tests_package_root()
 
 
 def _with_src_on_pythonpath() -> str:

--- a/implementations/python/sugar-lift-py-tests/tests/test_factory_walk_unclassified_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factory_walk_unclassified_law.py
@@ -6,7 +6,10 @@ import importlib.util
 import json
 from pathlib import Path
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "factory_walk_unclassified_law.py"
 _SPEC = importlib.util.spec_from_file_location(
     "factory_walk_unclassified_law", _SCANNER_PATH

--- a/implementations/python/sugar-lift-py-tests/tests/test_finite_cap_opaque_completion_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_finite_cap_opaque_completion_law.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _PATH = _KIT / "scripts" / "finite_cap_opaque_completion_law.py"
 _SPEC = importlib.util.spec_from_file_location("finite_cap_law", _PATH)
 assert _SPEC is not None and _SPEC.loader is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_finite_unfold_compact_projection_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_finite_unfold_compact_projection_law.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _PATH = _KIT / "scripts" / "finite_unfold_compact_projection_law.py"
 _SPEC = importlib.util.spec_from_file_location("finite_unfold_compact_law", _PATH)
 assert _SPEC is not None and _SPEC.loader is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py
@@ -15,12 +15,15 @@ from sugar_source_tree.tree import SourceFile
 from sugar_source_tree.tree import SourceTree
 
 from sugar_lift_py_tests.fixture_resource_obligation import (
+
     FixtureResourceOutcome,
     FixtureResourceBindingRefusal,
     FixtureSuppliedResourceObligationV1,
     classify_fixture_resource_outcome,
 )
 
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
 @dataclass(frozen=True)
 class _FormalResourceSite:
@@ -277,7 +280,7 @@ def test_authenticated_pandas_303_temp_file_population_is_partitioned_by_formal(
     assert corpus.manifest_cid == CANONICAL_CORPUS_MANIFEST_CID
     with tempfile.TemporaryDirectory() as scratch:
         demand_table = pull_shared_demand_table(
-            Path(__file__).resolve().parents[4],
+            resolve_repo_root(),
             Path(scratch) / "python-demand-table.json",
         )
     assert demand_table["contentKey"] == SHARED_DEMAND_TABLE_CONTENT_KEY

--- a/implementations/python/sugar-lift-py-tests/tests/test_floor_measurement_integrity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_floor_measurement_integrity.py
@@ -17,7 +17,9 @@ from pathlib import Path
 
 import pytest
 
-_KIT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _RUNTIME = _KIT / "scripts" / "_enum_floor_runtime.py"
 _SPEC = importlib.util.spec_from_file_location("enum_floor_runtime", _RUNTIME)
 assert _SPEC is not None and _SPEC.loader is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_floor_output_portability.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_floor_output_portability.py
@@ -8,9 +8,12 @@ import subprocess
 import sys
 
 
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 def test_vendor_floor_emits_arrows_under_cp1252(tmp_path: Path) -> None:
     script = (
-        Path(__file__).resolve().parents[1] / "scripts" / "vendor_special_case_law.py"
+        sugar_lift_py_tests_package_root() / "scripts" / "vendor_special_case_law.py"
     )
     surface = tmp_path / "surface"
     surface.mkdir()

--- a/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
@@ -14,7 +14,9 @@ import json
 import sys
 from pathlib import Path
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 _SCRIPT = _SCRIPTS / "compose_control_effect_board.py"
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_gap_testimony_independent_of_audit.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_gap_testimony_independent_of_audit.py
@@ -6,12 +6,15 @@ import ast
 from pathlib import Path
 
 from sugar_lift_py_tests.gap.audit_row import (
+
     ConstructionAuditStatus,
     gap_kind_status,
 )
 from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind
 
-_GAP = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests" / "gap"
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_GAP = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests" / "gap"
 
 
 def test_info_module_does_not_import_audit_row() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_construction_law.py
@@ -2,7 +2,10 @@ import importlib.util
 import sys
 from pathlib import Path
 
-_REPOSITORY = Path(__file__).resolve().parents[4]
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+_REPOSITORY = resolve_repo_root()
 _SCANNER_PATH = (
     _REPOSITORY
     / "implementations/python/sugar-lift-py-tests/scripts/generator_construction_law.py"

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_loop_recurrence_idd.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_loop_recurrence_idd.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 
 from sugar_lift_py_tests.idd.guarded_loop_recurrence import (
+
     scan_guarded_loop_recurrence,
     summarize_guarded_loop_recurrence,
 )
 
+
+from sugar_lift_py_tests.repo_root import python_implementations_root
 
 def test_instrument_names_each_forbidden_symbolic_loop_shape(tmp_path: Path) -> None:
     source = tmp_path / "nodes.py"
@@ -108,7 +111,7 @@ class ComprehensionSugar:
 
 
 def test_current_tree_measurement_is_stable_zero() -> None:
-    root = Path(__file__).parents[2]
+    root = python_implementations_root()
     findings = scan_guarded_loop_recurrence(root)
 
     assert findings == ()

--- a/implementations/python/sugar-lift-py-tests/tests/test_hermetic_sugar_pool.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_hermetic_sugar_pool.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
+
 """Regression guard: ambient sugar pool poison must not reach hermetic prove.
 
 Closes the class of bug tracked by #3902: without SUGAR_HOME isolation, the
@@ -10,6 +11,8 @@ one-door hermetic recipe.
 """
 
 from __future__ import annotations
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
 import os
 from pathlib import Path
@@ -133,7 +136,7 @@ def test_conftest_refuses_bare_sugar_mint_without_sugar_home(
 
 def test_no_duplicate_mint_prove_doors_outside_witness_harness() -> None:
     """Static guard: suite sources must not re-implement bare sugar mint/prove."""
-    root = Path(__file__).resolve().parents[1]
+    root = sugar_lift_py_tests_package_root()
     offenders: list[str] = []
     for path in root.rglob("*.py"):
         if "__pycache__" in path.parts:

--- a/implementations/python/sugar-lift-py-tests/tests/test_implications_target_candidate_no_swallow.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_implications_target_candidate_no_swallow.py
@@ -17,6 +17,9 @@ import pytest
 from sugar_source_tree.panic import SugarNotWritten
 
 
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 def test_truthful_function_contract_rows_exception_propagates():
     """Truthful twin: a raise from function_contract_rows is not continue."""
 
@@ -66,7 +69,7 @@ def test_lying_continue_manufactures_absence():
 def test_production_implications_loop_has_no_exception_continue():
     """Static twin: lift_rpc implications arm has no try/except around the call."""
     source = (
-        Path(__file__).resolve().parents[1]
+        sugar_lift_py_tests_package_root()
         / "src"
         / "sugar_lift_py_tests"
         / "lift_rpc.py"

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_alias_fatal_corpus.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_alias_fatal_corpus.py
@@ -13,6 +13,9 @@ import pytest
 
 from declared_corpus import HEAVY_OPT_IN, optional_law_skipif
 
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 REPRESENTATIVES = (
     ("numpy", "_core/tests/test_deprecations.py", "ImportAliasValue"),
     (
@@ -66,7 +69,7 @@ def test_import_alias_named_representative_advances_loudly_or_completes(
     retired_owner: str,
 ) -> None:
     path = _package_file(package, relative)
-    script = Path(__file__).resolve().parents[1] / "scripts" / "corpus_fatal_triage.py"
+    script = sugar_lift_py_tests_package_root() / "scripts" / "corpus_fatal_triage.py"
     rel = f"{package}/{relative}"
     result = subprocess.run(
         [

--- a/implementations/python/sugar-lift-py-tests/tests/test_iterative_term_table_encoder.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_iterative_term_table_encoder.py
@@ -9,6 +9,7 @@ from textwrap import dedent
 
 from sugar_lift_py_tests.canonicalizer import encode_jcs, jcs_hash
 from sugar_lift_py_tests.ir import (
+
     _Ctor,
     Term,
     TermTableBuilder,
@@ -17,6 +18,8 @@ from sugar_lift_py_tests.ir import (
 )
 from sugar_lift_py_tests.floor.call_site_value import _term_cycle_key
 
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
 def _spine(depth: int, *, name: str = "ssa") -> Term:
     term: Term = make_var("leaf")
@@ -27,7 +30,7 @@ def _spine(depth: int, *, name: str = "ssa") -> Term:
 
 def _subprocess_env() -> dict[str, str]:
     env = dict(os.environ)
-    tests_pkg = Path(__file__).resolve().parents[1]
+    tests_pkg = sugar_lift_py_tests_package_root()
     source_root = tests_pkg / "src"
     # LiftReportPayloadDto imports pull sugar_lift_python_source transitively.
     python_source_root = tests_pkg.parent / "sugar-lift-python-source" / "src"

--- a/implementations/python/sugar-lift-py-tests/tests/test_law_of_one_vector_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_law_of_one_vector_law.py
@@ -6,7 +6,10 @@ import importlib.util
 import sys
 from pathlib import Path
 
-_SCRIPT = Path(__file__).parents[1] / "scripts" / "law_of_one_vector_law.py"
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root, sugar_lift_py_tests_package_root
+
+_SCRIPT = sugar_lift_py_tests_package_root() / "scripts" / "law_of_one_vector_law.py"
 _SPEC = importlib.util.spec_from_file_location("law_of_one_vector_law", _SCRIPT)
 assert _SPEC is not None and _SPEC.loader is not None
 LAW = importlib.util.module_from_spec(_SPEC)
@@ -25,7 +28,7 @@ def test_parent_has_no_scan_python_source_reimplementation() -> None:
 
 
 def test_report_separates_product_and_instrument_layers() -> None:
-    repo = Path(__file__).resolve().parents[4]
+    repo = resolve_repo_root()
     citations = LAW.collect_citations(repo)
     rendered = LAW.format_report(citations)
     assert "R_product_second_mechanism_cited" in rendered
@@ -51,7 +54,7 @@ def test_missing_owner_is_red_not_zero() -> None:
 
 
 def test_self_sealing_citation_uses_child_r_only() -> None:
-    repo = Path(__file__).resolve().parents[4]
+    repo = resolve_repo_root()
     c = LAW._cite_self_sealing(repo)
     assert c.status == "ok"
     assert c.axis == "self_sealing"

--- a/implementations/python/sugar-lift-py-tests/tests/test_lift_coverage_harness.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_lift_coverage_harness.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import pytest
 
 from sugar_lift_py_tests.idd.collect_panic_audit import (
+
     _hermetic_env_for_sugar_command,
     _prepare_audit_workspace,
     _resolve_audit_sugar_bin,
@@ -47,7 +48,9 @@ from declared_corpus import (
     require_declared_corpus,
 )
 
-ROOT = Path(__file__).resolve().parents[4]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 
 
 def _run_lift_report_json(workspace: Path, *, require_success: bool = True) -> dict:

--- a/implementations/python/sugar-lift-py-tests/tests/test_lift_ownership_gate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_lift_ownership_gate.py
@@ -23,7 +23,10 @@ import ast
 import warnings
 from pathlib import Path
 
-_KIT_SRC = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT_SRC = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests"
 # Solving belongs to verify. A lift module that imports any of these has crossed
 # the ownership line and is doing the verifier's job.
 _SOLVER_MODULES = frozenset({"z3", "z3solver", "cvc5", "pysmt", "pysat"})

--- a/implementations/python/sugar-lift-py-tests/tests/test_match_decided_one_matcher_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_match_decided_one_matcher_law.py
@@ -28,7 +28,10 @@ from pathlib import Path
 
 import pytest
 
-_PKG_SRC = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root, sugar_lift_py_tests_package_root
+
+_PKG_SRC = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests"
 
 # Sole owner of MatchDecided(False) meaning. Every other production mint is a
 # second mechanism.
@@ -147,7 +150,7 @@ def test_sourcefile_construction_door_auditor_is_blind_to_fabricated_match_decid
     that gap so nobody confuses a green SOURCEFILE_CONSTRUCTION_DOOR receipt with coverage of
     fabricated decided-miss.
     """
-    repo_tests = Path(__file__).resolve().parents[4] / "tests"
+    repo_tests = resolve_repo_root() / "tests"
     auditor = repo_tests / "sourcefile_construction_door_auditor.py"
     evidence = repo_tests / "sourcefile_construction_door_evidence.py"
     assert auditor.is_file(), auditor

--- a/implementations/python/sugar-lift-py-tests/tests/test_measured_corpus_is_authenticated.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_measured_corpus_is_authenticated.py
@@ -38,6 +38,7 @@ import sysconfig
 import pytest
 
 from sugar_lift_py_tests.authenticated_pytest import (
+
     ExecutionEnvironmentMismatch,
     InterpreterIdentity,
     authenticate_corpus_manifest,
@@ -47,7 +48,9 @@ from sugar_lift_py_tests.authenticated_pytest import (
 )
 from sugar_lift_py_tests.demand_table_identity import corpus_manifest_cid
 
-_PYPROJECT = pathlib.Path(__file__).resolve().parents[1] / "pyproject.toml"
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_PYPROJECT = sugar_lift_py_tests_package_root() / "pyproject.toml"
 _CORPUS_PACKAGES = ("pandas", "numpy")
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_crash_zero_tolerance.py
@@ -10,7 +10,10 @@ import subprocess
 import sys
 import pytest
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "native_crash_zero_tolerance.py"
 _SPEC = importlib.util.spec_from_file_location(
     "native_crash_zero_tolerance", _SCANNER_PATH

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_side_door.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_side_door.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-_SRC = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SRC = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests"
 _FORBIDDEN_NAMES = (
     "build_function_call_sugar",
     "build_fcs_from_call_site",

--- a/implementations/python/sugar-lift-py-tests/tests/test_numpy_attribute_safety_showcase_routing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_numpy_attribute_safety_showcase_routing.py
@@ -12,7 +12,9 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[4]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 PY_TESTS_SRC = ROOT / "implementations/python/sugar-lift-py-tests/src"
 PY_SOURCE_SRC = ROOT / "implementations/python/sugar-lift-python-source/src"
 SOURCE_TREE_SRC = ROOT / "implementations/python/sugar-source-tree/src"

--- a/implementations/python/sugar-lift-py-tests/tests/test_numpy_pandas_panic_audit.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_numpy_pandas_panic_audit.py
@@ -10,11 +10,14 @@ import numpy
 import pytest
 
 from sugar_lift_py_tests.idd import (
+
     CommandResult,
     collect_panic_audit,
     main,
     render_text,
 )
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
 panic_audit_module = importlib.import_module(
     "sugar_lift_py_tests.idd.collect_panic_audit"
@@ -24,7 +27,7 @@ from sugar_lift_py_tests.idd.collect_panic_audit import (
     _prepare_audit_workspace,
 )
 
-ROOT = Path(__file__).resolve().parents[4]
+ROOT = resolve_repo_root()
 
 
 def _is_visual_lift(command: list[str]) -> bool:

--- a/implementations/python/sugar-lift-py-tests/tests/test_numpy_wall_gate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_numpy_wall_gate.py
@@ -7,6 +7,7 @@ import pytest
 
 from sugar_lift_py_tests.idd.command_result import CommandResult
 from sugar_lift_py_tests.idd.numpy_wall import (
+
     NumpyWallFloors,
     NumpyWallSummary,
     build_numpy_wall,
@@ -15,6 +16,8 @@ from sugar_lift_py_tests.idd.numpy_wall import (
     summarize_numpy_wall,
 )
 
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
 def test_summarizes_wall_with_report_json_census_definitions() -> None:
     # Criterion 14 (#3706): the summary is built entirely from
@@ -318,7 +321,7 @@ def _frontier_summary(independent: int, suppressed: int) -> NumpyWallSummary:
 
 
 def test_frontier_ceilings_load_from_pinned_floors_json() -> None:
-    root = Path(__file__).resolve().parents[4]
+    root = resolve_repo_root()
     floors = NumpyWallFloors.from_json_dict(
         json.loads((root / "tools" / "numpy-wall-floors.json").read_text())
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_one_authoritative_scoreboard.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_one_authoritative_scoreboard.py
@@ -22,7 +22,10 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+KIT = sugar_lift_py_tests_package_root()
 SEARCHED = (KIT / "scripts", KIT / "src" / "sugar_lift_py_tests")
 
 DECLARATION = "SCOREBOARD_AUTHORITY"

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_census_checkpoint.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_census_checkpoint.py
@@ -11,7 +11,10 @@ import time
 
 import pytest
 
-SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 from pandas_census_checkpoint import (

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_floor_summary.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_floor_summary.py
@@ -6,7 +6,10 @@ import sys
 
 import pytest
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 sys.path.insert(0, str(_SCRIPTS))
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_wall_gate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_wall_gate.py
@@ -8,6 +8,7 @@ import pytest
 
 from sugar_lift_py_tests.idd.command_result import CommandResult
 from sugar_lift_py_tests.idd.pandas_wall import (
+
     PandasWallFloors,
     PandasWallSummary,
     build_pandas_wall,
@@ -18,8 +19,10 @@ from sugar_lift_py_tests.idd.pandas_wall import (
 )
 
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 def test_wall_workflows_install_both_python_lift_packages() -> None:
-    root = Path(__file__).resolve().parents[4]
+    root = resolve_repo_root()
 
     for workflow_name in ("pandas-wall.yml", "numpy-wall.yml"):
         workflow = (root / ".github" / "workflows" / workflow_name).read_text(
@@ -816,7 +819,7 @@ def _pandas_frontier_floors() -> PandasWallFloors:
 
 
 def test_pandas_frontier_ceilings_load_from_pinned_floors_json() -> None:
-    root = Path(__file__).resolve().parents[4]
+    root = resolve_repo_root()
     floors = PandasWallFloors.from_json_dict(
         json.loads((root / "tools" / "pandas-wall-floors.json").read_text())
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
@@ -25,8 +25,9 @@ from sugar_lift_py_tests.prebuilt_demand_table import (
 from sugar_lift_py_tests.authenticated_pytest import AuthenticatedPandasCorpus
 from sugar_lift_py_tests.authenticated_pytest import authenticate_corpus
 from sugar_lift_py_tests.corpus_pin import pin_corpus
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_private_orphan_transition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_private_orphan_transition.py
@@ -7,8 +7,11 @@ import sys
 
 import pytest
 
-SCRIPT = Path(__file__).parents[1] / "scripts" / "private_orphan_transition.py"
-REPO = Path(__file__).parents[4]
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root, sugar_lift_py_tests_package_root
+
+SCRIPT = sugar_lift_py_tests_package_root() / "scripts" / "private_orphan_transition.py"
+REPO = resolve_repo_root()
 
 
 def _load_audit():

--- a/implementations/python/sugar-lift-py-tests/tests/test_process_floor_measurement_cache.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_process_floor_measurement_cache.py
@@ -11,7 +11,9 @@ import json
 import sys
 from pathlib import Path
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 _SPEC = importlib.util.spec_from_file_location(
     "process_floor_measurement_cache",
     _SCRIPTS / "process_floor_measurement_cache.py",

--- a/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_production_lift_child.py
@@ -15,7 +15,10 @@ from pathlib import Path
 
 import pytest
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _MOD_PATH = _KIT / "scripts" / "_production_lift_child.py"
 _SPEC = importlib.util.spec_from_file_location("_production_lift_child", _MOD_PATH)
 assert _SPEC is not None and _SPEC.loader is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_python_component_plan.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_python_component_plan.py
@@ -7,7 +7,10 @@ import sys
 import tomllib
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[4]
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 PYTHON_SOURCE_SRC = ROOT / "implementations/python/sugar-lift-python-source/src"
 PYTHON_COMPONENT_MANIFEST = ROOT / ".sugar/components/python/manifest.toml"
 KIT_DECLARATION_METHOD = "sugar.plugin.kit_declaration"

--- a/implementations/python/sugar-lift-py-tests/tests/test_python_test_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_python_test_composition.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[4]
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 
 
 def test_primary_python_suite_installs_its_source_table_owner() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_aggregation_keyerror.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_aggregation_keyerror.py
@@ -24,7 +24,9 @@ from pathlib import Path
 
 import pytest
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 SCRIPT = _SCRIPTS / "control_effect_recensus.py"
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_bounded_run_equivalence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_bounded_run_equivalence.py
@@ -27,7 +27,10 @@ import json
 import sys
 from pathlib import Path
 
-SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 SCRIPT = SCRIPTS / "control_effect_recensus.py"
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_construction_panic_escape.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_construction_panic_escape.py
@@ -17,8 +17,9 @@ import pytest
 
 from sugar_lift_py_tests.gap.info import ConstructionGap
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 
 
 def _load(name: str) -> ModuleType:

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_denominator_complete_schema.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_denominator_complete_schema.py
@@ -6,7 +6,9 @@ import importlib.util
 import sys
 from pathlib import Path
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 _SCRIPT = _SCRIPTS / "control_effect_recensus.py"
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_file_open_profile.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_file_open_profile.py
@@ -7,7 +7,9 @@ import json
 import sys
 from pathlib import Path
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 SCRIPT = _SCRIPTS / "control_effect_recensus.py"
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -9,7 +9,10 @@ import pytest
 from sugar_lift_py_tests.gap.info import ConstructionGap
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 
 
 def _load(name: str):

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_preserve_fns_on_populate_snw.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_preserve_fns_on_populate_snw.py
@@ -15,9 +15,10 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 from sugar_source_tree.panic import SugarNotWritten
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 
 
 def _load(name: str):

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_runtime_preflight.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_runtime_preflight.py
@@ -10,8 +10,9 @@ from pathlib import Path
 import pytest
 
 import sugar_lift_py_tests.authenticated_pytest as runtime_authority
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 _SCRIPT = _SCRIPTS / "control_effect_recensus.py"
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_recorded_seat_locus_authority.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recorded_seat_locus_authority.py
@@ -27,11 +27,14 @@ from pathlib import Path
 import pytest
 
 from sugar_lift_python_source.source_oracle import (
+
     SourceUnavailable,
     recorded_seat_for,
     workspace_path_source,
 )
 
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
 def _installed_file():
     """One file of an installed distribution, with the seat it recorded."""
@@ -220,7 +223,7 @@ def _driver():
     import sys
 
     path = (
-        Path(__file__).resolve().parents[1] / "scripts" / "control_effect_recensus.py"
+        sugar_lift_py_tests_package_root() / "scripts" / "control_effect_recensus.py"
     )
     spec = importlib.util.spec_from_file_location("_recensus_under_test", path)
     module = importlib.util.module_from_spec(spec)

--- a/implementations/python/sugar-lift-py-tests/tests/test_recovered_audit_schema_golden.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recovered_audit_schema_golden.py
@@ -13,13 +13,16 @@ from pathlib import Path
 import pytest
 
 from sugar_lift_py_tests.kit_rpc import (
+
     AuditLeafEnvelopeDto,
     RecoveredAuditDto,
     RecoveredFrontierAuditDto,
 )
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 _FIXTURES = (
-    Path(__file__).resolve().parents[4] / "protocol" / "conformance" / "recovered-audit"
+    resolve_repo_root() / "protocol" / "conformance" / "recovered-audit"
 )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
@@ -49,6 +49,7 @@ import pytest
 from sugar_lift_py_tests.effect import RaiseEffect, UndeterminedRaiseEffect
 from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.floor.raise_value import (
+
     FABRICATED_EXCEPTIONAL_EXIT_MEANING_LITERALS,
     RaiseValue,
     _exceptional_exit_formula,
@@ -56,12 +57,15 @@ from sugar_lift_py_tests.floor.raise_value import (
 )
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import ctor, str_const
-
+from sugar_lift_py_tests.repo_root import (
+    resolve_repo_root,
+    sugar_lift_py_tests_package_root,
+)
 _SHA = "a" * 64
 _LOCUS = "pkg/mod.py:12:4"
 
 _RAISE_VALUE_PATH = (
-    Path(__file__).resolve().parents[1]
+    sugar_lift_py_tests_package_root()
     / "src"
     / "sugar_lift_py_tests"
     / "floor"
@@ -162,16 +166,8 @@ def test_law_of_one_auditor_cannot_see_render_edge_fabrication() -> None:
     is the signal the stronger substrate arrived and this note can retire.
     There is no hard-coded R=1; the probe is the absence of those markers.
     """
-    auditor = (
-        Path(__file__).resolve().parents[4]
-        / "tests"
-        / "sourcefile_construction_door_auditor.py"
-    )
-    evidence = (
-        Path(__file__).resolve().parents[4]
-        / "tests"
-        / "sourcefile_construction_door_evidence.py"
-    )
+    auditor = resolve_repo_root() / "tests" / "sourcefile_construction_door_auditor.py"
+    evidence = resolve_repo_root() / "tests" / "sourcefile_construction_door_evidence.py"
     assert auditor.is_file(), auditor
     assert evidence.is_file(), evidence
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_repo_root_door.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_repo_root_door.py
@@ -27,7 +27,6 @@ from sugar_lift_py_tests.repo_root import (
     sugar_lift_py_tests_package_root,
 )
 
-
 def _write_marker(repo: Path) -> Path:
     repo.mkdir(parents=True, exist_ok=True)
     marker = repo / MARKER

--- a/implementations/python/sugar-lift-py-tests/tests/test_restored_suite_telemetry.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_restored_suite_telemetry.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 import pytest
 
-_TOOL = Path(__file__).parents[4] / "tools" / "restored_suite_telemetry.py"
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+_TOOL = resolve_repo_root() / "tools" / "restored_suite_telemetry.py"
 _SPEC = importlib.util.spec_from_file_location("restored_suite_telemetry", _TOOL)
 assert _SPEC is not None and _SPEC.loader is not None
 _MODULE = importlib.util.module_from_spec(_SPEC)

--- a/implementations/python/sugar-lift-py-tests/tests/test_runtime_effect_witness_sweep.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_runtime_effect_witness_sweep.py
@@ -7,7 +7,10 @@ from typing import Iterator
 
 from sugar_lift_py_tests.effect import RuntimeEffect
 
-PACKAGE = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+PACKAGE = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests"
 EVIDENCE_DOORS = {
     "runtime_effect_evidence",
     "runtime_effect_evidence_from_terms",

--- a/implementations/python/sugar-lift-py-tests/tests/test_self_sealing_instrument_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_self_sealing_instrument_law.py
@@ -6,7 +6,10 @@ import importlib.util
 from pathlib import Path
 import sys
 
-_SCRIPT = Path(__file__).parents[1] / "scripts" / "self_sealing_instrument_law.py"
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root, sugar_lift_py_tests_package_root
+
+_SCRIPT = sugar_lift_py_tests_package_root() / "scripts" / "self_sealing_instrument_law.py"
 _SPEC = importlib.util.spec_from_file_location("self_sealing_instrument_law", _SCRIPT)
 assert _SPEC is not None and _SPEC.loader is not None
 LAW = importlib.util.module_from_spec(_SPEC)
@@ -103,7 +106,7 @@ def test_sourcefile_construction_door_live_self_seed_is_drained() -> None:
     Path(__file__)/auditor). Reachable by reintroducing the fallback.
     """
     # parents: tests -> sugar-lift-py-tests -> python -> implementations -> repo
-    repo = Path(__file__).resolve().parents[4]
+    repo = resolve_repo_root()
     auditor = repo / "tests" / "sourcefile_construction_door_auditor.py"
     assert auditor.is_file(), auditor
     source = auditor.read_text(encoding="utf-8")

--- a/implementations/python/sugar-lift-py-tests/tests/test_silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_silent_zero_tolerance.py
@@ -9,7 +9,10 @@ import pytest
 
 from sugar_lift_py_tests.idd.lift_coverage_census import census_source
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "silent_zero_tolerance.py"
 _SPEC = importlib.util.spec_from_file_location("silent_zero_tolerance", _SCANNER_PATH)
 assert _SPEC is not None and _SPEC.loader is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py
@@ -34,6 +34,9 @@ from sugar_lift_py_tests.ir import ctor, make_var
 from sugar_lift_py_tests.outcome import Complete
 from sugar_source_tree.panic import SugarNotWritten
 
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root, sugar_lift_py_tests_package_root
+
 SITE = "sin-cluster-2-ordering-site"
 
 _ORDERING_METHODS = frozenset(
@@ -64,7 +67,7 @@ def _callsite() -> CallSiteValue:
 
 def _floor_value_path() -> Path:
     return (
-        Path(__file__).resolve().parents[1]
+        sugar_lift_py_tests_package_root()
         / "src"
         / "sugar_lift_py_tests"
         / "floor"
@@ -82,11 +85,7 @@ def test_sourcefile_construction_door_auditor_cannot_see_ordering_floor_meaning_
     gains a floor-meaning denominator — do not pretend the shared auditor
     closed this sin.
     """
-    auditor = (
-        Path(__file__).resolve().parents[4]
-        / "tests"
-        / "sourcefile_construction_door_auditor.py"
-    )
+    auditor = resolve_repo_root() / "tests" / "sourcefile_construction_door_auditor.py"
     assert auditor.is_file(), "sourcefile_construction_door_auditor.py must exist"
     text = auditor.read_text(encoding="utf-8")
     assert "less_than_from_left" not in text

--- a/implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_sat_unsat.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_sat_unsat.py
@@ -6,7 +6,10 @@ import subprocess
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[4]
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 PY_TESTS = ROOT / "implementations/python/sugar-lift-py-tests"
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_identity_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_identity_law.py
@@ -13,13 +13,15 @@ present keys — then delete this file.
 
 from __future__ import annotations
 
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 import importlib.util
 import sys
 from pathlib import Path
 
 import pytest
 
-_KIT = Path(__file__).resolve().parents[1]
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "source_audit_presence_identity_law.py"
 _SPEC = importlib.util.spec_from_file_location(
     "source_audit_presence_identity_law", _SCANNER_PATH

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_via_execution_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_via_execution_law.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "source_via_execution_law.py"
 _SPEC = importlib.util.spec_from_file_location(
     "source_via_execution_law", _SCANNER_PATH

--- a/implementations/python/sugar-lift-py-tests/tests/test_stablezero_classify.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_stablezero_classify.py
@@ -9,7 +9,10 @@ import sugar_source_tree.tree as source_tree
 from sugar_lift_py_tests.gap.info import ConstructionGap
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
-_SCRIPT = Path(__file__).parents[1] / "scripts" / "stablezero_classify.py"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPT = sugar_lift_py_tests_package_root() / "scripts" / "stablezero_classify.py"
 _SPEC = importlib.util.spec_from_file_location("stablezero_classify", _SCRIPT)
 assert _SPEC is not None and _SPEC.loader is not None
 _MOD = importlib.util.module_from_spec(_SPEC)

--- a/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
@@ -26,6 +26,7 @@ from sugar_lift_py_tests.floor import ListValue, ObjectValue, TermValue
 from sugar_lift_py_tests.floor.floor_value import FloorValue
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
 from sugar_lift_py_tests.sugar.assign_sugar import (
+
     DynamicUnpackStoreAssignSugar,
     UnpackStoreAssignSugar,
 )
@@ -45,6 +46,8 @@ from sugar_source_tree.nodes import FunctionDef
 from sugar_source_tree.tree import SourceFile
 from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
 def _tree(source: str, name: str = "star_store.py") -> SourceFile:
     return SourceFile(
@@ -612,7 +615,7 @@ def test_no_fabricated_unpack_store_identity_in_module() -> None:
     """Zero fabricated __unpack_store_* string binding identities in source."""
     from pathlib import Path
 
-    root = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests"
+    root = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests"
     offenders = []
     for path in root.rglob("*.py"):
         text = path.read_text(encoding="utf-8")

--- a/implementations/python/sugar-lift-py-tests/tests/test_strict_pyright_ratchet.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_strict_pyright_ratchet.py
@@ -25,7 +25,10 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+ROOT = sugar_lift_py_tests_package_root()
 SRC = ROOT / "src" / "sugar_lift_py_tests"
 
 # The closed-to-zero frontier: #3662's six hierarchy-edge files plus the two

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
@@ -14,6 +14,7 @@ from sugar_lift_py_tests.context import ReduceContext
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.floor import (
+
     CallSiteValue,
     DictValue,
     ListValue,
@@ -44,6 +45,8 @@ from sugar_lift_py_tests.temporal import TemporalContext
 from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
 SITE_SHA256 = "0308786b24b61a2b98be5d649e57ee847d7993ae1d0e1823d7f760408523131f"
 # Content manifest (relative path + per-file BLAKE3-512). Path-shape
@@ -270,7 +273,7 @@ def test_authenticated_subscript_family_owns_no_construction_panics(
     tmp_path,
 ) -> None:
     corpus = authenticated_pandas_corpus()
-    repo_root = Path(__file__).resolve().parents[4]
+    repo_root = resolve_repo_root()
     payload = pull_shared_demand_table(repo_root, tmp_path / "python-demand-table.json")
     inventory = require_expected_denominators(
         discover_no_call_body_probes(

--- a/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
@@ -13,9 +13,11 @@ import json
 import os
 import subprocess
 
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
 os.environ.setdefault("SUGAR_PROCESS_FLOOR_CACHE_DIR", "off")
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 # scan() imports process_floor_measurement_cache as a scripts sibling — same
 # door floors open when invoked as scripts/*.py (sys.path has scripts/).
 if str(_SCRIPTS) not in sys.path:

--- a/implementations/python/sugar-lift-py-tests/tests/test_swallowed_throw_second_mechanism_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_swallowed_throw_second_mechanism_law.py
@@ -12,7 +12,10 @@ from pathlib import Path
 
 import pytest
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "swallowed_throw_second_mechanism_law.py"
 _SPEC = importlib.util.spec_from_file_location(
     "swallowed_throw_second_mechanism_law", _SCANNER_PATH

--- a/implementations/python/sugar-lift-py-tests/tests/test_timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_timeout_zero_tolerance.py
@@ -9,7 +9,10 @@ import sys
 
 import pytest
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "timeout_zero_tolerance.py"
 _SPEC = importlib.util.spec_from_file_location("timeout_zero_tolerance", _SCANNER_PATH)
 assert _SPEC is not None and _SPEC.loader is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_try_sat_unsat.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_try_sat_unsat.py
@@ -6,7 +6,10 @@ import subprocess
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[4]
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 PY_TESTS = ROOT / "implementations/python/sugar-lift-py-tests"
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_type_checker_ratchet.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_type_checker_ratchet.py
@@ -7,7 +7,10 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+ROOT = sugar_lift_py_tests_package_root()
 SRC = ROOT / "src" / "sugar_lift_py_tests"
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_boolop_exception_producers.py
@@ -16,6 +16,7 @@ import pytest
 
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
+
     ExpectationNotMetEffect,
 )
 from sugar_lift_py_tests.floor import RaiseValue, SymbolicValue, TermValue
@@ -29,6 +30,8 @@ from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSug
 from sugar_lift_py_tests.temporal import TemporalContext
 from sugar_lift_py_tests.context import ReduceContext
 from sugar_source_tree.panic import SugarNotWritten
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
 CORPUS = authenticated_pandas_corpus().root
 UNARY_SITE = CORPUS / "tests/extension/base/ops.py"
@@ -80,7 +83,7 @@ def test_verified_pandas_303_reproducers_are_content_pinned() -> None:
 
 
 def test_shared_table_authenticates_unary_and_complete_boolop_family(tmp_path) -> None:
-    root = Path(__file__).resolve().parents[4]
+    root = resolve_repo_root()
     output = tmp_path / "python-demand-table.json"
     pulled = subprocess.run(
         [

--- a/implementations/python/sugar-lift-py-tests/tests/test_vendor_special_case_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_vendor_special_case_law.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-_KIT = Path(__file__).resolve().parents[1]
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_KIT = sugar_lift_py_tests_package_root()
 _SCANNER_PATH = _KIT / "scripts" / "vendor_special_case_law.py"
 _SPEC = importlib.util.spec_from_file_location("vendor_special_case_law", _SCANNER_PATH)
 assert _SPEC is not None and _SPEC.loader is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_wall_conservation_diff.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_wall_conservation_diff.py
@@ -8,7 +8,10 @@ from pathlib import Path
 
 import pytest
 
-_ROOT = Path(__file__).parents[4]
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+_ROOT = resolve_repo_root()
 _DIFF_TOOL = _ROOT / "tools" / "wall_conservation_diff.py"
 _TEL_TOOL = _ROOT / "tools" / "wall_frontier_telemetry.py"
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_wall_effect_witness_sites.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_wall_effect_witness_sites.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests" / "floor"
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+ROOT = sugar_lift_py_tests_package_root() / "src" / "sugar_lift_py_tests" / "floor"
 WALL_CARRIERS = ("dict_value.py", "call_site_value.py", "symbolic_value.py")
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_wall_frontier_telemetry.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_wall_frontier_telemetry.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 import pytest
 
-_TOOL = Path(__file__).parents[4] / "tools" / "wall_frontier_telemetry.py"
+
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+_TOOL = resolve_repo_root() / "tools" / "wall_frontier_telemetry.py"
 _SPEC = importlib.util.spec_from_file_location("wall_frontier_telemetry", _TOOL)
 assert _SPEC is not None and _SPEC.loader is not None
 _MODULE = importlib.util.module_from_spec(_SPEC)

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
@@ -19,7 +19,9 @@ from pathlib import Path
 
 import pytest
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 SCRIPT = _SCRIPTS / "control_effect_recensus.py"
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_v2_step1_laws.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_v2_step1_laws.py
@@ -3,12 +3,15 @@
 from pathlib import Path
 
 from with_v2_law_detector import (
+
     ModuleGraph,
     analyze_consumer_enrollment,
     analyze_single_authority,
 )
 
-PYTHON_ROOT = Path(__file__).resolve().parents[2]
+from sugar_lift_py_tests.repo_root import python_implementations_root
+
+PYTHON_ROOT = python_implementations_root()
 PRODUCTION_ROOTS = (
     PYTHON_ROOT / "sugar-lift-py-tests" / "src" / "sugar_lift_py_tests",
     PYTHON_ROOT / "sugar-source-tree" / "src" / "sugar_source_tree",

--- a/implementations/python/sugar-lift-py-tests/tests/test_worker_demand_table_gate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_worker_demand_table_gate.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 import pytest
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 

--- a/tests/examples_gate_test.py
+++ b/tests/examples_gate_test.py
@@ -6,7 +6,9 @@ import sys
 import tempfile
 import unittest
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))
 
 import examples_gate  # noqa: E402

--- a/tests/sugarbin_legacy_shelf_migration.py
+++ b/tests/sugarbin_legacy_shelf_migration.py
@@ -13,8 +13,9 @@ import sys
 import tempfile
 import unittest
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
-REPO = Path(__file__).resolve().parents[1]
+REPO = resolve_repo_root()
 TOOL = REPO / "tools" / "migrate_legacy_binary_shelf.py"
 PLATFORM = "linux-x86_64"
 PROFILE = "release"

--- a/tests/test_authenticated_python_launcher.py
+++ b/tests/test_authenticated_python_launcher.py
@@ -175,11 +175,7 @@ def test_checkout_import_roots_come_from_the_managed_closure_declaration(
     declared.mkdir(parents=True)
     # activate_checkout_import_roots loads tools/managed_checkout_pythonpath.py
     # from the checkout (shared with the CI action).
-    tool_src = (
-        Path(__file__).resolve().parents[1]
-        / "tools"
-        / "managed_checkout_pythonpath.py"
-    )
+    tool_src = resolve_repo_root() / "tools" / "managed_checkout_pythonpath.py"
     tool_dst = repo / "tools" / "managed_checkout_pythonpath.py"
     tool_dst.parent.mkdir(parents=True, exist_ok=True)
     tool_dst.write_text(tool_src.read_text(encoding="utf-8"), encoding="utf-8")

--- a/tests/test_authenticated_python_launcher.py
+++ b/tests/test_authenticated_python_launcher.py
@@ -8,6 +8,7 @@ from types import ModuleType
 
 import pytest
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 from sugar_lift_py_tests.authenticated_pytest import (
     ExecutionEnvironmentMismatch,
     activate_checkout_import_roots,
@@ -223,7 +224,7 @@ def test_launcher_refuses_before_pytest_on_environment_mismatch(
 
 
 def test_bpytest_wrapper_contract_is_collected_by_pytest() -> None:
-    repo = Path(__file__).resolve().parents[1]
+    repo = resolve_repo_root()
     completed = subprocess.run(
         ["bash", str(repo / "tests/bpytest_authenticated_wrapper.sh"), str(repo)],
         text=True,
@@ -242,7 +243,7 @@ def test_bootstrap_venv_py312_twins_are_collected_by_pytest() -> None:
     absent, if pins are not post-editable, or if a non-exact 3.12.x / bare
     python3 is accepted.
     """
-    repo = Path(__file__).resolve().parents[1]
+    repo = resolve_repo_root()
     completed = subprocess.run(
         ["bash", str(repo / "tests/bootstrap_venv_py312_twins.sh"), str(repo)],
         text=True,

--- a/tests/test_board_function_facts_c4.py
+++ b/tests/test_board_function_facts_c4.py
@@ -21,7 +21,9 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 PKG_SRC = (
     ROOT
     / "implementations/python/sugar-lift-py-tests/src"

--- a/tests/test_bx_corpus_pin_gate.py
+++ b/tests/test_bx_corpus_pin_gate.py
@@ -10,7 +10,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 GATE = ROOT / "tools" / "bx_corpus_pin_gate.py"
 EXIT_PIN = 78
 

--- a/tests/test_checkout_import_foreign_site_packages_unit_twin.py
+++ b/tests/test_checkout_import_foreign_site_packages_unit_twin.py
@@ -22,6 +22,8 @@ from types import ModuleType
 
 import pytest
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 from sugar_lift_py_tests.authenticated_pytest import (
     ExecutionEnvironmentMismatch,
     activate_checkout_import_roots,
@@ -108,11 +110,7 @@ def _mini_repo_with_planted_site_packages(
         (repo / rel).mkdir(parents=True, exist_ok=True)
 
     # Prefer production managed tool when present (shared with #6997 action).
-    prod_tool = (
-        Path(__file__).resolve().parents[1]
-        / "tools"
-        / "managed_checkout_pythonpath.py"
-    )
+    prod_tool = resolve_repo_root() / "tools" / "managed_checkout_pythonpath.py"
     tool_dst = repo / "tools" / "managed_checkout_pythonpath.py"
     tool_dst.parent.mkdir(parents=True, exist_ok=True)
     if prod_tool.is_file():

--- a/tests/test_ci_python_env_checkout_lift_import.py
+++ b/tests/test_ci_python_env_checkout_lift_import.py
@@ -26,7 +26,9 @@ import textwrap
 import venv
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 ACTION = ROOT / ".github/actions/python-test-environment/action.yml"
 MANAGED_TOOL = ROOT / "tools/managed_checkout_pythonpath.py"
 DOCKERFILE = ROOT / "tools/sugar-build/Dockerfile"

--- a/tests/test_commit_measurement.py
+++ b/tests/test_commit_measurement.py
@@ -15,7 +15,9 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 
 
 def _load(name: str, rel: str):

--- a/tests/test_conservation_mint_contract.py
+++ b/tests/test_conservation_mint_contract.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 PKG_SRC = ROOT / "implementations/python/sugar-lift-py-tests/src"
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))

--- a/tests/test_control_effect_recensus_lpt_ci_matrix.py
+++ b/tests/test_control_effect_recensus_lpt_ci_matrix.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 WORKFLOW = ROOT / ".github/workflows/control-effect-recensus.yml"
 
 

--- a/tests/test_core_matrix_parallel_fanout.py
+++ b/tests/test_core_matrix_parallel_fanout.py
@@ -7,7 +7,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 CI = ROOT / ".github/workflows/ci.yml"
 CLAIM_SHARDS = ROOT / "tools/claim_mass_tripwire_shards.py"
 CLAIM_ATTEND = ROOT / "tools/claim_mass_tripwire_attendance.py"

--- a/tests/test_first_party_venv_contamination_guard.py
+++ b/tests/test_first_party_venv_contamination_guard.py
@@ -7,8 +7,9 @@ import subprocess
 import venv
 from pathlib import Path
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = resolve_repo_root()
 GUARD = ROOT / "tools/refuse_first_party_venv_contamination.py"
 PACKAGE = "sugar-lift-py-tests"
 

--- a/tests/test_floor_summary_residual_emission.py
+++ b/tests/test_floor_summary_residual_emission.py
@@ -7,7 +7,9 @@ import json
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 SCRIPTS = ROOT / "implementations/python/sugar-lift-py-tests/scripts"
 TOOLS = ROOT / "tools"
 

--- a/tests/test_gh_rate_budget.py
+++ b/tests/test_gh_rate_budget.py
@@ -7,7 +7,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 TOOL = ROOT / "tools" / "gh_rate_budget.py"
 
 

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -11,7 +11,9 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 WORKFLOWS = ROOT / ".github" / "workflows"
 LEASE_WRAPPER = "tools/heavy_measurement_lease.py"
 GATE = "tools/heavy_measurement_lease_gate.py"

--- a/tests/test_job_log_heartbeat.py
+++ b/tests/test_job_log_heartbeat.py
@@ -7,7 +7,9 @@ import sys
 import time
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))
 
 from job_log_heartbeat import JOB_LOG_MAX_SILENCE_S, JobLogHeartbeat, narrate  # noqa: E402

--- a/tests/test_lpt_acceptance_real_prior.py
+++ b/tests/test_lpt_acceptance_real_prior.py
@@ -19,7 +19,9 @@ import json
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))
 
 from lpt_file_shards import equal_count_bins, lpt_bins  # noqa: E402

--- a/tests/test_lpt_file_shards.py
+++ b/tests/test_lpt_file_shards.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))
 
 from lpt_file_shards import (  # noqa: E402

--- a/tests/test_managed_python_closure_is_import_closed.py
+++ b/tests/test_managed_python_closure_is_import_closed.py
@@ -30,7 +30,9 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 DOCKERFILE = ROOT / "tools" / "sugar-build" / "Dockerfile"
 WORKSPACE = "/workspace/sugar/"
 

--- a/tests/test_pandas_timeout_residual_disposition.py
+++ b/tests/test_pandas_timeout_residual_disposition.py
@@ -7,7 +7,9 @@ from collections import Counter
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+REPO_ROOT = resolve_repo_root()
 SOURCE_LEDGER = (
     REPO_ROOT / "docs/ledgers/pandas-timeout-shared-mechanism-5306.json"
 )

--- a/tests/test_process_floor_demand_table.py
+++ b/tests/test_process_floor_demand_table.py
@@ -8,7 +8,9 @@ from pathlib import Path
 import subprocess
 import sys
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 SCRIPTS = ROOT / "implementations/python/sugar-lift-py-tests/scripts"
 WORKFLOW = ROOT / ".github/workflows/factory-zero-tolerance.yml"
 FLOOR_SCRIPTS = (

--- a/tests/test_python_package_suite_shards.py
+++ b/tests/test_python_package_suite_shards.py
@@ -7,7 +7,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 SHARDS = ROOT / "tools" / "python_package_suite_shards.py"
 ATTENDANCE = ROOT / "tools" / "python_package_suite_shard_attendance.py"
 WORKFLOW = ROOT / ".github" / "workflows" / "python-package-suite.yml"

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -12,7 +12,9 @@ import json
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 WORKFLOW = ROOT / ".github" / "workflows" / "factory-zero-tolerance.yml"
 ENROLL = ROOT / "tools" / "sole_construction_floor_enrollment.py"
 STATIC = ROOT / "tools" / "run_static_sole_construction_floors.sh"

--- a/tests/test_recensus_enumerate_mass_and_clean.py
+++ b/tests/test_recensus_enumerate_mass_and_clean.py
@@ -17,7 +17,9 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 SCRIPTS = ROOT / "implementations/python/sugar-lift-py-tests/scripts"
 
 

--- a/tests/test_recensus_lpt_prior_write_through.py
+++ b/tests/test_recensus_lpt_prior_write_through.py
@@ -12,7 +12,9 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))
 
 from lpt_file_shards import ContentAddressedCostPrior, assign_files  # noqa: E402

--- a/tests/test_rerank_input.py
+++ b/tests/test_rerank_input.py
@@ -8,7 +8,9 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 _SPEC = importlib.util.spec_from_file_location(
     "rerank_input", ROOT / "tools" / "rerank_input.py"
 )

--- a/tests/test_showcase_retirement.py
+++ b/tests/test_showcase_retirement.py
@@ -10,7 +10,9 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))
 
 import showcase_scope  # noqa: E402

--- a/tests/test_showcase_shared_setup_enrollment.py
+++ b/tests/test_showcase_shared_setup_enrollment.py
@@ -8,7 +8,9 @@ import sys
 import zipfile
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))
 
 import showcase_wheelhouse  # noqa: E402

--- a/tests/test_sole_construction_floor_enrollment_measured.py
+++ b/tests/test_sole_construction_floor_enrollment_measured.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 _SPEC = importlib.util.spec_from_file_location(
     "sole_construction_floor_enrollment",
     ROOT / "tools" / "sole_construction_floor_enrollment.py",

--- a/tests/test_source_stamp_provisioning.py
+++ b/tests/test_source_stamp_provisioning.py
@@ -9,8 +9,9 @@ from pathlib import Path
 
 import pytest
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = resolve_repo_root()
 STAMP = ROOT / "tools" / "sugar_source_stamp.py"
 
 

--- a/tests/test_static_floor_residual_report.py
+++ b/tests/test_static_floor_residual_report.py
@@ -5,7 +5,9 @@ import json
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 
 
 def _load(name: str, path: Path):

--- a/tests/test_sugar_build_contract.py
+++ b/tests/test_sugar_build_contract.py
@@ -6,7 +6,9 @@ from pathlib import Path
 import pytest
 
 
-ROOT = Path(__file__).parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 SPEC = importlib.util.spec_from_file_location(
     "sugar_build_contract", ROOT / "tools/sugar-build/contract.py"
 )

--- a/tests/test_sugarbin_shell_tier.py
+++ b/tests/test_sugarbin_shell_tier.py
@@ -10,7 +10,10 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+_TOOLS = Path(__file__).resolve().parent.parent / "tools"
+sys.path.insert(0, str(_TOOLS))
+
+from sugar_repo_root import resolve_repo_root  # noqa: E402
 
 ROOT = resolve_repo_root()
 TOOL = ROOT / "tools" / "sugarbin_shell_tier.py"

--- a/tests/test_sugarbin_shell_tier.py
+++ b/tests/test_sugarbin_shell_tier.py
@@ -10,8 +10,9 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = resolve_repo_root()
 TOOL = ROOT / "tools" / "sugarbin_shell_tier.py"
 WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 EXPECTED_BATCHES = {

--- a/tests/test_suite_pytest_job_log_heartbeat.py
+++ b/tests/test_suite_pytest_job_log_heartbeat.py
@@ -9,7 +9,9 @@ import sys
 import textwrap
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 TOOLS = ROOT / "tools"
 
 

--- a/tests/test_suite_report_lpt_prior_import.py
+++ b/tests/test_suite_report_lpt_prior_import.py
@@ -14,7 +14,9 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 PLUGIN = ROOT / "tools" / "python_package_suite_report.py"
 TOOLS = ROOT / "tools"
 

--- a/tests/test_test_extras_are_the_dependency_authority.py
+++ b/tests/test_test_extras_are_the_dependency_authority.py
@@ -38,7 +38,9 @@ import sys
 import tomllib
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 PACKAGE = ROOT / "implementations/python/sugar-lift-py-tests"
 PYPROJECT = PACKAGE / "pyproject.toml"
 WORKFLOWS = ROOT / ".github/workflows"

--- a/tests/test_workflow_context_availability.py
+++ b/tests/test_workflow_context_availability.py
@@ -9,8 +9,9 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = resolve_repo_root()
 WORKFLOWS = ROOT / ".github" / "workflows"
 ACTIONLINT = os.environ.get("ACTIONLINT", "actionlint")
 ACTIONLINT_VERSION = "v1.7.12"

--- a/tests/test_workflow_context_availability.py
+++ b/tests/test_workflow_context_availability.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+_TOOLS = Path(__file__).resolve().parent.parent / "tools"
+sys.path.insert(0, str(_TOOLS))
+
+from sugar_repo_root import resolve_repo_root  # noqa: E402
 
 ROOT = resolve_repo_root()
 WORKFLOWS = ROOT / ".github" / "workflows"

--- a/tests/wall_workflow_prerequisites_test.py
+++ b/tests/wall_workflow_prerequisites_test.py
@@ -3,7 +3,9 @@
 from pathlib import Path
 import re
 
-ROOT = Path(__file__).resolve().parents[1]
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 WALL_WORKFLOWS = {
     "numpy": ROOT / ".github/workflows/numpy-wall.yml",
     "pandas": ROOT / ".github/workflows/pandas-wall.yml",

--- a/tools/check-lift-refusal-vocabulary.py
+++ b/tools/check-lift-refusal-vocabulary.py
@@ -23,7 +23,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-ROOT = Path(__file__).resolve().parents[1]
+import sys
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 DEFAULT_CENSUS = ROOT / "tools" / "lift_refusal_vocabulary_census.json"
 REFUS_PATTERN = re.compile(r"refus", re.IGNORECASE)
 SCAN_PATHS = (

--- a/tools/check_lift_manifest_pythonpath.py
+++ b/tools/check_lift_manifest_pythonpath.py
@@ -23,7 +23,14 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+import sys
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 EXAMPLES = ROOT / "examples"
 
 SOURCE_MARK = "sugar-lift-python-source"

--- a/tools/claim_mass_tripwire_shards.py
+++ b/tools/claim_mass_tripwire_shards.py
@@ -17,9 +17,15 @@ import argparse
 import ast
 import json
 import re
+import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root  # noqa: E402
+
+ROOT = resolve_repo_root()
 # Single source of truth: pin names live in the tripwire test module's PINS
 # tuple. Parse the AST (do not import the test — it needs sugar packages).
 _TRIPWIRE = (

--- a/tools/commit_measurement.py
+++ b/tools/commit_measurement.py
@@ -49,10 +49,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence, Union
 
-_PACKAGE_SRC = (
-    Path(__file__).resolve().parents[1]
-    / "implementations/python/sugar-lift-py-tests/src"
-)
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root  # noqa: E402
+
+_PACKAGE_SRC = resolve_repo_root() / "implementations/python/sugar-lift-py-tests/src"
 if str(_PACKAGE_SRC) not in sys.path:
     sys.path.insert(0, str(_PACKAGE_SRC))
 

--- a/tools/numpy_wall.py
+++ b/tools/numpy_wall.py
@@ -5,8 +5,15 @@ import sys
 from pathlib import Path
 
 
+import sys
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root
+
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[1]
+    return resolve_repo_root()
 
 
 def main() -> int:

--- a/tools/pandas_wall.py
+++ b/tools/pandas_wall.py
@@ -5,8 +5,15 @@ import sys
 from pathlib import Path
 
 
+import sys
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root
+
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[1]
+    return resolve_repo_root()
 
 
 def main() -> int:

--- a/tools/plan_control_effect_recensus_shards.py
+++ b/tools/plan_control_effect_recensus_shards.py
@@ -17,11 +17,9 @@ SCOREBOARD_AUTHORITY = False
 _TOOLS = Path(__file__).resolve().parent
 if str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root  # noqa: E402
 
-_SCRIPTS = (
-    Path(__file__).resolve().parents[1]
-    / "implementations/python/sugar-lift-py-tests/scripts"
-)
+_SCRIPTS = resolve_repo_root() / "implementations/python/sugar-lift-py-tests/scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 

--- a/tools/python_format_shards.py
+++ b/tools/python_format_shards.py
@@ -8,9 +8,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root  # noqa: E402
+
+ROOT = resolve_repo_root()
 PYTHON_ROOT = ROOT / "implementations" / "python"
 SKIP = frozenset({"target", "bin", "__pycache__", ".venv", "conformance"})
 

--- a/tools/repo_root_parents_n_census.py
+++ b/tools/repo_root_parents_n_census.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Live instrument: Path(__file__).parents[N] outside package src.
+
+R_repo_root_by_parents_count_outside_package_src — layout arithmetic residual
+after the monorepo resolve door. Exit 1 while R > 0.
+
+Buckets (outside ``sugar-lift-py-tests/src``):
+  package tests/, package scripts/, repo tests/, tools/
+
+Does not trust a hand list: rescans the tree every run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+PAT = re.compile(
+    r"(?:pathlib\.)?Path\(__file__\)(?:\.resolve\(\))?\.parents\[(\d+)\]"
+)
+BUCKETS = (
+    ("package_tests", Path("implementations/python/sugar-lift-py-tests/tests")),
+    ("package_scripts", Path("implementations/python/sugar-lift-py-tests/scripts")),
+    ("repo_tests", Path("tests")),
+    ("tools", Path("tools")),
+)
+SKIP_NAMES = frozenset(
+    {
+        "repo_root.py",
+        "sugar_repo_root.py",
+        "test_repo_root_door.py",
+        "repo_root_parents_n_census.py",
+    }
+)
+
+
+def scan(repo: Path) -> list[tuple[str, str, int, int, str]]:
+    hits: list[tuple[str, str, int, int, str]] = []
+    for bucket, rel in BUCKETS:
+        base = repo / rel
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*.py")):
+            if path.name in SKIP_NAMES:
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if line.lstrip().startswith("#"):
+                    continue
+                for match in PAT.finditer(line):
+                    hits.append(
+                        (
+                            bucket,
+                            str(path.relative_to(repo)),
+                            lineno,
+                            int(match.group(1)),
+                            line.strip()[:140],
+                        )
+                    )
+    return hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=None,
+        help="monorepo root (default: walk from cwd for sugar-build.toml)",
+    )
+    args = parser.parse_args(argv)
+    if args.repo is not None:
+        repo = args.repo.resolve()
+    else:
+        # Prefer tools door so this instrument does not use parents[N]
+        try:
+            from sugar_repo_root import resolve_repo_root  # type: ignore
+
+            repo = resolve_repo_root()
+        except Exception:
+            # Fallback walk from this file without a fixed index
+            here = Path(__file__).resolve()
+            repo = None
+            for parent in here.parents:
+                if (parent / "sugar-build.toml").is_file():
+                    repo = parent
+                    break
+            if repo is None:
+                print("FAIL: cannot resolve monorepo root", file=sys.stderr)
+                return 2
+
+    hits = scan(repo)
+    by_bucket = Counter(h[0] for h in hits)
+    print(f"R_repo_root_by_parents_count_outside_package_src={len(hits)}")
+    for bucket, _rel in BUCKETS:
+        print(f"  {bucket}={by_bucket.get(bucket, 0)}")
+    for bucket, path, line, n, text in hits:
+        print(f"{path}:{line}: parents[{n}] {text}")
+    return 1 if hits else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/resident_ownership_census.py
+++ b/tools/resident_ownership_census.py
@@ -22,7 +22,14 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+import sys
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 
 # Resident kit surfaces that hold process-lifetime state across RPC generations.
 SCAN_ROOTS = (

--- a/tools/showcase_bulk_refuse_class.py
+++ b/tools/showcase_bulk_refuse_class.py
@@ -24,7 +24,14 @@ import json
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+import sys
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT))
 
 from tools.showcase.durable_consistency import (  # noqa: E402

--- a/tools/showcase_kit_preflight.py
+++ b/tools/showcase_kit_preflight.py
@@ -22,7 +22,14 @@ import venv
 from dataclasses import dataclass
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+import sys
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 
 # Source trees showcases put on PYTHONPATH for bind_rpc / lean lift.
 SOURCE_PATHS = (

--- a/tools/showcase_verdict_scoreboard.py
+++ b/tools/showcase_verdict_scoreboard.py
@@ -27,7 +27,14 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+import sys
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 SCHEMA = "sugar.showcase.verdict.v1"
 
 

--- a/tools/sole_construction_floor_enrollment.py
+++ b/tools/sole_construction_floor_enrollment.py
@@ -25,10 +25,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
 
-_PACKAGE_SRC = (
-    Path(__file__).resolve().parents[1]
-    / "implementations/python/sugar-lift-py-tests/src"
-)
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root  # noqa: E402
+
+_PACKAGE_SRC = resolve_repo_root() / "implementations/python/sugar-lift-py-tests/src"
 if str(_PACKAGE_SRC) not in sys.path:
     sys.path.insert(0, str(_PACKAGE_SRC))
 

--- a/tools/static_floor_residual_report.py
+++ b/tools/static_floor_residual_report.py
@@ -9,7 +9,12 @@ import sys
 from collections import Counter
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root  # noqa: E402
+
+ROOT = resolve_repo_root()
 PACKAGE_SRC = ROOT / "implementations/python/sugar-lift-py-tests/src"
 if str(PACKAGE_SRC) not in sys.path:
     sys.path.insert(0, str(PACKAGE_SRC))

--- a/tools/sugar-build/contract.py
+++ b/tools/sugar-build/contract.py
@@ -9,7 +9,14 @@ import sys
 import tomllib
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[2]
+import sys
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 DEFAULT_CONTRACT = ROOT / "sugar-build.toml"
 PUBLISHED_BINARIES = frozenset({"sugar", "sugar-ir-smt-lib"})
 TASK_KEYS = frozenset({"capabilities", "binaries", "command", "network"})

--- a/tools/sugar-build/contract.py
+++ b/tools/sugar-build/contract.py
@@ -9,12 +9,10 @@ import sys
 import tomllib
 from pathlib import Path
 
-import sys
-
-_TOOLS = Path(__file__).resolve().parent
+_TOOLS = Path(__file__).resolve().parent.parent
 if str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
-from sugar_repo_root import resolve_repo_root
+from sugar_repo_root import resolve_repo_root  # noqa: E402
 
 ROOT = resolve_repo_root()
 DEFAULT_CONTRACT = ROOT / "sugar-build.toml"

--- a/tools/sugar_repo_root.py
+++ b/tools/sugar_repo_root.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Monorepo root door for tools/ and repo-level scripts (no package import).
+
+Same law as ``sugar_lift_py_tests.repo_root.resolve_repo_root``: resolve by
+asking for ``sugar-build.toml`` (env then walk), never ``Path(__file__).parents[N]``.
+Kept free of package deps so ``python tools/foo.py`` from a bare checkout works.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Mapping, Sequence
+
+MARKER = "sugar-build.toml"
+_ENV_KEYS: tuple[str, ...] = ("SUGAR_REPO_ROOT", "GITHUB_WORKSPACE")
+
+
+class RepoRootUnresolved(RuntimeError):
+    """The monorepo root could not be resolved; the marker was never found."""
+
+
+def resolve_repo_root(
+    *,
+    start: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    extra_starts: Sequence[Path] = (),
+) -> Path:
+    source = os.environ if env is None else env
+    searched: list[str] = []
+
+    for key in _ENV_KEYS:
+        raw = source.get(key)
+        if raw is None or not str(raw).strip():
+            searched.append(f"env:{key}=<unset>")
+            continue
+        candidate = Path(str(raw)).expanduser().resolve()
+        searched.append(f"env:{key}={candidate}")
+        if candidate.is_dir() and (candidate / MARKER).is_file():
+            return candidate
+
+    anchors: list[Path] = []
+    primary = Path.cwd().resolve() if start is None else Path(start).resolve()
+    anchors.append(primary)
+    for extra in extra_starts:
+        resolved = Path(extra).resolve()
+        if resolved not in anchors:
+            anchors.append(resolved)
+
+    for anchor in anchors:
+        current = anchor if anchor.is_dir() else anchor.parent
+        seen: set[Path] = set()
+        while current not in seen:
+            seen.add(current)
+            searched.append(f"walk:{current}")
+            if (current / MARKER).is_file():
+                return current
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+
+    raise RepoRootUnresolved(
+        "cannot resolve Sugar monorepo root: "
+        f"looked for {MARKER!r} via explicit env ({', '.join(_ENV_KEYS)}) "
+        f"and by walking up from anchors; searched: {searched}. "
+        f"Set SUGAR_REPO_ROOT to the checkout that contains {MARKER}, "
+        "or run with that checkout as the working directory."
+    )

--- a/tools/vendor_source_ledger.py
+++ b/tools/vendor_source_ledger.py
@@ -21,10 +21,17 @@ import subprocess
 import sys
 from pathlib import Path
 
+import sys
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root
+
 sys.path.insert(
     0,
     str(
-        Path(__file__).resolve().parents[1]
+        resolve_repo_root()
         / "implementations/python/sugar-lift-py-tests/src"
     ),
 )
@@ -40,7 +47,7 @@ def main(argv: list[str]) -> int:
         print("usage: vendor_source_ledger.py <package> <output-dir>", file=sys.stderr)
         return 2
     package, output_dir = argv[0], Path(argv[1])
-    root = Path(__file__).resolve().parents[1]
+    root = resolve_repo_root()
 
     sugar_bin = os.environ.get("SUGAR_BIN")
     if not sugar_bin:

--- a/tools/wall_progress_scoreboard.py
+++ b/tools/wall_progress_scoreboard.py
@@ -23,7 +23,14 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-ROOT = Path(__file__).resolve().parents[1]
+import sys
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+from sugar_repo_root import resolve_repo_root
+
+ROOT = resolve_repo_root()
 SCHEMA = "sugar.wall.progress.v1"
 
 DISCONNECT_RE = re.compile(


### PR DESCRIPTION
## Live instrument (not a hand list)

```bash
python3 tools/repo_root_parents_n_census.py
```

Rebased and re-measured against current main `7863ea5843dd94cf068b9ee8b8585721798d3e9f`.

| Tree | R | package tests | package scripts | repo tests | tools | Exit |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| current main before this PR | 221 | 128 | 35 | 40 | 18 | 1 |
| old Aug 1 patch after rebase | 69 | 20 | 14 | 29 | 6 | 1 |
| final head `5df9866f89d46dd7b8724680166ce37ca148b518` | 0 | 0 | 0 | 0 | 0 | 0 |

The old body’s 156 was truthful on its Aug 1 snapshot but is not the live preimage. The current population is 221, so this PR’s measured `Epsilon R` is **221 -> 0**. This does not attribute all +65 rows to particular intervening commits; it establishes that the live instrument saw them and the rebased patch drains them.

## Missing object / one door

Same door as #6978: ask for the monorepo root by locating `sugar-build.toml`, never derive positional identity with `parents[N]`.

- Package code uses `resolve_repo_root`, `sugar_lift_py_tests_package_root`, and `python_implementations_root`.
- Tools and repo-level scripts use the dependency-free twin `tools/sugar_repo_root.py`.
- Nested `tools/sugar-build/contract.py` seats the tools directory only to import that twin; the twin still owns root resolution.

The drain has two correct entrances depending on runtime authority. Package tests and
scripts running behind the prepared Python environment use the package helper. Bare
repo-level teeth running before package installation must use the dependency-free
tools twin. The original rebased patch crossed that boundary at two workflow sites:
`test_workflow_context_availability.py` and `test_sugarbin_shell_tier.py`. Both now
seat the tools twin directly; the package refusal was not weakened or bypassed.

A wrong `parents[N]` value is especially dangerous because it returns a plausible path rather than refusing.

## Verification

- Live census: R=0 across all four measured buckets, exit 0.
- Authenticated remote tooth: `bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_repo_root_door.py` -> 8 passed, exit 0.
- Authenticated bare workflow-context tooth with actionlint v1.7.12: 7 passed, exit 0.
- Authenticated bare sugarbin-shell-tier tooth: 7 passed, exit 0.
- Direct-workflow sweep: 3 repo-level Python teeth run before package preparation; 2 use the tools twin and 1 needs no root helper. Zero import the package helper.
- Current-main two-tree diff: exit 0, no deleted paths.
- `git diff --check origin/main HEAD`: exit 0.
- `.receipts/first-sealed-frontier-1b3ac2dd9/closing-account.json`: SHA256 `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.

## Scope and nonclaims

This drains only `R_repo_root_by_parents_count_outside_package_src`. It does not claim a corpus/product delta, does not relax corpus pins, and does not classify package-relative seats inside package `src` as this residual.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `Path(__file__).parents[N]` repo root resolution with `resolve_repo_root()` across scripts and tests
> - Adds [sugar_repo_root.py](https://github.com/TSavo/sugar/pull/6989/files#diff-aa3534ff81338a439ebb8fa3554bc6b362b4e4645c4c9e4b977a6c254ee9dd58) in `tools/`, which provides `resolve_repo_root()` — an environment-aware monorepo root resolver that checks `SUGAR_REPO_ROOT`, `GITHUB_WORKSPACE`, and walks up from the caller's path looking for `sugar-build.toml`.
> - Updates all scripts and tests under `implementations/python/sugar-lift-py-tests/` and `tests/` and `tools/` to import `resolve_repo_root()`, `sugar_lift_py_tests_package_root()`, or `python_implementations_root()` instead of hardcoded `Path(__file__).resolve().parents[N]` traversals.
> - Adds [repo_root_parents_n_census.py](https://github.com/TSavo/sugar/pull/6989/files#diff-e68bf6877694e9c0c05e2fbef502886d48e5eaca40067d5c32986aa2401a9648), a new CLI tool that audits Python files for remaining `parents[N]`-based root resolution and exits non-zero when hits are found.
> - Risk: `tools/sugar-build/contract.py` now resolves `DEFAULT_CONTRACT` via `resolve_repo_root()` instead of `parents[2]`, which changes where `sugar-build.toml` is found at runtime if the file is invoked from outside the repo tree.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5df9866.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
