### PR TITLE
Name supervised-enum context refusal; separate init budget from file lift

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
@@ -19,12 +19,19 @@ import os
 import signal
 import subprocess
 import sys
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator, Mapping, Sequence
 
 _WORKER = Path(__file__).resolve().parent / "_supervised_enum_worker.py"
+
+# Context init walks the full corpus for provisional demand rows when no
+# shared demand table is supplied. Authenticated pandas (~1421 files) is
+# multi-minute work — never share the 30s per-file lift timeout.
+# Floors run 30728650857: POPULATION → refused: None at ~30.0s exactly.
+_DEFAULT_CONTEXT_INIT_TIMEOUT = 1800.0
 
 
 @dataclass(frozen=True)
@@ -40,11 +47,36 @@ class FileTerminal:
     worker_restarts: int
 
 
+def _named_lift_error_tail(response: Mapping[str, Any]) -> str:
+    """Serialize lift-error without 'None: None' (criterion-3 nameless refusal)."""
+    error_type = response.get("error_type")
+    message = response.get("message")
+    if error_type is None and message is None:
+        return (
+            "lift-error with no error_type and no message; "
+            f"worker response keys={sorted(response)!r}; "
+            "coordinate=supervised-enum-supervisor.lift-error"
+        )
+    if error_type is None:
+        return (
+            "lift-error missing error_type; "
+            f"message={message!r}; "
+            "coordinate=supervised-enum-supervisor.lift-error"
+        )
+    if message is None:
+        return (
+            f"{error_type}: (message field absent); "
+            "coordinate=supervised-enum-supervisor.lift-error"
+        )
+    return f"{error_type}: {message}"
+
+
 class SupervisedEnumSupervisor:
     def __init__(
         self,
         *,
         file_timeout: float = 30.0,
+        context_init_timeout: float = _DEFAULT_CONTEXT_INIT_TIMEOUT,
         python: str | None = None,
         env: Mapping[str, str] | None = None,
         corpus_root: Path,
@@ -53,7 +85,10 @@ class SupervisedEnumSupervisor:
     ) -> None:
         if file_timeout > 30:
             raise ValueError("per-file timeout may not exceed 30 seconds")
+        if context_init_timeout <= 0:
+            raise ValueError("context_init_timeout must be positive")
         self.file_timeout = float(file_timeout)
+        self.context_init_timeout = float(context_init_timeout)
         self.python = python or sys.executable
         self.env = dict(env or os.environ)
         self.env.setdefault("PYTHONFAULTHANDLER", "1")
@@ -65,10 +100,100 @@ class SupervisedEnumSupervisor:
         self._proc: subprocess.Popen[str] | None = None
         self.worker_restarts = 0
         self._current_file: str | None = None
+        self._stderr_chunks: list[str] = []
+        self._stderr_thread: threading.Thread | None = None
 
     @property
     def current_file(self) -> str | None:
         return self._current_file
+
+    def _start_stderr_drain(self) -> None:
+        """Drain worker stderr so a full pipe cannot deadlock the lift."""
+        proc = self._proc
+        if proc is None or proc.stderr is None:
+            return
+        self._stderr_chunks = []
+
+        def _drain() -> None:
+            try:
+                assert proc.stderr is not None
+                for line in proc.stderr:
+                    self._stderr_chunks.append(line)
+            except Exception:  # noqa: BLE001
+                return
+
+        self._stderr_thread = threading.Thread(
+            target=_drain, name="supervised-enum-stderr", daemon=True
+        )
+        self._stderr_thread.start()
+
+    def _worker_stderr_tail(self, *, limit: int = 2000) -> str:
+        text = "".join(self._stderr_chunks)
+        return text[-limit:] if text else ""
+
+    def _named_context_init_failure(
+        self,
+        *,
+        response: Mapping[str, Any] | None,
+        last_progress: Mapping[str, Any] | None,
+        elapsed: float,
+        timed_out: bool,
+    ) -> RuntimeError:
+        """Refusal that names the artifact — never 'refused: None'."""
+        proc = self._proc
+        rc = proc.poll() if proc is not None else None
+        stderr_tail = self._worker_stderr_tail()
+        demand = (
+            str(self.demand_table_path) if self.demand_table_path is not None else None
+        )
+        parts = [
+            "supervised enum worker context initialization refused",
+            "coordinate=supervised-enum-worker.construction-context",
+            f"corpus_root={self.corpus_root}",
+            f"demand_table_path={demand!r}",
+            f"allow_local_demand_derivation={self.allow_local_demand_derivation}",
+            f"context_init_timeout_s={self.context_init_timeout}",
+            f"elapsed_s={elapsed:.1f}",
+        ]
+        if timed_out:
+            parts.append("mode=timeout")
+            parts.append(
+                "fix=pass demand_table_path (shared python-demand-table) or "
+                "raise context_init_timeout; local provisional demand derivation "
+                "over authenticated pandas is multi-minute work and must not "
+                "share the 30s per-file lift timeout"
+            )
+        elif rc is not None:
+            parts.append("mode=worker-exited")
+            parts.append(f"worker_returncode={rc}")
+        else:
+            parts.append("mode=no-response")
+        if last_progress is not None:
+            parts.append(f"last_phase={last_progress.get('phase')!r}")
+            parts.append(f"last_progress={dict(last_progress)!r}")
+        else:
+            parts.append("last_phase=None")
+            parts.append(
+                "artifact_unseen=no initialize-progress/context-ready line from worker"
+            )
+        if response is not None:
+            kind = response.get("kind")
+            parts.append(f"response_kind={kind!r}")
+            if kind == "initialize-refusal":
+                reason = response.get("reason")
+                if reason is None or reason == "":
+                    parts.append(
+                        "reason=(absent); "
+                        "initialize-refusal payload carried no reason string"
+                    )
+                else:
+                    parts.append(f"reason={reason!r}")
+                parts.append(f"phase={response.get('phase')!r}")
+            else:
+                parts.append(f"response={dict(response)!r}")
+        if stderr_tail:
+            parts.append(f"worker_stderr_tail={stderr_tail!r}")
+        return RuntimeError("; ".join(parts))
 
     def start(self) -> None:
         if self._proc is not None and self._proc.poll() is None:
@@ -82,18 +207,39 @@ class SupervisedEnumSupervisor:
             bufsize=1,
             env=self.env,
         )
+        self._start_stderr_drain()
         ready = self._readline(timeout=30.0)
         if ready is None:
-            self._kill()
-            raise RuntimeError("supervised enum worker did not become ready")
-        if ready.get("kind") == "bootstrap-error":
+            stderr_tail = self._worker_stderr_tail()
+            rc = self._proc.poll() if self._proc is not None else None
             self._kill()
             raise RuntimeError(
-                f"supervised enum worker bootstrap failed: {ready.get('message')}"
+                "supervised enum worker did not become ready; "
+                f"worker_returncode={rc}; worker_stderr_tail={stderr_tail!r}; "
+                f"worker={_WORKER}; "
+                "artifact=no ready/bootstrap-error line before handshake timeout"
+            )
+        if ready.get("kind") == "bootstrap-error":
+            message = ready.get("message")
+            self._kill()
+            if message is None or message == "":
+                raise RuntimeError(
+                    "supervised enum worker bootstrap failed: "
+                    "message field absent from bootstrap-error payload; "
+                    f"response_keys={sorted(ready)!r}; worker={_WORKER}; "
+                    "coordinate=supervised-enum-worker.bootstrap"
+                )
+            raise RuntimeError(
+                "supervised enum worker bootstrap failed: "
+                f"message={message!r}; worker={_WORKER}; "
+                "coordinate=supervised-enum-worker.bootstrap"
             )
         if ready.get("kind") != "ready":
             self._kill()
-            raise RuntimeError(f"supervised enum worker bad handshake: {ready!r}")
+            raise RuntimeError(
+                "supervised enum worker bad handshake: "
+                f"response={ready!r}; worker={_WORKER}"
+            )
         assert self._proc.stdin is not None
         initialize = {"kind": "initialize", "corpus_root": str(self.corpus_root)}
         if self.demand_table_path is not None:
@@ -101,13 +247,55 @@ class SupervisedEnumSupervisor:
         initialize["allow_local_demand_derivation"] = self.allow_local_demand_derivation
         self._proc.stdin.write(json.dumps(initialize) + "\n")
         self._proc.stdin.flush()
-        initialized = self._readline(timeout=30.0)
-        if initialized is None or initialized.get("kind") != "context-ready":
-            self._kill()
-            raise RuntimeError(
-                "supervised enum worker context initialization refused: "
-                f"{initialized!r}"
+
+        # Drain progress heartbeats until context-ready, a named refusal, or
+        # the context-init budget (NOT the 30s per-file lift budget).
+        deadline = time.monotonic() + self.context_init_timeout
+        last_progress: Mapping[str, Any] | None = None
+        started = time.monotonic()
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                error = self._named_context_init_failure(
+                    response=None,
+                    last_progress=last_progress,
+                    elapsed=time.monotonic() - started,
+                    timed_out=True,
+                )
+                self._kill()
+                raise error
+            message = self._readline(timeout=remaining)
+            if message is None:
+                timed_out = time.monotonic() >= deadline
+                if (
+                    not timed_out
+                    and self._proc is not None
+                    and self._proc.poll() is None
+                ):
+                    continue
+                error = self._named_context_init_failure(
+                    response=None,
+                    last_progress=last_progress,
+                    elapsed=time.monotonic() - started,
+                    timed_out=timed_out
+                    or (self._proc is not None and self._proc.poll() is None),
+                )
+                self._kill()
+                raise error
+            kind = message.get("kind")
+            if kind == "initialize-progress":
+                last_progress = message
+                continue
+            if kind == "context-ready":
+                return
+            error = self._named_context_init_failure(
+                response=message,
+                last_progress=last_progress,
+                elapsed=time.monotonic() - started,
+                timed_out=False,
             )
+            self._kill()
+            raise error
 
     def stop(self) -> None:
         proc = self._proc
@@ -237,9 +425,7 @@ class SupervisedEnumSupervisor:
                 category="bare-exception",
                 returncode=1,
                 signal_name=None,
-                stderr_tail=(
-                    f"{response.get('error_type')}: {response.get('message')}"
-                )[-2000:],
+                stderr_tail=_named_lift_error_tail(response)[-2000:],
                 terminal=None,
                 worker_restarts=self.worker_restarts,
             )
@@ -297,6 +483,10 @@ class SupervisedEnumSupervisor:
         skip the worker lift. Misses are full honest measurement. Only
         completed / typed-gap / bare-exception rows are banked.
         """
+        # Sibling module lives next to this file under scripts/.
+        _scripts = str(Path(__file__).resolve().parent)
+        if _scripts not in sys.path:
+            sys.path.insert(0, _scripts)
         from process_floor_measurement_cache import (
             DEFAULT_AXIS,
             MeasurementKey,
@@ -394,18 +584,23 @@ class SupervisedEnumSupervisor:
         return rows
 
 
+def _relative_to_root(path: Path, root: Path) -> str:
+    """Repo-relative locus without importing _enum_floor_runtime (scripts path)."""
+    return path.resolve().relative_to(root.resolve()).as_posix()
+
+
 def scan_paths(
     paths: Sequence[Path],
     *,
     root: Path,
     file_timeout: float = 30.0,
+    context_init_timeout: float = _DEFAULT_CONTEXT_INIT_TIMEOUT,
     demand_table_path: Path | None = None,
 ) -> list[FileTerminal]:
-    from _enum_floor_runtime import relative_to_root
-
-    pairs = [(path, relative_to_root(path, root)) for path in paths]
+    pairs = [(_p, _relative_to_root(_p, root)) for _p in paths]
     supervisor = SupervisedEnumSupervisor(
         file_timeout=file_timeout,
+        context_init_timeout=context_init_timeout,
         corpus_root=root,
         demand_table_path=demand_table_path,
         allow_local_demand_derivation=demand_table_path is None,

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
@@ -53,7 +53,7 @@ def _lift(path: str, rel: str) -> dict:
     if plant_timeout and plant_timeout == rel:
         import time
 
-        time.sleep(3600)
+        time.sleep(30)
 
     from _production_lift_child import production_lift_testimony
 
@@ -73,6 +73,17 @@ def _lift(path: str, rel: str) -> dict:
     return {"kind": "lift-result", "file": rel, "terminal": terminal}
 
 
+def _progress(phase: str, **fields: object) -> None:
+    """Heartbeat so the supervisor can name a hung initialize phase."""
+    payload: dict[str, object] = {
+        "kind": "initialize-progress",
+        "phase": phase,
+        "coordinate": "supervised-enum-worker.construction-context",
+    }
+    payload.update(fields)
+    print(json.dumps(payload), flush=True)
+
+
 def _initialize(
     corpus_root: str,
     demand_table_path: str | None,
@@ -80,18 +91,68 @@ def _initialize(
     allow_local_demand_derivation: bool,
 ) -> dict:
     global _CONSTRUCTION_CONTEXT, _CORPUS_ROOT
+    import os
+
+    # Test-only plant: hang after first progress so supervisor timeout names phase.
+    if os.environ.get("SUGAR_SUPERVISOR_PLANT_INIT_HANG") == "1":
+        _progress(
+            "planted-init-hang",
+            corpus_root=corpus_root or None,
+            note="SUGAR_SUPERVISOR_PLANT_INIT_HANG",
+        )
+        import time
+
+        time.sleep(30)
     if _CONSTRUCTION_CONTEXT is not None:
         return {
             "kind": "initialize-refusal",
             "coordinate": "supervised-enum-worker.construction-context",
             "reason": "frozen construction context was already initialized",
+            "corpus_root": corpus_root or None,
+            "demand_table_path": demand_table_path,
+            "phase": "already-initialized",
         }
     from sugar_lift_py_tests.lift_rpc import (
         provisional_contract_refs_from_demand_rows,
+        provisional_contract_refs_from_demands,
         tree_construction_context_for_workspace,
     )
 
+    if not corpus_root:
+        return {
+            "kind": "initialize-refusal",
+            "coordinate": "supervised-enum-worker.construction-context",
+            "reason": (
+                "corpus_root is empty; cannot build TreeConstructionContext "
+                "without a named population root"
+            ),
+            "corpus_root": None,
+            "demand_table_path": demand_table_path,
+            "phase": "resolve-corpus-root",
+        }
+
     root = Path(corpus_root).resolve()
+    _progress(
+        "resolve-corpus-root",
+        corpus_root=str(root),
+        demand_table_path=demand_table_path,
+        allow_local_demand_derivation=allow_local_demand_derivation,
+        root_exists=root.exists(),
+        root_is_dir=root.is_dir(),
+    )
+    if not root.exists():
+        return {
+            "kind": "initialize-refusal",
+            "coordinate": "supervised-enum-worker.construction-context",
+            "reason": (
+                f"corpus_root does not exist: {root} "
+                "(nothing to derive demands or freeze construction context against)"
+            ),
+            "corpus_root": str(root),
+            "demand_table_path": demand_table_path,
+            "phase": "resolve-corpus-root",
+        }
+
     contract_refs = None
     demand_table_identity = None
     if demand_table_path:
@@ -100,17 +161,64 @@ def _initialize(
             validate_shared_demand_table,
         )
 
+        table_path = Path(demand_table_path)
+        _progress(
+            "load-shared-demand-table",
+            corpus_root=str(root),
+            demand_table_path=str(table_path),
+            table_exists=table_path.is_file(),
+        )
+        if not table_path.is_file():
+            return {
+                "kind": "initialize-refusal",
+                "coordinate": "supervised-enum-worker.construction-context",
+                "reason": (
+                    f"demand_table_path is not a file: {table_path} "
+                    "(shared python-demand-table testimony missing on disk)"
+                ),
+                "corpus_root": str(root),
+                "demand_table_path": str(table_path),
+                "phase": "load-shared-demand-table",
+            }
         payload = validate_shared_demand_table(
-            json.loads(Path(demand_table_path).read_text(encoding="utf-8")),
+            json.loads(table_path.read_text(encoding="utf-8")),
             expected_content_key=SHARED_DEMAND_TABLE_CONTENT_KEY,
         )
         contract_refs = provisional_contract_refs_from_demand_rows(payload["rows"])
         demand_table_identity = SHARED_DEMAND_TABLE_CONTENT_KEY
     elif not allow_local_demand_derivation:
-        raise RuntimeError(
-            "supervised-enum-worker.shared-demand-table: authenticated demand "
-            "table testimony is absent"
+        return {
+            "kind": "initialize-refusal",
+            "coordinate": "supervised-enum-worker.construction-context",
+            "reason": (
+                "authenticated demand table testimony is absent and "
+                "allow_local_demand_derivation is false; pass demand_table_path "
+                "or allow local derivation"
+            ),
+            "corpus_root": str(root),
+            "demand_table_path": None,
+            "phase": "demand-table-required",
+        }
+    else:
+        # Local derivation walks every *.py under corpus_root — authenticated
+        # pandas (~1421 files) is multi-minute. Progress lands before the walk
+        # so a supervisor timeout names this phase instead of refused: None.
+        _progress(
+            "derive-provisional-demands",
+            corpus_root=str(root),
+            demand_table_path=None,
+            note=(
+                "walking corpus_root for With/call demands; "
+                "authenticated pandas is expected to take minutes"
+            ),
         )
+        contract_refs = provisional_contract_refs_from_demands(root)
+    _progress(
+        "freeze-construction-context",
+        corpus_root=str(root),
+        demand_table_identity=demand_table_identity,
+        using_provisional_demands=demand_table_path is None,
+    )
     _CORPUS_ROOT = root
     _CONSTRUCTION_CONTEXT = tree_construction_context_for_workspace(
         root, contract_refs=contract_refs
@@ -160,23 +268,26 @@ def main() -> int:
             print(json.dumps({"kind": "pong"}), flush=True)
             continue
         if kind == "initialize":
+            corpus_root = str(msg.get("corpus_root") or "")
+            demand_table_path = (
+                str(msg["demand_table_path"]) if msg.get("demand_table_path") else None
+            )
             try:
                 response = _initialize(
-                    str(msg.get("corpus_root") or ""),
-                    (
-                        str(msg["demand_table_path"])
-                        if msg.get("demand_table_path")
-                        else None
-                    ),
+                    corpus_root,
+                    demand_table_path,
                     allow_local_demand_derivation=bool(
                         msg.get("allow_local_demand_derivation", False)
                     ),
                 )
-            except Exception as error:
+            except Exception as error:  # noqa: BLE001 — named refusal to parent
                 response = {
                     "kind": "initialize-refusal",
                     "coordinate": "supervised-enum-worker.construction-context",
                     "reason": f"{type(error).__name__}: {error}",
+                    "corpus_root": corpus_root or None,
+                    "demand_table_path": demand_table_path,
+                    "phase": "initialize-exception",
                 }
             print(json.dumps(response), flush=True)
             continue
@@ -189,13 +300,18 @@ def main() -> int:
                 # Bare Python failures only. ConstructionPanic is BaseException:
                 # it is not caught here — the worker dies; the supervisor records
                 # the active file and restarts a fresh worker.
+                # Always emit non-empty error_type and message — never None:None.
+                err_type = type(error).__name__ or "Exception"
+                err_msg = str(error)
+                if not err_msg:
+                    err_msg = f"(empty str({err_type})); coordinate=lift-error"
                 print(
                     json.dumps(
                         {
                             "kind": "lift-error",
                             "file": rel,
-                            "error_type": type(error).__name__,
-                            "message": str(error)[-4000:],
+                            "error_type": err_type,
+                            "message": err_msg[-4000:],
                         }
                     ),
                     flush=True,

--- a/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
@@ -10,9 +10,16 @@ import pytest
 
 import sys
 import json
+import os
 import subprocess
 
+os.environ.setdefault("SUGAR_PROCESS_FLOOR_CACHE_DIR", "off")
+
 _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+# scan() imports process_floor_measurement_cache as a scripts sibling — same
+# door floors open when invoked as scripts/*.py (sys.path has scripts/).
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
 _SPEC = importlib.util.spec_from_file_location(
     "_supervised_enum_supervisor",
     _SCRIPTS / "_supervised_enum_supervisor.py",
@@ -109,3 +116,130 @@ def test_worker_refuses_file_before_frozen_context_initialization(
         worker.stdin.write(json.dumps({"kind": "shutdown"}) + "\n")
         worker.stdin.flush()
         worker.wait(timeout=5)
+
+
+def test_context_init_timeout_names_phase_not_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Init timeout must name phase + corpus_root — never 'refused: None'.
+
+    Floors 30728650857 banked refused: None because the 30s per-file budget
+    gated multi-minute provisional demand derivation over authenticated pandas.
+    """
+    _write(tmp_path, "clean.py", "def a(z):\n    return z\n")
+    monkeypatch.setenv("SUGAR_SUPERVISOR_PLANT_INIT_HANG", "1")
+    supervisor = _SUP.SupervisedEnumSupervisor(
+        corpus_root=tmp_path,
+        file_timeout=30.0,
+        context_init_timeout=1.0,
+        allow_local_demand_derivation=True,
+    )
+    try:
+        with pytest.raises(RuntimeError) as raised:
+            supervisor.start()
+        message = str(raised.value)
+        assert "refused: None" not in message
+        assert "mode=timeout" in message
+        assert "last_phase='planted-init-hang'" in message
+        assert f"corpus_root={tmp_path.resolve()}" in message
+        assert "coordinate=supervised-enum-worker.construction-context" in message
+        assert "context_init_timeout_s=1.0" in message
+    finally:
+        supervisor.stop()
+
+
+def test_context_init_missing_corpus_root_names_artifact(tmp_path: Path) -> None:
+    worker = subprocess.Popen(
+        [sys.executable, str(_SCRIPTS / "_supervised_enum_worker.py")],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert worker.stdin is not None and worker.stdout is not None
+    try:
+        assert json.loads(worker.stdout.readline())["kind"] == "ready"
+        worker.stdin.write(
+            json.dumps(
+                {
+                    "kind": "initialize",
+                    "corpus_root": "",
+                    "allow_local_demand_derivation": True,
+                }
+            )
+            + "\n"
+        )
+        worker.stdin.flush()
+        response = None
+        for _ in range(10):
+            line = worker.stdout.readline()
+            assert line, "worker exited without initialize-refusal"
+            response = json.loads(line)
+            if response.get("kind") != "initialize-progress":
+                break
+        assert response is not None
+        assert response["kind"] == "initialize-refusal"
+        assert response["phase"] == "resolve-corpus-root"
+        assert "corpus_root is empty" in response["reason"]
+    finally:
+        worker.stdin.write(json.dumps({"kind": "shutdown"}) + "\n")
+        worker.stdin.flush()
+        worker.wait(timeout=5)
+
+
+def test_context_init_nonexistent_root_names_path(tmp_path: Path) -> None:
+    missing = tmp_path / "no-such-corpus"
+    supervisor = _SUP.SupervisedEnumSupervisor(
+        corpus_root=missing,
+        file_timeout=30.0,
+        context_init_timeout=30.0,
+        allow_local_demand_derivation=True,
+    )
+    try:
+        with pytest.raises(RuntimeError) as raised:
+            supervisor.start()
+        message = str(raised.value)
+        assert "refused: None" not in message
+        assert "does not exist" in message or "resolve-corpus-root" in message
+        assert str(missing.resolve()) in message
+    finally:
+        supervisor.stop()
+
+
+def test_named_lift_error_tail_never_none_none() -> None:
+    """Sibling: incomplete lift-error must not serialize as 'None: None'."""
+    assert "None: None" not in _SUP._named_lift_error_tail({})
+    assert "no error_type" in _SUP._named_lift_error_tail({})
+    assert "missing error_type" in _SUP._named_lift_error_tail({"message": "x"})
+    assert "(message field absent)" in _SUP._named_lift_error_tail(
+        {"error_type": "RuntimeError"}
+    )
+    assert _SUP._named_lift_error_tail(
+        {"error_type": "RuntimeError", "message": "boom"}
+    ) == "RuntimeError: boom"
+
+
+def test_lift_error_incomplete_payload_names_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sibling: incomplete lift-error body reaches FileTerminal named."""
+    source = _write(tmp_path, "clean.py", "def a(z):\n    return z\n")
+    supervisor = _SUP.SupervisedEnumSupervisor(
+        corpus_root=tmp_path,
+        allow_local_demand_derivation=True,
+    )
+    try:
+        supervisor.start()
+        # Inject incomplete lift-error as if worker returned it.
+        original = supervisor._readline
+
+        def fake_readline(*, timeout: float):
+            return {"kind": "lift-error"}  # no error_type, no message
+
+        supervisor._readline = fake_readline  # type: ignore[method-assign]
+        row = supervisor.lift_file(source, "clean.py")
+        supervisor._readline = original  # type: ignore[method-assign]
+        assert row.category == "bare-exception"
+        assert "None: None" not in row.stderr_tail
+        assert "no error_type" in row.stderr_tail or "lift-error" in row.stderr_tail
+    finally:
+        supervisor.stop()


### PR DESCRIPTION
## Summary

Unblocks Criterion-2 process floors (native-crash / bare-exception / timeout) blocked on:

```
RuntimeError: supervised enum worker context initialization refused: None
```

**Cause:** `start()` used the **30s per-file** `_readline` budget while the worker walked authenticated pandas (~1421 files) for provisional demand derivation. Silent never uses this path — measured fine.

**Fix (no demand-derivation climb):**
1. `context_init_timeout` default **1800s**, separate from `file_timeout ≤ 30`
2. Worker `initialize-progress` phases (denominator-adjacent narration for this path)
3. Named refusals — never `refused: None` / `failed: None` / `None: None` (three siblings)

## Naming siblings (mr_blue census)

| Site | Was | Now |
|---|---|---|
| context init L105-110 | `refused: {initialized!r}` → `None` | mode, corpus_root, last_phase, demand_table, fix |
| bootstrap | `failed: {message}` → `None` | absent message named |
| lift-error | `f'{type}: {msg}'` → `None: None` | `_named_lift_error_tail` |
| did-not-become-ready | closed phrase only | returncode + stderr + worker path |

## Not in this PR

- Expensive per-worker demand derivation climb / shared demand-table wiring
- Full process-floor per-file scan logging (mr_grey) — **initialize-progress covers `start()` only**; do not re-instrument that path

## Test plan

- [x] Unit teeth: plant hang names phase; empty/missing root; lift-error tail never `None: None`
- [ ] Re-fire parallel process-floor axes after merge (merge_dog; no CI wait)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Separate context-init timeout from per-file timeout and name context-init refusals in supervised enum
> - Introduces `_DEFAULT_CONTEXT_INIT_TIMEOUT` (1800s) and a `context_init_timeout` parameter on `SupervisedEnumSupervisor` so context initialization has its own 30-minute budget instead of sharing the 30s per-file timeout.
> - Rewrites the `start` method to stream `initialize-progress` heartbeats until `context-ready`, a named refusal, or the new timeout; failures raise detailed `RuntimeError`s via `_named_context_init_failure` that include mode, phase, elapsed time, and worker stderr.
> - Worker's `_initialize` now emits structured `initialize-refusal` responses (with phase and coordinates) instead of raising, and emits progress heartbeats at each validation step.
> - Adds async stderr draining (`_start_stderr_drain`) to prevent pipe backpressure stalls, and includes stderr tail in all failure errors.
> - Fixes `lift-error` responses to never render `None: None` via the new `_named_lift_error_tail` helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca0d17e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->