### PR TITLE
R_shelf_exercise: EXERCISED_CLEAN ≠ NEVER_TOUCHED ≠ UNMEASURED

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -561,6 +561,74 @@ rust_workspace="$repo_root/implementations/rust"
 
 log() {
   printf 'sugarbin: %s\n' "$*" >&2
+  # Receipt-side shelf exercise testimony (tools/shelf_exercise_report.py).
+  # Silence without resolveOpened is UNMEASURED; resolve without shelf events
+  # is NEVER_TOUCHED; shelf events without crimes is EXERCISED_CLEAN.
+  shelf_exercise_note_log "$*"
+}
+
+# Path of the shelf-exercise receipt for this resolve, or empty when not
+# enrolled (local ad-hoc use without GITHUB_WORKSPACE / SUGAR_SHELF_EXERCISE_RECEIPT).
+shelf_exercise_receipt_path() {
+  if [[ -n "${SUGAR_SHELF_EXERCISE_RECEIPT:-}" ]]; then
+    printf '%s\n' "$SUGAR_SHELF_EXERCISE_RECEIPT"
+    return 0
+  fi
+  if [[ -n "${GITHUB_WORKSPACE:-}" ]]; then
+    printf '%s\n' "$GITHUB_WORKSPACE/.sugar/shelf-exercise.json"
+    return 0
+  fi
+  return 1
+}
+
+shelf_exercise_open_resolve() {
+  # Positive claim: binary resolve ran. Without this, NEVER_TOUCHED cannot be
+  # distinguished from UNMEASURED (the silence-as-testimony hole).
+  local out reporter
+  out="$(shelf_exercise_receipt_path 2>/dev/null)" || return 0
+  reporter="$repo_root/tools/shelf_exercise_report.py"
+  [[ -f "$reporter" ]] || return 0
+  python3 "$reporter" open --output "$out" 2>/dev/null || true
+}
+
+shelf_exercise_note_log() {
+  local msg="$1" out reporter op outcome crime=""
+  out="$(shelf_exercise_receipt_path 2>/dev/null)" || return 0
+  reporter="$repo_root/tools/shelf_exercise_report.py"
+  [[ -f "$reporter" ]] || return 0
+  case "$msg" in
+    crime=unevictable-shelf-*|crime=private-filesystem-shelf-*|crime=cas-address-payload-mismatch*|crime=corrupt-shelf-cell*|crime=uncreatable-filesystem-shelf-*|crime=private-shared-cache-cell*)
+      op=crime
+      outcome=crime
+      crime="${msg%% *}"
+      crime="${crime#crime=}"
+      ;;
+    filesystem\ shelf\ hit*)
+      op=pull; outcome=hit ;;
+    filesystem\ shelf\ miss*)
+      op=pull; outcome=miss ;;
+    filesystem\ shelf\ already\ has\ content*)
+      op=publish; outcome=already ;;
+    published\ *\ content\ *\ to\ filesystem\ shelf*)
+      op=publish; outcome=published ;;
+    filesystem\ shelf\ publish\ raced*)
+      op=publish; outcome=raced ;;
+    filesystem\ shelf\ publication\ failed*)
+      op=publish; outcome=failed ;;
+    prebuilt\ cache\ hit*|prebuilt\ cache\ rejected*)
+      # Local stamp-keyed cache sits in front of CAS pull — still shelf path.
+      op=pull; outcome=prebuilt ;;
+    *)
+      return 0
+      ;;
+  esac
+  if [[ "$op" == crime ]]; then
+    python3 "$reporter" event --output "$out" --op crime --outcome crime \
+      --crime "$crime" --name "${bin_name:-}" 2>/dev/null || true
+  else
+    python3 "$reporter" event --output "$out" --op "$op" --outcome "$outcome" \
+      --name "${bin_name:-}" 2>/dev/null || true
+  fi
 }
 
 quote_sh() {
@@ -1804,6 +1872,9 @@ main() {
   tool_versions || return $?
   identity="$(build_identity "$stamp")"
   name="$(artifact_name "$identity")"
+  # Enroll this resolve on the shelf-exercise receipt before any shelf path.
+  # A resolve that never pulls/publishes is SHELF_NEVER_TOUCHED, not silence.
+  shelf_exercise_open_resolve
 
   candidate="${SUGAR_BINARY_TARGET_ROOT:-$rust_workspace/target}/$profile/$bin_name"
   if verify_artifact_manifest "$candidate" "$stamp" "$identity" "local target"; then

--- a/tests/shelf_exercise_report.sh
+++ b/tests/shelf_exercise_report.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# R_shelf_exercise teeth: EXERCISED_CLEAN vs NEVER_TOUCHED vs UNMEASURED vs CRIME.
+#
+# The defect: a heavy run that dies before the filesystem shelf path is entered
+# leaves no shelf crimes, and silence was being read as "doors load-cleared".
+# Existing lease / identity receipts carry zero shelf-exercise fields — proven
+# here as a lying twin, not a comment.
+#
+# No local pytest (watchdog). Pure python3 + fixtures.
+set -euo pipefail
+
+repo="${1:?usage: shelf_exercise_report.sh REPO_ROOT}"
+tool="$repo/tools/shelf_exercise_report.py"
+[[ -f "$tool" ]] || { echo "missing $tool" >&2; exit 1; }
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/shelf-exercise.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+classify() {
+  python3 "$tool" classify "$@"
+}
+
+verdict_of() {
+  # Last "**VERDICT**" style line from classify stdout.
+  classify "$@" | sed -n 's/^- verdict: \*\*\(.*\)\*\*/\1/p' | tail -1
+}
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# --- Twin 0: lease receipt is silent on shelf (existing mechanism insufficient) ---
+cat >"$tmp/lease.json" <<'JSON'
+{
+  "schemaVersion": 1,
+  "leaseClass": "control-effect-recensus",
+  "measurementStatus": "completed/findings",
+  "supportsZeroClaim": false,
+  "acquired": true,
+  "measuredCommit": "8857e4071761174141f1c6c8ef8a05684f1316af",
+  "waitSeconds": 0.0,
+  "heldSeconds": 3.3
+}
+JSON
+python3 - "$tmp/lease.json" "$tool" <<'PY'
+import json, sys
+from pathlib import Path
+sys.path.insert(0, str(Path(sys.argv[2]).resolve().parent.parent / "tools"))
+# Import by path load
+import importlib.util
+spec = importlib.util.spec_from_file_location("shelf_exercise_report", sys.argv[2])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+lease = json.loads(Path(sys.argv[1]).read_text())
+assert mod.lease_record_is_silent_on_shelf(lease), "lease must not carry shelf axes"
+# Classifying a lease-as-if-receipt must not pretend EXERCISED_CLEAN
+try:
+    mod.load_receipt(Path(sys.argv[1]))
+    raise SystemExit("lease must not load as shelf-exercise receipt")
+except ValueError:
+    pass
+print("PASS: lease receipt is silent on shelf (no fourth-mechanism reuse)")
+PY
+
+# --- Twin 1: no testimony → UNMEASURED (not clean) ---
+v="$(verdict_of --receipt "$tmp/missing.json" --advisory 2>/dev/null || true)"
+# missing file: classify prints UNMEASURED; advisory exits 0
+v="$(python3 "$tool" classify --receipt "$tmp/no-such.json" --advisory | sed -n 's/^- verdict: \*\*\(.*\)\*\*/\1/p' | tail -1)"
+[[ "$v" == "SHELF_UNMEASURED" ]] || fail "missing receipt should be UNMEASURED, got $v"
+
+# --- Twin 2: resolve opened, no shelf events → NEVER_TOUCHED ---
+python3 "$tool" open --output "$tmp/never.json"
+v="$(verdict_of --receipt "$tmp/never.json" --advisory)"
+[[ "$v" == "SHELF_NEVER_TOUCHED" ]] || fail "open-only receipt should be NEVER_TOUCHED, got $v"
+# Load-clear question must go red
+if python3 "$tool" classify --receipt "$tmp/never.json" --require-exercised-clean >/dev/null 2>&1; then
+  fail "NEVER_TOUCHED must fail --require-exercised-clean"
+fi
+
+# --- Twin 3: pull hit, no crime → EXERCISED_CLEAN ---
+python3 "$tool" open --output "$tmp/clean.json"
+python3 "$tool" event --output "$tmp/clean.json" --op pull --outcome hit --name sugar \
+  --content-key blake3-512_$(printf 'a%.0s' {1..128} | tr -d '\n' | head -c 128)
+v="$(verdict_of --receipt "$tmp/clean.json" --advisory)"
+[[ "$v" == "SHELF_EXERCISED_CLEAN" ]] || fail "hit receipt should be EXERCISED_CLEAN, got $v"
+python3 "$tool" classify --receipt "$tmp/clean.json" --require-exercised-clean >/dev/null
+
+# --- Twin 4: crime event → EXERCISED_CRIME (not silence) ---
+python3 "$tool" open --output "$tmp/crime.json"
+python3 "$tool" event --output "$tmp/crime.json" --op crime --outcome crime \
+  --crime unevictable-shelf-cell --name sugar
+v="$(verdict_of --receipt "$tmp/crime.json" --advisory)"
+[[ "$v" == "SHELF_EXERCISED_CRIME" ]] || fail "crime receipt should be EXERCISED_CRIME, got $v"
+
+# --- Twin 5: log of the 2026-08-01 failed recensus shape → NEVER_TOUCHED ---
+# Identity/sourceStamp only; no filesystem shelf lines (the real failure mode).
+cat >"$tmp/recensus-early-death.log" <<'LOG'
+##[group]Prepare immutable Python test environment
+environment identity: 3f098a85c3c6bd38269cce5b88ffd4e56bad737a4a1deb4d081ad8ce6e6112d5
+- sourceStamp: `blake3-512_b536f988a64aa054491a35399fd25a8d5e296a07ab9c4738fcc64a8b05bb81163e06b79d35ec30ee58f4002a547fbf2382b45d1a72875e72d1105a4c1f5e0d05`
+b3sum 1.8.1
+##[error]cannot authenticate pandas corpus for the recensus
+ExecutionEnvironmentMismatch: lift import escaped the synced checkout
+LOG
+v="$(verdict_of --log "$tmp/recensus-early-death.log" --advisory)"
+[[ "$v" == "SHELF_UNMEASURED" || "$v" == "SHELF_NEVER_TOUCHED" ]] || fail \
+  "early-death log must not be EXERCISED_CLEAN, got $v"
+[[ "$v" != "SHELF_EXERCISED_CLEAN" ]] || fail "early-death log must not load-clear"
+
+# --- Twin 6: log with shelf hit → EXERCISED_CLEAN ---
+cat >"$tmp/shelf-hit.log" <<'LOG'
+sugarbin: filesystem shelf hit for sugar content blake3-512_abc
+LOG
+v="$(verdict_of --log "$tmp/shelf-hit.log" --advisory)"
+[[ "$v" == "SHELF_EXERCISED_CLEAN" ]] || fail "hit log should be EXERCISED_CLEAN, got $v"
+
+# --- Twin 7: log with shelf crime → EXERCISED_CRIME ---
+cat >"$tmp/shelf-crime.log" <<'LOG'
+sugarbin: crime=unevictable-shelf-cell owner=bin/sugarbin cell=/cache/cas/x/sugar
+LOG
+v="$(verdict_of --log "$tmp/shelf-crime.log" --advisory)"
+[[ "$v" == "SHELF_EXERCISED_CRIME" ]] || fail "crime log should be EXERCISED_CRIME, got $v"
+
+# --- Twin 8: resolve log without shelf → NEVER_TOUCHED ---
+cat >"$tmp/resolve-only.log" <<'LOG'
+sugarbin: local target cache hit for sugar
+sugarbin: building sugar once for this session (set SUGAR_BIN to skip)
+LOG
+v="$(verdict_of --log "$tmp/resolve-only.log" --advisory)"
+[[ "$v" == "SHELF_NEVER_TOUCHED" ]] || fail "resolve-only log should be NEVER_TOUCHED, got $v"
+
+# --- Twin 9: sugarbin producer wires open + event when receipt enrolled ---
+if command -v python3 >/dev/null 2>&1; then
+  export SUGAR_SHELF_EXERCISE_RECEIPT="$tmp/from-sugarbin.json"
+  # Drive the reporter the same way log() does — static tooth that the helper
+  # names exist in bin/sugarbin.
+  grep -Fq 'shelf_exercise_open_resolve' "$repo/bin/sugarbin" || fail "sugarbin missing open hook"
+  grep -Fq 'shelf_exercise_note_log' "$repo/bin/sugarbin" || fail "sugarbin missing log hook"
+  grep -Fq 'tools/shelf_exercise_report.py' "$repo/bin/sugarbin" || fail "sugarbin missing reporter path"
+  # Simulate the log path the hooks use
+  python3 "$tool" open --output "$SUGAR_SHELF_EXERCISE_RECEIPT"
+  # empty after open → NEVER_TOUCHED
+  v="$(verdict_of --receipt "$SUGAR_SHELF_EXERCISE_RECEIPT" --advisory)"
+  [[ "$v" == "SHELF_NEVER_TOUCHED" ]] || fail "producer open-only → NEVER_TOUCHED, got $v"
+  python3 "$tool" event --output "$SUGAR_SHELF_EXERCISE_RECEIPT" --op publish --outcome already --name sugar
+  v="$(verdict_of --receipt "$SUGAR_SHELF_EXERCISE_RECEIPT" --advisory)"
+  [[ "$v" == "SHELF_EXERCISED_CLEAN" ]] || fail "producer publish → CLEAN, got $v"
+fi
+
+echo "PASS: R_shelf_exercise — EXERCISED_CLEAN ≠ NEVER_TOUCHED ≠ UNMEASURED ≠ CRIME"

--- a/tests/sugarbin_shelf_immutability.sh
+++ b/tests/sugarbin_shelf_immutability.sh
@@ -49,6 +49,10 @@ echo 'PASS: sugarbin shelf assets are immutable and race-idempotent'
 # R_shelf_content_addressed_cell: address = h(payload), not sourceStamp name.
 "$repo/tests/sugarbin_shelf_content_addressed.sh" "$repo"
 
+# R_shelf_exercise: SHELF_EXERCISED_CLEAN ≠ SHELF_NEVER_TOUCHED ≠ SHELF_UNMEASURED.
+# Silence (no crimes) is not load-clear testimony — attendance one layer down.
+"$repo/tests/shelf_exercise_report.sh" "$repo"
+
 # Exercise the python-demand-table artifact through the shelf boundary. Static
 # inspection cannot prove that a partial cell is refused or that concurrent
 # publication never exposes a mixture of two producers' bytes.

--- a/tools/shelf_exercise_report.py
+++ b/tools/shelf_exercise_report.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""Was the filesystem shelf actually exercised in this run?
+
+THE DEFECT THIS FIXES
+=====================
+
+After #6977 (peer-evictable publish) and #6982 (content-addressed cell) landed,
+two heavy runs failed before they ever touched the binary shelf. From the
+outside those logs read the same as a successful load-clear:
+
+    no shelf crimes  ==  "shelf looks fine"  ==  silence as testimony
+
+That is the attendance roll call's confusion one layer down. A run that never
+entered ``pull_from_filesystem_shelf`` / ``publish_to_filesystem_shelf`` cannot
+clear those doors; it can only fail to exercise them. The clean-looking
+absence of ``crime=unevictable-*`` is not a measurement.
+
+Existing receipts do NOT answer this question:
+
+* ``leaseRecord``  -- did a heavy class acquire the machine-wide lease?
+* suite / environment identity -- did ``sourceStamp`` resolve?
+* ``*.sugarbin.json`` -- is the binary's identity field-equal?
+
+None of those fire only when the filesystem shelf path is entered. A fourth
+schema is required; this is it. It is not a lease and not a drain.
+
+Verdict vocabulary (closed; callers exhaustive over these four)::
+
+    SHELF_EXERCISED_CLEAN   -- at least one pull/publish event; zero crimes
+    SHELF_EXERCISED_CRIME   -- shelf path entered and a shelf crime fired
+    SHELF_NEVER_TOUCHED     -- resolve opened (or log is present) but no
+                              filesystem-shelf event
+    SHELF_UNMEASURED        -- no receipt and no usable log; silence is not clean
+
+Receipt schema (``schemaVersion`` 1)::
+
+    {
+      "schemaVersion": 1,
+      "kind": "shelf-exercise",
+      "resolveOpened": true,
+      "owner": { "githubRunId", "githubWorkflow", "githubJob", "measuredCommit" },
+      "events": [
+        {"op": "pull"|"publish"|"crime", "outcome": "...", "crime": null|str,
+         "name": str, "contentKey": str|null, "atUnix": float|null}
+      ]
+    }
+
+Producer: ``bin/sugarbin`` appends events when the filesystem shelf path is
+entered; it opens the receipt on every resolve so NEVER_TOUCHED is a positive
+claim, not an absent file.
+
+Log fallback: classify a CI transcript by the same ``sugarbin:`` lines the
+producer emits, so runs that predate the receipt can still be scored without
+pretending a missing receipt was clean.
+
+Usage::
+
+    python3 tools/shelf_exercise_report.py open --output path.json
+    python3 tools/shelf_exercise_report.py event --output path.json \\
+        --op pull --outcome hit --name sugar --content-key KEY
+    python3 tools/shelf_exercise_report.py classify --receipt path.json
+    python3 tools/shelf_exercise_report.py classify --log path.txt
+    python3 tools/shelf_exercise_report.py classify --receipt path.json --require-exercised-clean
+
+Exit: 0 green under the asked question, 1 red, 2 usage/IO.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping, Optional, Sequence
+
+SCHEMA_VERSION = 1
+KIND = "shelf-exercise"
+
+VERDICT_EXERCISED_CLEAN = "SHELF_EXERCISED_CLEAN"
+VERDICT_EXERCISED_CRIME = "SHELF_EXERCISED_CRIME"
+VERDICT_NEVER_TOUCHED = "SHELF_NEVER_TOUCHED"
+VERDICT_UNMEASURED = "SHELF_UNMEASURED"
+
+# Outcomes that prove the filesystem shelf path was entered (not local-target-only).
+SHELF_OPS = frozenset({"pull", "publish", "crime"})
+
+# sugarbin log lines that are positive shelf-path testimony (not mere resolve).
+_LOG_EXERCISE = (
+    re.compile(r"sugarbin:\s*filesystem shelf hit\b"),
+    re.compile(r"sugarbin:\s*filesystem shelf miss\b"),
+    re.compile(r"sugarbin:\s*filesystem shelf already has content\b"),
+    re.compile(r"sugarbin:\s*published \S+ content \S+ to filesystem shelf\b"),
+    re.compile(r"sugarbin:\s*filesystem shelf publish raced\b"),
+    re.compile(r"sugarbin:\s*filesystem shelf publication failed\b"),
+    re.compile(r"sugarbin:\s*evicting regenerable shelf cell\b"),
+    re.compile(r"sugarbin:\s*prebuilt cache hit\b"),  # local cache in front of shelf path
+    re.compile(r"sugarbin:\s*prebuilt cache rejected\b"),
+)
+# Crimes that mean the shelf path was entered and refused.
+_LOG_CRIME = re.compile(
+    r"sugarbin:\s*crime=(?:unevictable-shelf-|private-filesystem-shelf-|"
+    r"cas-address-payload-mismatch|corrupt-shelf-cell|"
+    r"uncreatable-filesystem-shelf-|private-shared-cache-cell)"
+)
+# Evidence the binary resolve path ran at all (so NEVER_TOUCHED is claimable).
+_LOG_RESOLVE = (
+    re.compile(r"sugarbin:\s*local target cache hit\b"),
+    re.compile(r"sugarbin:\s*building \S+ once for this session\b"),
+    re.compile(r"sugarbin:\s*no matching \S+ binary for stamp\b"),
+    re.compile(r"sugarbin:\s*shelf miss for\b"),
+    re.compile(r"sugarbin:\s*filesystem shelf\b"),
+    re.compile(r"sugarbin:\s*prebuilt cache\b"),
+    re.compile(r"sugarbin:\s*published \S+"),
+)
+
+
+def default_receipt_path() -> Optional[Path]:
+    """Where a CI run should leave the receipt when no --output is given."""
+    explicit = os.environ.get("SUGAR_SHELF_EXERCISE_RECEIPT")
+    if explicit:
+        return Path(explicit)
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if workspace:
+        return Path(workspace) / ".sugar" / "shelf-exercise.json"
+    return None
+
+
+def empty_receipt() -> dict[str, Any]:
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "kind": KIND,
+        "resolveOpened": False,
+        "owner": {
+            "githubRunId": os.environ.get("GITHUB_RUN_ID"),
+            "githubWorkflow": os.environ.get("GITHUB_WORKFLOW"),
+            "githubJob": os.environ.get("GITHUB_JOB"),
+            "measuredCommit": os.environ.get("GITHUB_SHA"),
+        },
+        "events": [],
+    }
+
+
+def load_receipt(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: not an object")
+    if payload.get("kind") != KIND:
+        raise ValueError(f"{path}: kind={payload.get('kind')!r}, expected {KIND!r}")
+    if payload.get("schemaVersion") != SCHEMA_VERSION:
+        raise ValueError(
+            f"{path}: unsupported schemaVersion {payload.get('schemaVersion')!r}"
+        )
+    if not isinstance(payload.get("events"), list):
+        raise ValueError(f"{path}: events must be a list")
+    return payload
+
+
+def write_receipt(path: Path, receipt: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(receipt, handle, indent=2, sort_keys=False)
+        handle.write("\n")
+    tmp.replace(path)
+
+
+def open_receipt(path: Path) -> dict[str, Any]:
+    """Mark that a binary resolve session started. NEVER_TOUCHED needs this."""
+    if path.is_file():
+        try:
+            receipt = load_receipt(path)
+        except ValueError:
+            receipt = empty_receipt()
+    else:
+        receipt = empty_receipt()
+    receipt["resolveOpened"] = True
+    # Refresh owner from current env if fields were empty.
+    owner = receipt.setdefault("owner", {})
+    for key, env in (
+        ("githubRunId", "GITHUB_RUN_ID"),
+        ("githubWorkflow", "GITHUB_WORKFLOW"),
+        ("githubJob", "GITHUB_JOB"),
+        ("measuredCommit", "GITHUB_SHA"),
+    ):
+        if not owner.get(key):
+            owner[key] = os.environ.get(env)
+    write_receipt(path, receipt)
+    return receipt
+
+
+def append_event(
+    path: Path,
+    *,
+    op: str,
+    outcome: str,
+    name: str = "",
+    content_key: Optional[str] = None,
+    crime: Optional[str] = None,
+) -> dict[str, Any]:
+    if op not in SHELF_OPS:
+        raise ValueError(f"op must be one of {sorted(SHELF_OPS)}, got {op!r}")
+    if path.is_file():
+        receipt = load_receipt(path)
+    else:
+        receipt = empty_receipt()
+    receipt["resolveOpened"] = True
+    event = {
+        "op": op,
+        "outcome": outcome,
+        "name": name or None,
+        "contentKey": content_key,
+        "crime": crime,
+        "atUnix": round(time.time(), 6),
+    }
+    receipt.setdefault("events", []).append(event)
+    write_receipt(path, receipt)
+    return receipt
+
+
+def classify_receipt(receipt: Mapping[str, Any]) -> tuple[str, list[str]]:
+    """Return (verdict, reasons)."""
+    reasons: list[str] = []
+    events = receipt.get("events") or []
+    crimes = [
+        e
+        for e in events
+        if isinstance(e, dict)
+        and (e.get("op") == "crime" or e.get("crime") or str(e.get("outcome", "")).startswith("crime"))
+    ]
+    shelf_events = [
+        e
+        for e in events
+        if isinstance(e, dict) and e.get("op") in SHELF_OPS
+    ]
+
+    if crimes:
+        reasons.append(f"{len(crimes)} shelf crime event(s) in receipt")
+        return VERDICT_EXERCISED_CRIME, reasons
+
+    if shelf_events:
+        reasons.append(f"{len(shelf_events)} filesystem-shelf event(s); zero crimes")
+        return VERDICT_EXERCISED_CLEAN, reasons
+
+    if receipt.get("resolveOpened") is True:
+        reasons.append(
+            "resolveOpened=true but events[] has no pull/publish/crime — "
+            "shelf path never entered (local target / override / never resolved)"
+        )
+        return VERDICT_NEVER_TOUCHED, reasons
+
+    reasons.append("receipt present but resolveOpened is not true and events empty")
+    return VERDICT_UNMEASURED, reasons
+
+
+def classify_log(text: str) -> tuple[str, list[str]]:
+    """Classify a CI transcript. Absence of crimes is not EXERCISED_CLEAN."""
+    reasons: list[str] = []
+    exercise_hits = [p for p in _LOG_EXERCISE if p.search(text)]
+    resolve_hits = [p for p in _LOG_RESOLVE if p.search(text)]
+
+    # Extract crime= tags for the reason line.
+    crime_tags = re.findall(
+        r"sugarbin:\s*(crime=(?:unevictable-shelf-|private-filesystem-shelf-|"
+        r"cas-address-payload-mismatch|corrupt-shelf-cell|"
+        r"uncreatable-filesystem-shelf-|private-shared-cache-cell)[^\s]*)",
+        text,
+    )
+
+    if crime_tags:
+        reasons.append(f"log shelf crime(s): {', '.join(sorted(set(crime_tags)))}")
+        return VERDICT_EXERCISED_CRIME, reasons
+
+    if exercise_hits:
+        reasons.append(
+            f"log shows {len(exercise_hits)} filesystem-shelf / prebuilt-cache "
+            "exercise pattern(s); zero shelf crimes"
+        )
+        return VERDICT_EXERCISED_CLEAN, reasons
+
+    if resolve_hits:
+        reasons.append(
+            "sugarbin resolve lines present but no filesystem-shelf hit/miss/"
+            "publish — shelf never touched"
+        )
+        return VERDICT_NEVER_TOUCHED, reasons
+
+    # A CI log that only has identity/b3sum/checkout has no sugarbin resolve.
+    if "sugarbin:" in text:
+        reasons.append(
+            "sugarbin: lines present but none are resolve or shelf — "
+            "treat as never-touched (e.g. --print-source-stamp only)"
+        )
+        return VERDICT_NEVER_TOUCHED, reasons
+
+    reasons.append(
+        "no shelf-exercise receipt and no sugarbin shelf/resolve lines in log; "
+        "silence is SHELF_UNMEASURED, not clean"
+    )
+    return VERDICT_UNMEASURED, reasons
+
+
+def classify(
+    *,
+    receipt: Optional[Mapping[str, Any]] = None,
+    log_text: Optional[str] = None,
+) -> tuple[str, list[str]]:
+    """Prefer receipt; fall back to log; never invent EXERCISED_CLEAN from silence."""
+    if receipt is not None:
+        return classify_receipt(receipt)
+    if log_text is not None:
+        return classify_log(log_text)
+    return VERDICT_UNMEASURED, [
+        "no --receipt and no --log; cannot distinguish EXERCISED from NEVER_TOUCHED"
+    ]
+
+
+def lease_record_is_silent_on_shelf(lease: Mapping[str, Any]) -> bool:
+    """Live instrument: a lease receipt carries no shelf-exercise axis."""
+    # Explicit: none of the lease fields name shelf traffic.
+    shelf_keys = {k for k in lease if "shelf" in k.lower()}
+    return not shelf_keys and "events" not in lease
+
+
+def print_report(verdict: str, reasons: Sequence[str], *, source: str) -> None:
+    print(f"### shelf exercise report")
+    print()
+    print(f"- source: `{source}`")
+    print(f"- verdict: **{verdict}**")
+    print()
+    print("| reason |")
+    print("| --- |")
+    for reason in reasons:
+        print(f"| {reason} |")
+    print()
+    if verdict == VERDICT_EXERCISED_CLEAN:
+        print(
+            "SHELF EXERCISED AND CLEAN: filesystem shelf path ran; "
+            "no shelf crime in testimony."
+        )
+    elif verdict == VERDICT_EXERCISED_CRIME:
+        print(
+            "SHELF EXERCISED AND DIRTY: path ran and a crime fired — "
+            "this is a door regression, not silence."
+        )
+    elif verdict == VERDICT_NEVER_TOUCHED:
+        print(
+            "SHELF NEVER TOUCHED: this run cannot load-clear #6977/#6982. "
+            "Absence of crimes is not a green shelf."
+        )
+    else:
+        print(
+            "SHELF UNMEASURED: no receipt and no usable log. "
+            "Do not read this as clean."
+        )
+
+
+def cmd_open(args: argparse.Namespace) -> int:
+    path = Path(args.output) if args.output else default_receipt_path()
+    if path is None:
+        print(
+            "shelf-exercise: open requires --output or "
+            "SUGAR_SHELF_EXERCISE_RECEIPT / GITHUB_WORKSPACE",
+            file=sys.stderr,
+        )
+        return 2
+    open_receipt(path)
+    print(f"shelf-exercise: opened {path}", file=sys.stderr)
+    return 0
+
+
+def cmd_event(args: argparse.Namespace) -> int:
+    path = Path(args.output) if args.output else default_receipt_path()
+    if path is None:
+        print(
+            "shelf-exercise: event requires --output or "
+            "SUGAR_SHELF_EXERCISE_RECEIPT / GITHUB_WORKSPACE",
+            file=sys.stderr,
+        )
+        return 2
+    append_event(
+        path,
+        op=args.op,
+        outcome=args.outcome,
+        name=args.name or "",
+        content_key=args.content_key,
+        crime=args.crime,
+    )
+    return 0
+
+
+def cmd_classify(args: argparse.Namespace) -> int:
+    receipt = None
+    log_text = None
+    source = "none"
+    if args.receipt:
+        path = Path(args.receipt)
+        if not path.is_file():
+            print(f"shelf-exercise: receipt missing: {path}", file=sys.stderr)
+            # Missing receipt under --receipt is UNMEASURED, not IO error:
+            # the question was asked and the answer is "no testimony".
+            verdict, reasons = VERDICT_UNMEASURED, [f"receipt path does not exist: {path}"]
+            print_report(verdict, reasons, source=str(path))
+            return _exit_for(verdict, args)
+        try:
+            receipt = load_receipt(path)
+        except (OSError, ValueError) as exc:
+            print(f"shelf-exercise: unreadable receipt: {exc}", file=sys.stderr)
+            return 2
+        source = str(path)
+    elif args.log:
+        path = Path(args.log)
+        try:
+            log_text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            print(f"shelf-exercise: cannot read log: {exc}", file=sys.stderr)
+            return 2
+        source = str(path)
+    else:
+        default = default_receipt_path()
+        if default and default.is_file():
+            try:
+                receipt = load_receipt(default)
+                source = str(default)
+            except ValueError as exc:
+                print(f"shelf-exercise: unreadable default receipt: {exc}", file=sys.stderr)
+                return 2
+        else:
+            verdict, reasons = classify()
+            print_report(verdict, reasons, source="none")
+            return _exit_for(verdict, args)
+
+    verdict, reasons = classify(receipt=receipt, log_text=log_text)
+    print_report(verdict, reasons, source=source)
+    return _exit_for(verdict, args)
+
+
+def _exit_for(verdict: str, args: argparse.Namespace) -> int:
+    if args.advisory:
+        return 0
+    if args.require_exercised_clean:
+        return 0 if verdict == VERDICT_EXERCISED_CLEAN else 1
+    # Default: UNMEASURED and CRIME are red; NEVER_TOUCHED is red when asking
+    # the load-clear question (default), CLEAN is green.
+    if verdict == VERDICT_EXERCISED_CLEAN:
+        return 0
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    open_p = sub.add_parser("open", help="mark resolveOpened on the receipt")
+    open_p.add_argument("--output", default=None)
+    open_p.set_defaults(func=cmd_open)
+
+    event_p = sub.add_parser("event", help="append one filesystem-shelf event")
+    event_p.add_argument("--output", default=None)
+    event_p.add_argument("--op", required=True, choices=sorted(SHELF_OPS))
+    event_p.add_argument("--outcome", required=True)
+    event_p.add_argument("--name", default="")
+    event_p.add_argument("--content-key", default=None)
+    event_p.add_argument("--crime", default=None)
+    event_p.set_defaults(func=cmd_event)
+
+    class_p = sub.add_parser(
+        "classify",
+        help="print verdict: EXERCISED_CLEAN | EXERCISED_CRIME | NEVER_TOUCHED | UNMEASURED",
+    )
+    class_p.add_argument("--receipt", default=None, help="shelf-exercise receipt JSON")
+    class_p.add_argument("--log", default=None, help="CI / sugarbin transcript")
+    class_p.add_argument(
+        "--require-exercised-clean",
+        action="store_true",
+        help="exit 0 only for SHELF_EXERCISED_CLEAN (load-clear question)",
+    )
+    class_p.add_argument(
+        "--advisory",
+        action="store_true",
+        help="always exit 0 after printing the verdict (telemetry mode)",
+    )
+    class_p.set_defaults(func=cmd_classify)
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## R axis / Epsilon R / floors / shell

| | |
| --- | --- |
| **R axis** | `R_shelf_exercise` — residual when a run's shelf testimony is not `SHELF_EXERCISED_CLEAN` |
| **Epsilon R** | Instrument lands. Existing and frozen heavy runs stay **UNMEASURED** until they emit the receipt — we do **not** claim #6977/#6982 are load-cleared. |
| **Floors** | Strict verify unchanged. No lease change. No workflow_dispatch. No drain of residual CAS half. |
| **Shell deleted** | **Silence-as-clean** for the filesystem shelf doors (the chat-only distinction that "no crimes ≈ doors OK"). |

## Honest answer first (no fourth mechanism if existing receipts suffice)

**They do not.** Live check on tip:

- `tools/heavy_measurement_lease_record.py` — zero shelf fields
- `tools/heavy_measurement_lease_gate.py` — zero shelf fields
- `tools/python_suite_identity_gate.py` — `sourceStamp` only; not "shelf path entered"

Lease answers "did the heavy class acquire?" Identity answers "did stamp resolve?" Neither answers "was `pull_from_filesystem_shelf` / `publish_to_filesystem_shelf` entered?" So this is a **required** receipt, not a decorative fourth.

## Defect

After #6977 / #6982, recensus + sole-construction floors both failed on env-auth **before** heavy shelf traffic. From outside:

```
no shelf crimes  ==  "shelf looks fine"  ==  silence as testimony
```

That is the attendance roll call's confusion one layer down. A run that never entered the shelf path cannot load-clear those doors.

Re-derived on the actual CI logs (not a hand list):

```text
python3 tools/shelf_exercise_report.py classify --log <recensus full log> --advisory
→ SHELF_UNMEASURED

python3 tools/shelf_exercise_report.py classify --log <sole-floors full log> --advisory
→ SHELF_UNMEASURED
```

## Instrument

`tools/shelf_exercise_report.py` — closed verdict vocabulary:

| Verdict | Meaning |
| --- | --- |
| `SHELF_EXERCISED_CLEAN` | ≥1 pull/publish event; zero crimes |
| `SHELF_EXERCISED_CRIME` | shelf path entered and a shelf crime fired |
| `SHELF_NEVER_TOUCHED` | resolve opened; no filesystem-shelf event |
| `SHELF_UNMEASURED` | no receipt and no usable log — **not clean** |

Producer: `bin/sugarbin` opens the receipt on every binary resolve (`resolveOpened=true`) and appends events from shelf-relevant `log()` lines when `SUGAR_SHELF_EXERCISE_RECEIPT` or `GITHUB_WORKSPACE/.sugar/shelf-exercise.json` is enrolled.

Log fallback: classify a CI transcript by the same `sugarbin:` lines so pre-receipt runs stay scoreable without inventing green from silence.

## Ladder

| Question | Answer |
| --- | --- |
| Type forbid? | No — open log/path space |
| One door? | Yes — classify only through this report; sugarbin is sole event producer |
| Panic at contact? | Crimes already panic-loud via `crime=*`; this measures *exercise*, not integrity |
| Auditor? | This is the report; retires when every load-clear claim requires `--require-exercised-clean` |

## Teeth

`tests/shelf_exercise_report.sh` (bash; no local pytest), enrolled from `tests/sugarbin_shelf_immutability.sh`.

Lying twins: lease silent on shelf; missing → UNMEASURED; open-only → NEVER_TOUCHED; hit → CLEAN; crime → CRIME; early-death log ≠ CLEAN.

## Not this PR

- Residual CAS harder half (local stamp-keyed cache, dead GH path, …)
- env-auth fix (mr_black critical path; heavy runs frozen)
- Lease / dispatch / drain

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Distinguish EXERCISED_CLEAN, NEVER_TOUCHED, and UNMEASURED shelf exercise verdicts
> - Adds [tools/shelf_exercise_report.py](https://github.com/TSavo/sugar/pull/6996/files#diff-6de961f9f89dd3d7f66e96093f194e5dcad258f4795ad40577e09bc8b96ac5cc), a new CLI tool that records structured shelf events to a JSON receipt and classifies runs into `SHELF_EXERCISED_CLEAN`, `SHELF_EXERCISED_CRIME`, `SHELF_NEVER_TOUCHED`, or `SHELF_UNMEASURED`.
> - Updates [bin/sugarbin](https://github.com/TSavo/sugar/pull/6996/files#diff-2b8f7e68bdef16827d284767f61c9a26ffa589c12f114f50129677d05e35383b) to call `shelf_exercise_report.py open` at resolve start and to forward matching log messages as structured events to the receipt via a new `shelf_exercise_note_log` helper.
> - Receipt path is resolved from `SUGAR_SHELF_EXERCISE_RECEIPT` or `$GITHUB_WORKSPACE/.sugar/shelf-exercise.json`; logging hooks are no-ops when neither is set.
> - Adds [tests/shelf_exercise_report.sh](https://github.com/TSavo/sugar/pull/6996/files#diff-4f780b7ee071404a023c1338804d0e676cac79525a51bcf0feb9ada21836e80e) covering all verdict paths and wires it into [tests/sugarbin_shelf_immutability.sh](https://github.com/TSavo/sugar/pull/6996/files#diff-94b09c486da93fe31f7db7ce2fb0533913fe71050bc3c8740db6086e5c2eb90a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 492dc4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->