### PR TITLE
Fleet-wide process-floor CA shelf (actions/cache for matrix jobs)

### DIFF
--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -38,14 +38,33 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare immutable Python test environment
         uses: ./.github/actions/python-test-environment
+      # Host path ($HOME/...) only shares when matrix jobs land the same
+      # self-hosted user. Fleet-wide: restore/save CA terminal shelf via
+      # actions/cache. Key is tip; MeasurementKey still gates corpus/file
+      # content so a restored shelf cannot serve wrong population.
+      - name: Resolve process-floor CA shelf path
+        id: shelf
+        shell: bash
+        run: |
+          set -euo pipefail
+          dir="${HOME}/.cache/sugar/process-floor-terminals"
+          mkdir -p "$dir"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+          echo "SUGAR_PROCESS_FLOOR_CACHE_DIR=$dir" >> "$GITHUB_ENV"
+      - name: Restore process-floor CA terminal shelf (fleet)
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.shelf.outputs.dir }}
+          key: process-floor-term-${{ github.sha }}
+          restore-keys: |
+            process-floor-term-
       - name: Run process floor ${{ matrix.axis }}
         id: floor
         shell: bash
         env:
-          # Tip pins the CA terminal key. Cache dir defaults to host-durable
-          # $HOME/.cache/sugar/process-floor-terminals (see run_one_process_floor_axis.sh)
-          # so matrix jobs share hits — workspace .cache is job-private.
+          # Tip pins the CA terminal key. Dir from shelf step (HOME + GHA cache).
           SUGAR_MEASUREMENT_TIP: ${{ github.sha }}
+          SUGAR_PROCESS_FLOOR_CACHE_DIR: ${{ steps.shelf.outputs.dir }}
         run: |
           set -uo pipefail
           chmod +x tools/run_one_process_floor_axis.sh
@@ -57,6 +76,14 @@ jobs:
           # Always keep the identity report for enrollment even when residual red.
           test -f floor-axis-report.json
           exit "$code"
+      # Save after every attempt so partial fills warm peers / next runs.
+      # Concurrent saves of the same key: first wins; content is CA so safe.
+      - name: Save process-floor CA terminal shelf (fleet)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.shelf.outputs.dir }}
+          key: process-floor-term-${{ github.sha }}
       - name: Upload axis report
         if: always()
         uses: actions/upload-artifact@v4

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -189,3 +189,18 @@ def test_floor_workflow_is_parallel_matrix_with_enrollment():
     assert "run_static_sole_construction_floors.sh" in text
     assert "run_sole_construction_floors.sh" not in text
     assert LEASE_WRAPPER not in text
+
+
+def test_process_floor_matrix_restores_and_saves_ca_terminal_shelf():
+    """Parallel jobs must not each cold-lift: fleet-wide actions/cache over the CA shelf.
+
+    HOME alone only shares same-host matrix landings. restore/save keyed by tip
+    makes the shelf available across runners; MeasurementKey still binds corpus
+    and file content so wrong population cannot hit.
+    """
+    text = _text("factory-zero-tolerance.yml")
+    assert "actions/cache/restore@v4" in text
+    assert "actions/cache/save@v4" in text
+    assert "process-floor-term-${{ github.sha }}" in text
+    assert "process-floor-terminals" in text
+    assert "SUGAR_PROCESS_FLOOR_CACHE_DIR" in text


### PR DESCRIPTION
## Decision (mr_brown + mr_blonde)

| Layer | Role |
| --- | --- |
| **HOME** `$HOME/.cache/sugar/process-floor-terminals` | Same-host progressive hits (mid-fanout) |
| **actions/cache** restore/save `process-floor-term-${{ github.sha }}` | Fleet-wide across runners |
| **MeasurementKey** tip×corpus×file… | Still gates hits — restored shelf cannot serve wrong population |

Without this, #7013 parallel matrix jobs each cold-lift (cache regression).

## What

Wire `actions/cache/restore@v4` before and `save@v4` after each `process-floor` matrix job. Explicit `SUGAR_PROCESS_FLOOR_CACHE_DIR` matches the restored path.

No lease. No merged residual. Identity-bound axis reports unchanged.

## Validation

Topology tooth: restore + save + tip key + process-floor-terminals present in workflow.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `actions/cache` restore/save steps for the process-floor CA terminal shelf in matrix jobs
> - Adds a step to resolve `~/.cache/sugar/process-floor-terminals` and export it as `SUGAR_PROCESS_FLOOR_CACHE_DIR` in [factory-zero-tolerance.yml](.github/workflows/factory-zero-tolerance.yml)
> - Adds `actions/cache/restore@v4` before the run step and `actions/cache/save@v4` (guarded by `if: always()`) after it, both keyed by `process-floor-term-${{ github.sha }}`
> - Adds a test in `test_heavy_measurement_concurrency_topology.py` that validates the cache steps, key, path, and env var are present in the workflow file
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17c9dbe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->