### PR TITLE
Instrument: R_families_without_lying_twin (criterion 5 inventory)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/semantic_family_twin_inventory_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/semantic_family_twin_inventory_law.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Criterion 5 inventory: every semantic family ships a lying twin.
+
+CLASS
+    SEMANTIC-FAMILY TWIN COVERAGE
+
+DEFINITION
+    Enrollment is existence: a semantic family is whatever the live catalog
+    enumerates (factory-owned Sugar classes with ``witnesses()``, plus the
+    ProofIR node-class registry). Each family must have a TRUTHFUL face and a
+    LYING face. A family with only a truthful twin is untested for the thing
+    that matters: a positive test proves the instrument fires; only a lying
+    twin proves it can FAIL (AGENTS.md: only a flipping bad-twin can check the
+    honest-arm clause).
+
+AXES
+    R_families_without_lying_twin
+        Families that lack a discriminable lying face.
+    R_families_without_truthful_twin
+        Symmetric gap (reported; primary red is lying).
+    R_families_without_either_twin
+        No witnesses / empty enrollment surface.
+
+Not the board. SCOREBOARD_AUTHORITY = False.
+
+ENFORCEMENT LADDER
+    Rung: **auditor** (static recognition over live catalog enrollment).
+
+    Why not higher:
+    1. Type system: cannot forbid a classmethod that returns only one face of a
+       pair without a closed witness type that requires both constructors.
+    2. One door: a sealed ``SugarWitnessPair`` / ``VerdictWitnessPair`` type
+       that refuses construction without both faces would climb; today Python
+       allows free-form ``witnesses()`` returns including partial shapes.
+    3. Panic at contact: missing twins are absence of a test face, not a
+       runtime contact path until the catalog test runs.
+
+    Retirement path (name what would delete this auditor):
+    - ``witnesses()`` return type is ``SugarWitnesses`` sealed at the type
+      level: ``SugarWitnessPair`` (or lawful ``NotVerdictBearing`` opt-out)
+      is the only constructible result; a single-face object cannot be built.
+    - ProofIR ``verdict_witnesses()`` similarly sealed.
+    When those doors refuse incomplete pairs, delete this inventory auditor.
+
+This is MEASUREMENT only: it does not write missing twins. Exit 1 while R > 0.
+"""
+
+from __future__ import annotations
+
+# Not the board.
+SCOREBOARD_AUTHORITY = False
+
+import argparse
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+from typing import Iterable
+
+
+@dataclass(frozen=True, order=True)
+class FamilyTwinStatus:
+    catalog: str
+    family: str
+    path: str
+    line: int
+    has_truthful: bool
+    has_lying: bool
+    status: str  # both | truthful_only | lying_only | neither | opt_out
+    plant: str
+
+    @property
+    def missing_lying(self) -> bool:
+        return self.status in {"truthful_only", "neither"} and self.status != "opt_out"
+
+    @property
+    def missing_truthful(self) -> bool:
+        return self.status in {"lying_only", "neither"} and self.status != "opt_out"
+
+
+_OPT_OUT_MARKERS = frozenset(
+    {
+        "NotVerdictBearing",
+        "not_verdict_bearing",
+        "temporal_opt_out",
+        "NON_FOL_OPT_OUT",
+    }
+)
+
+_TRUTHFUL_MARKERS = frozenset(
+    {
+        "truthful",
+        "SugarWitnessPair",
+        "SugarUnwitnessedPair",
+        "SugarRedEffectWitnessPair",
+        "_call_pair",
+        "_call_return_pair",
+        "_boolop_wrapped_pair",
+        "_unwitnessed_call_return_pair",
+        "inert_statement_return_witness",
+        "typed_red_effect_witness",
+        "VerdictWitnessPair",
+        "VerdictWitnessCase",
+    }
+)
+
+_LYING_MARKERS = frozenset(
+    {
+        "lying",
+        "SugarWitnessPair",
+        "SugarUnwitnessedPair",
+        "SugarRedEffectWitnessPair",
+        "_call_pair",
+        "_call_return_pair",
+        "_boolop_wrapped_pair",
+        "_unwitnessed_call_return_pair",
+        "inert_statement_return_witness",
+        "typed_red_effect_witness",
+        "VerdictWitnessPair",
+        "VerdictWitnessCase",
+    }
+)
+
+
+def _method(class_node: ast.ClassDef, name: str) -> ast.FunctionDef | None:
+    for item in class_node.body:
+        if (
+            isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and item.name == name
+        ):
+            return item
+    return None
+
+
+def _terminal_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _kw_present(tree: ast.AST, name: str) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.keyword) and node.arg == name:
+            return True
+        if isinstance(node, ast.Name) and node.id == name:
+            return True
+        if isinstance(node, ast.Attribute) and node.attr == name:
+            return True
+    return False
+
+
+def _call_names(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name):
+            names.add(node.func.id)
+        elif isinstance(node.func, ast.Attribute):
+            names.add(node.func.attr)
+    return names
+
+
+def _classify_witnesses_method(
+    witnesses: ast.FunctionDef | None,
+) -> tuple[bool, bool, bool]:
+    """Return (has_truthful, has_lying, is_opt_out)."""
+    if witnesses is None:
+        return False, False, False
+    body_text = ast.unparse(witnesses)
+    if any(marker in body_text for marker in _OPT_OUT_MARKERS):
+        return False, False, True
+    calls = _call_names(witnesses)
+    has_kw_truthful = _kw_present(witnesses, "truthful")
+    has_kw_lying = _kw_present(witnesses, "lying")
+    # Pair constructors that always carry both faces by API.
+    pair_ctors = calls & {
+        "SugarWitnessPair",
+        "SugarUnwitnessedPair",
+        "SugarRedEffectWitnessPair",
+        "_call_pair",
+        "_call_return_pair",
+        "_boolop_wrapped_pair",
+        "_unwitnessed_call_return_pair",
+        "inert_statement_return_witness",
+        "typed_red_effect_witness",
+        "VerdictWitnessPair",
+    }
+    if pair_ctors:
+        # These APIs require both faces; treat as both present.
+        return True, True, False
+    has_truthful = has_kw_truthful or bool(calls & _TRUTHFUL_MARKERS)
+    has_lying = has_kw_lying or bool(calls & _LYING_MARKERS)
+    # Bare return of something without markers → neither (unenrolled).
+    return has_truthful, has_lying, False
+
+
+def _status(has_truthful: bool, has_lying: bool, opt_out: bool) -> str:
+    if opt_out:
+        return "opt_out"
+    if has_truthful and has_lying:
+        return "both"
+    if has_truthful and not has_lying:
+        return "truthful_only"
+    if has_lying and not has_truthful:
+        return "lying_only"
+    return "neither"
+
+
+def _plant_for(status: str, family: str) -> str:
+    if status == "opt_out":
+        return (
+            f"{family}: lawful NotVerdictBearing opt-out — no verdict twin owed; "
+            "if this family becomes FOL-bearing, plant SugarWitnessPair(truthful=…, lying=…)"
+        )
+    if status == "both":
+        return f"{family}: both faces enrolled"
+    if status == "truthful_only":
+        return (
+            f"{family}: plant a LYING twin that flips the instrument red "
+            f"(wrong assertion / wrong effect / construction-open) while the "
+            f"truthful face stays SAT; register as SugarWitnessPair.lying or "
+            f"VerdictWitnessPair.lying"
+        )
+    if status == "lying_only":
+        return (
+            f"{family}: plant a TRUTHFUL twin that proves the recognizer fires "
+            f"(SAT / expected typed red) as SugarWitnessPair.truthful"
+        )
+    return (
+        f"{family}: plant BOTH faces — SugarWitnessPair(name=…, owner_sugar={family!r}, "
+        f"truthful=WitnessSource(…, expected='sat'), "
+        f"lying=WitnessSource(…, expected='unsat')) "
+        f"or lawful NotVerdictBearing opt-out with floor reason"
+    )
+
+
+def enumerate_sugar_families(sugar_root: Path) -> list[FamilyTwinStatus]:
+    """Live catalog: concrete *Sugar classes that define witnesses()."""
+    rows: list[FamilyTwinStatus] = []
+    if not sugar_root.is_dir():
+        return rows
+    for path in sorted(sugar_root.rglob("*.py")):
+        if path.name.startswith("_") and path.name != "__init__.py":
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(path))
+        except (OSError, UnicodeError, SyntaxError):
+            continue
+        rel = f"sugar/{path.relative_to(sugar_root).as_posix()}"
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef):
+                continue
+            if not node.name.endswith("Sugar"):
+                continue
+            if any(_terminal_name(base) in {"ABC", "Protocol"} for base in node.bases):
+                continue
+            witnesses = _method(node, "witnesses")
+            if witnesses is None:
+                # Not enrolled in the witness catalog — not a semantic family
+                # for criterion 5 (enrollment is existence via witnesses).
+                continue
+            has_t, has_l, opt = _classify_witnesses_method(witnesses)
+            status = _status(has_t, has_l, opt)
+            rows.append(
+                FamilyTwinStatus(
+                    catalog="sugar",
+                    family=node.name,
+                    path=rel,
+                    line=node.lineno,
+                    has_truthful=has_t,
+                    has_lying=has_l,
+                    status=status,
+                    plant=_plant_for(status, node.name),
+                )
+            )
+    return rows
+
+
+def _registry_names(init_path: Path, registry_name: str) -> list[str]:
+    """Read class names from a module-level registry tuple assignment."""
+    try:
+        tree = ast.parse(init_path.read_text(encoding="utf-8"), filename=str(init_path))
+    except (OSError, UnicodeError, SyntaxError):
+        return []
+    names: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, ast.AnnAssign):
+            if not isinstance(node, ast.Assign):
+                continue
+            targets = node.targets
+            value = node.value
+        else:
+            targets = [node.target]
+            value = node.value
+        for target in targets:
+            if not isinstance(target, ast.Name) or target.id != registry_name:
+                continue
+            if not isinstance(value, (ast.Tuple, ast.List)):
+                continue
+            for elt in value.elts:
+                name = _terminal_name(elt)
+                if name:
+                    names.append(name)
+    return names
+
+
+def _find_class_def(
+    package_root: Path, class_name: str
+) -> tuple[Path, ast.ClassDef] | None:
+    for path in sorted(package_root.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, UnicodeError, SyntaxError):
+            continue
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and node.name == class_name:
+                return path, node
+    return None
+
+
+def enumerate_proofir_families(proofir_nodes_root: Path) -> list[FamilyTwinStatus]:
+    """Live catalog: ProofIR node classes named in the registry tuples."""
+    rows: list[FamilyTwinStatus] = []
+    init_path = proofir_nodes_root / "__init__.py"
+    if not init_path.is_file():
+        return [
+            FamilyTwinStatus(
+                catalog="proofir",
+                family="__catalog_missing__",
+                path=str(init_path),
+                line=0,
+                has_truthful=False,
+                has_lying=False,
+                status="neither",
+                plant=f"missing ProofIR nodes package at {proofir_nodes_root}",
+            )
+        ]
+    names = _registry_names(init_path, "REGISTERED_PROOFIR_NODE_CLASSES")
+    names += _registry_names(init_path, "_ADDITIONAL_PROOFIR_WITNESS_CLASSES")
+    # Enrollment is existence: empty registry is itself a catalog failure.
+    if not names:
+        rows.append(
+            FamilyTwinStatus(
+                catalog="proofir",
+                family="__catalog_empty__",
+                path=f"proofir/nodes/{init_path.name}",
+                line=0,
+                has_truthful=False,
+                has_lying=False,
+                status="neither",
+                plant="ProofIR registry tuples are empty — enroll node classes",
+            )
+        )
+        return rows
+    for class_name in names:
+        found = _find_class_def(proofir_nodes_root, class_name)
+        if found is None:
+            rows.append(
+                FamilyTwinStatus(
+                    catalog="proofir",
+                    family=class_name,
+                    path="proofir/nodes/",
+                    line=0,
+                    has_truthful=False,
+                    has_lying=False,
+                    status="neither",
+                    plant=(
+                        f"{class_name}: registry names a class with no source "
+                        "definition under proofir/nodes"
+                    ),
+                )
+            )
+            continue
+        path, class_node = found
+        witnesses = _method(class_node, "verdict_witnesses")
+        has_t, has_l, opt = _classify_witnesses_method(witnesses)
+        # ProofIR pairs always construct both faces when method exists; refine
+        # with keyword detection for truthful=/lying= on VerdictWitnessPair.
+        if witnesses is not None and not opt:
+            has_t = has_t or _kw_present(witnesses, "truthful")
+            has_l = has_l or _kw_present(witnesses, "lying")
+            if _call_names(witnesses) & {"VerdictWitnessPair"}:
+                has_t, has_l = True, True
+        status = _status(has_t, has_l, opt)
+        try:
+            rel = f"proofir/nodes/{path.relative_to(proofir_nodes_root).as_posix()}"
+        except ValueError:
+            rel = path.as_posix()
+        rows.append(
+            FamilyTwinStatus(
+                catalog="proofir",
+                family=class_name,
+                path=rel,
+                line=class_node.lineno,
+                has_truthful=has_t,
+                has_lying=has_l,
+                status=status,
+                plant=_plant_for(status, class_name),
+            )
+        )
+    return rows
+
+
+def inventory(
+    *,
+    sugar_root: Path,
+    proofir_nodes_root: Path | None = None,
+    include_proofir: bool = True,
+) -> list[FamilyTwinStatus]:
+    rows = enumerate_sugar_families(sugar_root)
+    if include_proofir:
+        if proofir_nodes_root is None:
+            proofir_nodes_root = (
+                sugar_root.parent / "proofir" / "nodes"
+            )
+        rows.extend(enumerate_proofir_families(proofir_nodes_root))
+    return sorted(rows, key=lambda r: (r.catalog, r.family, r.path, r.line))
+
+
+def format_report(rows: Iterable[FamilyTwinStatus]) -> str:
+    rows = list(rows)
+    missing_lying = [r for r in rows if r.missing_lying]
+    missing_truthful = [r for r in rows if r.missing_truthful]
+    opt_out = [r for r in rows if r.status == "opt_out"]
+    both = [r for r in rows if r.status == "both"]
+    lines = [
+        "SEMANTIC-FAMILY TWIN INVENTORY (criterion 5)",
+        f"catalog_families = {len(rows)}",
+        f"R_families_without_lying_twin = {len(missing_lying)}",
+        f"R_families_without_truthful_twin = {len(missing_truthful)}",
+        f"families_with_both = {len(both)}",
+        f"families_opt_out_not_verdict_bearing = {len(opt_out)}",
+        "",
+        "Law: enrollment is existence. Every catalog family must ship a lying "
+        "twin that can flip red. Positive-only coverage is unfalsifiable.",
+        "Retirement: seal witnesses() / verdict_witnesses() so incomplete pairs "
+        "are unconstructable; then delete this auditor.",
+        "",
+    ]
+    if missing_lying:
+        lines.append("OFFENDERS (missing lying twin):")
+        for row in missing_lying:
+            lines.append(
+                f"  {row.catalog}:{row.family} @ {row.path}:{row.line} "
+                f"status={row.status}"
+            )
+            lines.append(f"    plant: {row.plant}")
+        lines.append("")
+    if missing_truthful:
+        lines.append("OFFENDERS (missing truthful twin):")
+        for row in missing_truthful:
+            lines.append(
+                f"  {row.catalog}:{row.family} @ {row.path}:{row.line} "
+                f"status={row.status}"
+            )
+            lines.append(f"    plant: {row.plant}")
+        lines.append("")
+    lines.append("FULL INVENTORY:")
+    for row in rows:
+        lines.append(
+            f"  {row.catalog}:{row.family} status={row.status} "
+            f"truthful={int(row.has_truthful)} lying={int(row.has_lying)} "
+            f"@ {row.path}:{row.line}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sugar-root",
+        type=Path,
+        default=(
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "sugar_lift_py_tests"
+            / "sugar"
+        ),
+    )
+    parser.add_argument(
+        "--proofir-nodes-root",
+        type=Path,
+        default=(
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "sugar_lift_py_tests"
+            / "proofir"
+            / "nodes"
+        ),
+    )
+    parser.add_argument(
+        "--no-proofir",
+        action="store_true",
+        help="skip ProofIR registry (sugar catalog only)",
+    )
+    args = parser.parse_args(argv)
+    rows = inventory(
+        sugar_root=args.sugar_root,
+        proofir_nodes_root=args.proofir_nodes_root,
+        include_proofir=not args.no_proofir,
+    )
+    report = format_report(rows)
+    print(report)
+    r_lying = sum(1 for r in rows if r.missing_lying)
+    return 1 if r_lying > 0 or not rows else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/tests/test_semantic_family_twin_inventory_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_semantic_family_twin_inventory_law.py
@@ -1,0 +1,121 @@
+"""Twins for the semantic-family twin inventory instrument (criterion 5).
+
+Measurement only: does not drain missing twins. Proves the auditor teeth.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+import sys
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "semantic_family_twin_inventory_law.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "semantic_family_twin_inventory_law", _SCRIPT
+)
+assert _SPEC is not None and _SPEC.loader is not None
+LAW = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = LAW
+_SPEC.loader.exec_module(LAW)
+
+
+def test_planted_truthful_only_family_is_red() -> None:
+    """Lying twin of the instrument: a family with only a truthful face is red."""
+    source = '''
+class OnlyTruthfulSugar:
+    @classmethod
+    def witnesses(cls):
+        return WitnessSource(source="assert True", expected="sat")
+'''
+    tree = ast.parse(source)
+    class_node = tree.body[0]
+    witnesses = LAW._method(class_node, "witnesses")
+    has_t, has_l, opt = LAW._classify_witnesses_method(witnesses)
+    status = LAW._status(has_t, has_l, opt)
+    assert status == "truthful_only" or (
+        has_t and not has_l and not opt
+    ), (status, has_t, has_l, opt)
+    assert LAW._status(True, False, False) == "truthful_only"
+    assert LAW.FamilyTwinStatus(
+        catalog="sugar",
+        family="OnlyTruthfulSugar",
+        path="planted.py",
+        line=1,
+        has_truthful=True,
+        has_lying=False,
+        status="truthful_only",
+        plant="plant lying",
+    ).missing_lying
+
+
+def test_planted_both_faces_is_green_for_that_family() -> None:
+    """Truthful twin of the classifier: pair constructors count as both faces."""
+    source = '''
+class BothFacesSugar:
+    @classmethod
+    def witnesses(cls):
+        return _call_pair(
+            name="x",
+            owner_sugar="BothFacesSugar",
+            truthful="def test_a():\\n    assert A(1)==1\\n",
+            lying="def test_a():\\n    assert A(1)==2\\n",
+        )
+'''
+    tree = ast.parse(source)
+    class_node = tree.body[0]
+    witnesses = LAW._method(class_node, "witnesses")
+    has_t, has_l, opt = LAW._classify_witnesses_method(witnesses)
+    assert (has_t, has_l, opt) == (True, True, False)
+    assert LAW._status(has_t, has_l, opt) == "both"
+
+
+def test_live_catalog_enumerates_from_source_not_hand_list() -> None:
+    """Enrollment is existence: inventory walks sugar/ + ProofIR registry."""
+    sugar_root = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "sugar_lift_py_tests"
+        / "sugar"
+    )
+    proofir_root = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "sugar_lift_py_tests"
+        / "proofir"
+        / "nodes"
+    )
+    rows = LAW.inventory(sugar_root=sugar_root, proofir_nodes_root=proofir_root)
+    assert rows, "live catalog must be non-empty"
+    sugar_names = {r.family for r in rows if r.catalog == "sugar"}
+    # Live enrollment: IntLiteralSugar is a catalog family with both faces.
+    assert "IntLiteralSugar" in sugar_names
+    int_lit = next(r for r in rows if r.family == "IntLiteralSugar")
+    assert int_lit.status == "both"
+    # ProofIR registry is live, not hand-listed in this test file.
+    proofir = [r for r in rows if r.catalog == "proofir"]
+    assert proofir
+    assert all(r.status == "both" for r in proofir), proofir
+
+
+def test_report_names_r_axis_and_plant_recipe() -> None:
+    planted = [
+        LAW.FamilyTwinStatus(
+            catalog="sugar",
+            family="MissingLyingSugar",
+            path="sugar/missing.py",
+            line=3,
+            has_truthful=True,
+            has_lying=False,
+            status="truthful_only",
+            plant="plant a LYING twin",
+        )
+    ]
+    rendered = LAW.format_report(planted)
+    assert "R_families_without_lying_twin = 1" in rendered
+    assert "MissingLyingSugar" in rendered
+    assert "plant a LYING twin" in rendered


### PR DESCRIPTION
## Shot accounting (IDD)

| Field | Value |
| --- | --- |
| **R axis** | `R_families_without_lying_twin` |
| **Live tip** | `8857e4071` |
| **Measured R** | **30** (of 107 catalog families) |
| **Predicted Epsilon R** | **0** this PR (measurement only; does not drain) |
| **Also reported** | `families_with_both=59`, `opt_out=18`, `R_families_without_truthful_twin=30` (same 30 neither) |
| **Floors preserved** | no production sugar/ProofIR meaning change; not the corpus scoreboard (`SCOREBOARD_AUTHORITY=False`) |
| **Shell deleted** | **none** — this PR *creates* the inventory auditor. Retires when `witnesses()` / `verdict_witnesses()` are sealed so incomplete pairs are unconstructable |

## Leash (advisor)

**Report-first only.** This PR produces the number and the instrument. It does **not** drain twins, claim work order, or re-rank against other axes. **R is parked until S1.1** (advisor-owned live re-rank). No heavy measurement / bx / workflow_dispatch from this lane.

## Criterion 5

Truthful AND lying twins prove each semantic family. A family with only a truthful twin is unfalsifiable. Enrollment is existence: families are enumerated from the **live** Sugar `witnesses()` catalog and the ProofIR node registry — not a hand list.

## Ladder

1. Type forbid incomplete pairs? **Not yet** (open `witnesses()` returns).  
2. One door refuse? **Would** be sealed `SugarWitnessPair` / `VerdictWitnessPair` constructors.  
3. Panic at contact? Catalog absence is not runtime contact until the twin suite runs.  

→ **Auditor** with retirement path named in the script docstring.

## Live inventory (re-derived; not drained; parked)

```
catalog_families = 107
R_families_without_lying_twin = 30
families_with_both = 59
families_opt_out_not_verdict_bearing = 18
```

ProofIR registry (7 classes): all `both`.  
30 sugar families have `witnesses()` that return empty / non-pair shapes (status `neither`).

## How to re-measure

```bash
cd implementations/python/sugar-lift-py-tests
PYTHONPATH=src python3 scripts/semantic_family_twin_inventory_law.py
# EXIT=1 while R>0
```

No local pytest; no bx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inventory auditor for semantic-family witness coverage.
  * Reports truthful, lying, paired, missing, and opted-out family statuses.
  * Provides guidance for adding missing lying counterparts.
  * Returns a failure status when required coverage is missing or catalogs are empty.

* **Tests**
  * Added coverage for family detection, paired constructors, live catalog enumeration, and report output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CLI audit tool to inventory semantic family witness twins (criterion 5)
> - Adds [`semantic_family_twin_inventory_law.py`](https://github.com/TSavo/sugar/pull/6990/files#diff-5caeb9417b6b1bd9d51f972d1c41f847902c0d3fb23a0bf8767a20f71a426895), a new CLI script that walks sugar and ProofIR source trees via AST inspection to classify each semantic family's `witnesses`/`verdict_witnesses` method as having truthful, lying, both, or opt-out twin faces.
> - Produces a human-readable report with per-family status, counts of offenders, and remediation recipes ("plant" guidance) for missing lying twins.
> - Exits with code 1 when any family is missing a lying twin or when no rows are found, enabling CI enforcement.
> - Adds four tests in [`test_semantic_family_twin_inventory_law.py`](https://github.com/TSavo/sugar/pull/6990/files#diff-cbcb110a7b6d7954220a6f66d19aef812fc78b339c2f01e1781c7f5af6aca1a7) covering synthetic AST classification, live catalog enumeration against the repo, and report content validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b32bc9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->