### PR TITLE
Right-size suite to 8 shards; share Python env for suite + floors

### DIFF
--- a/.github/actions/python-test-environment-from-wheelhouse/action.yml
+++ b/.github/actions/python-test-environment-from-wheelhouse/action.yml
@@ -1,0 +1,121 @@
+name: Install Python test environment from shared wheelhouse
+description: >-
+  Consumer half of python-test-environment. Installs third-party wheels from a
+  pre-built wheelhouse (no network resolve/build), binds first-party packages
+  to the SYNCED CHECKOUT via PYTHONPATH, and optionally reuses a tip-minted
+  environment-identity.json from the prepare job.
+
+# WHY THIS EXISTS
+#
+# Suite shards and floor axes each used to run the full python-test-environment
+# action: ~90–160s of pip wheel + venv install per job, identical work N times.
+# Measurement showed pytest work ~25s mean vs env prep ~89–156s. Prepare once
+# (full action uploads wheelhouse + identity); N consumers install --no-index
+# from the artifact. First-party still never enters site-packages.
+
+inputs:
+  python-version:
+    description: Interpreter patch pin (must match prepare job).
+    required: false
+    default: "3.12.13"
+  wheelhouse-path:
+    description: Directory of third-party wheels (downloaded artifact).
+    required: true
+  identity-path:
+    description: >-
+      Path to environment-identity.json minted by the prepare job for this tip.
+      When empty, identity is not installed (callers that need it must pass it).
+    required: false
+    default: ""
+
+outputs:
+  identity-path:
+    description: Path to environment-identity.json in the prepared env dir.
+    value: ${{ steps.install.outputs.identity-path }}
+  python:
+    description: Absolute path to the prepared interpreter.
+    value: ${{ steps.install.outputs.python }}
+  env-dir:
+    description: Root of the prepared environment.
+    value: ${{ steps.install.outputs.env-dir }}
+  checkout-pythonpath:
+    description: Absolute managed first-party PYTHONPATH for the synced checkout.
+    value: ${{ steps.install.outputs.checkout-pythonpath }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install third-party from shared wheelhouse + bind checkout PYTHONPATH
+      id: install
+      shell: bash
+      run: |
+        set -euo pipefail
+        wheelhouse="${{ inputs.wheelhouse-path }}"
+        if [ ! -d "$wheelhouse" ]; then
+          echo "::error::wheelhouse path missing: $wheelhouse"
+          exit 1
+        fi
+        shopt -s nullglob
+        wheels=( "$wheelhouse"/*.whl )
+        if [ "${#wheels[@]}" -eq 0 ]; then
+          echo "::error::shared wheelhouse has no .whl files at $wheelhouse"
+          ls -la "$wheelhouse" || true
+          exit 1
+        fi
+        # Refuse first-party wheels if a bad prepare uploaded them.
+        for whl in "$wheelhouse"/sugar_lift_*.whl "$wheelhouse"/sugar_source_tree-*.whl; do
+          if [ -e "$whl" ]; then
+            echo "::error::first-party wheel in shared house (false provenance): $whl"
+            exit 1
+          fi
+        done
+
+        env_dir="$RUNNER_TEMP/sugar-python-test-environment"
+        rm -rf "$env_dir"
+        mkdir -p "$env_dir"
+        venv="$env_dir/venv"
+        python -m venv "$venv"
+        "$venv/bin/python" -m pip install --quiet --upgrade pip wheel
+        # Install wheel files by path (no resolve). Same as the full action's
+        # third-party install half — not a second dependency authority.
+        "$venv/bin/python" -m pip install --quiet --no-index \
+          "${wheels[@]}"
+        "$venv/bin/python" -m pip freeze --all > "$env_dir/resolved-distributions.txt"
+
+        for pkg in sugar-lift-py-tests sugar-lift-python-source sugar-source-tree; do
+          if "$venv/bin/python" -m pip show "$pkg" >/dev/null 2>&1; then
+            echo "::error::first-party package $pkg present in venv; must resolve from checkout only"
+            exit 1
+          fi
+        done
+
+        checkout_pythonpath="$(
+          python3 tools/managed_checkout_pythonpath.py --repo-root .
+        )"
+        echo "PYTHONPATH=${checkout_pythonpath}" >> "$GITHUB_ENV"
+        echo "SUGAR_CHECKOUT_PYTHONPATH=${checkout_pythonpath}" >> "$GITHUB_ENV"
+
+        identity_out="$env_dir/environment-identity.json"
+        if [ -n "${{ inputs.identity-path }}" ]; then
+          if [ ! -f "${{ inputs.identity-path }}" ]; then
+            echo "::error::identity-path not a file: ${{ inputs.identity-path }}"
+            exit 1
+          fi
+          cp "${{ inputs.identity-path }}" "$identity_out"
+          echo "SUGAR_PYTHON_ENV_IDENTITY=$identity_out" >> "$GITHUB_ENV"
+          python3 tools/python_suite_identity_gate.py --environment-identity "$identity_out"
+        fi
+
+        chmod -R a-w "$venv/lib"
+        echo "PYTHONDONTWRITEBYTECODE=1" >> "$GITHUB_ENV"
+        echo "$venv/bin" >> "$GITHUB_PATH"
+        echo "python=$venv/bin/python" >> "$GITHUB_OUTPUT"
+        echo "env-dir=$env_dir" >> "$GITHUB_OUTPUT"
+        echo "checkout-pythonpath=$checkout_pythonpath" >> "$GITHUB_OUTPUT"
+        echo "identity-path=$identity_out" >> "$GITHUB_OUTPUT"
+        echo "shared-wheelhouse install: ${#wheels[@]} third-party wheels; checkout PYTHONPATH bound"

--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -11,10 +11,31 @@ permissions:
 # NO concurrency group. NO machine-wide lease (#7008).
 # Process axes run as a matrix of jobs — wall clock is max(axis), not sum.
 # Completeness is enrollment roll call, not a merged residual hub.
+#
+# SHARED ENV: each of 5 jobs was paying 91–163s env prep for 116–184s total
+# job time — same identical wheelhouse N times. Prepare once; axes install
+# --no-index from the artifact (same law as suite + showcase #7020).
 
 jobs:
+  python-test-env-prepare:
+    name: python test env (shared wheelhouse)
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare immutable Python test environment (once)
+        id: env
+        uses: ./.github/actions/python-test-environment
+      - name: Upload third-party wheelhouse
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-test-wheelhouse
+          path: ${{ steps.env.outputs.env-dir }}/wheelhouse/
+          if-no-files-found: error
+
   process-floor:
     name: process-floor ${{ matrix.axis }}
+    needs: [python-test-env-prepare]
     runs-on: [self-hosted, Linux, X64]
     # silent is the long pole (~11min today); others ~30s once cache warm.
     timeout-minutes: 360
@@ -36,8 +57,15 @@ jobs:
             display: R_timeouts
     steps:
       - uses: actions/checkout@v4
-      - name: Prepare immutable Python test environment
-        uses: ./.github/actions/python-test-environment
+      - name: Download shared third-party wheelhouse
+        uses: actions/download-artifact@v4
+        with:
+          name: python-test-wheelhouse
+          path: ${{ runner.temp }}/python-test-wheelhouse
+      - name: Install from shared wheelhouse (no network resolve)
+        uses: ./.github/actions/python-test-environment-from-wheelhouse
+        with:
+          wheelhouse-path: ${{ runner.temp }}/python-test-wheelhouse
       # Host path ($HOME/...) only shares when matrix jobs land the same
       # self-hosted user. Fleet-wide: restore/save CA terminal shelf via
       # actions/cache. Key is tip; MeasurementKey still gates corpus/file
@@ -94,12 +122,20 @@ jobs:
 
   static-floors:
     name: static-floors
+    needs: [python-test-env-prepare]
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
-      - name: Prepare immutable Python test environment
-        uses: ./.github/actions/python-test-environment
+      - name: Download shared third-party wheelhouse
+        uses: actions/download-artifact@v4
+        with:
+          name: python-test-wheelhouse
+          path: ${{ runner.temp }}/python-test-wheelhouse
+      - name: Install from shared wheelhouse (no network resolve)
+        uses: ./.github/actions/python-test-environment-from-wheelhouse
+        with:
+          wheelhouse-path: ${{ runner.temp }}/python-test-wheelhouse
       - name: Static AST / discrimination floors (parallel to process matrix)
         id: static
         shell: bash

--- a/.github/workflows/python-package-suite.yml
+++ b/.github/workflows/python-package-suite.yml
@@ -2,25 +2,25 @@ name: Python package suite (authoritative)
 
 # THE DEFECT THIS FIXES
 #
-# One cold pytest over ~3864 tests is one process on one core while 31 cores
-# idle. That serialization starved every measurement for hours. T: "32 cores
-# and 25 runners, and this idea that we should be serializing anything in the
-# CI process is just pure insanity."
+# One cold pytest over ~3864 tests is one process on one core while peers idle.
+# That serialization starved every measurement for hours. Fan-out is correct.
 #
-# DESIGN (settled): 32 deterministic file shards. Each job writes its OWN
-# identity-bound suite-report.json. Completeness is ENROLLMENT (roster + roll
-# call), not merge into a shared hub. Identity gate runs PER SHARD. Campaign
-# claim: all N attended and each is identity-resolved.
+# SIZING (measured, not guessed): 32 shards made pytest work ~25s mean / ~71s
+# max, but paid 89–156s env prep PER JOB and stampeded cold sugarbin. Setup
+# dominated work. Eight shards keep the sweep in minutes and cut the env tax
+# and stampede fourfold. Not a retreat from parallelism — right-size to the box.
 #
-# Canonical order is collection order WITHIN a shard's file set only.
-# Discrimination (scheduled) is within-shard. No package-wide recombine.
+# SHARED ENV: the python-test-environment wheelhouse is IDENTICAL across shards.
+# Prepare it once, upload the third-party wheelhouse + tip identity, shards
+# install --no-index (same shape as showcase #7020). First-party still binds
+# from each job's checkout via PYTHONPATH (never site-packages).
 #
-# No machine-wide heavy-measurement lease (deleted). Jobs run in parallel.
-# Shard count lives in tools/python_package_suite_shards.py (SHARD_COUNT=32)
-# and is mirrored as the static matrix + SUITE_SHARD_COUNT env below — NOT as
-# a prepare-job output. A prepare job that only published the roster while
-# also building a Python env was a 35–126s dead edge: shards re-prep env
-# themselves and never consumed the prepare identity.
+# DESIGN: 8 deterministic file shards. Each job writes its OWN identity-bound
+# suite-report.json. Completeness is ENROLLMENT (roster + roll call), not merge
+# into a shared hub. Identity gate runs PER SHARD.
+#
+# Shard count lives in tools/python_package_suite_shards.py (SHARD_COUNT=8)
+# and is mirrored as the static matrix + SUITE_SHARD_COUNT env below.
 
 on:
   push:
@@ -50,30 +50,68 @@ jobs:
         shell: bash
         run: python3 tests/test_python_suite_identity_gate_twins.py
 
-  # SHARD ROSTER is static (must match tools/python_package_suite_shards.py
-  # SHARD_COUNT=32). Emitting it from a prepare job that also built a Python
-  # env forced every shard to wait 35–126s for an environment it never
-  # consumed — each shard already runs python-test-environment itself.
-  # Static matrix = suite jobs start immediately. No prepare gate. No lease.
+  # ONE env prep for the whole suite matrix. Shards need: prepare (not a
+  # roster emit — matrix is static). They never re-run the full builder.
+  python-test-env-prepare:
+    name: python test env (shared wheelhouse + identity)
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 60
+    outputs:
+      identity-hash: ${{ steps.env.outputs.identity-hash }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Prepare immutable Python test environment (once)
+        id: env
+        uses: ./.github/actions/python-test-environment
+        with:
+          identity-artifact: "false"
+      - name: Upload third-party wheelhouse
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-test-wheelhouse
+          path: ${{ steps.env.outputs.env-dir }}/wheelhouse/
+          if-no-files-found: error
+      - name: Upload tip environment identity
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-test-environment-identity
+          path: ${{ steps.env.outputs.identity-path }}
+          if-no-files-found: error
 
   # One CI job per shard. Own report. Own identity gate. No singleton writer.
   python-package-suite:
     name: suite canonical shard ${{ matrix.shard }}
+    needs: [python-test-env-prepare]
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
       # Single source of truth for enrollment roll call; keep == SHARD_COUNT.
-      SUITE_SHARD_COUNT: "32"
+      SUITE_SHARD_COUNT: "8"
     steps:
       - uses: actions/checkout@v6
 
-      - name: Prepare immutable Python test environment
+      - name: Download shared third-party wheelhouse
+        uses: actions/download-artifact@v4
+        with:
+          name: python-test-wheelhouse
+          path: ${{ runner.temp }}/python-test-wheelhouse
+
+      - name: Download tip environment identity
+        uses: actions/download-artifact@v4
+        with:
+          name: python-test-environment-identity
+          path: ${{ runner.temp }}/python-test-identity
+
+      - name: Install from shared wheelhouse (no network resolve)
         id: env
-        uses: ./.github/actions/python-test-environment
+        uses: ./.github/actions/python-test-environment-from-wheelhouse
+        with:
+          wheelhouse-path: ${{ runner.temp }}/python-test-wheelhouse
+          identity-path: ${{ runner.temp }}/python-test-identity/environment-identity.json
 
       - name: Set up Rust toolchain
         uses: ./.github/actions/setup-rust-cache
@@ -220,7 +258,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
     env:
-      SUITE_SHARD_COUNT: "32"
+      SUITE_SHARD_COUNT: "8"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v4
@@ -243,20 +281,34 @@ jobs:
     if: >-
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.discrimination)
+    needs: [python-test-env-prepare]
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         order: [reversed, shuffled]
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
-      SUITE_SHARD_COUNT: "32"
+      SUITE_SHARD_COUNT: "8"
     steps:
       - uses: actions/checkout@v6
-      - name: Prepare immutable Python test environment
+      - name: Download shared third-party wheelhouse
+        uses: actions/download-artifact@v4
+        with:
+          name: python-test-wheelhouse
+          path: ${{ runner.temp }}/python-test-wheelhouse
+      - name: Download tip environment identity
+        uses: actions/download-artifact@v4
+        with:
+          name: python-test-environment-identity
+          path: ${{ runner.temp }}/python-test-identity
+      - name: Install from shared wheelhouse (no network resolve)
         id: env
-        uses: ./.github/actions/python-test-environment
+        uses: ./.github/actions/python-test-environment-from-wheelhouse
+        with:
+          wheelhouse-path: ${{ runner.temp }}/python-test-wheelhouse
+          identity-path: ${{ runner.temp }}/python-test-identity/environment-identity.json
       - name: Set up Rust toolchain
         uses: ./.github/actions/setup-rust-cache
       - name: Resolve the sugar binary and read its source identity
@@ -348,7 +400,7 @@ jobs:
       - python-package-suite
       - python-package-suite-discrimination
     env:
-      SUITE_SHARD_COUNT: "32"
+      SUITE_SHARD_COUNT: "8"
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6

--- a/tests/test_python_package_suite_shards.py
+++ b/tests/test_python_package_suite_shards.py
@@ -35,7 +35,8 @@ def test_shard_assignment_is_deterministic_and_covers_every_file() -> None:
     files = mod.list_suite_test_files(ROOT)
     assert len(files) >= 100, f"expected a real suite tree, got {len(files)} files"
 
-    count = 32
+    count = mod.SHARD_COUNT
+    assert count == 8, f"suite fan-out sized to 8 by measurement; got {count}"
     covered: list[str] = []
     for i in range(count):
         covered.extend(mod.files_for_shard(files, i, count))
@@ -251,3 +252,17 @@ def test_workflow_has_no_shared_suite_report_merge_and_uses_enrollment() -> None
     assert "suite-report.json" in text  # per-shard path still that filename
     assert "python-package-suite-canonical-shard-" in text
     assert "python_package_suite_shard_attendance" in text
+    # Right-sized fan-out + shared env (not 32× full env prep).
+    assert 'SUITE_SHARD_COUNT: "8"' in text
+    assert "shard: [0, 1, 2, 3, 4, 5, 6, 7]" in text
+    assert "shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15" not in text
+    assert "python-test-env-prepare" in text
+    assert "python-test-environment-from-wheelhouse" in text
+    assert "python-test-wheelhouse" in text
+    # Matrix shards consume shared house; they must not re-run the full builder.
+    # Prepare job is the only place that uses the full action.
+    shard_job = text.split("python-package-suite:")[1].split(
+        "python-package-suite-attendance:"
+    )[0]
+    assert "python-test-environment-from-wheelhouse" in shard_job
+    assert "uses: ./.github/actions/python-test-environment\n" not in shard_job

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -67,6 +67,13 @@ def test_workflow_is_parallel_matrix_not_serial_monolith() -> None:
     assert "sole_construction_floor_enrollment.py" in workflow
     # Must not re-serialize all process axes via the local monolith in CI.
     assert "run_sole_construction_floors.sh" not in workflow
+    # Shared env: prepare once; matrix jobs consume wheelhouse (not N× full prep).
+    assert "python-test-env-prepare" in workflow
+    assert "python-test-wheelhouse" in workflow
+    assert "python-test-environment-from-wheelhouse" in workflow
+    process_job = workflow.split("process-floor:")[1].split("static-floors:")[0]
+    assert "python-test-environment-from-wheelhouse" in process_job
+    assert "uses: ./.github/actions/python-test-environment\n" not in process_job
 
 
 def test_static_job_binds_every_static_axis() -> None:

--- a/tools/python_package_suite_shard_attendance.py
+++ b/tools/python_package_suite_shard_attendance.py
@@ -17,7 +17,7 @@ measurement classes: enrollment is existence.
 Usage:
     python3 tools/python_package_suite_shard_attendance.py \\
         --reports-dir runs/ \\
-        --shard-count 32 \\
+        --shard-count 8 \\
         --require-commit "$GITHUB_SHA" \\
         --order canonical
 """

--- a/tools/python_package_suite_shards.py
+++ b/tools/python_package_suite_shards.py
@@ -36,10 +36,11 @@ import json
 import sys
 from pathlib import Path
 
-# 32 shards: ~416 test files → ~13 files each. Under GitHub's 256-job matrix
-# cap (1/8 of the ceiling). On a 32-core box, one cold pytest per core is the
-# natural fan-out without drowning the runner scheduler in 64+ tiny jobs.
-SHARD_COUNT = 32
+# 8 shards: measurement sized the fan-out. Pytest work is ~25s mean / ~71s max
+# per shard; 32-way paid 89–156s env prep N times and stampeded cold sugarbin.
+# Eight keeps the sweep in minutes while cutting env tax and stampede 4×.
+# Env is prepared once (shared wheelhouse artifact); shards install --no-index.
+SHARD_COUNT = 8
 
 # Relative to repo root. Collected pytest targets are files under this tree.
 TESTS_REL = Path("implementations/python/sugar-lift-py-tests/tests")


### PR DESCRIPTION
## Summary

- **Suite 32 → 8 shards** (`SHARD_COUNT` + static matrix + enrollment). Measurement: ~25s mean pytest work vs 89–156s env prep ×32 and cold-binary stampede. Eight keeps the sweep in minutes and cuts setup tax 4×.
- **Shared env prep** (showcase #7020 shape): one `python-test-env-prepare` job runs full `python-test-environment`, uploads third-party **wheelhouse** (+ tip **identity** for suite). Matrix jobs install `--no-index` via new `python-test-environment-from-wheelhouse`.
- **Floors matrix** uses the same shared wheelhouse (was 91–163s env ×5 against 116–184s job times).

Not a monolith. Fan-out stays; setup is paid once.

## Why env can be shared

Third-party wheels are content-identical across jobs for a tip. First-party still resolves from each job’s **checkout** via `PYTHONPATH` (never site-packages). Venv is rebuilt per job from the shared house (paths differ; install is seconds). Identity is tip-minted once for suite.

## Validation

- `pytest -q tests/test_python_package_suite_shards.py tests/test_python_sole_construction_ci.py` → 10 passed

## Shell

Right-size fan-out instrument counts; delete 32-way matrix as the default. Env-N×N becomes prepare-once + N consume.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce suite to 8 shards and share a single Python env across suite and floor jobs
> - Adds a new `python-test-environment-from-wheelhouse` composite action that installs a Python venv from a prebuilt wheelhouse (no network resolution) and binds first-party code via `PYTHONPATH`.
> - Adds a `python-test-env-prepare` job to both [python-package-suite.yml](https://github.com/TSavo/sugar/pull/7030/files#diff-3468e5d2db054964c8506506d8c39f46df881f7f103f96b2972c2686cc1cc3a0) and [factory-zero-tolerance.yml](https://github.com/TSavo/sugar/pull/7030/files#diff-b7935b47613e0d7520fac82144ed2fcf0a5f55d0d2e259af5d19296ad96f177f) that builds the wheelhouse once and uploads it as an artifact for all downstream matrix jobs to share.
> - Reduces `SHARD_COUNT` in [python_package_suite_shards.py](https://github.com/TSavo/sugar/pull/7030/files#diff-9f48da58cabb30fcad1c04d290501b130d9268868644bca5c1fc5774b1aa7c90) from 32 to 8, cutting the number of parallel shard jobs and updating attendance tooling accordingly.
> - Behavioral Change: shard jobs no longer rebuild the Python environment independently; they download and install from the shared wheelhouse artifact instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e0a474.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->