### PR TITLE
Kill dead prepare→suite edge: static 32-shard matrix

### DIFF
--- a/.github/workflows/python-package-suite.yml
+++ b/.github/workflows/python-package-suite.yml
@@ -16,7 +16,11 @@ name: Python package suite (authoritative)
 # Discrimination (scheduled) is within-shard. No package-wide recombine.
 #
 # No machine-wide heavy-measurement lease (deleted). Jobs run in parallel.
-# Shard count lives in tools/python_package_suite_shards.py (SHARD_COUNT=32).
+# Shard count lives in tools/python_package_suite_shards.py (SHARD_COUNT=32)
+# and is mirrored as the static matrix + SUITE_SHARD_COUNT env below — NOT as
+# a prepare-job output. A prepare job that only published the roster while
+# also building a Python env was a 35–126s dead edge: shards re-prep env
+# themselves and never consumed the prepare identity.
 
 on:
   push:
@@ -46,57 +50,24 @@ jobs:
         shell: bash
         run: python3 tests/test_python_suite_identity_gate_twins.py
 
-  prepare-python-test-environment:
-    name: prepare-python-test-environment
-    runs-on: [self-hosted, Linux, X64]
-    timeout-minutes: 60
-    outputs:
-      identity-hash: ${{ steps.env.outputs.identity-hash }}
-      shard-matrix: ${{ steps.shards.outputs.matrix }}
-      shard-list: ${{ steps.shards.outputs.list }}
-      shard-count: ${{ steps.shards.outputs.count }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Prepare immutable Python test environment
-        id: env
-        uses: ./.github/actions/python-test-environment
-        with:
-          identity-artifact: "true"
-      - name: Emit deterministic shard matrix
-        id: shards
-        shell: bash
-        run: |
-          set -euo pipefail
-          matrix="$(python3 tools/python_package_suite_shards.py --emit-matrix-json)"
-          list="$(python3 tools/python_package_suite_shards.py --emit-shard-list-json)"
-          count="$(python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' <<<"$list")"
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-          echo "list=$list" >> "$GITHUB_OUTPUT"
-          echo "count=$count" >> "$GITHUB_OUTPUT"
-          echo "suite shard matrix count=$count"
-      - name: Publish environment identity to the run summary
-        shell: bash
-        run: |
-          set -euo pipefail
-          {
-            echo "### Python test environment"
-            echo
-            echo '`environmentIdentityHash`: `${{ steps.env.outputs.identity-hash }}`'
-            echo
-            echo "suite shards: `${{ steps.shards.outputs.count }}` (enrollment roster)"
-            echo
-            echo 'Runs that do not share this hash are not comparable measurements.'
-          } >> "$GITHUB_STEP_SUMMARY"
+  # SHARD ROSTER is static (must match tools/python_package_suite_shards.py
+  # SHARD_COUNT=32). Emitting it from a prepare job that also built a Python
+  # env forced every shard to wait 35–126s for an environment it never
+  # consumed — each shard already runs python-test-environment itself.
+  # Static matrix = suite jobs start immediately. No prepare gate. No lease.
 
   # One CI job per shard. Own report. Own identity gate. No singleton writer.
   python-package-suite:
     name: suite canonical shard ${{ matrix.shard }}
-    needs: prepare-python-test-environment
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 90
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.prepare-python-test-environment.outputs.shard-matrix) }}
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+    env:
+      # Single source of truth for enrollment roll call; keep == SHARD_COUNT.
+      SUITE_SHARD_COUNT: "32"
     steps:
       - uses: actions/checkout@v6
 
@@ -135,7 +106,7 @@ jobs:
           SUITE_IDENTITY_PATH: ${{ steps.env.outputs.identity-path }}
           SUITE_BINARY_STAMP: ${{ steps.binary.outputs.stamp }}
           SHARD: ${{ matrix.shard }}
-          SHARD_COUNT: ${{ needs.prepare-python-test-environment.outputs.shard-count }}
+          SHARD_COUNT: ${{ env.SUITE_SHARD_COUNT }}
         run: |
           set -uo pipefail
           mapfile -t paths < <(
@@ -245,9 +216,11 @@ jobs:
   python-package-suite-attendance:
     name: suite shard enrollment (all attended)
     if: always() && !cancelled()
-    needs: [prepare-python-test-environment, python-package-suite]
+    needs: [python-package-suite]
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
+    env:
+      SUITE_SHARD_COUNT: "32"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v4
@@ -260,7 +233,7 @@ jobs:
           set -euo pipefail
           python3 tools/python_package_suite_shard_attendance.py \
             --reports-dir runs \
-            --shard-count '${{ needs.prepare-python-test-environment.outputs.shard-count }}' \
+            --shard-count "${{ env.SUITE_SHARD_COUNT }}" \
             --require-commit "$GITHUB_SHA" \
             --order canonical \
             | tee -a "$GITHUB_STEP_SUMMARY"
@@ -270,14 +243,15 @@ jobs:
     if: >-
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.discrimination)
-    needs: prepare-python-test-environment
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         order: [reversed, shuffled]
-        shard: ${{ fromJSON(needs.prepare-python-test-environment.outputs.shard-list) }}
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+    env:
+      SUITE_SHARD_COUNT: "32"
     steps:
       - uses: actions/checkout@v6
       - name: Prepare immutable Python test environment
@@ -303,7 +277,7 @@ jobs:
           SUITE_IDENTITY_PATH: ${{ steps.env.outputs.identity-path }}
           SUITE_BINARY_STAMP: ${{ steps.binary.outputs.stamp }}
           SHARD: ${{ matrix.shard }}
-          SHARD_COUNT: ${{ needs.prepare-python-test-environment.outputs.shard-count }}
+          SHARD_COUNT: ${{ env.SUITE_SHARD_COUNT }}
           SUITE_ORDER: ${{ matrix.order }}
         run: |
           set -uo pipefail
@@ -371,9 +345,10 @@ jobs:
         (github.event_name == 'workflow_dispatch' && inputs.discrimination)
       )
     needs:
-      - prepare-python-test-environment
       - python-package-suite
       - python-package-suite-discrimination
+    env:
+      SUITE_SHARD_COUNT: "32"
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
@@ -385,7 +360,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          count='${{ needs.prepare-python-test-environment.outputs.shard-count }}'
+          count="${{ env.SUITE_SHARD_COUNT }}"
           for order in canonical reversed shuffled; do
             python3 tools/python_package_suite_shard_attendance.py \
               --reports-dir runs \
@@ -406,7 +381,7 @@ jobs:
           from python_suite_discrimination import compare
 
           runs = Path("runs")
-          count = int("${{ needs.prepare-python-test-environment.outputs.shard-count }}")
+          count = int("${{ env.SUITE_SHARD_COUNT }}")
           by_order = {
               order: find_shard_reports(runs, order)
               for order in ("canonical", "reversed", "shuffled")


### PR DESCRIPTION
## Summary

- Removes `prepare-python-test-environment` as a gate on package-suite shards.
- That job built a full Python env and only exported the deterministic shard roster; every shard already re-runs `python-test-environment` and never consumed prepare's identity.
- Measured dead edge: **35–126s** on the suite critical path every push.
- Shard roster is static `matrix.shard: [0..31]` + `SUITE_SHARD_COUNT=32` (matches `tools/python_package_suite_shards.py` `SHARD_COUNT`). Shards start immediately.
- Enrollment roll call still requires all 32 attended — missing shard = UNMEASURED.
- No lease, no shared env artifact, no singleton report hub.

## Validation

- YAML job graph: suite has `needs=None`; attendance needs only `python-package-suite`.
- Structural check: 32 shards in matrix.

## Epsilon R

- Wall-clock serialization: recover prepare wait from suite CP (measured 35–126s).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `prepare-python-test-environment` job and replace dynamic shard matrix with static 32-shard list
> - Deletes the `prepare-python-test-environment` job from [python-package-suite.yml](.github/workflows/python-package-suite.yml), which previously generated shard count/matrix outputs and published a run summary.
> - Replaces all dynamic `needs.prepare-python-test-environment.outputs.*` references with a static shard list `[0..31]` and a hardcoded `SUITE_SHARD_COUNT: "32"` env var across all dependent jobs.
> - Shard jobs (`python-package-suite`, `python-package-suite-discrimination`, `discrimination-verdict`, `python-package-suite-attendance`) no longer wait on the prepare gate and can start immediately.
> - Behavioral Change: The run summary no longer includes the environment identity previously published by the prepare job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3490ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->