### PR TITLE
Showcase CI: shared wheelhouse + 4-shard enrollment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,8 +177,8 @@ jobs:
         with:
           subject-path: implementations/rust/target/release/sugar
 
-  # Showcase shards warm their own bins inside `make test-showcases`.
-  # Concurrent shards share the filesystem shelf; single-flight prevents stampede.
+  # ------------------------------------------------------------------
+  # claim-mass + python-format: N pins / N packages ⇒ N jobs + enrollment.
   # ------------------------------------------------------------------
   claim-mass-matrix:
     name: emit claim-mass pin matrix
@@ -370,8 +370,54 @@ jobs:
             --require-commit "$GITHUB_SHA" \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
+  # ------------------------------------------------------------------
+  # Showcases: shared wheelhouse + 4 shards + enrollment (#7020).
+  # One wheelhouse for third-party deps; 4 shards measure partitions;
+  # enrollment is existence (missing shard body = UNMEASURED).
+  # No needs: prepare — that job was deleted by #7021.
+  # Concurrent showcase shards still warm bins via make test-showcases;
+  # stamp-keyed single-flight covers multi-job cold miss.
+  # ------------------------------------------------------------------
+
+  showcase-prepare:
+    name: showcase env (shared wheelhouse)
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Build wheelhouse (one resolve for all shards)
+        shell: bash
+        run: |
+          set -euo pipefail
+          env_dir="$RUNNER_TEMP/showcase-wheelhouse"
+          rm -rf "$env_dir"
+          mkdir -p "$env_dir"
+          # Same package set every showcase shard used to install independently.
+          python -m pip wheel --quiet --wheel-dir "$env_dir" \
+            ./implementations/python/sugar-build-witness \
+            './implementations/python/sugar-lift-py-tests[test]' \
+            ./implementations/python/sugar-lift-python-source \
+            ./implementations/python/sugar-lift-py-pytest-witness
+          # Keep third-party wheels only. First-party installs from checkout
+          # paths so each shard measures this tip's tree.
+          shopt -s nullglob
+          rm -f "$env_dir"/sugar_*.whl
+          ls -la "$env_dir" | head -50
+      - name: Upload showcase wheelhouse
+        uses: actions/upload-artifact@v4
+        with:
+          name: showcase-wheelhouse
+          path: ${{ runner.temp }}/showcase-wheelhouse/
+          if-no-files-found: error
+
   showcases:
     name: showcases (${{ matrix.shard }}/4)
+    needs: [showcase-prepare]
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 180
     strategy:
@@ -390,12 +436,21 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-          cache: 'pip'
 
-      - name: Install lift package deps
-        # Sole dep authority: sugar-lift-py-tests[test] (pyproject.toml).
+      - name: Download shared wheelhouse
+        uses: actions/download-artifact@v4
+        with:
+          name: showcase-wheelhouse
+          path: ${{ runner.temp }}/showcase-wheelhouse
+
+      - name: Install Python deps from wheelhouse (no network resolve)
+        shell: bash
         run: |
+          set -euo pipefail
+          # Third-party from the prepared wheelhouse; first-party from checkout
+          # paths so the shard measures this tip's tree.
           python -m pip install --quiet \
+            --no-index --find-links "$RUNNER_TEMP/showcase-wheelhouse" \
             -e implementations/python/sugar-build-witness \
             -e 'implementations/python/sugar-lift-py-tests[test]' \
             -e implementations/python/sugar-lift-python-source \
@@ -407,7 +462,7 @@ jobs:
           distribution: temurin
           java-version: '21'
 
-      - name: Install system deps
+      - name: Install system deps (per-runner; apt no-op if already present)
         run: |
           tools/ci-apt-install.sh z3 cvc5 maven unzip b3sum
           if ! command -v vampire >/dev/null 2>&1; then
@@ -416,13 +471,68 @@ jobs:
             sudo install -m 0755 /tmp/vampire-bin/vampire /usr/local/bin/vampire
           fi
 
-      - name: Run showcase shard
-        run: make test-showcases
+      - name: Run showcase shard ${{ matrix.shard }}
+        id: shard
+        shell: bash
+        run: |
+          set -uo pipefail
+          set +e
+          make test-showcases
+          exit_code=$?
+          set -e
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          python3 - <<PY
+          import json, os
+          from pathlib import Path
+          body = {
+              "schemaVersion": 1,
+              "measurementClass": "test-showcases",
+              "shardIndex": int("${{ matrix.shard }}"),
+              "shardCount": 4,
+              "measuredCommit": os.environ.get("GITHUB_SHA"),
+              "status": "completed",
+              "exitCode": $exit_code,
+          }
+          Path("showcase-shard-body.json").write_text(
+              json.dumps(body, indent=2) + "\n", encoding="utf-8"
+          )
+          PY
+          exit "$exit_code"
         env:
           CI: '1'
           GH_TOKEN: ${{ github.token }}
           SHOWCASE_SHARD_COUNT: '4'
           SHOWCASE_SHARD_INDEX: ${{ matrix.shard }}
+
+      - name: Upload shard measurement body
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: showcase-shard-${{ matrix.shard }}
+          path: showcase-shard-body.json
+          if-no-files-found: error
+
+  showcase-attendance:
+    name: showcase enrollment (all shards)
+    if: always() && !cancelled()
+    needs: [showcase-prepare, showcases]
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: showcase-shard-*
+          path: runs
+      - name: Roll call — every showcase shard attended
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/showcase_shard_attendance.py \
+            --reports-dir runs \
+            --shard-count 4 \
+            --require-commit "$GITHUB_SHA" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
 
   acid-test:
     name: acid test (make ci)
@@ -435,7 +545,7 @@ jobs:
       - core-shelf
       - claim-mass-attendance
       - python-format-attendance
-      - showcases
+      - showcase-attendance
     runs-on: ubuntu-latest
     steps:
       - name: Report the complete acid-test vector
@@ -445,7 +555,7 @@ jobs:
           CORE_SHELF_RESULT: ${{ needs.core-shelf.result }}
           CLAIM_MASS_RESULT: ${{ needs.claim-mass-attendance.result }}
           FORMAT_RESULT: ${{ needs.python-format-attendance.result }}
-          SHOWCASE_RESULT: ${{ needs.showcases.result }}
+          SHOWCASE_RESULT: ${{ needs.showcase-attendance.result }}
         run: |
           echo "apt=$APT_RESULT core=$CORE_RESULT core-shelf=$CORE_SHELF_RESULT claim-mass=$CLAIM_MASS_RESULT format=$FORMAT_RESULT showcases=$SHOWCASE_RESULT"
           test "$APT_RESULT" = success

--- a/tests/test_showcase_shared_setup_enrollment.py
+++ b/tests/test_showcase_shared_setup_enrollment.py
@@ -1,0 +1,113 @@
+"""Teeth: showcase shared setup + per-shard enrollment (no merge hub)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CI = ROOT / ".github/workflows/ci.yml"
+ATTEND = ROOT / "tools/showcase_shard_attendance.py"
+
+
+def test_showcase_prepare_builds_one_wheelhouse_for_all_shards() -> None:
+    text = CI.read_text(encoding="utf-8")
+    assert "showcase-prepare" in text
+    assert "showcase-wheelhouse" in text
+    assert "pip wheel" in text
+    # Shards consume the artifact — not four independent network resolves of
+    # the same package set as the only install path.
+    assert "Download shared wheelhouse" in text
+    assert "--no-index --find-links" in text or "--find-links" in text
+
+
+def test_four_shards_remain_for_genuine_per_shard_work() -> None:
+    text = CI.read_text(encoding="utf-8")
+    assert "shard: [0, 1, 2, 3]" in text
+    assert "SHOWCASE_SHARD_INDEX" in text
+    assert "make test-showcases" in text
+
+
+def test_missing_showcase_shard_is_unmeasured(tmp_path: Path) -> None:
+    for i in range(3):
+        d = tmp_path / f"showcase-shard-{i}"
+        d.mkdir()
+        (d / "showcase-shard-body.json").write_text(
+            json.dumps(
+                {
+                    "measurementClass": "test-showcases",
+                    "shardIndex": i,
+                    "shardCount": 4,
+                    "measuredCommit": "abc",
+                    "exitCode": 0,
+                }
+            ),
+            encoding="utf-8",
+        )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ATTEND),
+            "--reports-dir",
+            str(tmp_path),
+            "--shard-count",
+            "4",
+            "--require-commit",
+            "abc",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode != 0
+    assert "shard-03" in proc.stdout or "UNMEASURED" in proc.stdout
+
+
+def test_full_showcase_roster_is_green(tmp_path: Path) -> None:
+    for i in range(4):
+        d = tmp_path / f"showcase-shard-{i}"
+        d.mkdir()
+        (d / "body.json").write_text(
+            json.dumps(
+                {
+                    "measurementClass": "test-showcases",
+                    "shardIndex": i,
+                    "shardCount": 4,
+                    "measuredCommit": "abc",
+                    "exitCode": 0,
+                }
+            ),
+            encoding="utf-8",
+        )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ATTEND),
+            "--reports-dir",
+            str(tmp_path),
+            "--shard-count",
+            "4",
+            "--require-commit",
+            "abc",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_acid_test_gates_on_enrollment_not_raw_matrix() -> None:
+    text = CI.read_text(encoding="utf-8")
+    # Post-#7021: no prepare job. Acid gates on enrollment, not the raw matrix.
+    acid = text.split("acid-test:")[1]
+    needs_block = acid.split("runs-on:")[0]
+    assert "showcase-attendance" in needs_block
+    assert "needs.showcase-attendance.result" in acid
+    assert "needs.showcases.result" not in acid
+    # Job-level needs must not reintroduce the deleted prepare job.
+    assert "- prepare" not in needs_block
+    assert "needs: prepare" not in needs_block
+    assert "needs: [prepare" not in needs_block

--- a/tools/showcase_shard_attendance.py
+++ b/tools/showcase_shard_attendance.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Enrollment roll call for showcase CI shards.
+
+Roster: shard-00 .. shard-(N-1) (default N=4).
+Attended: identity-bound body with measurementClass=test-showcases and
+matching shardIndex. Missing shard = UNMEASURED.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+DEFAULT_SHARD_COUNT = 4
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reports-dir", type=Path, required=True)
+    parser.add_argument("--shard-count", type=int, default=DEFAULT_SHARD_COUNT)
+    parser.add_argument("--require-commit", default=None)
+    args = parser.parse_args(argv)
+
+    roster = list(range(args.shard_count))
+    attended: dict[int, Path] = {}
+    if args.reports_dir.is_dir():
+        for path in sorted(args.reports_dir.rglob("*.json")):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            if payload.get("measurementClass") != "test-showcases":
+                continue
+            idx = payload.get("shardIndex")
+            if isinstance(idx, int):
+                attended.setdefault(idx, path)
+
+    missing = [i for i in roster if i not in attended]
+    crimes: list[str] = []
+    for idx, path in attended.items():
+        body = json.loads(path.read_text(encoding="utf-8"))
+        if args.require_commit and body.get("measuredCommit") not in (
+            None,
+            args.require_commit,
+        ):
+            crimes.append(
+                f"shard-{idx:02d}: measuredCommit {body.get('measuredCommit')!r} "
+                f"!= {args.require_commit!r}"
+            )
+            if idx not in missing:
+                missing.append(idx)
+        if body.get("exitCode") not in (0, "0"):
+            crimes.append(
+                f"shard-{idx:02d}: exitCode={body.get('exitCode')} (showcase red)"
+            )
+
+    print("### showcase shard enrollment")
+    print(f"- roster: `{args.shard_count}` shards")
+    print(f"- attended: `{len(attended)}`")
+    print(f"**R_showcase_shard_attendance = {len(set(missing))}**")
+    for i in roster:
+        spoke = "yes" if i in attended and i not in missing else "NO — UNMEASURED"
+        print(f"- `shard-{i:02d}`: {spoke}")
+    if missing or crimes:
+        for c in crimes:
+            print(f"::error::{c}", file=sys.stderr)
+        return 1
+    print("All showcase shards attended with exit 0.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Audit of the **showcases** matrix (same judgment style as #7012 / #7016).

### What is genuinely per-shard
`make test-showcases` with `SHOWCASE_SHARD_INDEX` / `COUNT=4` — ~54 `run.sh` scripts selected by ordinal. **Keep 4 jobs.**

### What was identical setup repeated ×4 (40–80s each)
Python + the same editable package install set. **One prepare job** builds a **wheelhouse artifact**; each shard installs `--no-index --find-links` from it (no network resolve/build).

### What stays on each shard (not a serial loop of showcases)
- `setup-java` (toolcache; different self-hosted machines)
- apt system deps / vampire (idempotent; pool may not share machines)

### Architecture
| | |
|--|--|
| Shared artifact | `showcase-wheelhouse` from `showcase-prepare` |
| Per-shard result | identity-bound `showcase-shard-body.json` |
| Completeness | `showcase-attendance` enrollment — missing shard = **UNMEASURED** |
| Merge hub | **none** |

### Out of scope
- `prepare` / `coretests_sweep` warm → **mr_orange** (do not duplicate)
- Replacing 4 showcase shards with 54 jobs → possible later; not required for the setup tax

### Teeth
`tests/test_showcase_shared_setup_enrollment.py` — 5 passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared wheelhouse and 4-shard enrollment check to showcase CI
> - Adds a `showcase-prepare` job that builds a shared third-party wheelhouse artifact once, so each showcase shard installs from it via `--no-index --find-links` instead of resolving dependencies online.
> - Each showcase shard now emits a JSON report artifact containing shard index, commit, status, and exit code.
> - Adds a `showcase-attendance` job that aggregates the per-shard reports via [showcase_shard_attendance.py](https://github.com/TSavo/sugar/pull/7020/files#diff-11c4e0af06b1155357b5c0e1689d5e96e1004d8ad10bc029945e1f9b2c4b8e59), failing if any of the 4 shards is missing, reports the wrong commit, or has a nonzero exit.
> - The `acid-test` job now gates on `showcase-attendance` rather than the raw `showcases` result.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5eba5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->