### PR TITLE
Job-log residual: factory_walk + silent heartbeats (after #7035)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/factory_walk_unclassified_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/factory_walk_unclassified_law.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 SCOREBOARD_AUTHORITY = False
 
 import argparse
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
 import os
 import subprocess
@@ -37,6 +37,11 @@ import sys
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
+
+# Repo tools/ for job-log heartbeats (≤30s doctrine — run 30731778056: 88s silence).
+_TOOLS = Path(__file__).resolve().parents[4] / "tools"
+if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
 
 from sugar_lift_py_tests.idd.factory_walk_unclassified_locus import (
     UNCLASSIFIED_STATUSES,
@@ -336,29 +341,87 @@ def measure_live_roots(
     file_timeout: int,
     workers: int,
 ) -> tuple[list[Any], dict[str, int]]:
+    """Live census with job-log heartbeats.
+
+    Run 30731778056: ~88s silence after group header — ``executor.map`` blocked
+    until the whole pool finished. Use ``as_completed`` + JobLogHeartbeat so
+    every finished file names phase/count on the Actions log within 30s.
+    """
+    from job_log_heartbeat import JobLogHeartbeat
+
     paths = _python_paths(roots)
     if not paths:
         raise ValueError(f"no Python source files found under {list(roots)}")
-    with ThreadPoolExecutor(max_workers=workers) as executor:
-        results = list(
-            executor.map(
-                lambda path: _measure_live_file(
-                    path, repo_root=repo_root, file_timeout=file_timeout
-                ),
-                paths,
-            )
+    total = len(paths)
+    beat = JobLogHeartbeat("factory-walk-live", total=total)
+    beat.watch()
+    beat.tick(
+        n=0,
+        force=True,
+        status="denominator",
+        files_discovered=total,
+        workers=workers,
+    )
+    results: list[Mapping[str, Any]] = []
+    done = 0
+    completed = timeouts = panics = crashes = errors = 0
+    try:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                executor.submit(
+                    _measure_live_file,
+                    path,
+                    repo_root=repo_root,
+                    file_timeout=file_timeout,
+                ): path
+                for path in paths
+            }
+            for fut in as_completed(futures):
+                path = futures[fut]
+                try:
+                    row = fut.result()
+                except Exception as exc:  # noqa: BLE001 — per-file containment
+                    rel = path.resolve().relative_to(repo_root.resolve()).as_posix()
+                    row = {
+                        "file": rel,
+                        "category": "auditor-error",
+                        "rows": [],
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                results.append(row)
+                done += 1
+                cat = str(row.get("category") or "")
+                if cat == "completed":
+                    completed += 1
+                elif cat == "timeout":
+                    timeouts += 1
+                elif cat == "factory-panic":
+                    panics += 1
+                elif cat == "native-crash":
+                    crashes += 1
+                elif cat == "auditor-error":
+                    errors += 1
+                beat.tick(
+                    n=done,
+                    force=True,
+                    file=row.get("file"),
+                    completed=completed,
+                    timeouts=timeouts,
+                    panics=panics,
+                    native_crashes=crashes,
+                    auditor_errors=errors,
+                )
+    finally:
+        beat.stop(
+            status="done",
         )
     counts = {
         "files_discovered": len(results),
-        "files_completed": sum(row.get("category") == "completed" for row in results),
-        "construction_panics": sum(
-            row.get("category") == "factory-panic" for row in results
-        ),
-        "timeouts": sum(row.get("category") == "timeout" for row in results),
-        "native_crashes": sum(row.get("category") == "native-crash" for row in results),
-        "auditor_errors": sum(
-            row.get("category") == "auditor-error" for row in results
-        ),
+        "files_completed": completed,
+        "construction_panics": panics,
+        "timeouts": timeouts,
+        "native_crashes": crashes,
+        "auditor_errors": errors,
     }
     rows = [
         walk_row
@@ -372,9 +435,16 @@ def measure_live_roots(
 def main(argv: Sequence[str] | None = None) -> int:
     for stream in (sys.stdout, sys.stderr):
         try:
-            stream.reconfigure(encoding="utf-8", errors="backslashreplace")
-        except (AttributeError, ValueError):
-            pass
+            stream.reconfigure(
+                encoding="utf-8",
+                errors="backslashreplace",
+                line_buffering=True,
+            )
+        except (AttributeError, ValueError, TypeError):
+            try:
+                stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+            except (AttributeError, ValueError):
+                pass
     repo_root = Path(__file__).resolve().parents[4]
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -297,18 +297,43 @@ def audit_paths(
                 f"# files={len(paths)} pending={len(pending)}\n"
             ),
         )
+    files_total = len(paths)
+    pending_total = len(pending)
+    already_done = files_total - pending_total
+    from job_log_heartbeat import JobLogHeartbeat
+
+    beat = JobLogHeartbeat("silent-audit", total=files_total)
+    beat.n = already_done
+    beat.watch()
+    beat.tick(
+        n=already_done,
+        force=True,
+        status="denominator",
+        pending=pending_total,
+        file_timeout_s=file_timeout,
+    )
     try:
         iterator: Any = pending
         if progress_stream is not None:
             iterator = iter_with_tqdm(
                 pending,
                 progress=progress_stream,
-                total=len(paths),
-                initial=len(paths) - len(pending),
+                total=files_total,
+                initial=already_done,
                 desc="silent",
-                progress_stdout=progress_stdout,
+                # Always mirror when requested — never isatty-gate job log.
+                progress_stdout=True if progress_stdout else False,
             )
-        for path in iterator:
+        for file_i, path in enumerate(pending, start=1):
+            rel = relative_to_root(path, root)
+            beat.tick(
+                n=already_done + file_i - 1,
+                force=True,
+                status="audit-file",
+                file=rel,
+                pending_index=file_i,
+                pending_total=pending_total,
+            )
             row = _run_one(path, root=root, file_timeout=file_timeout)
             if checkpoint is not None:
                 checkpoint.append(
@@ -321,7 +346,16 @@ def audit_paths(
                     },
                 )
             done_rows[row.file] = row
+            beat.tick(
+                n=already_done + file_i,
+                force=(file_i == pending_total or file_i % 10 == 0),
+                status="file-done",
+                file=row.file,
+                category=row.category,
+                silent_loci=r_silent(row.offenders),
+            )
     finally:
+        beat.stop(status="audit-complete")
         if progress_stream is not None:
             progress_stream.close()
 


### PR DESCRIPTION
## Rebase note (#7031 / #7035 absorption)

**#7035 landed** shared `tools/job_log_heartbeat.py` and wired it through
`_supervised_enum_supervisor` + `_enum_floor_runtime`. That **supersedes** this
PR’s original FLOOR-PROGRESS narration on the supervised scan path.

This branch was **reset onto main** and re-scoped to residual gaps only:

| Path | Status |
| --- | --- |
| Supervised enum / enum runtime | Already on main via #7035 — **not re-applied** |
| Discrimination / enrollment logging | #7031 — **not re-applied** |
| **factory_walk_unclassified live** | **This PR** — was ~88s silent (run 30731778056) |
| **silent audit walk** | **This PR** — per-file JOB_LOG heartbeats |

## factory_walk fix

`measure_live_roots` used `ThreadPoolExecutor.map`, which blocks until **all**
files finish — so the Actions log showed one group header then ~88s of silence
before “incomplete measurement”.

Now: `as_completed` + `JobLogHeartbeat("factory-walk-live")` with running
completed/timeout/panic/crash/auditor_error counts **to stdout** every file
(and 30s alive if a single child stalls).

## silent residual

Per-file `JobLogHeartbeat("silent-audit")` before/after each `_run_one` so a
hang names the in-flight file.

## Validation

- Live smoke: 2-file tree emits `JOB_LOG phase=factory-walk-live n=1/2 …`
- `py_compile` on touched scripts

## Floors

No change to R arithmetic or incompleteness rules (still exit 2 when live
measurement is incomplete).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `JobLogHeartbeat` and per-file error containment to factory_walk and silent_zero_tolerance scripts
> - [`factory_walk_unclassified_law.py`](https://github.com/TSavo/sugar/pull/7032/files#diff-9384e15a7ec551ec3e77f6b8ee83cbb950a467d7a29d2f62356a9bb3fc419ba1) now emits `factory-walk-live` heartbeat ticks during parallel processing, with initial denominator, per-file progress, and a final stop call.
> - Per-file exceptions in `measure_live_roots` are caught and recorded as `auditor-error` result rows instead of propagating, improving robustness over large file sets.
> - [`silent_zero_tolerance.py`](https://github.com/TSavo/sugar/pull/7032/files#diff-017af4b2b643b2bd518a956fda5e334d86d7f52ae29457078d354da18fa34546) emits `silent-audit` heartbeat ticks before and after each file, forced every 10 files, initialized from checkpoint progress.
> - Both scripts dynamically append the repo `tools` directory to `sys.path` at import time to resolve heartbeat utilities.
> - `stdout`/`stderr` reconfiguration in `factory_walk` now attempts `line_buffering=True` and falls back gracefully on `TypeError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed3ef33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->