### PR TITLE
CommitMeasurement: authenticate by body+population, not lease mutex

### DIFF
--- a/tests/test_commit_measurement.py
+++ b/tests/test_commit_measurement.py
@@ -1,25 +1,22 @@
-"""CommitMeasurement: identity + body CID; no lease seal."""
+"""Teeth for identity+population+body_cid seal (lease gone on main)."""
 
 from __future__ import annotations
 
 import importlib.util
 import json
+import sys
 from pathlib import Path
 
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-GATE = None
 
 
 def _load(name: str, rel: str):
     spec = importlib.util.spec_from_file_location(name, ROOT / rel)
+    assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
-    # Register before exec for dataclasses on some loaders
-    import sys
-
     sys.modules[name] = mod
-    assert spec.loader is not None
     spec.loader.exec_module(mod)
     return mod
 
@@ -28,156 +25,106 @@ CM = _load("commit_measurement", "tools/commit_measurement.py")
 GATE = _load("commit_measurement_gate", "tools/commit_measurement_gate.py")
 
 
-def test_measured_requires_body_cid() -> None:
-    with pytest.raises(CM.CommitMeasurementError, match="body_artifact_cid"):
-        CM.Measured(0, "", "totals.failed", 1, 0)
-    with pytest.raises(CM.CommitMeasurementError, match="value_field_path"):
-        CM.Measured(0, "body", "", 1, 0)
+def _body(failed: int = 3, collected: int = 12) -> dict:
+    return {
+        "totals": {"failed": failed, "collected": collected},
+        "failedNodeIds": ["x"] * failed,
+    }
 
 
-def test_measured_from_body_unmeasured_without_body_field() -> None:
-    reading = CM.measured_from_body(
-        commit_sha="abc",
-        body={"totals": {}},
-        body_artifact_cid="body:1",
-        value_field_path="totals.failed",
-    )
-    assert isinstance(reading, CM.Unmeasured)
+def test_scoreboard_authority_false() -> None:
+    assert CM.SCOREBOARD_AUTHORITY is False
 
 
-def test_measured_from_body_unmeasured_on_commit_mismatch() -> None:
-    reading = CM.measured_from_body(
-        commit_sha="abc",
-        body={"measuredCommit": "other", "totals": {"failed": 0, "collected": 3}},
-        body_artifact_cid="body:1",
-        value_field_path="totals.failed",
-    )
-    assert isinstance(reading, CM.Unmeasured)
-    assert "commit" in reading.reason
-
-
-def test_measured_from_body_cites_body_value() -> None:
-    body = {"totals": {"failed": 7, "collected": 40}}
-    reading = CM.measured_from_body(
-        commit_sha="abc",
-        body=body,
-        body_artifact_cid=CM.content_cid(body),
-        value_field_path="totals.failed",
-        collected_field_path="totals.collected",
-    )
-    assert isinstance(reading, CM.Measured)
-    assert reading.value == 7
-    assert reading.collected == 40
-    assert reading.body_artifact_cid.startswith("blake2b-256:")
-
-
-def test_unmeasured_is_third_value_not_zero() -> None:
-    u = CM.unmeasured("never ran")
+def test_measured_seal_is_identity_population_body_not_lease() -> None:
     m = CM.measured(
-        0,
-        body_artifact_cid="b",
+        3,
+        identity="python-package-suite",
+        population_id="pop:suite",
+        population_size=12,
+        body=_body(3, 12),
         value_field_path="totals.failed",
-        collected=1,
-        exit_code=0,
+        exit_code=1,
     )
-    assert type(u) is not type(m)
-    assert m.value == 0
-    assert not u.is_measured()
+    assert m.identity == "python-package-suite"
+    assert m.population_id == "pop:suite"
+    assert m.population_size == 12
+    assert m.body_cid == CM.content_cid(_body(3, 12))
+    assert not hasattr(m, "receipt_cid")
+    import inspect
+
+    sig = inspect.signature(CM.measured)
+    assert "receipt_cid" not in sig.parameters
+    assert "lease_receipt_cid" not in sig.parameters
 
 
-def test_complete_has_total_partial_does_not() -> None:
-    complete = CM.commit_measurement(
-        "sha",
-        "roster:tip",
-        {
-            "a": CM.measured(
-                1,
-                body_artifact_cid="b1",
-                value_field_path="totals.failed",
-                collected=2,
-                exit_code=1,
-            ),
-            "b": CM.measured(
-                2,
-                body_artifact_cid="b2",
-                value_field_path="totals.failed",
-                collected=2,
-                exit_code=1,
-            ),
-        },
-    )
-    assert isinstance(complete, CM.CompleteVector)
-    assert complete.total == 3
+def test_measured_requires_body_matching_value() -> None:
+    with pytest.raises(CM.CommitMeasurementError, match="parsed body|NoReport"):
+        CM.measured(
+            3,
+            identity="x",
+            population_id="p",
+            population_size=1,
+            body=None,  # type: ignore[arg-type]
+            value_field_path="totals.failed",
+            exit_code=1,
+        )
+    with pytest.raises(CM.CommitMeasurementError, match="does not match"):
+        CM.measured(
+            99,
+            identity="x",
+            population_id="p",
+            population_size=12,
+            body=_body(3, 12),
+            value_field_path="totals.failed",
+            exit_code=1,
+        )
+
+
+def test_empty_artifacts_partial_gate_red(tmp_path: Path) -> None:
+    empty = tmp_path / "arts"
+    empty.mkdir()
+    v = CM.compose_tip_from_artifacts_dir("deadbeef", empty)
+    assert isinstance(v, CM.PartialVector)
+    path = tmp_path / "cm.json"
+    path.write_text(json.dumps(v.to_json()), encoding="utf-8")
+    assert GATE.main(["--composition", str(path), "--require-complete"]) == 1
+
+
+def test_body_without_lease_is_measured(tmp_path: Path) -> None:
+    body = {
+        "totals": {"failed": 4, "collected": 20},
+        "failedNodeIds": ["a", "b", "c", "d"],
+        "measurementClass": "python-package-suite",
+        "populationId": "pandas-auth-corpus",
+        "populationSize": 20,
+    }
+    (tmp_path / "suite-report.json").write_text(json.dumps(body), encoding="utf-8")
+    v = CM.compose_tip_from_artifacts_dir("deadbeef", tmp_path)
+    assert isinstance(v, CM.PartialVector)
+    axis = v.axes["python-package-suite"]
+    assert isinstance(axis, CM.Measured)
+    assert axis.value == 4
+    assert axis.population_id == "pandas-auth-corpus"
+
+
+def test_partial_has_no_total() -> None:
     partial = CM.commit_measurement(
         "sha",
-        "roster:tip",
+        "roster",
         {
             "a": CM.measured(
                 1,
-                body_artifact_cid="b1",
+                identity="a",
+                population_id="p",
+                population_size=2,
+                body=_body(1, 2),
                 value_field_path="totals.failed",
-                collected=2,
                 exit_code=1,
             ),
-            "b": CM.unmeasured("missing body"),
+            "b": CM.unmeasured("NoReport"),
         },
     )
     assert isinstance(partial, CM.PartialVector)
     with pytest.raises(AttributeError):
         _ = partial.total  # type: ignore[attr-defined]
-
-
-def test_forbidden_board_axis_names() -> None:
-    with pytest.raises(CM.CommitMeasurementError, match="corpus-board"):
-        CM.commit_measurement(
-            "sha",
-            "roster",
-            {"R_construction": CM.unmeasured("no")},
-        )
-
-
-def test_compose_tip_without_body_is_unmeasured(tmp_path: Path) -> None:
-    v = CM.compose_tip_from_receipts_dir("deadbeef", tmp_path)
-    assert isinstance(v, CM.PartialVector)
-    assert "python-package-suite" in v.unmeasured_axes()
-
-
-def test_compose_tip_body_is_measured(tmp_path: Path) -> None:
-    body = {
-        "measurementClass": "python-package-suite",
-        "measuredCommit": "deadbeef",
-        "totals": {"failed": 4, "collected": 20},
-        "failedNodeIds": ["a", "b", "c", "d"],
-    }
-    (tmp_path / "suite-report.json").write_text(json.dumps(body), encoding="utf-8")
-    floor = {
-        "measurementClass": "python-sole-construction-floors",
-        "measuredCommit": "deadbeef",
-        "totals": {"failed": 0},
-        "exitCode": 0,
-    }
-    (tmp_path / "floor-measurement.json").write_text(
-        json.dumps(floor), encoding="utf-8"
-    )
-    v = CM.compose_tip_from_receipts_dir("deadbeef", tmp_path)
-    assert isinstance(v.axes["python-package-suite"], CM.Measured)
-    assert v.axes["python-package-suite"].value == 4
-    assert isinstance(v.axes["python-sole-construction-floors"], CM.Measured)
-
-
-def test_gate_missing_composition_is_red(tmp_path: Path) -> None:
-    assert (
-        GATE.main(["--composition", str(tmp_path / "nope.json"), "--require-complete"])
-        == 1
-    )
-
-
-def test_gate_partial_require_complete_is_red(tmp_path: Path) -> None:
-    v = CM.commit_measurement(
-        "sha",
-        "roster",
-        {"a": CM.unmeasured("gone")},
-    )
-    path = tmp_path / "cm.json"
-    path.write_text(json.dumps(v.to_json()), encoding="utf-8")
-    assert GATE.main(["--composition", str(path), "--require-complete"]) == 1

--- a/tools/commit_measurement.py
+++ b/tools/commit_measurement.py
@@ -1,27 +1,25 @@
 #!/usr/bin/env python3
 """CommitMeasurement — sealed composition of tip measurement testimony.
 
-Cite-compose only. SCOREBOARD_AUTHORITY = False. Never recompute product R
-(control_effect_recensus owns the corpus board). Never emit board axis names
-as computed residual.
+Cite-compose only. SCOREBOARD_AUTHORITY = False. Never recompute product R.
 
     AxisReading = Measured(...) | Unmeasured(reason)
     commit_measurement(...) -> CompleteVector | PartialVector
 
-Measured requires:
-  - body artifact CID + value_field_path (the report that owns the number)
-  - identity binding on the body when present (measuredCommit / commit)
+Measured is authenticated by WHAT IT PRODUCED + declared population:
 
-There is no machine-wide lease. A free-floating value without a body CID is
-unconstructible. lease_receipt_cid is gone from the seal.
+  - identity: which measurement class this axis is
+  - population_id + population_size: declared denominator
+  - body_cid: content address of the report body
+  - value_field_path / value / exit_code
+
+There is no machine-wide lease. No lease_receipt_cid in the seal (deleted with
+the lease architecture). Free-floating value without a body is unconstructible.
 
 CompleteVector has .total. PartialVector has no .total.
 Unmeasured is a third value, not zero.
 
-One door: ``commit_measurement`` / ``compose_tip_from_receipts_dir``.
-
-CI: ``tools/commit_measurement_gate.py --require-complete`` fails closed.
-Enrollment: heavy-measurement-attendance.yml composes + gates after roll call.
+One door: ``commit_measurement`` / ``compose_tip_from_artifacts_dir``.
 """
 
 from __future__ import annotations
@@ -34,7 +32,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Union
 
-# Board residual keys this composition must never invent as its own axes.
 FORBIDDEN_BOARD_AXIS_NAMES = frozenset(
     {
         "R_construction",
@@ -45,6 +42,8 @@ FORBIDDEN_BOARD_AXIS_NAMES = frozenset(
         "R_backend_defects",
     }
 )
+
+_MEASURED_SEAL = object()
 
 
 class CommitMeasurementError(TypeError):
@@ -70,7 +69,6 @@ def _require_int(name: str, value: object, *, min_value: int | None = None) -> i
 
 
 def content_cid(payload: bytes | str | Mapping[str, Any]) -> str:
-    """Content address for sealed artifacts (blake2b hex, schema-local)."""
     if isinstance(payload, Mapping):
         raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     elif isinstance(payload, str):
@@ -82,7 +80,6 @@ def content_cid(payload: bytes | str | Mapping[str, Any]) -> str:
 
 
 def _lookup_path(body: Mapping[str, Any], field_path: str) -> Any:
-    """Dot-path lookup; ``summary.failed`` or ``failedNodeIds`` (len if list)."""
     cur: Any = body
     for part in field_path.split("."):
         if part == "len" and isinstance(cur, (list, tuple, set, dict)):
@@ -97,32 +94,53 @@ def _lookup_path(body: Mapping[str, Any], field_path: str) -> Any:
 
 @dataclass(frozen=True, slots=True)
 class Measured:
-    """Measured axis: value cited from an identity-bound body artifact.
+    """Measured axis: identity + declared population + body_cid of produced report.
 
-    Unconstructible without body_artifact_cid AND value_field_path.
-    No lease receipt in the seal — the global mutex is gone.
+    No lease receipt. Sealed construction only via measured(body=...).
     """
 
     value: int
-    body_artifact_cid: str
+    identity: str
+    population_id: str
+    population_size: int
+    body_cid: str
     value_field_path: str
-    collected: int
     exit_code: int
+    _seal: object
 
     def __post_init__(self) -> None:
+        if self._seal is not _MEASURED_SEAL:
+            raise CommitMeasurementError(
+                "Measured is sealed: use measured(body=...) or measured_from_body(...)"
+            )
         _require_int("value", self.value, min_value=0)
         object.__setattr__(
+            self, "identity", _require_nonempty_str("identity", self.identity)
+        )
+        object.__setattr__(
             self,
-            "body_artifact_cid",
-            _require_nonempty_str("body_artifact_cid", self.body_artifact_cid),
+            "population_id",
+            _require_nonempty_str("population_id", self.population_id),
+        )
+        _require_int("population_size", self.population_size, min_value=0)
+        object.__setattr__(
+            self, "body_cid", _require_nonempty_str("body_cid", self.body_cid)
         )
         object.__setattr__(
             self,
             "value_field_path",
             _require_nonempty_str("value_field_path", self.value_field_path),
         )
-        _require_int("collected", self.collected, min_value=0)
         _require_int("exit_code", self.exit_code)
+
+    # Back-compat alias used by older JSON readers / tests
+    @property
+    def body_artifact_cid(self) -> str:
+        return self.body_cid
+
+    @property
+    def collected(self) -> int:
+        return self.population_size
 
     def is_measured(self) -> bool:
         return True
@@ -130,8 +148,6 @@ class Measured:
 
 @dataclass(frozen=True, slots=True)
 class Unmeasured:
-    """Third value: not measured. Not zero. Not coercible to Measured."""
-
     reason: str
 
     def __post_init__(self) -> None:
@@ -149,17 +165,43 @@ AxisReading = Union[Measured, Unmeasured]
 def measured(
     value: int,
     *,
-    body_artifact_cid: str,
+    identity: str,
+    population_id: str,
+    population_size: int,
+    body: Mapping[str, Any],
     value_field_path: str,
-    collected: int,
     exit_code: int,
 ) -> Measured:
+    """Build Measured from parsed body + declared population. No lease param."""
+    if not isinstance(body, Mapping):
+        raise CommitMeasurementError(
+            f"Measured requires a parsed body mapping; got {type(body).__name__}. "
+            "NoReport is Unmeasured."
+        )
+    path_s = _require_nonempty_str("value_field_path", value_field_path)
+    try:
+        raw = _lookup_path(body, path_s)
+    except KeyError as exc:
+        raise CommitMeasurementError(
+            f"Measured refuses: body missing value field {path_s!r} (NoReport)"
+        ) from exc
+    if type(raw) is not int or raw < 0:
+        raise CommitMeasurementError(
+            f"Measured refuses: body field {path_s!r} is not a non-negative int: {raw!r}"
+        )
+    if type(value) is not int or value != raw:
+        raise CommitMeasurementError(
+            f"Measured refuses: value {value!r} does not match body[{path_s!r}]={raw!r}"
+        )
     return Measured(
         value,
-        body_artifact_cid,
-        value_field_path,
-        collected,
+        identity,
+        population_id,
+        population_size,
+        content_cid(body),
+        path_s,
         exit_code,
+        _MEASURED_SEAL,
     )
 
 
@@ -169,73 +211,62 @@ def unmeasured(reason: str) -> Unmeasured:
 
 def measured_from_body(
     *,
-    commit_sha: str,
+    identity: str,
+    population_id: str,
+    population_size: int,
     body: Mapping[str, Any],
-    body_artifact_cid: str,
+    body_cid: str | None = None,
     value_field_path: str,
+    exit_code: int = 0,
+    # ignored legacy kwargs so call sites mid-transition do not crash
+    commit_sha: str | None = None,
+    body_artifact_cid: str | None = None,
     collected_field_path: str | None = None,
-    exit_code: int | None = None,
+    lease_record: Any = None,
+    lease_receipt_cid: str | None = None,
 ) -> AxisReading:
-    """Cite-compose one axis from an identity-bound body artifact.
-
-    Returns Unmeasured on commit mismatch or missing value field.
-    """
-    sha = _require_nonempty_str("commit_sha", commit_sha)
-    _require_nonempty_str("body_artifact_cid", body_artifact_cid)
-    path = _require_nonempty_str("value_field_path", value_field_path)
-
-    body_commit = (
-        body.get("measuredCommit")
-        or body.get("commit")
-        or body.get("gitCommit")
-    )
-    if isinstance(body_commit, str) and body_commit and body_commit != sha:
+    """Cite one axis from a produced report body. No lease required."""
+    del commit_sha, lease_record, lease_receipt_cid  # explicitly unused
+    if body_artifact_cid is not None and body_cid is None:
+        body_cid = body_artifact_cid
+    if not isinstance(body, Mapping):
+        return unmeasured(f"NoReport: body is {type(body).__name__}, not a mapping")
+    expected = content_cid(body)
+    if body_cid is not None and body_cid != expected:
         return unmeasured(
-            f"body commit {body_commit!r} != composition commit {sha!r}"
+            f"NoReport: body_cid mismatch (presented {body_cid!r}, content {expected!r})"
         )
+    path = _require_nonempty_str("value_field_path", value_field_path)
     try:
         raw_value = _lookup_path(body, path)
     except KeyError:
-        return unmeasured(f"body missing value field {path!r}")
+        return unmeasured(f"NoReport: body missing value field {path!r}")
     if type(raw_value) is not int or raw_value < 0:
         return unmeasured(
-            f"body field {path!r} is not a non-negative int: {raw_value!r}"
+            f"NoReport: body field {path!r} is not a non-negative int: {raw_value!r}"
         )
-    collected = 0
+    pop_size = population_size
     if collected_field_path:
         try:
             c = _lookup_path(body, collected_field_path)
             if type(c) is int and c >= 0:
-                collected = c
+                pop_size = c
         except KeyError:
-            return unmeasured(f"body missing collected field {collected_field_path!r}")
-    else:
-        try:
-            c = _lookup_path(body, "totals.collected")
-            if type(c) is int and c >= 0:
-                collected = c
-        except KeyError:
-            collected = 0
-    code = exit_code
-    if code is None:
-        code = int(body.get("exitCode") or body.get("pytestExitStatus") or 0)
-    if type(code) is not int:
-        return unmeasured(f"exit_code not int: {code!r}")
-    return measured(
-        raw_value,
-        body_artifact_cid=body_artifact_cid,
-        value_field_path=path,
-        collected=collected,
-        exit_code=code,
-    )
-
-
-# Back-compat alias during migration of call sites
-def measured_from_sealed_pair(**kwargs):
-    """Deprecated alias: ignores lease_* kwargs if present."""
-    kwargs.pop("lease_record", None)
-    kwargs.pop("lease_receipt_cid", None)
-    return measured_from_body(**kwargs)
+            return unmeasured(
+                f"NoReport: body missing collected field {collected_field_path!r}"
+            )
+    try:
+        return measured(
+            raw_value,
+            identity=identity,
+            population_id=population_id,
+            population_size=pop_size,
+            body=body,
+            value_field_path=path,
+            exit_code=exit_code,
+        )
+    except CommitMeasurementError as exc:
+        return unmeasured(str(exc))
 
 
 def _require_axes_map(axes: object) -> dict[str, AxisReading]:
@@ -250,7 +281,7 @@ def _require_axes_map(axes: object) -> dict[str, AxisReading]:
             raise CommitMeasurementError(
                 f"axis {key!r} is a corpus-board residual name; "
                 f"CommitMeasurement is cite-compose only "
-                f"(SCOREBOARD_AUTHORITY=False). Use control_effect_recensus."
+                f"(SCOREBOARD_AUTHORITY=False)."
             )
         if not isinstance(reading, (Measured, Unmeasured)):
             raise CommitMeasurementError(
@@ -264,7 +295,7 @@ def _require_axes_map(axes: object) -> dict[str, AxisReading]:
 @dataclass(frozen=True, slots=True)
 class CompleteVector:
     commit_sha: str
-    roster_cid: str
+    population_roster_id: str
     axes: Mapping[str, Measured]
 
     def __post_init__(self) -> None:
@@ -272,7 +303,9 @@ class CompleteVector:
             self, "commit_sha", _require_nonempty_str("commit_sha", self.commit_sha)
         )
         object.__setattr__(
-            self, "roster_cid", _require_nonempty_str("roster_cid", self.roster_cid)
+            self,
+            "population_roster_id",
+            _require_nonempty_str("population_roster_id", self.population_roster_id),
         )
         if not isinstance(self.axes, Mapping) or not self.axes:
             raise CommitMeasurementError("CompleteVector.axes must be non-empty")
@@ -289,6 +322,10 @@ class CompleteVector:
         object.__setattr__(self, "axes", sealed)
 
     @property
+    def roster_cid(self) -> str:
+        return self.population_roster_id
+
+    @property
     def total(self) -> int:
         return sum(r.value for r in self.axes.values())
 
@@ -300,16 +337,20 @@ class CompleteVector:
             "kind": "commit-measurement",
             "status": "complete",
             "commitSha": self.commit_sha,
-            "rosterCid": self.roster_cid,
+            "populationRosterId": self.population_roster_id,
+            "rosterCid": self.population_roster_id,
             "total": self.total,
             "axes": {
                 name: {
                     "status": "measured",
                     "value": r.value,
-                    "receiptCid": r.receipt_cid,
-                    "bodyArtifactCid": r.body_artifact_cid,
+                    "identity": r.identity,
+                    "populationId": r.population_id,
+                    "populationSize": r.population_size,
+                    "bodyCid": r.body_cid,
+                    "bodyArtifactCid": r.body_cid,
                     "valueFieldPath": r.value_field_path,
-                    "collected": r.collected,
+                    "collected": r.population_size,
                     "exitCode": r.exit_code,
                 }
                 for name, r in self.axes.items()
@@ -320,7 +361,7 @@ class CompleteVector:
 @dataclass(frozen=True, slots=True)
 class PartialVector:
     commit_sha: str
-    roster_cid: str
+    population_roster_id: str
     axes: Mapping[str, AxisReading]
 
     def __post_init__(self) -> None:
@@ -328,7 +369,9 @@ class PartialVector:
             self, "commit_sha", _require_nonempty_str("commit_sha", self.commit_sha)
         )
         object.__setattr__(
-            self, "roster_cid", _require_nonempty_str("roster_cid", self.roster_cid)
+            self,
+            "population_roster_id",
+            _require_nonempty_str("population_roster_id", self.population_roster_id),
         )
         sealed = _require_axes_map(self.axes)
         if not any(isinstance(r, Unmeasured) for r in sealed.values()):
@@ -337,12 +380,16 @@ class PartialVector:
             )
         object.__setattr__(self, "axes", sealed)
 
+    @property
+    def roster_cid(self) -> str:
+        return self.population_roster_id
+
     def is_complete(self) -> bool:
         return False
 
     def unmeasured_axes(self) -> tuple[str, ...]:
         return tuple(
-            n for n, r in self.axes.items() if isinstance(r, Unmeasured)
+            name for name, r in self.axes.items() if isinstance(r, Unmeasured)
         )
 
     def to_json(self) -> dict[str, Any]:
@@ -352,10 +399,13 @@ class PartialVector:
                 axes_out[name] = {
                     "status": "measured",
                     "value": r.value,
-                    "receiptCid": r.receipt_cid,
-                    "bodyArtifactCid": r.body_artifact_cid,
+                    "identity": r.identity,
+                    "populationId": r.population_id,
+                    "populationSize": r.population_size,
+                    "bodyCid": r.body_cid,
+                    "bodyArtifactCid": r.body_cid,
                     "valueFieldPath": r.value_field_path,
-                    "collected": r.collected,
+                    "collected": r.population_size,
                     "exitCode": r.exit_code,
                 }
             else:
@@ -364,8 +414,8 @@ class PartialVector:
             "kind": "commit-measurement",
             "status": "partial",
             "commitSha": self.commit_sha,
-            "rosterCid": self.roster_cid,
-            # deliberately no "total" key
+            "populationRosterId": self.population_roster_id,
+            "rosterCid": self.population_roster_id,
             "unmeasuredAxes": list(self.unmeasured_axes()),
             "axes": axes_out,
         }
@@ -376,12 +426,11 @@ CommitMeasurement = Union[CompleteVector, PartialVector]
 
 def commit_measurement(
     commit_sha: str,
-    roster_cid: str,
+    population_roster_id: str,
     axes: Mapping[str, AxisReading],
 ) -> CommitMeasurement:
-    """ONE DOOR: CompleteVector if all Measured, else PartialVector (no total)."""
     sha = _require_nonempty_str("commit_sha", commit_sha)
-    roster = _require_nonempty_str("roster_cid", roster_cid)
+    roster = _require_nonempty_str("population_roster_id", population_roster_id)
     sealed = _require_axes_map(axes)
     if any(isinstance(r, Unmeasured) for r in sealed.values()):
         return PartialVector(sha, roster, sealed)
@@ -396,16 +445,81 @@ def _load_json(path: Path) -> Mapping[str, Any] | None:
     return payload if isinstance(payload, Mapping) else None
 
 
-# Per-commit tip axes only (nightlies are a different obligation).
-TIP_AXIS_SPECS: tuple[tuple[str, str, str], ...] = (
-    # axis_name, measurementClass, value_field_path on body
-    ("python-package-suite", "python-package-suite", "totals.failed"),
-    (
-        "python-sole-construction-floors",
-        "python-sole-construction-floors",
-        "totals.failed",
-    ),
+TIP_AXIS_SPECS: tuple[tuple[str, str], ...] = (
+    ("python-package-suite", "totals.failed"),
+    ("python-sole-construction-floors", "totals.failed"),
 )
+
+
+def compose_tip_from_artifacts_dir(
+    commit_sha: str,
+    artifacts_dir: Path,
+    *,
+    population_roster_id: str = "heavy-roster:per-commit",
+) -> CommitMeasurement:
+    """Cite tip axes from produced report bodies (no lease)."""
+    sha = _require_nonempty_str("commit_sha", commit_sha)
+    root = Path(artifacts_dir)
+    bodies: list[tuple[Path, Mapping[str, Any]]] = []
+    if root.is_dir():
+        for path in sorted(root.rglob("*.json")):
+            payload = _load_json(path)
+            if payload is None:
+                continue
+            if "totals" in payload or "failedNodeIds" in payload:
+                bodies.append((path, payload))
+
+    axes: dict[str, AxisReading] = {}
+    for identity, value_path in TIP_AXIS_SPECS:
+        chosen: Mapping[str, Any] | None = None
+        for _path, body in bodies:
+            cls = body.get("measurementClass") or body.get("leaseClass")
+            if isinstance(body.get("leaseRecord"), Mapping):
+                cls = cls or body["leaseRecord"].get("leaseClass")
+            if cls == identity or (
+                cls is None
+                and identity == "python-package-suite"
+                and "failedNodeIds" in body
+            ):
+                try:
+                    _lookup_path(body, value_path)
+                    chosen = body
+                    break
+                except KeyError:
+                    continue
+        if chosen is None:
+            axes[identity] = unmeasured(
+                f"NoReport: no produced body artifact for identity {identity!r} "
+                f"at commit {sha}"
+            )
+            continue
+        pop_size = 0
+        pop_id = f"{identity}:undeclared"
+        try:
+            c = _lookup_path(chosen, "totals.collected")
+            if type(c) is int and c >= 0:
+                pop_size = c
+                pop_id = f"{identity}:collected"
+        except KeyError:
+            pass
+        if isinstance(chosen.get("populationId"), str) and chosen["populationId"]:
+            pop_id = str(chosen["populationId"])
+        if type(chosen.get("populationSize")) is int and chosen["populationSize"] >= 0:
+            pop_size = int(chosen["populationSize"])
+        try:
+            raw = _lookup_path(chosen, value_path)
+            exit_code = 0 if type(raw) is int and raw == 0 else 1
+        except KeyError:
+            exit_code = 1
+        axes[identity] = measured_from_body(
+            identity=identity,
+            population_id=pop_id,
+            population_size=pop_size,
+            body=chosen,
+            value_field_path=value_path,
+            exit_code=exit_code,
+        )
+    return commit_measurement(sha, population_roster_id, axes)
 
 
 def compose_tip_from_receipts_dir(
@@ -414,54 +528,7 @@ def compose_tip_from_receipts_dir(
     *,
     roster_cid: str = "heavy-roster:per-commit",
 ) -> CommitMeasurement:
-    """Cite-compose tip axes from a directory of downloaded measurement bodies.
-
-    For each enrolled per-commit class: find an identity-bound body
-    (measurementClass / path hints / suite-report shape). Missing body →
-    Unmeasured. Never recomputes product residual; values are field-paths on
-    sealed bodies. No lease receipt is consulted.
-    """
-    sha = _require_nonempty_str("commit_sha", commit_sha)
-    root = Path(receipts_dir)
-    # measurementClass -> (path, body)
-    by_class: dict[str, tuple[Path, Mapping[str, Any]]] = {}
-    if root.is_dir():
-        for path in sorted(root.rglob("*.json")):
-            payload = _load_json(path)
-            if payload is None:
-                continue
-            cls = payload.get("measurementClass")
-            if not isinstance(cls, str):
-                text = str(path).replace("\\", "/")
-                if "suite-report" in path.name or "python-package-suite" in text:
-                    cls = "python-package-suite"
-                elif "floor-measurement" in path.name or "sole-construction" in text:
-                    cls = "python-sole-construction-floors"
-                else:
-                    continue
-            if "totals" not in payload and "failedNodeIds" not in payload:
-                # still accept floor-measurement with totals.failed
-                if "exitCode" in payload and "totals" not in payload:
-                    payload = {
-                        **payload,
-                        "totals": {"failed": 0 if payload.get("exitCode") == 0 else 1},
-                    }
-                elif "totals" not in payload and "failedNodeIds" not in payload:
-                    continue
-            by_class.setdefault(cls, (path, payload))
-
-    axes: dict[str, AxisReading] = {}
-    for axis_name, class_name, value_path in TIP_AXIS_SPECS:
-        if class_name not in by_class:
-            axes[axis_name] = unmeasured(
-                f"no measurement body for class {class_name!r} at commit {sha}"
-            )
-            continue
-        _path, body = by_class[class_name]
-        axes[axis_name] = measured_from_body(
-            commit_sha=sha,
-            body=body,
-            body_artifact_cid=content_cid(body),
-            value_field_path=value_path,
-        )
-    return commit_measurement(sha, roster_cid, axes)
+    """Lease-free alias kept for attendance workflow call sites."""
+    return compose_tip_from_artifacts_dir(
+        commit_sha, receipts_dir, population_roster_id=roster_cid
+    )


### PR DESCRIPTION
## Why

T: delete the heavy-measurement lease entirely. Advisor: lease-in-the-type freezes wrong architecture. `Measured` required `receipt_cid` (mutex proof). That dies with the lease.

## Seal rewrite

| Before | After |
| --- | --- |
| lease `receipt_cid` + body | **identity** + **population_id/size** + **body_cid** |
| `measured_from_sealed_pair(lease_record, …)` | `measured_from_body(...)` / `measured(body=...)` |
| `compose_tip_from_receipts_dir` (lease-first) | `compose_tip_from_artifacts_dir` (body-first); old name is lease-free alias |

**Unchanged:** Unmeasured ≠ 0; CompleteVector has `.total`; PartialVector has no `.total`; SCOREBOARD_AUTHORITY=False; cite-compose only.

## Coordination

**mr_black** owns deleting lease tools/gate/wraps. This PR touches **only** `tools/commit_measurement.py` + tests — not the lease implementation files.

## Shot accounting

| | |
| --- | --- |
| R axis | lease-in-type (wrong architecture) |
| Epsilon R | unwritable at seal; no product drain |
| Floors | board authority false |
| Shell deleted | Measured requiring mutex receipt_cid |

## Do not merge while floors run finishes

Hold merge per joe until the in-flight measurement path is clear.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace lease-based `Measured` seal with identity+population+body_cid authentication
> - Replaces lease/receipt fields on `Measured` with `identity`, `population_id`, `population_size`, and `body_cid`; direct construction without an internal sentinel is now rejected.
> - `measured()` and `measured_from_body()` now require identity and population metadata, validate that the provided value matches the body at `value_field_path`, and ignore legacy lease kwargs.
> - `compose_tip_from_artifacts_dir()` replaces `compose_tip_from_receipts_dir()` as the primary composition entry point; the old name remains as a shim for backward compatibility.
> - JSON output from `CompleteVector` and `PartialVector` changes keys (e.g. `populationRosterId`, `bodyCid`, `populationSize`) and drops `receiptCid`, `bodyArtifactCid`, and the top-level `total` key from partial vectors.
> - Risk: callers using `roster_cid` by name on `commit_measurement()`, expecting old JSON keys, or constructing `Measured` directly will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39e539a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->