### PR TITLE
S0.3-ready: compose CommitMeasurement Partial (no require-complete)

### DIFF
--- a/docs/path-forward.md
+++ b/docs/path-forward.md
@@ -211,7 +211,11 @@
 
 1. **S0.1** — Finish recensus `30720169468`; bank board artifact (DONE-WHEN above).  
 2. **S0.2** — Finish sole-construction `30720199631`; bank process-floor R triple (DONE-WHEN above).  
-3. **S0.3** — Package tip measurement (board + floors + optional CommitMeasurement complete); only then **S1.1** live re-rank.
+3. **S0.3** — Package tip measurement (board + floors + optional CommitMeasurement); only then **S1.1** live re-rank.
+   - **REQUIRED:** board JSON (S0.1) + process-floor R triple native/bare/timeout (S0.2).
+   - **OPTIONAL:** `CommitMeasurement` via `tools/compose_commit_measurement.py` — **may be PartialVector** (unmeasured axes expected if package suite has not spoken). Do **not** use `commit_measurement_gate --require-complete` for S0.3 packaging.
+   - Ready command (run only after S0.1/S0.2 receipts exist; do not contend in-flight runs):
+     `python3 tools/compose_commit_measurement.py --commit "$SHA" --receipts-dir receipts/ --output commit-measurement.json`
 
 ---
 

--- a/tests/test_commit_measurement.py
+++ b/tests/test_commit_measurement.py
@@ -280,3 +280,37 @@ def test_workflow_runs_gate_even_when_attendance_would_exit_red() -> None:
     # Decorative pattern: separate gate step after roll call under set -e only
     # would skip on attendance red. The fixed job uses att_exit/gate_exit OR.
     assert "att_exit" in text and "gate_exit" in text
+
+
+def test_s03_compose_cli_allows_partial_exit_zero(tmp_path: Path) -> None:
+    """S0.3 packaging: empty/partial receipts still write PartialVector exit 0.
+
+    --require-complete is attendance tip-complete claim only — not S0.3.
+    """
+    import subprocess
+    import sys
+
+    empty = tmp_path / "receipts"
+    empty.mkdir()
+    out = tmp_path / "commit-measurement.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "tools" / "compose_commit_measurement.py"),
+            "--commit",
+            "s03-tip",
+            "--receipts-dir",
+            str(empty),
+            "--output",
+            str(out),
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert out.is_file()
+    payload = __import__("json").loads(out.read_text(encoding="utf-8"))
+    assert payload["status"] == "partial"
+    assert "total" not in payload
+    assert payload["unmeasuredAxes"]

--- a/tools/compose_commit_measurement.py
+++ b/tools/compose_commit_measurement.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Compose CommitMeasurement from sealed receipts — S0.3-ready, allow Partial.
+
+S0.3 REQUIRED artifacts (path-forward.md): board JSON + process-floor R triple.
+CommitMeasurement is OPTIONAL and MAY BE PARTIAL (package suite may not have
+spoken yet). This CLI never uses --require-complete.
+
+    python3 tools/compose_commit_measurement.py \\
+      --commit "$SHA" \\
+      --receipts-dir receipts/ \\
+      --output commit-measurement.json
+
+Exit codes:
+  0  composition written (CompleteVector or PartialVector)
+  2  usage / IO / constructor failure
+
+Do NOT fire this against in-flight S0.1/S0.2 runs until their artifacts land.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_cm():
+    path = Path(__file__).resolve().parent / "commit_measurement.py"
+    spec = importlib.util.spec_from_file_location("commit_measurement", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit("cannot load tools/commit_measurement.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--commit", required=True, help="tip SHA under composition")
+    parser.add_argument(
+        "--receipts-dir",
+        type=Path,
+        required=True,
+        help="directory of downloaded lease/body JSON artifacts",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("commit-measurement.json"),
+        help="where to write the composition JSON (default: commit-measurement.json)",
+    )
+    parser.add_argument(
+        "--roster-cid",
+        default="heavy-roster:per-commit",
+        help="roster content id string bound into the vector",
+    )
+    # Intentionally NO --require-complete. S0.3 packaging allows PartialVector.
+    args = parser.parse_args(argv)
+
+    cm = _load_cm()
+    try:
+        vector = cm.compose_tip_from_receipts_dir(
+            args.commit,
+            args.receipts_dir,
+            roster_cid=args.roster_cid,
+        )
+    except cm.CommitMeasurementError as exc:
+        print(f"compose-commit-measurement REFUSED: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"compose-commit-measurement IO: {exc}", file=sys.stderr)
+        return 2
+
+    payload = vector.to_json()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    status = payload.get("status")
+    print(f"wrote {args.output} status={status}")
+    if status == "partial":
+        print(
+            "PartialVector (honest): unmeasuredAxes="
+            f"{payload.get('unmeasuredAxes')!r} — no total; "
+            "S0.3 allows this (package suite may not have spoken)"
+        )
+        # Exit 0: partial is success for this CLI. Use
+        # commit_measurement_gate --require-complete only for tip-complete claims.
+        return 0
+    print(f"CompleteVector total={payload.get('total')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Scope (advisor / S0.3)

S0.3 **required** artifacts: board JSON (S0.1) + process-floor R triple (S0.2).  
**CommitMeasurement is optional and may be Partial** — package suite may not have spoken yet.

Do **not** use `commit_measurement_gate --require-complete` for S0.3 packaging (that is for tip-complete attendance claims only).

## What landed

- `tools/compose_commit_measurement.py` — one ready command:
  ```bash
  python3 tools/compose_commit_measurement.py \
    --commit "$SHA" \
    --receipts-dir receipts/ \
    --output commit-measurement.json
  ```
  Writes Complete or **Partial**, exit **0** on Partial (honest unmeasured axes).
- `docs/path-forward.md` S0.3 step documents required vs optional and this command.
- Twin: empty receipts → Partial, no total, CLI exit 0.

## Not fired

In-flight S0.1 recensus and S0.2 sole-construction must not be contended. Compose is **ready**, not executed against those runs.

## Shot accounting

| | |
| --- | --- |
| R axis | none drained |
| Epsilon R | 0 (prepare path only) |
| Floors | no `--require-complete` on S0.3 path; board authority untouched |
| Shell deleted | none — prepares optional Partial packaging for S0.3 |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `compose_commit_measurement.py` CLI that exits 0 for partial commit measurements
> - Adds [compose_commit_measurement.py](https://github.com/TSavo/sugar/pull/6991/files#diff-9066aa1cffce0350f9c191cc4cd7b49340f68c975e686e7c55280513692ad112) as a new CLI that composes a commit measurement from receipts and writes the JSON payload to a specified output file, intentionally omitting any `--require-complete` flag so that partial vectors (no total) still exit 0.
> - For partial status, logs that no total is present and that S0.3 allows partial results; for complete status, logs the total.
> - Adds a test in [test_commit_measurement.py](https://github.com/TSavo/sugar/pull/6991/files#diff-81137490bc719fa11ba8c7349e84cb97bb1d5af5bf7c7d3e404b8922ef063a32) that verifies the CLI exits 0 with an empty receipts dir, and that the output has `status: partial`, no `total`, and an `unmeasuredAxes` field.
> - Updates [path-forward.md](https://github.com/TSavo/sugar/pull/6991/files#diff-252f34604f8be9b73e38fa618cbab7843a1327de703a045be225b57b2a41ee01) to document that CommitMeasurement is optional and may be a PartialVector at S0.3, with a concrete ready command to run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dbad7b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->