### PR TITLE
Measurement logging: discrimination, enrollment, attendance phases

### DIFF
--- a/.github/workflows/bare-exception-zero-tolerance.yml
+++ b/.github/workflows/bare-exception-zero-tolerance.yml
@@ -1,8 +1,9 @@
 name: Bare exception zero tolerance (discrimination)
 
-# Discrimination only. Full corpus R_bare_exceptions runs exclusively under
-# factory-zero-tolerance.yml so heavy floors share one pinned run and one
-# concurrency group (no multi-workflow pending-run cancellation).
+# Discrimination only. Full corpus R_bare_exceptions runs under
+# factory-zero-tolerance.yml process-floor matrix.
+#
+# SILENCE CONCEALS: named phases + PYTHONUNBUFFERED so stall vs work is visible.
 on:
   push:
     branches: [main]
@@ -15,22 +16,29 @@ jobs:
   bare-exception-discrimination:
     runs-on: [self-hosted, Linux, X64]
     env:
+      PYTHONUNBUFFERED: "1"
       PYTHONPATH: "implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-py-tests/src"
     steps:
-      - uses: actions/checkout@v4
-      # ONE environment definition, shared read-only with the authoritative
-      # suite. `sugar-lift-py-tests[test]` remains the sole dependency
-      # authority (#6275) — the action installs from that table and this floor
-      # hand-lists nothing. This floor stays a distinct instrument: one
-      # discrimination file, never a second whole-package sweep.
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Prepare immutable Python test environment
         uses: ./.github/actions/python-test-environment
-      - name: R_bare_exceptions discrimination
-        run: >-
-          python -m pytest --noconftest
-          implementations/python/sugar-lift-py-tests/tests/test_bare_exception_zero_tolerance.py
-          -q
-      - name: Panic-catch self-check
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+      - name: "Phase: R_bare_exceptions discrimination (pytest)"
+        env:
+          PYTHONUNBUFFERED: "1"
+        run: |
+          set -euo pipefail
+          echo "discrimination phase=bare_exception status=start"
+          python -u -m pytest --noconftest \
+            implementations/python/sugar-lift-py-tests/tests/test_bare_exception_zero_tolerance.py \
+            -v --tb=short
+          echo "discrimination phase=bare_exception status=done"
+      - name: "Phase: panic-catch self-check"
+        env:
+          PYTHONUNBUFFERED: "1"
+        run: |
+          set -euo pipefail
+          echo "discrimination phase=panic_catch status=start"
+          python -u \
+            implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+          echo "discrimination phase=panic_catch status=done"

--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -39,6 +39,8 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     # silent is the long pole (~11min today); others ~30s once cache warm.
     timeout-minutes: 360
+    env:
+      PYTHONUNBUFFERED: "1"
     strategy:
       fail-fast: false
       matrix:
@@ -125,6 +127,8 @@ jobs:
     needs: [python-test-env-prepare]
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 60
+    env:
+      PYTHONUNBUFFERED: "1"
     steps:
       - uses: actions/checkout@v4
       - name: Download shared third-party wheelhouse
@@ -136,17 +140,21 @@ jobs:
         uses: ./.github/actions/python-test-environment-from-wheelhouse
         with:
           wheelhouse-path: ${{ runner.temp }}/python-test-wheelhouse
-      - name: Static AST / discrimination floors (parallel to process matrix)
+      - name: "Phase: static AST / discrimination floors"
         id: static
         shell: bash
+        env:
+          PYTHONUNBUFFERED: "1"
         run: |
           set -uo pipefail
+          echo "static_floors phase=job status=start"
           chmod +x tools/run_static_sole_construction_floors.sh
           set +e
           bash tools/run_static_sole_construction_floors.sh
           code=$?
           set -e
-          python3 tools/sole_construction_floor_enrollment.py \
+          echo "static_floors phase=mint_report exit=$code"
+          python3 -u tools/sole_construction_floor_enrollment.py \
             --mint-report floor-axis-report.json \
             --axis-id static-laws \
             --display R_static_sole_construction \
@@ -168,43 +176,58 @@ jobs:
     if: always()
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
+    env:
+      PYTHONUNBUFFERED: "1"
     steps:
       - uses: actions/checkout@v4
-      - name: Download all axis reports
+      - name: "Phase: download axis reports"
         uses: actions/download-artifact@v4
         with:
           path: floor-axis-artifacts
           pattern: floor-axis-*
           merge-multiple: false
-      - name: Enrollment roll call (missing axis = UNMEASURED)
+      - name: "Phase: enrollment roll call (missing = UNMEASURED)"
         shell: bash
+        env:
+          PYTHONUNBUFFERED: "1"
         run: |
           set -euo pipefail
-          python3 tools/sole_construction_floor_enrollment.py \
+          echo "floor_enrollment phase=job status=start commit=$GITHUB_SHA"
+          python3 -u tools/sole_construction_floor_enrollment.py \
             --check-attendance floor-axis-artifacts \
             --require-commit "${GITHUB_SHA}" \
             --write-campaign-body floor-measurement.json \
+            --partial-json floor-axis-artifacts/enrollment-partial.json \
             | tee -a "$GITHUB_STEP_SUMMARY"
           # Fail attendance if incomplete (tool exit already).
           # Also fail if any residual-red axis attended: residual red is campaign red.
-          python3 - <<'PY'
+          python3 -u - <<'PY'
           import json, sys
           from pathlib import Path
           body = json.loads(Path("floor-measurement.json").read_text())
           enr = body.get("enrollment") or {}
+          print(
+              f"floor_enrollment phase=campaign_gate "
+              f"status={enr.get('status')} attended={enr.get('attended')} "
+              f"missing={enr.get('missing')} residual={enr.get('residualRed')}",
+              flush=True,
+          )
           if enr.get("status") != "complete":
-              print("UNMEASURED: enrollment incomplete", enr, file=sys.stderr)
+              print("UNMEASURED: enrollment incomplete", enr, file=sys.stderr, flush=True)
               sys.exit(1)
           residual = enr.get("residualRed") or []
           if residual:
-              print(f"RESIDUAL RED axes: {residual}", file=sys.stderr)
+              print(f"RESIDUAL RED axes: {residual}", file=sys.stderr, flush=True)
               sys.exit(1)
-          print("enrollment complete; all axes residual-green")
+          print("enrollment complete; all axes residual-green", flush=True)
           PY
       - name: Upload campaign measurement body
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: python-sole-construction-floors-measurement
-          path: floor-measurement.json
+          path: |
+            floor-measurement.json
+            floor-axis-artifacts/enrollment-partial.json
+            floor-axis-artifacts/attendance-partial.json
           if-no-files-found: error

--- a/.github/workflows/heavy-measurement-attendance.yml
+++ b/.github/workflows/heavy-measurement-attendance.yml
@@ -53,10 +53,14 @@ jobs:
   roll-call:
     name: roll call (R_attendance = 0)
     runs-on: ubuntu-latest
+    env:
+      # Phase lines must hit the job log as they print (silence conceals hang).
+      PYTHONUNBUFFERED: "1"
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Resolve the commit under roll call
+      - name: "Phase: resolve roll-call subject commit"
         id: subject
         env:
           GH_TOKEN: ${{ github.token }}
@@ -65,9 +69,9 @@ jobs:
           sha="${{ github.event.inputs.commit || github.event.workflow_run.head_sha }}"
           [ -n "$sha" ] || { echo "no commit to hold a roll call for"; exit 1; }
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
-          echo "roll call subject: $sha"
+          echo "attendance phase=resolve_subject status=done sha=$sha"
 
-      - name: Collect lease receipts for the commit
+      - name: "Phase: collect measurement receipts (download artifacts)"
         env:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ steps.subject.outputs.sha }}
@@ -78,45 +82,66 @@ jobs:
           # under-reports: on 2026-08-01 it returned 6 non-completed runs where
           # the API returned 234, and a bankruptcy sweep was declared complete
           # on the strength of it.
+          echo "attendance phase=list_runs status=start sha=$SHA"
           gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&per_page=100" \
             --paginate --jq '.workflow_runs[]?|.id' > run-ids.txt || true
-          echo "runs for this commit: $(wc -l < run-ids.txt)"
+          total=$(wc -l < run-ids.txt | tr -d ' ')
+          echo "attendance phase=list_runs status=done runs=$total"
+          index=0
           while read -r id; do
             [ -z "$id" ] && continue
-            gh run download "$id" --dir "receipts/$id" 2>/dev/null || true
+            index=$((index + 1))
+            echo "attendance phase=download_run index=${index}/${total} run_id=$id status=start"
+            if gh run download "$id" --dir "receipts/$id" 2>/dev/null; then
+              echo "attendance phase=download_run index=${index}/${total} run_id=$id status=ok"
+            else
+              echo "attendance phase=download_run index=${index}/${total} run_id=$id status=no_artifacts"
+            fi
           done < run-ids.txt
-          echo "receipt files found: $(find receipts -name '*.json' | wc -l)"
+          json_n=$(find receipts -name '*.json' 2>/dev/null | wc -l | tr -d ' ')
+          echo "attendance phase=collect_receipts status=done json_files=$json_n"
 
-      - name: Roll call + CommitMeasurement gate (fail closed)
-        id: measure
+      - name: "Phase: roll call (expected vs spoke)"
+        id: attendance
         env:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ steps.subject.outputs.sha }}
+          PYTHONUNBUFFERED: "1"
         run: |
           set -uo pipefail
           # PER-COMMIT cadence only. Nightlies are a different obligation.
-          #
-          # CRITICAL: attendance exit 1 must NOT skip compose/gate. A gate that
-          # only runs when attendance is already green is decorative. Capture
-          # attendance exit, ALWAYS compose, ALWAYS gate, then OR the reds.
+          # CRITICAL: attendance exit 1 must NOT skip compose/gate.
           set +e
-          python3 tools/heavy_measurement_attendance.py \
+          python3 -u tools/heavy_measurement_attendance.py \
             --commit "$SHA" \
             --cadence per-commit \
             --receipts-dir receipts \
             --repo "${GITHUB_REPOSITORY}" \
+            --partial-json receipts/attendance-partial.json \
             > attendance.md 2>&1
           att_exit=$?
           set -e
           cat attendance.md | tee -a "$GITHUB_STEP_SUMMARY"
-          echo "attendance_exit=$att_exit"
+          echo "attendance_exit=$att_exit" | tee -a "$GITHUB_OUTPUT"
+          echo "attendance phase=roll_call status=done exit=$att_exit"
 
+      - name: "Phase: CommitMeasurement compose + gate"
+        id: measure
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ steps.subject.outputs.sha }}
+          PYTHONUNBUFFERED: "1"
+        run: |
+          set -uo pipefail
+          att_exit="${{ steps.attendance.outputs.attendance_exit }}"
           # Compose even when receipts/ are empty: that is PartialVector, not silence.
-          python3 - <<'PY'
+          echo "attendance phase=compose status=start"
+          python3 -u - <<'PY'
           from pathlib import Path
           import json
           import importlib.util
           import os
+          print("attendance phase=compose status=loading_commit_measurement", flush=True)
           spec = importlib.util.spec_from_file_location(
               "cm", Path("tools/commit_measurement.py")
           )
@@ -128,19 +153,22 @@ jobs:
               json.dumps(vector.to_json(), indent=2, sort_keys=True) + "\n",
               encoding="utf-8",
           )
-          print(json.dumps(vector.to_json(), indent=2, sort_keys=True))
+          print(json.dumps(vector.to_json(), indent=2, sort_keys=True), flush=True)
+          print("attendance phase=compose status=done", flush=True)
           PY
 
           set +e
-          python3 tools/commit_measurement_gate.py \
+          echo "attendance phase=gate status=start"
+          python3 -u tools/commit_measurement_gate.py \
             --composition commit-measurement.json \
             --require-complete \
             | tee -a "$GITHUB_STEP_SUMMARY"
           gate_exit=$?
           set -e
           echo "gate_exit=$gate_exit"
+          echo "attendance phase=gate status=done exit=$gate_exit"
           # Fail closed: either attendance minority OR incomplete composition.
-          if [ "$att_exit" -ne 0 ] || [ "$gate_exit" -ne 0 ]; then
+          if [ "$att_exit" != "0" ] || [ "$gate_exit" -ne 0 ]; then
             echo "RED: attendance_exit=$att_exit gate_exit=$gate_exit"
             exit 1
           fi
@@ -153,4 +181,5 @@ jobs:
           path: |
             attendance.md
             commit-measurement.json
+            receipts/attendance-partial.json
           if-no-files-found: warn

--- a/.github/workflows/native-crash-zero-tolerance.yml
+++ b/.github/workflows/native-crash-zero-tolerance.yml
@@ -1,7 +1,9 @@
 name: Python native-crash floor (discrimination)
 
-# Discrimination only. Full corpus R_native_crashes runs exclusively under
-# factory-zero-tolerance.yml (one heavy orchestrator).
+# Discrimination only. Full corpus R_native_crashes runs under
+# factory-zero-tolerance.yml process-floor matrix.
+#
+# SILENCE CONCEALS: named phases + PYTHONUNBUFFERED so stall vs work is visible.
 on:
   push:
     branches: [main]
@@ -14,17 +16,20 @@ jobs:
   native-crash-discrimination:
     name: native-crash-discrimination
     runs-on: [self-hosted, Linux, X64]
+    env:
+      PYTHONUNBUFFERED: "1"
     steps:
-      - uses: actions/checkout@v4
-      # ONE environment definition, shared read-only with the authoritative
-      # suite. `sugar-lift-py-tests[test]` remains the sole dependency
-      # authority (#6275) — the action installs from that table and this floor
-      # hand-lists nothing. This floor stays a distinct instrument: one
-      # discrimination file, never a second whole-package sweep.
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Prepare immutable Python test environment
         uses: ./.github/actions/python-test-environment
-      - name: R_native_crashes discrimination
-        run: >-
-          python -m pytest --noconftest
-          implementations/python/sugar-lift-py-tests/tests/test_native_crash_zero_tolerance.py
-          -q
+      - name: "Phase: R_native_crashes discrimination (pytest)"
+        env:
+          PYTHONUNBUFFERED: "1"
+        run: |
+          set -euo pipefail
+          echo "discrimination phase=native_crash status=start"
+          python -u -m pytest --noconftest \
+            implementations/python/sugar-lift-py-tests/tests/test_native_crash_zero_tolerance.py \
+            -v --tb=short
+          echo "discrimination phase=native_crash status=done"

--- a/.github/workflows/timeout-zero-tolerance.yml
+++ b/.github/workflows/timeout-zero-tolerance.yml
@@ -1,7 +1,9 @@
 name: Timeout zero tolerance (discrimination)
 
-# Discrimination only. Full corpus R_timeouts runs exclusively under
-# factory-zero-tolerance.yml (one heavy orchestrator).
+# Discrimination only. Full corpus R_timeouts runs under
+# factory-zero-tolerance.yml process-floor matrix.
+#
+# SILENCE CONCEALS: named phases + PYTHONUNBUFFERED so stall vs work is visible.
 on:
   push:
     branches: [main]
@@ -14,22 +16,29 @@ jobs:
   timeout-discrimination:
     runs-on: [self-hosted, Linux, X64]
     env:
+      PYTHONUNBUFFERED: "1"
       PYTHONPATH: "implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-py-tests/src"
     steps:
-      - uses: actions/checkout@v4
-      # ONE environment definition, shared read-only with the authoritative
-      # suite. `sugar-lift-py-tests[test]` remains the sole dependency
-      # authority (#6275) — the action installs from that table and this floor
-      # hand-lists nothing. This floor stays a distinct instrument: one
-      # discrimination file, never a second whole-package sweep.
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Prepare immutable Python test environment
         uses: ./.github/actions/python-test-environment
-      - name: R_timeouts discrimination
-        run: >-
-          python -m pytest --noconftest
-          implementations/python/sugar-lift-py-tests/tests/test_timeout_zero_tolerance.py
-          -q
-      - name: Panic-catch self-check
-        run: >-
-          python
-          implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+      - name: "Phase: R_timeouts discrimination (pytest)"
+        env:
+          PYTHONUNBUFFERED: "1"
+        run: |
+          set -euo pipefail
+          echo "discrimination phase=timeout status=start"
+          python -u -m pytest --noconftest \
+            implementations/python/sugar-lift-py-tests/tests/test_timeout_zero_tolerance.py \
+            -v --tb=short
+          echo "discrimination phase=timeout status=done"
+      - name: "Phase: panic-catch self-check"
+        env:
+          PYTHONUNBUFFERED: "1"
+        run: |
+          set -euo pipefail
+          echo "discrimination phase=panic_catch status=start"
+          python -u \
+            implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+          echo "discrimination phase=panic_catch status=done"

--- a/implementations/python/sugar-lift-py-tests/scripts/corpus_enrollment_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/corpus_enrollment_law.py
@@ -109,6 +109,14 @@ def is_corpus_py_path(path: Path, *, root: Path) -> bool:
     return True
 
 
+def _log(msg: str) -> None:
+    print(msg, flush=True)
+    try:
+        sys.stdout.flush()
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def discover_corpus_paths_structural(root: Path) -> tuple[Path, ...]:
     """Path selection identical to ``SourceTree.paths`` (structural only).
 
@@ -134,7 +142,12 @@ def discover_corpus_paths_structural(root: Path) -> tuple[Path, ...]:
 def denominator_paths(root: Path) -> tuple[Path, ...]:
     """Live denominator: same set as SourceTree.paths() under root."""
     root = root.resolve()
+    _log(f"corpus_enrollment phase=discover_structural status=start root={root}")
     structural = discover_corpus_paths_structural(root)
+    _log(
+        f"corpus_enrollment phase=discover_structural status=done "
+        f"paths={len(structural)}"
+    )
     bad = [p for p in structural if not is_corpus_py_path(p, root=root)]
     if bad:
         raise ValueError(
@@ -144,8 +157,17 @@ def denominator_paths(root: Path) -> tuple[Path, ...]:
     try:
         from sugar_source_tree.tree import SourceTree
 
+        _log("corpus_enrollment phase=sourcetree_crosscheck status=start")
         tree_paths = tuple(path.resolve() for path in SourceTree(root).paths())
+        _log(
+            f"corpus_enrollment phase=sourcetree_crosscheck status=done "
+            f"paths={len(tree_paths)}"
+        )
     except ImportError:
+        _log(
+            "corpus_enrollment phase=sourcetree_crosscheck status=skip "
+            "reason=ImportError"
+        )
         return structural
     if tree_paths != structural:
         raise ValueError(
@@ -205,10 +227,16 @@ def measure_enrollment(
     recensus_payload: dict | None,
 ) -> EnrollmentReport:
     """Compute denominator live; enrollment only from a terminal receipt."""
+    _log(f"corpus_enrollment phase=measure status=start corpus_root={corpus_root}")
     paths = denominator_paths(corpus_root)
     denom_ids = tuple(relative_file_identity(p, corpus_root=corpus_root) for p in paths)
     denom_n = len(denom_ids)
+    _log(f"corpus_enrollment phase=denominator status=done files={denom_n}")
     if recensus_payload is None:
+        _log(
+            "corpus_enrollment phase=terminals status=skip "
+            "reason=no_recensus enrollment=UNMEASURED"
+        )
         return EnrollmentReport(
             denominator_files=denom_n,
             enrolled_files=None,
@@ -220,12 +248,19 @@ def measure_enrollment(
                 "(no --from-recensus receipt). Do not invent enrolled=denominator."
             ),
         )
+    _log("corpus_enrollment phase=terminals status=start")
     terminal = terminal_file_identities_from_recensus(recensus_payload)
     denom_set = set(denom_ids)
     # Unenrolled relative to the live denominator, not a curated list
     unenrolled = sorted(denom_set - terminal)
     # Also surface terminals not in denominator (population drift)
     extra = sorted(terminal - denom_set)
+    enrolled_n = len(terminal & denom_set)
+    _log(
+        f"corpus_enrollment phase=terminals status=done "
+        f"terminals={len(terminal)} enrolled={enrolled_n} "
+        f"unenrolled={len(unenrolled)} drift_extra={len(extra)}"
+    )
     note = (
         f"live denominator={denom_n}; terminals={len(terminal)}; "
         f"unenrolled={len(unenrolled)}"
@@ -234,7 +269,7 @@ def measure_enrollment(
         note += f"; terminals_outside_denominator={len(extra)} (population drift)"
     return EnrollmentReport(
         denominator_files=denom_n,
-        enrolled_files=len(terminal & denom_set),
+        enrolled_files=enrolled_n,
         unenrolled_files=len(unenrolled),
         unenrolled_identities=tuple(unenrolled),
         measured_enrollment=True,
@@ -299,9 +334,14 @@ def format_report(report: EnrollmentReport) -> str:
 def main(argv: Sequence[str] | None = None) -> int:
     for stream in (sys.stdout, sys.stderr):
         try:
-            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
-        except (AttributeError, ValueError):
-            pass
+            stream.reconfigure(
+                encoding="utf-8", errors="backslashreplace", line_buffering=True
+            )
+        except (AttributeError, ValueError, TypeError):
+            try:
+                stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+            except (AttributeError, ValueError):
+                pass
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--corpus-root",

--- a/tools/heavy_measurement_attendance.py
+++ b/tools/heavy_measurement_attendance.py
@@ -85,25 +85,102 @@ def _class_from_payload(path: Path, payload: dict) -> str | None:
     return None
 
 
-def receipts_attendance(receipts_dir):
-    """Which classes produced an identity-bound measurement body."""
+def _log(msg: str) -> None:
+    """Unbuffered measurement narration — silence conceals hang vs work."""
+    print(msg, flush=True)
+    try:
+        sys.stdout.flush()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def receipts_attendance(receipts_dir, *, partial_path: Path | None = None):
+    """Which classes produced an identity-bound measurement body.
+
+    Narrates expected roster, walk progress, and running attended/missing
+    counts. Writes *partial_path* after each classification so a mid-walk
+    crash still leaves testimony of what was already seen.
+    """
+    root = Path(receipts_dir)
+    paths = sorted(root.rglob("*.json"))
+    total = len(paths)
+    _log(
+        f"attendance phase=scan_receipts status=start paths={total} "
+        f"receipts_dir={root}"
+    )
     attended, testimony = {}, []
-    for path in sorted(Path(receipts_dir).rglob("*.json")):
+    classified = 0
+    skipped = 0
+    for index, path in enumerate(paths, start=1):
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
+            skipped += 1
+            if index == 1 or index == total or index % 25 == 0:
+                _log(
+                    f"attendance progress path={index}/{total} "
+                    f"classified={classified} skipped={skipped} "
+                    f"attended={len(attended)}"
+                )
             continue
         if not isinstance(payload, dict):
+            skipped += 1
             continue
         # Skip pure lease records if any linger in old artifacts
         if payload.get("leaseClass") and "acquired" in payload and "measurementClass" not in payload:
             if "failedNodeIds" not in payload and "totals" not in payload:
+                skipped += 1
                 continue
         cls = _class_from_payload(path, payload)
         if cls is None:
+            skipped += 1
+            if index == 1 or index == total or index % 25 == 0:
+                _log(
+                    f"attendance progress path={index}/{total} "
+                    f"classified={classified} skipped={skipped} "
+                    f"attended={len(attended)}"
+                )
             continue
+        classified += 1
+        first = cls not in attended
         testimony.append((cls, str(path), True))
         attended.setdefault(cls, str(path))
+        if first:
+            _log(
+                f"attendance spoke class={cls} path={path} "
+                f"running_attended={len(attended)} path_index={index}/{total}"
+            )
+        if index == 1 or index == total or index % 25 == 0:
+            _log(
+                f"attendance progress path={index}/{total} "
+                f"classified={classified} skipped={skipped} "
+                f"attended={len(attended)}"
+            )
+        if partial_path is not None:
+            try:
+                partial_path.parent.mkdir(parents=True, exist_ok=True)
+                partial_path.write_text(
+                    json.dumps(
+                        {
+                            "phase": "scan_receipts",
+                            "pathsSeen": index,
+                            "pathsTotal": total,
+                            "attended": dict(attended),
+                            "classified": classified,
+                            "skipped": skipped,
+                        },
+                        indent=2,
+                        sort_keys=True,
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+            except OSError as error:
+                _log(f"attendance partial_write_failed: {error}")
+    _log(
+        f"attendance phase=scan_receipts status=done paths={total} "
+        f"classified={classified} skipped={skipped} attended={len(attended)}"
+    )
     return attended, testimony
 
 
@@ -143,6 +220,12 @@ def workflow_runs(commit, repo=None):
 
 
 def main(argv=None):
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(line_buffering=True)
+        except (AttributeError, ValueError, OSError):
+            pass
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--commit", required=True)
     parser.add_argument("--receipts-dir", default=None)
@@ -153,13 +236,42 @@ def main(argv=None):
         choices=(PER_COMMIT, NIGHTLY_WINDOW),
         default=PER_COMMIT,
     )
+    parser.add_argument(
+        "--partial-json",
+        type=Path,
+        default=None,
+        help="Write running attendance partial during receipt scan (crash-safe).",
+    )
     args = parser.parse_args(argv)
+
+    obliged = owed(args.cadence)
+    _log(
+        f"attendance phase=roster status=start cadence={args.cadence} "
+        f"commit={args.commit} expected_count={len(obliged)}"
+    )
+    for index, cls in enumerate(obliged, start=1):
+        _log(
+            f"attendance expected index={index}/{len(obliged)} class={cls} "
+            f"workflow={HEAVY_ROSTER[cls]!r}"
+        )
 
     attended, testimony = ({}, [])
     if args.receipts_dir:
-        attended, testimony = receipts_attendance(args.receipts_dir)
+        partial = args.partial_json
+        if partial is None:
+            partial = Path(args.receipts_dir) / "attendance-partial.json"
+        attended, testimony = receipts_attendance(
+            args.receipts_dir, partial_path=partial
+        )
+    else:
+        _log("attendance phase=scan_receipts status=skip reason=no_receipts_dir")
 
+    _log("attendance phase=workflow_api status=start")
     runs = workflow_runs(args.commit, args.repo) if not attended else None
+    if runs is None and not attended:
+        _log("attendance phase=workflow_api status=unavailable_or_skipped")
+    elif runs is not None:
+        _log(f"attendance phase=workflow_api status=done runs={len(runs)}")
     run_state = {}
     if runs:
         for run in runs:
@@ -170,8 +282,17 @@ def main(argv=None):
                         f"{run.get('status')}/{run.get('conclusion')} (#{run.get('databaseId')})"
                     )
 
-    obliged = owed(args.cadence)
     minority = [c for c in obliged if c not in attended]
+    _log(
+        f"attendance phase=compose status=start "
+        f"expected={len(obliged)} attended={len([c for c in obliged if c in attended])} "
+        f"missing={len(minority)} testimony_rows={len(testimony)}"
+    )
+    for cls in obliged:
+        if cls in attended:
+            _log(f"attendance result class={cls} spoke=yes body={attended[cls]}")
+        else:
+            _log(f"attendance result class={cls} spoke=NO status=UNMEASURED")
 
     print(f"### heavy-measurement attendance ({args.cadence}) for `{args.commit}`")
     print()
@@ -199,6 +320,7 @@ def main(argv=None):
         else "R_attendance_nightly"
     )
     print(f"**{axis} = {len(minority)}**")
+    _log(f"attendance phase=compose status=done {axis}={len(minority)}")
     not_asked = [c for c in HEAVY_ROSTER if c not in obliged]
     if not_asked:
         print()

--- a/tools/run_static_sole_construction_floors.sh
+++ b/tools/run_static_sole_construction_floors.sh
@@ -1,82 +1,96 @@
 #!/usr/bin/env bash
 # Cheap static / discrimination sole-construction floors — own parallel job.
 # Must not wait on process-floor matrix (silent ~11min). Collect reds; exit 1 if any.
+#
+# SILENCE CONCEALS: named phases + index/total + unbuffered python so a stall
+# names which discrimination is live (not one fused black box).
 
 set -uo pipefail
+export PYTHONUNBUFFERED=1
 
 TESTS=implementations/python/sugar-lift-py-tests
 SCRIPTS="$TESTS/scripts"
 
 red_axes=()
 green_axes=()
+axis_index=0
+# Count axis() invocations for progress (updated as axes are declared below).
+AXIS_TOTAL=20
 
 axis() {
   local name="$1"; shift
-  echo "::group::$name"
+  axis_index=$((axis_index + 1))
+  echo "static_floors phase=axis index=${axis_index}/${AXIS_TOTAL} name=${name} status=start"
+  echo "::group::[${axis_index}/${AXIS_TOTAL}] $name"
   if "$@"; then
     green_axes+=("$name")
     echo "$name: GREEN (measurement completed)"
+    echo "static_floors phase=axis index=${axis_index}/${AXIS_TOTAL} name=${name} status=green running_green=${#green_axes[@]} running_red=${#red_axes[@]}"
   else
     local status=$?
     red_axes+=("$name (exit $status)")
     echo "::error::$name is RED (exit $status)"
+    echo "static_floors phase=axis index=${axis_index}/${AXIS_TOTAL} name=${name} status=red exit=${status} running_green=${#green_axes[@]} running_red=${#red_axes[@]}"
   fi
   echo "::endgroup::"
 }
 
-axis "R_ownership = 0" python "$SCRIPTS/factory_ownership_law.py"
+echo "static_floors phase=begin axis_total=${AXIS_TOTAL}"
+
+axis "R_ownership = 0" python -u "$SCRIPTS/factory_ownership_law.py"
 axis "R_construction_panic_catches_outside_membrane = 0" \
-  python "$SCRIPTS/construction_panic_catch_law.py"
+  python -u "$SCRIPTS/construction_panic_catch_law.py"
 
 axis "All permanent axes are bound" \
-  python -m pytest tests/test_python_sole_construction_ci.py -q
+  python -u -m pytest tests/test_python_sole_construction_ci.py -v --tb=line
 axis '`sugar-lift-py-tests[test]` is the sole dependency authority' \
-  python -m pytest tests/test_test_extras_are_the_dependency_authority.py -q
+  python -u -m pytest tests/test_test_extras_are_the_dependency_authority.py -v --tb=line
 
 axis "R_vendor_special_case discrimination" \
-  python -m pytest --noconftest "$TESTS/tests/test_vendor_special_case_law.py" -q
-axis "R_vendor_special_case = 0" python "$SCRIPTS/vendor_special_case_law.py"
+  python -u -m pytest --noconftest "$TESTS/tests/test_vendor_special_case_law.py" -v --tb=line
+axis "R_vendor_special_case = 0" python -u "$SCRIPTS/vendor_special_case_law.py"
 
 axis "R_silent discrimination" \
-  python -m pytest --noconftest "$TESTS/tests/test_silent_zero_tolerance.py" -q
+  python -u -m pytest --noconftest "$TESTS/tests/test_silent_zero_tolerance.py" -v --tb=line
 
 axis "R_factory_walk_unclassified discrimination" \
-  python -m pytest --noconftest "$TESTS/tests/test_factory_walk_unclassified_law.py" -q
+  python -u -m pytest --noconftest "$TESTS/tests/test_factory_walk_unclassified_law.py" -v --tb=line
 axis "R_factory_walk_unclassified = 0" \
-  python "$SCRIPTS/factory_walk_unclassified_law.py" \
+  python -u "$SCRIPTS/factory_walk_unclassified_law.py" \
   --live-root "$TESTS/src/sugar_lift_py_tests" \
   --live-root "$SCRIPTS"
 
 axis "R_finite_cap_opaque_completions discrimination" \
-  python -m pytest --noconftest "$TESTS/tests/test_finite_cap_opaque_completion_law.py" -q
+  python -u -m pytest --noconftest "$TESTS/tests/test_finite_cap_opaque_completion_law.py" -v --tb=line
 axis "R_finite_cap_opaque_completions = 0" \
-  python "$SCRIPTS/finite_cap_opaque_completion_law.py"
+  python -u "$SCRIPTS/finite_cap_opaque_completion_law.py"
 
 axis "R_finite_unfold_compact_gaps discrimination" \
-  python -m pytest --noconftest \
-  "$TESTS/tests/test_finite_unfold_compact_projection_law.py" -q
+  python -u -m pytest --noconftest \
+  "$TESTS/tests/test_finite_unfold_compact_projection_law.py" -v --tb=line
 axis "R_finite_unfold_compact_gaps = 0" \
-  python "$SCRIPTS/finite_unfold_compact_projection_law.py"
+  python -u "$SCRIPTS/finite_unfold_compact_projection_law.py"
 
 axis "R_source_via_execution discrimination" \
-  python -m pytest --noconftest "$TESTS/tests/test_source_via_execution_law.py" -q
-axis "R_source_via_execution = 0" python "$SCRIPTS/source_via_execution_law.py"
+  python -u -m pytest --noconftest "$TESTS/tests/test_source_via_execution_law.py" -v --tb=line
+axis "R_source_via_execution = 0" python -u "$SCRIPTS/source_via_execution_law.py"
 
 axis "R_no_sugar_in_desugar discrimination" \
-  python "$SCRIPTS/no_sugar_in_desugar_law.py" --self-test
-axis "R_no_sugar_in_desugar = 0" python "$SCRIPTS/no_sugar_in_desugar_law.py"
+  python -u "$SCRIPTS/no_sugar_in_desugar_law.py" --self-test
+axis "R_no_sugar_in_desugar = 0" python -u "$SCRIPTS/no_sugar_in_desugar_law.py"
 
 axis "R_construction_side_doors discrimination" \
-  python -m pytest --noconftest "$TESTS/tests/test_construction_side_door_law.py" -q
-axis "R_construction_side_doors = 0" python "$SCRIPTS/construction_side_door_law.py"
+  python -u -m pytest --noconftest "$TESTS/tests/test_construction_side_door_law.py" -v --tb=line
+axis "R_construction_side_doors = 0" python -u "$SCRIPTS/construction_side_door_law.py"
 
 axis "R_bare_construction_door discrimination" \
-  python -m pytest --noconftest \
-  "$TESTS/tests/test_construction_context_door_law.py" -q
+  python -u -m pytest --noconftest \
+  "$TESTS/tests/test_construction_context_door_law.py" -v --tb=line
 axis "R_bare_construction_door = 0" \
-  python "$SCRIPTS/construction_context_door_law.py"
+  python -u "$SCRIPTS/construction_context_door_law.py"
 
 echo
+echo "static_floors phase=end green=${#green_axes[@]} red=${#red_axes[@]}"
 echo "static sole-construction floors: ${#green_axes[@]} green, ${#red_axes[@]} red"
 if [ ${#red_axes[@]} -gt 0 ]; then
   echo "RED AXES:"

--- a/tools/sole_construction_floor_enrollment.py
+++ b/tools/sole_construction_floor_enrollment.py
@@ -103,27 +103,97 @@ def mint_axis_report(
     }
 
 
-def check_attendance(directory: Path, *, require_commit: str) -> tuple[int, dict]:
+def _log(msg: str) -> None:
+    print(msg, flush=True)
+    try:
+        sys.stdout.flush()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def check_attendance(
+    directory: Path,
+    *,
+    require_commit: str,
+    partial_path: Path | None = None,
+) -> tuple[int, dict]:
     """Enrollment roll call. Missing axis ⇒ UNMEASURED (exit 1).
 
     Residual-red axes still attend; campaign residual is separate from attendance.
+    Narrates expected axes, discovery walk, and per-axis spoke/silence.
     """
     require_commit = require_commit.strip()
     if not require_commit:
         raise ValueError("require_commit must be non-empty")
 
-    by_id: dict[str, list[dict]] = {i: [] for i in enrolled_ids()}
-    for path in sorted(directory.rglob(REPORT_FILENAME)):
+    expected = list(enrolled_ids())
+    _log(
+        f"floor_enrollment phase=roster status=start expected_count={len(expected)} "
+        f"require_commit={require_commit} directory={directory}"
+    )
+    for index, axis_id in enumerate(expected, start=1):
+        axis = next(a for a in ENROLLED if a.axis_id == axis_id)
+        _log(
+            f"floor_enrollment expected index={index}/{len(expected)} "
+            f"axis={axis_id} display={axis.display} kind={axis.kind}"
+        )
+
+    by_id: dict[str, list[dict]] = {i: [] for i in expected}
+    report_paths = sorted(directory.rglob(REPORT_FILENAME))
+    total = len(report_paths)
+    _log(
+        f"floor_enrollment phase=scan_reports status=start "
+        f"report_files={total} pattern={REPORT_FILENAME}"
+    )
+    for index, path in enumerate(report_paths, start=1):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError) as error:
+            _log(
+                f"floor_enrollment progress report={index}/{total} "
+                f"path={path} status=unreadable error={type(error).__name__}"
+            )
             continue
         if not isinstance(data, dict) or data.get("kind") != REPORT_KIND:
+            _log(
+                f"floor_enrollment progress report={index}/{total} "
+                f"path={path} status=skip_kind kind={data.get('kind') if isinstance(data, dict) else type(data).__name__}"
+            )
             continue
         aid = data.get("axisId")
         if aid in by_id:
             data["_path"] = str(path)
             by_id[aid].append(data)
+            _log(
+                f"floor_enrollment progress report={index}/{total} "
+                f"axis={aid} status=loaded path={path}"
+            )
+        else:
+            _log(
+                f"floor_enrollment progress report={index}/{total} "
+                f"axis={aid} status=not_enrolled path={path}"
+            )
+        if partial_path is not None:
+            try:
+                partial_path.parent.mkdir(parents=True, exist_ok=True)
+                partial_path.write_text(
+                    json.dumps(
+                        {
+                            "phase": "scan_reports",
+                            "reportsSeen": index,
+                            "reportsTotal": total,
+                            "loadedAxes": {
+                                k: len(v) for k, v in by_id.items() if v
+                            },
+                        },
+                        indent=2,
+                        sort_keys=True,
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+            except OSError as error:
+                _log(f"floor_enrollment partial_write_failed: {error}")
 
     missing: list[str] = []
     unresolved: list[str] = []
@@ -131,21 +201,47 @@ def check_attendance(directory: Path, *, require_commit: str) -> tuple[int, dict
     residual_red: list[str] = []
     attended: list[str] = []
 
-    for axis in ENROLLED:
+    _log(
+        f"floor_enrollment phase=classify status=start enrolled={len(ENROLLED)}"
+    )
+    for index, axis in enumerate(ENROLLED, start=1):
         rows = by_id[axis.axis_id]
         if not rows:
             missing.append(axis.axis_id)
+            _log(
+                f"floor_enrollment result index={index}/{len(ENROLLED)} "
+                f"axis={axis.axis_id} spoke=NO status=MISSING"
+            )
             continue
         row = rows[0]
         if not row.get("identityResolved") or not row.get("measured"):
             unresolved.append(axis.axis_id)
+            _log(
+                f"floor_enrollment result index={index}/{len(ENROLLED)} "
+                f"axis={axis.axis_id} spoke=partial status=UNRESOLVED"
+            )
             continue
         if str(row.get("measuredCommit", "")).strip() != require_commit:
             wrong_commit.append(axis.axis_id)
+            _log(
+                f"floor_enrollment result index={index}/{len(ENROLLED)} "
+                f"axis={axis.axis_id} spoke=partial status=WRONG_COMMIT "
+                f"got={row.get('measuredCommit')!r}"
+            )
             continue
         attended.append(axis.axis_id)
-        if int(row.get("exitCode", 1)) != 0:
+        exit_code = int(row.get("exitCode", 1))
+        if exit_code != 0:
             residual_red.append(axis.axis_id)
+            _log(
+                f"floor_enrollment result index={index}/{len(ENROLLED)} "
+                f"axis={axis.axis_id} spoke=yes residual=RED exit={exit_code}"
+            )
+        else:
+            _log(
+                f"floor_enrollment result index={index}/{len(ENROLLED)} "
+                f"axis={axis.axis_id} spoke=yes residual=green exit=0"
+            )
 
     complete = not missing and not unresolved and not wrong_commit
     summary = {
@@ -161,6 +257,11 @@ def check_attendance(directory: Path, *, require_commit: str) -> tuple[int, dict
         "status": "complete" if complete else "UNMEASURED",
         "measurementClass": CAMPAIGN_CLASS,
     }
+    _log(
+        f"floor_enrollment phase=compose status=done "
+        f"status={summary['status']} attended={len(attended)} "
+        f"missing={missing} residual_red={residual_red}"
+    )
     return (0 if complete else 1), summary
 
 
@@ -185,6 +286,12 @@ def mint_campaign_body(attendance: dict, *, commit_sha: str) -> dict:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(line_buffering=True)
+        except (AttributeError, ValueError, OSError):
+            pass
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--emit-process-matrix-json", action="store_true")
     parser.add_argument("--emit-roster-json", action="store_true")
@@ -197,10 +304,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--check-attendance", type=Path)
     parser.add_argument("--require-commit", default="")
     parser.add_argument("--write-campaign-body", type=Path)
+    parser.add_argument(
+        "--partial-json",
+        type=Path,
+        default=None,
+        help="Crash-safe running enrollment partial during report scan.",
+    )
     args = parser.parse_args(argv)
 
     if args.emit_process_matrix_json:
-        print(emit_process_matrix_json())
+        print(emit_process_matrix_json(), flush=True)
         return 0
     if args.emit_roster_json:
         print(
@@ -215,10 +328,15 @@ def main(argv: Sequence[str] | None = None) -> int:
                 },
                 indent=2,
                 sort_keys=True,
-            )
+            ),
+            flush=True,
         )
         return 0
     if args.mint_report is not None:
+        _log(
+            f"floor_enrollment phase=mint_report axis={args.axis_id} "
+            f"exit={args.exit_code} commit={args.commit_sha}"
+        )
         report = mint_axis_report(
             axis_id=args.axis_id,
             display=args.display,
@@ -230,17 +348,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.mint_report.write_text(
             json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
-        print(json.dumps(report, sort_keys=True))
+        print(json.dumps(report, sort_keys=True), flush=True)
         return 0
     if args.check_attendance is not None:
+        partial = args.partial_json
+        if partial is None:
+            partial = Path(args.check_attendance) / "enrollment-partial.json"
         code, summary = check_attendance(
-            args.check_attendance, require_commit=args.require_commit
+            args.check_attendance,
+            require_commit=args.require_commit,
+            partial_path=partial,
         )
-        print(json.dumps(summary, indent=2, sort_keys=True))
+        print(json.dumps(summary, indent=2, sort_keys=True), flush=True)
         if args.write_campaign_body is not None:
             body = mint_campaign_body(summary, commit_sha=args.require_commit)
             args.write_campaign_body.write_text(
                 json.dumps(body, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+            _log(
+                f"floor_enrollment phase=campaign_body path={args.write_campaign_body} "
+                f"status={body.get('status')}"
             )
         if code != 0:
             print(
@@ -248,12 +375,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 f"missing={summary['missing']} unresolved={summary['unresolved']} "
                 f"wrongCommit={summary['wrongCommit']}",
                 file=sys.stderr,
+                flush=True,
             )
         else:
             print(
                 f"FLOOR ENROLLMENT GREEN: all {len(ENROLLED)} axes attended "
                 f"(residualRed={summary['residualRed']})",
                 file=sys.stderr,
+                flush=True,
             )
         return code
     parser.error("pick an action")


### PR DESCRIPTION
## What

T killed black-box CI measurements. This PR owns the surfaces that decide whether a measurement **counts**:

| Surface | Logging |
| --- | --- |
| **Discrimination floors** (native/bare/timeout workflows + static job) | Named phases, `PYTHONUNBUFFERED`, `python -u`, pytest `-v` |
| **Floor enrollment** (`sole_construction_floor_enrollment.py`) | Expected axes, report walk index/total, per-axis spoke/MISSING/UNRESOLVED/RED, partial JSON |
| **Heavy attendance** (`heavy_measurement_attendance.py` + workflow) | Expected roster, receipt scan progress, spoke/NO, download index/total, partial JSON |

## Requirements met

- Named phases (`phase=… status=…`)
- Progress with index/total on walks
- Running counts as they accumulate
- Unbuffered stdout (`flush=True`, `PYTHONUNBUFFERED=1`, `python -u`)
- Partial results on crash (`attendance-partial.json`, `enrollment-partial.json`)

## Does not change

What anything measures. Roster, predicates, exit codes, and R axes are unchanged — only narration and crash-safe partials.

## Validation

```
uv run --with pytest python -m pytest \
  tests/test_heavy_measurement_concurrency_topology.py \
  tests/test_python_sole_construction_ci.py -q
# 30 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add real-time phase logging and partial JSON snapshots to discrimination, enrollment, and attendance workflows
> - All CI workflows now set `PYTHONUNBUFFERED=1` and run Python with `-u` so logs stream immediately; steps are renamed with `Phase:` prefixes and emit start/done echo markers.
> - [`corpus_enrollment_law.py`](https://github.com/TSavo/sugar/pull/7031/files#diff-46fcd148c7c201cbb8a978968afd674a1967dee8d12f4e149177966429fa44dd), [`sole_construction_floor_enrollment.py`](https://github.com/TSavo/sugar/pull/7031/files#diff-97da7ddf4a53542ab183832c1fedf5e3201fc8f4395b58fc71155d4040db58db), and [`heavy_measurement_attendance.py`](https://github.com/TSavo/sugar/pull/7031/files#diff-488ea1f5082769971d9377e07807b0fef693e2d67727f202b2a8c34ba0963556) each gain a `_log` helper that flushes stdout on every message.
> - Enrollment and attendance scripts now accept `--partial-json` and write incremental progress snapshots on each iteration so in-progress state is visible if a run crashes.
> - Partial JSON artifacts (`enrollment-partial.json`, `attendance-partial.json`) are uploaded as CI artifacts alongside the existing `floor-measurement.json`.
> - [`run_static_sole_construction_floors.sh`](https://github.com/TSavo/sugar/pull/7031/files#diff-fe37c87c9dc044d5189f871624437d0fd0857b8ffb2f70af355c37ed02d4ff2b) switches pytest from `-q` to `-v --tb=line` and adds indexed axis progress counters.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91bb8e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->