### PR TITLE
Enrollment mint: crash banks UNMEASURED, not measured residual

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -129,7 +129,7 @@ def main() -> int:
         paths = require_explicit_scan_roots(args.paths)
     except ValueError as error:
         print(f"BARE-EXCEPTION ZERO-TOLERANCE RED: {error}")
-        return 1
+        return 2
     print(
         "BARE-EXCEPTION POPULATION: "
         f"roots={[str(p) for p in args.paths]} files={len(paths)}"
@@ -145,7 +145,7 @@ def main() -> int:
         )
     except (OSError, ValueError) as error:
         print(format_unmeasured_axis("R_bare_exceptions", reason=str(error)))
-        return 1
+        return 2
     progress_path.write_text(
         f"# bare-exception supervised enum scan\n"
         f"# engine={engine_path}\n"

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -187,7 +187,7 @@ def main() -> int:
         paths = require_explicit_scan_roots(args.paths)
     except ValueError as error:
         print(f"NATIVE-CRASH ZERO-TOLERANCE RED: {error}")
-        return 1
+        return 2
     print(
         "NATIVE-CRASH POPULATION: "
         f"roots={[str(p) for p in args.paths]} files={len(paths)}"
@@ -203,7 +203,7 @@ def main() -> int:
         )
     except (OSError, ValueError) as error:
         print(format_unmeasured_axis("R_native_crashes", reason=str(error)))
-        return 1
+        return 2
     summary = audit_paths(
         paths,
         root=args.repo_root,

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -382,7 +382,7 @@ def main() -> int:
         paths = require_explicit_scan_roots(roots)
     except ValueError as error:
         print(f"SILENT ZERO-TOLERANCE RED: {error}")
-        return 1
+        return 2
 
     try:
         _base, engine_path, progress_path = prepare_floor_io(
@@ -394,7 +394,7 @@ def main() -> int:
         )
     except (OSError, ValueError) as error:
         print(format_unmeasured_axis("R_silent", reason=str(error)))
-        return 1
+        return 2
     summary = audit_paths(
         paths,
         root=args.repo_root,

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -128,7 +128,7 @@ def main() -> int:
         paths = require_explicit_scan_roots(args.paths)
     except ValueError as error:
         print(f"TIMEOUT ZERO-TOLERANCE RED: {error}")
-        return 1
+        return 2
     print(
         "TIMEOUT POPULATION: "
         f"roots={[str(p) for p in args.paths]} files={len(paths)}"
@@ -144,7 +144,7 @@ def main() -> int:
         )
     except (OSError, ValueError) as error:
         print(format_unmeasured_axis("R_timeouts", reason=str(error)))
-        return 1
+        return 2
     summary = audit_paths(
         paths,
         root=args.repo_root,

--- a/tests/test_sole_construction_floor_enrollment_measured.py
+++ b/tests/test_sole_construction_floor_enrollment_measured.py
@@ -1,0 +1,119 @@
+"""Teeth: enrollment mint must not bank crash as measured residual."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location(
+    "sole_construction_floor_enrollment",
+    ROOT / "tools" / "sole_construction_floor_enrollment.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+ENR = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = ENR
+_SPEC.loader.exec_module(ENR)
+
+
+def test_crash_before_scan_mints_unmeasured_not_completed() -> None:
+    """Plant infrastructure death (exit 2): body must be UNMEASURED, not residual."""
+    report = ENR.mint_axis_report(
+        axis_id="silent",
+        display="R_silent",
+        commit_sha="deadbeef",
+        exit_code=2,
+        kind="process",
+        unmeasured_reason="planted auth/init failure",
+    )
+    assert report["measured"] is False
+    assert report["status"] == "unmeasured"
+    assert report["floorExitGreen"] is False
+    assert report["unmeasuredReason"]
+    assert "auth" in report["unmeasuredReason"].lower() or "planted" in report["unmeasuredReason"].lower()
+    # Must not look like a measured residual red (status=completed measured=True exit=1).
+    assert report["status"] != "completed"
+    assert report.get("totals", {}).get("unmeasured") == 1
+
+
+def test_genuine_nonzero_residual_is_measured_not_unmeasured() -> None:
+    """Plant residual red (exit 1 after completed scan): measured with residual."""
+    report = ENR.mint_axis_report(
+        axis_id="native-crash",
+        display="R_native_crashes",
+        commit_sha="deadbeef",
+        exit_code=1,
+        kind="process",
+    )
+    assert report["measured"] is True
+    assert report["status"] == "completed"
+    assert report["floorExitGreen"] is False
+    assert report["exitCode"] == 1
+    assert report.get("unmeasuredReason") is None
+
+
+def test_green_residual_is_measured() -> None:
+    report = ENR.mint_axis_report(
+        axis_id="timeout",
+        display="R_timeouts",
+        commit_sha="deadbeef",
+        exit_code=0,
+        kind="process",
+    )
+    assert report["measured"] is True
+    assert report["status"] == "completed"
+    assert report["floorExitGreen"] is True
+
+
+def test_crash_and_residual_never_look_alike() -> None:
+    crash = ENR.mint_axis_report(
+        axis_id="bare-exception",
+        display="R_bare_exceptions",
+        commit_sha="c",
+        exit_code=2,
+        kind="process",
+    )
+    residual = ENR.mint_axis_report(
+        axis_id="bare-exception",
+        display="R_bare_exceptions",
+        commit_sha="c",
+        exit_code=1,
+        kind="process",
+    )
+    # The distinction enrollment exists to make:
+    assert (crash["measured"], crash["status"]) != (residual["measured"], residual["status"])
+    assert crash["measured"] is False and residual["measured"] is True
+
+
+def test_enrollment_roll_call_unmeasured_not_residual_red(tmp_path: Path) -> None:
+    """UNMEASURED axis fails completeness; must not be counted as residualRed."""
+    # Four axes measured green; silent is crash-unmeasured.
+    for axis in ENR.ENROLLED:
+        if axis.axis_id == "silent":
+            report = ENR.mint_axis_report(
+                axis_id=axis.axis_id,
+                display=axis.display,
+                commit_sha="tip",
+                exit_code=2,
+                kind=axis.kind,
+                unmeasured_reason="planted crash before measurement",
+            )
+        else:
+            report = ENR.mint_axis_report(
+                axis_id=axis.axis_id,
+                display=axis.display,
+                commit_sha="tip",
+                exit_code=0,
+                kind=axis.kind,
+            )
+        path = tmp_path / f"floor-axis-{axis.axis_id}" / ENR.REPORT_FILENAME
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps(report), encoding="utf-8")
+    code, summary = ENR.check_attendance(tmp_path, require_commit="tip")
+    assert code == 1
+    assert summary["status"] == "UNMEASURED"
+    assert "silent" in summary["unresolved"]
+    assert "silent" not in summary["residualRed"]
+    assert "silent" not in summary["attended"]

--- a/tools/run_one_process_floor_axis.sh
+++ b/tools/run_one_process_floor_axis.sh
@@ -2,11 +2,11 @@
 # Run exactly one Criterion-2 process floor axis; emit identity-bound report.
 #
 # Usage: tools/run_one_process_floor_axis.sh <axis_id> <script_name>
-#   axis_id: silent | native-crash | bare-exception | timeout
-#   script:  silent_zero_tolerance.py | …
 #
-# Host-durable terminal cache (cross-job): default HOME/.cache/sugar/…
-# Workspace-local cache is job-private and would cold-lift every matrix axis.
+# Exit vocabulary (enrollment mint):
+#   0 — scan completed, residual green
+#   1 — scan completed, residual red
+#   2+ — scan did not complete (auth/init/crash) → report UNMEASURED
 
 set -uo pipefail
 
@@ -26,14 +26,30 @@ PANDAS_CORPUS="$(
   python -c 'from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus; print(authenticated_pandas_corpus().root)'
 )" || {
   echo "::error::cannot authenticate pandas corpus for process floor $axis_id"
-  exit 1
+  # Auth failure is infrastructure UNMEASURED, not residual red.
+  commit="${GITHUB_SHA:-unpinned}"
+  case "$axis_id" in
+    silent) display=R_silent ;;
+    native-crash) display=R_native_crashes ;;
+    bare-exception) display=R_bare_exceptions ;;
+    timeout) display=R_timeouts ;;
+    *) display="R_${axis_id}" ;;
+  esac
+  python3 tools/sole_construction_floor_enrollment.py \
+    --mint-report floor-axis-report.json \
+    --axis-id "$axis_id" \
+    --display "$display" \
+    --kind process \
+    --commit-sha "$commit" \
+    --exit-code 2 \
+    --no-scan-completed \
+    --unmeasured-reason "authenticated pandas corpus auth/init failed"
+  exit 2
 }
 
 FLOOR_SCRATCH="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}/.sugar/ci-floors/${axis_id}"
 export SUGAR_FLOOR_WORKSPACE="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}"
 
-# Cross-job shelf: HOME survives separate matrix jobs on self-hosted runners.
-# Workspace paths do not. Override with SUGAR_PROCESS_FLOOR_CACHE_DIR=off to disable.
 if [ -z "${SUGAR_PROCESS_FLOOR_CACHE_DIR+x}" ]; then
   export SUGAR_PROCESS_FLOOR_CACHE_DIR="${HOME}/.cache/sugar/process-floor-terminals"
 fi
@@ -60,12 +76,19 @@ case "$axis_id" in
   *) display="R_${axis_id}" ;;
 esac
 
-python3 tools/sole_construction_floor_enrollment.py \
-  --mint-report floor-axis-report.json \
-  --axis-id "$axis_id" \
-  --display "$display" \
-  --kind process \
-  --commit-sha "$commit" \
+# 0/1 = scan completed (green/red residual); >=2 = infrastructure UNMEASURED
+mint_args=(
+  --mint-report floor-axis-report.json
+  --axis-id "$axis_id"
+  --display "$display"
+  --kind process
+  --commit-sha "$commit"
   --exit-code "$exit_code"
+)
+if [ "$exit_code" -ge 2 ]; then
+  mint_args+=(--no-scan-completed --unmeasured-reason "process floor exit=${exit_code} (auth/init/bootstrap/crash — not residual)")
+fi
+
+python3 tools/sole_construction_floor_enrollment.py "${mint_args[@]}"
 
 exit "$exit_code"

--- a/tools/sole_construction_floor_enrollment.py
+++ b/tools/sole_construction_floor_enrollment.py
@@ -76,6 +76,13 @@ def emit_process_matrix_json() -> str:
     return json.dumps({"include": include})
 
 
+# Exit-code vocabulary for enrollment mint (scan-complete vs infrastructure):
+#   0 — scan completed; residual green (R=0)
+#   1 — scan completed; residual red (R>0)
+#   2+ — scan did NOT complete (auth/init/crash/IO); UNMEASURED, not residual
+SCAN_COMPLETED_EXITS = frozenset({0, 1})
+
+
 def mint_axis_report(
     *,
     axis_id: str,
@@ -83,9 +90,41 @@ def mint_axis_report(
     commit_sha: str,
     exit_code: int,
     kind: str,
+    scan_completed: bool | None = None,
+    unmeasured_reason: str | None = None,
 ) -> dict:
+    """Mint an identity-bound axis body.
+
+    ``measured=True`` only when the scan completed with a body (exit 0 or 1 by
+    default). Auth/init/crash (exit >= 2, or scan_completed=False) mints
+    UNMEASURED with a named reason — never banked as attended residual green.
+    """
     if axis_id not in enrolled_ids():
         raise ValueError(f"axis_id {axis_id!r} is not enrolled")
+    code = int(exit_code)
+    if scan_completed is None:
+        scan_completed = code in SCAN_COMPLETED_EXITS
+    if scan_completed:
+        return {
+            "schemaVersion": 1,
+            "kind": REPORT_KIND,
+            "axisId": axis_id,
+            "display": display,
+            "axisKind": kind,
+            "measurementClass": CAMPAIGN_CLASS,
+            "measuredCommit": commit_sha,
+            "status": "completed",
+            "exitCode": code,
+            "identityResolved": True,
+            "measured": True,
+            "floorExitGreen": code == 0,
+            "unmeasuredReason": None,
+            "totals": {"failed": 0 if code == 0 else 1},
+        }
+    reason = unmeasured_reason or (
+        f"scan did not complete (exit={code}); infrastructure/auth/init/crash "
+        "— not a residual reading"
+    )
     return {
         "schemaVersion": 1,
         "kind": REPORT_KIND,
@@ -94,12 +133,13 @@ def mint_axis_report(
         "axisKind": kind,
         "measurementClass": CAMPAIGN_CLASS,
         "measuredCommit": commit_sha,
-        "status": "completed",
-        "exitCode": int(exit_code),
+        "status": "unmeasured",
+        "exitCode": code,
         "identityResolved": True,
-        "measured": True,
-        "floorExitGreen": int(exit_code) == 0,
-        "totals": {"failed": 0 if int(exit_code) == 0 else 1},
+        "measured": False,
+        "floorExitGreen": False,
+        "unmeasuredReason": reason,
+        "totals": {"failed": 1, "unmeasured": 1},
     }
 
 
@@ -214,19 +254,29 @@ def check_attendance(
             )
             continue
         row = rows[0]
-        if not row.get("identityResolved") or not row.get("measured"):
-            unresolved.append(axis.axis_id)
-            _log(
-                f"floor_enrollment result index={index}/{len(ENROLLED)} "
-                f"axis={axis.axis_id} spoke=partial status=UNRESOLVED"
-            )
-            continue
         if str(row.get("measuredCommit", "")).strip() != require_commit:
             wrong_commit.append(axis.axis_id)
             _log(
                 f"floor_enrollment result index={index}/{len(ENROLLED)} "
                 f"axis={axis.axis_id} spoke=partial status=WRONG_COMMIT "
                 f"got={row.get('measuredCommit')!r}"
+            )
+            continue
+        # Crash/auth/init: status=unmeasured measured=False — NOT residual red.
+        if row.get("status") == "unmeasured" or not row.get("measured"):
+            unresolved.append(axis.axis_id)
+            reason = row.get("unmeasuredReason") or "no scan body"
+            _log(
+                f"floor_enrollment result index={index}/{len(ENROLLED)} "
+                f"axis={axis.axis_id} spoke=yes status=UNMEASURED "
+                f"reason={reason!r} exit={row.get('exitCode')}"
+            )
+            continue
+        if not row.get("identityResolved"):
+            unresolved.append(axis.axis_id)
+            _log(
+                f"floor_enrollment result index={index}/{len(ENROLLED)} "
+                f"axis={axis.axis_id} spoke=partial status=UNRESOLVED"
             )
             continue
         attended.append(axis.axis_id)
@@ -301,6 +351,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--kind", default="process")
     parser.add_argument("--commit-sha", default="")
     parser.add_argument("--exit-code", type=int, default=0)
+    parser.add_argument(
+        "--scan-completed",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Force measured/unmeasured mint (default: exit 0/1 measured, >=2 unmeasured).",
+    )
+    parser.add_argument(
+        "--unmeasured-reason",
+        default=None,
+        help="Named reason when minting UNMEASURED (auth/init/crash).",
+    )
     parser.add_argument("--check-attendance", type=Path)
     parser.add_argument("--require-commit", default="")
     parser.add_argument("--write-campaign-body", type=Path)
@@ -343,6 +404,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             commit_sha=args.commit_sha,
             exit_code=args.exit_code,
             kind=args.kind,
+            scan_completed=args.scan_completed,
+            unmeasured_reason=args.unmeasured_reason,
         )
         args.mint_report.parent.mkdir(parents=True, exist_ok=True)
         args.mint_report.write_text(


### PR DESCRIPTION
## Defect

`tools/sole_construction_floor_enrollment.py` `mint_axis_report` always wrote `status=completed` + `measured=True`. Only exit code distinguished residual. **Auth/init/crash** was banked as **attended and measured** — silence-as-testimony one layer above the R print channel.

S0.C2 could not tell Unmeasured from residual-red from the enrollment body alone.

## Fix

| Exit / signal | Mint |
| --- | --- |
| 0 | measured, residual green |
| 1 | measured, residual red |
| ≥2 or `--no-scan-completed` | **`status=unmeasured` `measured=False`** + named `unmeasuredReason` |

Process floors return **2** for infrastructure (`format_unmeasured_axis`, empty roots). `run_one_process_floor_axis.sh` mints corpus auth failure as UNMEASURED exit 2.

Roll call treats unmeasured bodies as **unresolved UNMEASURED**, never `residualRed`.

## Teeth

- Plant exit 2 → not `completed`/`measured`
- Plant exit 1 → measured residual red
- Crash and residual never look alike
- Roll call: crash in `unresolved`, not `residualRed`

## Does not change

What floors measure or residual R for completed scans.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark enrollment reports as UNMEASURED instead of residualRed when scan exit code is >=2
> - `mint_axis_report` in [sole_construction_floor_enrollment.py](https://github.com/TSavo/sugar/pull/7034/files#diff-97da7ddf4a53542ab183832c1fedf5e3201fc8f4395b58fc71155d4040db58db) now mints reports with `status=unmeasured`, `measured=False`, and an `unmeasuredReason` when the scan did not complete (exit ≥2 or `--no-scan-completed` flag), instead of treating all exits as completed/measured.
> - `check_attendance` now classifies axes with `status=unmeasured` or `measured=False` as UNMEASURED (unresolved) and excludes them from `residualRed`; `WRONG_COMMIT` classification is also moved before the measured checks.
> - [run_one_process_floor_axis.sh](https://github.com/TSavo/sugar/pull/7034/files#diff-e2f37947c64a438368c7b6c2e4b00a46231fdc6065bcaaec43954d2ada2be00e) now mints an UNMEASURED report and exits 2 on auth/init failure, instead of exiting 1 without minting.
> - CLI scripts in the test suite update setup-error exit codes from 1 to 2 to align with the new vocabulary.
> - Behavioral Change: any axis that previously produced a `residualRed` result due to a crashed or unstarted scan will now appear as UNMEASURED instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c150b74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->