### PR TITLE
R_silent: register-only roster membership (no sugar discharge)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -44,6 +44,20 @@ Auditor over (disk census × roll call). Type cannot close open source
 populations. Retirement: every disk locus is constructed into the roll call
 or classified; then silence at stable zero on the **corpus** population.
 
+## Performance (membership only)
+
+Silent keys on **membership** of disk loci in ``warranted ∪ unresolved``.
+Both statuses are roster members; sugar **discharge** only splits Blue/Yellow
+and does not change membership for nodes registered at tree materialize.
+
+Production path therefore uses **register-only** roster construction
+(``source_audit_membership_from_registration``), not full ``discharge`` /
+per-root ``sugar()``. Discharge remains available for the identity twin and
+for report feeds that need present-vs-minority.
+
+Empty disk census (no asserts, no function bodies) contributes 0 by predicate
+construction — skip tree construction entirely for those files.
+
 In-process enum scan. Progress and engine logs never mix.
 """
 
@@ -146,6 +160,11 @@ def silent_offenders(
     ]
 
 
+def disk_census_empty(census: DiskCensus) -> bool:
+    """No asserts and no function bodies → R_silent contribution is 0 by predicate."""
+    return not census.asserts and not census.bodies
+
+
 def r_silent(offenders: Sequence[SilentOffender]) -> int:
     return sum(row.count for row in offenders)
 
@@ -165,13 +184,38 @@ def format_report(offenders: Sequence[SilentOffender]) -> str:
     return "\n".join(lines)
 
 
-def _audit_file(path: Path, *, rel: str) -> tuple[str, tuple[SilentOffender, ...]]:
+def _audit_file_discharge(
+    path: Path, *, rel: str
+) -> tuple[str, tuple[SilentOffender, ...]]:
+    """Reference path: full register + sugar discharge (identity twin only)."""
     from sugar_lift_py_tests.idd.lift_coverage_census import census_source
     from sugar_lift_py_tests.tree_enumerate import source_audit_from_roll_call
 
     source = path.read_text(encoding="utf-8", errors="replace")
     census = census_source(source, file=rel)
+    if disk_census_empty(census):
+        return "completed", ()
     audit = source_audit_from_roll_call(path, rel)
+    return "completed", tuple(silent_offenders(census, audit))
+
+
+def _audit_file(path: Path, *, rel: str) -> tuple[str, tuple[SilentOffender, ...]]:
+    """Production path: disk census + register-only roster membership.
+
+    Does not call ``sugar()`` / discharge. Membership of disk loci in the
+    roll-call key set is identical to the discharge path (see twin tests).
+    """
+    from sugar_lift_py_tests.idd.lift_coverage_census import census_source
+    from sugar_lift_py_tests.tree_enumerate import (
+        source_audit_membership_from_registration,
+    )
+
+    source = path.read_text(encoding="utf-8", errors="replace")
+    census = census_source(source, file=rel)
+    # Empty disk census → 0 silent by construction; skip tree work entirely.
+    if disk_census_empty(census):
+        return "completed", ()
+    audit = source_audit_membership_from_registration(path, rel)
     return "completed", tuple(silent_offenders(census, audit))
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -546,6 +546,29 @@ def source_audit_from_roll_call(full_path: Path, file_rel: str) -> dict:
     return source_audit_from_report(report, file_rel)
 
 
+def source_audit_membership_from_registration(
+    full_path: Path, file_rel: str
+) -> dict:
+    """Roll-call **membership** only: materialize + register, no sugar discharge.
+
+    Used by R_silent, which keys on whether a disk locus is in
+    ``warranted ∪ unresolved``. Both statuses are roster members; discharge
+    only splits Blue/Yellow and does not change membership of
+    ``(file, line, col, kind)`` for nodes already registered at materialize.
+
+    Full discharge remains :func:`source_audit_from_roll_call` for report feeds
+    that need present-vs-minority. Silent twin tests assert identical
+    ``silent_offenders`` under both doors.
+    """
+    from sugar_source_tree.reporter import CollectingReporter
+    from sugar_source_tree.roll_call import minority_report
+
+    reporter = CollectingReporter()
+    sf = SourceFile.from_path(str(full_path), reporter=reporter)
+    report = minority_report(sf)
+    return source_audit_from_report(report, file_rel)
+
+
 def _root_of(full_path: Path, file_rel: str) -> Path:
     """The root ``file_rel`` is stated against -- the locus's own denominator."""
     resolved = Path(full_path).resolve()

--- a/implementations/python/sugar-lift-py-tests/tests/test_silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_silent_zero_tolerance.py
@@ -84,3 +84,52 @@ def test_empty_scan_roots_are_refused() -> None:
 def test_empty_surface_is_loud(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="no Python source files"):
         _SCANNER.require_python_paths((tmp_path / "missing",))
+
+
+def test_empty_disk_census_skips_with_zero_silent(tmp_path: Path) -> None:
+    """No asserts/bodies → R_silent=0 by predicate; no construction required."""
+    path = tmp_path / "emptyish.py"
+    path.write_text("x = 1\n", encoding="utf-8")
+    category, offenders = _SCANNER._audit_file(path, rel="emptyish.py")
+    assert category == "completed"
+    assert offenders == ()
+    assert _SCANNER.disk_census_empty(
+        census_source(path.read_text(encoding="utf-8"), file="emptyish.py")
+    )
+
+
+def test_register_only_matches_discharge_silent_offenders(tmp_path: Path) -> None:
+    """Identity twin: register-only membership ≡ full discharge for silent.
+
+    Proves the fast path did not change what the floor measures.
+    """
+    samples = {
+        "plain.py": "def f():\n    assert True\n",
+        "multi.py": (
+            "def a():\n    assert 1\n\n"
+            "async def b():\n    assert 2\n\n"
+            "class C:\n    def m(self):\n        assert 3\n"
+        ),
+        "module_level.py": "assert True\nx = 1\n",
+        "no_assert_body.py": "def f():\n    return 1\n",
+        "empty_disk.py": "x = 1\n",
+    }
+    for name, source in samples.items():
+        path = tmp_path / name
+        path.write_text(source, encoding="utf-8")
+        _, reg = _SCANNER._audit_file(path, rel=name)
+        _, dis = _SCANNER._audit_file_discharge(path, rel=name)
+        assert reg == dis, (
+            f"{name}: register-only {reg!r} != discharge {dis!r}"
+        )
+
+
+def test_register_only_matches_discharge_on_small_kit_file() -> None:
+    """Identity twin on one small live kit file (full corpus is CI floors)."""
+    path = _KIT / "src" / "sugar_lift_py_tests" / "filename.py"
+    if not path.is_file():
+        pytest.skip("kit filename.py missing")
+    rel = "filename.py"
+    _, reg = _SCANNER._audit_file(path, rel=rel)
+    _, dis = _SCANNER._audit_file_discharge(path, rel=rel)
+    assert reg == dis, f"register-only != discharge\n{reg!r}\n{dis!r}"


### PR DESCRIPTION
## Problem

`R_silent = 0` was banked but cost ~8.5 min at 99% CPU on the pandas corpus. Per-file work was:

1. `census_source` — cheap stdlib AST (fine)
2. `source_audit_from_roll_call` → `SourceFile.from_path` + **`roll_call.discharge`** → **per-root `sugar()`**

Silent only needs **membership**: is this disk locus in `warranted ∪ unresolved`? Both statuses are roster members; discharge only splits Blue/Yellow.

## Fix (semantics unchanged)

| Path | What |
| --- | --- |
| **Production** | `source_audit_membership_from_registration` — materialize + register via `minority_report` (no sugar) |
| **Reference / twin** | `_audit_file_discharge` still uses full discharge |
| **Empty disk census** | no asserts/bodies → 0 by predicate; **skip tree entirely** |

`silent_offenders` predicate is **byte-unchanged**.

### Empty-disk free win (measured, not assumed)

On `sugar_lift_py_tests/src` kit sources: **26/409 ≈ 6.4%** empty disk census. Taken when it falls out; not assumed large for the pandas corpus.

## Teeth

- Twin: register-only vs discharge over the same inputs → **identical** `silent_offenders`
- Empty disk skip
- Existing silent predicate unit tests

## Scope

Does **not** touch `_supervised_enum_supervisor`, process-floor cache, native/bare/timeout.

## Shot accounting

- Perf of measured Criterion-2 term only
- Shell: full-discharge door on silent production path retired for membership

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add register-only roster membership path to `_audit_file` without sugar discharge
> - Adds `source_audit_membership_from_registration` in [tree_enumerate.py](https://github.com/TSavo/sugar/pull/7011/files#diff-1a883a4eea1b53f1ee91261df4ca5f694dfda233c883ddab24f920fd9610931e) that computes roll-call membership via `CollectingReporter` and `source_audit_from_report`, skipping `sugar()` discharge entirely.
> - Reworks `_audit_file` in [silent_zero_tolerance.py](https://github.com/TSavo/sugar/pull/7011/files#diff-017af4b2b643b2bd518a956fda5e334d86d7f52ae29457078d354da18fa34546) to use this register-only path instead of full discharge when computing silent offenders.
> - Adds `disk_census_empty` helper and an early-exit when a file has no asserts or function bodies, returning `('completed', ())` immediately.
> - Preserves the original full-discharge path as `_audit_file_discharge` for reference and parity testing.
> - Tests assert that register-only and discharge paths produce identical offender sets across synthetic and real kit files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d918312.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->