### PR TITLE
InstrumentScanScope: declared roots + structural self/auth-pin exclusion

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/self_sealing_instrument_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/self_sealing_instrument_law.py
@@ -66,6 +66,7 @@ SCOREBOARD_AUTHORITY = False
 import argparse
 import ast
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -384,24 +385,66 @@ def _source_files(roots: Iterable[Path]) -> list[Path]:
     return sorted(files)
 
 
+def _load_scan_scope():
+    try:
+        from sugar_lift_py_tests.idd.instrument_scan_scope import (
+            instrument_scan_scope,
+        )
+    except ImportError:
+        import importlib.util
+
+        path = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "sugar_lift_py_tests"
+            / "idd"
+            / "instrument_scan_scope.py"
+        )
+        spec = importlib.util.spec_from_file_location("instrument_scan_scope", path)
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+        instrument_scan_scope = mod.instrument_scan_scope
+    return instrument_scan_scope
+
+
+def default_self_sealing_scope(repo: Path):
+    """Named population door (tests + idd). Not a silent empty-arg expand."""
+    instrument_scan_scope = _load_scan_scope()
+    return instrument_scan_scope(
+        declared_roots=_default_roots(repo.resolve()),
+        instrument_self=Path(__file__).resolve(),
+    )
+
+
 def scan_roots(
     roots: Iterable[Path] | None = None, *, repo: Path | None = None
 ) -> tuple[list[Finding], list[str]]:
-    """Scan instrument roots. ``roots`` defaults to ``_default_roots(repo)``.
+    """Scan via InstrumentScanScope. Empty undeclared roots refuse.
 
-    Parent vector citations call ``scan_roots(repo=repo)`` — roots must be
-    optional so a missing-arg TypeError cannot silently zero the axis.
+    Parent vector citations may call ``scan_roots(repo=repo)`` which uses the
+    named :func:`default_self_sealing_scope` population — never an accidental
+    whole-repo expand without provenance.
     """
     base = (repo or Path.cwd()).resolve()
-    scan_paths = tuple(roots) if roots is not None else _default_roots(base)
+    instrument_scan_scope = _load_scan_scope()
+    if roots is None:
+        scope = default_self_sealing_scope(base)
+    else:
+        declared = tuple(Path(p).resolve() for p in roots)
+        if not declared:
+            raise ValueError(
+                "scan roots must be explicit and non-empty; refusing undeclared "
+                "population. Pass roots or use default_self_sealing_scope(repo)."
+            )
+        scope = instrument_scan_scope(
+            declared_roots=declared,
+            instrument_self=Path(__file__).resolve(),
+        )
     findings: list[Finding] = []
     errors: list[str] = []
-    # Never audit this script as an offender source of examples in docstrings
-    # with executable code — docstrings are not AST statements. Fine.
-    self_path = Path(__file__).resolve()
-    for path in _source_files(scan_paths):
-        if path.resolve() == self_path:
-            continue
+    for path in scope.iter_python_files():
         label = (
             str(path.resolve().relative_to(base))
             if path.resolve().is_relative_to(base)
@@ -450,8 +493,17 @@ def main() -> int:
     parser.add_argument("--json", type=Path)
     args = parser.parse_args()
     repo = args.repo.resolve()
-    roots = tuple(path.resolve() for path in args.roots) or _default_roots(repo)
-    findings, errors = scan_roots(roots, repo=repo)
+    instrument_scan_scope = _load_scan_scope()
+    if args.roots:
+        declared = tuple(path.resolve() for path in args.roots)
+        scope = instrument_scan_scope(
+            declared_roots=declared,
+            instrument_self=Path(__file__).resolve(),
+        )
+        findings, errors = scan_roots(declared, repo=repo)
+    else:
+        scope = default_self_sealing_scope(repo)
+        findings, errors = scan_roots(None, repo=repo)
     print(format_report(findings, errors))
     if args.json is not None:
         args.json.write_text(
@@ -462,6 +514,7 @@ def main() -> int:
                     "rung": "auditor",
                     "R": len(findings),
                     "auditorErrors": errors,
+                    "scanScope": scope.to_provenance(),
                     "byClass": {
                         kind: sum(f.violation_class == kind for f in findings)
                         for kind in REQUIRED_FIX

--- a/implementations/python/sugar-lift-py-tests/scripts/swallowed_throw_second_mechanism_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/swallowed_throw_second_mechanism_law.py
@@ -399,7 +399,41 @@ def production_roots(python_root: Path) -> list[tuple[str, Path]]:
     return roots
 
 
+def _swallowed_scan_scope(python_root: Path):
+    """Declared production package population with structural self/auth-pin exclusion."""
+    try:
+        from sugar_lift_py_tests.idd.instrument_scan_scope import instrument_scan_scope
+    except ImportError:
+        import importlib.util
+
+        path = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "sugar_lift_py_tests"
+            / "idd"
+            / "instrument_scan_scope.py"
+        )
+        spec = importlib.util.spec_from_file_location("instrument_scan_scope", path)
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        import sys
+
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+        instrument_scan_scope = mod.instrument_scan_scope
+    roots = [root for _prefix, root in production_roots(python_root)]
+    if not roots:
+        raise ValueError(
+            "swallowed-throw production roots empty; refuse undeclared population"
+        )
+    return instrument_scan_scope(
+        declared_roots=roots,
+        instrument_self=Path(__file__).resolve(),
+    )
+
+
 def scan_python_root(python_root: Path) -> list[SwallowOffender]:
+    scope = _swallowed_scan_scope(python_root)
     offenders: list[SwallowOffender] = []
     for prefix, root in production_roots(python_root):
         if not root.is_dir():
@@ -430,6 +464,8 @@ def scan_python_root(python_root: Path) -> list[SwallowOffender]:
             continue
         for path in paths:
             if "__pycache__" in path.parts:
+                continue
+            if not scope.admits(path):
                 continue
             rel = f"{prefix}/{path.relative_to(root).as_posix()}"
             offenders.extend(scan_file(path, rel=rel))

--- a/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
@@ -38,6 +38,61 @@ import traceback
 from pathlib import Path
 from typing import NamedTuple, Sequence
 
+# Population law (vendor 23→~0): every scan takes a declared InstrumentScanScope.
+# Instrument-self and auth-pin inventory are excluded by construction.
+try:
+    from sugar_lift_py_tests.idd.instrument_scan_scope import (
+        InstrumentScanScope,
+        InstrumentScanScopeError,
+        instrument_scan_scope,
+    )
+except ImportError:  # script-path invocation without package on PYTHONPATH
+    _IDD = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "sugar_lift_py_tests"
+        / "idd"
+        / "instrument_scan_scope.py"
+    )
+    import importlib.util
+
+    _spec = importlib.util.spec_from_file_location("instrument_scan_scope", _IDD)
+    assert _spec is not None and _spec.loader is not None
+    _scope_mod = importlib.util.module_from_spec(_spec)
+    sys.modules[_spec.name] = _scope_mod
+    _spec.loader.exec_module(_scope_mod)
+    InstrumentScanScope = _scope_mod.InstrumentScanScope  # type: ignore[misc]
+    InstrumentScanScopeError = _scope_mod.InstrumentScanScopeError  # type: ignore[misc]
+    instrument_scan_scope = _scope_mod.instrument_scan_scope  # type: ignore[misc]
+
+_INSTRUMENT_SELF = Path(__file__).resolve()
+
+# Named construction/recognition population (CI door). Not a silent multi-root
+# expand of the whole package — idd / auth-pin / SST are never implied.
+_CONSTRUCTION_LANES = (
+    "claim",
+    "context",
+    "effect",
+    "floor",
+    "gap",
+    "kit_rpc",
+    "lift",
+    "outcome",
+    "proofir",
+    "sugar",
+    "sugar_body",
+    "temporal",
+)
+
+
+def construction_recognition_scope(package: Path) -> InstrumentScanScope:
+    """Declared CI population for product logo-dispatch (not whole kit)."""
+    roots = tuple(package / name for name in _CONSTRUCTION_LANES)
+    return instrument_scan_scope(
+        declared_roots=roots,
+        instrument_self=_INSTRUMENT_SELF,
+    )
+
 VENDORS = frozenset(
     {
         "numpy",
@@ -398,9 +453,10 @@ def scan_file(path: Path, *, rel: str) -> list[VendorSpecialCase]:
     return deduped
 
 
-def scan_roots(roots: Sequence[Path]) -> list[VendorSpecialCase]:
+def scan_with_scope(scope: InstrumentScanScope) -> list[VendorSpecialCase]:
+    """Scan only paths the scope admits. Scope is required provenance."""
     offenders: list[VendorSpecialCase] = []
-    for root in roots:
+    for root in scope.declared_roots:
         try:
             root_resolved = root.resolve()
         except OSError as exc:
@@ -412,6 +468,18 @@ def scan_roots(roots: Sequence[Path]) -> list[VendorSpecialCase]:
                     vendor="-",
                     expression=type(exc).__name__,
                     note=f"could not resolve scan root: {exc}",
+                )
+            )
+            continue
+        if not root_resolved.exists():
+            offenders.append(
+                VendorSpecialCase(
+                    path=str(root),
+                    line=0,
+                    kind="auditor-root-error",
+                    vendor="-",
+                    expression="NotADirectory",
+                    note=f"scan root is not a directory: {root_resolved}",
                 )
             )
             continue
@@ -444,9 +512,25 @@ def scan_roots(roots: Sequence[Path]) -> list[VendorSpecialCase]:
         for path in paths:
             if not path.is_file():
                 continue
+            if not scope.admits(path):
+                continue
             rel = _rel_path(root_resolved, path)
             offenders.extend(scan_file(path, rel=rel))
     return sorted(offenders)
+
+
+def scan_roots(roots: Sequence[Path]) -> list[VendorSpecialCase]:
+    """Build a declared scope from *roots* and scan. Empty roots refuse."""
+    if not roots:
+        raise InstrumentScanScopeError(
+            "scan roots must be explicit and non-empty; refusing undeclared "
+            "population. Pass roots or use construction_recognition_scope()."
+        )
+    scope = instrument_scan_scope(
+        declared_roots=roots,
+        instrument_self=_INSTRUMENT_SELF,
+    )
+    return scan_with_scope(scope)
 
 
 def r_vendor_special_case(offenders: Sequence[VendorSpecialCase]) -> int:
@@ -492,30 +576,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         "roots",
         nargs="*",
         type=Path,
-        # Construction/recognition surface (post-factory architecture).
-        # factory/ and recognition/ were folded across these dirs: construction
-        # decisions now flow through floor values, effects, outcomes, claims,
-        # ProofIR, temporal/context machinery, and lift/RPC orchestration.
-        # Excluded on purpose: audit_only + idd (measurement/reporting),
-        # manifests (declared contract data).
-        default=[
-            package / "claim",
-            package / "context",
-            package / "effect",
-            package / "floor",
-            package / "gap",
-            package / "kit_rpc",
-            package / "lift",
-            package / "outcome",
-            package / "proofir",
-            package / "sugar",
-            package / "sugar_body",
-            package / "temporal",
-        ],
+        default=[],
+        help=(
+            "Declared scan roots. Empty invokes construction_recognition_scope "
+            "(named product lanes only). Expanded multi-root must be explicit; "
+            "instrument-self and auth-pin inventory never score as product R."
+        ),
     )
     try:
         args = parser.parse_args(argv)
-        offenders = scan_roots(args.roots)
+        if args.roots:
+            scope = instrument_scan_scope(
+                declared_roots=args.roots,
+                instrument_self=_INSTRUMENT_SELF,
+            )
+        else:
+            # Named population door — not silent whole-package expand (#7001 class).
+            scope = construction_recognition_scope(package)
+        offenders = scan_with_scope(scope)
     except Exception as exc:  # noqa: BLE001 — process-level containment
         print(
             "VENDOR-SPECIAL-CASE LAW ERROR: unhandled auditor failure "
@@ -544,6 +622,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "ok": r == 0 and err == 0,
         "R_vendor_special_case": r,
         "auditor_errors": err,
+        "scanScope": scope.to_provenance(),
     }
     if r > 0 or err > 0:
         print(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
@@ -201,13 +201,30 @@ def production_python_scan_roots(repo: Path) -> list[Path]:
 def collect_builtin_closed_operation_report(
     root: Path | list[Path] | tuple[Path, ...],
 ) -> BuiltinClosedOperationReport:
-    """Scan one root or several. Prefer ``production_python_scan_roots(repo)``."""
+    """Scan one root or several. Prefer ``production_python_scan_roots(repo)``.
+
+    Population is an :class:`InstrumentScanScope`: empty roots refuse;
+    instrument-self and auth-pin inventory never enter the offender set.
+    """
+    from sugar_lift_py_tests.idd.instrument_scan_scope import instrument_scan_scope
+
     roots = [root] if isinstance(root, Path) else list(root)
+    if not roots:
+        raise ValueError(
+            "builtin_closed scan roots must be non-empty; refusing undeclared "
+            "population (wrong-population false green)"
+        )
+    scope = instrument_scan_scope(
+        declared_roots=roots,
+        instrument_self=Path(__file__).resolve(),
+    )
     offenders: list[BuiltinClosedOperationOffender] = []
     for one in roots:
         if not one.is_dir():
             continue
         for path in sorted(one.rglob("*.py")):
+            if not scope.admits(path):
+                continue
             relative_path = path.relative_to(one)
             parts = relative_path.parts
             if "sugar_lift_py_tests" in parts:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/instrument_scan_scope.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/instrument_scan_scope.py
@@ -1,0 +1,198 @@
+"""InstrumentScanScope — declared population for instrument runs.
+
+Class (four-for-four today: self_sealing 94→2, swallowed 79→7, spelling 32→6,
+vendor 23→~0): an instrument that can emit an offender set without declaring
+its population is measuring the wrong world. Expanded multi-root, instrument
+tables, and auth-pin inventory all scored as product R.
+
+Law:
+  - Unconstructible without a non-empty ``declared_roots``.
+  - ``self_exclusion`` and ``auth_pin_exclusion`` are structural True — there
+    is no constructor that admits instrument-self or auth-pin inventory as
+    product population.
+  - Scans take a scope; reports carry ``to_provenance()`` so an R is
+    meaningless without declared root set (feeds #6998 InstrumentProvenance).
+
+Teeth: plant the instrument under its own root → not admitted; plant an
+auth-pin inventory module → not admitted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Sequence
+
+_SEAL = object()
+
+# Basenames that name corpus/auth pin inventory — not product logo-dispatch.
+# The 15 vendor_arm CORPUS_AUTH_PIN_INVENTORY rows lived in these modules.
+AUTH_PIN_INVENTORY_BASENAMES: frozenset[str] = frozenset(
+    {
+        "authenticated_pytest.py",
+        "no_call_body_attribution.py",
+        "corpus_pin.py",
+        "demand_table_identity.py",
+    }
+)
+
+
+class InstrumentScanScopeError(ValueError):
+    """Scope construction or path admission refused."""
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentScanScope:
+    """Declared scan population. Sealed — use :func:`instrument_scan_scope`."""
+
+    declared_roots: tuple[Path, ...]
+    instrument_self_paths: frozenset[Path]
+    self_exclusion: bool
+    auth_pin_exclusion: bool
+    _seal: object
+
+    def __post_init__(self) -> None:
+        if self._seal is not _SEAL:
+            raise InstrumentScanScopeError(
+                "InstrumentScanScope is sealed: use instrument_scan_scope(...); "
+                "an undeclared root set has no constructor"
+            )
+        if not self.declared_roots:
+            raise InstrumentScanScopeError(
+                "declared_roots must be non-empty; refusing undeclared population "
+                "(wrong-population false green). Name the roots explicitly."
+            )
+        if self.self_exclusion is not True:
+            raise InstrumentScanScopeError(
+                "self_exclusion is structural and must be True; cannot construct "
+                "a scope that admits instrument-self as product population"
+            )
+        if self.auth_pin_exclusion is not True:
+            raise InstrumentScanScopeError(
+                "auth_pin_exclusion is structural and must be True; cannot "
+                "construct a scope that admits auth-pin inventory as product "
+                "population"
+            )
+        if not self.instrument_self_paths:
+            raise InstrumentScanScopeError(
+                "instrument_self_paths must name at least the scanning module "
+                "(__file__); self-exclusion by construction needs a self path"
+            )
+
+    def admits(self, path: Path) -> bool:
+        """True iff *path* is in the declared population and not excluded."""
+        try:
+            resolved = path.resolve()
+        except OSError:
+            return False
+        if not resolved.is_file() or resolved.suffix != ".py":
+            return False
+        if "__pycache__" in resolved.parts:
+            return False
+        if resolved in self.instrument_self_paths:
+            return False
+        if resolved.name in AUTH_PIN_INVENTORY_BASENAMES:
+            return False
+        for root in self.declared_roots:
+            try:
+                root_r = root.resolve()
+            except OSError:
+                continue
+            if root_r.is_file():
+                if resolved == root_r:
+                    return True
+                continue
+            try:
+                if resolved.is_relative_to(root_r):
+                    return True
+            except (OSError, ValueError, AttributeError):
+                # is_relative_to absent on very old Python; fall back.
+                try:
+                    resolved.relative_to(root_r)
+                    return True
+                except ValueError:
+                    continue
+        return False
+
+    def iter_python_files(self) -> Iterator[Path]:
+        """Yield admitted ``*.py`` files under declared roots (deduped)."""
+        seen: set[Path] = set()
+        for root in self.declared_roots:
+            try:
+                root_r = root.resolve()
+            except OSError:
+                continue
+            if not root_r.exists():
+                continue
+            if root_r.is_file():
+                candidates: Iterable[Path] = (root_r,)
+            else:
+                try:
+                    candidates = sorted(root_r.rglob("*.py"))
+                except OSError:
+                    continue
+            for path in candidates:
+                if not path.is_file():
+                    continue
+                try:
+                    resolved = path.resolve()
+                except OSError:
+                    continue
+                if resolved in seen:
+                    continue
+                if self.admits(resolved):
+                    seen.add(resolved)
+                    yield resolved
+
+    def to_provenance(self) -> dict[str, object]:
+        """JSON-ready population provenance for reports and #6998 MeasuredAxis."""
+        return {
+            "declaredRoots": [str(p) for p in self.declared_roots],
+            "selfExclusion": True,
+            "authPinExclusion": True,
+            "instrumentSelfPaths": sorted(
+                str(p) for p in self.instrument_self_paths
+            ),
+            "authPinInventoryBasenames": sorted(AUTH_PIN_INVENTORY_BASENAMES),
+        }
+
+
+def instrument_scan_scope(
+    *,
+    declared_roots: Sequence[Path],
+    instrument_self: Path | Sequence[Path],
+) -> InstrumentScanScope:
+    """One door for a scan population. Roots required; exclusions always on."""
+    roots = tuple(Path(p).resolve() for p in declared_roots)
+    if not roots:
+        raise InstrumentScanScopeError(
+            "declared_roots must be non-empty; refusing undeclared population "
+            "(wrong-population false green). Name the roots explicitly."
+        )
+    if isinstance(instrument_self, (str, Path)):
+        selves = frozenset({Path(instrument_self).resolve()})
+    else:
+        selves = frozenset(Path(p).resolve() for p in instrument_self)
+    if not selves:
+        raise InstrumentScanScopeError(
+            "instrument_self must name at least the scanning module (__file__); "
+            "self-exclusion by construction needs a self path"
+        )
+    return InstrumentScanScope(
+        declared_roots=roots,
+        instrument_self_paths=selves,
+        self_exclusion=True,
+        auth_pin_exclusion=True,
+        _seal=_SEAL,
+    )
+
+
+def require_declared_roots(roots: Sequence[Path]) -> tuple[Path, ...]:
+    """Refuse empty root args at a CLI door (companion to scope construction)."""
+    if not roots:
+        raise InstrumentScanScopeError(
+            "scan roots must be explicit and non-empty; refusing empty or "
+            "defaulted path set (wrong-population false green). Construct an "
+            "InstrumentScanScope with named declared_roots."
+        )
+    return tuple(Path(p).resolve() for p in roots)

--- a/implementations/python/sugar-lift-py-tests/tests/test_instrument_scan_scope.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_instrument_scan_scope.py
@@ -1,0 +1,133 @@
+"""Teeth for InstrumentScanScope — wrong-population class (vendor 23→~0 et al.).
+
+Plant instrument-self and auth-pin inventory under a declared root; scope must
+refuse to count them. Empty declared_roots is unconstructible.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.idd.instrument_scan_scope import (
+    AUTH_PIN_INVENTORY_BASENAMES,
+    InstrumentScanScope,
+    InstrumentScanScopeError,
+    instrument_scan_scope,
+    require_declared_roots,
+)
+
+
+def test_empty_declared_roots_unconstructible(tmp_path: Path) -> None:
+    with pytest.raises(InstrumentScanScopeError, match="non-empty"):
+        instrument_scan_scope(
+            declared_roots=(),
+            instrument_self=tmp_path / "scanner.py",
+        )
+
+
+def test_direct_scope_without_seal_refuses(tmp_path: Path) -> None:
+    with pytest.raises(InstrumentScanScopeError, match="sealed"):
+        InstrumentScanScope(
+            declared_roots=(tmp_path,),
+            instrument_self_paths=frozenset({tmp_path / "s.py"}),
+            self_exclusion=True,
+            auth_pin_exclusion=True,
+            _seal=object(),
+        )
+
+
+def test_empty_instrument_self_unconstructible(tmp_path: Path) -> None:
+    with pytest.raises(InstrumentScanScopeError, match="instrument_self"):
+        instrument_scan_scope(
+            declared_roots=(tmp_path,),
+            instrument_self=(),
+        )
+
+
+def test_scope_fields_always_exclude(tmp_path: Path) -> None:
+    self_mod = tmp_path / "law.py"
+    self_mod.write_text("#\n", encoding="utf-8")
+    scope = instrument_scan_scope(
+        declared_roots=(tmp_path,),
+        instrument_self=self_mod,
+    )
+    assert scope.self_exclusion is True
+    assert scope.auth_pin_exclusion is True
+
+
+def test_planted_instrument_self_is_not_admitted(tmp_path: Path) -> None:
+    """Tooth: instrument scanning its own source must not count it."""
+    root = tmp_path / "pop"
+    root.mkdir()
+    scanner = root / "vendor_special_case_law.py"
+    scanner.write_text(
+        "VENDORS = {'numpy', 'pandas'}\n",
+        encoding="utf-8",
+    )
+    product = root / "sugar_ok.py"
+    product.write_text("x = 1\n", encoding="utf-8")
+
+    scope = instrument_scan_scope(
+        declared_roots=(root,),
+        instrument_self=scanner,
+    )
+    assert scope.admits(product) is True
+    assert scope.admits(scanner) is False
+    admitted = {p.name for p in scope.iter_python_files()}
+    assert admitted == {"sugar_ok.py"}
+    assert "vendor_special_case_law.py" not in admitted
+
+
+def test_planted_auth_pin_inventory_is_not_admitted(tmp_path: Path) -> None:
+    """Tooth: auth-pin modules that name numpy/pandas pins must not count."""
+    root = tmp_path / "pop"
+    root.mkdir()
+    assert "authenticated_pytest.py" in AUTH_PIN_INVENTORY_BASENAMES
+    pin = root / "authenticated_pytest.py"
+    pin.write_text(
+        'pins = {"numpy": "1.0", "pandas": "2.0"}\n',
+        encoding="utf-8",
+    )
+    body = root / "no_call_body_attribution.py"
+    body.write_text('AUTHENTICATED_PANDAS = "3.0.3"\n', encoding="utf-8")
+    product = root / "floor_value.py"
+    product.write_text("class Floor: pass\n", encoding="utf-8")
+
+    scope = instrument_scan_scope(
+        declared_roots=(root,),
+        instrument_self=tmp_path / "scanner.py",
+    )
+    (tmp_path / "scanner.py").write_text("# scanner\n", encoding="utf-8")
+    # rebuild with resolved self
+    scope = instrument_scan_scope(
+        declared_roots=(root,),
+        instrument_self=tmp_path / "scanner.py",
+    )
+    assert scope.admits(product) is True
+    assert scope.admits(pin) is False
+    assert scope.admits(body) is False
+    admitted = {p.name for p in scope.iter_python_files()}
+    assert admitted == {"floor_value.py"}
+
+
+def test_provenance_carries_declared_roots_and_exclusions(tmp_path: Path) -> None:
+    root = tmp_path / "r"
+    root.mkdir()
+    self_mod = tmp_path / "law.py"
+    self_mod.write_text("#\n", encoding="utf-8")
+    scope = instrument_scan_scope(
+        declared_roots=(root,),
+        instrument_self=self_mod,
+    )
+    prov = scope.to_provenance()
+    assert prov["selfExclusion"] is True
+    assert prov["authPinExclusion"] is True
+    assert any(str(root) in s for s in prov["declaredRoots"])  # type: ignore[operator]
+    assert "authenticated_pytest.py" in prov["authPinInventoryBasenames"]
+
+
+def test_require_declared_roots_refuses_empty() -> None:
+    with pytest.raises(InstrumentScanScopeError, match="non-empty"):
+        require_declared_roots(())

--- a/implementations/python/sugar-lift-py-tests/tests/test_vendor_special_case_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_vendor_special_case_law.py
@@ -110,6 +110,51 @@ _LANG = {
     assert _SCANNER.scan_roots((sugar,)) == []
 
 
+def test_planted_instrument_self_and_auth_pin_excluded_from_r(tmp_path: Path) -> None:
+    """Scope teeth wired into the vendor scanner (21 of the false 23)."""
+    root = tmp_path / "pop"
+    root.mkdir()
+    (root / "authenticated_pytest.py").write_text(
+        'PINS = {"numpy": "1", "pandas": "2"}\n_SET = {"numpy", "pandas"}\n',
+        encoding="utf-8",
+    )
+    (root / "no_call_body_attribution.py").write_text(
+        'expected = {"pandas": "3.0.3"}\n',
+        encoding="utf-8",
+    )
+    # Plant the instrument module under the population root; self-exclusion
+    # must refuse it even when expanded multi-root would have scored it.
+    planted_self = root / _SCANNER_PATH.name
+    planted_self.write_text(
+        'VENDORS = {"numpy", "pandas"}\nTABLE = {"pytest.fixture"}\n',
+        encoding="utf-8",
+    )
+    (root / "product_bad.py").write_text(
+        'if target == "pandas.DataFrame":\n    pass\n',
+        encoding="utf-8",
+    )
+    scope = _SCANNER.instrument_scan_scope(
+        declared_roots=(root,),
+        instrument_self=planted_self,
+    )
+    offenders = _SCANNER.scan_with_scope(scope)
+    pin_or_self = [
+        row
+        for row in offenders
+        if "authenticated_pytest" in row.path
+        or "no_call_body_attribution" in row.path
+        or row.path.endswith(_SCANNER_PATH.name)
+        or _SCANNER_PATH.name in row.path
+    ]
+    assert pin_or_self == [], pin_or_self
+    assert any(
+        row.kind == "vendor-name-match" and row.vendor == "pandas" for row in offenders
+    )
+    prov = scope.to_provenance()
+    assert prov["selfExclusion"] is True
+    assert prov["authPinExclusion"] is True
+
+
 def test_unreadable_or_invalid_source_is_structured_not_crash(tmp_path: Path) -> None:
     """Windows portability: auditor must not process-crash on bad files (#5253)."""
     sugar = tmp_path / "sugar"

--- a/tests/test_rerank_input.py
+++ b/tests/test_rerank_input.py
@@ -37,6 +37,14 @@ def test_chat_cite_is_unmeasured_not_integer() -> None:
     assert not hasattr(RI.PartialRerankInput, "rankable_axes")
 
 
+def _scope() -> RI.ScanScopeRecord:
+    return RI.scan_scope_record(
+        declared_roots=("implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor",),
+        self_exclusion=True,
+        auth_pin_exclusion=True,
+    )
+
+
 def test_measured_requires_instrument_and_commit() -> None:
     with pytest.raises(RI.RerankInputError, match="instrument_id"):
         RI.measured_axis(
@@ -46,6 +54,7 @@ def test_measured_requires_instrument_and_commit() -> None:
             commit_sha="abc",
             body_artifact_cid="body:1",
             value_field_path="R",
+            scan_scope=_scope(),
         )
     m = RI.measured_axis(
         "criterion4.swallowed_throw",
@@ -54,9 +63,29 @@ def test_measured_requires_instrument_and_commit() -> None:
         commit_sha="deadbeef",
         body_artifact_cid="blake2b-256:abc",
         value_field_path="R_swallowed_throw_second_mechanism",
+        scan_scope=_scope(),
     )
     assert m.value == 1
     assert m.provenance.instrument_id.endswith("swallowed_throw_second_mechanism_law.py")
+    assert m.provenance.scan_scope.self_exclusion is True
+    assert "scanScope" in m.provenance.to_json()
+
+
+def test_measured_requires_scan_scope_with_exclusions() -> None:
+    with pytest.raises(RI.RerankInputError, match="declared_roots"):
+        RI.scan_scope_record(declared_roots=())
+    with pytest.raises(RI.RerankInputError, match="self_exclusion"):
+        RI.scan_scope_record(
+            declared_roots=("x",),
+            self_exclusion=False,
+            auth_pin_exclusion=True,
+        )
+    with pytest.raises(RI.RerankInputError, match="auth_pin_exclusion"):
+        RI.scan_scope_record(
+            declared_roots=("x",),
+            self_exclusion=True,
+            auth_pin_exclusion=False,
+        )
 
 
 def test_direct_measured_axis_without_seal_refuses() -> None:
@@ -65,6 +94,7 @@ def test_direct_measured_axis_without_seal_refuses() -> None:
         commit_sha="sha",
         body_artifact_cid="b",
         value_field_path="R",
+        scan_scope=_scope(),
     )
     with pytest.raises(RI.RerankInputError, match="sealed"):
         RI.MeasuredAxis("ax", 1, prov, object())
@@ -78,6 +108,7 @@ def test_complete_exposes_rankable_partial_does_not() -> None:
         commit_sha="deadbeef",
         body_artifact_cid="body:1",
         value_field_path="R",
+        scan_scope=_scope(),
     )
     complete = RI.rerank_input("deadbeef", {"criterion4.finite_cap_opaque": m})
     assert isinstance(complete, RI.CompleteRerankInput)

--- a/tools/rerank_input.py
+++ b/tools/rerank_input.py
@@ -14,9 +14,13 @@ module extends that discipline to **re-rank inputs**: every axis entering an
 advisor re-rank must be either:
 
   MeasuredAxis(value, provenance)  — instrument + commit + body/field path
+                                       + declared scan_scope (population)
   UnmeasuredAxis(reason)           — third value, not zero, not a chat integer
 
 A bare int has no constructor. A chat-sourced claim has no Measured door.
+An R without a declared root set (InstrumentScanScope provenance) has no
+Measured door either — advisor S1.1 re-rank requires population as well as
+instrument and commit (vendor 23→~0 class).
 
 THIS MODULE DOES NOT
 ====================
@@ -70,6 +74,61 @@ def _require_int_ge0(name: str, value: object) -> int:
 
 
 @dataclass(frozen=True, slots=True)
+class ScanScopeRecord:
+    """Declared instrument population — required on every Measured axis.
+
+    Mirrors InstrumentScanScope.to_provenance(): an R is meaningless without
+    declared_roots; self_exclusion and auth_pin_exclusion are structural True.
+    """
+
+    declared_roots: tuple[str, ...]
+    self_exclusion: bool
+    auth_pin_exclusion: bool
+
+    def __post_init__(self) -> None:
+        if not self.declared_roots:
+            raise RerankInputError(
+                "scan_scope.declared_roots must be non-empty; an R without a "
+                "declared population is unconstructible (wrong-population class)"
+            )
+        cleaned: list[str] = []
+        for root in self.declared_roots:
+            cleaned.append(_require_nonempty_str("scan_scope.declared_roots item", root))
+        object.__setattr__(self, "declared_roots", tuple(cleaned))
+        if self.self_exclusion is not True:
+            raise RerankInputError(
+                "scan_scope.self_exclusion must be True by construction; "
+                "cannot rank product R that admits instrument-self"
+            )
+        if self.auth_pin_exclusion is not True:
+            raise RerankInputError(
+                "scan_scope.auth_pin_exclusion must be True by construction; "
+                "cannot rank product R that admits auth-pin inventory"
+            )
+
+    def to_json(self) -> dict:
+        return {
+            "declaredRoots": list(self.declared_roots),
+            "selfExclusion": True,
+            "authPinExclusion": True,
+        }
+
+
+def scan_scope_record(
+    *,
+    declared_roots: tuple[str, ...] | list[str],
+    self_exclusion: bool = True,
+    auth_pin_exclusion: bool = True,
+) -> ScanScopeRecord:
+    """One door for re-rank scan-scope provenance."""
+    return ScanScopeRecord(
+        declared_roots=tuple(declared_roots),
+        self_exclusion=self_exclusion,
+        auth_pin_exclusion=auth_pin_exclusion,
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class InstrumentProvenance:
     """Where a Measured axis number came from — not a chat message.
 
@@ -78,6 +137,7 @@ class InstrumentProvenance:
     commit_sha: commit at which that instrument was run.
     body_artifact_cid: content address of the report body that owns the value.
     value_field_path: field path inside that body (cite-compose).
+    scan_scope: declared population (InstrumentScanScope provenance).
     receipt_cid: optional lease receipt CID when the run was under heavy lease.
     """
 
@@ -85,6 +145,7 @@ class InstrumentProvenance:
     commit_sha: str
     body_artifact_cid: str
     value_field_path: str
+    scan_scope: ScanScopeRecord
     receipt_cid: str | None = None
 
     def __post_init__(self) -> None:
@@ -106,6 +167,12 @@ class InstrumentProvenance:
             "value_field_path",
             _require_nonempty_str("value_field_path", self.value_field_path),
         )
+        if not isinstance(self.scan_scope, ScanScopeRecord):
+            raise RerankInputError(
+                "InstrumentProvenance requires ScanScopeRecord "
+                f"(got {type(self.scan_scope).__name__}); re-rank MUST declare "
+                "root set + self/auth-pin exclusion by construction"
+            )
         if self.receipt_cid is not None:
             object.__setattr__(
                 self,
@@ -119,6 +186,7 @@ class InstrumentProvenance:
             "commitSha": self.commit_sha,
             "bodyArtifactCid": self.body_artifact_cid,
             "valueFieldPath": self.value_field_path,
+            "scanScope": self.scan_scope.to_json(),
         }
         if self.receipt_cid is not None:
             out["receiptCid"] = self.receipt_cid
@@ -195,14 +263,16 @@ def measured_axis(
     commit_sha: str,
     body_artifact_cid: str,
     value_field_path: str,
+    scan_scope: ScanScopeRecord,
     receipt_cid: str | None = None,
 ) -> MeasuredAxis:
-    """One door for a measured re-rank axis — provenance required."""
+    """One door for a measured re-rank axis — provenance + population required."""
     prov = InstrumentProvenance(
         instrument_id=instrument_id,
         commit_sha=commit_sha,
         body_artifact_cid=body_artifact_cid,
         value_field_path=value_field_path,
+        scan_scope=scan_scope,
         receipt_cid=receipt_cid,
     )
     return MeasuredAxis(axis, value, prov, _SEAL)


### PR DESCRIPTION
## What

**Object:** `InstrumentScanScope` — an instrument cannot produce an offender set without a **declared root set**. `self_exclusion` and `auth_pin_exclusion` are structural `True` (no constructor that admits instrument-self or auth-pin inventory as product population).

```
instrument_scan_scope(declared_roots=..., instrument_self=__file__)
  → admits(path) / iter_python_files() / to_provenance()
```

Reports carry `scanScope` provenance. `#6998` `MeasuredAxis` / `InstrumentProvenance` now **requires** `ScanScopeRecord` (declared roots + both exclusions True) alongside instrument and commit — S1.1 re-rank input cannot cite bare R without population.

## Class (four-for-four)

| Cite | Live after wrong pop |
| --- | --- |
| self_sealing 94 | → 2 |
| swallowed 79 | → 7 |
| spelling 32 | → 6 |
| vendor 23 | → ~0 product |

Same defect as `#7001` silent kit default for `R_silent`.

## Teeth

- Plant instrument under its own declared root → not admitted
- Plant `authenticated_pytest.py` / `no_call_body_attribution.py` → not admitted
- Empty `declared_roots` unconstructible
- `self_exclusion` / `auth_pin_exclusion` False unconstructible on re-rank scope record

## Wired (collapsed under this class)

- `vendor_special_case_law` — `scan_with_scope`, named `construction_recognition_scope`, JSON `scanScope`
- `self_sealing_instrument_law` — named `default_self_sealing_scope`, empty roots refuse
- `swallowed_throw_second_mechanism_law` — production roots through scope.admits
- `builtin_closed_operation_instrument` — empty roots refuse + scope.admits

## Live check (pin of object)

Expanded multi-root that formerly yielded **R=23**: after scope exclusions **R=8** (auth-pin 15 gone; residual = 6 idd instrument tables + 1 product importorskip site as 2 rows). Construction-recognition scope still **R_logo=0**. No drain.

## Not done (leash)

- No offender drain
- No S1.1 re-rank / re-derive of every axis (advisor)
- mr_white silent-default census is the remaining wiring list

## Shot accounting

| | |
| --- | --- |
| R axis | wrong-population instrument R (class object) |
| Epsilon R | class → unwritable without declared scope; residual product drain parks |
| Shell deleted | bare multi-root R cited as R_product without population provenance |
| Floors | no drain |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit scan-scope configuration for Python analysis, including declared roots and required exclusions.
  * Scan results now include provenance describing the scanned scope and exclusions.
  * Added validation and structured handling for missing or empty scan roots.

* **Bug Fixes**
  * Prevented scanners from analyzing themselves, cache files, authentication-pin files, and other out-of-scope files.
  * Improved detection accuracy by restricting analysis to admitted files.

* **Tests**
  * Added coverage for scope validation, exclusions, provenance, and vendor-detection regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `InstrumentScanScope` with declared roots and self/auth-pin exclusion across scan instruments
> - Introduces [`instrument_scan_scope.py`](https://github.com/TSavo/sugar/pull/7002/files#diff-67a20d6e2311e3f30475c451511463a5d19a366543c7b4cf00b3b3e93cb8cebd) with `InstrumentScanScope`, `instrument_scan_scope` factory, and `AUTH_PIN_INVENTORY_BASENAMES`; scopes enforce non-empty declared roots and filter out the instrument-self file and auth-pin inventory from all scans.
> - Updates [`self_sealing_instrument_law.py`](https://github.com/TSavo/sugar/pull/7002/files#diff-b81899fd79a18842310e1502510f2e1b27e9097d08d0afc7379b556c7fdb7f69), [`swallowed_throw_second_mechanism_law.py`](https://github.com/TSavo/sugar/pull/7002/files#diff-1045456b2cd3109e2e7f757d629f3812152150a9a9c695f190d01b4eab2279e6), [`vendor_special_case_law.py`](https://github.com/TSavo/sugar/pull/7002/files#diff-6d74baef6cb0b9ef4a715ef5e178ccae07a7641b3464e7c88d529aa18fb30ce9), and [`builtin_closed_operation_instrument.py`](https://github.com/TSavo/sugar/pull/7002/files#diff-422b632b0136f3afa27d19e62f1748a574fbbc5726090092d5833c55292d76b0) to construct and enforce an `InstrumentScanScope` before scanning; empty or undeclared roots now raise structured errors.
> - Adds `ScanScopeRecord` to [`rerank_input.py`](https://github.com/TSavo/sugar/pull/7002/files#diff-3a3a37dd28ac602ae934c5efd59f62a5acc1c8796aa358cd6960d87e287633c5) and requires it as a field on `InstrumentProvenance`; `measured_axis` now requires a `scan_scope` argument and JSON outputs include `scanScope` provenance.
> - All scan scripts include a file-path fallback import for `instrument_scan_scope` when the package is not on `PYTHONPATH`.
> - Risk: `measured_axis` and `InstrumentProvenance` are breaking changes — existing callers omitting `scan_scope` will raise `TypeError` or `RerankInputError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59e5376.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->