### PR TITLE
Scoreboard: shape CID from pin population; vocab tooth 41

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -253,10 +253,13 @@ def _with_census_partition(
     from sugar_source_tree.panic import WithConstructionGapKind
 
     vocabulary = tuple(member.value for member in WithConstructionGapKind)
-    if len(vocabulary) != 39:
+    # ENTER_MAY_HALT / EXIT_MAY_HALT are source-derived resource lifecycle
+    # gaps, added with the generator-backed resource contract. Keep the exact
+    # cardinality tooth current; do not replace it with an open-ended bucket.
+    if len(vocabulary) != 41:
         raise ValueError(
             "WithConstructionGapKind vocabulary changed: "
-            f"expected 39 members, found {len(vocabulary)}"
+            f"expected 41 members, found {len(vocabulary)}"
         )
     allowed = {"derived-contract", *(f"gap:{kind}" for kind in vocabulary)}
     unexpected = sorted(set(cm_resolutions) - allowed)
@@ -693,7 +696,13 @@ def main() -> int:
         require_pin,
         write_pin,
     )
-    from sugar_lift_py_tests.authenticated_pytest import corpus_manifest_cid
+    # Path-shape CID only (relative path names). Content authentication is the
+    # pin aggregate. Do NOT call demand_table_identity.corpus_manifest_cid here:
+    # that is the content manifest (root, abs paths) -> (blake3, count), a
+    # different preimage than the enrolled shape axis a223.... Paths MUST come
+    # from the pin's enrolled population — the same door as pin_corpus /
+    # SourceTree — never a re-walk or guessed alternate set.
+    from pandas_floor_summary import corpus_cid as corpus_manifest_shape_cid
     from sugar_source_tree.tree import SourceTree
 
     # Pin FIRST. A run that cannot name its corpus has no denominator, and a
@@ -706,9 +715,9 @@ def main() -> int:
         )
         if args.require_corpus_pin is not None:
             require_pin(load_pin(args.require_corpus_pin), observed_pin)
-        manifest_shape_cid = corpus_manifest_cid(
-            [entry.path for entry in observed_pin.files]
-        )
+        # Same door as "recensus population: authenticated … at …": pin.files
+        # is the authenticated corpus population already resolved above.
+        manifest_shape_cid = corpus_manifest_shape_cid(list(observed_pin.paths))
         _authenticate_declared_pandas_corpus(observed_pin, manifest_shape_cid)
     except CorpusPinDefect as defect:
         print(str(defect), file=sys.stderr, flush=True)

--- a/implementations/python/sugar-lift-py-tests/tests/test_control_effect_with_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_control_effect_with_census.py
@@ -37,7 +37,7 @@ def test_with_census_emits_the_complete_closed_vocabulary_and_conserves():
         member.value for member in WithConstructionGapKind
     )
     assert partition["typed_gap_kinds_total"] == len(WithConstructionGapKind)
-    assert partition["typed_gap_kinds_total"] == 39
+    assert partition["typed_gap_kinds_total"] == 41
     assert partition["accounted"] == partition["with_items_total"] == 10
     assert partition["unrecognized_resolution_kinds"] == {}
     assert partition["reconciliation"] == "10 = 2 constructed + 8 typed gaps"
@@ -173,3 +173,38 @@ def test_shape_drift_is_a_separately_named_refusal():
             SimpleNamespace(aggregate_hash=module._PANDAS_3_0_3_AGGREGATE_HASH),
             "sha256:" + "0" * 64,
         )
+
+
+def test_manifest_shape_cid_uses_pin_population_same_door(tmp_path):
+    """Shape CID binds the pin's enrolled paths — not a re-walk or content API.
+
+    The TypeError at recensus was the instrument speaking once enrollment
+    existed: corpus_manifest_cid is the content door (root, abs paths) ->
+    (blake3, count). The shape axis is path names only, over the same
+    population pin_corpus already authenticated.
+    """
+    scripts = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    from pandas_floor_summary import corpus_cid
+    from sugar_lift_py_tests.corpus_pin import pin_corpus
+
+    root = tmp_path / "pkg"
+    root.mkdir()
+    (root / "a.py").write_text("x = 1\n", encoding="utf-8")
+    (root / "b.py").write_text("y = 2\n", encoding="utf-8")
+    observed = pin_corpus(root, distribution="pkg", version="test-pin")
+
+    # Same door: pin.paths is the authenticated population.
+    assert corpus_cid(list(observed.paths)) == corpus_cid(
+        [entry.path for entry in observed.files]
+    )
+    # Content API has a different arity and preimage — must not be the shape door.
+    from sugar_lift_py_tests.demand_table_identity import corpus_manifest_cid
+
+    content_cid, count = corpus_manifest_cid(
+        root, [root / p for p in observed.paths]
+    )
+    assert count == len(observed.paths) == 2
+    assert content_cid != corpus_cid(list(observed.paths))
+    assert not content_cid.startswith("sha256:a223")

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_bounded_run_equivalence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_bounded_run_equivalence.py
@@ -56,6 +56,24 @@ class Completed:
 
 def _invoke(argv: list[str], capsys=None) -> Completed:
     module = _recensus()
+    if (
+        "--corpus-root" in argv
+        and "--corpus-version" in argv
+        and argv[argv.index("--corpus-version") + 1] == "test-pin"
+    ):
+        # These teeth exercise bounded/full-root equivalence, not the one
+        # production pandas pin. Keep the authentication door live by deriving
+        # its two expected identities from this test's enrolled corpus instead
+        # of bypassing or monkeypatching the door away.
+        from pandas_floor_summary import corpus_cid
+        from sugar_lift_py_tests.corpus_pin import pin_corpus
+
+        root = Path(argv[argv.index("--corpus-root") + 1]).resolve()
+        observed = pin_corpus(
+            root, distribution=root.name, version="test-pin"
+        )
+        module._PANDAS_3_0_3_AGGREGATE_HASH = observed.aggregate_hash
+        module._PANDAS_3_0_3_MANIFEST_SHAPE_CID = corpus_cid(list(observed.paths))
     saved = sys.argv
     sys.argv = ["control_effect_recensus.py", *argv]
     try:


### PR DESCRIPTION
## Summary

Unblocks the authoritative scoreboard re-fire. Advisor constraints applied:

1. **Same door.** `manifestShapeCid` is computed with `pandas_floor_summary.corpus_cid` over `list(observed_pin.paths)` — the authenticated corpus population `pin_corpus` already resolved. Not a re-walk, not a hard-coded alternate, not `demand_table_identity.corpus_manifest_cid` (content preimage: `(root, abs paths) → (blake3, count)`).
2. **Stack, not first landmine.** Census of `corpus_manifest_cid` / related shape callers in this script family, and fix of the second preflight landmine (`WithConstructionGapKind` cardinality 39→41).

The TypeError was not a setback: *Broken: the enrolled authority SPEAKS and reds.* Enrollment made the crash possible; silence before was unscheduled.

## Stale-caller stack

| Site | Role | Status |
| --- | --- | --- |
| `control_effect_recensus.py` preflight | shape axis (a223…) | **Fixed** — was only production call with content-API arity |
| `authenticated_pytest.authenticate_corpus_manifest` | content CID | Already correct `(root, paths)` |
| `demand_table_identity.demand_table_identity` | content key | Already correct internal |
| `pandas_floor_summary.corpus_cid` / `pandas_census_checkpoint` | path-shape | Already correct; recensus now shares this door |
| tests of content aliases / historical a223 refuse | membranes | Already correct (a223 is not a content alias) |

**Related script drift (same re-fire path):** vocabulary tooth 39→41 (ENTER_MAY_HALT / EXIT_MAY_HALT / … live enum has 41). Without this, auth greens then partition reds.

**Named residual (UNMEASURED, not a landmine for pandas re-fire):** `_authenticate_declared_pandas_corpus` always compares to hard-coded pandas 3.0.3 aggregate+shape constants; non-production pins (test harness) rewrite the module constants rather than gating auth on distribution. Production recensus of declared pandas is unaffected.

## Done-when (unchanged — user re-fires once after merge)

Board artifact with commit + sourceStamp and readable `R_construction_panics` with denominator fields, on the tip. Advisor judges.

## Validation

Direct in-process checks (pytest runner SIGTERM’d in this environment; logic exercised):

- partition vocabulary total = 41
- shape CID from pin.paths ≠ content `corpus_manifest_cid` over same files
- wrong-pin refuse exit 2 before source selection
- test-pin with rewritten constants produces board JSON including `R_construction_panics`

## Shot accounting

- **R component:** scoreboard preflight / enrollment integrity (not a product construction axis)
- **Epsilon R:** TypeError + vocab ValueError → green preflight
- **Floors:** no secret, no silent swallow of auth, no deleted test without replacement tooth

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive scoreboard manifest shape CID from pin population and expand `WithConstructionGapKind` vocab to 41
> - Switches manifest shape CID computation in `control_effect_recensus.main` from a content-manifest function to `corpus_manifest_shape_cid` (via `pandas_floor_summary.corpus_cid`) over `observed_pin.paths`.
> - Expands the closed-vocabulary size check for `WithConstructionGapKind` from 39 to 41, reflecting two new gap kinds, and updates the associated error message.
> - Updates the test suite to expect `typed_gap_kinds_total == 41` and adds a new test verifying that shape CID uses the pin population door and differs from the content-manifest CID.
> - The `_invoke` helper in [test_recensus_bounded_run_equivalence.py](https://github.com/TSavo/sugar/pull/7025/files#diff-d26adb83d69a12172a3bf21fbceb2790ca9444d80530a170012f532e9f910ef7) now derives authentication identities from the test pin's enrolled corpus when a test pin is detected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a78d18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->