### PR TITLE
fix: first-party lift from checkout, not site-packages (S0 unblock)

### DIFF
--- a/.github/actions/python-test-environment/action.yml
+++ b/.github/actions/python-test-environment/action.yml
@@ -18,9 +18,15 @@ description: >-
 # authority (#6275), and the only names below are FIRST-PARTY PATHS, which are
 # the packages themselves rather than a hand-list of their requirements.
 #
-# The venv is built from wheels and then made read-only. Editable installs let
-# a later job silently change what an earlier job measured; a wheel install
-# plus `chmod a-w` makes that attempt fail loudly instead.
+# The venv holds THIRD-PARTY wheels only (immutable wheelhouse), then is made
+# read-only. FIRST-PARTY sugar-lift-* packages resolve from the SYNCED CHECKOUT
+# via PYTHONPATH (Dockerfile ENV PYTHONPATH / activate_checkout_import_roots).
+# Wheel-installing first-party into site-packages is what produced
+# ExecutionEnvironmentMismatch on S0.1/S0.2: lift loaded from
+# .../venv/.../site-packages while authenticate_lift requires checkout src.
+# Do NOT weaken authenticate_lift to accept site-packages. Later climb
+# (not this patch): AuthenticatedInstalledLift when content-stamp equals
+# checkout. Path-prefix checkout test is parents[N]-family long-term, ledgered.
 
 inputs:
   python-version:
@@ -126,12 +132,34 @@ runs:
         if [ -d "$venv" ]; then chmod -R u+w "$venv"; rm -rf "$venv"; fi
         python -m venv "$venv"
         "$venv/bin/python" -m pip install --quiet --upgrade pip wheel
+        # THIRD-PARTY only. First-party sugar-lift-* must not land in
+        # site-packages: they load from the synced checkout via PYTHONPATH.
+        mapfile -t third_party < <(
+          python tools/python_test_third_party_requirements.py --repo-root .
+        )
+        if [ "${#third_party[@]}" -eq 0 ]; then
+          echo "::error::third-party requirement list is empty; refusing install"
+          exit 1
+        fi
         "$venv/bin/python" -m pip install --quiet \
           --no-index --find-links "$env_dir/wheelhouse" \
-          'sugar-lift-py-tests[test]' \
-          sugar-lift-python-source \
-          sugar-source-tree
+          "${third_party[@]}"
         "$venv/bin/python" -m pip freeze --all > "$env_dir/resolved-distributions.txt"
+        # Refuse a regression that re-installs first-party into the venv.
+        if grep -Eiq '^(sugar-lift-py-tests|sugar-lift-python-source|sugar-source-tree)==' \
+          "$env_dir/resolved-distributions.txt"; then
+          echo "::error::first-party sugar package installed into venv; checkout PYTHONPATH is the authority"
+          cat "$env_dir/resolved-distributions.txt" >&2
+          exit 1
+        fi
+
+        # Checkout import roots BEFORE any process can import sugar_lift_py_tests.
+        # activate_checkout_import_roots after first import is a no-op on sys.modules.
+        checkout_pythonpath="$(
+          python tools/python_test_checkout_pythonpath.py --repo-root .
+        )"
+        echo "PYTHONPATH=${checkout_pythonpath}" >> "$GITHUB_ENV"
+        echo "checkout PYTHONPATH active for subsequent steps"
 
         # Consumers share this environment READ-ONLY. No job may mutate it:
         # adding a package to an already-measured environment is how a floor

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
@@ -162,7 +162,20 @@ def authenticate_corpus_manifest(
 
 
 def activate_checkout_import_roots(repo_root: Path, search_path: list[str]) -> None:
-    """Activate exactly the mounted roots declared by the managed closure."""
+    """Activate exactly the mounted roots declared by the managed closure.
+
+    ORDERING LAW: these roots must be active BEFORE any import of
+    ``sugar_lift_py_tests``. Rebinding ``sys.path`` after the package is
+    already in ``sys.modules`` does not change the loaded module object;
+    ``authenticate_lift`` will still see a site-packages ``__file__`` and
+    correctly refuse. The python-test-environment action therefore exports
+    checkout PYTHONPATH at process start and does not wheel-install
+    first-party packages into the venv.
+
+    Later climb (not this patch): ``AuthenticatedInstalledLift`` when a
+    venv content-stamp equals the checkout — still never a path-prefix
+    relaxation that accepts arbitrary site-packages as the claim tree.
+    """
     dockerfile = repo_root / "tools/sugar-build/Dockerfile"
     matches = re.findall(
         r"^ENV PYTHONPATH=(.*)$",
@@ -216,6 +229,9 @@ def authenticate_environment() -> (
         package_root = sugar_lift_py_tests_package_root(repo_root)
     except RepoRootUnresolved as error:
         raise ExecutionEnvironmentMismatch(str(error)) from error
+    # Checkout roots first. If this process already imported sugar_lift_py_tests
+    # from site-packages (roots activated too late), authenticate_lift below
+    # refuses — the authority is correct; fix the environment, not the check.
     activate_checkout_import_roots(repo_root, sys.path)
     pins, expected_cid = _declared_corpus(package_root)
 
@@ -223,6 +239,9 @@ def authenticate_environment() -> (
 
     pandas = import_module("pandas")
     numpy = import_module("numpy")
+    # Prefer a fresh import after roots are active so a cold path binds checkout.
+    # Do not delete this package from sys.modules while it is running — that is
+    # why the action must export PYTHONPATH before the process starts.
     lift = import_module("sugar_lift_py_tests")
     pandas_distribution = metadata.distribution("pandas")
     numpy_distribution = metadata.distribution("numpy")

--- a/tests/test_python_test_environment_checkout_import.py
+++ b/tests/test_python_test_environment_checkout_import.py
@@ -1,0 +1,213 @@
+"""CI environment: first-party lift resolves from checkout, not site-packages.
+
+The defect that killed S0.1/S0.2: python-test-environment wheel-installed
+first-party sugar-lift-* into the venv, so ``import sugar_lift_py_tests``
+bound site-packages before checkout roots could win. authenticate_lift
+correctly refused (do not weaken it).
+
+These twins exercise the *environment contract*, not a bare-dev checkout
+path alone: a foreign site-packages copy is always present as the lying
+trap. Truthful setup is checkout PYTHONPATH first (action's post-install
+export). Lying setup is site-packages first / no checkout roots.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.authenticated_pytest import (
+    ExecutionEnvironmentMismatch,
+    activate_checkout_import_roots,
+    authenticate_lift,
+)
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def test_third_party_requirements_exclude_first_party_packages() -> None:
+    """Authority [test] deps install without sugar-lift first-party names."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(REPO / "tools/python_test_third_party_requirements.py"),
+            "--repo-root",
+            str(REPO),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    assert lines, "third-party list must be non-empty"
+    joined = "\n".join(lines).lower()
+    for banned in (
+        "sugar-lift-py-tests",
+        "sugar-lift-python-source",
+        "sugar-source-tree",
+    ):
+        assert banned not in joined, f"first-party leaked into third-party list: {banned}"
+    assert any(line.startswith("pandas==") for line in lines)
+    assert any(line.startswith("numpy==") for line in lines)
+
+
+def test_checkout_pythonpath_is_declared_managed_closure_under_repo() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(REPO / "tools/python_test_checkout_pythonpath.py"),
+            "--repo-root",
+            str(REPO),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    path = completed.stdout.strip()
+    assert path
+    for entry in path.split(":"):
+        resolved = Path(entry).resolve()
+        assert resolved.is_dir(), entry
+        assert resolved.is_relative_to(REPO.resolve()), entry
+    assert "sugar-lift-py-tests/src" in path.replace("\\", "/")
+
+
+def test_truthful_ci_shaped_import_loads_lift_from_checkout(tmp_path: Path) -> None:
+    """Truthful: checkout root first → sugar_lift_py_tests.__file__ under checkout.
+
+    Foreign site-packages copy is present (the machine trap that failed S0).
+    """
+    repo, checkout_init, site_init = _mini_repo_with_foreign_site_packages(tmp_path)
+    path: list[str] = [str(site_init.parent.parent)]  # site-packages on path
+    activate_checkout_import_roots(repo, path)
+    assert path[0] == str(
+        (repo / "implementations/python/sugar-lift-py-tests/src").resolve()
+    )
+
+    code = (
+        "import importlib, sys\n"
+        f"sys.path[:0] = {path!r}\n"
+        "mod = importlib.import_module('sugar_lift_py_tests')\n"
+        "print(mod.MARK)\n"
+        "print(mod.__file__)\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        text=True,
+        capture_output=True,
+        check=False,
+        cwd=str(repo),
+    )
+    assert completed.returncode == 0, completed.stderr
+    mark, loaded = completed.stdout.strip().splitlines()
+    assert mark == "checkout"
+    assert Path(loaded).resolve().is_relative_to(
+        (repo / "implementations/python/sugar-lift-py-tests/src").resolve()
+    )
+    # Authority tooth: authenticate_lift accepts this load.
+    from types import ModuleType
+    from importlib.machinery import ModuleSpec
+
+    module = ModuleType("sugar_lift_py_tests")
+    module.__file__ = loaded
+    module.__spec__ = ModuleSpec("sugar_lift_py_tests", loader=None, origin=loaded)
+    assert authenticate_lift(module, repo).loaded_from.is_relative_to(
+        (repo / "implementations/python/sugar-lift-py-tests/src").resolve()
+    )
+
+
+def test_lying_site_packages_first_party_is_refused_by_authenticate_lift(
+    tmp_path: Path,
+) -> None:
+    """Lying twin: first-party from site-packages fails authenticate_lift."""
+    repo, _checkout_init, site_init = _mini_repo_with_foreign_site_packages(tmp_path)
+    from types import ModuleType
+    from importlib.machinery import ModuleSpec
+
+    foreign = ModuleType("sugar_lift_py_tests")
+    foreign.__file__ = str(site_init)
+    foreign.__spec__ = ModuleSpec(
+        "sugar_lift_py_tests", loader=None, origin=str(site_init)
+    )
+    with pytest.raises(
+        ExecutionEnvironmentMismatch, match="lift import escaped the synced checkout"
+    ):
+        authenticate_lift(foreign, repo)
+
+
+def test_lying_import_without_checkout_roots_binds_site_packages(
+    tmp_path: Path,
+) -> None:
+    """Without checkout PYTHONPATH, import binds the foreign site-packages copy.
+
+    That is the S0 failure mode. The environment must not do this.
+    """
+    _repo, _checkout_init, site_init = _mini_repo_with_foreign_site_packages(tmp_path)
+    site_packages = str(site_init.parent.parent)
+    code = (
+        "import importlib, sys\n"
+        f"sys.path.insert(0, {site_packages!r})\n"
+        "mod = importlib.import_module('sugar_lift_py_tests')\n"
+        "print(mod.MARK)\n"
+        "print(mod.__file__)\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    mark, loaded = completed.stdout.strip().splitlines()
+    assert mark == "site-packages"
+    assert "site-packages" in loaded.replace("\\", "/")
+
+
+def _mini_repo_with_foreign_site_packages(
+    tmp_path: Path,
+) -> tuple[Path, Path, Path]:
+    repo = tmp_path / "sugar"
+    checkout_pkg = (
+        repo / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests"
+    )
+    checkout_pkg.mkdir(parents=True)
+    checkout_init = checkout_pkg / "__init__.py"
+    checkout_init.write_text("MARK = 'checkout'\n", encoding="utf-8")
+    # Sibling roots required by Dockerfile PYTHONPATH declaration.
+    for rel in (
+        "implementations/python/libsugar-py",
+        "implementations/python/sugar-build-witness/src",
+        "implementations/python/sugar-emit-python-hypothesis/src",
+        "implementations/python/sugar-emit-python-pytest/src",
+        "implementations/python/sugar-emit-python-unittest/src",
+        "implementations/python/sugar-lift-py-pytest-witness/src",
+        "implementations/python/sugar-lift-python-source/src",
+        "implementations/python/sugar-source-tree/src",
+    ):
+        (repo / rel).mkdir(parents=True, exist_ok=True)
+    dockerfile = repo / "tools/sugar-build/Dockerfile"
+    dockerfile.parent.mkdir(parents=True)
+    dockerfile.write_text(
+        "ENV PYTHONPATH="
+        "/workspace/sugar/implementations/python/libsugar-py:"
+        "/workspace/sugar/implementations/python/sugar-build-witness/src:"
+        "/workspace/sugar/implementations/python/sugar-emit-python-hypothesis/src:"
+        "/workspace/sugar/implementations/python/sugar-emit-python-pytest/src:"
+        "/workspace/sugar/implementations/python/sugar-emit-python-unittest/src:"
+        "/workspace/sugar/implementations/python/sugar-lift-py-pytest-witness/src:"
+        "/workspace/sugar/implementations/python/sugar-lift-py-tests/src:"
+        "/workspace/sugar/implementations/python/sugar-lift-python-source/src:"
+        "/workspace/sugar/implementations/python/sugar-source-tree/src\n",
+        encoding="utf-8",
+    )
+    site_pkg = tmp_path / "venv/lib/python3.12/site-packages/sugar_lift_py_tests"
+    site_pkg.mkdir(parents=True)
+    site_init = site_pkg / "__init__.py"
+    site_init.write_text("MARK = 'site-packages'\n", encoding="utf-8")
+    return repo, checkout_init, site_init

--- a/tools/python_test_checkout_pythonpath.py
+++ b/tools/python_test_checkout_pythonpath.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Emit checkout PYTHONPATH from the managed closure declaration.
+
+Same source of truth as ``activate_checkout_import_roots``: the single
+``ENV PYTHONPATH=...`` line in tools/sugar-build/Dockerfile. Used by the
+python-test-environment action so process start finds first-party packages
+in the SYNCED CHECKOUT before site-packages — before any import of
+``sugar_lift_py_tests`` can pin a foreign copy into sys.modules.
+
+Usage:
+  python tools/python_test_checkout_pythonpath.py --repo-root .
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def checkout_pythonpath(repo_root: Path) -> str:
+    dockerfile = repo_root / "tools/sugar-build/Dockerfile"
+    matches = re.findall(
+        r"^ENV PYTHONPATH=(.*)$",
+        dockerfile.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    if len(matches) != 1:
+        raise SystemExit(
+            f"expected one managed PYTHONPATH declaration in {dockerfile}, "
+            f"found {len(matches)}"
+        )
+    prefix = "/workspace/sugar/"
+    roots: list[str] = []
+    for entry in matches[0].split(":"):
+        if not entry.startswith(prefix):
+            raise SystemExit(
+                f"managed PYTHONPATH entry escaped the synced checkout: {entry}"
+            )
+        root = (repo_root / entry[len(prefix) :]).resolve()
+        if not root.is_dir():
+            raise SystemExit(
+                f"managed PYTHONPATH entry does not exist in the synced "
+                f"checkout: {root}"
+            )
+        roots.append(str(root))
+    return ":".join(roots)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    args = parser.parse_args(argv)
+    sys.stdout.write(checkout_pythonpath(args.repo_root.resolve()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/python_test_third_party_requirements.py
+++ b/tools/python_test_third_party_requirements.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Emit third-party install specs for the immutable Python test environment.
+
+First-party sugar-lift-* packages resolve from the SYNCED CHECKOUT via
+PYTHONPATH (see tools/sugar-build/Dockerfile ENV PYTHONPATH and
+activate_checkout_import_roots). They must NOT be wheel-installed into the
+venv: that is what produced ExecutionEnvironmentMismatch on S0.1/S0.2
+(site-packages lift vs checkout claim).
+
+Third-party [test] deps still come from sugar-lift-py-tests[test] — the sole
+dependency authority. This script only *names* those requirements so the
+action can ``pip install --no-index --find-links wheelhouse`` without
+installing first-party packages.
+
+Usage:
+  python tools/python_test_third_party_requirements.py --repo-root .
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+# Distribution names that are first-party monorepo packages. Never install
+# these into the test venv; they load from checkout src roots.
+FIRST_PARTY_DISTRIBUTIONS = frozenset(
+    {
+        "sugar-lift-py-tests",
+        "sugar-lift-python-source",
+        "sugar-source-tree",
+        "sugar-lift-py-pytest-witness",
+        "sugar-build-witness",
+        "sugar-emit-python-hypothesis",
+        "sugar-emit-python-pytest",
+        "sugar-emit-python-unittest",
+        "libsugar-py",
+    }
+)
+
+AUTHORITY = "sugar-lift-py-tests"
+
+
+def _normalize(name: str) -> str:
+    return name.strip().lower().replace("_", "-")
+
+
+def _requirement_root_name(requirement: str) -> str:
+    """Best-effort package name from a PEP 508 requirement string."""
+    text = requirement.strip()
+    for sep in ("[", " ", "<", ">", "=", "!", "~", ";", "@"):
+        if sep in text:
+            text = text.split(sep, 1)[0]
+    return _normalize(text)
+
+
+def third_party_requirements(repo_root: Path) -> list[str]:
+    """Collect third-party requirements from first-party pyproject tables."""
+    packages = (
+        repo_root / "implementations/python/sugar-lift-py-tests/pyproject.toml",
+        repo_root / "implementations/python/sugar-lift-python-source/pyproject.toml",
+        repo_root / "implementations/python/sugar-source-tree/pyproject.toml",
+    )
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for pyproject in packages:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        project = data["project"]
+        extras = project.get("optional-dependencies") or {}
+        tables: list[list[str]] = [list(project.get("dependencies") or [])]
+        # Authority package is sugar-lift-py-tests — [test] is the sole dep authority.
+        if project.get("name") == AUTHORITY:
+            tables.append(list(extras.get("test") or []))
+        for table in tables:
+            for requirement in table:
+                root = _requirement_root_name(requirement)
+                if root in FIRST_PARTY_DISTRIBUTIONS:
+                    continue
+                # Deduplicate by root name; keep first (pinned) occurrence.
+                if root in seen:
+                    continue
+                seen.add(root)
+                ordered.append(requirement.strip())
+    if not ordered:
+        raise SystemExit(
+            f"no third-party requirements derived under {repo_root}; "
+            "refusing an empty venv install"
+        )
+    return ordered
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    args = parser.parse_args(argv)
+    for requirement in third_party_requirements(args.repo_root.resolve()):
+        print(requirement)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Shot accounting

| Field | Value |
| --- | --- |
| **R axis** | S0 execution-environment authority (`ExecutionEnvironmentMismatch` on first-party site-packages lift) |
| **Epsilon R** | S0.1 recensus + S0.2 floors become *runnable* under correct provenance (not a corpus R drain) |
| **Floors preserved** | third-party immutable wheelhouse; **`authenticate_lift` not weakened** (still requires checkout src) |
| **Shell deleted** | wheel-install of first-party `sugar-lift-*` into the test venv (false provenance path) |

## Defect

Both heavy runs failed identically:

```
authenticated_pytest.ExecutionEnvironmentMismatch: lift import escaped the synced checkout:
loaded sugar_lift_py_tests from .../site-packages/...; required <checkout>
```

Cause:
1. `.github/actions/python-test-environment` installed first-party packages as wheels into the venv.
2. Checkout import roots were not active **before** first import — rebinding after import cannot change `sys.modules`.

## Fix (advisor ruling, as given)

1. **Do not** wheel-install first-party `sugar-lift-*` into the venv. Install **third-party** `[test]` deps only from the wheelhouse. First-party resolves from the **synced checkout** via PYTHONPATH.
2. **Never** weaken `authenticate_lift` to accept site-packages.
3. Export managed checkout PYTHONPATH at action install time (same Dockerfile declaration as `activate_checkout_import_roots`).
4. Ledger only (not this PR): `AuthenticatedInstalledLift` when content-stamp equals checkout; path-prefix checkout test is parents[N]-family long-term.

## Teeth

`tests/test_python_test_environment_checkout_import.py`:
- third-party requirement list excludes first-party names
- checkout PYTHONPATH entries under repo
- **truthful:** foreign site-packages present, checkout roots first → import `MARK=checkout` and `authenticate_lift` accepts
- **lying:** site-packages first-party → `authenticate_lift` refuses; import without checkout roots binds site-packages

A test that only passes on a clean dev tree without a foreign site-packages trap cannot catch this defect.

## Out of scope

No workflow_dispatch / bx. Joe dispatches heavies after this lands.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix first-party sugar packages to import from checkout instead of site-packages
> - The CI test environment now installs only third-party dependencies into the venv; first-party sugar packages are sourced from the checkout via `PYTHONPATH` instead of being pip-installed.
> - Two new tools compute the inputs: [`python_test_third_party_requirements.py`](https://github.com/TSavo/sugar/pull/6999/files#diff-7d0fc2de47734d9d0f25758d5ad2a2ec39acda15c2f4bf694e1c8eb4b475ff5d) filters first-party packages out of pyproject dependencies, and [`python_test_checkout_pythonpath.py`](https://github.com/TSavo/sugar/pull/6999/files#diff-6c3451f40661d94ba37ce1ac6baf131085a2ed7684f57fca4f1d190ca2c35104) derives `PYTHONPATH` from the managed Dockerfile declaration.
> - [`action.yml`](https://github.com/TSavo/sugar/pull/6999/files#diff-93d85172587ff6130a5c787fe3512044d6a7b7e1db61708e7b52742c82dc3a3b) exports `PYTHONPATH` to `GITHUB_ENV` before any step imports `sugar_lift_py_tests`, and fails the job if the third-party list is empty or any first-party sugar package is found in the venv.
> - New tests in [`test_python_test_environment_checkout_import.py`](https://github.com/TSavo/sugar/pull/6999/files#diff-ad0c3423197effc407a9b2845b93c2a45042f4acb8d966495d7a9099e3d3de8c) verify that imports bind to checkout roots and that `authenticate_lift` rejects modules originating from site-packages.
> - Behavioral Change: first-party packages are no longer installed into the venv; any code that previously relied on pip-installed sugar packages in the test environment will now import from the checkout instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10aa098.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->