### PR TITLE
Seal R_silent population to authenticated pandas (Criterion 2)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -1,5 +1,48 @@
 #!/usr/bin/env python3
-"""R_silent — independent disk census versus current construction roll call.
+"""R_silent — Criterion 2 fourth term: silent/unaccounted construction loci.
+
+## Class
+
+**Silent/unaccounted** = a source locus that is on disk (assert or body) and
+is absent from the construction roll call as either *warranted* or
+*unresolved*. The locus vanished from the denominator without classification.
+
+That is Crime-1 construction completeness (lift_coverage_accounting doctrine):
+stated work that never engaged the instrument. Panic / gap / timeout /
+native-crash are *classified* failures — not silent.
+
+## Population law (Criterion 2)
+
+Criterion 2 requires, over the **authenticated pandas corpus**,
+simultaneously:
+
+    R(construction panics) = R(native crashes) = R(timeouts) = R(silent) = 0
+
+Native / timeout / bare-exception floors already refuse empty scan roots and
+are bound to ``PANDAS_CORPUS`` in ``tools/run_sole_construction_floors.sh``.
+This floor must do the same: **explicit non-empty scan roots required**.
+Defaulting to kit ``production_roots`` (~444 files) is a wrong-population
+false green — R=0 on kit while the corpus is never entered.
+
+## Not this class (do not collapse)
+
+| Axis | Owner | Difference |
+| --- | --- | --- |
+| ``Unmeasured`` / SHELF_UNMEASURED | commit_measurement / shelf | Measurement *of* measurement: no reading was taken |
+| Heavy attendance absent-artifact | heavy_measurement_attendance | Job never ran / no artifact |
+| Gap / ConstructionPanic held | roll call ``unresolved`` | Instrument engaged; unfinished is classified |
+| R_silent | **this module** | Disk locus never appeared on the roll call |
+
+## Predicate
+
+    silent ⇔ (file, line, col, kind) ∈ disk_census
+             ∧ (file, line, col, kind) ∉ roll_call{warranted ∪ unresolved}
+
+## Ladder
+
+Auditor over (disk census × roll call). Type cannot close open source
+populations. Retirement: every disk locus is constructed into the roll call
+or classified; then silence at stable zero on the **corpus** population.
 
 In-process enum scan. Progress and engine logs never mix.
 """
@@ -26,6 +69,7 @@ from _enum_floor_runtime import (  # noqa: E402
     prepare_floor_io,
     production_roots,
     relative_to_root,
+    require_explicit_scan_roots,
     require_python_paths,
     with_file_timeout,
 )
@@ -263,7 +307,16 @@ def main() -> int:
             pass
     repo_root = Path(__file__).resolve().parents[4]
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("paths", nargs="*", type=Path)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[],
+        help=(
+            "Scan roots (required, non-empty). Criterion-2 silent floor police "
+            "the authenticated pandas corpus — never silent kit production_roots."
+        ),
+    )
     parser.add_argument("--live-root", action="append", type=Path, default=[])
     parser.add_argument("--repo-root", type=Path, default=repo_root)
     parser.add_argument("--file-timeout", type=int, default=30)
@@ -277,8 +330,10 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        roots = args.live_root or args.paths or list(production_roots(repo_root))
-        paths = require_python_paths(roots)
+        # Same population door as native_crash / timeout / bare_exception:
+        # refuse empty args. Kit production_roots is never an implied default.
+        roots = list(args.live_root) + list(args.paths)
+        paths = require_explicit_scan_roots(roots)
     except ValueError as error:
         print(f"SILENT ZERO-TOLERANCE RED: {error}")
         return 1

--- a/implementations/python/sugar-lift-py-tests/tests/test_silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_silent_zero_tolerance.py
@@ -66,12 +66,19 @@ def test_wrong_kind_at_same_coordinate_is_silent() -> None:
 
 
 def test_production_roots_cover_package_and_corpus_tooling(tmp_path: Path) -> None:
+    """Kit roots still exist for intentional self-check — never CLI default."""
     roots = _SCANNER.production_roots(tmp_path)
 
     assert roots == (
         tmp_path / "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests",
         tmp_path / "implementations/python/sugar-lift-py-tests/scripts",
     )
+
+
+def test_empty_scan_roots_are_refused() -> None:
+    """Wrong-population door closed: empty args cannot green on kit default."""
+    with pytest.raises(ValueError, match="scan roots must be explicit"):
+        _SCANNER.require_explicit_scan_roots(())
 
 
 def test_empty_surface_is_loud(tmp_path: Path) -> None:

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -72,10 +72,11 @@ def test_binding_job_invokes_every_permanent_axis() -> None:
             "R_native_crashes = 0",
             "R_bare_exceptions = 0",
             "R_timeouts = 0",
+            "R_silent = 0",
         }:
-            # Process floors must name a population. Bare script invocation
-            # used to default to kit production_roots (~444 files) — false
-            # green while the authenticated pandas corpus went unmeasured.
+            # Process floors + Criterion-2 silent must name a population.
+            # Bare silent_zero_tolerance used to default to kit production_roots
+            # (~444 files) — false green while authenticated pandas was unmeasured.
             assert "PANDAS_CORPUS" in step or "authenticated_pandas" in step, (
                 f"{axis} must pass an explicit corpus path; silent default "
                 "to kit production_roots is a wrong-population false green"
@@ -87,19 +88,20 @@ def test_binding_job_invokes_every_permanent_axis() -> None:
 
 
 def test_process_floors_resolve_authenticated_pandas_population() -> None:
-    """The floor set must authenticate pandas before the three process axes."""
+    """The floor set must authenticate pandas before the four corpus axes."""
     floors = FLOOR_SET.read_text()
     assert "authenticated_pandas_corpus" in floors, (
         "process floors must resolve the authenticated pandas corpus root"
     )
     assert "PANDAS_CORPUS=" in floors
-    # Order: corpus resolved once, then all three axes use it.
+    # Order: corpus resolved once, then all four Criterion-2 population axes use it.
     corpus_at = floors.find("PANDAS_CORPUS=")
     native_at = floors.find('axis "R_native_crashes = 0"')
     bare_at = floors.find('axis "R_bare_exceptions = 0"')
     timeout_at = floors.find('axis "R_timeouts = 0"')
-    assert 0 <= corpus_at < native_at < bare_at < timeout_at, (
-        "PANDAS_CORPUS must be bound before the process-floor axes"
+    silent_at = floors.find('axis "R_silent = 0"')
+    assert 0 <= corpus_at < native_at < bare_at < timeout_at < silent_at, (
+        "PANDAS_CORPUS must be bound before native/bare/timeout/silent axes"
     )
 
 

--- a/tools/run_sole_construction_floors.sh
+++ b/tools/run_sole_construction_floors.sh
@@ -70,6 +70,11 @@ axis "R_bare_exceptions = 0" \
 axis "R_timeouts = 0" \
   python "$SCRIPTS/timeout_zero_tolerance.py" "$PANDAS_CORPUS" \
   --repo-root "$PANDAS_CORPUS"
+# R_silent is Criterion 2's fourth simultaneous term — same population as the
+# three process floors. Kit-default silent was a false green (unmeasured corpus).
+axis "R_silent = 0" \
+  python "$SCRIPTS/silent_zero_tolerance.py" "$PANDAS_CORPUS" \
+  --repo-root "$PANDAS_CORPUS"
 
 axis "All permanent axes are bound" \
   python -m pytest tests/test_python_sole_construction_ci.py -q
@@ -84,7 +89,8 @@ axis "R_vendor_special_case = 0" python "$SCRIPTS/vendor_special_case_law.py"
 
 axis "R_silent discrimination" \
   python -m pytest --noconftest "$TESTS/tests/test_silent_zero_tolerance.py" -q
-axis "R_silent = 0" python "$SCRIPTS/silent_zero_tolerance.py"
+# Live R_silent over corpus is bound with the process floors above (PANDAS_CORPUS).
+# Do not re-invoke with kit defaults — that is the wrong-population door.
 
 axis "R_factory_walk_unclassified discrimination" \
   python -m pytest --noconftest "$TESTS/tests/test_factory_walk_unclassified_law.py" -q


### PR DESCRIPTION
## Finding (report-first)

Criterion 2 requires over the **authenticated pandas corpus**:

`R(construction panics) = R(native crashes) = R(timeouts) = R(silent/unaccounted) = 0` **simultaneously**.

| Term | Instrument | Bound population in sole-construction floors |
| --- | --- | --- |
| native crashes | `native_crash_zero_tolerance.py` | **PANDAS_CORPUS** (explicit) |
| timeouts | `timeout_zero_tolerance.py` | **PANDAS_CORPUS** |
| bare exceptions | `bare_exception_zero_tolerance.py` | **PANDAS_CORPUS** |
| **silent/unaccounted** | `silent_zero_tolerance.py` | **was kit `production_roots` (~444)** |

**Does any instrument produce silent/unaccounted over authenticated pandas?**  
**No** — not on the bound measurement path. The class owner exists; the **corpus population was never entered**. Live R over pandas: **UNMEASURED** (not 0).

That is the same shape as compatibility_door an hour ago: a term declared part of DONE and never measured on the population that matters — here as a **wrong-population false green**, not a missing file.

## Definition (predicate)

```
silent ⇔ (file, line, col, kind) ∈ disk_census
         ∧ (file, line, col, kind) ∉ roll_call{warranted ∪ unresolved}
```

A stated assert/body locus that never appears on the construction roll call.

### Not this class (no collapse)

| Axis | Difference |
| --- | --- |
| `Unmeasured` / SHELF_UNMEASURED | No measurement reading taken |
| Heavy attendance absent-artifact | Job never ran / no artifact |
| Gap / ConstructionPanic | Instrument engaged; classified unfinished |
| **R_silent** | Disk locus never on the roll call |

## Recognition in this PR (no drain, no corpus run)

1. Document Criterion-2 silent class on `silent_zero_tolerance.py`
2. **`require_explicit_scan_roots`** — empty args refuse (kit default unrepresentable)
3. Bind `R_silent = 0` to `"$PANDAS_CORPUS"` beside the three process floors
4. CI pin: silent is a fourth corpus axis (must pass PANDAS_CORPUS)

**Did not** run the pandas silent floor (S0.2 floors contending; no lease).

## Shot accounting

- **R axis:** `R_silent` population seal (corpus binding)
- **Live R over pandas:** UNMEASURED until next leased sole-construction pass
- **Epsilon R:** n/a (recognition / binding; no locus drain)
- **Shell deleted:** silent kit-default CLI door
- **R parked** until S1.1; no re-rank claim

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require explicit scan roots for the `R_silent = 0` CI floor axis
> - The `silent_zero_tolerance.py` CLI no longer falls back to kit `production_roots` when no paths are provided; it now requires non-empty explicit scan roots via `require_explicit_scan_roots`, raising `ValueError` and exiting with status 1 if none are given.
> - The `R_silent = 0` axis in [run_sole_construction_floors.sh](https://github.com/TSavo/sugar/pull/7001/files#diff-2425932b3b3850c1dce0e1350ce9dadb9c8d59942a7fb072ba19c29e2f913421) now passes `$PANDAS_CORPUS` explicitly, replacing the previous argument-less invocation that silently defaulted to kit roots.
> - CI tests in [test_python_sole_construction_ci.py](https://github.com/TSavo/sugar/pull/7001/files#diff-b94b7a42638a5f3bf792d21deb778da5ee5b7f32e26a112cf32599b545b71fe0) now assert that `R_silent = 0` receives an explicit corpus path and is ordered after the other process-floor axes.
> - Behavioral Change: any invocation of `silent_zero_tolerance.py` without explicit scan roots now fails loudly instead of scanning kit defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28411da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->