### PR TITLE
R_shelf_rebuild_single_flight: stamp-keyed lock before cargo

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -1606,6 +1606,60 @@ evict_shelf_cell() {
   return 0
 }
 
+# R_shelf_rebuild_single_flight: exclusive lock per (platform, profile, stamp, bin).
+# NOT a machine-wide heavy lease — distinct stamps do not block each other.
+# Concurrent matrix jobs that all miss the same cell must wait here so only
+# one cargo runs; waiters re-pull after the winner publishes.
+#
+# Mechanism: atomic mkdir (portable; no flock(1) dependency). Holder writes
+# pid; waiters reclaim if the holder pid is gone (cancelled job). A subprocess
+# flock would release when the child exits and would NOT protect the parent
+# rebuild — so we never flock in a short-lived child.
+_rebuild_lock_dir=""
+
+acquire_rebuild_single_flight() {
+  local stamp="$1" name="$2" lock_parent lockdir waited=0
+  _rebuild_lock_dir=""
+  lock_parent="$(cache_dir)/.rebuild-locks"
+  if ! mkdir -p "$lock_parent" 2>/dev/null; then
+    log "rebuild single-flight: cannot create $lock_parent; degraded (no lock)"
+    return 0
+  fi
+  # Directory name IS the lock: mkdir succeeds for exactly one contender.
+  lockdir="$lock_parent/$(platform_key)-${profile}-$(stamp_for_filename "$stamp")-${bin_name}.lock"
+  log "rebuild single-flight: waiting for $bin_name stamp lock"
+  while true; do
+    if mkdir "$lockdir" 2>/dev/null; then
+      printf '%s\n' "$$" >"$lockdir/pid"
+      _rebuild_lock_dir="$lockdir"
+      log "rebuild single-flight: acquired $bin_name stamp lock"
+      return 0
+    fi
+    # Stale reclaim: holder pid gone (SIGKILL / cancelled runner job).
+    if [[ -f "$lockdir/pid" ]]; then
+      local holder
+      holder="$(tr -d '[:space:]' <"$lockdir/pid" 2>/dev/null || true)"
+      if [[ -n "$holder" ]] && ! kill -0 "$holder" 2>/dev/null; then
+        log "rebuild single-flight: reclaiming stale lock from dead pid $holder"
+        rm -rf "$lockdir" 2>/dev/null || true
+        continue
+      fi
+    fi
+    sleep 0.25
+    waited=$((waited + 1))
+    # Loud breadcrumb every ~30s so a wedged lock is not silent.
+    if (( waited % 120 == 0 )); then
+      log "rebuild single-flight: still waiting for $bin_name stamp lock (${waited} ticks)"
+    fi
+  done
+}
+
+release_rebuild_single_flight() {
+  [[ -n "${_rebuild_lock_dir:-}" ]] || return 0
+  rm -rf "$_rebuild_lock_dir" 2>/dev/null || true
+  _rebuild_lock_dir=""
+}
+
 pull_from_filesystem_shelf() {
   local stamp="$1" identity="$2" name="$3" dir candidate_dir candidate manifest cell tmp
   dir="$(cache_dir)"
@@ -1906,13 +1960,31 @@ main() {
   if [[ "${SUGAR_BINARY_ALLOW_BUILD:-1}" == "0" ]]; then
     log "shelf miss for $name; self-healing rebuild (regenerable cell)"
   fi
+
+  # Single-flight rebuild (R_shelf_rebuild_single_flight). Concurrent matrix
+  # jobs that all miss the same stamp must not each cargo-build sugar: the
+  # publish race dedupes the CAS *cell* after waste; this lock prevents the
+  # waste. Key is stamp+bin+platform+profile — not a machine-wide lease.
+  # Double-check pull after the lock: the winner's publish is visible to waiters.
+  acquire_rebuild_single_flight "$stamp" "$name"
+  if candidate="$(pull_from_filesystem_shelf "$stamp" "$identity" "$name")"; then
+    log "rebuild single-flight: peer published $name while we waited"
+    release_rebuild_single_flight
+    printf '%s\n' "$candidate"
+    return 0
+  fi
   build_from_source "$stamp" "$identity"
   built="${SUGAR_BINARY_TARGET_ROOT:-$rust_workspace/target}/$profile/$bin_name"
   if ! verify_artifact_manifest "$built" "$stamp" "$identity" "built binary"; then
     log "built binary did not match requested stamp $stamp"
+    release_rebuild_single_flight
     return 1
   fi
-  publish_to_filesystem_shelf "$built" "$stamp" "$name" || return $?
+  if ! publish_to_filesystem_shelf "$built" "$stamp" "$name"; then
+    release_rebuild_single_flight
+    return 1
+  fi
+  release_rebuild_single_flight
   printf '%s\n' "$built"
 }
 

--- a/tests/sugarbin_rebuild_single_flight.sh
+++ b/tests/sugarbin_rebuild_single_flight.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# R_shelf_rebuild_single_flight teeth.
+# Concurrent matrix resolvers must not each cargo-build the same stamp.
+# The publish race only dedupes the CAS cell AFTER waste; this lock prevents waste.
+set -euo pipefail
+
+repo="${1:?usage: sugarbin_rebuild_single_flight.sh REPO_ROOT}"
+sugarbin="$repo/bin/sugarbin"
+[[ -x "$sugarbin" ]] || { echo "missing $sugarbin" >&2; exit 1; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Static: ONE door shapes present on the miss→rebuild path.
+grep -Fq 'acquire_rebuild_single_flight' "$sugarbin" || fail 'missing acquire_rebuild_single_flight'
+grep -Fq 'release_rebuild_single_flight' "$sugarbin" || fail 'missing release_rebuild_single_flight'
+grep -Fq 'rebuild single-flight: peer published' "$sugarbin" || fail 'missing double-check after lock'
+grep -Fq '.rebuild-locks' "$sugarbin" || fail 'missing lock directory under cache'
+
+# Lock key must include stamp + bin + platform + profile (not a global mutex).
+acquire_body="$(sed -n '/^acquire_rebuild_single_flight()/,/^release_rebuild_single_flight()/p' "$sugarbin")"
+grep -Fq 'stamp_for_filename "$stamp"' <<<"$acquire_body" || fail 'lock key does not include stamp'
+grep -Fq 'bin_name' <<<"$acquire_body" || fail 'lock key does not include bin_name'
+grep -Fq 'platform_key' <<<"$acquire_body" || fail 'lock key does not include platform'
+# Atomic mkdir is the portable lock (not a short-lived flock child).
+grep -Fq 'mkdir "$lockdir"' <<<"$acquire_body" || fail 'lock must use atomic mkdir'
+if grep -Fq 'heavy-measurement' <<<"$acquire_body"; then
+  fail 'rebuild single-flight must not use the deleted heavy-measurement lease'
+fi
+
+# main() miss path: acquire before build_from_source, release on every exit.
+main_body="$(sed -n '/^main()/,/^if \[\[ -n "\$artifact_subcommand" \]\]/p' "$sugarbin")"
+acquire_line="$(grep -n 'acquire_rebuild_single_flight' <<<"$main_body" | head -1 | cut -d: -f1)"
+build_line="$(grep -n 'build_from_source' <<<"$main_body" | head -1 | cut -d: -f1)"
+[[ -n "$acquire_line" && -n "$build_line" ]] || fail 'main missing acquire or build_from_source'
+[[ "$acquire_line" -lt "$build_line" ]] || fail 'acquire must precede build_from_source'
+n_release=$(grep -c 'release_rebuild_single_flight' <<<"$main_body" || true)
+# peer-hit, verify-fail, publish-fail, success — at least three release sites.
+[[ "$n_release" -ge 3 ]] || fail "main must release lock on every exit (found $n_release)"
+
+# Dynamic: two processes cannot hold the same mkdir-lock simultaneously.
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/shelf-sflight.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+lock="$tmp/demo.lock"
+# Holder keeps the lock for 2s via mkdir.
+(
+  mkdir "$lock"
+  echo $$ >"$lock/pid"
+  sleep 2
+  rm -rf "$lock"
+) &
+holder=$!
+sleep 0.2
+start=$(date +%s)
+# Waiter spins until mkdir succeeds (same algorithm as acquire).
+while ! mkdir "$lock" 2>/dev/null; do
+  if [[ -f "$lock/pid" ]]; then
+    h="$(tr -d '[:space:]' <"$lock/pid" 2>/dev/null || true)"
+    if [[ -n "$h" ]] && ! kill -0 "$h" 2>/dev/null; then
+      rm -rf "$lock" 2>/dev/null || true
+    fi
+  fi
+  sleep 0.1
+done
+rm -rf "$lock"
+end=$(date +%s)
+wait "$holder" || true
+elapsed=$((end - start))
+[[ "$elapsed" -ge 1 ]] || fail "mkdir lock did not serialize waiters (elapsed=${elapsed}s)"
+echo "PASS: dynamic mkdir-lock serialization (${elapsed}s wait)"
+
+echo 'PASS: R_shelf_rebuild_single_flight — stamp-keyed lock before rebuild, double-check after'

--- a/tests/sugarbin_shelf_immutability.sh
+++ b/tests/sugarbin_shelf_immutability.sh
@@ -49,6 +49,9 @@ echo 'PASS: sugarbin shelf assets are immutable and race-idempotent'
 # R_shelf_content_addressed_cell: address = h(payload), not sourceStamp name.
 "$repo/tests/sugarbin_shelf_content_addressed.sh" "$repo"
 
+# R_shelf_rebuild_single_flight: 36 matrix jobs must not each cargo the same stamp.
+"$repo/tests/sugarbin_rebuild_single_flight.sh" "$repo"
+
 # R_shelf_exercise: SHELF_EXERCISED_CLEAN ≠ SHELF_NEVER_TOUCHED ≠ SHELF_UNMEASURED.
 # Silence (no crimes) is not load-clear testimony — attendance one layer down.
 "$repo/tests/shelf_exercise_report.sh" "$repo"


### PR DESCRIPTION
## Answer first (why this PR)

**36 concurrent readers of an existing cell: SAFE.** CAS is immutable; pull is read-only decompress+verify; publish races already treat peer-won as success.

**36 concurrent cold-miss rebuilds: NOT safe against stampede.** `main()` does miss → `build_from_source` with no single-flight. Publish dedupes the *cell* after waste; it does not prevent 36 cargos. That would eat the parallelism sharding buys on the first resolve after a stamp change / empty shelf.

## Fix

Stamp-keyed rebuild lock (`cache_dir/.rebuild-locks/<platform>-<profile>-<stamp>-<bin>.lock`):

1. Acquire (atomic mkdir; reclaim if holder pid dead)
2. Double-check shelf pull (peer may have published while we waited)
3. Only then build + publish
4. Release on every exit path

**Not** a machine-wide heavy lease (#7008 stays deleted). Distinct stamps do not block each other.

## PR accounting

| | |
| --- | --- |
| **R** | `R_shelf_rebuild_single_flight` |
| **εR** | cold-miss stampede → one rebuild + N hits |
| **Floors** | no global mutex; strict verify; peer-evictable CAS unchanged |
| **Shell deleted** | unbounded concurrent rebuild of the same stamp |

## Teeth

`tests/sugarbin_rebuild_single_flight.sh` (static + dynamic mkdir serialization), enrolled via shelf immutability.

## Ladder

Type no → one door (acquire before build on miss path) → no panic needed → auditor is the bash tooth until flock geometry is a type.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize sugarbin shelf rebuilds per (platform, profile, stamp, bin) using a stamp-keyed lock
> - Adds `acquire_rebuild_single_flight` in [bin/sugarbin](https://github.com/TSavo/sugar/pull/7014/files#diff-2b8f7e68bdef16827d284767f61c9a26ffa589c12f114f50129677d05e35383b), which uses an atomic `mkdir` under `$(cache_dir)/.rebuild-locks` to serialize rebuilds for the same (platform_key, profile, stamp, bin_name) tuple; waiters spin with periodic logs and reclaim stale locks when the recorded PID is no longer alive.
> - Adds `release_rebuild_single_flight` to remove the lock directory on all exit paths (peer hit after waiting, verify failure, publish failure, and success).
> - After acquiring the lock, `main` performs a double-check `pull_from_filesystem_shelf` so a waiter skips rebuilding if a peer already published the artifact.
> - Adds [tests/sugarbin_rebuild_single_flight.sh](https://github.com/TSavo/sugar/pull/7014/files#diff-3493587c81a430046f683f9f74a37b9480b15ac3993804953846e40850dbe6ae) with static and dynamic tests verifying lock acquisition, release coverage, and mutual exclusion.
> - Risk: if the lock parent directory cannot be created, the mechanism degrades silently to a no-op (no lock held).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd512c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->