### PR TITLE
Shard python package suite: 32 parallel identity-bound reports

### DIFF
--- a/.github/workflows/python-package-suite.yml
+++ b/.github/workflows/python-package-suite.yml
@@ -2,37 +2,26 @@ name: Python package suite (authoritative)
 
 # THE DEFECT THIS FIXES
 #
-# `sugar-lift-py-tests` had no PR-gate coverage. `python-sole-construction-floors`
-# runs targeted law scripts with `--noconftest` -- not the suite. The only
-# workflow that touched the whole `sugar-lift-py-tests/tests` directory was
-# `restored-suite-scoreboard`, nightly cron / manual dispatch only. `make
-# test-python` was in no workflow at all. So the unit tests for
-# `ExitSet.and_exit` did not run against #6270, the PR that rewrote that
-# algebra.
+# One cold pytest over ~3864 tests is one process on one core while 31 cores
+# idle. That serialization starved every measurement for hours. T: "32 cores
+# and 25 runners, and this idea that we should be serializing anything in the
+# CI process is just pure insanity."
 #
-# This workflow is the ONE authoritative whole-package sweep. Nothing else may
-# define, install, or run "the Python suite": the environment comes from
-# ./.github/actions/python-test-environment, and the zero-tolerance floors
-# consume that same action rather than building their own.
+# DESIGN (settled): 32 deterministic file shards. Each job writes its OWN
+# identity-bound suite-report.json. Completeness is ENROLLMENT (roster + roll
+# call), not merge into a shared hub. Identity gate runs PER SHARD. Campaign
+# claim: all N attended and each is identity-resolved.
 #
-# IT DOES NOT GATE ON VERDICTS; IT DOES GATE ON IDENTITY. ~131 known failures
-# exist. Turning that red into a merge gate is a merge-policy change and this
-# wiring is a measurement-ownership change, so the job records pytest's exit
-# status as evidence and does not exit on it.
+# Canonical order is collection order WITHIN a shard's file set only.
+# Discrimination (scheduled) is within-shard. No package-wide recombine.
 #
-# Identity is a different question from verdicts. A measurement that cannot say
-# which authenticated source and which test-input universe produced its
-# verdicts is not a lenient measurement, it is not a measurement -- so the
-# identity gate DOES fail the job, and the authoritative artifact is not
-# published when it does. The SCHEDULED discrimination job also fails, because
-# order-dependence is not a known failure -- it is a claim that our verdicts
-# are not verdicts.
+# No machine-wide heavy-measurement lease (deleted). Jobs run in parallel.
+# Shard count lives in tools/python_package_suite_shards.py (SHARD_COUNT=32).
 
 on:
   push:
     branches: [main]
   schedule:
-    # Discrimination cadence: canonical vs reversed vs shuffled, each cold.
     - cron: "41 7 * * *"
   workflow_dispatch:
     inputs:
@@ -44,30 +33,9 @@ on:
 permissions:
   contents: read
 
-# NO `concurrency:` BLOCK. THAT IS THE FIX.
-#
-# This workflow had its own ref-independent group with cancel-in-progress:
-# false, and it was starved inside that group anyway: five runs (dea47f1f8,
-# e0a78ec52, d243fcacf, 6d9db3a8f, f0cddfd76) cancelled, zero artifacts, until
-# 30174018299 finally landed one behind a merge freeze. `cancel-in-progress:
-# false` only protects a run that has already STARTED; GitHub keeps exactly ONE
-# pending run per group, so every new push EVICTS the queued one. Our own merge
-# rate was the thing killing the measurement.
-#
-# So the queue and the serialization are separated:
-#
-#   GitHub queue: preserve every requested measurement  (no group -- here)
-# No machine-wide heavy-measurement lease; jobs run in parallel.
-#
-# Every run is retained and every run eventually measures. Overlap is settled
-# on the box by an flock the kernel releases even on SIGKILL, not by a queue
-# that drops the thing it was asked to remember.
+# NO concurrency group — every run retained.
 
 jobs:
-  # The gate's own discrimination twins. Six teeth, both faces each, no
-  # environment and no lease: pure JSON in, verdict out, seconds. It runs
-  # BEFORE the environment is prepared so a weakened identity gate is red on
-  # its own terms rather than red-by-absence three hours later.
   identity-gate-twins:
     name: identity gate teeth (both faces)
     runs-on: [self-hosted, Linux, X64]
@@ -84,6 +52,9 @@ jobs:
     timeout-minutes: 60
     outputs:
       identity-hash: ${{ steps.env.outputs.identity-hash }}
+      shard-matrix: ${{ steps.shards.outputs.matrix }}
+      shard-list: ${{ steps.shards.outputs.list }}
+      shard-count: ${{ steps.shards.outputs.count }}
     steps:
       - uses: actions/checkout@v6
       - name: Prepare immutable Python test environment
@@ -91,6 +62,18 @@ jobs:
         uses: ./.github/actions/python-test-environment
         with:
           identity-artifact: "true"
+      - name: Emit deterministic shard matrix
+        id: shards
+        shell: bash
+        run: |
+          set -euo pipefail
+          matrix="$(python3 tools/python_package_suite_shards.py --emit-matrix-json)"
+          list="$(python3 tools/python_package_suite_shards.py --emit-shard-list-json)"
+          count="$(python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' <<<"$list")"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "list=$list" >> "$GITHUB_OUTPUT"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "suite shard matrix count=$count"
       - name: Publish environment identity to the run summary
         shell: bash
         run: |
@@ -100,14 +83,20 @@ jobs:
             echo
             echo '`environmentIdentityHash`: `${{ steps.env.outputs.identity-hash }}`'
             echo
+            echo "suite shards: `${{ steps.shards.outputs.count }}` (enrollment roster)"
+            echo
             echo 'Runs that do not share this hash are not comparable measurements.'
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # One CI job per shard. Own report. Own identity gate. No singleton writer.
   python-package-suite:
-    name: python-package-suite (canonical)
+    name: suite canonical shard ${{ matrix.shard }}
     needs: prepare-python-test-environment
     runs-on: [self-hosted, Linux, X64]
-    timeout-minutes: 180
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare-python-test-environment.outputs.shard-matrix) }}
     steps:
       - uses: actions/checkout@v6
 
@@ -115,22 +104,9 @@ jobs:
         id: env
         uses: ./.github/actions/python-test-environment
 
-      # The suite exercises the real lift over RPC. `tests/conftest.py` already
-      # resolves the binary in a session fixture and exits(2) if it cannot, so
-      # this step is not what makes the sweep work -- it is what keeps the
-      # sweep's WALL TIME a measurement of the suite rather than of a cold
-      # Rust build that happened to land inside it. Resolved through the one
-      # door, bin/sugarbin, by source stamp: shelf hit unless Rust inputs moved.
       - name: Set up Rust toolchain
         uses: ./.github/actions/setup-rust-cache
 
-      # The stamp is READ OFF THE RESOLVED BINARY, not recomputed beside it.
-      # `<binary>.sugarbin.json` is written by the build that produced this
-      # exact file and verified against its sha256 on every shelf hit, so it is
-      # the source identity the measured binary ACTUALLY has. The identity gate
-      # requires it to equal the environment identity's sourceStamp: a suite
-      # that measures one binary while reporting another source universe is the
-      # unresolved-identity defect wearing a populated field.
       - name: Resolve the sugar binary and read its source identity
         id: binary
         shell: bash
@@ -140,7 +116,7 @@ jobs:
           echo "SUGAR_BIN=$sugar_bin" >> "$GITHUB_ENV"
           manifest="$sugar_bin.sugarbin.json"
           if [ ! -f "$manifest" ]; then
-            echo "::error::resolved binary $sugar_bin has no $manifest; its source identity is unknown."
+            echo "::error::resolved binary $sugar_bin has no $manifest"
             exit 1
           fi
           stamp="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["sourceStamp"])' "$manifest")"
@@ -149,54 +125,69 @@ jobs:
             *) echo "::error::binary manifest sourceStamp is malformed: $stamp"; exit 1 ;;
           esac
           echo "stamp=$stamp" >> "$GITHUB_OUTPUT"
-          echo "measured binary sourceStamp: $stamp"
 
-      # ONE cold process. Whole package. Canonical collection order.
-      # `-p no:cacheprovider` so no run inherits another's cache; `-p
-      # no:randomly` so canonical means canonical.
-      #
-      # And ONE AT A TIME ON THE BOX. The wall time of this sweep is a claim
-      # about the suite; measured beside a pandas census it is a claim about
-      # nothing. The lease is machine-wide, so the NumPy wall, the pandas wall,
-      # the sole-construction floors and the restored-suite sweep all wait for
-      # this one, and it waits for them -- while GitHub keeps every run.
-      - name: Whole-package sweep (no machine-wide lease)
+      - name: Shard ${{ matrix.shard }} sweep (own identity-bound report)
         id: sweep
         shell: bash
         working-directory: implementations/python
         env:
-          # tools/ for the suite report plugin; checkout roots from the env
-          # action (first-party must NOT come from site-packages).
           PYTHONPATH: ${{ github.workspace }}/tools:${{ env.SUGAR_CHECKOUT_PYTHONPATH }}
+          SUITE_IDENTITY_PATH: ${{ steps.env.outputs.identity-path }}
+          SUITE_BINARY_STAMP: ${{ steps.binary.outputs.stamp }}
+          SHARD: ${{ matrix.shard }}
+          SHARD_COUNT: ${{ needs.prepare-python-test-environment.outputs.shard-count }}
         run: |
           set -uo pipefail
-          cat > "$RUNNER_TEMP/sweep.sh" <<'SWEEP'
-          set -uo pipefail
-          python -m pytest sugar-lift-py-tests/tests -q \
-            -p no:cacheprovider -p no:randomly \
-            -p python_package_suite_report \
-            --suite-report="$GITHUB_WORKSPACE/suite-report.json" \
-            --suite-identity="$SUITE_IDENTITY_PATH" \
-            --suite-commit="$GITHUB_SHA" \
-            --suite-binary-stamp="$SUITE_BINARY_STAMP" \
-            --suite-order=canonical \
-            --suite-label=python-package-suite-canonical \
-            2>&1 | tee "$GITHUB_WORKSPACE/suite.log"
-          exit "${PIPESTATUS[0]}"
-          SWEEP
-          set +e
-          SUITE_IDENTITY_PATH='${{ steps.env.outputs.identity-path }}' \
-          SUITE_BINARY_STAMP='${{ steps.binary.outputs.stamp }}' \
-          bash "$RUNNER_TEMP/sweep.sh"
-          pytest_exit=$?
-          set -e
-          echo "pytest_exit=$pytest_exit" >> "$GITHUB_OUTPUT"
+          mapfile -t paths < <(
+            python3 "$GITHUB_WORKSPACE/tools/python_package_suite_shards.py" \
+              --repo-root "$GITHUB_WORKSPACE" \
+              --shard-count "$SHARD_COUNT" \
+              --shard-index "$SHARD" \
+              --emit-paths-for-cwd
+          )
+          echo "shard $SHARD / $SHARD_COUNT paths (${#paths[@]}):"
+          printf '  %s\n' "${paths[@]:-}"
+          if [ "${#paths[@]}" -eq 0 ]; then
+            python3 "$GITHUB_WORKSPACE/tools/python_package_suite_shards.py" \
+              --shard-count "$SHARD_COUNT" \
+              --shard-index "$SHARD" \
+              --mint-empty-report "$GITHUB_WORKSPACE/suite-report.json" \
+              --suite-identity "$SUITE_IDENTITY_PATH" \
+              --suite-commit "$GITHUB_SHA" \
+              --suite-binary-stamp "$SUITE_BINARY_STAMP" \
+              --suite-order canonical
+            echo "empty shard $SHARD" | tee "$GITHUB_WORKSPACE/suite.log"
+            echo "pytest_exit=0" >> "$GITHUB_OUTPUT"
+          else
+            set +e
+            python -m pytest "${paths[@]}" -q \
+              -p no:cacheprovider -p no:randomly \
+              -p python_package_suite_report \
+              --suite-report="$GITHUB_WORKSPACE/suite-report.json" \
+              --suite-identity="$SUITE_IDENTITY_PATH" \
+              --suite-commit="$GITHUB_SHA" \
+              --suite-binary-stamp="$SUITE_BINARY_STAMP" \
+              --suite-order=canonical \
+              --suite-shard-index="$SHARD" \
+              --suite-shard-count="$SHARD_COUNT" \
+              --suite-label="python-package-suite-canonical-shard-$(printf '%02d' "$SHARD")" \
+              2>&1 | tee "$GITHUB_WORKSPACE/suite.log"
+            pytest_exit="${PIPESTATUS[0]}"
+            set -e
+            echo "pytest_exit=$pytest_exit" >> "$GITHUB_OUTPUT"
+          fi
           test -s "$GITHUB_WORKSPACE/suite.log"
           test -s "$GITHUB_WORKSPACE/suite-report.json"
+          # Attendance marker for heavy roll call (measurementClass).
+          python3 -c "
+          import json, os
+          from pathlib import Path
+          p = Path(os.environ['GITHUB_WORKSPACE']) / 'suite-report.json'
+          body = json.loads(p.read_text())
+          body['measurementClass'] = 'python-package-suite'
+          p.write_text(json.dumps(body, indent=2) + '\n')
+          "
 
-      # No timing claim is accepted if the lease was not acquired. This is that
-      # sentence with teeth: red unless the artifact's own embedded receipt
-      # shows request -> acquisition -> release around THIS commit.
       - name: Publish the node-ID vector
         if: always()
         shell: bash
@@ -208,23 +199,7 @@ jobs:
             --node-id-dir suite-node-ids \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
-      # EVERY IDENTITY FIELD RESOLVED -- CHECKED ON THE ARTIFACT, BEFORE IT IS
-      # CALLED AUTHORITATIVE.
-      #
-      # Run 30175741263 was complete and conserved (1212 collected, 1212
-      # verdicts) and concluded `success` while its sourceStamp was the object
-      # `{"unavailable": "CalledProcessError: ..."}` and its testExtraInputHash
-      # was null. Conservation is not authority: this step is where the run
-      # proves WHICH source and WHICH test-input universe produced the
-      # verdicts, and it reads suite-report.json as serialized -- a value that
-      # was populated in the sweep but lost on the way to the file is caught
-      # here and nowhere else.
-      #
-      # Deliberately NOT `if: always()` in the sense of being toothless: this
-      # step fails the job, and the authoritative upload below does not run
-      # when it does.
-      - name: Identity gate (R_identity = 0)
-        id: identity-gate
+      - name: Identity gate (per-shard R_identity = 0)
         if: always()
         shell: bash
         run: |
@@ -235,16 +210,11 @@ jobs:
             | tee identity-gate.md \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
-      # Artifacts carry the node-ID lists. The step summary carries counts.
-      # Counts are summaries of the lists; the lists are the evidence.
-      #
-      # This name means authoritative. It is published only when the identity
-      # gate passed on the serialized report.
-      - name: Upload authoritative suite artifacts
+      - name: Upload authoritative shard artifact
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-suite-canonical
+          name: python-package-suite-canonical-shard-${{ matrix.shard }}
           path: |
             suite.log
             suite-report.json
@@ -252,14 +222,11 @@ jobs:
             identity-gate.md
           if-no-files-found: error
 
-      # Evidence is never thrown away -- it is just not allowed to wear the
-      # authoritative name. A consumer that downloads this one is holding a
-      # provisional receipt and the artifact says so in its own name.
-      - name: Upload provisional (identity-unresolved) suite artifacts
+      - name: Upload provisional (identity-unresolved) shard artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-suite-canonical-PROVISIONAL-identity-unresolved
+          name: python-package-suite-canonical-shard-${{ matrix.shard }}-PROVISIONAL-identity-unresolved
           path: |
             suite.log
             suite-report.json
@@ -267,42 +234,57 @@ jobs:
             identity-gate.md
           if-no-files-found: warn
 
-      # Deliberately no `exit $pytest_exit`. See the header: this job reports.
-      - name: Report, do not gate
+      - name: Report, do not gate on pytest verdict
         if: always()
         shell: bash
         run: |
-          echo "pytest exit status ${{ steps.sweep.outputs.pytest_exit }} recorded as evidence."
-          echo "This job does not gate merges; it owns the measurement."
+          echo "pytest exit ${{ steps.sweep.outputs.pytest_exit }} recorded as evidence."
+          echo "Identity + enrollment gate completeness; verdicts do not gate merges."
+
+  # Completeness: all shards attended. Missing shard = UNMEASURED. No merge.
+  python-package-suite-attendance:
+    name: suite shard enrollment (all attended)
+    if: always() && !cancelled()
+    needs: [prepare-python-test-environment, python-package-suite]
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: python-package-suite-canonical-shard-*
+          path: runs
+      - name: Roll call — enrollment is existence
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/python_package_suite_shard_attendance.py \
+            --reports-dir runs \
+            --shard-count '${{ needs.prepare-python-test-environment.outputs.shard-count }}' \
+            --require-commit "$GITHUB_SHA" \
+            --order canonical \
+            | tee -a "$GITHUB_STEP_SUMMARY"
 
   python-package-suite-discrimination:
-    name: python-package-suite (${{ matrix.order }})
-    # Scheduled cadence only -- plus explicit dispatch. Per-merge CI pays for
-    # exactly one sweep; order-dependence is caught nightly, not by tripling
-    # every merge's cost.
+    name: suite ${{ matrix.order }} shard ${{ matrix.shard }}
     if: >-
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.discrimination)
     needs: prepare-python-test-environment
     runs-on: [self-hosted, Linux, X64]
-    timeout-minutes: 180
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         order: [reversed, shuffled]
+        shard: ${{ fromJSON(needs.prepare-python-test-environment.outputs.shard-list) }}
     steps:
       - uses: actions/checkout@v6
-
       - name: Prepare immutable Python test environment
         id: env
         uses: ./.github/actions/python-test-environment
-
-      # Same binary, resolved the same way and warmed the same way, so the only
-      # difference between the canonical run and these is the order. Anything
-      # else differing would make a divergence uninterpretable.
       - name: Set up Rust toolchain
         uses: ./.github/actions/setup-rust-cache
-
       - name: Resolve the sugar binary and read its source identity
         id: binary
         shell: bash
@@ -311,48 +293,56 @@ jobs:
           sugar_bin="$(bin/sugarbin --profile release)"
           echo "SUGAR_BIN=$sugar_bin" >> "$GITHUB_ENV"
           manifest="$sugar_bin.sugarbin.json"
-          if [ ! -f "$manifest" ]; then
-            echo "::error::resolved binary $sugar_bin has no $manifest; its source identity is unknown."
-            exit 1
-          fi
           stamp="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["sourceStamp"])' "$manifest")"
           echo "stamp=$stamp" >> "$GITHUB_OUTPUT"
-
-      # A SEPARATE COLD PROCESS per order. Sharing a process would let the
-      # first order warm exactly the caches whose influence we are measuring.
-      #       - name: Whole-package sweep (${{ matrix.order }}, no machine-wide lease)
+      - name: Shard sweep (${{ matrix.order }})
         shell: bash
         working-directory: implementations/python
         env:
-          # tools/ for the suite report plugin; checkout roots from the env
-          # action (first-party must NOT come from site-packages).
           PYTHONPATH: ${{ github.workspace }}/tools:${{ env.SUGAR_CHECKOUT_PYTHONPATH }}
+          SUITE_IDENTITY_PATH: ${{ steps.env.outputs.identity-path }}
+          SUITE_BINARY_STAMP: ${{ steps.binary.outputs.stamp }}
+          SHARD: ${{ matrix.shard }}
+          SHARD_COUNT: ${{ needs.prepare-python-test-environment.outputs.shard-count }}
+          SUITE_ORDER: ${{ matrix.order }}
         run: |
           set -uo pipefail
-          cat > "$RUNNER_TEMP/sweep-${{ matrix.order }}.sh" <<'SWEEP'
-          set -uo pipefail
-          python -m pytest sugar-lift-py-tests/tests -q \
-            -p no:cacheprovider -p no:randomly \
-            -p python_package_suite_report \
-            --suite-report="$GITHUB_WORKSPACE/suite-report.json" \
-            --suite-identity="$SUITE_IDENTITY_PATH" \
-            --suite-commit="$GITHUB_SHA" \
-            --suite-binary-stamp="$SUITE_BINARY_STAMP" \
-            --suite-order="$SUITE_ORDER" \
-            --suite-shuffle-seed="$GITHUB_RUN_ID" \
-            --suite-label="python-package-suite-$SUITE_ORDER" \
-            2>&1 | tee "$GITHUB_WORKSPACE/suite.log"
-          exit "${PIPESTATUS[0]}"
-          SWEEP
-          set +e
-          SUITE_IDENTITY_PATH='${{ steps.env.outputs.identity-path }}' \
-          SUITE_BINARY_STAMP='${{ steps.binary.outputs.stamp }}' \
-          SUITE_ORDER='${{ matrix.order }}' \
-          bash "$RUNNER_TEMP/sweep-${{ matrix.order }}.sh"
-          set -e
+          mapfile -t paths < <(
+            python3 "$GITHUB_WORKSPACE/tools/python_package_suite_shards.py" \
+              --repo-root "$GITHUB_WORKSPACE" \
+              --shard-count "$SHARD_COUNT" \
+              --shard-index "$SHARD" \
+              --emit-paths-for-cwd
+          )
+          if [ "${#paths[@]}" -eq 0 ]; then
+            python3 "$GITHUB_WORKSPACE/tools/python_package_suite_shards.py" \
+              --shard-count "$SHARD_COUNT" \
+              --shard-index "$SHARD" \
+              --mint-empty-report "$GITHUB_WORKSPACE/suite-report.json" \
+              --suite-identity "$SUITE_IDENTITY_PATH" \
+              --suite-commit "$GITHUB_SHA" \
+              --suite-binary-stamp "$SUITE_BINARY_STAMP" \
+              --suite-order "$SUITE_ORDER"
+            echo "empty shard $SHARD ($SUITE_ORDER)" | tee "$GITHUB_WORKSPACE/suite.log"
+          else
+            set +e
+            python -m pytest "${paths[@]}" -q \
+              -p no:cacheprovider -p no:randomly \
+              -p python_package_suite_report \
+              --suite-report="$GITHUB_WORKSPACE/suite-report.json" \
+              --suite-identity="$SUITE_IDENTITY_PATH" \
+              --suite-commit="$GITHUB_SHA" \
+              --suite-binary-stamp="$SUITE_BINARY_STAMP" \
+              --suite-order="$SUITE_ORDER" \
+              --suite-shuffle-seed="$GITHUB_RUN_ID" \
+              --suite-shard-index="$SHARD" \
+              --suite-shard-count="$SHARD_COUNT" \
+              --suite-label="python-package-suite-${SUITE_ORDER}-shard-$(printf '%02d' "$SHARD")" \
+              2>&1 | tee "$GITHUB_WORKSPACE/suite.log"
+            set -e
+          fi
           test -s "$GITHUB_WORKSPACE/suite-report.json"
-
-      - name: Identity gate (R_identity = 0)
+      - name: Identity gate (per-shard)
         if: always()
         shell: bash
         run: |
@@ -362,12 +352,11 @@ jobs:
             --require-commit "$GITHUB_SHA" \
             | tee identity-gate.md \
             | tee -a "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload discrimination artifacts
+      - name: Upload discrimination shard artifact
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-suite-${{ matrix.order }}
+          name: python-package-suite-${{ matrix.order }}-shard-${{ matrix.shard }}
           path: |
             suite.log
             suite-report.json
@@ -375,34 +364,74 @@ jobs:
           if-no-files-found: error
 
   discrimination-verdict:
-    name: identical verdict sets across orders
+    name: identical within-shard verdict sets across orders
     if: >-
       always() && !cancelled() && (
         github.event_name == 'schedule' ||
         (github.event_name == 'workflow_dispatch' && inputs.discrimination)
       )
-    needs: [python-package-suite, python-package-suite-discrimination]
+    needs:
+      - prepare-python-test-environment
+      - python-package-suite
+      - python-package-suite-discrimination
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v4
         with:
-          pattern: python-package-suite-*
+          pattern: python-package-suite-*-shard-*
           path: runs
-      # THIS ONE HAS TEETH. A verdict that changes with execution order is not
-      # a verdict. Red here means one of the two runs lied and we do not know
-      # which; fix the dependence, do not re-run for green.
-      # Were the three arms actually serialized? Same kernel must mean the same
-      # lock inode, and no two acquisition intervals may overlap. If the lease
-      # file is not shared between runner containers this is where it shows up
-      # -- otherwise the mechanism could be pure theatre and every arm would
-      # still look green.
-      - name: Require identical verdict sets
+      - name: Enrollment for each order
         shell: bash
         run: |
           set -euo pipefail
-          python tools/python_suite_discrimination.py \
-            --baseline runs/python-package-suite-canonical/suite-report.json \
-            --candidate runs/python-package-suite-reversed/suite-report.json \
-            --candidate runs/python-package-suite-shuffled/suite-report.json \
-            | tee -a "$GITHUB_STEP_SUMMARY"
+          count='${{ needs.prepare-python-test-environment.outputs.shard-count }}'
+          for order in canonical reversed shuffled; do
+            python3 tools/python_package_suite_shard_attendance.py \
+              --reports-dir runs \
+              --shard-count "$count" \
+              --require-commit "$GITHUB_SHA" \
+              --order "$order" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+          done
+      - name: Within-shard order-independence (no merged hub)
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import sys
+          from pathlib import Path
+          sys.path.insert(0, "tools")
+          from python_package_suite_shard_attendance import find_shard_reports
+          from python_suite_discrimination import compare
+
+          runs = Path("runs")
+          count = int("${{ needs.prepare-python-test-environment.outputs.shard-count }}")
+          by_order = {
+              order: find_shard_reports(runs, order)
+              for order in ("canonical", "reversed", "shuffled")
+          }
+          crimes = []
+          for i in range(count):
+              if i not in by_order["canonical"]:
+                  crimes.append(f"shard {i:02d}: canonical missing")
+                  continue
+              _, baseline = by_order["canonical"][i]
+              for order in ("reversed", "shuffled"):
+                  if i not in by_order[order]:
+                      crimes.append(f"shard {i:02d}: {order} missing")
+                      continue
+                  _, candidate = by_order[order][i]
+                  for line in compare(baseline, candidate):
+                      crimes.append(f"shard {i:02d}: {line}")
+          if crimes:
+              print("### discrimination: DIVERGENT or incomplete\n")
+              for c in crimes:
+                  print(f"- `{c}`")
+                  print(f"::error::{c}", file=sys.stderr)
+              sys.exit(1)
+          print(
+              f"### discrimination: identical verdict sets within each of "
+              f"{count} shards (no shared aggregate)"
+          )
+          PY

--- a/tests/test_python_package_suite_shards.py
+++ b/tests/test_python_package_suite_shards.py
@@ -1,0 +1,253 @@
+"""Teeth for suite shards: deterministic split + enrollment without a shared hub."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SHARDS = ROOT / "tools" / "python_package_suite_shards.py"
+ATTENDANCE = ROOT / "tools" / "python_package_suite_shard_attendance.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "python-package-suite.yml"
+
+
+def _run(argv: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, *argv],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        **kwargs,
+    )
+
+
+def test_shard_assignment_is_deterministic_and_covers_every_file() -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("suite_shards", SHARDS)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+
+    files = mod.list_suite_test_files(ROOT)
+    assert len(files) >= 100, f"expected a real suite tree, got {len(files)} files"
+
+    count = 32
+    covered: list[str] = []
+    for i in range(count):
+        covered.extend(mod.files_for_shard(files, i, count))
+
+    assert sorted(covered) == sorted(files)
+    # Same file always same shard across two pure calls.
+    assert mod.files_for_shard(files, 0, count) == mod.files_for_shard(
+        files, 0, count
+    )
+    # Spot-check: a middle file's seat is index % count.
+    mid = files[len(files) // 2]
+    assert mod.shard_index_for(mid, files, count) == files.index(mid) % count
+
+
+def test_missing_shard_makes_attendance_red_not_a_smaller_pass() -> None:
+    """Lying face: N-1 identity-resolved reports ⇒ UNMEASURED, not green."""
+    import tempfile
+
+    from importlib import util
+
+    spec = util.spec_from_file_location(
+        "identity_gate", ROOT / "tools" / "python_suite_identity_gate.py"
+    )
+    # Build minimal identity-valid reports for seats 0..2, omit seat 3 of 4.
+    stamp = "blake3-512_" + ("ab" * 64)
+    extras = "cd" * 32
+    identity = {
+        "environmentIdentityHash": "ee" * 32,
+        "sourceStamp": {"value": stamp},
+        "dependencyAuthority": {
+            "testExtraInputHash": extras,
+            "declared": {"optional-dependencies": {"test": ["pytest"]}},
+        },
+    }
+
+    def report(shard: int, count: int = 4) -> dict:
+        return {
+            "schemaVersion": 1,
+            "label": f"python-package-suite-canonical-shard-{shard:02d}",
+            "order": "canonical",
+            "shardIndex": shard,
+            "shardCount": count,
+            "measuredCommit": "abc1234",
+            "sourceStamp": stamp,
+            "testExtraInputHash": extras,
+            "environmentIdentityHash": identity["environmentIdentityHash"],
+            "binarySourceStamp": stamp,
+            "environmentIdentity": identity,
+            "runnerIdentity": {"githubSha": "abc1234"},
+            "collectedNodeIds": [],
+            "executedOrderNodeIds": [],
+            "failedNodeIds": [],
+            "errorNodeIds": [],
+            "skippedNodeIds": [],
+            "xfailedNodeIds": [],
+            "xpassedNodeIds": [],
+            "passedNodeIds": [],
+            "collectionErrorNodeIds": [],
+            "notReportedNodeIds": [],
+            "counts": {
+                "collected": 0,
+                "passed": 0,
+                "failed": 0,
+                "error": 0,
+                "skipped": 0,
+                "xfailed": 0,
+                "xpassed": 0,
+                "collectionError": 0,
+                "notReported": 0,
+            },
+            "conservation": {
+                "collected": 0,
+                "verdicts": 0,
+                "executedOrder": 0,
+                "buckets": {
+                    "passed": 0,
+                    "failed": 0,
+                    "error": 0,
+                    "skipped": 0,
+                    "xfailed": 0,
+                    "xpassed": 0,
+                    "notReported": 0,
+                },
+                "collectionError": 0,
+            },
+        }
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for i in range(3):  # omit shard 3
+            d = root / f"python-package-suite-canonical-shard-{i}"
+            d.mkdir()
+            (d / "suite-report.json").write_text(
+                json.dumps(report(i)) + "\n", encoding="utf-8"
+            )
+        result = _run(
+            [
+                str(ATTENDANCE),
+                "--reports-dir",
+                str(root),
+                "--shard-count",
+                "4",
+                "--require-commit",
+                "abc1234",
+                "--order",
+                "canonical",
+            ]
+        )
+    assert result.returncode != 0, result.stdout
+    assert "R_suite_shard_attendance = 1" in result.stdout
+    assert "shard-03" in result.stdout
+    assert "UNMEASURED" in result.stdout
+
+
+def test_full_roster_attendance_is_green() -> None:
+    import tempfile
+
+    stamp = "blake3-512_" + ("ab" * 64)
+    extras = "cd" * 32
+    identity = {
+        "environmentIdentityHash": "ee" * 32,
+        "sourceStamp": {"value": stamp},
+        "dependencyAuthority": {
+            "testExtraInputHash": extras,
+            "declared": {"optional-dependencies": {"test": ["pytest"]}},
+        },
+    }
+
+    def report(shard: int, count: int = 2) -> dict:
+        return {
+            "schemaVersion": 1,
+            "label": f"python-package-suite-canonical-shard-{shard:02d}",
+            "order": "canonical",
+            "shardIndex": shard,
+            "shardCount": count,
+            "measuredCommit": "abc1234",
+            "sourceStamp": stamp,
+            "testExtraInputHash": extras,
+            "environmentIdentityHash": identity["environmentIdentityHash"],
+            "binarySourceStamp": stamp,
+            "environmentIdentity": identity,
+            "runnerIdentity": {"githubSha": "abc1234"},
+            "collectedNodeIds": [],
+            "executedOrderNodeIds": [],
+            "failedNodeIds": [],
+            "errorNodeIds": [],
+            "skippedNodeIds": [],
+            "xfailedNodeIds": [],
+            "xpassedNodeIds": [],
+            "passedNodeIds": [],
+            "collectionErrorNodeIds": [],
+            "notReportedNodeIds": [],
+            "counts": {
+                "collected": 0,
+                "passed": 0,
+                "failed": 0,
+                "error": 0,
+                "skipped": 0,
+                "xfailed": 0,
+                "xpassed": 0,
+                "collectionError": 0,
+                "notReported": 0,
+            },
+            "conservation": {
+                "collected": 0,
+                "verdicts": 0,
+                "executedOrder": 0,
+                "buckets": {
+                    "passed": 0,
+                    "failed": 0,
+                    "error": 0,
+                    "skipped": 0,
+                    "xfailed": 0,
+                    "xpassed": 0,
+                    "notReported": 0,
+                },
+                "collectionError": 0,
+            },
+        }
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for i in range(2):
+            d = root / f"python-package-suite-canonical-shard-{i}"
+            d.mkdir()
+            (d / "suite-report.json").write_text(
+                json.dumps(report(i)) + "\n", encoding="utf-8"
+            )
+        result = _run(
+            [
+                str(ATTENDANCE),
+                "--reports-dir",
+                str(root),
+                "--shard-count",
+                "2",
+                "--require-commit",
+                "abc1234",
+                "--order",
+                "canonical",
+            ]
+        )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "R_suite_shard_attendance = 0" in result.stdout
+
+
+def test_workflow_has_no_shared_suite_report_merge_and_uses_enrollment() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "python_package_suite_shard_attendance" in text
+    assert "suite-shard-index" in text or "shard-matrix" in text
+    # No merge tool / single shared aggregate path (word "merge" may appear
+    # in prose forbidding it — ban the tool and the singleton artifact name).
+    assert "python_package_suite_merge" not in text
+    assert "suite-report.json" in text  # per-shard path still that filename
+    assert "python-package-suite-canonical-shard-" in text
+    assert "python_package_suite_shard_attendance" in text

--- a/tools/python_package_suite_report.py
+++ b/tools/python_package_suite_report.py
@@ -116,6 +116,26 @@ def pytest_addoption(parser):
         metavar="LABEL",
         help="free-form label recorded in the report (e.g. the CI job name)",
     )
+    group.addoption(
+        "--suite-shard-index",
+        action="store",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "0-based shard index when the suite runs as parallel CI jobs. "
+            "Recorded in the report for enrollment roll call; each shard "
+            "writes its own identity-bound report (no shared aggregate)."
+        ),
+    )
+    group.addoption(
+        "--suite-shard-count",
+        action="store",
+        type=int,
+        default=None,
+        metavar="N",
+        help="enrolled shard count (roster size) for this campaign",
+    )
 
 
 class SuiteReporter:
@@ -202,6 +222,8 @@ class SuiteReporter:
             "label": self.config.getoption("--suite-label"),
             "order": self.config.getoption("--suite-order"),
             "shuffleSeed": self.shuffle_seed,
+            "shardIndex": self.config.getoption("--suite-shard-index"),
+            "shardCount": self.config.getoption("--suite-shard-count"),
             "pytestExitStatus": int(exitstatus),
             # THE REPORT ITSELF CARRIES ITS IDENTITY.
             #

--- a/tools/python_package_suite_shard_attendance.py
+++ b/tools/python_package_suite_shard_attendance.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Enrollment roll call for suite shards — completeness without a shared hub.
+
+THE LAW
+-------
+Each shard writes its own identity-bound suite-report.json. There is no merge
+into a singleton report (a shared identity hub). Completeness is enrollment:
+
+    roster = {shard-00, ..., shard-(N-1)}
+    attended = shards with a present, identity-resolved report for this commit
+    R_suite_shard_attendance = |roster \\ attended|
+
+A missing shard is UNMEASURED, not a smaller pass count. Silence is not a
+clean suite. Same shape as ``tools/heavy_measurement_attendance.py`` for heavy
+measurement classes: enrollment is existence.
+
+Usage:
+    python3 tools/python_package_suite_shard_attendance.py \\
+        --reports-dir runs/ \\
+        --shard-count 32 \\
+        --require-commit "$GITHUB_SHA" \\
+        --order canonical
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Local imports: tools/ is on PYTHONPATH in CI; load by path when not.
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
+from python_package_suite_shards import SHARD_COUNT, roster_ids  # noqa: E402
+from python_suite_identity_gate import gate  # noqa: E402
+
+
+class ShardAttendanceError(RuntimeError):
+    """Roll call failed: missing shards or unresolved identity."""
+
+
+def _load_report(path: Path) -> dict | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def find_shard_reports(reports_dir: Path, order: str) -> dict[int, tuple[Path, dict]]:
+    """Map shard_index -> (path, report) for reports under reports_dir.
+
+    Accepts either:
+      runs/python-package-suite-{order}-shard-07/suite-report.json
+      runs/**/suite-report.json with label/shardIndex fields
+    """
+    found: dict[int, tuple[Path, dict]] = {}
+    if not reports_dir.is_dir():
+        return found
+
+    for path in sorted(reports_dir.rglob("suite-report.json")):
+        report = _load_report(path)
+        if report is None:
+            continue
+        # Prefer explicit shardIndex when the reporter recorded it.
+        shard_index = report.get("shardIndex")
+        label = str(report.get("label") or "")
+        report_order = report.get("order") or "canonical"
+
+        if order and report_order != order and f"-{order}" not in label:
+            # Discrimination uploads use order in the artifact dirname/label.
+            parent = path.parent.name
+            if order not in parent and order not in label:
+                continue
+
+        if shard_index is None:
+            # Parse ...-shard-07 or shard-07 from path / label.
+            import re
+
+            match = re.search(r"shard-(\d+)", f"{path.parent.name} {label}")
+            if not match:
+                continue
+            shard_index = int(match.group(1))
+        else:
+            shard_index = int(shard_index)
+
+        # Keep the first path; prefer identity-richer later if needed.
+        if shard_index not in found:
+            found[shard_index] = (path, report)
+    return found
+
+
+def attendance(
+    *,
+    reports_dir: Path,
+    shard_count: int,
+    require_commit: str | None,
+    order: str,
+) -> tuple[list[str], list[str], list[str]]:
+    """Return (attended_ids, missing_ids, crimes).
+
+    crimes non-empty means at least one present shard failed the identity gate
+    or disagreed about commit/shard metadata — still not a clean suite.
+    """
+    roster = roster_ids(shard_count)
+    found = find_shard_reports(reports_dir, order)
+    attended: list[str] = []
+    missing: list[str] = []
+    crimes: list[str] = []
+
+    for i, shard_id in enumerate(roster):
+        if i not in found:
+            missing.append(shard_id)
+            continue
+        path, report = found[i]
+        # Identity gate per shard — each proves its own provenance.
+        gate_crimes = gate(report, require_commit)
+        if gate_crimes:
+            crimes.append(f"{shard_id} at {path}: identity UNRESOLVED")
+            for crime in gate_crimes:
+                crimes.append(f"  {crime}")
+            # Present but unresolved is not attendance.
+            missing.append(shard_id)
+            continue
+        # Shard self-description must match enrollment seat when present.
+        if report.get("shardIndex") is not None and int(report["shardIndex"]) != i:
+            crimes.append(
+                f"{shard_id}: report shardIndex {report.get('shardIndex')} "
+                f"!= enrolled seat {i}"
+            )
+            missing.append(shard_id)
+            continue
+        if (
+            report.get("shardCount") is not None
+            and int(report["shardCount"]) != shard_count
+        ):
+            crimes.append(
+                f"{shard_id}: report shardCount {report.get('shardCount')} "
+                f"!= roster size {shard_count}"
+            )
+            missing.append(shard_id)
+            continue
+        attended.append(shard_id)
+
+    return attended, missing, crimes
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--reports-dir",
+        required=True,
+        type=Path,
+        help="directory of downloaded per-shard artifacts",
+    )
+    parser.add_argument(
+        "--shard-count",
+        type=int,
+        default=SHARD_COUNT,
+        help=f"enrolled shard count (default {SHARD_COUNT})",
+    )
+    parser.add_argument(
+        "--require-commit",
+        default=None,
+        help="commit each shard report must bind",
+    )
+    parser.add_argument(
+        "--order",
+        default="canonical",
+        help="suite-order label filter (canonical / reversed / shuffled)",
+    )
+    parser.add_argument(
+        "--advisory",
+        action="store_true",
+        help="print minority without failing",
+    )
+    args = parser.parse_args(argv)
+
+    attended, missing, crimes = attendance(
+        reports_dir=args.reports_dir,
+        shard_count=args.shard_count,
+        require_commit=args.require_commit,
+        order=args.order,
+    )
+    roster = roster_ids(args.shard_count)
+
+    print(f"### suite shard attendance ({args.order}) — enrollment is existence")
+    print()
+    print(f"- roster size: `{len(roster)}`")
+    print(f"- attended (identity-resolved): `{len(attended)}`")
+    print(f"- missing / unresolved: `{len(missing)}`")
+    print()
+    print("| shard | spoke |")
+    print("| --- | --- |")
+    for shard_id in roster:
+        spoke = "yes" if shard_id in attended else "NO — UNMEASURED"
+        print(f"| `{shard_id}` | {spoke} |")
+    print()
+    print(f"**R_suite_shard_attendance = {len(missing)}**")
+    if missing:
+        print()
+        print(
+            "These shards did not report an identity-resolved suite-report. "
+            "Their silence is NOT a smaller suite — R is UNMEASURED:"
+        )
+        for shard_id in missing:
+            print(f"- `{shard_id}`")
+    if crimes:
+        print()
+        print("Identity / enrollment crimes on present artifacts:")
+        for crime in crimes:
+            print(f"- `{crime}`")
+            print(f"::error::{crime}", file=sys.stderr)
+
+    if missing or crimes:
+        return 0 if args.advisory else 1
+    print()
+    print(
+        f"All {len(roster)} shards attended; each is identity-resolved. "
+        "No shared aggregate was required."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/python_package_suite_shards.py
+++ b/tools/python_package_suite_shards.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Deterministic file shards for the authoritative Python package suite.
+
+WHY SHARDS, NOT ONE PROCESS
+---------------------------
+A single pytest over the whole package is one writer of one suite-report and
+one long hold of a shared resource. Parallel CI jobs each own one shard: each
+writes its own identity-bound report. Completeness is enrollment (all shards
+attended), not aggregation into a shared hub.
+
+SHARD LAW
+---------
+- Test *files* are the unit of assignment (not individual tests).
+- Assignment is pure: sort relative paths, then ``index % shard_count``.
+- The same file always lands in the same shard for a fixed ``shard_count``.
+- Empty shards are legal: they still attend with collected=0.
+
+CANONICAL ORDER (stated, not silent)
+------------------------------------
+``suite-order=canonical`` is the collection order **within one shard's file
+set**, not a single package-wide sequence. Discrimination arms reverse/shuffle
+within a shard only. Cross-shard interleaving order is not a measured claim
+under parallel jobs — there is no recombine step that would invent one.
+
+Usage:
+    python3 tools/python_package_suite_shards.py --list-files
+    python3 tools/python_package_suite_shards.py --shard-index 3 --print-paths
+    python3 tools/python_package_suite_shards.py --emit-matrix-json
+    python3 tools/python_package_suite_shards.py --print-roster
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# 32 shards: ~416 test files → ~13 files each. Under GitHub's 256-job matrix
+# cap (1/8 of the ceiling). On a 32-core box, one cold pytest per core is the
+# natural fan-out without drowning the runner scheduler in 64+ tiny jobs.
+SHARD_COUNT = 32
+
+# Relative to repo root. Collected pytest targets are files under this tree.
+TESTS_REL = Path("implementations/python/sugar-lift-py-tests/tests")
+
+# Paths that are never pytest targets (corpus / fixtures, not collected suite).
+_SKIP_DIR_PARTS = frozenset({"vendor", "fixtures", "__pycache__"})
+
+
+def repo_root_from(start: Path | None = None) -> Path:
+    here = (start or Path.cwd()).resolve()
+    for candidate in (here, *here.parents):
+        if (candidate / "sugar-build.toml").is_file():
+            return candidate
+    raise SystemExit(f"cannot find sugar-build.toml above {here}")
+
+
+def list_suite_test_files(repo_root: Path) -> list[str]:
+    """Sorted repo-relative POSIX paths of suite test modules."""
+    root = (repo_root / TESTS_REL).resolve()
+    if not root.is_dir():
+        raise SystemExit(f"suite tests tree missing: {root}")
+    files: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        rel = path.relative_to(repo_root).as_posix()
+        parts = set(path.relative_to(root).parts)
+        if parts & _SKIP_DIR_PARTS:
+            continue
+        name = path.name
+        if name == "conftest.py":
+            continue
+        # pytest collects test_*.py and *_test.py by default.
+        if not (name.startswith("test_") or name.endswith("_test.py")):
+            continue
+        files.append(rel)
+    return files
+
+
+def shard_index_for(path: str, files: list[str], shard_count: int) -> int:
+    try:
+        return files.index(path) % shard_count
+    except ValueError as exc:
+        raise SystemExit(f"path not in suite file roster: {path}") from exc
+
+
+def files_for_shard(
+    files: list[str], shard_index: int, shard_count: int
+) -> list[str]:
+    if shard_count < 1:
+        raise SystemExit("shard_count must be >= 1")
+    if not (0 <= shard_index < shard_count):
+        raise SystemExit(
+            f"shard_index {shard_index} out of range for shard_count {shard_count}"
+        )
+    return [path for i, path in enumerate(files) if i % shard_count == shard_index]
+
+
+def roster_ids(shard_count: int) -> list[str]:
+    return [f"shard-{i:02d}" for i in range(shard_count)]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="checkout root (default: walk up to sugar-build.toml)",
+    )
+    parser.add_argument(
+        "--shard-count",
+        type=int,
+        default=SHARD_COUNT,
+        help=f"number of shards (default {SHARD_COUNT})",
+    )
+    parser.add_argument(
+        "--shard-index",
+        type=int,
+        default=None,
+        help="0-based shard index for --print-paths",
+    )
+    parser.add_argument(
+        "--list-files",
+        action="store_true",
+        help="print every suite test file (sorted)",
+    )
+    parser.add_argument(
+        "--print-paths",
+        action="store_true",
+        help="print paths for --shard-index (pytest args); requires --shard-index",
+    )
+    parser.add_argument(
+        "--print-roster",
+        action="store_true",
+        help="print expected shard ids (enrollment roster)",
+    )
+    parser.add_argument(
+        "--emit-matrix-json",
+        action="store_true",
+        help='print GitHub Actions matrix JSON: {"shard":[0,1,...]}',
+    )
+    parser.add_argument(
+        "--emit-shard-list-json",
+        action="store_true",
+        help="print JSON array of shard indices for nested matrix.order × shard",
+    )
+    parser.add_argument(
+        "--mint-empty-report",
+        action="store",
+        default=None,
+        metavar="PATH",
+        help="write an identity-bound empty shard report to PATH (enrollment seat)",
+    )
+    parser.add_argument(
+        "--suite-identity",
+        default=None,
+        help="environment-identity.json for --mint-empty-report",
+    )
+    parser.add_argument(
+        "--suite-commit",
+        default=None,
+        help="measured commit for --mint-empty-report",
+    )
+    parser.add_argument(
+        "--suite-binary-stamp",
+        default=None,
+        help="binary sourceStamp for --mint-empty-report",
+    )
+    parser.add_argument(
+        "--suite-order",
+        default="canonical",
+        help="order field for --mint-empty-report",
+    )
+    parser.add_argument(
+        "--emit-paths-for-cwd",
+        action="store_true",
+        help=(
+            "like --print-paths but paths relative to implementations/python "
+            "(workflow working-directory)"
+        ),
+    )
+    args = parser.parse_args(argv)
+    root = repo_root_from(args.repo_root)
+    files = list_suite_test_files(root)
+
+    if args.list_files:
+        for path in files:
+            print(path)
+        return 0
+
+    if args.print_roster:
+        for shard_id in roster_ids(args.shard_count):
+            print(shard_id)
+        return 0
+
+    if args.emit_matrix_json:
+        matrix = {"shard": list(range(args.shard_count))}
+        print(json.dumps(matrix, separators=(",", ":")))
+        return 0
+
+    if args.emit_shard_list_json:
+        print(json.dumps(list(range(args.shard_count)), separators=(",", ":")))
+        return 0
+
+    if args.mint_empty_report is not None:
+        if args.shard_index is None:
+            parser.error("--mint-empty-report requires --shard-index")
+        if not args.suite_identity or not args.suite_commit or not args.suite_binary_stamp:
+            parser.error(
+                "--mint-empty-report requires --suite-identity, --suite-commit, "
+                "--suite-binary-stamp"
+            )
+        identity = json.loads(
+            Path(args.suite_identity).read_text(encoding="utf-8")
+        )
+        stamp = (identity.get("sourceStamp") or {}).get("value")
+        extras = (identity.get("dependencyAuthority") or {}).get(
+            "testExtraInputHash"
+        )
+        shard = args.shard_index
+        count = args.shard_count
+        report = {
+            "schemaVersion": 1,
+            "label": (
+                f"python-package-suite-{args.suite_order}-shard-{shard:02d}"
+            ),
+            "order": args.suite_order,
+            "shuffleSeed": None,
+            "shardIndex": shard,
+            "shardCount": count,
+            "pytestExitStatus": 5,
+            "measuredCommit": args.suite_commit,
+            "sourceStamp": stamp,
+            "testExtraInputHash": extras,
+            "environmentIdentityHash": identity.get("environmentIdentityHash"),
+            "binarySourceStamp": args.suite_binary_stamp,
+            "environmentIdentity": identity,
+            "runnerIdentity": {"githubSha": args.suite_commit},
+            "resourceTelemetry": {},
+            "timing": {"wallSeconds": 0},
+            "collectedNodeIds": [],
+            "executedOrderNodeIds": [],
+            "failedNodeIds": [],
+            "errorNodeIds": [],
+            "skippedNodeIds": [],
+            "xfailedNodeIds": [],
+            "xpassedNodeIds": [],
+            "passedNodeIds": [],
+            "collectionErrorNodeIds": [],
+            "notReportedNodeIds": [],
+            "counts": {
+                "collected": 0,
+                "passed": 0,
+                "failed": 0,
+                "error": 0,
+                "skipped": 0,
+                "xfailed": 0,
+                "xpassed": 0,
+                "collectionError": 0,
+                "notReported": 0,
+            },
+            "conservation": {
+                "collected": 0,
+                "verdicts": 0,
+                "executedOrder": 0,
+                "buckets": {
+                    "passed": 0,
+                    "failed": 0,
+                    "error": 0,
+                    "skipped": 0,
+                    "xfailed": 0,
+                    "xpassed": 0,
+                    "notReported": 0,
+                },
+                "collectionError": 0,
+            },
+        }
+        out = Path(args.mint_empty_report)
+        out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        print(f"minted empty-shard report at {out}", file=sys.stderr)
+        return 0
+
+    if args.print_paths or args.emit_paths_for_cwd:
+        if args.shard_index is None:
+            parser.error("--print-paths requires --shard-index")
+        chosen = files_for_shard(files, args.shard_index, args.shard_count)
+        prefix = "implementations/python/"
+        for path in chosen:
+            if args.emit_paths_for_cwd:
+                if not path.startswith(prefix):
+                    raise SystemExit(f"path not under implementations/python: {path}")
+                print(path[len(prefix) :])
+            else:
+                print(path)
+        return 0
+
+    parser.error(
+        "pass one of --list-files / --print-paths / --print-roster / "
+        "--emit-matrix-json / --emit-shard-list-json / --mint-empty-report"
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Revives the **sharding half** of #7003 on current main (lease already gone via #7008). The authoritative suite still ran ~3864 tests as **one** pytest process — measured tonight at 92% of one core while 31 idled.

T: *32 cores and 25 runners, and serializing anything in CI is pure insanity.*

### Design (settled)

| | |
|--|--|
| **Shards** | **32** deterministic file shards (`index % 32` after sorted paths) |
| **Reports** | Each job writes its **own** identity-bound `suite-report.json` (`shardIndex` / `shardCount`) |
| **Completeness** | Enrollment roll call — missing shard = **UNMEASURED**, not a smaller pass |
| **Identity** | Gate runs **per shard** |
| **Aggregate** | **None** — no merge hub, no singleton writer |
| **Order** | Canonical = within-shard collection order; discrimination within-shard only |

### Why 32
~418 suite test files → ~13/shard. Under GitHub's 256-job matrix cap. Matches a 32-core fan-out.

### Honest finding (unchanged)
Nothing requires a merged suite-report. Cross-shard interleaving order is not a measured claim under parallel jobs.

### Teeth
`tests/test_python_package_suite_shards.py` — 4 passed (deterministic cover, missing-shard red, full roster green, workflow enrollment).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Shard the Python package suite into 32 parallel identity-bound report jobs
> - Converts the single Python suite job into a matrix of 32 shards using modulo-based deterministic file assignment in [`tools/python_package_suite_shards.py`](https://github.com/TSavo/sugar/pull/7012/files#diff-9f48da58cabb30fcad1c04d290501b130d9268868644bca5c1fc5774b1aa7c90); each shard runs pytest on its subset and uploads its own identity-bound `suite-report.json`.
> - Adds a new `python-package-suite-attendance` job in [`python-package-suite.yml`](https://github.com/TSavo/sugar/pull/7012/files#diff-3468e5d2db054964c8506506d8c39f46df881f7f103f96b2972c2686cc1cc3a0) that downloads all shard artifacts and fails the workflow if any shard is missing or identity-unresolved.
> - Extends the suite reporter in [`tools/python_package_suite_report.py`](https://github.com/TSavo/sugar/pull/7012/files#diff-3411b9f5ad80bc5885a1bb8107067510f62372210ed5e8dac63f162e2dbe4af4) with `--suite-shard-index` and `--suite-shard-count` flags, recording shard metadata in each report.
> - Adds [`tools/python_package_suite_shard_attendance.py`](https://github.com/TSavo/sugar/pull/7012/files#diff-57d226269abac43d9ad0eacbcba8b26841b28e66f830f818e07b1d965a915553) for roll call logic and adds tests in [`tests/test_python_package_suite_shards.py`](https://github.com/TSavo/sugar/pull/7012/files#diff-135118e0e15994ea97f714207423203e19ef0642a46a0fd5566ec55f3a242670) covering shard determinism, missing-shard failure, and workflow config consistency.
> - Discrimination (reversed/shuffled order) runs per-shard and compares verdicts within each shard rather than merging into a shared report.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d02d0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->