### PR TITLE
Seal RefusalDecidability: closed grounds with holds(world)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mapping_object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mapping_object_value.py
@@ -196,12 +196,28 @@ class MappingObjectValue(ObjectValue):
             _closed_member_equal(key, candidate) for candidate, _ in self.entries
         )
         if any(decision is None for decision in decisions):
+            from sugar_lift_py_tests.sealed_ground import (
+                KeyEqualityUndecided,
+                MappingKeyEqualityArtifact,
+            )
+
             construction_panic_gap(
                 owner="MappingObjectValue.get",
                 blame=blame,
-                observed="undecidable mapping key equality",
+                observed=(
+                    "undecidable mapping key equality: "
+                    f"key={type(key).__name__} over {type(self).__name__}"
+                ),
                 requested="one source-decided finite mapping key",
                 fix="construct key equality or keep get typed loud",
+                decidability=KeyEqualityUndecided(
+                    artifact=MappingKeyEqualityArtifact(
+                        key_type_name=type(key).__name__,
+                        mapping_type_name=type(self).__name__,
+                        site=str(blame),
+                    )
+                ),
+                world={"key_equality_undecided": True},
             )
         matching = tuple(index for index, decision in enumerate(decisions) if decision)
         if len(matching) > 1:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/gap/info.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/gap/info.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 from typing import Never, NoReturn
+
+if TYPE_CHECKING:
+    from sugar_lift_py_tests.sealed_ground import RefusalDecidability
 
 # ``owner`` is the panic board's DISPATCH KEY: every row is worked as
 # (owner × value category), so an owner that is not a name makes the row
@@ -92,8 +95,35 @@ class ConstructionGap:
     # this away once it decided pass/fail). Empty string when the producer
     # does not (yet) compute a callee resolution — never invented downstream.
     resolution_kind: str = ""
+    # Sealed RefusalDecidability (Criterion 3). Default kit-incomplete when
+    # omitted so legacy ConstructionGap(...) mints still carry a closed ground.
+    decidability: "RefusalDecidability | None" = None
 
     def __post_init__(self) -> None:
+        if self.decidability is None:
+            from sugar_lift_py_tests.sealed_ground import kit_incomplete
+
+            object.__setattr__(
+                self,
+                "decidability",
+                kit_incomplete(owner=self.owner, observed=self.observed),
+            )
+        else:
+            from sugar_lift_py_tests.sealed_ground import (
+                KitConstructionIncomplete,
+                is_refusal_decidability,
+                require_refusal_ground_holds,
+            )
+
+            if not is_refusal_decidability(self.decidability):
+                raise TypeError(
+                    "ConstructionGap.decidability must be RefusalDecidability: "
+                    f"shape={type(self.decidability).__name__}"
+                )
+            # Kit-incomplete always holds. Runtime grounds need world — checked
+            # only at construction_panic_gap(..., world=), not at bare rebuild.
+            if isinstance(self.decidability, KitConstructionIncomplete):
+                require_refusal_ground_holds(self.decidability, world=None)
         if not isinstance(self.gap_kind, GapKind):
             raise TypeError(
                 "ConstructionGap.gap_kind must be GapKind: owner=ConstructionGap "

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/gap/panic.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/gap/panic.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from typing import NoReturn
+from typing import Any, Mapping, NoReturn
+
+from sugar_lift_py_tests.sealed_ground import (
+    RefusalDecidability,
+    kit_incomplete,
+    require_refusal_ground_holds,
+)
 
 from .info import ConstructionGap, GapKind, GapLocus
 
@@ -53,22 +59,33 @@ def construction_panic_gap(
     fix: str,
     gap_kind: GapKind = GapKind.FLOOR,
     gap_locus: GapLocus = GapLocus.CONSTRUCTION,
+    decidability: RefusalDecidability | None = None,
+    world: Mapping[str, Any] | None = None,
 ) -> NoReturn:
     """Mouth for residual floor/temporal None arms.
 
     ``blame`` may be the one tree SourceFragment (RuntimeEffectSite) or prose.
     ConstructionGap.blame is prose: project at this boundary, nowhere earlier.
     Status/audit-row authority lives on construction testimony (#6029), not here.
+
+    ``decidability`` is a sealed RefusalDecidability ground (Criterion 3).
+    Omitted → ``KitConstructionIncomplete`` (OUR missing arm). Runtime-undecided
+    grounds require ``world`` and must ``holds(world)`` or the mint refuses as
+    over-decidable source.
     """
+    if decidability is None:
+        decidability = kit_incomplete(owner=owner, observed=observed)
+    require_refusal_ground_holds(decidability, world)
     prose = _blame_prose(blame)
     info = ConstructionGap(
         owner=owner,
         blame=prose,
-        observed=observed,
+        observed=observed if isinstance(observed, str) else repr(observed),
         requested=requested,
         fix=fix,
         gap_kind=gap_kind,
         gap_locus=gap_locus,
+        decidability=decidability,
     )
     construction_panic(info)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -1291,10 +1291,19 @@ def outcome_to_exitset(outcome) -> ExitSet:
         ).normalize()
 
     if isinstance(outcome, NativeOperationExitCarrierV1):
+        from sugar_lift_py_tests.sealed_ground import (
+            FormalDemandArtifact,
+            FormalDemandUndischarged,
+        )
+
         construction_panic_gap(
             owner="outcome_to_exitset",
             blame=outcome.demand.source_node,
-            observed="undischarged native operation demand",
+            observed=(
+                "undischarged native operation demand: "
+                f"{type(outcome).__name__} demand="
+                f"{type(outcome.demand).__name__}"
+            ),
             requested=(
                 "an ExitSet projected from authenticated caller actual operands"
             ),
@@ -1303,6 +1312,14 @@ def outcome_to_exitset(outcome) -> ExitSet:
                 "absence of a halted edge as normal completion"
             ),
             gap_kind=GapKind.FLOOR,
+            decidability=FormalDemandUndischarged(
+                artifact=FormalDemandArtifact(
+                    carrier_type_name=type(outcome).__name__,
+                    demand_type_name=type(outcome.demand).__name__,
+                    site=str(outcome.demand.source_node),
+                )
+            ),
+            world={"formal_demand_undischarged": True},
         )
 
     construction_panic_gap(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sealed_ground.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sealed_ground.py
@@ -1,0 +1,214 @@
+"""Sealed grounds — closed 'why this could not be decided' (no free-text exemption).
+
+Shared shell for:
+  - **RefusalDecidability** — named refusals / construction panics (this module)
+  - **NotVerdictBearing** (mr_white) — same idea: replace ``reason: str`` with a
+    closed ground that ``holds(world)``. Opt-out kinds land here as siblings
+    later; do not invent a second vocabulary.
+
+Law (Criterion 3 axis 2):
+  A refusal is final only when its ground ``holds(world)``.
+  ``R_refusals_over_decidable_source`` = count of mints where the ground does
+  not hold — a MEASUREMENT, not a static guess.
+
+  Pure re-attempt-and-see without a sealed ground is ill-defined and forbidden:
+  success does not prove the refused path was wrong.
+
+Not the board.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Union
+
+# ---------------------------------------------------------------------------
+# Artifacts — what is invisible / incomplete (typed payload, not prose alone)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FloorRuntimeTypeArtifact:
+    """Receiver/operand runtime type not source-decided."""
+
+    floor_type_name: str
+    site: str | None = None
+
+
+@dataclass(frozen=True)
+class MappingKeyEqualityArtifact:
+    """Whether a key equals a stored mapping key is undecided."""
+
+    key_type_name: str
+    mapping_type_name: str
+    site: str | None = None
+
+
+@dataclass(frozen=True)
+class FormalDemandArtifact:
+    """Native-operation demand still undischarged at a boundary."""
+
+    carrier_type_name: str
+    demand_type_name: str
+    site: str | None = None
+
+
+@dataclass(frozen=True)
+class ObligationCoordinateArtifact:
+    """Two unequal obligations claim the same source-call coordinate."""
+
+    coordinate: str
+    existing_type_name: str
+    new_type_name: str
+
+
+@dataclass(frozen=True)
+class KitIncompleteArtifact:
+    """OUR missing match arm / law — construction incomplete, not runtime undecidable."""
+
+    owner: str
+    observed_shape: str
+
+
+# ---------------------------------------------------------------------------
+# RefusalDecidability — closed set (extend only with a floor move)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RuntimeTypeUndecided:
+    """Source has not decided the floor's runtime type; neither edge is honest."""
+
+    artifact: FloorRuntimeTypeArtifact
+
+    def holds(self, world: Mapping[str, Any] | None = None) -> bool:
+        if world is None or "runtime_type_is_decided" not in world:
+            raise TypeError(
+                "RuntimeTypeUndecided.holds requires world["
+                "'runtime_type_is_decided']=bool at mint"
+            )
+        return not bool(world["runtime_type_is_decided"])
+
+
+@dataclass(frozen=True)
+class KeyEqualityUndecided:
+    """At least one mapping-key equality probe returned undecided (None)."""
+
+    artifact: MappingKeyEqualityArtifact
+
+    def holds(self, world: Mapping[str, Any] | None = None) -> bool:
+        if world is None or "key_equality_undecided" not in world:
+            raise TypeError(
+                "KeyEqualityUndecided.holds requires world["
+                "'key_equality_undecided']=bool at mint"
+            )
+        return bool(world["key_equality_undecided"])
+
+
+@dataclass(frozen=True)
+class FormalDemandUndischarged:
+    """Carrier still holds undischarged formal demand at exit-set boundary."""
+
+    artifact: FormalDemandArtifact
+
+    def holds(self, world: Mapping[str, Any] | None = None) -> bool:
+        if world is None or "formal_demand_undischarged" not in world:
+            raise TypeError(
+                "FormalDemandUndischarged.holds requires world["
+                "'formal_demand_undischarged']=bool at mint"
+            )
+        return bool(world["formal_demand_undischarged"])
+
+
+@dataclass(frozen=True)
+class ConflictingObligation:
+    """Existing opaque obligation disagrees with the new one at a coordinate."""
+
+    artifact: ObligationCoordinateArtifact
+
+    def holds(self, world: Mapping[str, Any] | None = None) -> bool:
+        if world is None or "obligations_conflict" not in world:
+            raise TypeError(
+                "ConflictingObligation.holds requires world["
+                "'obligations_conflict']=bool at mint"
+            )
+        return bool(world["obligations_conflict"])
+
+
+@dataclass(frozen=True)
+class KitConstructionIncomplete:
+    """Legal construction panic: OUR incomplete sugar/floor arm.
+
+    ``holds`` is always True — the incompleteness is the kit, not a false
+    claim that source was undecidable. Distinct from runtime-undecided grounds.
+    """
+
+    artifact: KitIncompleteArtifact
+
+    def holds(self, world: Mapping[str, Any] | None = None) -> bool:
+        del world
+        return True
+
+
+RefusalDecidability = Union[
+    RuntimeTypeUndecided,
+    KeyEqualityUndecided,
+    FormalDemandUndischarged,
+    ConflictingObligation,
+    KitConstructionIncomplete,
+]
+
+_REFUSAL_KINDS = (
+    RuntimeTypeUndecided,
+    KeyEqualityUndecided,
+    FormalDemandUndischarged,
+    ConflictingObligation,
+    KitConstructionIncomplete,
+)
+
+
+def is_refusal_decidability(value: object) -> bool:
+    return isinstance(value, _REFUSAL_KINDS)
+
+
+def kit_incomplete(*, owner: str, observed: object) -> KitConstructionIncomplete:
+    """One door for ordinary construction-panic sites (OUR missing arm)."""
+    return KitConstructionIncomplete(
+        artifact=KitIncompleteArtifact(
+            owner=owner,
+            observed_shape=observed if isinstance(observed, str) else repr(observed),
+        )
+    )
+
+
+def require_refusal_ground_holds(
+    decidability: RefusalDecidability,
+    world: Mapping[str, Any] | None = None,
+) -> None:
+    """Mint door: sealed ground must hold, or the refusal is over-decidable.
+
+    - ``KitConstructionIncomplete``: always holds (no world).
+    - Runtime grounds: require ``world`` and ``holds(world) is True``.
+    - Free-text / unknown types: TypeError (unconstructible).
+    """
+    if not is_refusal_decidability(decidability):
+        raise TypeError(
+            "RefusalDecidability must be a closed sealed ground: "
+            f"observed={type(decidability).__name__} "
+            "replacement=RuntimeTypeUndecided | KeyEqualityUndecided | "
+            "FormalDemandUndischarged | ConflictingObligation | "
+            "KitConstructionIncomplete"
+        )
+    if isinstance(decidability, KitConstructionIncomplete):
+        return
+    if world is None:
+        raise TypeError(
+            f"{type(decidability).__name__} mint requires world= for holds(); "
+            "kit-incomplete sites use KitConstructionIncomplete instead"
+        )
+    if not decidability.holds(world):
+        raise TypeError(
+            "RefusalDecidability ground does not hold — refused over decidable "
+            f"source. ground={type(decidability).__name__} "
+            "replacement=construct the value, or mint only when holds(world)"
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_result_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_result_sugar.py
@@ -68,12 +68,28 @@ class MappingPopResultSugar(ConstructedTermSugar):
         entries = receiver.mapping_entries()
         decisions = tuple(_closed_member_equal(key, candidate) for candidate, _ in entries)
         if any(decision is None for decision in decisions):
+            from sugar_lift_py_tests.sealed_ground import (
+                KeyEqualityUndecided,
+                MappingKeyEqualityArtifact,
+            )
+
             construction_panic_gap(
                 owner="MappingPopResultSugar",
                 blame=self.site,
-                observed="undecidable mapping key equality",
+                observed=(
+                    "undecidable mapping key equality: "
+                    f"key={type(key).__name__} over {type(receiver).__name__}"
+                ),
                 requested="one source-decided finite mapping key",
                 fix="construct key equality or keep pop typed loud",
+                decidability=KeyEqualityUndecided(
+                    artifact=MappingKeyEqualityArtifact(
+                        key_type_name=type(key).__name__,
+                        mapping_type_name=type(receiver).__name__,
+                        site=str(self.site),
+                    )
+                ),
+                world={"key_equality_undecided": True},
             )
         matches = tuple(index for index, decision in enumerate(decisions) if decision)
         if len(matches) > 1:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_state_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_state_sugar.py
@@ -69,12 +69,28 @@ class MappingPopStateSugar(ConstructedTermSugar):
         entries = receiver.mapping_entries()
         decisions = tuple(_closed_member_equal(key, candidate) for candidate, _ in entries)
         if any(decision is None for decision in decisions):
+            from sugar_lift_py_tests.sealed_ground import (
+                KeyEqualityUndecided,
+                MappingKeyEqualityArtifact,
+            )
+
             construction_panic_gap(
                 owner="MappingPopStateSugar",
                 blame=self.site,
-                observed="undecidable mapping key equality",
+                observed=(
+                    "undecidable mapping key equality: "
+                    f"key={type(key).__name__} over {type(receiver).__name__}"
+                ),
                 requested="one source-decided finite mapping key",
                 fix="construct key equality or keep pop typed loud",
+                decidability=KeyEqualityUndecided(
+                    artifact=MappingKeyEqualityArtifact(
+                        key_type_name=type(key).__name__,
+                        mapping_type_name=type(receiver).__name__,
+                        site=str(self.site),
+                    )
+                ),
+                world={"key_equality_undecided": True},
             )
         matching = tuple(index for index, decision in enumerate(decisions) if decision)
         if len(matching) > 1:

--- a/implementations/python/sugar-lift-py-tests/tests/test_sealed_ground_refusal_decidability.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sealed_ground_refusal_decidability.py
@@ -1,0 +1,112 @@
+"""Teeth for RefusalDecidability sealed grounds (Criterion 3 axis-2 unblock)."""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
+from sugar_lift_py_tests.gap.panic import construction_panic_gap, ConstructionPanic
+from sugar_lift_py_tests.sealed_ground import (
+    FloorRuntimeTypeArtifact,
+    FormalDemandArtifact,
+    FormalDemandUndischarged,
+    KeyEqualityUndecided,
+    KitConstructionIncomplete,
+    KitIncompleteArtifact,
+    MappingKeyEqualityArtifact,
+    RuntimeTypeUndecided,
+    is_refusal_decidability,
+    kit_incomplete,
+    require_refusal_ground_holds,
+)
+
+
+def test_kit_incomplete_always_holds() -> None:
+    ground = kit_incomplete(owner="Owner", observed="shape")
+    assert isinstance(ground, KitConstructionIncomplete)
+    assert ground.holds() is True
+    assert ground.holds({}) is True
+    require_refusal_ground_holds(ground)
+
+
+def test_runtime_type_undecided_holds_only_when_undecided() -> None:
+    ground = RuntimeTypeUndecided(
+        artifact=FloorRuntimeTypeArtifact(floor_type_name="SymbolicValue")
+    )
+    assert ground.holds({"runtime_type_is_decided": False}) is True
+    assert ground.holds({"runtime_type_is_decided": True}) is False
+    require_refusal_ground_holds(ground, {"runtime_type_is_decided": False})
+    with pytest.raises(TypeError, match="does not hold"):
+        require_refusal_ground_holds(ground, {"runtime_type_is_decided": True})
+
+
+def test_runtime_ground_requires_world_at_mint() -> None:
+    ground = RuntimeTypeUndecided(
+        artifact=FloorRuntimeTypeArtifact(floor_type_name="X")
+    )
+    with pytest.raises(TypeError, match="requires world"):
+        require_refusal_ground_holds(ground, world=None)
+
+
+def test_free_text_is_not_a_ground() -> None:
+    assert is_refusal_decidability("undecidable") is False
+    with pytest.raises(TypeError, match="closed sealed ground"):
+        require_refusal_ground_holds("undecidable")  # type: ignore[arg-type]
+
+
+def test_construction_gap_defaults_to_kit_incomplete() -> None:
+    gap = ConstructionGap(
+        owner="law",
+        blame="b.py:1:0",
+        observed="missing arm",
+        requested="floor",
+        fix="write more Floor",
+        gap_kind=GapKind.FLOOR,
+        gap_locus=GapLocus.CONSTRUCTION,
+    )
+    assert isinstance(gap.decidability, KitConstructionIncomplete)
+    assert gap.decidability.artifact.owner == "law"
+
+
+def test_construction_panic_gap_refuses_over_decidable_source() -> None:
+    ground = KeyEqualityUndecided(
+        artifact=MappingKeyEqualityArtifact(
+            key_type_name="TermValue",
+            mapping_type_name="DictValue",
+        )
+    )
+    with pytest.raises(TypeError, match="does not hold"):
+        construction_panic_gap(
+            owner="test",
+            blame="t.py:1:0",
+            observed="key eq",
+            requested="decided",
+            fix="construct",
+            decidability=ground,
+            world={"key_equality_undecided": False},
+        )
+
+
+def test_construction_panic_gap_defaults_sealed_and_raises_panic() -> None:
+    with pytest.raises(ConstructionPanic):
+        construction_panic_gap(
+            owner="test",
+            blame="t.py:1:0",
+            observed="no arm",
+            requested="arm",
+            fix="write",
+        )
+
+
+def test_formal_demand_ground() -> None:
+    ground = FormalDemandUndischarged(
+        artifact=FormalDemandArtifact(
+            carrier_type_name="NativeOperationExitCarrierV1",
+            demand_type_name="Demand",
+        )
+    )
+    assert ground.holds({"formal_demand_undischarged": True})
+    with pytest.raises(TypeError, match="does not hold"):
+        require_refusal_ground_holds(
+            ground, {"formal_demand_undischarged": False}
+        )


### PR DESCRIPTION
## Summary

Criterion 3 axis 2 (`R_refusals_over_decidable_source`) cannot be a measurement until refusals carry a **checkable** ground. Free-text `observed` / `reason: str` is an exemption nobody can audit — same shape as **NotVerdictBearing.reason:str** (mr_white).

This PR lands the **seal only** (not the CA measurement pass).

### `sugar_lift_py_tests.sealed_ground`

Closed `RefusalDecidability` set:

| Ground | `holds(world)` |
|--------|----------------|
| `RuntimeTypeUndecided` | `not world['runtime_type_is_decided']` |
| `KeyEqualityUndecided` | `world['key_equality_undecided']` |
| `FormalDemandUndischarged` | `world['formal_demand_undischarged']` |
| `ConflictingObligation` | `world['obligations_conflict']` |
| `KitConstructionIncomplete` | always `True` (OUR missing arm) |

Mint door: `require_refusal_ground_holds` — ground that does not hold → `TypeError` (**refused over decidable source**). Free-text is not a ground.

Shared shell for mr_white NVB climb: same module, domain-specific kinds later as siblings — **one vocabulary**.

### Wiring

- `construction_panic_gap(..., decidability=, world=)` — default `KitConstructionIncomplete`
- `ConstructionGap.decidability` always set
- Example runtime grounds: mapping key-equality (3 sites), undischarged native demand (`exit_set`)

### Explicitly not in this PR

- Measurement pass counting `not holds` over a corpus (follow-on; cacheable tip×fileCid×site×ground)
- Full `SugarNotWritten` climb (source-tree; next)
- Merge of #6988 (advisor-held)

### Negative case preserved

Pure re-attempt-and-see without sealed ground remains **ill-defined** and is not offered as a path.

### Shot accounting

| | |
|--|--|
| R axis | RefusalDecidability seal (axis2 unblock) |
| Epsilon R | unsealed panic_gap mouth → sealed ground |
| Floors | no false green via free-text exemption |
| Shell deleted | construction_panic_gap without closed ground |

### Validation

Sealed-ground teeth (importlib): kit incomplete, over-decidable refuse, free-text refuse, ConstructionGap default, panic default.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seal `RefusalDecidability` with structured ground types and `holds(world)` validation
> - Introduces a set of sealed-ground dataclasses (`KitConstructionIncomplete`, `KeyEqualityUndecided`, `FormalDemandUndischarged`, `ConflictingObligation`, `RuntimeTypeUndecided`) in [`sealed_ground.py`](https://github.com/TSavo/sugar/pull/7022/files#diff-c487dc78e65c7d85136d425ff790f8d7aaab5c711756a3be4eaff85e67451e17), each with a `holds(world)` method that validates against a provided world mapping.
> - Extends `construction_panic_gap` to accept `decidability` and `world` parameters; defaults to `KitConstructionIncomplete` when not provided and calls `require_refusal_ground_holds` to assert the ground holds before constructing the panic.
> - Updates `ConstructionGap` to require and validate a `RefusalDecidability` on construction, defaulting to `KitConstructionIncomplete` and asserting it holds.
> - Updates undecidable key-equality paths in mapping floor/sugar and the `NativeOperationExitCarrierV1` branch in exit-set to pass structured `decidability` and `world` arguments.
> - Risk: `construction_panic_gap` now raises `TypeError` if the provided ground does not hold for the given world, changing behavior for callers that pass mismatched decidability/world pairs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c297815.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->