### PR TITLE
Fix CI first-party lift import: checkout PYTHONPATH, not site-packages

### DIFF
--- a/.github/actions/python-test-environment/action.yml
+++ b/.github/actions/python-test-environment/action.yml
@@ -1,8 +1,9 @@
 name: Prepare Python test environment
 description: >-
   The ONE definition of the sugar Python test environment. Builds an immutable
-  wheel-installed venv from the package's declared dependency authority, mints
-  its environment identity, and puts it on PATH read-only.
+  third-party wheelhouse from the package's declared dependency authority,
+  installs those third-party wheels read-only into a venv, and binds first-party
+  packages to the SYNCED CHECKOUT via PYTHONPATH (never site-packages).
 
 # WHY THIS EXISTS
 #
@@ -15,12 +16,30 @@ description: >-
 # There is now one definition and it lives here. The authoritative suite job
 # consumes it. Every zero-tolerance floor consumes it. No caller installs its
 # own dependency list: `sugar-lift-py-tests[test]` is the sole dependency
-# authority (#6275), and the only names below are FIRST-PARTY PATHS, which are
-# the packages themselves rather than a hand-list of their requirements.
+# authority (#6275), and the only names below are FIRST-PARTY PATHS used to
+# *resolve* that table into a third-party wheelhouse — not to install the
+# packages themselves into the venv.
 #
-# The venv is built from wheels and then made read-only. Editable installs let
-# a later job silently change what an earlier job measured; a wheel install
-# plus `chmod a-w` makes that attempt fail loudly instead.
+# FIRST-PARTY vs THIRD-PARTY (load-bearing split)
+#
+# Third-party [test] dependencies (pytest, numpy, pandas, ...) are wheel-
+# installed into a read-only venv. That property is deliberate: a later job
+# cannot silently change what an earlier job measured.
+#
+# First-party packages (sugar-lift-*, sugar-source-tree, ...) MUST resolve from
+# the SYNCED CHECKOUT via PYTHONPATH. Wheel-installing them into site-packages
+# is false provenance: authenticate_lift then sees a different build than the
+# tree the measurement claims about (ExecutionEnvironmentMismatch). Do NOT
+# weaken authenticate_lift to accept site-packages; do NOT install first-party
+# into the venv. AuthenticatedInstalledLift (content-stamp equality) is a
+# later design and is NOT this action.
+#
+# ORDERING
+#
+# Checkout roots must be on PYTHONPATH before any process imports
+# sugar_lift_py_tests. Activating roots after the first import is a no-op:
+# sys.modules already holds the site-packages (or other) copy. This action
+# exports PYTHONPATH via GITHUB_ENV so every subsequent step inherits it.
 
 inputs:
   python-version:
@@ -51,6 +70,9 @@ outputs:
   env-dir:
     description: Root of the prepared environment.
     value: ${{ steps.install.outputs.env-dir }}
+  checkout-pythonpath:
+    description: Absolute managed first-party PYTHONPATH for the synced checkout.
+    value: ${{ steps.install.outputs.checkout-pythonpath }}
 
 runs:
   using: composite
@@ -100,21 +122,44 @@ runs:
         # never resolved, and only the file travels to the next job.
         python3 tools/python_suite_identity_gate.py --environment-identity "$identity"
 
-    - name: Build wheelhouse from the declared dependency authority
+    - name: Build third-party wheelhouse from the declared dependency authority
       shell: bash
       run: |
         set -euo pipefail
         env_dir="$RUNNER_TEMP/sugar-python-test-environment"
         rm -rf "$env_dir/wheelhouse"
+        mkdir -p "$env_dir/wheelhouse"
         # `[test]` is the sole dependency authority. The three paths are the
-        # first-party packages themselves; every third-party requirement is
-        # resolved transitively FROM that table, never named here.
+        # first-party packages themselves — used only so pip can resolve their
+        # declared third-party requirements into the wheelhouse. The first-party
+        # wheels themselves are dropped: they must not be installed into the
+        # venv (false provenance against the synced checkout).
         python -m pip wheel --quiet --wheel-dir "$env_dir/wheelhouse" \
           './implementations/python/sugar-lift-py-tests[test]' \
           ./implementations/python/sugar-lift-python-source \
           ./implementations/python/sugar-source-tree
+        # Keep the wheelhouse third-party only. First-party resolves via
+        # PYTHONPATH from the checkout (next step).
+        shopt -s nullglob
+        removed=0
+        for whl in "$env_dir/wheelhouse"/sugar_lift_*.whl \
+                   "$env_dir/wheelhouse"/sugar_source_tree-*.whl; do
+          rm -f "$whl"
+          removed=$((removed + 1))
+        done
+        if [ "$removed" -eq 0 ]; then
+          echo "::error::expected first-party wheels to strip from wheelhouse; none matched"
+          ls -la "$env_dir/wheelhouse" || true
+          exit 1
+        fi
+        third_party=( "$env_dir/wheelhouse"/*.whl )
+        if [ "${#third_party[@]}" -eq 0 ]; then
+          echo "::error::third-party wheelhouse is empty after stripping first-party"
+          exit 1
+        fi
+        echo "third-party wheelhouse: ${#third_party[@]} wheels (stripped $removed first-party)"
 
-    - name: Install immutable environment
+    - name: Install immutable third-party environment + bind checkout PYTHONPATH
       id: install
       shell: bash
       run: |
@@ -126,12 +171,38 @@ runs:
         if [ -d "$venv" ]; then chmod -R u+w "$venv"; rm -rf "$venv"; fi
         python -m venv "$venv"
         "$venv/bin/python" -m pip install --quiet --upgrade pip wheel
-        "$venv/bin/python" -m pip install --quiet \
-          --no-index --find-links "$env_dir/wheelhouse" \
-          'sugar-lift-py-tests[test]' \
-          sugar-lift-python-source \
-          sugar-source-tree
+
+        # Install ONLY third-party wheels. Never sugar-lift-* / sugar-source-tree.
+        shopt -s nullglob
+        third_party=( "$env_dir/wheelhouse"/*.whl )
+        if [ "${#third_party[@]}" -eq 0 ]; then
+          echo "::error::no third-party wheels to install"
+          exit 1
+        fi
+        "$venv/bin/python" -m pip install --quiet --no-index \
+          "${third_party[@]}"
         "$venv/bin/python" -m pip freeze --all > "$env_dir/resolved-distributions.txt"
+
+        # Refuse if a first-party package snuck into site-packages. Check each
+        # name alone: `pip show a b` exits non-zero if any is missing, which
+        # would mask a partial install.
+        for pkg in sugar-lift-py-tests sugar-lift-python-source sugar-source-tree; do
+          if "$venv/bin/python" -m pip show "$pkg" >/dev/null 2>&1; then
+            echo "::error::first-party package $pkg present in venv; must resolve from checkout only"
+            "$venv/bin/python" -m pip show "$pkg" || true
+            exit 1
+          fi
+        done
+
+        # Checkout roots BEFORE any subsequent import of sugar_lift_py_tests.
+        # tools/managed_checkout_pythonpath.py is stdlib-only so it can run
+        # without the package on path (the ordering this action exists to fix).
+        checkout_pythonpath="$(
+          python3 tools/managed_checkout_pythonpath.py --repo-root .
+        )"
+        echo "PYTHONPATH=${checkout_pythonpath}" >> "$GITHUB_ENV"
+        echo "SUGAR_CHECKOUT_PYTHONPATH=${checkout_pythonpath}" >> "$GITHUB_ENV"
+        echo "checkout PYTHONPATH bound ($(echo "$checkout_pythonpath" | tr ':' '\n' | wc -l | tr -d ' ') roots)"
 
         # Consumers share this environment READ-ONLY. No job may mutate it:
         # adding a package to an already-measured environment is how a floor
@@ -143,6 +214,7 @@ runs:
         echo "$venv/bin" >> "$GITHUB_PATH"
         echo "python=$venv/bin/python" >> "$GITHUB_OUTPUT"
         echo "env-dir=$env_dir" >> "$GITHUB_OUTPUT"
+        echo "checkout-pythonpath=$checkout_pythonpath" >> "$GITHUB_OUTPUT"
 
     - name: Upload environment identity
       if: inputs.identity-artifact == 'true'

--- a/.github/workflows/python-package-suite.yml
+++ b/.github/workflows/python-package-suite.yml
@@ -169,7 +169,9 @@ jobs:
         shell: bash
         working-directory: implementations/python
         env:
-          PYTHONPATH: ${{ github.workspace }}/tools
+          # tools/ for the suite report plugin; checkout roots from the env
+          # action (first-party must NOT come from site-packages).
+          PYTHONPATH: ${{ github.workspace }}/tools:${{ env.SUGAR_CHECKOUT_PYTHONPATH }}
         run: |
           set -uo pipefail
           cat > "$RUNNER_TEMP/sweep.sh" <<'SWEEP'
@@ -357,7 +359,9 @@ jobs:
         shell: bash
         working-directory: implementations/python
         env:
-          PYTHONPATH: ${{ github.workspace }}/tools
+          # tools/ for the suite report plugin; checkout roots from the env
+          # action (first-party must NOT come from site-packages).
+          PYTHONPATH: ${{ github.workspace }}/tools:${{ env.SUGAR_CHECKOUT_PYTHONPATH }}
         run: |
           set -uo pipefail
           cat > "$RUNNER_TEMP/sweep-${{ matrix.order }}.sh" <<'SWEEP'

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 import sys
 import sysconfig
 import tomllib
@@ -162,30 +161,44 @@ def authenticate_corpus_manifest(
 
 
 def activate_checkout_import_roots(repo_root: Path, search_path: list[str]) -> None:
-    """Activate exactly the mounted roots declared by the managed closure."""
-    dockerfile = repo_root / "tools/sugar-build/Dockerfile"
-    matches = re.findall(
-        r"^ENV PYTHONPATH=(.*)$",
-        dockerfile.read_text(encoding="utf-8"),
-        re.MULTILINE,
-    )
-    if len(matches) != 1:
-        raise ExecutionEnvironmentMismatch(
-            f"expected one managed PYTHONPATH declaration in {dockerfile}, found {len(matches)}"
+    """Activate exactly the mounted roots declared by the managed closure.
+
+    Shares the Dockerfile declaration with ``tools/managed_checkout_pythonpath.py``
+    (the CI env binder). Prefer that tool for process-start PYTHONPATH: by the
+    time this function runs inside ``sugar_lift_py_tests``, the package is
+    already imported, so rebinding ``sys.path`` cannot unseat a site-packages
+    copy already in ``sys.modules``. CI must export checkout roots *before*
+    any import of this package.
+    """
+    try:
+        from managed_checkout_pythonpath import (  # type: ignore[import-not-found]
+            ManagedCheckoutPythonpathError,
+            managed_checkout_import_roots,
         )
-    prefix = "/workspace/sugar/"
-    roots: list[str] = []
-    for entry in matches[0].split(":"):
-        if not entry.startswith(prefix):
+    except ImportError:
+        # stdlib-only loader so authentication still works when tools/ is not
+        # already on sys.path (the common authenticated-pytest entry shape).
+        import importlib.util
+
+        tool = (
+            Path(repo_root).resolve() / "tools" / "managed_checkout_pythonpath.py"
+        )
+        spec = importlib.util.spec_from_file_location(
+            "managed_checkout_pythonpath", tool
+        )
+        if spec is None or spec.loader is None:
             raise ExecutionEnvironmentMismatch(
-                f"managed PYTHONPATH entry escaped the synced checkout: {entry}"
+                f"cannot load managed checkout PYTHONPATH tool from {tool}"
             )
-        root = (repo_root / entry[len(prefix) :]).resolve()
-        if not root.is_dir():
-            raise ExecutionEnvironmentMismatch(
-                f"managed PYTHONPATH entry does not exist in the synced checkout: {root}"
-            )
-        roots.append(str(root))
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        ManagedCheckoutPythonpathError = module.ManagedCheckoutPythonpathError
+        managed_checkout_import_roots = module.managed_checkout_import_roots
+
+    try:
+        roots = [str(root) for root in managed_checkout_import_roots(repo_root)]
+    except ManagedCheckoutPythonpathError as error:
+        raise ExecutionEnvironmentMismatch(str(error)) from error
     search_path[0:0] = roots
 
 
@@ -216,6 +229,11 @@ def authenticate_environment() -> (
         package_root = sugar_lift_py_tests_package_root(repo_root)
     except RepoRootUnresolved as error:
         raise ExecutionEnvironmentMismatch(str(error)) from error
+    # Activate checkout roots before any further first-party import (e.g.
+    # sugar_source_tree). sugar_lift_py_tests itself is already loaded when this
+    # module runs; process-start PYTHONPATH (python-test-environment) is the
+    # authority for that first import. authenticate_lift still refuses a
+    # site-packages copy — never relax that check.
     activate_checkout_import_roots(repo_root, sys.path)
     pins, expected_cid = _declared_corpus(package_root)
 
@@ -223,7 +241,10 @@ def authenticate_environment() -> (
 
     pandas = import_module("pandas")
     numpy = import_module("numpy")
-    lift = import_module("sugar_lift_py_tests")
+    # Prefer the already-loaded package (process-start path) over a second
+    # import_module after path mutation, which would leave a wrong copy in
+    # sys.modules if the first import came from site-packages.
+    lift = sys.modules.get("sugar_lift_py_tests") or import_module("sugar_lift_py_tests")
     pandas_distribution = metadata.distribution("pandas")
     numpy_distribution = metadata.distribution("numpy")
     pandas_identity = authenticate_distribution(

--- a/tests/test_authenticated_python_launcher.py
+++ b/tests/test_authenticated_python_launcher.py
@@ -172,8 +172,18 @@ def test_checkout_import_roots_come_from_the_managed_closure_declaration(
     repo = tmp_path / "sugar"
     declared = repo / "implementations/python/sugar-source-tree/src"
     declared.mkdir(parents=True)
+    # activate_checkout_import_roots loads tools/managed_checkout_pythonpath.py
+    # from the checkout (shared with the CI action).
+    tool_src = (
+        Path(__file__).resolve().parents[1]
+        / "tools"
+        / "managed_checkout_pythonpath.py"
+    )
+    tool_dst = repo / "tools" / "managed_checkout_pythonpath.py"
+    tool_dst.parent.mkdir(parents=True, exist_ok=True)
+    tool_dst.write_text(tool_src.read_text(encoding="utf-8"), encoding="utf-8")
     dockerfile = repo / "tools/sugar-build/Dockerfile"
-    dockerfile.parent.mkdir(parents=True)
+    dockerfile.parent.mkdir(parents=True, exist_ok=True)
     dockerfile.write_text(
         "ENV PYTHONPATH=/workspace/sugar/implementations/python/sugar-source-tree/src\n",
         encoding="utf-8",

--- a/tests/test_ci_python_env_checkout_lift_import.py
+++ b/tests/test_ci_python_env_checkout_lift_import.py
@@ -1,0 +1,345 @@
+"""CI python-test-environment: first-party lift resolves from the checkout.
+
+Both S0.1 recensus and S0.2 floors died with the same
+``ExecutionEnvironmentMismatch``: ``sugar_lift_py_tests`` was loaded from the
+immutable venv's site-packages, not the synced checkout. The authority
+(``authenticate_lift``) is correct — measuring with a different build than the
+tree you claim about is false provenance. The fix is the environment shape:
+
+1. Do NOT wheel-install first-party packages into the venv.
+2. Export managed checkout PYTHONPATH before any process imports the package.
+3. ``activate_checkout_import_roots`` after first import cannot unseat
+   ``sys.modules`` — so a test that only imports from a dev editable checkout
+   cannot fail on this defect.
+
+These twins rebuild CI's install contract in a mini checkout + venv. They do
+not require numpy/pandas; they prove import provenance under the same path
+rules the action uses.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+import venv
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTION = ROOT / ".github/actions/python-test-environment/action.yml"
+MANAGED_TOOL = ROOT / "tools/managed_checkout_pythonpath.py"
+DOCKERFILE = ROOT / "tools/sugar-build/Dockerfile"
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+
+
+def _mini_checkout(tmp_path: Path) -> Path:
+    """Synthetic monorepo whose lift package lives only under checkout src."""
+    repo = tmp_path / "sugar"
+    # Marker for resolve_repo_root / identity of a real checkout.
+    (repo / "sugar-build.toml").parent.mkdir(parents=True, exist_ok=True)
+    (repo / "sugar-build.toml").write_text("# mini\n", encoding="utf-8")
+
+    # Managed PYTHONPATH declaration — same shape as production Dockerfile.
+    dockerfile = repo / "tools/sugar-build/Dockerfile"
+    _write(
+        dockerfile,
+        """
+        FROM scratch
+        ENV PYTHONPATH=/workspace/sugar/implementations/python/sugar-lift-py-tests/src:/workspace/sugar/implementations/python/sugar-source-tree/src
+        """,
+    )
+
+    lift_root = (
+        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests"
+    )
+    _write(
+        lift_root / "__init__.py",
+        '''
+        """Checkout-resident first-party package (truthful face)."""
+        CHECKOUT_MARKER = "from-synced-checkout"
+        ''',
+    )
+    # Minimal authenticated_pytest surface for authenticate_lift import path.
+    _write(
+        lift_root / "authenticated_pytest.py",
+        '''
+        from pathlib import Path
+        from types import ModuleType
+
+        class ExecutionEnvironmentMismatch(RuntimeError):
+            pass
+
+        def authenticate_lift(module: ModuleType, repo_root: Path):
+            expected = (
+                repo_root / "implementations/python/sugar-lift-py-tests/src"
+            ).resolve()
+            loaded = Path(str(getattr(module, "__file__", ""))).resolve()
+            if not (loaded == expected or expected in loaded.parents):
+                raise ExecutionEnvironmentMismatch(
+                    f"lift import escaped the synced checkout: loaded "
+                    f"sugar_lift_py_tests from {loaded}; required {expected}"
+                )
+            return loaded
+        ''',
+    )
+    source_tree = (
+        repo / "implementations/python/sugar-source-tree/src/sugar_source_tree"
+    )
+    _write(source_tree / "__init__.py", 'MARKER = "source-tree-checkout"\n')
+
+    # Stdlib-only managed PYTHONPATH tool (copy production tool into mini repo
+    # so the twin exercises the same file the action runs).
+    tool_src = MANAGED_TOOL.read_text(encoding="utf-8")
+    _write(repo / "tools/managed_checkout_pythonpath.py", tool_src)
+    return repo
+
+
+def _make_venv(path: Path) -> Path:
+    venv.create(path, with_pip=False, clear=True)
+    python = path / ("Scripts" if os.name == "nt" else "bin") / "python"
+    assert python.is_file(), python
+    return python
+
+
+def _site_packages(venv_python: Path) -> Path:
+    completed = subprocess.run(
+        [
+            str(venv_python),
+            "-c",
+            "import sysconfig; print(sysconfig.get_paths()['purelib'])",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(completed.stdout.strip())
+
+
+def _install_foreign_lift_into_site_packages(purelib: Path) -> Path:
+    """Simulate the broken CI shape: first-party wheel-installed into venv."""
+    pkg = purelib / "sugar_lift_py_tests"
+    _write(
+        pkg / "__init__.py",
+        '''
+        """Foreign site-packages copy (lying face)."""
+        CHECKOUT_MARKER = "from-site-packages"
+        ''',
+    )
+    return pkg / "__init__.py"
+
+
+PROBE = textwrap.dedent(
+    """
+    import importlib
+    import sys
+    from pathlib import Path
+
+    repo = Path(sys.argv[1]).resolve()
+    # Optional: activate roots AFTER import (the ordering bug).
+    activate_after = sys.argv[2] == "activate-after"
+
+    if activate_after:
+        # Import first (as -m sugar_lift_py_tests.* does), then rebind path.
+        import sugar_lift_py_tests  # noqa: F401
+        tool = repo / "tools/managed_checkout_pythonpath.py"
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("mcp", tool)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        for root in reversed(mod.managed_checkout_import_roots(repo)):
+            sys.path.insert(0, str(root))
+        # Rebinding path does not replace sys.modules — the defect.
+        lift = sys.modules["sugar_lift_py_tests"]
+    else:
+        lift = importlib.import_module("sugar_lift_py_tests")
+
+    loaded = Path(lift.__file__).resolve()
+    marker = getattr(lift, "CHECKOUT_MARKER", "<missing>")
+    print(f"loaded_from={loaded}")
+    print(f"marker={marker}")
+
+    # authenticate_lift law (same predicate CI uses)
+    expected = (repo / "implementations/python/sugar-lift-py-tests/src").resolve()
+    inside = loaded == expected or expected in loaded.parents
+    print(f"inside_checkout={inside}")
+    if not inside:
+        raise SystemExit(2)
+    if marker != "from-synced-checkout":
+        raise SystemExit(3)
+    """
+).lstrip()
+
+
+def test_action_strips_first_party_and_binds_checkout_pythonpath() -> None:
+    """Static teeth on the shared action both S0.1 and S0.2 consume."""
+    text = ACTION.read_text(encoding="utf-8")
+    assert ACTION.is_file()
+    assert "managed_checkout_pythonpath" in text
+    assert "SUGAR_CHECKOUT_PYTHONPATH" in text
+    # First-party must be stripped from the wheelhouse / not installed.
+    assert "sugar_lift_*.whl" in text or "sugar_lift_" in text
+    assert "first-party" in text.lower()
+    # Must not pip-install the authority package by name into the venv.
+    install_lines = [
+        line
+        for line in text.splitlines()
+        if "pip install" in line and "sugar-lift-py-tests" in line
+    ]
+    assert not install_lines, (
+        "action must not pip-install sugar-lift-py-tests into the venv; "
+        f"found: {install_lines}"
+    )
+    # Wheel build still names the authority so the third-party table resolves.
+    assert "pip wheel" in text and "sugar-lift-py-tests[test]" in text
+
+
+def test_managed_checkout_pythonpath_tool_matches_production_dockerfile() -> None:
+    """The CI binder and the live Dockerfile agree on the root list."""
+    sys.path.insert(0, str(ROOT / "tools"))
+    try:
+        from managed_checkout_pythonpath import managed_checkout_import_roots
+    finally:
+        if str(ROOT / "tools") in sys.path:
+            sys.path.remove(str(ROOT / "tools"))
+
+    roots = managed_checkout_import_roots(ROOT)
+    assert roots, "managed PYTHONPATH produced no roots"
+    lift_src = (
+        ROOT / "implementations/python/sugar-lift-py-tests/src"
+    ).resolve()
+    assert lift_src in roots
+    assert all(root.is_dir() for root in roots)
+    assert DOCKERFILE.is_file()
+
+
+def test_truthful_ci_shape_import_resolves_inside_checkout(tmp_path: Path) -> None:
+    """No first-party in site-packages + process-start PYTHONPATH → checkout.
+
+    This is the python-test-environment contract after the fix. A subprocess
+    with only the managed PYTHONPATH (not a developer editable install) must
+    load sugar_lift_py_tests from the checkout src tree.
+    """
+    repo = _mini_checkout(tmp_path)
+    venv_python = _make_venv(tmp_path / "venv")
+    purelib = _site_packages(venv_python)
+    # Truthful: site-packages has NO sugar_lift_py_tests.
+    assert not (purelib / "sugar_lift_py_tests").exists()
+
+    checkout_pp = subprocess.run(
+        [
+            sys.executable,
+            str(repo / "tools/managed_checkout_pythonpath.py"),
+            "--repo-root",
+            str(repo),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert checkout_pp
+    assert str(repo) in checkout_pp
+
+    probe = tmp_path / "probe.py"
+    probe.write_text(PROBE, encoding="utf-8")
+    completed = subprocess.run(
+        [str(venv_python), str(probe), str(repo), "no-activate"],
+        env={**os.environ, "PYTHONPATH": checkout_pp},
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "inside_checkout=True" in completed.stdout
+    assert "marker=from-synced-checkout" in completed.stdout
+    assert "site-packages" not in completed.stdout
+
+
+def test_lying_site_packages_install_is_outside_checkout_even_if_activated_after(
+    tmp_path: Path,
+) -> None:
+    """First-party in site-packages + activate-after-import = the S0 defect.
+
+    Rebinding sys.path after the package is already in sys.modules leaves the
+    foreign copy loaded. authenticate_lift's predicate (inside_checkout) is
+    false — the twin must go red, not pass because a later path mutation
+    looked correct.
+    """
+    repo = _mini_checkout(tmp_path)
+    venv_python = _make_venv(tmp_path / "venv")
+    purelib = _site_packages(venv_python)
+    foreign = _install_foreign_lift_into_site_packages(purelib)
+
+    checkout_pp = subprocess.run(
+        [
+            sys.executable,
+            str(repo / "tools/managed_checkout_pythonpath.py"),
+            "--repo-root",
+            str(repo),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    probe = tmp_path / "probe.py"
+    probe.write_text(PROBE, encoding="utf-8")
+
+    # Process starts WITHOUT checkout PYTHONPATH so the first import hits
+    # site-packages (the broken CI wheel-install shape). Then the probe
+    # activates roots after import — which must not green the lie.
+    completed = subprocess.run(
+        [str(venv_python), str(probe), str(repo), "activate-after"],
+        env={k: v for k, v in os.environ.items() if k != "PYTHONPATH"},
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0, (
+        "activate-after-import must not accept a site-packages first-party "
+        f"load:\n{completed.stdout}\n{completed.stderr}"
+    )
+    assert "inside_checkout=False" in completed.stdout or completed.returncode == 2
+    assert "from-site-packages" in completed.stdout or str(foreign.parent) in (
+        completed.stdout + completed.stderr
+    )
+
+
+def test_lying_site_packages_with_checkout_pythonpath_prefers_checkout(
+    tmp_path: Path,
+) -> None:
+    """If both exist, process-start PYTHONPATH must win (checkout first).
+
+    Belt: even a leftover site-packages copy must lose to managed PYTHONPATH
+    when the action exports it correctly before import.
+    """
+    repo = _mini_checkout(tmp_path)
+    venv_python = _make_venv(tmp_path / "venv")
+    purelib = _site_packages(venv_python)
+    _install_foreign_lift_into_site_packages(purelib)
+
+    checkout_pp = subprocess.run(
+        [
+            sys.executable,
+            str(repo / "tools/managed_checkout_pythonpath.py"),
+            "--repo-root",
+            str(repo),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    probe = tmp_path / "probe.py"
+    probe.write_text(PROBE, encoding="utf-8")
+    completed = subprocess.run(
+        [str(venv_python), str(probe), str(repo), "no-activate"],
+        env={**os.environ, "PYTHONPATH": checkout_pp},
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "marker=from-synced-checkout" in completed.stdout
+    assert "inside_checkout=True" in completed.stdout

--- a/tests/test_test_extras_are_the_dependency_authority.py
+++ b/tests/test_test_extras_are_the_dependency_authority.py
@@ -218,11 +218,22 @@ def bare_requirements(command: str) -> list[str]:
             skip_next = False
             continue
         if token.startswith("-"):
-            if token in {"--index-url", "--extra-index-url", "-r", "-c"}:
+            if token in {
+                "--index-url",
+                "--extra-index-url",
+                "--find-links",
+                "-r",
+                "-c",
+                "-f",
+            }:
                 skip_next = True
             continue
         if "/" in token or token.startswith(".") or token.endswith(".txt"):
             continue  # path install
+        if token.endswith(".whl"):
+            continue  # wheel file by name (third-party wheelhouse install)
+        if "$" in token or token.startswith("{"):
+            continue  # shell expansion / array (e.g. "${third_party[@]}")
         if token in {"pip", "install", "python", "-m"}:
             continue
         bare.append(normalize(token))
@@ -417,8 +428,14 @@ def test_the_environment_action_is_the_one_bound_definition() -> None:
 
     Tooth 5 accepts delegation to `.github/actions/python-test-environment`.
     That acceptance is worth exactly as much as this test: if the action stops
-    existing, stops installing `[test]`, or starts hand-listing, then every
-    floor that delegates to it is unbound and tooth 5's green is a lie.
+    existing, stops acquiring `[test]` into the wheelhouse, or starts
+    hand-listing, then every floor that delegates to it is unbound and tooth
+    5's green is a lie.
+
+    First-party packages are resolved from the synced checkout (PYTHONPATH),
+    not wheel-installed into the venv. The authority still drives the
+    *wheelhouse* via ``pip wheel ... sugar-lift-py-tests[test]``; the install
+    step must not put first-party packages into site-packages.
     """
     assert ENVIRONMENT_ACTION.exists(), (
         f"{ENVIRONMENT_ACTION_USE} is the single definition of the Python test "
@@ -438,26 +455,37 @@ def test_the_environment_action_is_the_one_bound_definition() -> None:
     for command in commands:
         if f"{AUTHORITY}[test]" not in command:
             offenders.append(f"acquires {AUTHORITY} without [test]: {command}")
+        # First-party must not be installed into the venv. `pip wheel` may
+        # still name the path so the third-party wheelhouse resolves from the
+        # authority table; `pip install` of the first-party package is the
+        # false-provenance defect authenticate_lift exists to refuse.
+        if command.startswith("pip install") and AUTHORITY in command:
+            offenders.append(
+                f"wheel-installs first-party {AUTHORITY} into the venv "
+                f"(must resolve from checkout via PYTHONPATH): {command}"
+            )
     for command in pip_install_commands(text):
         hand_listed = [
             requirement
             for requirement in bare_requirements(command)
-            # The three first-party package NAMES are how the wheelhouse is
-            # installed by name rather than by path; they are the packages
-            # themselves, not requirements of them.
             if requirement
             not in {
-                normalize(AUTHORITY),
-                "sugar-lift-python-source",
-                "sugar-source-tree",
+                # wheel bootstrap only; third-party deps arrive as wheel paths.
                 "wheel",
             }
         ]
         if hand_listed:
             offenders.append(f"hand-lists {sorted(set(hand_listed))}: {command}")
 
+    if "managed_checkout_pythonpath" not in text and "SUGAR_CHECKOUT_PYTHONPATH" not in text:
+        offenders.append(
+            "does not bind managed checkout PYTHONPATH before consumers import "
+            "first-party packages"
+        )
+
     assert not offenders, (
         f"{ENVIRONMENT_ACTION.name} is the ONE definition of the Python test "
-        f"environment; it must draw everything from `{AUTHORITY}[test]`:\n  "
+        f"environment; third-party from `{AUTHORITY}[test]` wheelhouse, "
+        f"first-party from the synced checkout:\n  "
         + "\n  ".join(offenders)
     )

--- a/tools/managed_checkout_pythonpath.py
+++ b/tools/managed_checkout_pythonpath.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Managed first-party PYTHONPATH from the sugar-build Dockerfile declaration.
+
+First-party Sugar packages resolve from the SYNCED CHECKOUT, never from a
+wheel-installed site-packages copy of a different build. The managed closure
+declares exactly one PYTHONPATH in ``tools/sugar-build/Dockerfile``; this tool
+maps that declaration onto a real checkout so CI and authentication share one
+root list.
+
+This module is stdlib-only on purpose: the python-test-environment action must
+export these roots BEFORE anything imports ``sugar_lift_py_tests``. Importing
+the package to learn where the package lives is the ordering defect this
+exists to prevent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+DOCKERFILE_REL = Path("tools/sugar-build/Dockerfile")
+MANAGED_PREFIX = "/workspace/sugar/"
+
+
+class ManagedCheckoutPythonpathError(RuntimeError):
+    """The managed PYTHONPATH declaration is missing, escaped, or broken."""
+
+
+def managed_checkout_import_roots(repo_root: Path) -> list[Path]:
+    """Return absolute checkout import roots declared by the managed closure."""
+    repo_root = repo_root.resolve()
+    dockerfile = repo_root / DOCKERFILE_REL
+    if not dockerfile.is_file():
+        raise ManagedCheckoutPythonpathError(
+            f"managed PYTHONPATH declaration missing: {dockerfile}"
+        )
+    matches = re.findall(
+        r"^ENV PYTHONPATH=(.*)$",
+        dockerfile.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    if len(matches) != 1:
+        raise ManagedCheckoutPythonpathError(
+            f"expected one managed PYTHONPATH declaration in {dockerfile}, "
+            f"found {len(matches)}"
+        )
+    roots: list[Path] = []
+    for entry in matches[0].split(":"):
+        if not entry.startswith(MANAGED_PREFIX):
+            raise ManagedCheckoutPythonpathError(
+                f"managed PYTHONPATH entry escaped the synced checkout: {entry}"
+            )
+        root = (repo_root / entry[len(MANAGED_PREFIX) :]).resolve()
+        if not root.is_dir():
+            raise ManagedCheckoutPythonpathError(
+                f"managed PYTHONPATH entry does not exist in the synced checkout: "
+                f"{root}"
+            )
+        roots.append(root)
+    return roots
+
+
+def managed_checkout_pythonpath(repo_root: Path) -> str:
+    """Colon-joined absolute PYTHONPATH for the managed first-party roots."""
+    return ":".join(str(root) for root in managed_checkout_import_roots(repo_root))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Synced checkout root (directory containing sugar-build.toml).",
+    )
+    args = parser.parse_args(argv)
+    try:
+        print(managed_checkout_pythonpath(args.repo_root))
+    except ManagedCheckoutPythonpathError as error:
+        print(str(error), file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

**Critical path.** Both S0.2 floors (run 30720199631) and S0.1 recensus (run 30720169468) failed with the same cause:

```
ExecutionEnvironmentMismatch: lift import escaped the synced checkout:
loaded sugar_lift_py_tests from .../site-packages/...; required <checkout>
```

One fix unblocks both. S0.3 needs the process-floor R triple that only S0.2 produces.

### Advisor ruling (implemented as given)

1. **Do not** wheel-install first-party `sugar-lift-*` / `sugar-source-tree` into the venv. Resolve from the **synced checkout** via `PYTHONPATH`.
2. **Keep** the immutable third-party `[test]` wheelhouse (pytest/numpy/pandas/…).
3. **Never** weaken `authenticate_lift` to accept site-packages. False provenance is the class we spent the day deleting.
4. **Not this PR:** `AuthenticatedInstalledLift` (content-stamp equality) stays on the ledger.

### Ordering bug (also fixed)

`activate_checkout_import_roots` after first import cannot unseat `sys.modules`. Checkout roots must be on `PYTHONPATH` **before** any process imports `sugar_lift_py_tests`. The shared action now exports `PYTHONPATH` / `SUGAR_CHECKOUT_PYTHONPATH` via `GITHUB_ENV` using `tools/managed_checkout_pythonpath.py` (stdlib-only, runs without the package on path).

### Changes

| Area | Change |
|------|--------|
| `.github/actions/python-test-environment` | Wheel authority table → strip first-party wheels → install third-party only → bind checkout PYTHONPATH; refuse if first-party appears in venv |
| `tools/managed_checkout_pythonpath.py` | Shared Dockerfile→checkout root binder |
| `authenticated_pytest` | Uses shared tool; documents process-start authority for first import |
| `python-package-suite.yml` | Compose `tools:` + `SUGAR_CHECKOUT_PYTHONPATH` (was clobbering checkout roots) |
| Teeth | CI-shape twins + updated authority tooth |

### Validation (local, no workflow/bx fired)

```
python3.12 -m pytest tests/test_ci_python_env_checkout_lift_import.py  # 5 passed
python3.12 -m pytest tests/test_test_extras_are_the_dependency_authority.py  # 6 passed
python3.12 -m pytest tests/test_authenticated_python_launcher.py::test_checkout_import_roots_...  # passed
python3.12 -m pytest tests/test_authenticated_python_launcher.py::test_lift_must_resolve_...  # passed
```

**Please re-dispatch S0.1 / S0.2 (or the action consumer jobs) after merge — agent did not fire workflow or bx.**

## Test plan

- [ ] Merge this PR
- [ ] Re-run python-sole-construction-floors (S0.2) — expect authenticate_lift green, process-floor R triple produced
- [ ] Re-run control-effect-recensus / authoritative suite path (S0.1) — same env
- [ ] Confirm `pip show sugar-lift-py-tests` is absent from the prepared venv; `liftPath=` under checkout in auth banner

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI first-party lift import to use checkout PYTHONPATH instead of venv site-packages
> - Adds [managed_checkout_pythonpath.py](https://github.com/TSavo/sugar/pull/6997/files#diff-bed3000cda355b0999d98ee9c2141ee96936fbbeb4461544df9ca0a1abd05209), a shared tool that parses the repo Dockerfile for `ENV PYTHONPATH=...`, validates entries, and returns resolved checkout import roots as a colon-separated string.
> - Updates the [python-test-environment action](https://github.com/TSavo/sugar/pull/6997/files#diff-93d85172587ff6130a5c787fe3512044d6a7b7e1db61708e7b52742c82dc3a3b) to strip first-party wheels (`sugar_lift_*.whl`, `sugar_source_tree-*.whl`) from the wheelhouse, install only third-party wheels into the venv, and export the managed checkout PYTHONPATH as `PYTHONPATH` and `SUGAR_CHECKOUT_PYTHONPATH`.
> - Updates `activate_checkout_import_roots` in [authenticated_pytest.py](https://github.com/TSavo/sugar/pull/6997/files#diff-6f32158e9034cf4948d264c100017b0e2fa8902654ebd9c5cae4496a4d9a1120) to use the managed tool instead of inline Dockerfile parsing, and prevents re-importing `sugar_lift_py_tests` after `sys.path` mutation to avoid picking up the site-packages copy.
> - Adds tests in [test_ci_python_env_checkout_lift_import.py](https://github.com/TSavo/sugar/pull/6997/files#diff-8f058dc929a0a13cdae37d956eebf117290debc318d563a95e78f38d6d2e17b4) asserting that imports resolve from the checkout and not site-packages when `SUGAR_CHECKOUT_PYTHONPATH` is set.
> - Behavioral Change: the venv no longer contains first-party packages; resolving them requires `SUGAR_CHECKOUT_PYTHONPATH` to be set correctly, so misconfigured environments will now fail with an import error rather than silently using a stale site-packages copy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e61035f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->