### PR TITLE
S1.1 re-rank input format: no bare integers without provenance

### DIFF
--- a/docs/path-forward.md
+++ b/docs/path-forward.md
@@ -212,6 +212,7 @@
 1. **S0.1** — Finish recensus `30720169468`; bank board artifact (DONE-WHEN above).  
 2. **S0.2** — Finish sole-construction `30720199631`; bank process-floor R triple (DONE-WHEN above).  
 3. **S0.3** — Package tip measurement (board + floors + optional CommitMeasurement); only then **S1.1** live re-rank.
+   - **S1.1 input format (empty of numbers):** `tools/rerank_input.py` — each axis is MeasuredAxis(value, instrument+commit+body) or UnmeasuredAxis; bare chat integers unconstructible. Do not populate until live re-derivation.
    - **REQUIRED:** board JSON (S0.1) + process-floor R triple native/bare/timeout (S0.2).
    - **OPTIONAL:** `CommitMeasurement` via `tools/compose_commit_measurement.py` — **may be PartialVector** (unmeasured axes expected if package suite has not spoken). Do **not** use `commit_measurement_gate --require-complete` for S0.3 packaging.
    - Ready command (run only after S0.1/S0.2 receipts exist; do not contend in-flight runs):

--- a/tests/test_rerank_input.py
+++ b/tests/test_rerank_input.py
@@ -1,0 +1,109 @@
+"""Construction teeth for S1.1 re-rank input format (CI; no local agent pytest)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location(
+    "rerank_input", ROOT / "tools" / "rerank_input.py"
+)
+assert _SPEC is not None and _SPEC.loader is not None
+RI = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = RI
+_SPEC.loader.exec_module(RI)
+
+
+def test_scoreboard_authority_false() -> None:
+    assert RI.SCOREBOARD_AUTHORITY is False
+
+
+def test_bare_integer_axis_unconstructible() -> None:
+    with pytest.raises(RI.RerankInputError, match="bare integer"):
+        RI.rerank_input("deadbeef", {"criterion4.spelling_dispatch": 74})  # type: ignore[dict-item]
+
+
+def test_chat_cite_is_unmeasured_not_integer() -> None:
+    u = RI.unmeasured_chat_cite("criterion4.spelling_dispatch")
+    assert isinstance(u, RI.UnmeasuredAxis)
+    assert "chat-cite" in u.reason
+    v = RI.rerank_input("deadbeef", {"criterion4.spelling_dispatch": u})
+    assert isinstance(v, RI.PartialRerankInput)
+    assert "rankable_axes" not in type(v).__dict__
+    assert not hasattr(RI.PartialRerankInput, "rankable_axes")
+
+
+def test_measured_requires_instrument_and_commit() -> None:
+    with pytest.raises(RI.RerankInputError, match="instrument_id"):
+        RI.measured_axis(
+            "criterion4.swallowed_throw",
+            1,
+            instrument_id="",
+            commit_sha="abc",
+            body_artifact_cid="body:1",
+            value_field_path="R",
+        )
+    m = RI.measured_axis(
+        "criterion4.swallowed_throw",
+        1,
+        instrument_id="scripts/swallowed_throw_second_mechanism_law.py",
+        commit_sha="deadbeef",
+        body_artifact_cid="blake2b-256:abc",
+        value_field_path="R_swallowed_throw_second_mechanism",
+    )
+    assert m.value == 1
+    assert m.provenance.instrument_id.endswith("swallowed_throw_second_mechanism_law.py")
+
+
+def test_direct_measured_axis_without_seal_refuses() -> None:
+    prov = RI.InstrumentProvenance(
+        instrument_id="scripts/x.py",
+        commit_sha="sha",
+        body_artifact_cid="b",
+        value_field_path="R",
+    )
+    with pytest.raises(RI.RerankInputError, match="sealed"):
+        RI.MeasuredAxis("ax", 1, prov, object())
+
+
+def test_complete_exposes_rankable_partial_does_not() -> None:
+    m = RI.measured_axis(
+        "criterion4.finite_cap_opaque",
+        1,
+        instrument_id="scripts/finite_cap_opaque_completion_law.py",
+        commit_sha="deadbeef",
+        body_artifact_cid="body:1",
+        value_field_path="R",
+    )
+    complete = RI.rerank_input("deadbeef", {"criterion4.finite_cap_opaque": m})
+    assert isinstance(complete, RI.CompleteRerankInput)
+    assert len(complete.rankable_axes()) == 1
+    partial = RI.rerank_input(
+        "deadbeef",
+        {
+            "criterion4.finite_cap_opaque": m,
+            "criterion1.authenticated_denominator": RI.unmeasured_axis(
+                "criterion1.authenticated_denominator",
+                "UNMEASURED: no authenticated denominator at tip",
+            ),
+        },
+    )
+    assert isinstance(partial, RI.PartialRerankInput)
+    with pytest.raises(AttributeError):
+        _ = partial.rankable_axes()  # type: ignore[attr-defined]
+    assert "rankableAxes" not in partial.to_json()
+    assert "total" not in partial.to_json()
+
+
+def test_enrolled_axis_ids_are_names_only_no_numbers() -> None:
+    """Format enrolls slots without parking chat integers."""
+    assert RI.ENROLLED_RERANK_AXIS_IDS
+    for axis_id in RI.ENROLLED_RERANK_AXIS_IDS:
+        assert isinstance(axis_id, str)
+        assert axis_id  # non-empty name
+    # No integer values in the enrollment tuple
+    assert all(not isinstance(x, int) for x in RI.ENROLLED_RERANK_AXIS_IDS)

--- a/tools/rerank_input.py
+++ b/tools/rerank_input.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""S1.1 re-rank input format — provenance-bound axes only (no bare integers).
+
+THE GAP
+=======
+
+Parked residual numbers lived in chat and PR bodies (criterion 4/5/3/1, parent
+vector 208). Axes were ranked as bare integers with no instrument, no commit,
+and no Measured/Unmeasured distinction — the same shape as R_total over mixed
+testimony.
+
+CommitMeasurement already refuses to total over Unmeasured tip axes. This
+module extends that discipline to **re-rank inputs**: every axis entering an
+advisor re-rank must be either:
+
+  MeasuredAxis(value, provenance)  — instrument + commit + body/field path
+  UnmeasuredAxis(reason)           — third value, not zero, not a chat integer
+
+A bare int has no constructor. A chat-sourced claim has no Measured door.
+
+THIS MODULE DOES NOT
+====================
+
+- Populate residual numbers
+- Rank or re-rank anything
+- Fire compose / lease / recensus / sole-construction
+- Claim SCOREBOARD_AUTHORITY (False)
+
+Advisor owns S1.1 re-rank. This is only the input **format**.
+
+ONE DOOR
+========
+
+``rerank_input(tip_sha, axes) -> CompleteRerankInput | PartialRerankInput``
+
+CompleteRerankInput: every enrolled axis is Measured (``.rankable_axes()``).
+PartialRerankInput: any Unmeasured — **no** rankable projection that pretends
+completeness (no silent drop of Unmeasured into a total or ordered list of ints).
+"""
+
+from __future__ import annotations
+
+SCOREBOARD_AUTHORITY = False
+
+from dataclasses import dataclass
+from typing import Mapping, Union
+
+
+class RerankInputError(TypeError):
+    """Illegal re-rank input — refused at construction."""
+
+
+_SEAL = object()
+
+
+def _require_nonempty_str(name: str, value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise RerankInputError(
+            f"{name} must be a non-empty str; got {type(value).__name__!r}={value!r}"
+        )
+    return value.strip()
+
+
+def _require_int_ge0(name: str, value: object) -> int:
+    if type(value) is not int:
+        raise RerankInputError(f"{name} must be int, not {type(value).__name__}")
+    if value < 0:
+        raise RerankInputError(f"{name} must be >= 0; got {value}")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentProvenance:
+    """Where a Measured axis number came from — not a chat message.
+
+    instrument_id: repo path or stable id of the owning instrument
+      (e.g. scripts/self_sealing_instrument_law.py).
+    commit_sha: commit at which that instrument was run.
+    body_artifact_cid: content address of the report body that owns the value.
+    value_field_path: field path inside that body (cite-compose).
+    receipt_cid: optional lease receipt CID when the run was under heavy lease.
+    """
+
+    instrument_id: str
+    commit_sha: str
+    body_artifact_cid: str
+    value_field_path: str
+    receipt_cid: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "instrument_id",
+            _require_nonempty_str("instrument_id", self.instrument_id),
+        )
+        object.__setattr__(
+            self, "commit_sha", _require_nonempty_str("commit_sha", self.commit_sha)
+        )
+        object.__setattr__(
+            self,
+            "body_artifact_cid",
+            _require_nonempty_str("body_artifact_cid", self.body_artifact_cid),
+        )
+        object.__setattr__(
+            self,
+            "value_field_path",
+            _require_nonempty_str("value_field_path", self.value_field_path),
+        )
+        if self.receipt_cid is not None:
+            object.__setattr__(
+                self,
+                "receipt_cid",
+                _require_nonempty_str("receipt_cid", self.receipt_cid),
+            )
+
+    def to_json(self) -> dict:
+        out = {
+            "instrumentId": self.instrument_id,
+            "commitSha": self.commit_sha,
+            "bodyArtifactCid": self.body_artifact_cid,
+            "valueFieldPath": self.value_field_path,
+        }
+        if self.receipt_cid is not None:
+            out["receiptCid"] = self.receipt_cid
+        return out
+
+
+@dataclass(frozen=True, slots=True)
+class MeasuredAxis:
+    """A residual count with sealed provenance. Unconstructible as a bare int."""
+
+    axis: str
+    value: int
+    provenance: InstrumentProvenance
+    _seal: object
+
+    def __post_init__(self) -> None:
+        if self._seal is not _SEAL:
+            raise RerankInputError(
+                "MeasuredAxis is sealed: use measured_axis(...); "
+                "a bare integer from chat/PR body has no constructor"
+            )
+        object.__setattr__(self, "axis", _require_nonempty_str("axis", self.axis))
+        _require_int_ge0("value", self.value)
+        if not isinstance(self.provenance, InstrumentProvenance):
+            raise RerankInputError(
+                "MeasuredAxis requires InstrumentProvenance "
+                f"(got {type(self.provenance).__name__})"
+            )
+
+    def is_measured(self) -> bool:
+        return True
+
+    def to_json(self) -> dict:
+        return {
+            "status": "measured",
+            "axis": self.axis,
+            "value": self.value,
+            "provenance": self.provenance.to_json(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class UnmeasuredAxis:
+    """Third value: this axis has no re-derived number at the tip. Not zero."""
+
+    axis: str
+    reason: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "axis", _require_nonempty_str("axis", self.axis))
+        object.__setattr__(
+            self, "reason", _require_nonempty_str("reason", self.reason)
+        )
+
+    def is_measured(self) -> bool:
+        return False
+
+    def to_json(self) -> dict:
+        return {
+            "status": "unmeasured",
+            "axis": self.axis,
+            "reason": self.reason,
+        }
+
+
+AxisEntry = Union[MeasuredAxis, UnmeasuredAxis]
+
+
+def measured_axis(
+    axis: str,
+    value: int,
+    *,
+    instrument_id: str,
+    commit_sha: str,
+    body_artifact_cid: str,
+    value_field_path: str,
+    receipt_cid: str | None = None,
+) -> MeasuredAxis:
+    """One door for a measured re-rank axis — provenance required."""
+    prov = InstrumentProvenance(
+        instrument_id=instrument_id,
+        commit_sha=commit_sha,
+        body_artifact_cid=body_artifact_cid,
+        value_field_path=value_field_path,
+        receipt_cid=receipt_cid,
+    )
+    return MeasuredAxis(axis, value, prov, _SEAL)
+
+
+def unmeasured_axis(axis: str, reason: str) -> UnmeasuredAxis:
+    """One door for Unmeasured — chat-only cites belong here, not as integers."""
+    return UnmeasuredAxis(axis, reason)
+
+
+def unmeasured_chat_cite(axis: str, *, source: str = "chat/PR body") -> UnmeasuredAxis:
+    """Explicit constructor for the R_total=208 failure mode: chat-parked numbers."""
+    return UnmeasuredAxis(
+        axis,
+        f"chat-cite only ({source}): not re-derived by an instrument at tip; "
+        f"cannot enter re-rank as a bare integer",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class CompleteRerankInput:
+    """Every axis Measured — the only shape that may expose rankable axes."""
+
+    tip_sha: str
+    axes: Mapping[str, MeasuredAxis]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "tip_sha", _require_nonempty_str("tip_sha", self.tip_sha)
+        )
+        if not isinstance(self.axes, Mapping) or not self.axes:
+            raise RerankInputError("CompleteRerankInput.axes must be non-empty")
+        sealed: dict[str, MeasuredAxis] = {}
+        for name, entry in self.axes.items():
+            key = _require_nonempty_str("axis key", name)
+            if not isinstance(entry, MeasuredAxis):
+                raise RerankInputError(
+                    f"CompleteRerankInput refuses Unmeasured axis {key!r}"
+                )
+            if entry.axis != key:
+                raise RerankInputError(
+                    f"axis key {key!r} != entry.axis {entry.axis!r}"
+                )
+            sealed[key] = entry
+        object.__setattr__(self, "axes", sealed)
+
+    def is_complete(self) -> bool:
+        return True
+
+    def rankable_axes(self) -> tuple[MeasuredAxis, ...]:
+        """Advisor may re-rank these — all have instrument provenance at a commit."""
+        return tuple(self.axes[k] for k in sorted(self.axes))
+
+    def to_json(self) -> dict:
+        return {
+            "kind": "rerank-input",
+            "status": "complete",
+            "tipSha": self.tip_sha,
+            "scoreboardAuthority": False,
+            "axes": {k: v.to_json() for k, v in sorted(self.axes.items())},
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PartialRerankInput:
+    """Any Unmeasured axis — no rankable projection that drops silence."""
+
+    tip_sha: str
+    axes: Mapping[str, AxisEntry]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "tip_sha", _require_nonempty_str("tip_sha", self.tip_sha)
+        )
+        if not isinstance(self.axes, Mapping) or not self.axes:
+            raise RerankInputError("PartialRerankInput.axes must be non-empty")
+        sealed: dict[str, AxisEntry] = {}
+        saw_unmeasured = False
+        for name, entry in self.axes.items():
+            key = _require_nonempty_str("axis key", name)
+            if not isinstance(entry, (MeasuredAxis, UnmeasuredAxis)):
+                raise RerankInputError(
+                    f"axis {key!r}: must be MeasuredAxis or UnmeasuredAxis; "
+                    f"got {type(entry).__name__} — bare int unconstructible"
+                )
+            if isinstance(entry, UnmeasuredAxis):
+                saw_unmeasured = True
+            if entry.axis != key:
+                raise RerankInputError(
+                    f"axis key {key!r} != entry.axis {entry.axis!r}"
+                )
+            sealed[key] = entry
+        if not saw_unmeasured:
+            raise RerankInputError(
+                "PartialRerankInput requires ≥1 UnmeasuredAxis; "
+                "use CompleteRerankInput when all measured"
+            )
+        object.__setattr__(self, "axes", sealed)
+
+    def is_complete(self) -> bool:
+        return False
+
+    def unmeasured_axes(self) -> tuple[str, ...]:
+        return tuple(
+            k for k, v in self.axes.items() if isinstance(v, UnmeasuredAxis)
+        )
+
+    def to_json(self) -> dict:
+        return {
+            "kind": "rerank-input",
+            "status": "partial",
+            "tipSha": self.tip_sha,
+            "scoreboardAuthority": False,
+            # deliberately no rankableAxes / total
+            "unmeasuredAxes": list(self.unmeasured_axes()),
+            "axes": {k: v.to_json() for k, v in sorted(self.axes.items())},
+        }
+
+
+RerankInput = Union[CompleteRerankInput, PartialRerankInput]
+
+
+def rerank_input(
+    tip_sha: str,
+    axes: Mapping[str, AxisEntry],
+) -> RerankInput:
+    """ONE DOOR for S1.1 re-rank input. Bare integers never enter."""
+    sha = _require_nonempty_str("tip_sha", tip_sha)
+    if not isinstance(axes, Mapping) or not axes:
+        raise RerankInputError("axes must be a non-empty mapping")
+    sealed: dict[str, AxisEntry] = {}
+    for name, entry in axes.items():
+        key = _require_nonempty_str("axis key", name)
+        if isinstance(entry, int):
+            raise RerankInputError(
+                f"axis {key!r}: bare integer {entry!r} is unconstructible; "
+                f"use measured_axis(...) with instrument provenance or "
+                f"unmeasured_axis/unmeasured_chat_cite(...)"
+            )
+        if not isinstance(entry, (MeasuredAxis, UnmeasuredAxis)):
+            raise RerankInputError(
+                f"axis {key!r}: must be MeasuredAxis or UnmeasuredAxis; "
+                f"got {type(entry).__name__}"
+            )
+        if entry.axis != key:
+            raise RerankInputError(
+                f"axis key {key!r} != entry.axis {entry.axis!r}"
+            )
+        sealed[key] = entry
+    if any(isinstance(e, UnmeasuredAxis) for e in sealed.values()):
+        return PartialRerankInput(sha, sealed)
+    return CompleteRerankInput(sha, sealed)  # type: ignore[arg-type]
+
+
+# Enrolled criterion *slots* for S1.1 (names only — no numbers).
+# Population with Measured values is advisor S1.1 after live re-derivation.
+# Chat-parked figures must use unmeasured_chat_cite until re-derived.
+ENROLLED_RERANK_AXIS_IDS: tuple[str, ...] = (
+    # Criterion 4 — second-mechanism residual classes (instrument-owned when measured)
+    "criterion4.vendor_special_case",
+    "criterion4.spelling_dispatch",
+    "criterion4.space_hunting",
+    "criterion4.finite_cap_opaque",
+    "criterion4.swallowed_throw",
+    "criterion4.compatibility_door",
+    # Criterion 5 — twin / hatch inventory
+    "criterion5.missing_lying_twins",
+    "criterion5.honest_with_hatch_unsealed",
+    "criterion5.opt_outs",
+    # Criterion 3 — naming / decidability
+    "criterion3.naming_nothing_drained_but_held",
+    "criterion3.decidability_axis",
+    # Criterion 1 — authenticated denominator
+    "criterion1.authenticated_denominator",
+)


### PR DESCRIPTION
## What

**Format only** for advisor S1.1 re-rank input. No numbers filled, no ranking, no compose/lease fire.

`tools/rerank_input.py` — same discipline as CommitMeasurement:

| Constructor | Law |
| --- | --- |
| `MeasuredAxis(value, provenance)` | Sealed; requires `instrument_id`, `commit_sha`, `body_artifact_cid`, `value_field_path` |
| `UnmeasuredAxis(reason)` | Third value, not zero |
| `unmeasured_chat_cite(axis)` | Explicit door for chat/PR-parked claims |
| `rerank_input(tip_sha, axes)` | One door → Complete or Partial |
| `CompleteRerankInput.rankable_axes()` | Only when every axis Measured |
| `PartialRerankInput` | **No** `rankable_axes` — cannot rank while any Unmeasured |

Bare integer axes (`{"spelling": 74}`) are **unconstructible**.

`SCOREBOARD_AUTHORITY = False`. Enrolled axis **ids** only (names, no values) for criterion 1/3/4/5 slots.

## Shell deleted

Entering S1.1 re-rank with bare integers from chat/PR bodies (the R_total=208 input shape).

## Shot accounting

| | |
| --- | --- |
| R axis | chat-parked re-rank integers |
| Epsilon R | class → unwritable at type door; residual parks until S1.1 live re-derive |
| Floors | no drain, no lease, no re-rank claim |
| Shell deleted | bare-int ranking input |

## Not done (leash)

- No population of criterion numbers  
- No S1.1 re-rank  
- No S0.3 compose fire  

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `rerank_input` module enforcing provenance-backed axis format with no bare integers
> - Introduces [tools/rerank_input.py](https://github.com/TSavo/sugar/pull/6998/files#diff-3a3a37dd28ac602ae934c5efd59f62a5acc1c8796aa358cd6960d87e287633c5) with `MeasuredAxis` (requires instrument, commit, and body provenance via the `measured_axis` factory) and `UnmeasuredAxis` (requires explicit reason) as the only valid axis entry types.
> - Adds `rerank_input()` as the single construction entrypoint, which rejects bare integers and returns either `CompleteRerankInput` (all axes measured, exposes `rankable_axes`) or `PartialRerankInput` (at least one unmeasured, omits `rankableAxes`/`total` from JSON).
> - Adds `unmeasured_chat_cite()` as a standard way to mark values cited from chat or PR body, preventing them from being treated as measured counts.
> - Sets `SCOREBOARD_AUTHORITY = False` and exposes `ENROLLED_RERANK_AXIS_IDS` as a tuple of axis name strings.
> - Adds [tests/test_rerank_input.py](https://github.com/TSavo/sugar/pull/6998/files#diff-1d0ed124e2e666ddf0d77c7ef6364ff260c2342a4f1c044200a7e11d08a57cfb) covering construction rules, sealed `MeasuredAxis` instantiation, and JSON output shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3105886.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->