### PR TITLE
Fan out core CI: claim-mass pins + python-format packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,18 +91,7 @@ jobs:
             python: false
             z3: false
             b3sum: false
-          - name: Python format
-            target: test-python-format
-            python: true
-            z3: false
-            b3sum: false
-          # claim-mass tripwires is pytest over a small file set; b3sum was
-          # matrix baggage, not a sugarbin consumer (make target is pure Python).
-          - name: claim-mass tripwires
-            target: test-claim-mass-tripwires
-            python: true
-            z3: false
-            b3sum: false
+          # claim-mass + python-format: fan-out jobs below.
           # coretests-invariants and coretests-source-audit are Makefile targets
           # only (hand / future Rust work). Not on this per-commit matrix.
 
@@ -190,6 +179,197 @@ jobs:
 
   # Showcase shards warm their own bins inside `make test-showcases`.
   # Concurrent shards share the filesystem shelf; single-flight prevents stampede.
+  # ------------------------------------------------------------------
+  claim-mass-matrix:
+    name: emit claim-mass pin matrix
+    # no needs: prepare — pure Python (7019)
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.m.outputs.matrix }}
+      count: ${{ steps.m.outputs.count }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Emit pin matrix from PINS (single source of truth)
+        id: m
+        shell: bash
+        run: |
+          set -euo pipefail
+          matrix="$(python3 tools/claim_mass_tripwire_shards.py --emit-matrix-json)"
+          count="$(python3 -c 'import json,sys; print(len(json.load(sys.stdin)["pin"]))' <<<"$matrix")"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+  claim-mass-tripwires:
+    name: claim-mass (${{ matrix.pin }})
+    needs: [claim-mass-matrix]
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.claim-mass-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install tripwire deps
+        run: |
+          python -m pip install --quiet \
+            -e implementations/python/sugar-lift-python-source \
+            -e implementations/python/sugar-source-tree \
+            -e 'implementations/python/sugar-lift-py-tests[test]'
+      - name: Run pin ${{ matrix.pin }}
+        id: pin
+        shell: bash
+        working-directory: implementations/python/sugar-lift-py-tests
+        env:
+          PYTHONPATH: src:tests:${{ github.workspace }}/implementations/python/sugar-lift-python-source/src:${{ github.workspace }}/implementations/python/sugar-source-tree/src
+        run: |
+          set -uo pipefail
+          set +e
+          python -m pytest -q tests/test_claim_mass_tripwires.py -k '${{ matrix.pin }}'
+          exit_code=$?
+          set -e
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          python3 - <<PY
+          import json, os
+          from pathlib import Path
+          body = {
+              "schemaVersion": 1,
+              "measurementClass": "claim-mass-tripwires",
+              "pin": "${{ matrix.pin }}",
+              "measuredCommit": os.environ.get("GITHUB_SHA"),
+              "status": "completed",
+              "exitCode": $exit_code,
+          }
+          Path(os.environ["GITHUB_WORKSPACE"], "claim-mass-body.json").write_text(
+              json.dumps(body, indent=2) + "\n"
+          )
+          PY
+          exit "$exit_code"
+      - name: Upload pin measurement body
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claim-mass-${{ matrix.pin }}
+          path: claim-mass-body.json
+          if-no-files-found: error
+
+  claim-mass-attendance:
+    name: claim-mass enrollment (all pins)
+    if: always() && !cancelled()
+    needs: [claim-mass-matrix, claim-mass-tripwires]
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: claim-mass-*
+          path: runs
+      - name: Roll call — every pin attended
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/claim_mass_tripwire_attendance.py \
+            --reports-dir runs \
+            --require-commit "$GITHUB_SHA" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+  # ------------------------------------------------------------------
+  # python-format: N packages ⇒ N black jobs. Enrollment is existence.
+  # ------------------------------------------------------------------
+  python-format-matrix:
+    name: emit python-format package matrix
+    # no needs: prepare — pure Python (7019)
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.m.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: m
+        shell: bash
+        run: |
+          set -euo pipefail
+          matrix="$(python3 tools/python_format_shards.py --emit-matrix-json)"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  python-format:
+    name: black (${{ matrix.package }})
+    needs: [python-format-matrix]
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.python-format-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install black (via sugar-lift-py-tests[test])
+        run: |
+          python -m pip install --quiet \
+            -e 'implementations/python/sugar-lift-py-tests[test]'
+      - name: Black check ${{ matrix.package }}
+        id: fmt
+        shell: bash
+        run: |
+          set -uo pipefail
+          set +e
+          python -m black --check "implementations/python/${{ matrix.package }}"
+          exit_code=$?
+          set -e
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          python3 - <<PY
+          import json, os
+          from pathlib import Path
+          body = {
+              "schemaVersion": 1,
+              "measurementClass": "python-format",
+              "package": "${{ matrix.package }}",
+              "measuredCommit": os.environ.get("GITHUB_SHA"),
+              "status": "completed",
+              "exitCode": $exit_code,
+          }
+          Path("python-format-body.json").write_text(json.dumps(body, indent=2) + "\n")
+          PY
+          exit "$exit_code"
+      - name: Upload format measurement body
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-format-${{ matrix.package }}
+          path: python-format-body.json
+          if-no-files-found: error
+
+  python-format-attendance:
+    name: python-format enrollment (all packages)
+    if: always() && !cancelled()
+    needs: [python-format-matrix, python-format]
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: python-format-*
+          path: runs
+      - name: Roll call — every package attended
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/python_format_attendance.py \
+            --reports-dir runs \
+            --require-commit "$GITHUB_SHA" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
   showcases:
     name: showcases (${{ matrix.shard }}/4)
     runs-on: [self-hosted, Linux, X64]
@@ -249,7 +429,13 @@ jobs:
     # Aggregate genuine success/failure results, but do not manufacture a red
     # test result when concurrency intentionally supersedes the whole run.
     if: ${{ always() && !cancelled() }}
-    needs: [ci-apt-fast-path, core, core-shelf, showcases]
+    needs:
+      - ci-apt-fast-path
+      - core
+      - core-shelf
+      - claim-mass-attendance
+      - python-format-attendance
+      - showcases
     runs-on: ubuntu-latest
     steps:
       - name: Report the complete acid-test vector
@@ -257,10 +443,14 @@ jobs:
           APT_RESULT: ${{ needs.ci-apt-fast-path.result }}
           CORE_RESULT: ${{ needs.core.result }}
           CORE_SHELF_RESULT: ${{ needs.core-shelf.result }}
+          CLAIM_MASS_RESULT: ${{ needs.claim-mass-attendance.result }}
+          FORMAT_RESULT: ${{ needs.python-format-attendance.result }}
           SHOWCASE_RESULT: ${{ needs.showcases.result }}
         run: |
-          echo "apt=$APT_RESULT core=$CORE_RESULT core-shelf=$CORE_SHELF_RESULT showcases=$SHOWCASE_RESULT"
+          echo "apt=$APT_RESULT core=$CORE_RESULT core-shelf=$CORE_SHELF_RESULT claim-mass=$CLAIM_MASS_RESULT format=$FORMAT_RESULT showcases=$SHOWCASE_RESULT"
           test "$APT_RESULT" = success
           test "$CORE_RESULT" = success
           test "$CORE_SHELF_RESULT" = success
+          test "$CLAIM_MASS_RESULT" = success
+          test "$FORMAT_RESULT" = success
           test "$SHOWCASE_RESULT" = success

--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,7 @@ test-python-format:
 # numpy slice, requests recognition slice. Seconds, not wall-scale. Silent
 # must stay 0; lifted loci cannot disappear without a loud pin update.
 # Post-factory path: SourceFile + Assert.sugar() (sugar-source-tree required).
+# CLAIM_MASS_PIN=<name> runs one pin (CI matrix). Empty = all pins (local).
 .PHONY: test-claim-mass-tripwires
 test-claim-mass-tripwires:
 	$(PYTHON) -m venv $(PYTHON_KIT_VENV)
@@ -358,7 +359,8 @@ test-claim-mass-tripwires:
 		-e implementations/python/sugar-source-tree \
 		-e implementations/python/sugar-lift-py-tests[test]
 	cd implementations/python/sugar-lift-py-tests && \
-		$(abspath $(PYTHON_KIT)) -m pytest -q tests/test_claim_mass_tripwires.py
+		$(abspath $(PYTHON_KIT)) -m pytest -q tests/test_claim_mass_tripwires.py \
+		$(if $(CLAIM_MASS_PIN),-k $(CLAIM_MASS_PIN),)
 
 .PHONY: test-php
 test-php:

--- a/tests/test_core_matrix_parallel_fanout.py
+++ b/tests/test_core_matrix_parallel_fanout.py
@@ -1,0 +1,104 @@
+"""Teeth: core matrix loops fan out; enrollment proves completeness."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CI = ROOT / ".github/workflows/ci.yml"
+CLAIM_SHARDS = ROOT / "tools/claim_mass_tripwire_shards.py"
+CLAIM_ATTEND = ROOT / "tools/claim_mass_tripwire_attendance.py"
+FMT_SHARDS = ROOT / "tools/python_format_shards.py"
+FMT_ATTEND = ROOT / "tools/python_format_attendance.py"
+
+
+def test_claim_mass_pins_are_independent_and_matrixed() -> None:
+    names = subprocess.check_output(
+        [sys.executable, str(CLAIM_SHARDS), "--list"],
+        cwd=ROOT,
+        text=True,
+    ).split()
+    assert len(names) >= 4
+    assert "datetime" in names
+    matrix = json.loads(
+        subprocess.check_output(
+            [sys.executable, str(CLAIM_SHARDS), "--emit-matrix-json"],
+            cwd=ROOT,
+            text=True,
+        )
+    )
+    assert set(matrix["pin"]) == set(names)
+    text = CI.read_text(encoding="utf-8")
+    assert "claim-mass-tripwires" in text
+    assert "claim-mass-attendance" in text
+    assert "claim_mass_tripwire_attendance" in text
+    # Not a single core-matrix serial make target anymore
+    assert "target: test-claim-mass-tripwires" not in text
+
+
+def test_claim_mass_missing_pin_is_unmeasured(tmp_path: Path) -> None:
+    names = subprocess.check_output(
+        [sys.executable, str(CLAIM_SHARDS), "--list"],
+        cwd=ROOT,
+        text=True,
+    ).split()
+    # attend all but last
+    for name in names[:-1]:
+        d = tmp_path / f"claim-mass-{name}"
+        d.mkdir()
+        (d / "claim-mass-body.json").write_text(
+            json.dumps(
+                {
+                    "measurementClass": "claim-mass-tripwires",
+                    "pin": name,
+                    "measuredCommit": "abc",
+                    "exitCode": 0,
+                }
+            ),
+            encoding="utf-8",
+        )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(CLAIM_ATTEND),
+            "--reports-dir",
+            str(tmp_path),
+            "--require-commit",
+            "abc",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode != 0
+    assert "UNMEASURED" in proc.stdout or names[-1] in proc.stdout
+
+
+def test_python_format_is_matrixed_by_package() -> None:
+    units = subprocess.check_output(
+        [sys.executable, str(FMT_SHARDS), "--list"],
+        cwd=ROOT,
+        text=True,
+    ).splitlines()
+    assert len(units) >= 5
+    text = CI.read_text(encoding="utf-8")
+    assert "python-format-attendance" in text
+    assert "target: test-python-format" not in text
+
+
+def test_indivisible_core_entries_remain_single_jobs() -> None:
+    text = CI.read_text(encoding="utf-8")
+    assert "check-lift-refusal-vocabulary" in text
+    assert "check-fleet-claim-contract" in text
+    assert "self-attest" in text
+
+
+def test_coretests_not_redesigned_here() -> None:
+    """Do not reintroduce coretests fan-out in this PR (Rust out of campaign)."""
+    text = CI.read_text(encoding="utf-8")
+    assert "coretests-invariants" not in text or "matrix" in text
+    # Fan-out tools for coretests must not appear
+    assert "coretests_invariants_shards" not in text

--- a/tools/claim_mass_tripwire_attendance.py
+++ b/tools/claim_mass_tripwire_attendance.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Enrollment roll call for claim-mass tripwire shards.
+
+Roster = every pin in tools/claim_mass_tripwire_shards.pin_names().
+Attended = identity-bound body with measurementClass=claim-mass-tripwires
+and matching pin. Missing pin = UNMEASURED.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
+from claim_mass_tripwire_shards import pin_names  # noqa: E402
+
+
+def find_attended(reports_dir: Path) -> dict[str, Path]:
+    attended: dict[str, Path] = {}
+    if not reports_dir.is_dir():
+        return attended
+    for path in sorted(reports_dir.rglob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("measurementClass") != "claim-mass-tripwires":
+            continue
+        pin = payload.get("pin")
+        if isinstance(pin, str):
+            attended.setdefault(pin, path)
+    return attended
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reports-dir", type=Path, required=True)
+    parser.add_argument("--require-commit", default=None)
+    args = parser.parse_args(argv)
+
+    roster = pin_names()
+    attended = find_attended(args.reports_dir)
+    missing = [p for p in roster if p not in attended]
+    crimes: list[str] = []
+
+    for pin, path in attended.items():
+        body = json.loads(path.read_text(encoding="utf-8"))
+        if args.require_commit and body.get("measuredCommit") not in (
+            None,
+            args.require_commit,
+        ):
+            crimes.append(
+                f"{pin}: measuredCommit {body.get('measuredCommit')!r} "
+                f"!= {args.require_commit!r}"
+            )
+            missing.append(pin)
+            continue
+        if body.get("exitCode") not in (0, "0"):
+            crimes.append(f"{pin}: exitCode={body.get('exitCode')} (tripwire red)")
+
+    print("### claim-mass tripwire enrollment")
+    print()
+    print(f"- roster: `{len(roster)}` pins")
+    print(f"- attended: `{len(attended)}`")
+    print(f"- missing: `{len(missing)}`")
+    print()
+    print("| pin | spoke |")
+    print("| --- | --- |")
+    for pin in roster:
+        spoke = "yes" if pin in attended and pin not in missing else "NO — UNMEASURED"
+        print(f"| `{pin}` | {spoke} |")
+    print()
+    print(f"**R_claim_mass_pin_attendance = {len(set(missing))}**")
+    if missing or crimes:
+        for c in crimes:
+            print(f"- `{c}`")
+            print(f"::error::{c}", file=sys.stderr)
+        for pin in sorted(set(missing)):
+            print(f"- missing pin `{pin}`")
+        return 1
+    print("All claim-mass pins attended with exit 0.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/claim_mass_tripwire_shards.py
+++ b/tools/claim_mass_tripwire_shards.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Deterministic claim-mass tripwire shards (#4266).
+
+Each pin in PINS is an independent corpus tripwire. Standing law: N independent
+items ⇒ N CI jobs, not one serial pytest. Completeness is enrollment of every
+pin's identity-bound result body — missing pin = UNMEASURED.
+
+Usage:
+  python3 tools/claim_mass_tripwire_shards.py --list
+  python3 tools/claim_mass_tripwire_shards.py --emit-matrix-json
+  python3 tools/claim_mass_tripwire_shards.py --print-roster
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+# Single source of truth: pin names live in the tripwire test module's PINS
+# tuple. Parse the AST (do not import the test — it needs sugar packages).
+_TRIPWIRE = (
+    ROOT
+    / "implementations/python/sugar-lift-py-tests/tests/test_claim_mass_tripwires.py"
+)
+_CORPUS = (
+    ROOT / "implementations/python/sugar-lift-py-tests/tests/claim_mass_corpus.py"
+)
+
+
+def pin_names() -> list[str]:
+    """Extract pin names in declaration order without importing the test."""
+    names: list[str] = []
+    # DATETIME_PIN is imported into PINS first — resolve its name from corpus.
+    corpus = _CORPUS.read_text(encoding="utf-8")
+    m = re.search(
+        r"DATETIME_PIN\s*=\s*ClaimMassPin\(\s*name\s*=\s*\"([^\"]+)\"",
+        corpus,
+    )
+    if m:
+        names.append(m.group(1))
+    tree = ast.parse(_TRIPWIRE.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(getattr(t, "id", None) == "PINS" for t in node.targets):
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            continue
+        for elt in node.value.elts:
+            if isinstance(elt, ast.Name) and elt.id == "DATETIME_PIN":
+                continue  # already from corpus
+            if isinstance(elt, ast.Call):
+                for kw in elt.keywords:
+                    if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                        names.append(str(kw.value.value))
+    if len(names) < 2:
+        raise SystemExit(f"could not parse pin names from {_TRIPWIRE}")
+    return names
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true")
+    parser.add_argument("--emit-matrix-json", action="store_true")
+    parser.add_argument("--print-roster", action="store_true")
+    args = parser.parse_args(argv)
+    names = pin_names()
+    if args.list or args.print_roster:
+        for name in names:
+            print(name)
+        return 0
+    if args.emit_matrix_json:
+        print(json.dumps({"pin": names}, separators=(",", ":")))
+        return 0
+    parser.error("pass --list / --emit-matrix-json / --print-roster")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/python_format_attendance.py
+++ b/tools/python_format_attendance.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Enrollment roll call for python-format package shards."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
+from python_format_shards import format_units  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reports-dir", type=Path, required=True)
+    parser.add_argument("--require-commit", default=None)
+    args = parser.parse_args(argv)
+
+    roster = [Path(u).name for u in format_units()]
+    attended: dict[str, Path] = {}
+    if args.reports_dir.is_dir():
+        for path in sorted(args.reports_dir.rglob("*.json")):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            if payload.get("measurementClass") != "python-format":
+                continue
+            pkg = payload.get("package")
+            if isinstance(pkg, str):
+                attended.setdefault(pkg, path)
+
+    missing = [p for p in roster if p not in attended]
+    crimes = []
+    for pkg, path in attended.items():
+        body = json.loads(path.read_text(encoding="utf-8"))
+        if args.require_commit and body.get("measuredCommit") not in (
+            None,
+            args.require_commit,
+        ):
+            crimes.append(f"{pkg}: commit mismatch")
+            missing.append(pkg)
+        elif body.get("exitCode") not in (0, "0"):
+            crimes.append(f"{pkg}: black exitCode={body.get('exitCode')}")
+
+    print("### python-format package enrollment")
+    print(f"**R_python_format_attendance = {len(set(missing))}**")
+    for p in roster:
+        spoke = "yes" if p in attended and p not in missing else "NO"
+        print(f"- `{p}`: {spoke}")
+    if missing or crimes:
+        for c in crimes:
+            print(f"::error::{c}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/python_format_shards.py
+++ b/tools/python_format_shards.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Shard Black format checks by top-level package under implementations/python.
+
+N packages ⇒ N CI jobs. Completeness by enrollment of each package body.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHON_ROOT = ROOT / "implementations" / "python"
+SKIP = frozenset({"target", "bin", "__pycache__", ".venv", "conformance"})
+
+
+def format_units() -> list[str]:
+    """Repo-relative paths to top-level packages with .py files."""
+    units: list[str] = []
+    if not PYTHON_ROOT.is_dir():
+        return units
+    for path in sorted(PYTHON_ROOT.iterdir()):
+        if not path.is_dir() or path.name in SKIP or path.name.startswith("."):
+            continue
+        if any(path.rglob("*.py")):
+            units.append(path.relative_to(ROOT).as_posix())
+    return units
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true")
+    parser.add_argument("--emit-matrix-json", action="store_true")
+    parser.add_argument("--print-roster", action="store_true")
+    args = parser.parse_args(argv)
+    units = format_units()
+    if args.list or args.print_roster:
+        for u in units:
+            print(u)
+        return 0
+    if args.emit_matrix_json:
+        # GitHub matrix needs short labels; use package basename as key
+        pins = [Path(u).name for u in units]
+        print(json.dumps({"package": pins}, separators=(",", ":")))
+        return 0
+    parser.error("pass --list / --emit-matrix-json / --print-roster")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Apply the standing parallel-CI law to the **core** matrix in `ci.yml` (same architecture as #7012).

### Audit

| Entry | Shape | Action |
|-------|--------|--------|
| refusal vocabulary | one census script + self-test | **single job** (indivisible) |
| fleet claim contract | one gh-API instrument | **single job** |
| **claim-mass tripwires** (~4m10) | **5 independent pins** | **5 parallel jobs** + enrollment |
| **python-format** | Black over many packages | **N package jobs** + enrollment |
| self-attest | one package-release flow | **single job** |
| coretests | out of campaign | **not redesigned** |

### Design (#7012 shape)
- Matrix fan-out across runners (not threads in one job)
- Each job emits its **own** identity-bound body (`measurementClass` + pin/package)
- Completeness via **enrollment roll call** — missing unit = **UNMEASURED**
- **No** merged aggregate / shared writer

### Claim-mass pins (from PINS source of truth)
`datetime`, `itsdangerous`, `pandas`, `numpy`, `requests`

### Teeth
`tests/test_core_matrix_parallel_fanout.py` — 5 passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fan out claim-mass tripwires and python-format checks into parallel CI matrix jobs
> - Replaces single `core` matrix entries for `test-claim-mass-tripwires` and `test-python-format` with dedicated fan-out pipelines, each with a shard-matrix job, per-shard worker jobs, and an attendance aggregation gate.
> - Adds [`tools/claim_mass_tripwire_shards.py`](https://github.com/TSavo/sugar/pull/7016/files#diff-bfa9dbbcbf987c5d202087c0839a92bb1ced4506b7f57b68362455eba21040e3) and [`tools/python_format_shards.py`](https://github.com/TSavo/sugar/pull/7016/files#diff-080f83d46f5c5a425261773b7e1798a1aea017f0043b0d77f71fe02644b9b4de) to enumerate pins/packages and emit GitHub Actions matrix JSON.
> - Adds [`tools/claim_mass_tripwire_attendance.py`](https://github.com/TSavo/sugar/pull/7016/files#diff-c0e25ddb7daa4b67c493f9ba7d70a2d1b0d0363e94b4611fef7b92974fdc5c4c) and [`tools/python_format_attendance.py`](https://github.com/TSavo/sugar/pull/7016/files#diff-dbb3d2582074fc90d8802ee5d7590efc568f984126b69ce328777659ee1e8b25) to verify all shards reported results and had zero exit codes; both emit CI error annotations and a markdown step summary.
> - The `acid-test` job now requires both attendance jobs to pass, asserting `CLAIM_MASS_RESULT` and `FORMAT_RESULT` are success.
> - [`Makefile`](https://github.com/TSavo/sugar/pull/7016/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) gains support for `CLAIM_MASS_PIN` to filter a single pin when running `test-claim-mass-tripwires` locally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3d791d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->