### PR TITLE
Parallel sole-construction floors: one job per process axis

### DIFF
--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -8,44 +8,137 @@ on:
 permissions:
   contents: read
 
-# NO `concurrency:` BLOCK. GitHub retains every run. There is no machine-wide
-# heavy-measurement lease — jobs run in parallel.
+# NO concurrency group. NO machine-wide lease (#7008).
+# Process axes run as a matrix of jobs — wall clock is max(axis), not sum.
+# Completeness is enrollment roll call, not a merged residual hub.
 
 jobs:
-  python-sole-construction-floors:
-    name: python-sole-construction-floors
+  process-floor:
+    name: process-floor ${{ matrix.axis }}
     runs-on: [self-hosted, Linux, X64]
+    # silent is the long pole (~11min today); others ~30s once cache warm.
     timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - axis: silent
+            script: silent_zero_tolerance.py
+            display: R_silent
+          - axis: native-crash
+            script: native_crash_zero_tolerance.py
+            display: R_native_crashes
+          - axis: bare-exception
+            script: bare_exception_zero_tolerance.py
+            display: R_bare_exceptions
+          - axis: timeout
+            script: timeout_zero_tolerance.py
+            display: R_timeouts
     steps:
       - uses: actions/checkout@v4
       - name: Prepare immutable Python test environment
         uses: ./.github/actions/python-test-environment
-      - name: The complete floor set
-        id: floors
+      - name: Run process floor ${{ matrix.axis }}
+        id: floor
+        shell: bash
+        env:
+          # Tip pins the CA terminal key. Cache dir defaults to host-durable
+          # $HOME/.cache/sugar/process-floor-terminals (see run_one_process_floor_axis.sh)
+          # so matrix jobs share hits — workspace .cache is job-private.
+          SUGAR_MEASUREMENT_TIP: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+          chmod +x tools/run_one_process_floor_axis.sh
+          set +e
+          bash tools/run_one_process_floor_axis.sh "${{ matrix.axis }}" "${{ matrix.script }}"
+          code=$?
+          set -e
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          # Always keep the identity report for enrollment even when residual red.
+          test -f floor-axis-report.json
+          exit "$code"
+      - name: Upload axis report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: floor-axis-${{ matrix.axis }}
+          path: floor-axis-report.json
+          if-no-files-found: error
+
+  static-floors:
+    name: static-floors
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare immutable Python test environment
+        uses: ./.github/actions/python-test-environment
+      - name: Static AST / discrimination floors (parallel to process matrix)
+        id: static
         shell: bash
         run: |
           set -uo pipefail
+          chmod +x tools/run_static_sole_construction_floors.sh
           set +e
-          bash tools/run_sole_construction_floors.sh
-          floor_exit=$?
+          bash tools/run_static_sole_construction_floors.sh
+          code=$?
           set -e
-          echo "floor_exit=$floor_exit" >> "$GITHUB_OUTPUT"
-          python3 -c "
-          import json, os
-          from pathlib import Path
-          body = {
-              'schemaVersion': 1,
-              'measurementClass': 'python-sole-construction-floors',
-              'measuredCommit': os.environ.get('GITHUB_SHA'),
-              'status': 'completed',
-              'exitCode': $floor_exit,
-              'totals': {'failed': 0 if $floor_exit == 0 else 1},
-          }
-          Path('floor-measurement.json').write_text(json.dumps(body, indent=2) + '\n')
-          "
-          exit "$floor_exit"
+          python3 tools/sole_construction_floor_enrollment.py \
+            --mint-report floor-axis-report.json \
+            --axis-id static-laws \
+            --display R_static_sole_construction \
+            --kind static \
+            --commit-sha "${GITHUB_SHA}" \
+            --exit-code "$code"
+          exit "$code"
+      - name: Upload static axis report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: floor-axis-static-laws
+          path: floor-axis-report.json
+          if-no-files-found: error
 
-      - name: Upload floor measurement body
+  floor-enrollment:
+    name: floor-enrollment
+    needs: [process-floor, static-floors]
+    if: always()
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all axis reports
+        uses: actions/download-artifact@v4
+        with:
+          path: floor-axis-artifacts
+          pattern: floor-axis-*
+          merge-multiple: false
+      - name: Enrollment roll call (missing axis = UNMEASURED)
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/sole_construction_floor_enrollment.py \
+            --check-attendance floor-axis-artifacts \
+            --require-commit "${GITHUB_SHA}" \
+            --write-campaign-body floor-measurement.json \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          # Fail attendance if incomplete (tool exit already).
+          # Also fail if any residual-red axis attended: residual red is campaign red.
+          python3 - <<'PY'
+          import json, sys
+          from pathlib import Path
+          body = json.loads(Path("floor-measurement.json").read_text())
+          enr = body.get("enrollment") or {}
+          if enr.get("status") != "complete":
+              print("UNMEASURED: enrollment incomplete", enr, file=sys.stderr)
+              sys.exit(1)
+          residual = enr.get("residualRed") or []
+          if residual:
+              print(f"RESIDUAL RED axes: {residual}", file=sys.stderr)
+              sys.exit(1)
+          print("enrollment complete; all axes residual-green")
+          PY
+      - name: Upload campaign measurement body
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/implementations/python/sugar-lift-py-tests/scripts/process_floor_measurement_cache.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/process_floor_measurement_cache.py
@@ -84,8 +84,14 @@ def resolve_measurement_tip() -> str:
 def resolve_cache_root() -> Path | None:
     """Durable store root, or None to disable the cache.
 
-    Prefer explicit ``SUGAR_PROCESS_FLOOR_CACHE_DIR``. In GitHub Actions default
-    to a workspace-local dir so the three process floors in one job share hits.
+    Prefer explicit ``SUGAR_PROCESS_FLOOR_CACHE_DIR``.
+
+    Default is **host-durable** ``$HOME/.cache/sugar/process-floor-terminals`` so
+    parallel CI matrix jobs (separate workspaces) still share hits. A
+    workspace-local path is job-private on GitHub Actions and would force every
+    process-floor axis to cold-lift — slower under parallelization.
+
+    Disable: ``SUGAR_PROCESS_FLOOR_CACHE_DIR=off``.
     """
     explicit = os.environ.get("SUGAR_PROCESS_FLOOR_CACHE_DIR")
     if explicit is not None:
@@ -93,6 +99,15 @@ def resolve_cache_root() -> Path | None:
         if text in {"", "0", "off", "none", "disabled"}:
             return None
         return Path(text).expanduser().resolve()
+    home = os.environ.get("HOME")
+    if home:
+        return (
+            Path(home).expanduser().resolve()
+            / ".cache"
+            / "sugar"
+            / "process-floor-terminals"
+        )
+    # Last resort: workspace (job-local; poor for multi-job fan-out).
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if workspace:
         return Path(workspace).resolve() / ".cache" / "process-floor-terminals"

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -112,18 +112,28 @@ def test_standalone_floor_workflows_stay_discrimination_only():
 
 
 def test_orchestrator_still_runs_the_corpus_floors():
+    """Process axes are matrix jobs; static laws a sibling job; enrollment roll call."""
     text = _text("factory-zero-tolerance.yml")
-    assert "tools/run_sole_construction_floors.sh" in text
+    assert "run_one_process_floor_axis.sh" in text
+    assert "run_static_sole_construction_floors.sh" in text
+    assert "sole_construction_floor_enrollment.py" in text
+    assert "matrix:" in text
+    # Local serial convenience still lists the corpus instruments.
     floors = (ROOT / "tools" / "run_sole_construction_floors.sh").read_text()
+    static = (ROOT / "tools" / "run_static_sole_construction_floors.sh").read_text()
     for script in (
         "native_crash_zero_tolerance.py",
         "bare_exception_zero_tolerance.py",
         "timeout_zero_tolerance.py",
         "silent_zero_tolerance.py",
+    ):
+        assert script in floors, script
+        assert script in text, script
+    for script in (
         "factory_ownership_law.py",
         "construction_side_door_law.py",
     ):
-        assert script in floors, script
+        assert script in static, script
 
 
 def test_roster_cadence_matches_each_workflow_trigger():
@@ -168,3 +178,14 @@ def test_attendance_keys_off_measurement_body_not_lease(tmp_path):
     path.write_text(__import__("json").dumps(body), encoding="utf-8")
     attended, _ = module.receipts_attendance(tmp_path)
     assert "python-sole-construction-floors" in attended
+
+
+def test_floor_workflow_is_parallel_matrix_with_enrollment():
+    """Process axes must not serialize inside one job after lease deletion."""
+    text = _text("factory-zero-tolerance.yml")
+    assert "matrix:" in text
+    assert "floor-enrollment" in text or "floor-enrollment:" in text
+    assert "run_one_process_floor_axis.sh" in text
+    assert "run_static_sole_construction_floors.sh" in text
+    assert "run_sole_construction_floors.sh" not in text
+    assert LEASE_WRAPPER not in text

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -1,136 +1,144 @@
-"""The binding Python construction job must invoke every permanent R axis.
+"""Binding sole-construction floors: parallel jobs + enrollment, not serial sum.
 
-The axes moved out of the workflow YAML and into tools/run_sole_construction_
-floors.sh, because the whole floor set now runs inside ONE machine-wide heavy
-lease. Twenty leased steps would have let a pandas census interleave between
-two axes, and then "the complete floor set from one pinned run" would have been
-a fiction.
-
-What must not change is the property this file has always pinned: every
-permanent axis is invoked, none is silently dropped, and no axis is skipped
-because an earlier one was honestly red. The `if: always()` guarantee is now
-carried by the script's `axis` helper, which runs EVERY axis, collects the red
-ones, and fails at the end -- so the check below is that each axis goes through
-that helper, rather than that each has its own YAML step.
+CI runs each process axis as its own job (factory-zero-tolerance.yml matrix) and
+static laws as a sibling job. Completeness is enrollment roll call
+(tools/sole_construction_floor_enrollment.py). A missing axis is UNMEASURED.
 """
 
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "factory-zero-tolerance.yml"
+ENROLL = ROOT / "tools" / "sole_construction_floor_enrollment.py"
+STATIC = ROOT / "tools" / "run_static_sole_construction_floors.sh"
+PROCESS_ONE = ROOT / "tools" / "run_one_process_floor_axis.sh"
 FLOOR_SET = ROOT / "tools" / "run_sole_construction_floors.sh"
 
-# Permanent axes with live instruments. factory_zero_tolerance and
-# construction_cache_context_law retired with the factory era (#6028).
-AXIS_COMMANDS = {
+PROCESS_SCRIPTS = {
+    "silent": "silent_zero_tolerance.py",
+    "native-crash": "native_crash_zero_tolerance.py",
+    "bare-exception": "bare_exception_zero_tolerance.py",
+    "timeout": "timeout_zero_tolerance.py",
+}
+
+STATIC_SCRIPTS = {
     "R_ownership = 0": "factory_ownership_law.py",
     "R_construction_panic_catches_outside_membrane = 0": (
         "construction_panic_catch_law.py"
     ),
-    # Criterion-2 process floors: axis names carry no "= 0" (pre-measure crash
-    # must not paint a bankable zero in the group header).
-    "R_silent": "silent_zero_tolerance.py",
-    "R_native_crashes": "native_crash_zero_tolerance.py",
-    "R_bare_exceptions": "bare_exception_zero_tolerance.py",
-    "R_timeouts": "timeout_zero_tolerance.py",
     "R_vendor_special_case = 0": "vendor_special_case_law.py",
     "R_factory_walk_unclassified = 0": "factory_walk_unclassified_law.py",
-    "R_finite_cap_opaque_completions = 0": ("finite_cap_opaque_completion_law.py"),
-    "R_finite_unfold_compact_gaps = 0": ("finite_unfold_compact_projection_law.py"),
+    "R_finite_cap_opaque_completions = 0": "finite_cap_opaque_completion_law.py",
+    "R_finite_unfold_compact_gaps = 0": "finite_unfold_compact_projection_law.py",
     "R_source_via_execution = 0": "source_via_execution_law.py",
     "R_no_sugar_in_desugar = 0": "no_sugar_in_desugar_law.py",
-    # Whole-kit construction currency (adapters only may name stdlib ast).
-    # Live R includes dual-body sugar-lift-python-source residual — exit 1 until 0.
     "R_construction_side_doors = 0": "construction_side_door_law.py",
 }
 
 
-def test_binding_job_invokes_every_permanent_axis() -> None:
+def _enroll_mod():
+    spec = importlib.util.spec_from_file_location(
+        "sole_construction_floor_enrollment", ENROLL
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_workflow_is_parallel_matrix_not_serial_monolith() -> None:
     workflow = WORKFLOW.read_text()
-    floors = FLOOR_SET.read_text()
-
-    assert "python-sole-construction-floors:" in workflow
-    assert "tools/run_sole_construction_floors.sh" in workflow, (
-        "the binding job no longer runs the floor set at all"
-    )
-    # And it runs it via run_sole_construction_floors.sh -- an unleased floor set is a floor set
-    # measured beside whatever else the box happened to be doing.
-    assert "tools/run_sole_construction_floors.sh" in workflow
     assert "tools/heavy_measurement_lease.py" not in workflow
+    assert "process-floor:" in workflow or "process-floor " in workflow
+    assert "strategy:" in workflow and "matrix:" in workflow
+    assert "static-floors:" in workflow
+    assert "floor-enrollment:" in workflow
+    # Expensive process scripts appear in matrix includes, not one serial shell.
+    for script in PROCESS_SCRIPTS.values():
+        assert script in workflow
+    assert "run_one_process_floor_axis.sh" in workflow
+    assert "run_static_sole_construction_floors.sh" in workflow
+    assert "sole_construction_floor_enrollment.py" in workflow
+    # Must not re-serialize all process axes via the local monolith in CI.
+    assert "run_sole_construction_floors.sh" not in workflow
 
-    for axis, command in AXIS_COMMANDS.items():
-        axis_start = floors.find(f'axis "{axis}"')
+
+def test_static_job_binds_every_static_axis() -> None:
+    static = STATIC.read_text()
+    for axis, command in STATIC_SCRIPTS.items():
+        assert f'axis "{axis}"' in static or f"axis '{axis}'" in static
+        axis_start = static.find(f'axis "{axis}"')
         if axis_start < 0:
-            axis_start = floors.find(f"axis '{axis}'")
-        assert axis_start >= 0, f"{axis} is not bound to merge CI"
-        axis_end = floors.find("\naxis ", axis_start + 1)
-        step = floors[axis_start : axis_end if axis_end >= 0 else None]
-        assert command in step, f"{axis} does not invoke {command}"
+            axis_start = static.find(f"axis '{axis}'")
+        axis_end = static.find("\naxis ", axis_start + 1)
+        step = static[axis_start : axis_end if axis_end >= 0 else None]
+        assert command in step
         if axis == "R_factory_walk_unclassified = 0":
-            assert "--live-root" in step, (
-                "R_factory_walk_unclassified only runs a fixture/discrimination; "
-                "binding CI must census the checked-in production surface"
-            )
-        if axis in {
-            "R_native_crashes",
-            "R_bare_exceptions",
-            "R_timeouts",
-            "R_silent",
-        }:
-            # Process floors + Criterion-2 silent must name a population.
-            # Bare silent_zero_tolerance used to default to kit production_roots
-            # (~444 files) — false green while authenticated pandas was unmeasured.
-            assert "PANDAS_CORPUS" in step or "authenticated_pandas" in step, (
-                f"{axis} must pass an explicit corpus path; silent default "
-                "to kit production_roots is a wrong-population false green"
-            )
-            # Not only the script name: a path argument must follow.
-            assert '"$PANDAS_CORPUS"' in step or "'$PANDAS_CORPUS'" in step, (
-                f"{axis} must pass \"$PANDAS_CORPUS\" as the scan root"
-            )
-            # Scratch must not default under the population root.
-            assert "--out-dir" in step or "FLOOR_SCRATCH" in step, (
-                f"{axis} must direct floor scratch outside the population "
-                "(S0.2: mkdir under site-packages/pandas is measurement crime)"
-            )
-            # Group header must not embed a bankable zero.
-            assert " = 0" not in step.split("\n", 1)[0], (
-                f"{axis} group name must not embed '= 0' (pre-measure crash bank)"
-            )
+            assert "--live-root" in step
 
 
-def test_process_floors_resolve_authenticated_pandas_population() -> None:
-    """The floor set must authenticate pandas before the four corpus axes."""
+def test_process_one_axis_binds_corpus_and_host_cache() -> None:
+    text = PROCESS_ONE.read_text()
+    assert "authenticated_pandas_corpus" in text
+    assert '"$PANDAS_CORPUS"' in text or "'$PANDAS_CORPUS'" in text
+    assert "--out-dir" in text
+    # Host-durable cache — not workspace-only (job-private under parallel jobs).
+    assert "HOME" in text and "process-floor-terminals" in text
+
+
+def test_enrollment_missing_axis_is_unmeasured(tmp_path: Path) -> None:
+    mod = _enroll_mod()
+    # Only one of five enrolled axes present.
+    report = mod.mint_axis_report(
+        axis_id="silent",
+        display="R_silent",
+        commit_sha="deadbeef",
+        exit_code=0,
+        kind="process",
+    )
+    path = tmp_path / "floor-axis-silent" / mod.REPORT_FILENAME
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(report), encoding="utf-8")
+    code, summary = mod.check_attendance(tmp_path, require_commit="deadbeef")
+    assert code == 1
+    assert summary["status"] == "UNMEASURED"
+    assert "native-crash" in summary["missing"]
+    assert "silent" in summary["attended"]
+
+
+def test_enrollment_complete_with_all_axes(tmp_path: Path) -> None:
+    mod = _enroll_mod()
+    for axis in mod.ENROLLED:
+        report = mod.mint_axis_report(
+            axis_id=axis.axis_id,
+            display=axis.display,
+            commit_sha="abc123",
+            exit_code=0 if axis.axis_id != "timeout" else 1,
+            kind=axis.kind,
+        )
+        path = tmp_path / f"floor-axis-{axis.axis_id}" / mod.REPORT_FILENAME
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps(report), encoding="utf-8")
+    code, summary = mod.check_attendance(tmp_path, require_commit="abc123")
+    assert code == 0
+    assert summary["status"] == "complete"
+    assert summary["residualRed"] == ["timeout"]
+
+
+def test_local_monolith_still_lists_process_axes_for_workstation() -> None:
+    """Local serial script remains; CI must not depend on it."""
     floors = FLOOR_SET.read_text()
-    assert "authenticated_pandas_corpus" in floors, (
-        "process floors must resolve the authenticated pandas corpus root"
-    )
-    assert "PANDAS_CORPUS=" in floors
-    # Order: corpus resolved once, then all four Criterion-2 population axes use it.
-    corpus_at = floors.find("PANDAS_CORPUS=")
-    native_at = floors.find('axis "R_native_crashes"')
-    bare_at = floors.find('axis "R_bare_exceptions"')
-    timeout_at = floors.find('axis "R_timeouts"')
-    silent_at = floors.find('axis "R_silent"')
-    assert 0 <= corpus_at < native_at < bare_at < timeout_at < silent_at, (
-        "PANDAS_CORPUS must be bound before native/bare/timeout/silent axes"
-    )
-
-
-def test_no_axis_is_skipped_after_an_earlier_honest_red() -> None:
-    """What `if: always()` used to buy, now bought by the runner itself.
-
-    Every axis runs, reds are COLLECTED rather than short-circuited, and the
-    verdict comes at the end. A floor set that stopped at the first red would
-    report a smaller R than the truth.
-    """
-    floors = FLOOR_SET.read_text()
-    assert "set -uo pipefail" in floors and "set -e\n" not in floors, (
-        "the floor set must not abort on the first red axis"
-    )
-    assert "red_axes+=" in floors and "exit 1" in floors, (
-        "red axes must be collected and reported, then fail the job"
-    )
-    # Every axis in the ledger goes through the one helper. No side doors.
-    for axis in AXIS_COMMANDS:
-        assert f'axis "{axis}"' in floors or f"axis '{axis}'" in floors
+    for name in (
+        'axis "R_silent"',
+        'axis "R_native_crashes"',
+        'axis "R_bare_exceptions"',
+        'axis "R_timeouts"',
+    ):
+        assert name in floors
+    assert "authenticated_pandas_corpus" in floors

--- a/tools/run_one_process_floor_axis.sh
+++ b/tools/run_one_process_floor_axis.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Run exactly one Criterion-2 process floor axis; emit identity-bound report.
+#
+# Usage: tools/run_one_process_floor_axis.sh <axis_id> <script_name>
+#   axis_id: silent | native-crash | bare-exception | timeout
+#   script:  silent_zero_tolerance.py | …
+#
+# Host-durable terminal cache (cross-job): default HOME/.cache/sugar/…
+# Workspace-local cache is job-private and would cold-lift every matrix axis.
+
+set -uo pipefail
+
+axis_id="${1:?axis_id}"
+script_name="${2:?script}"
+
+TESTS=implementations/python/sugar-lift-py-tests
+SCRIPTS="$TESTS/scripts"
+SCRIPT="$SCRIPTS/$script_name"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "::error::process floor script missing: $SCRIPT"
+  exit 2
+fi
+
+PANDAS_CORPUS="$(
+  python -c 'from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus; print(authenticated_pandas_corpus().root)'
+)" || {
+  echo "::error::cannot authenticate pandas corpus for process floor $axis_id"
+  exit 1
+}
+
+FLOOR_SCRATCH="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}/.sugar/ci-floors/${axis_id}"
+export SUGAR_FLOOR_WORKSPACE="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}"
+
+# Cross-job shelf: HOME survives separate matrix jobs on self-hosted runners.
+# Workspace paths do not. Override with SUGAR_PROCESS_FLOOR_CACHE_DIR=off to disable.
+if [ -z "${SUGAR_PROCESS_FLOOR_CACHE_DIR+x}" ]; then
+  export SUGAR_PROCESS_FLOOR_CACHE_DIR="${HOME}/.cache/sugar/process-floor-terminals"
+fi
+if [ -z "${SUGAR_MEASUREMENT_TIP:-}" ] && [ -n "${GITHUB_SHA:-}" ]; then
+  export SUGAR_MEASUREMENT_TIP="${GITHUB_SHA}"
+fi
+
+echo "process-floor axis=$axis_id population=$PANDAS_CORPUS"
+echo "process-floor cache: dir=${SUGAR_PROCESS_FLOOR_CACHE_DIR} tip=${SUGAR_MEASUREMENT_TIP:-unpinned}"
+
+set +e
+python "$SCRIPT" "$PANDAS_CORPUS" \
+  --repo-root "$PANDAS_CORPUS" \
+  --out-dir "$FLOOR_SCRATCH"
+exit_code=$?
+set -e
+
+commit="${GITHUB_SHA:-unpinned}"
+case "$axis_id" in
+  silent) display=R_silent ;;
+  native-crash) display=R_native_crashes ;;
+  bare-exception) display=R_bare_exceptions ;;
+  timeout) display=R_timeouts ;;
+  *) display="R_${axis_id}" ;;
+esac
+
+python3 tools/sole_construction_floor_enrollment.py \
+  --mint-report floor-axis-report.json \
+  --axis-id "$axis_id" \
+  --display "$display" \
+  --kind process \
+  --commit-sha "$commit" \
+  --exit-code "$exit_code"
+
+exit "$exit_code"

--- a/tools/run_sole_construction_floors.sh
+++ b/tools/run_sole_construction_floors.sh
@@ -1,19 +1,12 @@
 #!/usr/bin/env bash
-# The complete Python sole-construction floor set, as ONE measured section.
+# LOCAL / serial convenience: run the full sole-construction floor set in-process.
 #
-# WHY THIS IS A SCRIPT AND NOT TWENTY WORKFLOW STEPS
+# CI is parallel: .github/workflows/factory-zero-tolerance.yml runs each process
+# axis as its own job + a static-laws job, with enrollment roll call. Prefer
+# that on push. This script remains for workstation re-runs and binding checks.
 #
-# It used to be twenty steps, each `if: always()`, so that one red axis never
-# hid the others: the complete floor set always comes from one pinned run.
-# Putting those twenty steps behind the machine-wide heavy lease one at a time
-# would have taken and released the lease twenty times, letting a pandas census
-# interleave between axes -- and then the "one pinned run" property would be a
-# fiction. One lease, one pass over every axis, one verdict.
-#
-# `if: always()` semantics are preserved here, not abandoned: EVERY axis runs,
-# failures are collected rather than short-circuited, and the script exits
-# non-zero at the end if any axis was red. R > 0 ⇒ CI red, on every axis, and
-# silence on an axis is never mistaken for zero.
+# `if: always()` semantics: EVERY axis runs, failures collected, exit non-zero
+# if any axis was red. R > 0 ⇒ red on every residual axis.
 #
 # Usage: tools/run_sole_construction_floors.sh   (from the repo root)
 
@@ -67,12 +60,12 @@ echo "process-floor population: authenticated pandas corpus at $PANDAS_CORPUS"
 FLOOR_SCRATCH="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}/.sugar/ci-floors"
 export SUGAR_FLOOR_WORKSPACE="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}"
 echo "process-floor scratch: $FLOOR_SCRATCH (never under population)"
-# Content-addressed process-floor terminal shelf:
+# Content-addressed process-floor terminal shelf (#7009):
 # tip × corpusManifestCid × axis × fileContentCid × demandTableCid × fileTimeoutMs
-# → terminal row. Three process floors share one body; 2nd/3rd axes hit.
+# Host-durable default so serial local runs and parallel CI jobs share hits.
 # Disable: SUGAR_PROCESS_FLOOR_CACHE_DIR=off
 if [ -z "${SUGAR_PROCESS_FLOOR_CACHE_DIR+x}" ]; then
-  export SUGAR_PROCESS_FLOOR_CACHE_DIR="${SUGAR_FLOOR_WORKSPACE}/.cache/process-floor-terminals"
+  export SUGAR_PROCESS_FLOOR_CACHE_DIR="${HOME}/.cache/sugar/process-floor-terminals"
 fi
 if [ -z "${SUGAR_MEASUREMENT_TIP:-}" ] && [ -n "${GITHUB_SHA:-}" ]; then
   export SUGAR_MEASUREMENT_TIP="${GITHUB_SHA}"

--- a/tools/run_static_sole_construction_floors.sh
+++ b/tools/run_static_sole_construction_floors.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Cheap static / discrimination sole-construction floors — own parallel job.
+# Must not wait on process-floor matrix (silent ~11min). Collect reds; exit 1 if any.
+
+set -uo pipefail
+
+TESTS=implementations/python/sugar-lift-py-tests
+SCRIPTS="$TESTS/scripts"
+
+red_axes=()
+green_axes=()
+
+axis() {
+  local name="$1"; shift
+  echo "::group::$name"
+  if "$@"; then
+    green_axes+=("$name")
+    echo "$name: GREEN (measurement completed)"
+  else
+    local status=$?
+    red_axes+=("$name (exit $status)")
+    echo "::error::$name is RED (exit $status)"
+  fi
+  echo "::endgroup::"
+}
+
+axis "R_ownership = 0" python "$SCRIPTS/factory_ownership_law.py"
+axis "R_construction_panic_catches_outside_membrane = 0" \
+  python "$SCRIPTS/construction_panic_catch_law.py"
+
+axis "All permanent axes are bound" \
+  python -m pytest tests/test_python_sole_construction_ci.py -q
+axis '`sugar-lift-py-tests[test]` is the sole dependency authority' \
+  python -m pytest tests/test_test_extras_are_the_dependency_authority.py -q
+
+axis "R_vendor_special_case discrimination" \
+  python -m pytest --noconftest "$TESTS/tests/test_vendor_special_case_law.py" -q
+axis "R_vendor_special_case = 0" python "$SCRIPTS/vendor_special_case_law.py"
+
+axis "R_silent discrimination" \
+  python -m pytest --noconftest "$TESTS/tests/test_silent_zero_tolerance.py" -q
+
+axis "R_factory_walk_unclassified discrimination" \
+  python -m pytest --noconftest "$TESTS/tests/test_factory_walk_unclassified_law.py" -q
+axis "R_factory_walk_unclassified = 0" \
+  python "$SCRIPTS/factory_walk_unclassified_law.py" \
+  --live-root "$TESTS/src/sugar_lift_py_tests" \
+  --live-root "$SCRIPTS"
+
+axis "R_finite_cap_opaque_completions discrimination" \
+  python -m pytest --noconftest "$TESTS/tests/test_finite_cap_opaque_completion_law.py" -q
+axis "R_finite_cap_opaque_completions = 0" \
+  python "$SCRIPTS/finite_cap_opaque_completion_law.py"
+
+axis "R_finite_unfold_compact_gaps discrimination" \
+  python -m pytest --noconftest \
+  "$TESTS/tests/test_finite_unfold_compact_projection_law.py" -q
+axis "R_finite_unfold_compact_gaps = 0" \
+  python "$SCRIPTS/finite_unfold_compact_projection_law.py"
+
+axis "R_source_via_execution discrimination" \
+  python -m pytest --noconftest "$TESTS/tests/test_source_via_execution_law.py" -q
+axis "R_source_via_execution = 0" python "$SCRIPTS/source_via_execution_law.py"
+
+axis "R_no_sugar_in_desugar discrimination" \
+  python "$SCRIPTS/no_sugar_in_desugar_law.py" --self-test
+axis "R_no_sugar_in_desugar = 0" python "$SCRIPTS/no_sugar_in_desugar_law.py"
+
+axis "R_construction_side_doors discrimination" \
+  python -m pytest --noconftest "$TESTS/tests/test_construction_side_door_law.py" -q
+axis "R_construction_side_doors = 0" python "$SCRIPTS/construction_side_door_law.py"
+
+axis "R_bare_construction_door discrimination" \
+  python -m pytest --noconftest \
+  "$TESTS/tests/test_construction_context_door_law.py" -q
+axis "R_bare_construction_door = 0" \
+  python "$SCRIPTS/construction_context_door_law.py"
+
+echo
+echo "static sole-construction floors: ${#green_axes[@]} green, ${#red_axes[@]} red"
+if [ ${#red_axes[@]} -gt 0 ]; then
+  echo "RED AXES:"
+  printf '  - %s\n' "${red_axes[@]}"
+  exit 1
+fi
+echo "every static axis reported, every axis green"
+exit 0

--- a/tools/sole_construction_floor_enrollment.py
+++ b/tools/sole_construction_floor_enrollment.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Sole-construction floor enrollment — completeness by roll call, not sum of R.
+
+T: serializing floors on a multi-runner fleet is pure insanity. Each process
+axis is its own CI job; wall clock is max(axis), not sum(axes). Completeness
+is enrollment: a missing axis is UNMEASURED, never a smaller green set.
+
+Process axes (expensive, parallel matrix — one job each):
+  silent | native-crash | bare-exception | timeout
+
+Static laws (cheap AST / discrimination): one parallel job that does not wait
+on the process matrix.
+
+Each job writes an identity-bound floor-axis-report.json. Attendance checks
+the enrolled roster; residual red is the axis job's own exit code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+SCOREBOARD_AUTHORITY = False
+
+REPORT_KIND = "sole-construction-floor-axis-report"
+REPORT_FILENAME = "floor-axis-report.json"
+CAMPAIGN_CLASS = "python-sole-construction-floors"
+CAMPAIGN_BODY = "floor-measurement.json"
+
+
+@dataclass(frozen=True, slots=True)
+class FloorAxis:
+    axis_id: str
+    display: str
+    kind: str  # process | static
+    script: str | None = None  # process floors only
+
+
+PROCESS_AXES: tuple[FloorAxis, ...] = (
+    FloorAxis("silent", "R_silent", "process", "silent_zero_tolerance.py"),
+    FloorAxis(
+        "native-crash", "R_native_crashes", "process", "native_crash_zero_tolerance.py"
+    ),
+    FloorAxis(
+        "bare-exception",
+        "R_bare_exceptions",
+        "process",
+        "bare_exception_zero_tolerance.py",
+    ),
+    FloorAxis("timeout", "R_timeouts", "process", "timeout_zero_tolerance.py"),
+)
+
+# One enrollment slot for the cheap static job (ownership, side doors, …).
+STATIC_AXIS = FloorAxis("static-laws", "R_static_sole_construction", "static")
+
+ENROLLED: tuple[FloorAxis, ...] = PROCESS_AXES + (STATIC_AXIS,)
+
+
+def enrolled_ids() -> tuple[str, ...]:
+    return tuple(a.axis_id for a in ENROLLED)
+
+
+def emit_process_matrix_json() -> str:
+    include = [
+        {
+            "axis": a.axis_id,
+            "display": a.display,
+            "script": a.script,
+        }
+        for a in PROCESS_AXES
+    ]
+    return json.dumps({"include": include})
+
+
+def mint_axis_report(
+    *,
+    axis_id: str,
+    display: str,
+    commit_sha: str,
+    exit_code: int,
+    kind: str,
+) -> dict:
+    if axis_id not in enrolled_ids():
+        raise ValueError(f"axis_id {axis_id!r} is not enrolled")
+    return {
+        "schemaVersion": 1,
+        "kind": REPORT_KIND,
+        "axisId": axis_id,
+        "display": display,
+        "axisKind": kind,
+        "measurementClass": CAMPAIGN_CLASS,
+        "measuredCommit": commit_sha,
+        "status": "completed",
+        "exitCode": int(exit_code),
+        "identityResolved": True,
+        "measured": True,
+        "floorExitGreen": int(exit_code) == 0,
+        "totals": {"failed": 0 if int(exit_code) == 0 else 1},
+    }
+
+
+def check_attendance(directory: Path, *, require_commit: str) -> tuple[int, dict]:
+    """Enrollment roll call. Missing axis ⇒ UNMEASURED (exit 1).
+
+    Residual-red axes still attend; campaign residual is separate from attendance.
+    """
+    require_commit = require_commit.strip()
+    if not require_commit:
+        raise ValueError("require_commit must be non-empty")
+
+    by_id: dict[str, list[dict]] = {i: [] for i in enrolled_ids()}
+    for path in sorted(directory.rglob(REPORT_FILENAME)):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict) or data.get("kind") != REPORT_KIND:
+            continue
+        aid = data.get("axisId")
+        if aid in by_id:
+            data["_path"] = str(path)
+            by_id[aid].append(data)
+
+    missing: list[str] = []
+    unresolved: list[str] = []
+    wrong_commit: list[str] = []
+    residual_red: list[str] = []
+    attended: list[str] = []
+
+    for axis in ENROLLED:
+        rows = by_id[axis.axis_id]
+        if not rows:
+            missing.append(axis.axis_id)
+            continue
+        row = rows[0]
+        if not row.get("identityResolved") or not row.get("measured"):
+            unresolved.append(axis.axis_id)
+            continue
+        if str(row.get("measuredCommit", "")).strip() != require_commit:
+            wrong_commit.append(axis.axis_id)
+            continue
+        attended.append(axis.axis_id)
+        if int(row.get("exitCode", 1)) != 0:
+            residual_red.append(axis.axis_id)
+
+    complete = not missing and not unresolved and not wrong_commit
+    summary = {
+        "kind": "sole-construction-floor-attendance",
+        "ok": complete,
+        "requireCommit": require_commit,
+        "enrolled": list(enrolled_ids()),
+        "attended": attended,
+        "missing": missing,
+        "unresolved": unresolved,
+        "wrongCommit": wrong_commit,
+        "residualRed": residual_red,
+        "status": "complete" if complete else "UNMEASURED",
+        "measurementClass": CAMPAIGN_CLASS,
+    }
+    return (0 if complete else 1), summary
+
+
+def mint_campaign_body(attendance: dict, *, commit_sha: str) -> dict:
+    """Identity-bound campaign body for heavy-measurement attendance roll call."""
+    residual = list(attendance.get("residualRed") or [])
+    unmeasured = attendance.get("status") != "complete"
+    return {
+        "schemaVersion": 1,
+        "measurementClass": CAMPAIGN_CLASS,
+        "measuredCommit": commit_sha,
+        "status": "unmeasured" if unmeasured else "completed",
+        "enrollment": attendance,
+        "exitCode": 1 if unmeasured or residual else 0,
+        "totals": {
+            "failed": 0 if not residual and not unmeasured else 1,
+            "enrolledAxes": len(enrolled_ids()),
+            "attendedAxes": len(attendance.get("attended") or []),
+            "residualRedAxes": len(residual),
+        },
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--emit-process-matrix-json", action="store_true")
+    parser.add_argument("--emit-roster-json", action="store_true")
+    parser.add_argument("--mint-report", type=Path)
+    parser.add_argument("--axis-id", default="")
+    parser.add_argument("--display", default="")
+    parser.add_argument("--kind", default="process")
+    parser.add_argument("--commit-sha", default="")
+    parser.add_argument("--exit-code", type=int, default=0)
+    parser.add_argument("--check-attendance", type=Path)
+    parser.add_argument("--require-commit", default="")
+    parser.add_argument("--write-campaign-body", type=Path)
+    args = parser.parse_args(argv)
+
+    if args.emit_process_matrix_json:
+        print(emit_process_matrix_json())
+        return 0
+    if args.emit_roster_json:
+        print(
+            json.dumps(
+                {
+                    "kind": "sole-construction-floor-roster",
+                    "enrolled": [
+                        {"axisId": a.axis_id, "display": a.display, "kind": a.kind}
+                        for a in ENROLLED
+                    ],
+                    "count": len(ENROLLED),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+    if args.mint_report is not None:
+        report = mint_axis_report(
+            axis_id=args.axis_id,
+            display=args.display,
+            commit_sha=args.commit_sha,
+            exit_code=args.exit_code,
+            kind=args.kind,
+        )
+        args.mint_report.parent.mkdir(parents=True, exist_ok=True)
+        args.mint_report.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        print(json.dumps(report, sort_keys=True))
+        return 0
+    if args.check_attendance is not None:
+        code, summary = check_attendance(
+            args.check_attendance, require_commit=args.require_commit
+        )
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        if args.write_campaign_body is not None:
+            body = mint_campaign_body(summary, commit_sha=args.require_commit)
+            args.write_campaign_body.write_text(
+                json.dumps(body, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+        if code != 0:
+            print(
+                f"FLOOR ENROLLMENT RED: status={summary['status']} "
+                f"missing={summary['missing']} unresolved={summary['unresolved']} "
+                f"wrongCommit={summary['wrongCommit']}",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"FLOOR ENROLLMENT GREEN: all {len(ENROLLED)} axes attended "
+                f"(residualRed={summary['residualRed']})",
+                file=sys.stderr,
+            )
+        return code
+    parser.error("pick an action")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

T: serializing floors across a multi-runner fleet is pure insanity. After #7008 deleted the lease, the remaining serialization was **inside** `factory-zero-tolerance` — one job running `run_sole_construction_floors.sh` end-to-end.

### CI shape (this PR)

| Job | Role |
| --- | --- |
| `process-floor` matrix | **silent**, **native-crash**, **bare-exception**, **timeout** — one runner each, `fail-fast: false` |
| `static-floors` | Cheap AST / discrimination laws — **sibling** job, not queued behind silent |
| `floor-enrollment` | Roll call over identity-bound `floor-axis-report.json`; missing axis = **UNMEASURED** |

Wall clock becomes **max(axis)** not **sum(axes)** (today: ~688s silent long pole vs ~854s serial sum).

Same law as suite shards: **no merged residual hub**. Campaign `floor-measurement.json` is enrollment testimony for heavy attendance, not an R total.

### #7009 terminal cache — cross-job finding

Default was **workspace** `.cache/process-floor-terminals` → **job-private**. Parallel matrix jobs would each cold-lift.

**Fix:** default store is host-durable `$HOME/.cache/sugar/process-floor-terminals` (explicit `SUGAR_PROCESS_FLOOR_CACHE_DIR` still wins; `off` disables). Timeout/native-crash remain **never banked** (unchanged).

### Local

`tools/run_sole_construction_floors.sh` still runs everything serially for workstations. CI no longer calls it.

## Validation

```
uv run --with pytest python -m pytest \
  tests/test_python_sole_construction_ci.py \
  tests/test_heavy_measurement_concurrency_topology.py -q
# 29 passed
```

## Shot accounting

| | |
| --- | --- |
| R axis | floors wall clock (serialization) |
| Epsilon R | sum → max; residual poles silent (mr_blue) / enum refusal (mr_white) |
| Shell deleted | serial process-floor chain inside one GHA job |
| Floors | no residual drain |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize sole-construction floor CI with one matrix job per process axis
> - Replaces the single monolithic CI job with a matrix-driven `process-floor` job in [factory-zero-tolerance.yml](.github/workflows/factory-zero-tolerance.yml), running four axes (silent, native-crash, bare-exception, timeout) in parallel via [run_one_process_floor_axis.sh](https://github.com/TSavo/sugar/pull/7013/files#diff-e2f37947c64a438368c7b6c2e4b00a46231fdc6065bcaaec43954d2ada2be00e).
> - Adds a sibling `static-floors` job running [run_static_sole_construction_floors.sh](https://github.com/TSavo/sugar/pull/7013/files#diff-fe37c87c9dc044d5189f871624437d0fd0857b8ffb2f70af355c37ed02d4ff2b), which executes all static/discrimination checks and fails if any are red.
> - Adds a `floor-enrollment` job that downloads all per-axis artifacts, calls [sole_construction_floor_enrollment.py](https://github.com/TSavo/sugar/pull/7013/files#diff-97da7ddf4a53542ab183832c1fedf5e3201fc8f4395b58fc71155d4040db58db) to check attendance, and fails if any axis is missing or any attended axis has a non-zero exit code.
> - Defaults the process-floor terminal cache to `$HOME/.cache/sugar/process-floor-terminals` (host-durable) in both the new per-axis runner and the local serial script, falling back to the workspace path only when `$HOME` is unavailable.
> - Behavioral Change: CI now fails on incomplete attendance (missing axis reports) in addition to failing on red axes; the old monolithic runner script is no longer used by CI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95297cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->