### PR TITLE
Floor scratch off population; never bank R=0 unmeasured (S0.2)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
@@ -16,6 +16,7 @@ import logging
 import os
 import signal
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any, Callable, Iterator, Sequence, TextIO, TypeVar
@@ -203,8 +204,41 @@ def iter_with_tqdm(
         progress.flush()
 
 
+def floor_workspace_root() -> Path:
+    """Writable workspace for floor scratch — never the scan population.
+
+    Population roots (authenticated pandas under site-packages) are read-only
+    vendor trees. Scratch under that root mutates the thing being measured and
+    fails when the tree is not writable (S0.2 / run 30727525884).
+
+    Prefer explicit SUGAR_FLOOR_WORKSPACE, then CI workspace/tmp env, else
+    process temp. Callers may still pass --out-dir; that path is still checked
+    against the population root and refused if nested under it.
+    """
+    for key in ("SUGAR_FLOOR_WORKSPACE", "GITHUB_WORKSPACE", "RUNNER_TEMP"):
+        raw = os.environ.get(key)
+        if raw:
+            return Path(raw)
+    return Path(tempfile.gettempdir()) / "sugar-floor-workspace"
+
+
 def default_out_dir(repo_root: Path, floor: str) -> Path:
-    return repo_root / ".sugar" / "ci-floors" / floor
+    """Scratch directory for one floor. ``repo_root`` is the population root.
+
+    Historically this returned ``repo_root / .sugar / ci-floors / floor``, which
+    wrote into vendor site-packages when --repo-root was the pandas corpus.
+    Scratch is always under floor_workspace_root(); population is never the base.
+    """
+    del repo_root  # population root must not host scratch
+    return floor_workspace_root() / ".sugar" / "ci-floors" / floor
+
+
+def _is_path_under(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
 
 
 def prepare_floor_io(
@@ -215,14 +249,62 @@ def prepare_floor_io(
     engine_log: Path | None,
     progress: Path | None,
 ) -> tuple[Path, Path, Path]:
+    """Open engine/progress logs under workspace scratch, not the population.
+
+    ``repo_root`` is the population root (relative loci / corpus). Scratch must
+    never nest under it — even when mkdir would succeed, mutating a vendor
+    corpus is wrong.
+    """
+    population = repo_root
     base = out_dir or default_out_dir(repo_root, floor)
-    base.mkdir(parents=True, exist_ok=True)
+    if _is_path_under(base, population):
+        raise ValueError(
+            "floor scratch must not live under the population root "
+            f"(population={population}, scratch={base}). "
+            "Pass --out-dir under a workspace/tmp path, or set "
+            "SUGAR_FLOOR_WORKSPACE / GITHUB_WORKSPACE / RUNNER_TEMP."
+        )
+    try:
+        base.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise OSError(
+            f"floor scratch mkdir failed under workspace path {base}: {error}. "
+            "Scratch is never under the population; check workspace permissions."
+        ) from error
     engine_path = engine_log or (base / "engine.jsonl")
     progress_path = progress or (base / "progress.log")
+    if _is_path_under(engine_path, population) or _is_path_under(
+        progress_path, population
+    ):
+        raise ValueError(
+            "engine/progress paths must not live under the population root "
+            f"(population={population})."
+        )
     silence_console_logging()
     configure_engine_log(engine_path)
     return base, engine_path, progress_path
 
+
+def format_completed_axis_report(axis: str, r_value: int) -> str:
+    """Print R only after a completed measurement. Never invent a zero.
+
+    Incomplete / crashed floors must use :func:`format_unmeasured_axis` so a
+    reader cannot bank ``R_axis = 0`` that was never taken.
+    """
+    return f"{axis} = {r_value}"
+
+
+def format_unmeasured_axis(axis: str, *, reason: str) -> str:
+    """Lease-gate vocabulary: unmeasured / completed-with-error / no-value.
+
+    Deliberately does **not** contain the substring ``{axis} = 0`` or bare
+    `` = 0`` — readers (and greps) bank that pattern as a completed zero.
+    """
+    return (
+        f"{axis}: unmeasured "
+        f"(status=completed-with-error; reason={reason!r}; value=no-value). "
+        f"Measurement did not complete; residual is not a completed zero."
+    )
 
 def timed_enum_file(
     path: Path,

--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -22,6 +22,8 @@ from typing import Any, Mapping, NamedTuple, Sequence
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _enum_floor_runtime import (  # noqa: E402
+    format_completed_axis_report,
+    format_unmeasured_axis,
     prepare_floor_io,
     production_roots,
     require_explicit_scan_roots,
@@ -135,13 +137,17 @@ def main() -> int:
         f"roots={[str(p) for p in args.paths]} files={len(paths)}"
     )
 
-    _base, engine_path, progress_path = prepare_floor_io(
-        repo_root=args.repo_root,
-        floor="bare-exception",
-        out_dir=args.out_dir,
-        engine_log=args.engine_log,
-        progress=args.progress,
-    )
+    try:
+        _base, engine_path, progress_path = prepare_floor_io(
+            repo_root=args.repo_root,
+            floor="bare-exception",
+            out_dir=args.out_dir,
+            engine_log=args.engine_log,
+            progress=args.progress,
+        )
+    except (OSError, ValueError) as error:
+        print(format_unmeasured_axis("R_bare_exceptions", reason=str(error)))
+        return 1
     progress_path.write_text(
         f"# bare-exception supervised enum scan\n"
         f"# engine={engine_path}\n"
@@ -167,7 +173,7 @@ def main() -> int:
         f"bare={len(offenders)} "
         f"progress={progress_path} engine={engine_path}"
     )
-    print(f"R_bare_exceptions = {len(offenders)}")
+    print(format_completed_axis_report("R_bare_exceptions", len(offenders)))
     for row in offenders:
         tail = (row.stderr_tail.splitlines() or ["no detail"])[-1]
         print(f"{row.file}:returncode={row.returncode}:bare-exception — {tail}")

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -23,6 +23,8 @@ from typing import NamedTuple, Sequence
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _enum_floor_runtime import (  # noqa: E402
+    format_completed_axis_report,
+    format_unmeasured_axis,
     prepare_floor_io,
     production_roots,
     require_explicit_scan_roots,
@@ -80,7 +82,9 @@ def r_native_crashes(offenders: Sequence[NativeCrashOffender]) -> int:
 
 def format_report(offenders: Sequence[NativeCrashOffender]) -> str:
     lines = [
-        f"R_native_crashes = {r_native_crashes(offenders)}",
+        format_completed_axis_report(
+            "R_native_crashes", r_native_crashes(offenders)
+        ),
         (
             "Replacement: corpus children terminate with completed testimony, "
             "typed gap, bare-exception row, or loud timeout; never signal."
@@ -192,13 +196,17 @@ def main() -> int:
         f"roots={[str(p) for p in args.paths]} files={len(paths)}"
     )
 
-    _base, engine_path, progress_path = prepare_floor_io(
-        repo_root=args.repo_root,
-        floor="native-crash",
-        out_dir=args.out_dir,
-        engine_log=args.engine_log,
-        progress=args.progress,
-    )
+    try:
+        _base, engine_path, progress_path = prepare_floor_io(
+            repo_root=args.repo_root,
+            floor="native-crash",
+            out_dir=args.out_dir,
+            engine_log=args.engine_log,
+            progress=args.progress,
+        )
+    except (OSError, ValueError) as error:
+        print(format_unmeasured_axis("R_native_crashes", reason=str(error)))
+        return 1
     summary = audit_paths(
         paths,
         root=args.repo_root,

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -64,6 +64,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from sugar_lift_py_tests.idd.lift_coverage_census import DiskCensus  # noqa: E402
 
 from _enum_floor_runtime import (  # noqa: E402
+    format_completed_axis_report,
+    format_unmeasured_axis,
     iter_with_tqdm,
     open_progress,
     prepare_floor_io,
@@ -150,7 +152,7 @@ def r_silent(offenders: Sequence[SilentOffender]) -> int:
 
 def format_report(offenders: Sequence[SilentOffender]) -> str:
     lines = [
-        f"R_silent = {r_silent(offenders)}",
+        format_completed_axis_report("R_silent", r_silent(offenders)),
         (
             "Replacement: every source locus speaks as warranted, support, "
             "inactive, typed effect, or loud ConstructionPanic."
@@ -338,13 +340,17 @@ def main() -> int:
         print(f"SILENT ZERO-TOLERANCE RED: {error}")
         return 1
 
-    _base, engine_path, progress_path = prepare_floor_io(
-        repo_root=args.repo_root,
-        floor="silent",
-        out_dir=args.out_dir,
-        engine_log=args.engine_log,
-        progress=args.progress,
-    )
+    try:
+        _base, engine_path, progress_path = prepare_floor_io(
+            repo_root=args.repo_root,
+            floor="silent",
+            out_dir=args.out_dir,
+            engine_log=args.engine_log,
+            progress=args.progress,
+        )
+    except (OSError, ValueError) as error:
+        print(format_unmeasured_axis("R_silent", reason=str(error)))
+        return 1
     summary = audit_paths(
         paths,
         root=args.repo_root,

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -20,6 +20,8 @@ from typing import NamedTuple, Sequence
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _enum_floor_runtime import (  # noqa: E402
+    format_completed_axis_report,
+    format_unmeasured_axis,
     prepare_floor_io,
     production_roots,
     require_explicit_scan_roots,
@@ -136,13 +138,17 @@ def main() -> int:
         f"roots={[str(p) for p in args.paths]} files={len(paths)}"
     )
 
-    _base, engine_path, progress_path = prepare_floor_io(
-        repo_root=args.repo_root,
-        floor="timeout",
-        out_dir=args.out_dir,
-        engine_log=args.engine_log,
-        progress=args.progress,
-    )
+    try:
+        _base, engine_path, progress_path = prepare_floor_io(
+            repo_root=args.repo_root,
+            floor="timeout",
+            out_dir=args.out_dir,
+            engine_log=args.engine_log,
+            progress=args.progress,
+        )
+    except (OSError, ValueError) as error:
+        print(format_unmeasured_axis("R_timeouts", reason=str(error)))
+        return 1
     summary = audit_paths(
         paths,
         root=args.repo_root,
@@ -186,7 +192,7 @@ def main() -> int:
         f"timeouts={len(offenders)} "
         f"progress={progress_path} engine={engine_path}"
     )
-    print(f"R_timeouts = {len(offenders)}")
+    print(format_completed_axis_report("R_timeouts", len(offenders)))
     for row in offenders:
         print(f"{row.file}:timeout>{row.timeout_seconds}s")
     return 1 if offenders else 0

--- a/implementations/python/sugar-lift-py-tests/tests/test_floor_measurement_integrity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_floor_measurement_integrity.py
@@ -1,0 +1,130 @@
+"""Measurement integrity for Criterion-2 process floors (S0.2 repair).
+
+Two co-equal defects from run 30727525884:
+
+1. Scratch must never mkdir under the population root (read-only vendor tree).
+2. Pre-measure crash must never serialize bankable ``R_axis = 0``.
+
+Recognition/teeth only — no corpus run, no drain.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+_KIT = Path(__file__).resolve().parents[1]
+_RUNTIME = _KIT / "scripts" / "_enum_floor_runtime.py"
+_SPEC = importlib.util.spec_from_file_location("enum_floor_runtime", _RUNTIME)
+assert _SPEC is not None and _SPEC.loader is not None
+_RT = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_RT)
+
+
+def test_default_out_dir_is_never_under_population(tmp_path: Path, monkeypatch) -> None:
+    population = tmp_path / "site-packages" / "pandas"
+    population.mkdir(parents=True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("SUGAR_FLOOR_WORKSPACE", str(workspace))
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    monkeypatch.delenv("RUNNER_TEMP", raising=False)
+
+    out = _RT.default_out_dir(population, "timeout")
+    assert out == workspace / ".sugar" / "ci-floors" / "timeout"
+    # Must not nest under the population even when env is empty later.
+    assert population.resolve() not in out.resolve().parents
+    assert not str(out.resolve()).startswith(str(population.resolve()))
+
+
+def test_prepare_floor_io_refuses_scratch_under_population(tmp_path: Path) -> None:
+    population = tmp_path / "pandas"
+    population.mkdir()
+    under = population / ".sugar" / "ci-floors" / "native-crash"
+    with pytest.raises(ValueError, match="must not live under the population"):
+        _RT.prepare_floor_io(
+            repo_root=population,
+            floor="native-crash",
+            out_dir=under,
+            engine_log=None,
+            progress=None,
+        )
+
+
+def test_prepare_floor_io_uses_workspace_when_population_is_read_only(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Plant: non-writable population. Scratch still lands and is outside it."""
+    population = tmp_path / "pandas"
+    population.mkdir()
+    # Make population non-writable (no mkdir of children).
+    population.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    monkeypatch.setenv("SUGAR_FLOOR_WORKSPACE", str(workspace))
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    monkeypatch.delenv("RUNNER_TEMP", raising=False)
+    # Avoid importing the full kit just to open engine logs.
+    monkeypatch.setattr(_RT, "configure_engine_log", lambda path: None)
+    monkeypatch.setattr(_RT, "silence_console_logging", lambda: None)
+
+    try:
+        base, engine, progress = _RT.prepare_floor_io(
+            repo_root=population,
+            floor="silent",
+            out_dir=None,
+            engine_log=None,
+            progress=None,
+        )
+    finally:
+        population.chmod(stat.S_IRWXU)
+
+    assert base.is_dir()
+    assert base.resolve().is_relative_to(workspace.resolve())
+    assert not base.resolve().is_relative_to(population.resolve())
+    assert engine.parent == base
+    assert progress.parent == base
+
+
+def test_format_unmeasured_never_serializes_r_equals_zero() -> None:
+    """Plant: pre-measure crash path — artifact must not bank R=0."""
+    text = _RT.format_unmeasured_axis(
+        "R_timeouts", reason="PermissionError: mkdir under population"
+    )
+    assert "unmeasured" in text
+    assert "completed-with-error" in text
+    assert "no-value" in text
+    assert "R_timeouts = 0" not in text
+    assert " = 0" not in text
+
+
+def test_format_completed_zero_only_when_measurement_finished() -> None:
+    """Completed measurement with zero findings may print = 0; that is honest."""
+    text = _RT.format_completed_axis_report("R_silent", 0)
+    assert text == "R_silent = 0"
+
+
+def test_sole_construction_group_names_do_not_embed_equals_zero() -> None:
+    here = Path(__file__).resolve()
+    floors = None
+    for parent in [here, *here.parents]:
+        candidate = parent / "tools" / "run_sole_construction_floors.sh"
+        if candidate.is_file():
+            floors = candidate
+            break
+    assert floors is not None, "run_sole_construction_floors.sh not found"
+    text = floors.read_text(encoding="utf-8")
+    for axis in (
+        "R_native_crashes",
+        "R_bare_exceptions",
+        "R_timeouts",
+        "R_silent",
+    ):
+        needle = f'axis "{axis}"'
+        assert needle in text, f"missing {needle}"
+        assert f'axis "{axis} = 0"' not in text
+    assert "FLOOR_SCRATCH" in text or "--out-dir" in text

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -27,10 +27,12 @@ AXIS_COMMANDS = {
     "R_construction_panic_catches_outside_membrane = 0": (
         "construction_panic_catch_law.py"
     ),
-    "R_silent = 0": "silent_zero_tolerance.py",
-    "R_native_crashes = 0": "native_crash_zero_tolerance.py",
-    "R_bare_exceptions = 0": "bare_exception_zero_tolerance.py",
-    "R_timeouts = 0": "timeout_zero_tolerance.py",
+    # Criterion-2 process floors: axis names carry no "= 0" (pre-measure crash
+    # must not paint a bankable zero in the group header).
+    "R_silent": "silent_zero_tolerance.py",
+    "R_native_crashes": "native_crash_zero_tolerance.py",
+    "R_bare_exceptions": "bare_exception_zero_tolerance.py",
+    "R_timeouts": "timeout_zero_tolerance.py",
     "R_vendor_special_case = 0": "vendor_special_case_law.py",
     "R_factory_walk_unclassified = 0": "factory_walk_unclassified_law.py",
     "R_finite_cap_opaque_completions = 0": ("finite_cap_opaque_completion_law.py"),
@@ -69,10 +71,10 @@ def test_binding_job_invokes_every_permanent_axis() -> None:
                 "binding CI must census the checked-in production surface"
             )
         if axis in {
-            "R_native_crashes = 0",
-            "R_bare_exceptions = 0",
-            "R_timeouts = 0",
-            "R_silent = 0",
+            "R_native_crashes",
+            "R_bare_exceptions",
+            "R_timeouts",
+            "R_silent",
         }:
             # Process floors + Criterion-2 silent must name a population.
             # Bare silent_zero_tolerance used to default to kit production_roots
@@ -85,6 +87,15 @@ def test_binding_job_invokes_every_permanent_axis() -> None:
             assert '"$PANDAS_CORPUS"' in step or "'$PANDAS_CORPUS'" in step, (
                 f"{axis} must pass \"$PANDAS_CORPUS\" as the scan root"
             )
+            # Scratch must not default under the population root.
+            assert "--out-dir" in step or "FLOOR_SCRATCH" in step, (
+                f"{axis} must direct floor scratch outside the population "
+                "(S0.2: mkdir under site-packages/pandas is measurement crime)"
+            )
+            # Group header must not embed a bankable zero.
+            assert " = 0" not in step.split("\n", 1)[0], (
+                f"{axis} group name must not embed '= 0' (pre-measure crash bank)"
+            )
 
 
 def test_process_floors_resolve_authenticated_pandas_population() -> None:
@@ -96,10 +107,10 @@ def test_process_floors_resolve_authenticated_pandas_population() -> None:
     assert "PANDAS_CORPUS=" in floors
     # Order: corpus resolved once, then all four Criterion-2 population axes use it.
     corpus_at = floors.find("PANDAS_CORPUS=")
-    native_at = floors.find('axis "R_native_crashes = 0"')
-    bare_at = floors.find('axis "R_bare_exceptions = 0"')
-    timeout_at = floors.find('axis "R_timeouts = 0"')
-    silent_at = floors.find('axis "R_silent = 0"')
+    native_at = floors.find('axis "R_native_crashes"')
+    bare_at = floors.find('axis "R_bare_exceptions"')
+    timeout_at = floors.find('axis "R_timeouts"')
+    silent_at = floors.find('axis "R_silent"')
     assert 0 <= corpus_at < native_at < bare_at < timeout_at < silent_at, (
         "PANDAS_CORPUS must be bound before native/bare/timeout/silent axes"
     )

--- a/tools/run_sole_construction_floors.sh
+++ b/tools/run_sole_construction_floors.sh
@@ -27,14 +27,16 @@ green_axes=()
 
 axis() {
   local name="$1"; shift
+  # Axis names must NOT embed "= 0". A pre-measure crash still paints the group
+  # header; embedding a zero there banks a number that was never taken (S0.2).
   echo "::group::$name"
   if "$@"; then
     green_axes+=("$name")
-    echo "$name: GREEN"
+    echo "$name: GREEN (measurement completed)"
   else
     local status=$?
     red_axes+=("$name (exit $status)")
-    echo "::error::$name is RED (exit $status)"
+    echo "::error::$name is RED (exit $status). If the body printed unmeasured/no-value, residual is not a completed zero."
   fi
   echo "::endgroup::"
 }
@@ -59,22 +61,31 @@ PANDAS_CORPUS="$(
   exit 1
 }
 echo "process-floor population: authenticated pandas corpus at $PANDAS_CORPUS"
-# --repo-root must be the corpus root (not the Sugar checkout): relative loci
-# and supervised-enum corpus_root are derived from it.
-axis "R_native_crashes = 0" \
+# --repo-root is the population (relative loci). Scratch must NOT nest under it
+# (vendor site-packages is read-only; mutating the population is wrong even when
+# mkdir succeeds). Workspace/tmp only — same vocabulary as prepare_floor_io.
+FLOOR_SCRATCH="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}/.sugar/ci-floors"
+export SUGAR_FLOOR_WORKSPACE="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}"
+echo "process-floor scratch: $FLOOR_SCRATCH (never under population)"
+# Axis names: R_axis only — never "R_axis = 0" (false banked zero on pre-measure crash).
+axis "R_native_crashes" \
   python "$SCRIPTS/native_crash_zero_tolerance.py" "$PANDAS_CORPUS" \
-  --repo-root "$PANDAS_CORPUS"
-axis "R_bare_exceptions = 0" \
+  --repo-root "$PANDAS_CORPUS" \
+  --out-dir "$FLOOR_SCRATCH/native-crash"
+axis "R_bare_exceptions" \
   python "$SCRIPTS/bare_exception_zero_tolerance.py" "$PANDAS_CORPUS" \
-  --repo-root "$PANDAS_CORPUS"
-axis "R_timeouts = 0" \
+  --repo-root "$PANDAS_CORPUS" \
+  --out-dir "$FLOOR_SCRATCH/bare-exception"
+axis "R_timeouts" \
   python "$SCRIPTS/timeout_zero_tolerance.py" "$PANDAS_CORPUS" \
-  --repo-root "$PANDAS_CORPUS"
+  --repo-root "$PANDAS_CORPUS" \
+  --out-dir "$FLOOR_SCRATCH/timeout"
 # R_silent is Criterion 2's fourth simultaneous term — same population as the
 # three process floors. Kit-default silent was a false green (unmeasured corpus).
-axis "R_silent = 0" \
+axis "R_silent" \
   python "$SCRIPTS/silent_zero_tolerance.py" "$PANDAS_CORPUS" \
-  --repo-root "$PANDAS_CORPUS"
+  --repo-root "$PANDAS_CORPUS" \
+  --out-dir "$FLOOR_SCRATCH/silent"
 
 axis "All permanent axes are bound" \
   python -m pytest tests/test_python_sole_construction_ci.py -q


### PR DESCRIPTION
## Why

S0.2 run **30727525884** on tip `522197e93` authenticated the pandas corpus, then all four Criterion-2 axes crashed before measuring:

```
FileNotFoundError / PermissionError
.../site-packages/pandas/.sugar/ci-floors/{native-crash,bare-exception,timeout,silent}
prepare_floor_io → base.mkdir under --repo-root (population)
```

Exit channel was honest (red; lease gate refused the zero claim). **Number channel lied**: group headers were named `R_* = 0`, so a reader can bank four zeros that were never taken.

## Fix (measurement integrity only — both defects)

### 1. Scratch never under the population
- `default_out_dir` no longer uses `repo_root / .sugar / ...`
- Workspace from `SUGAR_FLOOR_WORKSPACE` / `GITHUB_WORKSPACE` / `RUNNER_TEMP` / temp
- `prepare_floor_io` **refuses** `--out-dir` nested under population root
- `run_sole_construction_floors.sh` sets `FLOOR_SCRATCH` and passes `--out-dir` per axis

Population remains `--repo-root` for relative loci only. Vendor tree is not mutated.

### 2. Never bank `R_axis = 0` when unmeasured
- `format_unmeasured_axis` / `format_completed_axis_report` in `_enum_floor_runtime`
- Process floors wrap `prepare_floor_io` `OSError`/`ValueError` → unmeasured body (no `= 0` substring)
- Axis group names: `R_native_crashes` not `R_native_crashes = 0` (and same for bare/timeout/silent)
- Axis helper error text avoids painting a bankable zero

## Teeth
- Non-writable population: still opens scratch under workspace, never under population
- Explicit out_dir under population: refused
- Unmeasured body: asserts no `R_* = 0` / bare ` = 0`
- Sole-construction pins: PANDAS_CORPUS + `--out-dir` + group names without `= 0`

## Merge conditions (you execute — freeze exception)

Ready for merge **when**:
1. Machine-wide lease is FREE  
2. Residual heavies are zero  
3. On push: cancel any package-suite from the same SHA  
4. Exactly **one** floors re-fire on the tip carrying this fix  

I will not merge or dispatch.

## Shot accounting
- Measurement integrity only; no product drain  
- Shell deleted: `default_out_dir(population)` mkdir door; bankable `= 0` group headers on the four process floors  

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Floor scratch off population; never bank R=0 unmeasured in process floor scripts
> - Scratch directories for process floors now resolve under a workspace path (from `SUGAR_FLOOR_WORKSPACE`, `GITHUB_WORKSPACE`, or `RUNNER_TEMP`) instead of under the repo population root; `prepare_floor_io` raises `ValueError` if scratch would fall under the population.
> - Two new formatters, `format_completed_axis_report` and `format_unmeasured_axis`, standardize axis output and ensure unmeasured axes never emit `= 0`.
> - Each tolerance script (`bare_exception`, `native_crash`, `silent`, `timeout`) now catches `OSError`/`ValueError` from `prepare_floor_io` and reports the axis as unmeasured with a reason, then exits non-zero.
> - `run_sole_construction_floors.sh` exports `FLOOR_SCRATCH` and passes `--out-dir` per axis; group headers no longer include `= 0`.
> - Behavioral Change: a failed scratch setup previously had undefined behavior; it now always produces an unmeasured axis line and a non-zero exit code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f359a06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace-based temporary storage for scan results, keeping scratch data separate from source populations.
  * Added clear status reporting for completed, failed, and unmeasured measurements.
  * Process-floor results now use consistent axis names and output formatting.

* **Bug Fixes**
  * Prevented unsafe output paths nested within scanned populations.
  * Improved handling of read-only populations and workspace setup failures.
  * Failures now return an explicit error status instead of appearing as zero measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->