### PR TITLE
DO NOT MERGE: Suite shards by enrollment; no machine-wide lease

### DIFF
--- a/.github/workflows/python-package-suite.yml
+++ b/.github/workflows/python-package-suite.yml
@@ -5,34 +5,44 @@ name: Python package suite (authoritative)
 # `sugar-lift-py-tests` had no PR-gate coverage. `python-sole-construction-floors`
 # runs targeted law scripts with `--noconftest` -- not the suite. The only
 # workflow that touched the whole `sugar-lift-py-tests/tests` directory was
-# `restored-suite-scoreboard`, nightly cron / manual dispatch only. `make
-# test-python` was in no workflow at all. So the unit tests for
-# `ExitSet.and_exit` did not run against #6270, the PR that rewrote that
-# algebra.
+# `restored-suite-scoreboard`, nightly cron / manual dispatch only.
 #
-# This workflow is the ONE authoritative whole-package sweep. Nothing else may
+# This workflow is the ONE authoritative package suite. Nothing else may
 # define, install, or run "the Python suite": the environment comes from
-# ./.github/actions/python-test-environment, and the zero-tolerance floors
-# consume that same action rather than building their own.
+# ./.github/actions/python-test-environment.
 #
-# IT DOES NOT GATE ON VERDICTS; IT DOES GATE ON IDENTITY. ~131 known failures
-# exist. Turning that red into a merge gate is a merge-policy change and this
-# wiring is a measurement-ownership change, so the job records pytest's exit
-# status as evidence and does not exit on it.
+# IT DOES NOT GATE ON VERDICTS; IT DOES GATE ON IDENTITY AND ENROLLMENT.
+# ~131 known failures exist. Verdict red is evidence, not a merge gate.
+# Identity red and missing-shard red fail the campaign: that is UNMEASURED.
 #
-# Identity is a different question from verdicts. A measurement that cannot say
-# which authenticated source and which test-input universe produced its
-# verdicts is not a lenient measurement, it is not a measurement -- so the
-# identity gate DOES fail the job, and the authoritative artifact is not
-# published when it does. The SCHEDULED discrimination job also fails, because
-# order-dependence is not a known failure -- it is a claim that our verdicts
-# are not verdicts.
+# -------------------------------------------------------------------------
+# WHY NOT ONE suite-report.json
+# -------------------------------------------------------------------------
+#
+# A single report implies one writer, which implies serialization, which
+# invited a machine-wide mutex "to protect" it, which starved every corpus
+# floors run for hours. The singleton is the defect.
+#
+# Each shard writes its OWN identity-bound report. Completeness is enrollment
+# (roster of expected shards + roll call), not aggregation into a shared hub.
+# The identity gate runs PER SHARD. Campaign claim: all N shards attended and
+# each is identity-resolved — strictly stronger than one merged blob.
+#
+# No shared resource ⇒ no machine-wide lease. That is the reason, not a
+# preference. Lease stays on floors/recensus/walls (corpus measurement
+# integrity); those are not this workflow.
+#
+# Canonical order is collection order WITHIN a shard's deterministic file set.
+# There is no package-wide sequence under parallel jobs, and no recombine that
+# invents one. Discrimination checks within-shard order-independence only.
+#
+# Shard count (32) lives in tools/python_package_suite_shards.py — one source.
 
 on:
   push:
     branches: [main]
   schedule:
-    # Discrimination cadence: canonical vs reversed vs shuffled, each cold.
+    # Discrimination cadence: canonical vs reversed vs shuffled per shard.
     - cron: "41 7 * * *"
   workflow_dispatch:
     inputs:
@@ -44,30 +54,10 @@ on:
 permissions:
   contents: read
 
-# NO `concurrency:` BLOCK. THAT IS THE FIX.
-#
-# This workflow had its own ref-independent group with cancel-in-progress:
-# false, and it was starved inside that group anyway: five runs (dea47f1f8,
-# e0a78ec52, d243fcacf, 6d9db3a8f, f0cddfd76) cancelled, zero artifacts, until
-# 30174018299 finally landed one behind a merge freeze. `cancel-in-progress:
-# false` only protects a run that has already STARTED; GitHub keeps exactly ONE
-# pending run per group, so every new push EVICTS the queued one. Our own merge
-# rate was the thing killing the measurement.
-#
-# So the queue and the serialization are separated:
-#
-#   GitHub queue: preserve every requested measurement  (no group -- here)
-#   BX lease:     only one heavy measurement executes   (tools/heavy_measurement_lease.py)
-#
-# Every run is retained and every run eventually measures. Overlap is settled
-# on the box by an flock the kernel releases even on SIGKILL, not by a queue
-# that drops the thing it was asked to remember.
+# NO concurrency group (GitHub retains every run). NO heavy_measurement_lease
+# (suite is confidence telemetry; corpus classes hold the measurement mutex).
 
 jobs:
-  # The gate's own discrimination twins. Six teeth, both faces each, no
-  # environment and no lease: pure JSON in, verdict out, seconds. It runs
-  # BEFORE the environment is prepared so a weakened identity gate is red on
-  # its own terms rather than red-by-absence three hours later.
   identity-gate-twins:
     name: identity gate teeth (both faces)
     runs-on: [self-hosted, Linux, X64]
@@ -84,6 +74,9 @@ jobs:
     timeout-minutes: 60
     outputs:
       identity-hash: ${{ steps.env.outputs.identity-hash }}
+      shard-matrix: ${{ steps.shards.outputs.matrix }}
+      shard-list: ${{ steps.shards.outputs.list }}
+      shard-count: ${{ steps.shards.outputs.count }}
     steps:
       - uses: actions/checkout@v6
       - name: Prepare immutable Python test environment
@@ -91,6 +84,18 @@ jobs:
         uses: ./.github/actions/python-test-environment
         with:
           identity-artifact: "true"
+      - name: Emit deterministic shard matrix
+        id: shards
+        shell: bash
+        run: |
+          set -euo pipefail
+          matrix="$(python3 tools/python_package_suite_shards.py --emit-matrix-json)"
+          list="$(python3 tools/python_package_suite_shards.py --emit-shard-list-json)"
+          count="$(python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' <<<"$list")"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "list=$list" >> "$GITHUB_OUTPUT"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "suite shard matrix: $matrix (count=$count)"
       - name: Publish environment identity to the run summary
         shell: bash
         run: |
@@ -100,18 +105,22 @@ jobs:
             echo
             echo '`environmentIdentityHash`: `${{ steps.env.outputs.identity-hash }}`'
             echo
+            echo "suite shards: `${{ steps.shards.outputs.count }}` (enrollment roster)"
+            echo
             echo 'Runs that do not share this hash are not comparable measurements.'
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # -------------------------------------------------------------------------
+  # CANONICAL: one CI job per shard, own report, own identity gate, no lease.
+  # -------------------------------------------------------------------------
   python-package-suite:
-    name: python-package-suite (canonical)
+    name: suite canonical shard ${{ matrix.shard }}
     needs: prepare-python-test-environment
     runs-on: [self-hosted, Linux, X64]
-    # Measurement budget PLUS lease wait. Runs now queue on the box instead of
-    # being evicted from GitHub's pending slot, so the job must be allowed to
-    # sit in that queue; a job timeout shorter than the wait would recreate the
-    # dropped-measurement defect one layer down.
-    timeout-minutes: 360
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare-python-test-environment.outputs.shard-matrix) }}
     steps:
       - uses: actions/checkout@v6
 
@@ -119,22 +128,9 @@ jobs:
         id: env
         uses: ./.github/actions/python-test-environment
 
-      # The suite exercises the real lift over RPC. `tests/conftest.py` already
-      # resolves the binary in a session fixture and exits(2) if it cannot, so
-      # this step is not what makes the sweep work -- it is what keeps the
-      # sweep's WALL TIME a measurement of the suite rather than of a cold
-      # Rust build that happened to land inside it. Resolved through the one
-      # door, bin/sugarbin, by source stamp: shelf hit unless Rust inputs moved.
       - name: Set up Rust toolchain
         uses: ./.github/actions/setup-rust-cache
 
-      # The stamp is READ OFF THE RESOLVED BINARY, not recomputed beside it.
-      # `<binary>.sugarbin.json` is written by the build that produced this
-      # exact file and verified against its sha256 on every shelf hit, so it is
-      # the source identity the measured binary ACTUALLY has. The identity gate
-      # requires it to equal the environment identity's sourceStamp: a suite
-      # that measures one binary while reporting another source universe is the
-      # unresolved-identity defect wearing a populated field.
       - name: Resolve the sugar binary and read its source identity
         id: binary
         shell: bash
@@ -155,72 +151,59 @@ jobs:
           echo "stamp=$stamp" >> "$GITHUB_OUTPUT"
           echo "measured binary sourceStamp: $stamp"
 
-      # ONE cold process. Whole package. Canonical collection order.
-      # `-p no:cacheprovider` so no run inherits another's cache; `-p
-      # no:randomly` so canonical means canonical.
-      #
-      # And ONE AT A TIME ON THE BOX. The wall time of this sweep is a claim
-      # about the suite; measured beside a pandas census it is a claim about
-      # nothing. The lease is machine-wide, so the NumPy wall, the pandas wall,
-      # the sole-construction floors and the restored-suite sweep all wait for
-      # this one, and it waits for them -- while GitHub keeps every run.
-      - name: Whole-package sweep (under the machine-wide heavy lease)
+      - name: Shard ${{ matrix.shard }} sweep (own report; no measurement lease)
         id: sweep
         shell: bash
         working-directory: implementations/python
         env:
-          # tools/ for the suite report plugin; checkout roots from the env
-          # action (first-party must NOT come from site-packages).
           PYTHONPATH: ${{ github.workspace }}/tools:${{ env.SUGAR_CHECKOUT_PYTHONPATH }}
+          SUITE_IDENTITY_PATH: ${{ steps.env.outputs.identity-path }}
+          SUITE_BINARY_STAMP: ${{ steps.binary.outputs.stamp }}
+          SHARD: ${{ matrix.shard }}
+          SHARD_COUNT: ${{ needs.prepare-python-test-environment.outputs.shard-count }}
         run: |
           set -uo pipefail
-          cat > "$RUNNER_TEMP/sweep.sh" <<'SWEEP'
-          set -uo pipefail
-          python -m pytest sugar-lift-py-tests/tests -q \
-            -p no:cacheprovider -p no:randomly \
-            -p python_package_suite_report \
-            --suite-report="$GITHUB_WORKSPACE/suite-report.json" \
-            --suite-identity="$SUITE_IDENTITY_PATH" \
-            --suite-commit="$GITHUB_SHA" \
-            --suite-binary-stamp="$SUITE_BINARY_STAMP" \
-            --suite-order=canonical \
-            --suite-label=python-package-suite-canonical \
-            2>&1 | tee "$GITHUB_WORKSPACE/suite.log"
-          exit "${PIPESTATUS[0]}"
-          SWEEP
-          set +e
-          SUITE_IDENTITY_PATH='${{ steps.env.outputs.identity-path }}' \
-          SUITE_BINARY_STAMP='${{ steps.binary.outputs.stamp }}' \
-          python3 "$GITHUB_WORKSPACE/tools/heavy_measurement_lease.py" \
-            --class python-package-suite \
-            --record "$GITHUB_WORKSPACE/lease-record.json" \
-            --embed-into "$GITHUB_WORKSPACE/suite-report.json" \
-            -- bash "$RUNNER_TEMP/sweep.sh"
-          leased_exit=$?
-          set -e
-          # 75 is the lease refusing, not pytest failing. The distinction is the
-          # whole point: an unmeasured suite must never read as a measured one.
-          if [ "$leased_exit" = "75" ]; then
-            echo "::error::heavy-measurement lease not acquired; the suite did NOT run."
-            echo "pytest_exit=lease-refused" >> "$GITHUB_OUTPUT"
-            exit 75
+          mapfile -t paths < <(
+            python3 "$GITHUB_WORKSPACE/tools/python_package_suite_shards.py" \
+              --repo-root "$GITHUB_WORKSPACE" \
+              --shard-count "$SHARD_COUNT" \
+              --shard-index "$SHARD" \
+              --emit-paths-for-cwd
+          )
+          echo "shard $SHARD / $SHARD_COUNT paths (${#paths[@]}):"
+          printf '  %s\n' "${paths[@]:-}"
+          if [ "${#paths[@]}" -eq 0 ]; then
+            echo "empty shard — mint identity-bound empty report (still attends)"
+            python3 "$GITHUB_WORKSPACE/tools/python_package_suite_shards.py" \
+              --shard-count "$SHARD_COUNT" \
+              --shard-index "$SHARD" \
+              --mint-empty-report "$GITHUB_WORKSPACE/suite-report.json" \
+              --suite-identity "$SUITE_IDENTITY_PATH" \
+              --suite-commit "$GITHUB_SHA" \
+              --suite-binary-stamp "$SUITE_BINARY_STAMP" \
+              --suite-order canonical
+            echo "empty shard $SHARD" | tee "$GITHUB_WORKSPACE/suite.log"
+            echo "pytest_exit=0" >> "$GITHUB_OUTPUT"
+          else
+            set +e
+            python -m pytest "${paths[@]}" -q \
+              -p no:cacheprovider -p no:randomly \
+              -p python_package_suite_report \
+              --suite-report="$GITHUB_WORKSPACE/suite-report.json" \
+              --suite-identity="$SUITE_IDENTITY_PATH" \
+              --suite-commit="$GITHUB_SHA" \
+              --suite-binary-stamp="$SUITE_BINARY_STAMP" \
+              --suite-order=canonical \
+              --suite-shard-index="$SHARD" \
+              --suite-shard-count="$SHARD_COUNT" \
+              --suite-label="python-package-suite-canonical-shard-$(printf '%02d' "$SHARD")" \
+              2>&1 | tee "$GITHUB_WORKSPACE/suite.log"
+            pytest_exit="${PIPESTATUS[0]}"
+            set -e
+            echo "pytest_exit=$pytest_exit" >> "$GITHUB_OUTPUT"
           fi
-          echo "pytest_exit=$leased_exit" >> "$GITHUB_OUTPUT"
           test -s "$GITHUB_WORKSPACE/suite.log"
           test -s "$GITHUB_WORKSPACE/suite-report.json"
-
-      # No timing claim is accepted if the lease was not acquired. This is that
-      # sentence with teeth: red unless the artifact's own embedded receipt
-      # shows request -> acquisition -> release around THIS commit.
-      - name: Lease gate (R_lease = 0)
-        if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 tools/heavy_measurement_lease_gate.py \
-            --record suite-report.json \
-            --require-commit "$GITHUB_SHA" \
-            | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Publish the node-ID vector
         if: always()
@@ -233,22 +216,7 @@ jobs:
             --node-id-dir suite-node-ids \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
-      # EVERY IDENTITY FIELD RESOLVED -- CHECKED ON THE ARTIFACT, BEFORE IT IS
-      # CALLED AUTHORITATIVE.
-      #
-      # Run 30175741263 was complete and conserved (1212 collected, 1212
-      # verdicts) and concluded `success` while its sourceStamp was the object
-      # `{"unavailable": "CalledProcessError: ..."}` and its testExtraInputHash
-      # was null. Conservation is not authority: this step is where the run
-      # proves WHICH source and WHICH test-input universe produced the
-      # verdicts, and it reads suite-report.json as serialized -- a value that
-      # was populated in the sweep but lost on the way to the file is caught
-      # here and nowhere else.
-      #
-      # Deliberately NOT `if: always()` in the sense of being toothless: this
-      # step fails the job, and the authoritative upload below does not run
-      # when it does.
-      - name: Identity gate (R_identity = 0)
+      - name: Identity gate (per-shard R_identity = 0)
         id: identity-gate
         if: always()
         shell: bash
@@ -260,67 +228,79 @@ jobs:
             | tee identity-gate.md \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
-      # Artifacts carry the node-ID lists. The step summary carries counts.
-      # Counts are summaries of the lists; the lists are the evidence.
-      #
-      # This name means authoritative. It is published only when the identity
-      # gate passed on the serialized report.
-      - name: Upload authoritative suite artifacts
+      - name: Upload authoritative shard artifact
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-suite-canonical
+          name: python-package-suite-canonical-shard-${{ matrix.shard }}
           path: |
             suite.log
             suite-report.json
             suite-node-ids/
-            lease-record.json
             identity-gate.md
           if-no-files-found: error
 
-      # Evidence is never thrown away -- it is just not allowed to wear the
-      # authoritative name. A consumer that downloads this one is holding a
-      # provisional receipt and the artifact says so in its own name.
-      - name: Upload provisional (identity-unresolved) suite artifacts
+      - name: Upload provisional (identity-unresolved) shard artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-suite-canonical-PROVISIONAL-identity-unresolved
+          name: python-package-suite-canonical-shard-${{ matrix.shard }}-PROVISIONAL-identity-unresolved
           path: |
             suite.log
             suite-report.json
             suite-node-ids/
-            lease-record.json
             identity-gate.md
           if-no-files-found: warn
 
-      # Deliberately no `exit $pytest_exit`. See the header: this job reports.
-      - name: Report, do not gate
+      - name: Report, do not gate on pytest verdict
         if: always()
         shell: bash
         run: |
           echo "pytest exit status ${{ steps.sweep.outputs.pytest_exit }} recorded as evidence."
-          echo "This job does not gate merges; it owns the measurement."
+          echo "This job does not gate merges on verdicts; identity + enrollment do."
 
+  # Campaign completeness: all shards attended, each identity-resolved.
+  # NO merge of reports. Missing shard = UNMEASURED.
+  python-package-suite-attendance:
+    name: suite shard enrollment (all attended)
+    if: always() && !cancelled()
+    needs: [prepare-python-test-environment, python-package-suite]
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: python-package-suite-canonical-shard-*
+          path: runs
+          merge-multiple: false
+      - name: Roll call — enrollment is existence
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/python_package_suite_shard_attendance.py \
+            --reports-dir runs \
+            --shard-count '${{ needs.prepare-python-test-environment.outputs.shard-count }}' \
+            --require-commit "$GITHUB_SHA" \
+            --order canonical \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+  # -------------------------------------------------------------------------
+  # DISCRIMINATION: same shards, reversed/shuffled within each shard.
+  # -------------------------------------------------------------------------
   python-package-suite-discrimination:
-    name: python-package-suite (${{ matrix.order }})
-    # Scheduled cadence only -- plus explicit dispatch. Per-merge CI pays for
-    # exactly one sweep; order-dependence is caught nightly, not by tripling
-    # every merge's cost.
+    name: suite ${{ matrix.order }} shard ${{ matrix.shard }}
     if: >-
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.discrimination)
     needs: prepare-python-test-environment
     runs-on: [self-hosted, Linux, X64]
-    # Measurement budget PLUS lease wait. Runs now queue on the box instead of
-    # being evicted from GitHub's pending slot, so the job must be allowed to
-    # sit in that queue; a job timeout shorter than the wait would recreate the
-    # dropped-measurement defect one layer down.
-    timeout-minutes: 360
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         order: [reversed, shuffled]
+        shard: ${{ fromJSON(needs.prepare-python-test-environment.outputs.shard-list) }}
     steps:
       - uses: actions/checkout@v6
 
@@ -328,9 +308,6 @@ jobs:
         id: env
         uses: ./.github/actions/python-test-environment
 
-      # Same binary, resolved the same way and warmed the same way, so the only
-      # difference between the canonical run and these is the order. Anything
-      # else differing would make a divergence uninterpretable.
       - name: Set up Rust toolchain
         uses: ./.github/actions/setup-rust-cache
 
@@ -343,74 +320,61 @@ jobs:
           echo "SUGAR_BIN=$sugar_bin" >> "$GITHUB_ENV"
           manifest="$sugar_bin.sugarbin.json"
           if [ ! -f "$manifest" ]; then
-            echo "::error::resolved binary $sugar_bin has no $manifest; its source identity is unknown."
+            echo "::error::resolved binary $sugar_bin has no $manifest"
             exit 1
           fi
           stamp="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["sourceStamp"])' "$manifest")"
           echo "stamp=$stamp" >> "$GITHUB_OUTPUT"
 
-      # A SEPARATE COLD PROCESS per order. Sharing a process would let the
-      # first order warm exactly the caches whose influence we are measuring.
-      # Under the same lease as the canonical arm. A discrimination arm that
-      # ran beside another census would differ from canonical for a reason
-      # that is not the order -- which would make the one job in this file
-      # with teeth un-interpretable.
-      - name: Whole-package sweep (${{ matrix.order }}, under the heavy lease)
+      - name: Shard sweep (${{ matrix.order }}, no lease)
         shell: bash
         working-directory: implementations/python
         env:
-          # tools/ for the suite report plugin; checkout roots from the env
-          # action (first-party must NOT come from site-packages).
           PYTHONPATH: ${{ github.workspace }}/tools:${{ env.SUGAR_CHECKOUT_PYTHONPATH }}
+          SUITE_IDENTITY_PATH: ${{ steps.env.outputs.identity-path }}
+          SUITE_BINARY_STAMP: ${{ steps.binary.outputs.stamp }}
+          SHARD: ${{ matrix.shard }}
+          SHARD_COUNT: ${{ needs.prepare-python-test-environment.outputs.shard-count }}
+          SUITE_ORDER: ${{ matrix.order }}
         run: |
           set -uo pipefail
-          cat > "$RUNNER_TEMP/sweep-${{ matrix.order }}.sh" <<'SWEEP'
-          set -uo pipefail
-          python -m pytest sugar-lift-py-tests/tests -q \
-            -p no:cacheprovider -p no:randomly \
-            -p python_package_suite_report \
-            --suite-report="$GITHUB_WORKSPACE/suite-report.json" \
-            --suite-identity="$SUITE_IDENTITY_PATH" \
-            --suite-commit="$GITHUB_SHA" \
-            --suite-binary-stamp="$SUITE_BINARY_STAMP" \
-            --suite-order="$SUITE_ORDER" \
-            --suite-shuffle-seed="$GITHUB_RUN_ID" \
-            --suite-label="python-package-suite-$SUITE_ORDER" \
-            2>&1 | tee "$GITHUB_WORKSPACE/suite.log"
-          exit "${PIPESTATUS[0]}"
-          SWEEP
-          set +e
-          SUITE_IDENTITY_PATH='${{ steps.env.outputs.identity-path }}' \
-          SUITE_BINARY_STAMP='${{ steps.binary.outputs.stamp }}' \
-          SUITE_ORDER='${{ matrix.order }}' \
-          python3 "$GITHUB_WORKSPACE/tools/heavy_measurement_lease.py" \
-            --class python-package-suite \
-            --record "$GITHUB_WORKSPACE/lease-record.json" \
-            --embed-into "$GITHUB_WORKSPACE/suite-report.json" \
-            -- bash "$RUNNER_TEMP/sweep-${{ matrix.order }}.sh"
-          leased_exit=$?
-          set -e
-          if [ "$leased_exit" = "75" ]; then
-            echo "::error::heavy-measurement lease not acquired; the ${{ matrix.order }} arm did NOT run."
-            exit 75
+          mapfile -t paths < <(
+            python3 "$GITHUB_WORKSPACE/tools/python_package_suite_shards.py" \
+              --repo-root "$GITHUB_WORKSPACE" \
+              --shard-count "$SHARD_COUNT" \
+              --shard-index "$SHARD" \
+              --emit-paths-for-cwd
+          )
+          if [ "${#paths[@]}" -eq 0 ]; then
+            python3 "$GITHUB_WORKSPACE/tools/python_package_suite_shards.py" \
+              --shard-count "$SHARD_COUNT" \
+              --shard-index "$SHARD" \
+              --mint-empty-report "$GITHUB_WORKSPACE/suite-report.json" \
+              --suite-identity "$SUITE_IDENTITY_PATH" \
+              --suite-commit "$GITHUB_SHA" \
+              --suite-binary-stamp "$SUITE_BINARY_STAMP" \
+              --suite-order "$SUITE_ORDER"
+            echo "empty shard $SHARD ($SUITE_ORDER)" | tee "$GITHUB_WORKSPACE/suite.log"
+          else
+            set +e
+            python -m pytest "${paths[@]}" -q \
+              -p no:cacheprovider -p no:randomly \
+              -p python_package_suite_report \
+              --suite-report="$GITHUB_WORKSPACE/suite-report.json" \
+              --suite-identity="$SUITE_IDENTITY_PATH" \
+              --suite-commit="$GITHUB_SHA" \
+              --suite-binary-stamp="$SUITE_BINARY_STAMP" \
+              --suite-order="$SUITE_ORDER" \
+              --suite-shuffle-seed="$GITHUB_RUN_ID" \
+              --suite-shard-index="$SHARD" \
+              --suite-shard-count="$SHARD_COUNT" \
+              --suite-label="python-package-suite-${SUITE_ORDER}-shard-$(printf '%02d' "$SHARD")" \
+              2>&1 | tee "$GITHUB_WORKSPACE/suite.log"
+            set -e
           fi
-          echo "pytest exit $leased_exit"
           test -s "$GITHUB_WORKSPACE/suite-report.json"
 
-      - name: Lease gate (R_lease = 0)
-        if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 tools/heavy_measurement_lease_gate.py \
-            --record suite-report.json \
-            --require-commit "$GITHUB_SHA" \
-            | tee -a "$GITHUB_STEP_SUMMARY"
-
-      # Same law as the canonical arm: an arm whose identity is unresolved
-      # cannot be compared against anything, so it is not published under the
-      # name the comparison job reads.
-      - name: Identity gate (R_identity = 0)
+      - name: Identity gate (per-shard)
         if: always()
         shell: bash
         run: |
@@ -421,57 +385,95 @@ jobs:
             | tee identity-gate.md \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload discrimination artifacts
+      - name: Upload discrimination shard artifact
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-suite-${{ matrix.order }}
+          name: python-package-suite-${{ matrix.order }}-shard-${{ matrix.shard }}
           path: |
             suite.log
             suite-report.json
-            lease-record.json
             identity-gate.md
           if-no-files-found: error
 
   discrimination-verdict:
-    name: identical verdict sets across orders
+    name: identical within-shard verdict sets across orders
     if: >-
       always() && !cancelled() && (
         github.event_name == 'schedule' ||
         (github.event_name == 'workflow_dispatch' && inputs.discrimination)
       )
-    needs: [python-package-suite, python-package-suite-discrimination]
+    needs:
+      - prepare-python-test-environment
+      - python-package-suite
+      - python-package-suite-discrimination
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v4
         with:
-          pattern: python-package-suite-*
+          pattern: python-package-suite-*-shard-*
           path: runs
-      # THIS ONE HAS TEETH. A verdict that changes with execution order is not
-      # a verdict. Red here means one of the two runs lied and we do not know
-      # which; fix the dependence, do not re-run for green.
-      # Were the three arms actually serialized? Same kernel must mean the same
-      # lock inode, and no two acquisition intervals may overlap. If the lease
-      # file is not shared between runner containers this is where it shows up
-      # -- otherwise the mechanism could be pure theatre and every arm would
-      # still look green.
-      - name: Lease scope check (one machine, one lock, no overlap)
+      - name: Enrollment for each order
         shell: bash
         run: |
           set -euo pipefail
-          python3 tools/heavy_measurement_lease_gate.py \
-            --scope-check runs/python-package-suite-canonical/lease-record.json \
-            --scope-check runs/python-package-suite-reversed/lease-record.json \
-            --scope-check runs/python-package-suite-shuffled/lease-record.json \
-            | tee -a "$GITHUB_STEP_SUMMARY"
+          count='${{ needs.prepare-python-test-environment.outputs.shard-count }}'
+          for order in canonical reversed shuffled; do
+            python3 tools/python_package_suite_shard_attendance.py \
+              --reports-dir runs \
+              --shard-count "$count" \
+              --require-commit "$GITHUB_SHA" \
+              --order "$order" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+          done
+      - name: Within-shard order-independence (no merged hub)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # For each enrolled shard index, compare the three orders' reports.
+          # No package-wide recombine; each triple is content-addressed per seat.
+          python3 - <<'PY'
+          import json, sys
+          from pathlib import Path
 
-      - name: Require identical verdict sets
-        shell: bash
-        run: |
-          set -euo pipefail
-          python tools/python_suite_discrimination.py \
-            --baseline runs/python-package-suite-canonical/suite-report.json \
-            --candidate runs/python-package-suite-reversed/suite-report.json \
-            --candidate runs/python-package-suite-shuffled/suite-report.json \
-            | tee -a "$GITHUB_STEP_SUMMARY"
+          tools = Path("tools")
+          sys.path.insert(0, str(tools))
+          from python_package_suite_shard_attendance import find_shard_reports
+          from python_suite_discrimination import compare
+          from python_package_suite_shards import SHARD_COUNT
+
+          runs = Path("runs")
+          count = int("${{ needs.prepare-python-test-environment.outputs.shard-count }}")
+          if count != SHARD_COUNT:
+              # workflow may override via tool default; trust the prepare output
+              pass
+
+          by_order = {
+              order: find_shard_reports(runs, order)
+              for order in ("canonical", "reversed", "shuffled")
+          }
+          crimes = []
+          for i in range(count):
+              if i not in by_order["canonical"]:
+                  crimes.append(f"shard {i:02d}: canonical missing")
+                  continue
+              base_path, baseline = by_order["canonical"][i]
+              for order in ("reversed", "shuffled"):
+                  if i not in by_order[order]:
+                      crimes.append(f"shard {i:02d}: {order} missing")
+                      continue
+                  _, candidate = by_order[order][i]
+                  for line in compare(baseline, candidate):
+                      crimes.append(f"shard {i:02d}: {line}")
+          if crimes:
+              print("### discrimination: DIVERGENT or incomplete\n")
+              for c in crimes:
+                  print(f"- `{c}`")
+                  print(f"::error::{c}", file=sys.stderr)
+              sys.exit(1)
+          print(
+              f"### discrimination: identical verdict sets within each of "
+              f"{count} shards (no shared aggregate)"
+          )
+          PY

--- a/tests/test_commit_measurement.py
+++ b/tests/test_commit_measurement.py
@@ -39,7 +39,7 @@ def test_measured_requires_lease_and_body_cids() -> None:
 def test_measured_from_sealed_pair_unmeasured_without_body_field() -> None:
     reading = CM.measured_from_sealed_pair(
         commit_sha="abc",
-        lease_record={"acquired": True, "leaseClass": "python-package-suite"},
+        lease_record={"acquired": True, "leaseClass": "python-sole-construction-floors"},
         lease_receipt_cid="lease:1",
         body={"totals": {}},
         body_artifact_cid="body:1",
@@ -51,7 +51,7 @@ def test_measured_from_sealed_pair_unmeasured_without_body_field() -> None:
 def test_measured_from_sealed_pair_unmeasured_when_lease_not_acquired() -> None:
     reading = CM.measured_from_sealed_pair(
         commit_sha="abc",
-        lease_record={"acquired": False, "leaseClass": "python-package-suite"},
+        lease_record={"acquired": False, "leaseClass": "python-sole-construction-floors"},
         lease_receipt_cid="lease:1",
         body={"totals": {"failed": 0, "collected": 3}},
         body_artifact_cid="body:1",
@@ -67,7 +67,7 @@ def test_measured_from_sealed_pair_cites_body_value() -> None:
         commit_sha="abc",
         lease_record={
             "acquired": True,
-            "leaseClass": "python-package-suite",
+            "leaseClass": "python-sole-construction-floors",
             "measurementStatus": "completed/findings",
         },
         lease_receipt_cid="lease:1",
@@ -158,7 +158,7 @@ def test_forbidden_board_axis_names() -> None:
 def test_compose_tip_lease_without_body_is_unmeasured(tmp_path: Path) -> None:
     lease = {
         "schemaVersion": 1,
-        "leaseClass": "python-package-suite",
+        "leaseClass": "python-sole-construction-floors",
         "acquired": True,
         "measurementStatus": "completed/findings",
         "commit": "deadbeef",
@@ -166,8 +166,8 @@ def test_compose_tip_lease_without_body_is_unmeasured(tmp_path: Path) -> None:
     (tmp_path / "lease.json").write_text(json.dumps(lease), encoding="utf-8")
     v = CM.compose_tip_from_receipts_dir("deadbeef", tmp_path)
     assert isinstance(v, CM.PartialVector)
-    assert "python-package-suite" in v.unmeasured_axes()
-    assert "body artifact" in v.axes["python-package-suite"].reason
+    assert "python-sole-construction-floors" in v.unmeasured_axes()
+    assert "body artifact" in v.axes["python-sole-construction-floors"].reason
 
 
 def test_compose_tip_lease_plus_body_is_measured(tmp_path: Path) -> None:
@@ -178,21 +178,19 @@ def test_compose_tip_lease_plus_body_is_measured(tmp_path: Path) -> None:
     }
     lease = {
         "schemaVersion": 1,
-        "leaseClass": "python-package-suite",
+        "leaseClass": "python-sole-construction-floors",
         "acquired": True,
         "measurementStatus": "completed/findings",
         "commit": "deadbeef",
         "leaseRecord": None,
     }
-    # embed lease + body in one suite-report style object
+    # embed lease + body in one report style object
     suite = {**body, "leaseRecord": lease}
-    (tmp_path / "suite-report.json").write_text(json.dumps(suite), encoding="utf-8")
-    # floors absent → partial overall, but package suite measured
+    (tmp_path / "floor-report.json").write_text(json.dumps(suite), encoding="utf-8")
     v = CM.compose_tip_from_receipts_dir("deadbeef", tmp_path)
-    assert isinstance(v, CM.PartialVector)
-    assert isinstance(v.axes["python-package-suite"], CM.Measured)
-    assert v.axes["python-package-suite"].value == 4
-    assert isinstance(v.axes["python-sole-construction-floors"], CM.Unmeasured)
+    assert isinstance(v, CM.CompleteVector) or isinstance(v, CM.PartialVector)
+    assert isinstance(v.axes["python-sole-construction-floors"], CM.Measured)
+    assert v.axes["python-sole-construction-floors"].value == 4
 
 
 def test_gate_missing_composition_is_red(tmp_path: Path) -> None:

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -22,11 +22,16 @@ merge rate was killing our heaviest instruments.
 So the two responsibilities are split, and this file pins the split:
 
     GitHub queue: preserve every requested measurement  → NO concurrency group
-    BX lease:     only one heavy measurement executes   → the flock wrapper
+    BX lease:     only one heavy *corpus* measurement     → the flock wrapper
 
-A heavy workflow that declares a concurrency group is back in the eviction
-path. A heavy workflow that runs its measurement outside the lease is back to
-two censuses fighting over one box. Both are red here.
+CLASS SPLIT (load-bearing): the machine-wide lease is for exclusive
+MEASUREMENT INTEGRITY — sole-construction floors, recensus, walls — work that
+cannot interleave two corpus populations without lying about R.
+
+The package suite is CI CONFIDENCE TELEMETRY. It writes per-shard
+identity-bound reports with no shared aggregate, so it has no shared resource
+to protect and must NOT take the lease. A future edit that re-adds the suite
+to the claimant set is red here.
 """
 
 from __future__ import annotations
@@ -41,17 +46,19 @@ WORKFLOWS = ROOT / ".github" / "workflows"
 LEASE_WRAPPER = "tools/heavy_measurement_lease.py"
 GATE = "tools/heavy_measurement_lease_gate.py"
 
-# Every heavy measurement class: workflow file -> the --class name it leases
-# under. This is the same roster tools/heavy_measurement_attendance.py calls
-# the roll from, and the two are checked against each other below.
+# Corpus / heavy measurement classes: workflow file -> the --class name it
+# leases under. Package suite is deliberately ABSENT — confidence telemetry.
+# This roster matches tools/heavy_measurement_attendance.py.
 HEAVY_WORKFLOWS = {
-    "python-package-suite.yml": "python-package-suite",
     "factory-zero-tolerance.yml": "python-sole-construction-floors",
     "numpy-wall.yml": "numpy-wall",
     "pandas-wall.yml": "pandas-wall",
     "restored-suite-scoreboard.yml": "restored-suite-scoreboard",
     "control-effect-recensus.yml": "control-effect-recensus",
 }
+
+# Confidence telemetry: must not hold the measurement mutex.
+CONFIDENCE_TELEMETRY_WORKFLOWS = ("python-package-suite.yml",)
 
 # The dead group. Nothing may claim it again.
 RETIRED_GROUPS = ("sugar-python-heavy-measurement", "sugar-python-package-suite")
@@ -109,6 +116,23 @@ def test_heavy_workflows_measure_under_the_lease(workflow, lease_class):
         f"{workflow} must run {GATE}: a timing claim from a run that never "
         f"acquired the lease is not a measurement, and that has to be checked"
     )
+
+
+@pytest.mark.parametrize("workflow", CONFIDENCE_TELEMETRY_WORKFLOWS)
+def test_confidence_telemetry_takes_no_machine_wide_lease(workflow):
+    """The suite is not a corpus census. Lease re-introduction is the starvation class."""
+    text = _text(workflow)
+    assert LEASE_WRAPPER not in text, (
+        f"{workflow} must not call {LEASE_WRAPPER}: the package suite is CI "
+        f"confidence telemetry with per-shard identity-bound reports and no "
+        f"shared aggregate. Holding the machine-wide measurement mutex for it "
+        f"is the class that starved floors for hours. Keep the lease on corpus "
+        f"censuses only."
+    )
+    assert "--class python-package-suite" not in text
+    assert GATE not in text or "python_suite_identity_gate" in text
+    # Enrollment completeness, not a merged singleton.
+    assert "python_package_suite_shard_attendance" in text
 
 
 def test_no_heavy_workflow_cancels_a_superseded_run():

--- a/tests/test_heavy_measurement_lease.py
+++ b/tests/test_heavy_measurement_lease.py
@@ -478,17 +478,18 @@ def test_status_file_tracks_the_live_phase(lease, record, tmp_path):
 def test_attendance_counts_a_missing_receipt_as_unmeasured(lease, record, tmp_path):
     receipts = tmp_path / "receipts"
     receipts.mkdir()
-    run_wrapper(lease, receipts / "python-package-suite.json", [sys.executable, "-c", "pass"])
+    # Receipt for a class no longer on the lease roster (package suite is
+    # confidence telemetry). Per-commit roll call still misses the floors.
+    run_wrapper(lease, receipts / "not-a-roster-class.json", [sys.executable, "-c", "pass"])
     result = subprocess.run(
         [sys.executable, str(ROOT / "tools" / "heavy_measurement_attendance.py"),
          "--commit", "421ef4157", "--receipts-dir", str(receipts)],
         capture_output=True, text=True, timeout=60,
     )
-    # A real receipt is present, but it belongs to no roster class -- so NOT
-    # ONE roster instrument spoke, and the roll call must say five, not zero.
-    # An artifact directory that merely contains files is not attendance.
+    # A real receipt is present, but it belongs to no roster class -- so the
+    # per-commit instrument (floors) did not speak.
     assert result.returncode == 1
-    assert "R_attendance = 5" in result.stdout
+    assert "R_attendance_commit = 1" in result.stdout
     assert "NOT a clean floor" in result.stdout
     assert "python-sole-construction-floors" in result.stdout
 
@@ -515,7 +516,7 @@ def test_attendance_is_green_when_every_instrument_reported(lease, record, tmp_p
         capture_output=True, text=True, timeout=60,
     )
     assert result.returncode == 0, result.stdout
-    assert "R_attendance = 0" in result.stdout
+    assert "R_attendance_commit = 0" in result.stdout
 
 
 # -- the gate: no timing claim without an acquired lease --------------------

--- a/tests/test_python_package_suite_shards.py
+++ b/tests/test_python_package_suite_shards.py
@@ -1,0 +1,250 @@
+"""Teeth for suite shards: deterministic split + enrollment without a shared hub."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SHARDS = ROOT / "tools" / "python_package_suite_shards.py"
+ATTENDANCE = ROOT / "tools" / "python_package_suite_shard_attendance.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "python-package-suite.yml"
+
+
+def _run(argv: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, *argv],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        **kwargs,
+    )
+
+
+def test_shard_assignment_is_deterministic_and_covers_every_file() -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("suite_shards", SHARDS)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+
+    files = mod.list_suite_test_files(ROOT)
+    assert len(files) >= 100, f"expected a real suite tree, got {len(files)} files"
+
+    count = 32
+    covered: list[str] = []
+    for i in range(count):
+        covered.extend(mod.files_for_shard(files, i, count))
+
+    assert sorted(covered) == sorted(files)
+    # Same file always same shard across two pure calls.
+    assert mod.files_for_shard(files, 0, count) == mod.files_for_shard(
+        files, 0, count
+    )
+    # Spot-check: a middle file's seat is index % count.
+    mid = files[len(files) // 2]
+    assert mod.shard_index_for(mid, files, count) == files.index(mid) % count
+
+
+def test_missing_shard_makes_attendance_red_not_a_smaller_pass() -> None:
+    """Lying face: N-1 identity-resolved reports ⇒ UNMEASURED, not green."""
+    import tempfile
+
+    from importlib import util
+
+    spec = util.spec_from_file_location(
+        "identity_gate", ROOT / "tools" / "python_suite_identity_gate.py"
+    )
+    # Build minimal identity-valid reports for seats 0..2, omit seat 3 of 4.
+    stamp = "blake3-512_" + ("ab" * 64)
+    extras = "cd" * 32
+    identity = {
+        "environmentIdentityHash": "ee" * 32,
+        "sourceStamp": {"value": stamp},
+        "dependencyAuthority": {
+            "testExtraInputHash": extras,
+            "declared": {"optional-dependencies": {"test": ["pytest"]}},
+        },
+    }
+
+    def report(shard: int, count: int = 4) -> dict:
+        return {
+            "schemaVersion": 1,
+            "label": f"python-package-suite-canonical-shard-{shard:02d}",
+            "order": "canonical",
+            "shardIndex": shard,
+            "shardCount": count,
+            "measuredCommit": "abc1234",
+            "sourceStamp": stamp,
+            "testExtraInputHash": extras,
+            "environmentIdentityHash": identity["environmentIdentityHash"],
+            "binarySourceStamp": stamp,
+            "environmentIdentity": identity,
+            "runnerIdentity": {"githubSha": "abc1234"},
+            "collectedNodeIds": [],
+            "executedOrderNodeIds": [],
+            "failedNodeIds": [],
+            "errorNodeIds": [],
+            "skippedNodeIds": [],
+            "xfailedNodeIds": [],
+            "xpassedNodeIds": [],
+            "passedNodeIds": [],
+            "collectionErrorNodeIds": [],
+            "notReportedNodeIds": [],
+            "counts": {
+                "collected": 0,
+                "passed": 0,
+                "failed": 0,
+                "error": 0,
+                "skipped": 0,
+                "xfailed": 0,
+                "xpassed": 0,
+                "collectionError": 0,
+                "notReported": 0,
+            },
+            "conservation": {
+                "collected": 0,
+                "verdicts": 0,
+                "executedOrder": 0,
+                "buckets": {
+                    "passed": 0,
+                    "failed": 0,
+                    "error": 0,
+                    "skipped": 0,
+                    "xfailed": 0,
+                    "xpassed": 0,
+                    "notReported": 0,
+                },
+                "collectionError": 0,
+            },
+        }
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for i in range(3):  # omit shard 3
+            d = root / f"python-package-suite-canonical-shard-{i}"
+            d.mkdir()
+            (d / "suite-report.json").write_text(
+                json.dumps(report(i)) + "\n", encoding="utf-8"
+            )
+        result = _run(
+            [
+                str(ATTENDANCE),
+                "--reports-dir",
+                str(root),
+                "--shard-count",
+                "4",
+                "--require-commit",
+                "abc1234",
+                "--order",
+                "canonical",
+            ]
+        )
+    assert result.returncode != 0, result.stdout
+    assert "R_suite_shard_attendance = 1" in result.stdout
+    assert "shard-03" in result.stdout
+    assert "UNMEASURED" in result.stdout
+
+
+def test_full_roster_attendance_is_green() -> None:
+    import tempfile
+
+    stamp = "blake3-512_" + ("ab" * 64)
+    extras = "cd" * 32
+    identity = {
+        "environmentIdentityHash": "ee" * 32,
+        "sourceStamp": {"value": stamp},
+        "dependencyAuthority": {
+            "testExtraInputHash": extras,
+            "declared": {"optional-dependencies": {"test": ["pytest"]}},
+        },
+    }
+
+    def report(shard: int, count: int = 2) -> dict:
+        return {
+            "schemaVersion": 1,
+            "label": f"python-package-suite-canonical-shard-{shard:02d}",
+            "order": "canonical",
+            "shardIndex": shard,
+            "shardCount": count,
+            "measuredCommit": "abc1234",
+            "sourceStamp": stamp,
+            "testExtraInputHash": extras,
+            "environmentIdentityHash": identity["environmentIdentityHash"],
+            "binarySourceStamp": stamp,
+            "environmentIdentity": identity,
+            "runnerIdentity": {"githubSha": "abc1234"},
+            "collectedNodeIds": [],
+            "executedOrderNodeIds": [],
+            "failedNodeIds": [],
+            "errorNodeIds": [],
+            "skippedNodeIds": [],
+            "xfailedNodeIds": [],
+            "xpassedNodeIds": [],
+            "passedNodeIds": [],
+            "collectionErrorNodeIds": [],
+            "notReportedNodeIds": [],
+            "counts": {
+                "collected": 0,
+                "passed": 0,
+                "failed": 0,
+                "error": 0,
+                "skipped": 0,
+                "xfailed": 0,
+                "xpassed": 0,
+                "collectionError": 0,
+                "notReported": 0,
+            },
+            "conservation": {
+                "collected": 0,
+                "verdicts": 0,
+                "executedOrder": 0,
+                "buckets": {
+                    "passed": 0,
+                    "failed": 0,
+                    "error": 0,
+                    "skipped": 0,
+                    "xfailed": 0,
+                    "xpassed": 0,
+                    "notReported": 0,
+                },
+                "collectionError": 0,
+            },
+        }
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for i in range(2):
+            d = root / f"python-package-suite-canonical-shard-{i}"
+            d.mkdir()
+            (d / "suite-report.json").write_text(
+                json.dumps(report(i)) + "\n", encoding="utf-8"
+            )
+        result = _run(
+            [
+                str(ATTENDANCE),
+                "--reports-dir",
+                str(root),
+                "--shard-count",
+                "2",
+                "--require-commit",
+                "abc1234",
+                "--order",
+                "canonical",
+            ]
+        )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "R_suite_shard_attendance = 0" in result.stdout
+
+
+def test_workflow_has_no_shared_suite_report_merge_and_uses_enrollment() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "python_package_suite_shard_attendance" in text
+    assert "shardIndex" in text or "suite-shard-index" in text
+    # No merge tool / single shared aggregate path.
+    assert "merge" not in text.lower() or "merge-multiple" in text
+    assert "python_package_suite_merge" not in text

--- a/tools/commit_measurement.py
+++ b/tools/commit_measurement.py
@@ -410,9 +410,11 @@ def _lease_from_payload(payload: Mapping[str, Any]) -> Mapping[str, Any] | None:
 
 
 # Per-commit tip axes only (nightlies are a different obligation).
+# Package suite is confidence telemetry (per-shard reports, no lease) and is
+# not composed from lease receipts here — suite enrollment is
+# tools/python_package_suite_shard_attendance.py.
 TIP_AXIS_SPECS: tuple[tuple[str, str, str], ...] = (
     # axis_name, leaseClass, value_field_path on body
-    ("python-package-suite", "python-package-suite", "totals.failed"),
     (
         "python-sole-construction-floors",
         "python-sole-construction-floors",

--- a/tools/heavy_measurement_attendance.py
+++ b/tools/heavy_measurement_attendance.py
@@ -64,8 +64,11 @@ from pathlib import Path
 PER_COMMIT = "per-commit"
 NIGHTLY_WINDOW = "nightly-window"
 
+# Corpus / exclusive-measurement classes only. The package suite is CI
+# confidence telemetry (per-shard identity-bound reports, no shared hub) and
+# does not take the machine-wide lease — so it is not on this lease roster.
+# Suite completeness is tools/python_package_suite_shard_attendance.py.
 HEAVY_ROSTER = {
-    "python-package-suite": "Python package suite (authoritative)",
     "python-sole-construction-floors": "Python sole-construction floors (R>0 red)",
     "numpy-wall": "NumPy Wall Ratchet",
     "pandas-wall": "Pandas Wall Ratchet",
@@ -78,7 +81,6 @@ HEAVY_ROSTER = {
 # PER_COMMIT whose workflow has no `push: branches: [main]` is a contradiction
 # the roll call cannot detect at runtime, so the test makes it uncompilable.
 HEAVY_CADENCE = {
-    "python-package-suite": PER_COMMIT,
     "python-sole-construction-floors": PER_COMMIT,
     "numpy-wall": NIGHTLY_WINDOW,
     "pandas-wall": NIGHTLY_WINDOW,

--- a/tools/heavy_measurement_lease.py
+++ b/tools/heavy_measurement_lease.py
@@ -23,10 +23,12 @@ So the two jobs are split, and this program is half two::
     GitHub queue: preserve every requested measurement   (no concurrency group)
     BX lease:     ensure only one heavy measurement runs (this program)
 
-Every heavy class -- the authoritative package suite, the sole-construction
-corpus floors, the pandas/NumPy censuses, the restored-suite sweep -- wraps its
-measured command here. Overlapping GitHub runs all START and all survive; only
-one is ever inside the measured section.
+Every exclusive MEASUREMENT class -- sole-construction corpus floors, the
+pandas/NumPy censuses, the restored-suite sweep, the recensus -- wraps its
+measured command here. The package suite is CI confidence telemetry (per-shard
+identity-bound reports, no shared aggregate) and deliberately does NOT take
+this lease. Overlapping GitHub runs all START and all survive; only one
+corpus measurement is ever inside the measured section.
 
 WHY A FILE LOCK, AND WHY NOT ``flock(1)``
 =========================================
@@ -59,9 +61,9 @@ measurement. Refusing is the honest outcome, and the receipt says so in a field
 Usage::
 
     python3 tools/heavy_measurement_lease.py \\
-        --class python-package-suite \\
+        --class python-sole-construction-floors \\
         --record "$GITHUB_WORKSPACE/lease-record.json" \\
-        [--embed-into suite-report.json] [--timeout 14400] \\
+        [--embed-into report.json] [--timeout 14400] \\
         [--lease ~/.cache/sugar/binaries/.sugar-heavy-measurement.lease] \\
         -- <command> [args...]
 

--- a/tools/python_package_suite_report.py
+++ b/tools/python_package_suite_report.py
@@ -116,6 +116,26 @@ def pytest_addoption(parser):
         metavar="LABEL",
         help="free-form label recorded in the report (e.g. the CI job name)",
     )
+    group.addoption(
+        "--suite-shard-index",
+        action="store",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "0-based shard index when the suite runs as parallel CI jobs. "
+            "Recorded in the report for enrollment roll call; each shard "
+            "writes its own identity-bound report (no shared aggregate)."
+        ),
+    )
+    group.addoption(
+        "--suite-shard-count",
+        action="store",
+        type=int,
+        default=None,
+        metavar="N",
+        help="enrolled shard count (roster size) for this campaign",
+    )
 
 
 class SuiteReporter:
@@ -202,6 +222,10 @@ class SuiteReporter:
             "label": self.config.getoption("--suite-label"),
             "order": self.config.getoption("--suite-order"),
             "shuffleSeed": self.shuffle_seed,
+            # Shard seat for enrollment. Absent when the suite is not sharded.
+            # Completeness is "all seats attended", never a merged singleton.
+            "shardIndex": self.config.getoption("--suite-shard-index"),
+            "shardCount": self.config.getoption("--suite-shard-count"),
             "pytestExitStatus": int(exitstatus),
             # THE REPORT ITSELF CARRIES ITS IDENTITY.
             #

--- a/tools/python_package_suite_shard_attendance.py
+++ b/tools/python_package_suite_shard_attendance.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Enrollment roll call for suite shards — completeness without a shared hub.
+
+THE LAW
+-------
+Each shard writes its own identity-bound suite-report.json. There is no merge
+into a singleton report (a shared identity hub). Completeness is enrollment:
+
+    roster = {shard-00, ..., shard-(N-1)}
+    attended = shards with a present, identity-resolved report for this commit
+    R_suite_shard_attendance = |roster \\ attended|
+
+A missing shard is UNMEASURED, not a smaller pass count. Silence is not a
+clean suite. Same shape as ``tools/heavy_measurement_attendance.py`` for heavy
+measurement classes: enrollment is existence.
+
+Usage:
+    python3 tools/python_package_suite_shard_attendance.py \\
+        --reports-dir runs/ \\
+        --shard-count 32 \\
+        --require-commit "$GITHUB_SHA" \\
+        --order canonical
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Local imports: tools/ is on PYTHONPATH in CI; load by path when not.
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
+from python_package_suite_shards import SHARD_COUNT, roster_ids  # noqa: E402
+from python_suite_identity_gate import gate  # noqa: E402
+
+
+class ShardAttendanceError(RuntimeError):
+    """Roll call failed: missing shards or unresolved identity."""
+
+
+def _load_report(path: Path) -> dict | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def find_shard_reports(reports_dir: Path, order: str) -> dict[int, tuple[Path, dict]]:
+    """Map shard_index -> (path, report) for reports under reports_dir.
+
+    Accepts either:
+      runs/python-package-suite-{order}-shard-07/suite-report.json
+      runs/**/suite-report.json with label/shardIndex fields
+    """
+    found: dict[int, tuple[Path, dict]] = {}
+    if not reports_dir.is_dir():
+        return found
+
+    for path in sorted(reports_dir.rglob("suite-report.json")):
+        report = _load_report(path)
+        if report is None:
+            continue
+        # Prefer explicit shardIndex when the reporter recorded it.
+        shard_index = report.get("shardIndex")
+        label = str(report.get("label") or "")
+        report_order = report.get("order") or "canonical"
+
+        if order and report_order != order and f"-{order}" not in label:
+            # Discrimination uploads use order in the artifact dirname/label.
+            parent = path.parent.name
+            if order not in parent and order not in label:
+                continue
+
+        if shard_index is None:
+            # Parse ...-shard-07 or shard-07 from path / label.
+            import re
+
+            match = re.search(r"shard-(\d+)", f"{path.parent.name} {label}")
+            if not match:
+                continue
+            shard_index = int(match.group(1))
+        else:
+            shard_index = int(shard_index)
+
+        # Keep the first path; prefer identity-richer later if needed.
+        if shard_index not in found:
+            found[shard_index] = (path, report)
+    return found
+
+
+def attendance(
+    *,
+    reports_dir: Path,
+    shard_count: int,
+    require_commit: str | None,
+    order: str,
+) -> tuple[list[str], list[str], list[str]]:
+    """Return (attended_ids, missing_ids, crimes).
+
+    crimes non-empty means at least one present shard failed the identity gate
+    or disagreed about commit/shard metadata — still not a clean suite.
+    """
+    roster = roster_ids(shard_count)
+    found = find_shard_reports(reports_dir, order)
+    attended: list[str] = []
+    missing: list[str] = []
+    crimes: list[str] = []
+
+    for i, shard_id in enumerate(roster):
+        if i not in found:
+            missing.append(shard_id)
+            continue
+        path, report = found[i]
+        # Identity gate per shard — each proves its own provenance.
+        gate_crimes = gate(report, require_commit)
+        if gate_crimes:
+            crimes.append(f"{shard_id} at {path}: identity UNRESOLVED")
+            for crime in gate_crimes:
+                crimes.append(f"  {crime}")
+            # Present but unresolved is not attendance.
+            missing.append(shard_id)
+            continue
+        # Shard self-description must match enrollment seat when present.
+        if report.get("shardIndex") is not None and int(report["shardIndex"]) != i:
+            crimes.append(
+                f"{shard_id}: report shardIndex {report.get('shardIndex')} "
+                f"!= enrolled seat {i}"
+            )
+            missing.append(shard_id)
+            continue
+        if (
+            report.get("shardCount") is not None
+            and int(report["shardCount"]) != shard_count
+        ):
+            crimes.append(
+                f"{shard_id}: report shardCount {report.get('shardCount')} "
+                f"!= roster size {shard_count}"
+            )
+            missing.append(shard_id)
+            continue
+        attended.append(shard_id)
+
+    return attended, missing, crimes
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--reports-dir",
+        required=True,
+        type=Path,
+        help="directory of downloaded per-shard artifacts",
+    )
+    parser.add_argument(
+        "--shard-count",
+        type=int,
+        default=SHARD_COUNT,
+        help=f"enrolled shard count (default {SHARD_COUNT})",
+    )
+    parser.add_argument(
+        "--require-commit",
+        default=None,
+        help="commit each shard report must bind",
+    )
+    parser.add_argument(
+        "--order",
+        default="canonical",
+        help="suite-order label filter (canonical / reversed / shuffled)",
+    )
+    parser.add_argument(
+        "--advisory",
+        action="store_true",
+        help="print minority without failing",
+    )
+    args = parser.parse_args(argv)
+
+    attended, missing, crimes = attendance(
+        reports_dir=args.reports_dir,
+        shard_count=args.shard_count,
+        require_commit=args.require_commit,
+        order=args.order,
+    )
+    roster = roster_ids(args.shard_count)
+
+    print(f"### suite shard attendance ({args.order}) — enrollment is existence")
+    print()
+    print(f"- roster size: `{len(roster)}`")
+    print(f"- attended (identity-resolved): `{len(attended)}`")
+    print(f"- missing / unresolved: `{len(missing)}`")
+    print()
+    print("| shard | spoke |")
+    print("| --- | --- |")
+    for shard_id in roster:
+        spoke = "yes" if shard_id in attended else "NO — UNMEASURED"
+        print(f"| `{shard_id}` | {spoke} |")
+    print()
+    print(f"**R_suite_shard_attendance = {len(missing)}**")
+    if missing:
+        print()
+        print(
+            "These shards did not report an identity-resolved suite-report. "
+            "Their silence is NOT a smaller suite — R is UNMEASURED:"
+        )
+        for shard_id in missing:
+            print(f"- `{shard_id}`")
+    if crimes:
+        print()
+        print("Identity / enrollment crimes on present artifacts:")
+        for crime in crimes:
+            print(f"- `{crime}`")
+            print(f"::error::{crime}", file=sys.stderr)
+
+    if missing or crimes:
+        return 0 if args.advisory else 1
+    print()
+    print(
+        f"All {len(roster)} shards attended; each is identity-resolved. "
+        "No shared aggregate was required."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/python_package_suite_shards.py
+++ b/tools/python_package_suite_shards.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Deterministic file shards for the authoritative Python package suite.
+
+WHY SHARDS, NOT ONE PROCESS
+---------------------------
+A single pytest over the whole package is one writer of one suite-report and
+one long hold of a shared resource. Parallel CI jobs each own one shard: each
+writes its own identity-bound report. Completeness is enrollment (all shards
+attended), not aggregation into a shared hub.
+
+SHARD LAW
+---------
+- Test *files* are the unit of assignment (not individual tests).
+- Assignment is pure: sort relative paths, then ``index % shard_count``.
+- The same file always lands in the same shard for a fixed ``shard_count``.
+- Empty shards are legal: they still attend with collected=0.
+
+CANONICAL ORDER (stated, not silent)
+------------------------------------
+``suite-order=canonical`` is the collection order **within one shard's file
+set**, not a single package-wide sequence. Discrimination arms reverse/shuffle
+within a shard only. Cross-shard interleaving order is not a measured claim
+under parallel jobs — there is no recombine step that would invent one.
+
+Usage:
+    python3 tools/python_package_suite_shards.py --list-files
+    python3 tools/python_package_suite_shards.py --shard-index 3 --print-paths
+    python3 tools/python_package_suite_shards.py --emit-matrix-json
+    python3 tools/python_package_suite_shards.py --print-roster
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# 32 shards: ~416 test files → ~13 files each. Under GitHub's 256-job matrix
+# cap (1/8 of the ceiling). On a 32-core box, one cold pytest per core is the
+# natural fan-out without drowning the runner scheduler in 64+ tiny jobs.
+SHARD_COUNT = 32
+
+# Relative to repo root. Collected pytest targets are files under this tree.
+TESTS_REL = Path("implementations/python/sugar-lift-py-tests/tests")
+
+# Paths that are never pytest targets (corpus / fixtures, not collected suite).
+_SKIP_DIR_PARTS = frozenset({"vendor", "fixtures", "__pycache__"})
+
+
+def repo_root_from(start: Path | None = None) -> Path:
+    here = (start or Path.cwd()).resolve()
+    for candidate in (here, *here.parents):
+        if (candidate / "sugar-build.toml").is_file():
+            return candidate
+    raise SystemExit(f"cannot find sugar-build.toml above {here}")
+
+
+def list_suite_test_files(repo_root: Path) -> list[str]:
+    """Sorted repo-relative POSIX paths of suite test modules."""
+    root = (repo_root / TESTS_REL).resolve()
+    if not root.is_dir():
+        raise SystemExit(f"suite tests tree missing: {root}")
+    files: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        rel = path.relative_to(repo_root).as_posix()
+        parts = set(path.relative_to(root).parts)
+        if parts & _SKIP_DIR_PARTS:
+            continue
+        name = path.name
+        if name == "conftest.py":
+            continue
+        # pytest collects test_*.py and *_test.py by default.
+        if not (name.startswith("test_") or name.endswith("_test.py")):
+            continue
+        files.append(rel)
+    return files
+
+
+def shard_index_for(path: str, files: list[str], shard_count: int) -> int:
+    try:
+        return files.index(path) % shard_count
+    except ValueError as exc:
+        raise SystemExit(f"path not in suite file roster: {path}") from exc
+
+
+def files_for_shard(
+    files: list[str], shard_index: int, shard_count: int
+) -> list[str]:
+    if shard_count < 1:
+        raise SystemExit("shard_count must be >= 1")
+    if not (0 <= shard_index < shard_count):
+        raise SystemExit(
+            f"shard_index {shard_index} out of range for shard_count {shard_count}"
+        )
+    return [path for i, path in enumerate(files) if i % shard_count == shard_index]
+
+
+def roster_ids(shard_count: int) -> list[str]:
+    return [f"shard-{i:02d}" for i in range(shard_count)]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="checkout root (default: walk up to sugar-build.toml)",
+    )
+    parser.add_argument(
+        "--shard-count",
+        type=int,
+        default=SHARD_COUNT,
+        help=f"number of shards (default {SHARD_COUNT})",
+    )
+    parser.add_argument(
+        "--shard-index",
+        type=int,
+        default=None,
+        help="0-based shard index for --print-paths",
+    )
+    parser.add_argument(
+        "--list-files",
+        action="store_true",
+        help="print every suite test file (sorted)",
+    )
+    parser.add_argument(
+        "--print-paths",
+        action="store_true",
+        help="print paths for --shard-index (pytest args); requires --shard-index",
+    )
+    parser.add_argument(
+        "--print-roster",
+        action="store_true",
+        help="print expected shard ids (enrollment roster)",
+    )
+    parser.add_argument(
+        "--emit-matrix-json",
+        action="store_true",
+        help='print GitHub Actions matrix JSON: {"shard":[0,1,...]}',
+    )
+    parser.add_argument(
+        "--emit-shard-list-json",
+        action="store_true",
+        help="print JSON array of shard indices for nested matrix.order × shard",
+    )
+    parser.add_argument(
+        "--mint-empty-report",
+        action="store",
+        default=None,
+        metavar="PATH",
+        help="write an identity-bound empty shard report to PATH (enrollment seat)",
+    )
+    parser.add_argument(
+        "--suite-identity",
+        default=None,
+        help="environment-identity.json for --mint-empty-report",
+    )
+    parser.add_argument(
+        "--suite-commit",
+        default=None,
+        help="measured commit for --mint-empty-report",
+    )
+    parser.add_argument(
+        "--suite-binary-stamp",
+        default=None,
+        help="binary sourceStamp for --mint-empty-report",
+    )
+    parser.add_argument(
+        "--suite-order",
+        default="canonical",
+        help="order field for --mint-empty-report",
+    )
+    parser.add_argument(
+        "--emit-paths-for-cwd",
+        action="store_true",
+        help=(
+            "like --print-paths but paths relative to implementations/python "
+            "(workflow working-directory)"
+        ),
+    )
+    args = parser.parse_args(argv)
+    root = repo_root_from(args.repo_root)
+    files = list_suite_test_files(root)
+
+    if args.list_files:
+        for path in files:
+            print(path)
+        return 0
+
+    if args.print_roster:
+        for shard_id in roster_ids(args.shard_count):
+            print(shard_id)
+        return 0
+
+    if args.emit_matrix_json:
+        matrix = {"shard": list(range(args.shard_count))}
+        print(json.dumps(matrix, separators=(",", ":")))
+        return 0
+
+    if args.emit_shard_list_json:
+        print(json.dumps(list(range(args.shard_count)), separators=(",", ":")))
+        return 0
+
+    if args.mint_empty_report is not None:
+        if args.shard_index is None:
+            parser.error("--mint-empty-report requires --shard-index")
+        if not args.suite_identity or not args.suite_commit or not args.suite_binary_stamp:
+            parser.error(
+                "--mint-empty-report requires --suite-identity, --suite-commit, "
+                "--suite-binary-stamp"
+            )
+        identity = json.loads(
+            Path(args.suite_identity).read_text(encoding="utf-8")
+        )
+        stamp = (identity.get("sourceStamp") or {}).get("value")
+        extras = (identity.get("dependencyAuthority") or {}).get(
+            "testExtraInputHash"
+        )
+        shard = args.shard_index
+        count = args.shard_count
+        report = {
+            "schemaVersion": 1,
+            "label": (
+                f"python-package-suite-{args.suite_order}-shard-{shard:02d}"
+            ),
+            "order": args.suite_order,
+            "shuffleSeed": None,
+            "shardIndex": shard,
+            "shardCount": count,
+            "pytestExitStatus": 5,
+            "measuredCommit": args.suite_commit,
+            "sourceStamp": stamp,
+            "testExtraInputHash": extras,
+            "environmentIdentityHash": identity.get("environmentIdentityHash"),
+            "binarySourceStamp": args.suite_binary_stamp,
+            "environmentIdentity": identity,
+            "runnerIdentity": {"githubSha": args.suite_commit},
+            "resourceTelemetry": {},
+            "timing": {"wallSeconds": 0},
+            "collectedNodeIds": [],
+            "executedOrderNodeIds": [],
+            "failedNodeIds": [],
+            "errorNodeIds": [],
+            "skippedNodeIds": [],
+            "xfailedNodeIds": [],
+            "xpassedNodeIds": [],
+            "passedNodeIds": [],
+            "collectionErrorNodeIds": [],
+            "notReportedNodeIds": [],
+            "counts": {
+                "collected": 0,
+                "passed": 0,
+                "failed": 0,
+                "error": 0,
+                "skipped": 0,
+                "xfailed": 0,
+                "xpassed": 0,
+                "collectionError": 0,
+                "notReported": 0,
+            },
+            "conservation": {
+                "collected": 0,
+                "verdicts": 0,
+                "executedOrder": 0,
+                "buckets": {
+                    "passed": 0,
+                    "failed": 0,
+                    "error": 0,
+                    "skipped": 0,
+                    "xfailed": 0,
+                    "xpassed": 0,
+                    "notReported": 0,
+                },
+                "collectionError": 0,
+            },
+        }
+        out = Path(args.mint_empty_report)
+        out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        print(f"minted empty-shard report at {out}", file=sys.stderr)
+        return 0
+
+    if args.print_paths or args.emit_paths_for_cwd:
+        if args.shard_index is None:
+            parser.error("--print-paths requires --shard-index")
+        chosen = files_for_shard(files, args.shard_index, args.shard_count)
+        prefix = "implementations/python/"
+        for path in chosen:
+            if args.emit_paths_for_cwd:
+                if not path.startswith(prefix):
+                    raise SystemExit(f"path not under implementations/python: {path}")
+                print(path[len(prefix) :])
+            else:
+                print(path)
+        return 0
+
+    parser.error(
+        "pass one of --list-files / --print-paths / --print-roster / "
+        "--emit-matrix-json / --emit-shard-list-json / --mint-empty-report"
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## DO NOT MERGE

Lands **after** the S0.2 floors measurement banks (advisor sequencing). T decides WHAT; advisor sequences WHEN. Opening now; freeze-merge discipline still holds.

## Summary

T's design beats the merge-N-reports plan: **the singleton report was the defect.**

One `suite-report.json` ⇒ one writer ⇒ serialization ⇒ a mutex to protect it ⇒ the machine-wide lease ⇒ corpus floors starved for hours.

### Build (this PR)

1. **Per-shard identity-bound reports** — 32 deterministic file shards (`tools/python_package_suite_shards.py`). Each job writes its own report with `shardIndex`/`shardCount`. **No merge step, no shared hub.**

2. **Enrollment completeness** — `tools/python_package_suite_shard_attendance.py`: roster of expected shards; missing/unresolved = **UNMEASURED** (not a smaller pass count). Same law as heavy attendance.

3. **Identity gate per shard** — campaign claim is stronger: all N attended **and** each identity-resolved.

4. **No machine-wide lease on the suite** — reason: no shared resource to protect. **Lease kept** on floors, recensus, walls (unchanged).

5. **Canonical order (stated law)** — collection order **within** a shard's file set only. Discrimination is within-shard. No package-wide recombine invents a global sequence.

### Shard count: **32**

~416 test files → ~13 files/shard. Under GitHub's 256-job matrix cap (1/8 of ceiling). Matches a 32-core box fan-out without 64+ tiny jobs drowning the scheduler.

### Honest finding (no single aggregate required)

Nothing found that **requires** a merged hub. Discrimination becomes within-shard order-independence. Cross-shard interleaving order is not a measured claim under parallel jobs — that is the honest trade of killing the singleton.

### Out of scope (named, not fixed)

Push still fires `factory-zero-tolerance` on every merge (superseded floors pile). Needs cancel-supersede / campaign policy, not a lease change.

## Teeth

- Missing shard → attendance red / UNMEASURED
- Topology: `python-package-suite.yml` contains **no** `tools/heavy_measurement_lease.py`
- Corpus workflows still lease

## Validation (local)

```
python3.12 -m pytest tests/test_python_package_suite_shards.py tests/test_heavy_measurement_concurrency_topology.py  # 23 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Shard the Python package suite CI by enrollment without a machine-wide lease
> - Replaces the single lease-protected suite run with a matrix of 32 parallel shards, each running pytest on a deterministic file subset and writing its own `suite-report.json` with `shardIndex`/`shardCount` fields.
> - Adds [`tools/python_package_suite_shards.py`](https://github.com/TSavo/sugar/pull/7003/files#diff-9f48da58cabb30fcad1c04d290501b130d9268868644bca5c1fc5774b1aa7c90) to enumerate test files, assign them to shards by stable modulo, and emit GitHub Actions matrix JSON.
> - Adds [`tools/python_package_suite_shard_attendance.py`](https://github.com/TSavo/sugar/pull/7003/files#diff-57d226269abac43d9ad0eacbcba8b26841b28e66f830f818e07b1d965a915553) with an attendance job that downloads per-shard artifacts and fails the campaign if any shard is missing or identity-unresolved.
> - Removes `python-package-suite` from the machine-wide lease roster, heavy attendance roll call, and tip-axis composition in [`tools/heavy_measurement_attendance.py`](https://github.com/TSavo/sugar/pull/7003/files#diff-488ea1f5082769971d9377e07807b0fef693e2d67727f202b2a8c34ba0963556) and [`tools/commit_measurement.py`](https://github.com/TSavo/sugar/pull/7003/files#diff-034ed16ba84c4a527a93fb4c6f2ee50b10a1a08d9cb122bd440105312d686c07).
> - Discrimination checks (reversed/shuffled orders) now run per shard without the lease gate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86e308b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->