### PR TITLE
Delete shared Rust prepare gate; unhook light core from shelf warm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,15 @@
 #     explicitly, by driving those node IDs to zero and then wiring it here.
 #
 # No federation conformance gate; the Makefile is the contract.
+#
+# PREPARE SERIALIZATION (deleted): a `shared Rust build` job warmed the
+# sugarbin shelf (including `coretests_sweep`, consumed only by Makefile
+# coretests-invariants — off this matrix after #7006) and shelf consumers
+# `needs:`'d it. #7019 unhooked pure-Python core from that gate. This change
+# deletes the prepare JOB itself: self-attest and showcases already call
+# bin/sugarbin (consumer is warmer); stamp-keyed single-flight (#7014/#7017)
+# dedupes concurrent cold rebuilds. Do not reintroduce a job-level warm that
+# nothing requires as a gate.
 
 name: CI
 
@@ -51,45 +60,21 @@ permissions:
   id-token: write
 
 jobs:
-  prepare:
-    name: shared Rust build
+  # Tiny, independent. Was buried inside the deleted prepare job.
+  ci-apt-fast-path:
+    name: ci-apt installed-package fast path
     runs-on: [self-hosted, Linux, X64]
-    timeout-minutes: 180
-
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Set up Rust toolchain
-        uses: ./.github/actions/setup-rust-cache
-
       - name: Check apt installed-package fast path
         run: tools/test-ci-apt-install.sh
 
-      - name: Install sugarbin hashing dependency
-        run: tools/ci-apt-install.sh b3sum
-
-      # One door: bin/sugarbin. Content-addressed filesystem shelf.
-      # Same Rust inputs → shelf hit forever on this runner; only a source
-      # change (new stamp) rebuilds. No second cargo-target cache.
-      - name: Warm sugarbin shelf (build only on stamp miss)
-        run: |
-          set -euo pipefail
-          for b in sugar sugar-lift rust_test_assertions_rpc coretests_sweep; do
-            bin/sugarbin --profile release --bin "$b" >/dev/null
-          done
-          for b in sugar sugar-ir-smt-lib sugar-ir-lean sugar-ir-coq sugar-ir-maude sugar-walk-rpc rust_test_assertions_rpc witness_rpc discharge_cli; do
-            bin/sugarbin --profile debug --bin "$b" >/dev/null
-          done
-
-  # CONSUMERS of prepare (sugarbin shelf warm): self-attest, showcases.
-  # NON-CONSUMERS start immediately — pure Python / fmt checks that never
-  # invoke bin/sugarbin. Measured waste: fleet claim and refusal vocabulary
-  # finished in ~11s but waited 316–586s behind shared Rust prepare.
-
+  # Pure Python / fmt instruments. Never invoke bin/sugarbin.
+  # #7019 already removed needs: prepare; they start immediately.
   core:
     name: core (${{ matrix.name }})
-    # No needs: prepare. These targets do not consume the sugarbin shelf.
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 180
     strategy:
@@ -126,6 +111,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Rust toolchain
+        # cargo fmt needs a toolchain; not a sugar binary shelf warm.
+        if: matrix.target == 'check-lift-refusal-vocabulary'
         uses: ./.github/actions/setup-rust-cache
 
       - name: Check Rust formatting
@@ -162,17 +149,10 @@ jobs:
           CI: '1'
           GH_TOKEN: ${{ github.token }}
 
-      - name: Attest published sugar binary
-        if: matrix.target == 'self-attest' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-path: implementations/rust/target/release/sugar
-
-
+  # self-attest resolves sugar/sugar-lift via bin/sugarbin (consumer is warmer).
+  # No needs: prepare — single-flight covers multi-job cold miss.
   core-shelf:
     name: core (${{ matrix.name }})
-    # Consumes prepare: bin/sugarbin release sugar + sugar-lift for self-attest.
-    needs: prepare
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 180
     strategy:
@@ -208,9 +188,10 @@ jobs:
         with:
           subject-path: implementations/rust/target/release/sugar
 
+  # Showcase shards warm their own bins inside `make test-showcases`.
+  # Concurrent shards share the filesystem shelf; single-flight prevents stampede.
   showcases:
     name: showcases (${{ matrix.shard }}/4)
-    needs: prepare
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 180
     strategy:
@@ -268,18 +249,18 @@ jobs:
     # Aggregate genuine success/failure results, but do not manufacture a red
     # test result when concurrency intentionally supersedes the whole run.
     if: ${{ always() && !cancelled() }}
-    needs: [prepare, core, core-shelf, showcases]
+    needs: [ci-apt-fast-path, core, core-shelf, showcases]
     runs-on: ubuntu-latest
     steps:
       - name: Report the complete acid-test vector
         env:
-          PREPARE_RESULT: ${{ needs.prepare.result }}
+          APT_RESULT: ${{ needs.ci-apt-fast-path.result }}
           CORE_RESULT: ${{ needs.core.result }}
           CORE_SHELF_RESULT: ${{ needs.core-shelf.result }}
           SHOWCASE_RESULT: ${{ needs.showcases.result }}
         run: |
-          echo "prepare=$PREPARE_RESULT core=$CORE_RESULT core-shelf=$CORE_SHELF_RESULT showcases=$SHOWCASE_RESULT"
-          test "$PREPARE_RESULT" = success
+          echo "apt=$APT_RESULT core=$CORE_RESULT core-shelf=$CORE_SHELF_RESULT showcases=$SHOWCASE_RESULT"
+          test "$APT_RESULT" = success
           test "$CORE_RESULT" = success
           test "$CORE_SHELF_RESULT" = success
           test "$SHOWCASE_RESULT" = success

--- a/tests/ci_core_prepare_consumers.sh
+++ b/tests/ci_core_prepare_consumers.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# R_ci_prepare_dead_edge: after #7019 (light core unhooked), the remaining
+# defect is the prepare JOB itself and dead warms (coretests_sweep).
+# Live consumers self-warm via bin/sugarbin + single-flight.
+set -euo pipefail
+
+repo="${1:?usage: ci_core_prepare_consumers.sh REPO_ROOT}"
+ci="$repo/.github/workflows/ci.yml"
+[[ -f "$ci" ]] || { echo "missing $ci" >&2; exit 1; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Strip comments so narrative about the deleted edge does not fail the tooth.
+live="$(grep -vE '^\s*#' "$ci" || true)"
+
+# Dead warm: coretests_sweep only serves Makefile coretests-invariants.
+if grep -Eq 'coretests_sweep' <<<"$live"; then
+  fail 'ci.yml still warms or references coretests_sweep on the live path'
+fi
+
+# Shared prepare job and needs: edges must stay gone.
+if grep -Eq '^[[:space:]]+name: shared Rust build[[:space:]]*$' <<<"$live"; then
+  fail 'ci.yml reintroduced shared Rust prepare job'
+fi
+if grep -Eq '^[[:space:]]+needs:[[:space:]]*prepare[[:space:]]*$|^[[:space:]]+needs:[[:space:]]*\[prepare' <<<"$live"; then
+  fail 'ci.yml reintroduced needs: prepare serialization'
+fi
+
+# Light instruments still present and independent.
+for target in check-lift-refusal-vocabulary check-fleet-claim-contract \
+  test-python-format test-claim-mass-tripwires; do
+  grep -Fq "$target" "$ci" || fail "core matrix missing $target"
+done
+
+# Shelf consumers self-warm (no prepare gate).
+grep -Fq 'self-attest' "$ci" || fail 'self-attest missing'
+grep -Fq 'test-showcases' "$ci" || fail 'showcases missing'
+grep -Fq 'core-shelf' "$ci" || fail 'core-shelf job missing'
+
+echo 'PASS: R_ci_prepare_dead_edge — no prepare job, no dead warm, no needs:prepare'


### PR DESCRIPTION
## Delta on top of #7019 (rebased onto tip including #7024)

**Already on main (#7019):** light core matrix has **no** `needs: prepare` (refusal / fleet / format / claim-mass start immediately).

**What this PR still removes:**

| Item | Status on tip before this PR | This PR |
| --- | --- | --- |
| `prepare` job (`shared Rust build`) | **Still present** | **Deleted** |
| `coretests_sweep` warm | Still in prepare warm loop | **Gone with prepare** |
| `needs: prepare` on `core-shelf` (self-attest) | Still present | **Dropped** |
| `needs: prepare` on `showcases` | Still present | **Dropped** |
| apt fast-path | Buried inside prepare | **`ci-apt-fast-path` job** |
| acid-test needs vector | includes prepare | prepare removed |

Consumers already call `bin/sugarbin`; single-flight (#7014/#7017) covers concurrent cold miss. Deleting the gate beats scheduling around a warm nothing requires as a serialization point.

## PR accounting

| | |
| --- | --- |
| **R** | `R_ci_prepare_dead_edge` (prepare job + dead warm residual after #7019) |
| **εR** | prepare wall clock → 0; shelf consumers self-warm |
| **Floors** | no measurement mutex; single-flight unchanged |
| **Shell deleted** | shared prepare job + dead `coretests_sweep` CI warm |

## Coordination

#7016 / #7020 also touch CI topology and are rebasing. This branch only deletes prepare edges; claim-mass/format fan-out is #7016's lane.

## Teeth

`tests/ci_core_prepare_consumers.sh`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Delete shared Rust prepare gate and decouple `core-shelf` and `showcases` from it
> - Removes the shared `prepare` job from [ci.yml](.github/workflows/ci.yml) and replaces it with a lightweight `ci-apt-fast-path` job that only runs the apt installed-package fast path check (15-minute timeout, no Rust setup).
> - `core-shelf` and `showcases` no longer depend on `prepare`, so they start independently instead of serializing behind the shared Rust build.
> - The `core` job gates its Rust toolchain setup step so it only runs for the `check-lift-refusal-vocabulary` matrix target.
> - The `acid-test` aggregation job now depends on `ci-apt-fast-path` instead of `prepare` and validates `APT_RESULT` rather than `PREPARE_RESULT`.
> - Adds [tests/ci_core_prepare_consumers.sh](https://github.com/TSavo/sugar/pull/7021/files#diff-c9c634798803b6726889a4953f76dce3b08c2a9847b2a1186b6209e6e095ead9) to assert that the removed prepare job and `needs: prepare` edges are gone and that required jobs and matrix targets remain present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d952a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->