### PR TITLE
One supervised process pass → three axis projections

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_process_floor_shared_pass.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_process_floor_shared_pass.py
@@ -1,0 +1,195 @@
+"""One supervised production pass → three process-axis projections.
+
+CLASS
+=====
+
+``native_crash``, ``bare_exception``, and ``timeout`` are three classifiers over
+the **same** :class:`FileTerminal` stream. Each used to call ``scan_paths`` and
+re-lift every corpus file (~1421) independently — ~300% of one full supervised
+pass for process axes alone.
+
+Sound work: **one** ``scan_paths`` over the population, then three pure
+projections. No cache required. Sound by construction: the classifiers always
+read identical terminals; this only removes the redundant lifts.
+
+COVERAGE LAW
+============
+
+Every input path gets exactly one terminal. Offenders are process outcomes of
+the production door, not AST-local properties — there is **no** sound subtree
+exclusion. This module removes **redundant passes**, not files. If a change
+covers fewer files than ``len(paths)``, it is wrong.
+
+Endgame (mr_brown): content-addressed terminal cache keyed on file CID sits
+under this shared pass so unchanged corpus becomes near-zero work. Do not
+restructure the supervisor loop here for cache — only the three callers merge.
+"""
+
+from __future__ import annotations
+
+import signal
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NamedTuple, Sequence
+
+from _supervised_enum_supervisor import FileTerminal, scan_paths
+
+
+class NativeCrashOffender(NamedTuple):
+    file: str
+    returncode: int
+    signal: str
+    stderr_tail: str
+
+
+class BareExceptionOffender(NamedTuple):
+    file: str
+    returncode: int
+    stderr_tail: str
+
+
+class TimeoutOffender(NamedTuple):
+    file: str
+    timeout_seconds: float
+
+
+@dataclass(frozen=True, slots=True)
+class SharedProcessFloorResult:
+    """One terminal stream + three projected residual sets. Same coverage."""
+
+    paths: tuple[Path, ...]
+    terminals: tuple[FileTerminal, ...]
+    native_crashes: tuple[NativeCrashOffender, ...]
+    bare_exceptions: tuple[BareExceptionOffender, ...]
+    timeouts: tuple[TimeoutOffender, ...]
+    file_timeout: float
+
+    @property
+    def discovered(self) -> int:
+        return len(self.terminals)
+
+    def r_native_crashes(self) -> int:
+        return len(self.native_crashes)
+
+    def r_bare_exceptions(self) -> int:
+        return len(self.bare_exceptions)
+
+    def r_timeouts(self) -> int:
+        return len(self.timeouts)
+
+    def any_red(self) -> bool:
+        return bool(self.native_crashes or self.bare_exceptions or self.timeouts)
+
+
+def project_native_crash(row: FileTerminal) -> NativeCrashOffender | None:
+    """Classifier: signal death of the production-door child."""
+    if row.category != "native-crash":
+        return None
+    rc = row.returncode if row.returncode is not None else -1
+    if rc >= 0 and not row.signal_name:
+        return None
+    if rc < 0:
+        signal_number = -rc
+        try:
+            signal_name = signal.Signals(signal_number).name
+        except ValueError:
+            signal_name = f"signal-{signal_number}"
+    else:
+        signal_name = row.signal_name or f"returncode-{rc}"
+    return NativeCrashOffender(
+        file=row.file,
+        returncode=rc,
+        signal=signal_name,
+        stderr_tail=row.stderr_tail,
+    )
+
+
+def project_bare_exception(row: FileTerminal) -> BareExceptionOffender | None:
+    """Classifier: untyped failure terminal (not native, not timeout)."""
+    if row.category != "bare-exception":
+        return None
+    return BareExceptionOffender(
+        file=row.file,
+        returncode=row.returncode if row.returncode is not None else 1,
+        stderr_tail=row.stderr_tail,
+    )
+
+
+def project_timeout(
+    row: FileTerminal, *, file_timeout: float
+) -> TimeoutOffender | None:
+    """Classifier: wall-clock kill of the in-flight file."""
+    if row.category != "timeout":
+        return None
+    return TimeoutOffender(file=row.file, timeout_seconds=float(file_timeout))
+
+
+def assert_full_coverage(
+    paths: Sequence[Path], terminals: Sequence[FileTerminal], *, root: Path
+) -> None:
+    """Every path must produce one terminal. Fewer files ⇒ construction bug."""
+    from _enum_floor_runtime import relative_to_root
+
+    if len(terminals) != len(paths):
+        raise RuntimeError(
+            "process-floor coverage breach: "
+            f"paths={len(paths)} terminals={len(terminals)}; "
+            "every corpus file must get a terminal for every process axis "
+            "(no sound subtree exclusion)"
+        )
+    expected = [relative_to_root(path, root) for path in paths]
+    observed = [row.file for row in terminals]
+    if expected != observed:
+        # Order-preserving equality: scan is sequential over paths.
+        missing = [rel for rel in expected if rel not in set(observed)]
+        extra = [rel for rel in observed if rel not in set(expected)]
+        raise RuntimeError(
+            "process-floor coverage mismatch: "
+            f"missing={missing[:5]}{('…' if len(missing) > 5 else '')} "
+            f"extra={extra[:5]}{('…' if len(extra) > 5 else '')}"
+        )
+
+
+def shared_process_floor_pass(
+    paths: Sequence[Path],
+    *,
+    root: Path,
+    file_timeout: float = 30.0,
+) -> SharedProcessFloorResult:
+    """ONE supervised lift over *paths*; project all three process axes.
+
+    Call this once from CI. Solo axis CLIs may call it and discard other
+    residuals, but must not invent a second scan when the shared result exists.
+    """
+    if file_timeout > 30:
+        raise ValueError("per-file timeout may not exceed 30 seconds")
+    path_tuple = tuple(paths)
+    terminals = tuple(
+        scan_paths(path_tuple, root=root, file_timeout=float(file_timeout))
+    )
+    assert_full_coverage(path_tuple, terminals, root=root)
+
+    native = tuple(
+        offender
+        for row in terminals
+        if (offender := project_native_crash(row)) is not None
+    )
+    bare = tuple(
+        offender
+        for row in terminals
+        if (offender := project_bare_exception(row)) is not None
+    )
+    timeouts = tuple(
+        offender
+        for row in terminals
+        if (offender := project_timeout(row, file_timeout=float(file_timeout)))
+        is not None
+    )
+    return SharedProcessFloorResult(
+        paths=path_tuple,
+        terminals=terminals,
+        native_crashes=native,
+        bare_exceptions=bare,
+        timeouts=timeouts,
+        file_timeout=float(file_timeout),
+    )

--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """R_bare_exceptions — permanent baseline-free untyped-failure floor.
 
-Supervised persistent enum worker: reuses process across healthy files;
-restarts on native crash / timeout. Enumeration protocol only.
+Classifier over the supervised :class:`FileTerminal` stream (category
+``bare-exception``). Full corpus CI uses ``process_floor_shared_pass.py``
+(one lift, three projections). This CLI stays for discrimination / solo runs.
 """
 
 from __future__ import annotations
@@ -29,19 +30,18 @@ from _enum_floor_runtime import (  # noqa: E402
     require_explicit_scan_roots,
     require_python_paths,
 )
+from _process_floor_shared_pass import (  # noqa: E402
+    BareExceptionOffender,
+    project_bare_exception,
+    shared_process_floor_pass,
+)
 from _production_lift_child import (  # noqa: E402
     NON_FAILURE_OUTCOMES,
     OUTCOME_COMPLETED,
     OUTCOME_TYPED_GAP,
     production_lift_bootstrap_error,
 )
-from _supervised_enum_supervisor import FileTerminal, scan_paths  # noqa: E402
-
-
-class BareExceptionOffender(NamedTuple):
-    file: str
-    returncode: int
-    stderr_tail: str
+from _supervised_enum_supervisor import FileTerminal  # noqa: E402
 
 
 class ChildResult(NamedTuple):
@@ -80,17 +80,7 @@ def r_bare_exceptions(offenders: Sequence[BareExceptionOffender]) -> int:
 
 
 def _from_terminal(row: FileTerminal) -> ChildResult:
-    if row.category == "bare-exception":
-        return ChildResult(
-            row.file,
-            "bare-exception",
-            BareExceptionOffender(
-                row.file,
-                row.returncode if row.returncode is not None else 1,
-                row.stderr_tail,
-            ),
-        )
-    return ChildResult(row.file, row.category, None)
+    return ChildResult(row.file, row.category, project_bare_exception(row))
 
 
 def main() -> int:
@@ -148,21 +138,20 @@ def main() -> int:
     except (OSError, ValueError) as error:
         print(format_unmeasured_axis("R_bare_exceptions", reason=str(error)))
         return 1
-    progress_path.write_text(
-        f"# bare-exception supervised enum scan\n"
-        f"# engine={engine_path}\n"
-        f"# files={len(paths)}\n",
-        encoding="utf-8",
-    )
-    terminals = scan_paths(
+    shared = shared_process_floor_pass(
         paths, root=args.repo_root, file_timeout=float(args.file_timeout)
     )
-    rows = tuple(_from_terminal(t) for t in terminals)
-    with progress_path.open("a", encoding="utf-8") as progress:
-        for t in terminals:
+    rows = tuple(_from_terminal(t) for t in shared.terminals)
+    with progress_path.open("w", encoding="utf-8") as progress:
+        progress.write(
+            f"# bare-exception projection (shared pass)\n"
+            f"# engine={engine_path}\n"
+            f"# files={len(paths)}\n"
+        )
+        for t in shared.terminals:
             progress.write(f"{t.file}\t{t.category}\trestarts={t.worker_restarts}\n")
 
-    offenders = tuple(row.offender for row in rows if row.offender is not None)
+    offenders = shared.bare_exceptions
     print(
         "BARE-EXCEPTION SURFACE: "
         f"discovered={len(rows)} "

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """R_native_crashes — permanent baseline-free corpus process floor.
 
-Supervised persistent enum worker. A signal death is attributed to the file
-currently in flight; the worker restarts and the census continues so every
-file still gets a terminal row.
+Classifier over the supervised :class:`FileTerminal` stream (category
+``native-crash``). Full corpus measurement in CI goes through
+``process_floor_shared_pass.py`` (one lift, three projections). This CLI remains
+for discrimination tests and solo re-runs; ``audit_paths`` uses the shared pass
+so a solo run is still one lift, not a third redundant protocol.
 """
 
 from __future__ import annotations
@@ -14,7 +16,6 @@ from __future__ import annotations
 SCOREBOARD_AUTHORITY = False
 
 import argparse
-import os
 from pathlib import Path
 import signal
 import sys
@@ -30,15 +31,13 @@ from _enum_floor_runtime import (  # noqa: E402
     require_explicit_scan_roots,
     require_python_paths,
 )
+from _process_floor_shared_pass import (  # noqa: E402
+    NativeCrashOffender,
+    project_native_crash,
+    shared_process_floor_pass,
+)
 from _production_lift_child import production_lift_bootstrap_error  # noqa: E402
-from _supervised_enum_supervisor import FileTerminal, scan_paths  # noqa: E402
-
-
-class NativeCrashOffender(NamedTuple):
-    file: str
-    returncode: int
-    signal: str
-    stderr_tail: str
+from _supervised_enum_supervisor import FileTerminal  # noqa: E402
 
 
 class ChildResult(NamedTuple):
@@ -61,6 +60,7 @@ class AuditSummary(NamedTuple):
 def native_crash_offender(
     *, file: str, returncode: int, stderr: str
 ) -> NativeCrashOffender | None:
+    """Discrimination twin helper (subprocess-shaped); shared pass uses terminals."""
     if returncode >= 0:
         return None
     signal_number = -returncode
@@ -100,17 +100,11 @@ def format_report(offenders: Sequence[NativeCrashOffender]) -> str:
 
 
 def _from_terminal(row: FileTerminal) -> ChildResult:
+    offender = project_native_crash(row)
     if row.category == "native-crash":
         rc = row.returncode if row.returncode is not None else -1
-        offender = native_crash_offender(
-            file=row.file, returncode=rc, stderr=row.stderr_tail
-        )
-        if offender is None and row.signal_name:
-            offender = NativeCrashOffender(
-                row.file, rc, row.signal_name, row.stderr_tail
-            )
         return ChildResult(row.file, "native-crash", rc, row.stderr_tail, offender)
-    if row.category in {"bare-exception"}:
+    if row.category == "bare-exception":
         return ChildResult(
             row.file, "non-native-red", row.returncode, row.stderr_tail, None
         )
@@ -127,24 +121,26 @@ def audit_paths(
     progress_path: Path | None = None,
     progress_stdout: bool = False,
 ) -> AuditSummary:
+    """Project native-crash residuals from the **shared** supervised pass."""
     del workers, checkpoint_path, progress_stdout
-    if file_timeout > 30:
-        raise ValueError("per-file timeout may not exceed 30 seconds")
-    terminals = scan_paths(paths, root=root, file_timeout=float(file_timeout))
+    shared = shared_process_floor_pass(
+        paths, root=root, file_timeout=float(file_timeout)
+    )
     if progress_path is not None:
         progress_path.parent.mkdir(parents=True, exist_ok=True)
         with progress_path.open("w", encoding="utf-8") as stream:
-            stream.write(f"# native-crash supervised enum scan files={len(paths)}\n")
-            for t in terminals:
+            stream.write(
+                f"# native-crash projection (shared pass) files={len(paths)}\n"
+            )
+            for t in shared.terminals:
                 stream.write(f"{t.file}\t{t.category}\n")
-    rows = tuple(_from_terminal(t) for t in terminals)
-    offenders = tuple(row.offender for row in rows if row.offender is not None)
+    rows = tuple(_from_terminal(t) for t in shared.terminals)
     return AuditSummary(
         discovered=len(rows),
         completed=sum(row.category in {"completed", "typed-gap"} for row in rows),
         timeouts=sum(row.category == "timeout" for row in rows),
         non_native_red=sum(row.category == "non-native-red" for row in rows),
-        offenders=offenders,
+        offenders=shared.native_crashes,
         rows=rows,
     )
 

--- a/implementations/python/sugar-lift-py-tests/scripts/process_floor_shared_pass.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/process_floor_shared_pass.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""CI door: one supervised pass → R_native_crashes + R_bare_exceptions + R_timeouts.
+
+Replaces three sequential zero-tolerance corpus lifts in
+``tools/run_sole_construction_floors.sh``. Discrimination unit tests and the
+legacy per-axis CLIs remain; the **binding** floor set uses this door so the
+corpus is lifted once.
+
+Exit 1 if any of the three R axes is non-zero. Exit 2 on infrastructure
+failure. Coverage breach (fewer terminals than paths) is infrastructure red.
+"""
+
+from __future__ import annotations
+
+SCOREBOARD_AUTHORITY = False
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _enum_floor_runtime import (  # noqa: E402
+    format_completed_axis_report,
+    format_unmeasured_axis,
+    prepare_floor_io,
+    require_explicit_scan_roots,
+)
+from _process_floor_shared_pass import shared_process_floor_pass  # noqa: E402
+from _production_lift_child import production_lift_bootstrap_error  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (AttributeError, ValueError):
+            pass
+
+    repo_root = Path(__file__).resolve().parents[4]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[],
+        help=(
+            "Scan roots (required, non-empty). Authenticated pandas corpus — "
+            "never silent kit production_roots."
+        ),
+    )
+    parser.add_argument("--repo-root", type=Path, default=repo_root)
+    parser.add_argument("--file-timeout", type=int, default=30)
+    parser.add_argument("--out-dir", type=Path, default=None)
+    parser.add_argument("--engine-log", type=Path, default=None)
+    parser.add_argument("--progress", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    boot_error = production_lift_bootstrap_error()
+    if boot_error is not None:
+        print(
+            "PROCESS-FLOOR SHARED PASS INFRASTRUCTURE FAILURE: the production "
+            f"lift door did not bootstrap: {boot_error}"
+        )
+        return 2
+
+    try:
+        paths = require_explicit_scan_roots(args.paths)
+    except ValueError as error:
+        print(f"PROCESS-FLOOR SHARED PASS RED: {error}")
+        return 1
+
+    print(
+        "PROCESS-FLOOR SHARED POPULATION: "
+        f"roots={[str(p) for p in args.paths]} files={len(paths)} "
+        f"(one supervised pass → three projections)"
+    )
+
+    try:
+        _base, engine_path, progress_path = prepare_floor_io(
+            repo_root=args.repo_root,
+            floor="process-shared",
+            out_dir=args.out_dir,
+            engine_log=args.engine_log,
+            progress=args.progress,
+        )
+    except (OSError, ValueError) as error:
+        print(format_unmeasured_axis("R_native_crashes", reason=str(error)))
+        print(format_unmeasured_axis("R_bare_exceptions", reason=str(error)))
+        print(format_unmeasured_axis("R_timeouts", reason=str(error)))
+        return 1
+
+    try:
+        result = shared_process_floor_pass(
+            paths,
+            root=args.repo_root,
+            file_timeout=float(args.file_timeout),
+        )
+    except RuntimeError as error:
+        print(f"PROCESS-FLOOR SHARED PASS INFRASTRUCTURE FAILURE: {error}")
+        return 2
+
+    progress_path.parent.mkdir(parents=True, exist_ok=True)
+    with progress_path.open("w", encoding="utf-8") as stream:
+        stream.write(
+            f"# process-floor shared pass files={len(paths)} "
+            f"terminals={result.discovered}\n"
+        )
+        for t in result.terminals:
+            stream.write(f"{t.file}\t{t.category}\trestarts={t.worker_restarts}\n")
+
+    print(
+        "PROCESS-FLOOR SHARED SURFACE: "
+        f"discovered={result.discovered} "
+        f"native={result.r_native_crashes()} "
+        f"bare={result.r_bare_exceptions()} "
+        f"timeouts={result.r_timeouts()} "
+        f"progress={progress_path} engine={engine_path}"
+    )
+    # Three completed axes from one stream — never a merged single R.
+    print(format_completed_axis_report("R_native_crashes", result.r_native_crashes()))
+    for row in result.native_crashes:
+        print(f"{row.file}:returncode={row.returncode}:signal={row.signal}")
+        if row.stderr_tail:
+            print(row.stderr_tail)
+    print(
+        format_completed_axis_report("R_bare_exceptions", result.r_bare_exceptions())
+    )
+    for row in result.bare_exceptions:
+        tail = (row.stderr_tail.splitlines() or ["no detail"])[-1]
+        print(f"{row.file}:returncode={row.returncode}:bare-exception — {tail}")
+    print(format_completed_axis_report("R_timeouts", result.r_timeouts()))
+    for row in result.timeouts:
+        print(f"{row.file}:timeout>{row.timeout_seconds}s")
+
+    return 1 if result.any_red() else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """R_timeouts — permanent baseline-free bounded-termination floor.
 
-Supervised persistent enum worker. A file exceeding the wall clock kills only
-that worker (caches restart); the file is a timeout offender and the scan continues.
+Classifier over the supervised :class:`FileTerminal` stream (category
+``timeout``). Full corpus CI uses ``process_floor_shared_pass.py`` (one lift,
+three projections). This CLI stays for discrimination / solo runs.
 """
 
 from __future__ import annotations
@@ -27,13 +28,13 @@ from _enum_floor_runtime import (  # noqa: E402
     require_explicit_scan_roots,
     require_python_paths,
 )
+from _process_floor_shared_pass import (  # noqa: E402
+    TimeoutOffender,
+    project_timeout,
+    shared_process_floor_pass,
+)
 from _production_lift_child import production_lift_bootstrap_error  # noqa: E402
-from _supervised_enum_supervisor import FileTerminal, scan_paths  # noqa: E402
-
-
-class TimeoutOffender(NamedTuple):
-    file: str
-    timeout_seconds: float
+from _supervised_enum_supervisor import FileTerminal  # noqa: E402
 
 
 class ChildResult(NamedTuple):
@@ -56,13 +57,9 @@ def r_timeouts(offenders: Sequence[TimeoutOffender]) -> int:
 
 
 def _from_terminal(row: FileTerminal, *, file_timeout: float) -> ChildResult:
-    if row.category == "timeout":
-        return ChildResult(
-            row.file,
-            "timeout",
-            timeout_offender(file=row.file, timeout_seconds=file_timeout),
-        )
-    return ChildResult(row.file, row.category, None)
+    return ChildResult(
+        row.file, row.category, project_timeout(row, file_timeout=file_timeout)
+    )
 
 
 def audit_paths(
@@ -75,21 +72,21 @@ def audit_paths(
     progress_path: Path | None = None,
     progress_stdout: bool = False,
 ) -> AuditSummary:
+    """Project timeout residuals from the **shared** supervised pass."""
     del workers, checkpoint_path, progress_stdout
-    if file_timeout > 30:
-        raise ValueError("per-file timeout may not exceed 30 seconds")
-    terminals = scan_paths(paths, root=root, file_timeout=float(file_timeout))
+    shared = shared_process_floor_pass(
+        paths, root=root, file_timeout=float(file_timeout)
+    )
     if progress_path is not None:
         progress_path.parent.mkdir(parents=True, exist_ok=True)
         with progress_path.open("w", encoding="utf-8") as stream:
-            stream.write(f"# timeout supervised enum scan files={len(paths)}\n")
-            for t in terminals:
+            stream.write(f"# timeout projection (shared pass) files={len(paths)}\n")
+            for t in shared.terminals:
                 stream.write(f"{t.file}\t{t.category}\n")
-    rows = tuple(_from_terminal(t, file_timeout=float(file_timeout)) for t in terminals)
-    return AuditSummary(
-        rows=rows,
-        offenders=tuple(row.offender for row in rows if row.offender is not None),
+    rows = tuple(
+        _from_terminal(t, file_timeout=float(file_timeout)) for t in shared.terminals
     )
+    return AuditSummary(rows=rows, offenders=shared.timeouts)
 
 
 def main() -> int:

--- a/implementations/python/sugar-lift-py-tests/tests/test_process_floor_shared_pass.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_process_floor_shared_pass.py
@@ -1,0 +1,131 @@
+"""Teeth: one supervised pass → three projections; full path coverage required."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SPEC = importlib.util.spec_from_file_location(
+    "_process_floor_shared_pass",
+    _SCRIPTS / "_process_floor_shared_pass.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_SHARED = importlib.util.module_from_spec(_SPEC)
+# Register before exec so dataclasses can resolve __module__.
+import sys
+
+sys.modules[_SPEC.name] = _SHARED
+# Supervisor import path lives beside this module.
+sys.path.insert(0, str(_SCRIPTS))
+_SPEC.loader.exec_module(_SHARED)
+
+
+def _terminal(
+    file: str,
+    category: str,
+    *,
+    returncode: int | None = 0,
+    signal_name: str | None = None,
+    stderr: str = "",
+):
+    from _supervised_enum_supervisor import FileTerminal
+
+    return FileTerminal(
+        file=file,
+        category=category,
+        returncode=returncode,
+        signal_name=signal_name,
+        stderr_tail=stderr,
+        terminal=None,
+        worker_restarts=0,
+    )
+
+
+def test_projections_partition_terminal_categories() -> None:
+    native = _terminal("a.py", "native-crash", returncode=-6, signal_name="SIGABRT")
+    bare = _terminal("b.py", "bare-exception", returncode=1, stderr="boom")
+    timeout = _terminal("c.py", "timeout", returncode=None)
+    done = _terminal("d.py", "completed", returncode=0)
+
+    n = _SHARED.project_native_crash(native)
+    assert n is not None and n.signal == "SIGABRT"
+    assert _SHARED.project_native_crash(bare) is None
+    assert _SHARED.project_native_crash(done) is None
+
+    b = _SHARED.project_bare_exception(bare)
+    assert b is not None and b.returncode == 1
+    assert _SHARED.project_bare_exception(native) is None
+
+    t = _SHARED.project_timeout(timeout, file_timeout=30.0)
+    assert t is not None and t.timeout_seconds == 30.0
+    assert _SHARED.project_timeout(done, file_timeout=30.0) is None
+
+
+def test_coverage_breach_is_loud(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths = [tmp_path / "a.py", tmp_path / "b.py"]
+    for path in paths:
+        path.write_text("x = 1\n", encoding="utf-8")
+
+    def fake_scan(paths_arg, *, root, file_timeout=30.0, demand_table_path=None):
+        del root, file_timeout, demand_table_path
+        # Only one terminal for two paths — the forbidden under-coverage.
+        return [_terminal("a.py", "completed")]
+
+    monkeypatch.setattr(_SHARED, "scan_paths", fake_scan)
+    with pytest.raises(RuntimeError, match="coverage breach"):
+        _SHARED.shared_process_floor_pass(paths, root=tmp_path, file_timeout=5.0)
+
+
+def test_shared_pass_projects_all_three_without_second_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = [tmp_path / "a.py", tmp_path / "b.py", tmp_path / "c.py"]
+    for path in paths:
+        path.write_text("x = 1\n", encoding="utf-8")
+
+    calls = {"n": 0}
+
+    def fake_scan(paths_arg, *, root, file_timeout=30.0, demand_table_path=None):
+        del root, demand_table_path
+        calls["n"] += 1
+        rels = [p.name for p in paths_arg]
+        return [
+            _terminal(rels[0], "native-crash", returncode=-6, signal_name="SIGABRT"),
+            _terminal(rels[1], "bare-exception", returncode=1, stderr="e"),
+            _terminal(rels[2], "timeout", returncode=None),
+        ]
+
+    monkeypatch.setattr(_SHARED, "scan_paths", fake_scan)
+    result = _SHARED.shared_process_floor_pass(paths, root=tmp_path, file_timeout=30.0)
+    assert calls["n"] == 1
+    assert result.discovered == 3
+    assert result.r_native_crashes() == 1
+    assert result.r_bare_exceptions() == 1
+    assert result.r_timeouts() == 1
+    assert result.any_red() is True
+
+
+def test_binding_floor_set_uses_shared_pass_not_three_lifts() -> None:
+    """CI must not re-invoke three solo zero-tolerance corpus lifts."""
+    root = Path(__file__).resolve().parents[4]
+    floors = (root / "tools" / "run_sole_construction_floors.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "process_floor_shared_pass.py" in floors
+    # Solo CLIs may still exist for discrimination; they must not each appear
+    # as a separate corpus axis in the leased floor set.
+    for solo in (
+        'axis "R_native_crashes"',
+        'axis "R_bare_exceptions"',
+        'axis "R_timeouts"',
+    ):
+        assert solo not in floors, (
+            f"{solo} must not be a separate serial corpus lift; use shared pass"
+        )
+    # Still bind silent separately (different door).
+    assert 'axis "R_silent"' in floors
+    assert "silent_zero_tolerance.py" in floors

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -180,19 +180,28 @@ def test_standalone_floor_workflows_stay_discrimination_only():
 def test_orchestrator_still_runs_the_corpus_floors():
     """The floor set moved into one leased script -- ONE lease interval for the
     whole set, so no census interleaves between two axes and the complete set
-    still comes from one pinned run. It must not have lost an axis on the way."""
+    still comes from one pinned run. It must not have lost an axis on the way.
+
+    Process axes (native/bare/timeout) share one supervised pass
+    (process_floor_shared_pass.py) rather than three independent lifts.
+    """
     text = _text("factory-zero-tolerance.yml")
     assert "tools/run_sole_construction_floors.sh" in text
     floors = (ROOT / "tools" / "run_sole_construction_floors.sh").read_text()
     for script in (
-        "native_crash_zero_tolerance.py",
-        "bare_exception_zero_tolerance.py",
-        "timeout_zero_tolerance.py",
+        "process_floor_shared_pass.py",
         "silent_zero_tolerance.py",
         "factory_ownership_law.py",
         "construction_side_door_law.py",
     ):
         assert script in floors, f"the leased floor set must invoke {script}"
+    # Solo process CLIs are discrimination/solo doors — not three serial corpus lifts.
+    for solo_axis in (
+        'axis "R_native_crashes"',
+        'axis "R_bare_exceptions"',
+        'axis "R_timeouts"',
+    ):
+        assert solo_axis not in floors
 
 
 def test_roster_cadence_matches_each_workflow_trigger():

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -12,6 +12,9 @@ because an earlier one was honestly red. The `if: always()` guarantee is now
 carried by the script's `axis` helper, which runs EVERY axis, collects the red
 ones, and fails at the end -- so the check below is that each axis goes through
 that helper, rather than that each has its own YAML step.
+
+Process axes (native / bare / timeout) share ONE supervised production pass
+(process_floor_shared_pass.py) — three projections, not three lifts.
 """
 
 from pathlib import Path
@@ -27,12 +30,9 @@ AXIS_COMMANDS = {
     "R_construction_panic_catches_outside_membrane = 0": (
         "construction_panic_catch_law.py"
     ),
-    # Criterion-2 process floors: axis names carry no "= 0" (pre-measure crash
-    # must not paint a bankable zero in the group header).
+    # Criterion-2 process floors: one shared pass projects three R axes.
+    "R_process_floors_shared_pass": "process_floor_shared_pass.py",
     "R_silent": "silent_zero_tolerance.py",
-    "R_native_crashes": "native_crash_zero_tolerance.py",
-    "R_bare_exceptions": "bare_exception_zero_tolerance.py",
-    "R_timeouts": "timeout_zero_tolerance.py",
     "R_vendor_special_case = 0": "vendor_special_case_law.py",
     "R_factory_walk_unclassified = 0": "factory_walk_unclassified_law.py",
     "R_finite_cap_opaque_completions = 0": ("finite_cap_opaque_completion_law.py"),
@@ -71,49 +71,44 @@ def test_binding_job_invokes_every_permanent_axis() -> None:
                 "binding CI must census the checked-in production surface"
             )
         if axis in {
-            "R_native_crashes",
-            "R_bare_exceptions",
-            "R_timeouts",
+            "R_process_floors_shared_pass",
             "R_silent",
         }:
             # Process floors + Criterion-2 silent must name a population.
-            # Bare silent_zero_tolerance used to default to kit production_roots
-            # (~444 files) — false green while authenticated pandas was unmeasured.
             assert "PANDAS_CORPUS" in step or "authenticated_pandas" in step, (
                 f"{axis} must pass an explicit corpus path; silent default "
                 "to kit production_roots is a wrong-population false green"
             )
-            # Not only the script name: a path argument must follow.
             assert '"$PANDAS_CORPUS"' in step or "'$PANDAS_CORPUS'" in step, (
                 f"{axis} must pass \"$PANDAS_CORPUS\" as the scan root"
             )
-            # Scratch must not default under the population root.
             assert "--out-dir" in step or "FLOOR_SCRATCH" in step, (
                 f"{axis} must direct floor scratch outside the population "
                 "(S0.2: mkdir under site-packages/pandas is measurement crime)"
             )
-            # Group header must not embed a bankable zero.
             assert " = 0" not in step.split("\n", 1)[0], (
                 f"{axis} group name must not embed '= 0' (pre-measure crash bank)"
             )
 
 
-def test_process_floors_resolve_authenticated_pandas_population() -> None:
-    """The floor set must authenticate pandas before the four corpus axes."""
+def test_process_floors_share_one_supervised_pass() -> None:
+    """native / bare / timeout must not each re-lift the corpus in CI."""
     floors = FLOOR_SET.read_text()
-    assert "authenticated_pandas_corpus" in floors, (
-        "process floors must resolve the authenticated pandas corpus root"
-    )
+    assert "process_floor_shared_pass.py" in floors
+    assert "authenticated_pandas_corpus" in floors
     assert "PANDAS_CORPUS=" in floors
-    # Order: corpus resolved once, then all four Criterion-2 population axes use it.
-    corpus_at = floors.find("PANDAS_CORPUS=")
-    native_at = floors.find('axis "R_native_crashes"')
-    bare_at = floors.find('axis "R_bare_exceptions"')
-    timeout_at = floors.find('axis "R_timeouts"')
+    # Solo zero-tolerance CLIs must not appear as separate serial corpus axes.
+    for solo_axis in (
+        'axis "R_native_crashes"',
+        'axis "R_bare_exceptions"',
+        'axis "R_timeouts"',
+    ):
+        assert solo_axis not in floors
+    # Shared pass before silent (still a separate door).
+    shared_at = floors.find('axis "R_process_floors_shared_pass"')
     silent_at = floors.find('axis "R_silent"')
-    assert 0 <= corpus_at < native_at < bare_at < timeout_at < silent_at, (
-        "PANDAS_CORPUS must be bound before native/bare/timeout/silent axes"
-    )
+    corpus_at = floors.find("PANDAS_CORPUS=")
+    assert 0 <= corpus_at < shared_at < silent_at
 
 
 def test_no_axis_is_skipped_after_an_earlier_honest_red() -> None:

--- a/tools/run_sole_construction_floors.sh
+++ b/tools/run_sole_construction_floors.sh
@@ -49,7 +49,13 @@ axis "R_ownership = 0" python "$SCRIPTS/factory_ownership_law.py"
 axis "R_construction_panic_catches_outside_membrane = 0" \
   python "$SCRIPTS/construction_panic_catch_law.py"
 
-# Heavy supervised enum floors — sequential, inside the one lease interval.
+# Heavy supervised enum floors — ONE shared production pass for the three
+# process classifiers (native_crash / bare_exception / timeout). They read the
+# same FileTerminal stream; three independent scan_paths calls re-lifted the
+# corpus ~3× for no soundness reason. process_floor_shared_pass.py lifts once
+# and projects three R axes. Coverage is total (every corpus file → one
+# terminal); redundant PASSES are removed, not files.
+#
 # Population: authenticated pandas corpus (NOT kit production_roots).
 # Silent default to sugar-lift-py-tests src+scripts was a false green: R=0 on
 # ~444 kit files while the corpus process floors never entered pandas.
@@ -67,21 +73,16 @@ echo "process-floor population: authenticated pandas corpus at $PANDAS_CORPUS"
 FLOOR_SCRATCH="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}/.sugar/ci-floors"
 export SUGAR_FLOOR_WORKSPACE="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}"
 echo "process-floor scratch: $FLOOR_SCRATCH (never under population)"
-# Axis names: R_axis only — never "R_axis = 0" (false banked zero on pre-measure crash).
-axis "R_native_crashes" \
-  python "$SCRIPTS/native_crash_zero_tolerance.py" "$PANDAS_CORPUS" \
+# Shared pass prints R_native_crashes / R_bare_exceptions / R_timeouts as three
+# completed axes (not one merged residual). Group name has no bankable zero.
+axis "R_process_floors_shared_pass" \
+  python "$SCRIPTS/process_floor_shared_pass.py" "$PANDAS_CORPUS" \
   --repo-root "$PANDAS_CORPUS" \
-  --out-dir "$FLOOR_SCRATCH/native-crash"
-axis "R_bare_exceptions" \
-  python "$SCRIPTS/bare_exception_zero_tolerance.py" "$PANDAS_CORPUS" \
-  --repo-root "$PANDAS_CORPUS" \
-  --out-dir "$FLOOR_SCRATCH/bare-exception"
-axis "R_timeouts" \
-  python "$SCRIPTS/timeout_zero_tolerance.py" "$PANDAS_CORPUS" \
-  --repo-root "$PANDAS_CORPUS" \
-  --out-dir "$FLOOR_SCRATCH/timeout"
+  --out-dir "$FLOOR_SCRATCH/process-shared"
 # R_silent is Criterion 2's fourth simultaneous term — same population as the
 # three process floors. Kit-default silent was a false green (unmeasured corpus).
+# Still a separate door (census_source + roll-call); empty-census skip is a
+# follow-up after fraction measurement — not folded into the shared lift.
 axis "R_silent" \
   python "$SCRIPTS/silent_zero_tolerance.py" "$PANDAS_CORPUS" \
   --repo-root "$PANDAS_CORPUS" \


### PR DESCRIPTION
## DO NOT MERGE while the current floors run is still measuring

Open only. Wait for the in-flight floors measurement to finish before merge.

## Finding (mr_white)

`native_crash`, `bare_exception`, and `timeout` are **three classifiers over the same `FileTerminal` stream**. Each independently called `scan_paths` and full-lifted ~1421 corpus files. Sound work is **one** supervised enum pass, then **three projections**. Current cost was ~300% of one full lift for process axes alone. No soundness reason for three passes.

## What this PR builds

| Piece | Role |
| --- | --- |
| `_process_floor_shared_pass.py` | `shared_process_floor_pass` + `project_{native_crash,bare_exception,timeout}` |
| `process_floor_shared_pass.py` | CI door: one pass, prints three completed axes |
| Solo zero-tolerance CLIs | Still present for discrimination; `audit_paths` uses the shared pass |
| `run_sole_construction_floors.sh` | One axis `R_process_floors_shared_pass` instead of three serial lifts |

**Coverage law:** every input path gets one terminal. Coverage breach (`len(terminals) != len(paths)` or path/rel mismatch) is infrastructure red. Offenders are process outcomes — **no** sound subtree exclusion. This removes **redundant passes**, not files.

## What this is not

- **Not** parallelizing the four floors (that would make the wrong architecture faster).
- **Not** folding `R_silent` into the shared lift (different door: census + roll-call). Empty-census skip is a follow-up **after** measuring the empty fraction.
- **Not** the content-addressed terminal cache (mr_brown). Endgame is shared pass **plus** that cache; this PR only merges the three callers so cache has one customer.

## Teeth

- Planted terminals project only their axis
- Under-coverage from a fake `scan_paths` is loud
- Shared pass invokes `scan_paths` exactly once for three residuals
- Floor set binding forbids solo `axis "R_native_crashes"` etc. as serial corpus lifts

## Validation

```
PYTHONPATH=implementations/python/sugar-lift-py-tests/scripts \
  uv run --with pytest python -m pytest --noconftest \
  implementations/python/sugar-lift-py-tests/tests/test_process_floor_shared_pass.py \
  implementations/python/sugar-lift-py-tests/tests/test_native_crash_zero_tolerance.py \
  implementations/python/sugar-lift-py-tests/tests/test_bare_exception_zero_tolerance.py \
  implementations/python/sugar-lift-py-tests/tests/test_timeout_zero_tolerance.py \
  tests/test_python_sole_construction_ci.py \
  tests/test_heavy_measurement_concurrency_topology.py
# 18 + 23 related passed in local uv runs
```

## Shot accounting

| | |
| --- | --- |
| R axis | process-floor wall-time / redundant lifts |
| Epsilon R | ~3× → 1× supervised lift for native+bare+timeout |
| Shell deleted | three serial corpus `scan_paths` in the leased floor set |
| Floors | no residual drain; measurement architecture only |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace three serial process-floor scans with a single shared supervised pass producing three axis projections
> - Adds [`_process_floor_shared_pass.py`](https://github.com/TSavo/sugar/pull/7010/files#diff-8ac1933d3959688134d1e4618ec7f1181b8eeb9181bb76aa238abefe5f490d8b) with a `shared_process_floor_pass` helper that runs one `scan_paths` invocation and projects its terminals into three typed offender sets: `NativeCrashOffender`, `BareExceptionOffender`, and `TimeoutOffender`.
> - Adds a new CLI [`process_floor_shared_pass.py`](https://github.com/TSavo/sugar/pull/7010/files#diff-e5bf9d0904ff22d34ba04071f42538f09bc19f67749e0a01d6ef7d0422c71822) that performs the shared scan and emits all three axis reports (`R_native_crashes`, `R_bare_exceptions`, `R_timeouts`) in a single run.
> - Refactors `native_crash_zero_tolerance.py`, `bare_exception_zero_tolerance.py`, and `timeout_zero_tolerance.py` to delegate scanning and offender construction to the shared pass rather than calling `scan_paths` independently.
> - Replaces the three separate script invocations in [`run_sole_construction_floors.sh`](https://github.com/TSavo/sugar/pull/7010/files#diff-2425932b3b3850c1dce0e1350ce9dadb9c8d59942a7fb072ba19c29e2f913421) with a single call to `process_floor_shared_pass.py` under the axis name `R_process_floors_shared_pass`.
> - `assert_full_coverage` enforces a one-to-one mapping between input paths and emitted terminals, raising `RuntimeError` on any mismatch.
> - Risk: per-file timeouts above 30 seconds now raise `ValueError` in the shared pass, which is enforced earlier than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 807c99f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->