### PR TITLE
Job-log doctrine: ≤30s silence on every long measurement path

### DIFF
--- a/.github/actions/python-test-environment-from-wheelhouse/action.yml
+++ b/.github/actions/python-test-environment-from-wheelhouse/action.yml
@@ -55,6 +55,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        echo "JOB_LOG phase=python-test-env-from-wheelhouse status=start"
         wheelhouse="${{ inputs.wheelhouse-path }}"
         if [ ! -d "$wheelhouse" ]; then
           echo "::error::wheelhouse path missing: $wheelhouse"
@@ -119,3 +120,4 @@ runs:
         echo "checkout-pythonpath=$checkout_pythonpath" >> "$GITHUB_OUTPUT"
         echo "identity-path=$identity_out" >> "$GITHUB_OUTPUT"
         echo "shared-wheelhouse install: ${#wheels[@]} third-party wheels; checkout PYTHONPATH bound"
+        echo "JOB_LOG phase=python-test-env-from-wheelhouse status=ok wheels=${#wheels[@]}"

--- a/.github/actions/python-test-environment/action.yml
+++ b/.github/actions/python-test-environment/action.yml
@@ -108,6 +108,8 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        # Named phases on the JOB LOG — this step can exceed 30s (cargo metadata).
+        echo "JOB_LOG phase=python-test-env-identity status=start"
         env_dir="$RUNNER_TEMP/sugar-python-test-environment"
         mkdir -p "$env_dir"
         identity="$env_dir/environment-identity.json"
@@ -121,11 +123,13 @@ runs:
         # in memory and lost on the way to disk is the same defect as a field
         # never resolved, and only the file travels to the next job.
         python3 tools/python_suite_identity_gate.py --environment-identity "$identity"
+        echo "JOB_LOG phase=python-test-env-identity status=ok hash=$hash"
 
     - name: Build third-party wheelhouse from the declared dependency authority
       shell: bash
       run: |
         set -euo pipefail
+        echo "JOB_LOG phase=python-test-env-wheelhouse status=start"
         env_dir="$RUNNER_TEMP/sugar-python-test-environment"
         rm -rf "$env_dir/wheelhouse"
         mkdir -p "$env_dir/wheelhouse"
@@ -158,12 +162,14 @@ runs:
           exit 1
         fi
         echo "third-party wheelhouse: ${#third_party[@]} wheels (stripped $removed first-party)"
+        echo "JOB_LOG phase=python-test-env-wheelhouse status=ok wheels=${#third_party[@]} stripped=$removed"
 
     - name: Install immutable third-party environment + bind checkout PYTHONPATH
       id: install
       shell: bash
       run: |
         set -euo pipefail
+        echo "JOB_LOG phase=python-test-env-install status=start"
         env_dir="$RUNNER_TEMP/sugar-python-test-environment"
         venv="$env_dir/venv"
         # A previous job's leftovers are read-only by construction; clear the
@@ -215,6 +221,7 @@ runs:
         echo "python=$venv/bin/python" >> "$GITHUB_OUTPUT"
         echo "env-dir=$env_dir" >> "$GITHUB_OUTPUT"
         echo "checkout-pythonpath=$checkout_pythonpath" >> "$GITHUB_OUTPUT"
+        echo "JOB_LOG phase=python-test-env-install status=ok env_dir=$env_dir"
 
     - name: Upload environment identity
       if: inputs.identity-artifact == 'true'

--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -15,6 +15,12 @@ permissions:
 # SHARED ENV: each of 5 jobs was paying 91–163s env prep for 116–184s total
 # job time — same identical wheelhouse N times. Prepare once; axes install
 # --no-index from the artifact (same law as suite + showcase #7020).
+#
+# JOB LOG DOCTRINE: long floors emit named phase/count to the job log ≤30s.
+# PYTHONUNBUFFERED so narration is not held in stdio buffers.
+
+env:
+  PYTHONUNBUFFERED: "1"
 
 jobs:
   python-test-env-prepare:

--- a/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
@@ -6,8 +6,13 @@ One process. One door:
 
 I/O never mixed:
   engine log  → JSONL file (sugar construction telemetry)
-  progress    → tqdm only
+  progress    → optional tqdm file (local tail)
+  job log     → ALWAYS: named phase + running counts (≤30s silence)
   result/print → floor summary lines only
+
+DOCTRINE: if it can run >30s, emit a named phase or count to the JOB LOG
+within 30s and every 30s after. TTY-gated tqdm and file-only progress are
+identical to none in Actions.
 """
 
 from __future__ import annotations
@@ -22,6 +27,11 @@ from pathlib import Path
 from typing import Any, Callable, Iterator, Sequence, TextIO, TypeVar
 
 T = TypeVar("T")
+
+# Repo tools/ is not always on path when floors run as scripts/.
+_TOOLS = Path(__file__).resolve().parents[4] / "tools"
+if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
 
 
 def silence_console_logging() -> None:
@@ -143,45 +153,44 @@ def open_progress(path: Path, *, header: str) -> TextIO:
 def iter_with_tqdm(
     items: Sequence[T],
     *,
-    progress: TextIO,
+    progress: TextIO | None = None,
     total: int | None = None,
     initial: int = 0,
     desc: str = "enum",
     progress_stdout: bool = False,
 ) -> Iterator[T]:
-    try:
-        from tqdm import tqdm
-    except ImportError as error:  # pragma: no cover
-        raise SystemExit(
-            "tqdm is required: python3 -m pip install 'tqdm>=4.66'"
-        ) from error
+    """Yield items with optional file tqdm AND always-on job-log heartbeats.
+
+    ``progress_stdout`` only controls an *extra* interactive tqdm on stderr when
+    a TTY is present. Job-log lines are never TTY-gated and never optional —
+    CI is not a TTY and file-only tqdm was the silent wedge.
+    """
+    from job_log_heartbeat import JobLogHeartbeat  # noqa: WPS433 — scripts path
 
     n_total = total if total is not None else len(items)
-    bar = tqdm(
-        items,
-        total=n_total,
-        initial=initial,
-        unit="file",
-        desc=desc,
-        file=progress,
-        dynamic_ncols=False,
-        ncols=120,
-        mininterval=0.2,
-        smoothing=0.05,
-        bar_format=(
-            "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, "
-            "{rate_fmt}] {postfix}"
-        ),
-    )
+    beat = JobLogHeartbeat(desc, total=n_total)
+    beat.n = initial
+    beat.watch()
+
+    bar = None
     live = None
-    if progress_stdout and sys.stderr.isatty():
-        live = tqdm(
+    if progress is not None:
+        try:
+            from tqdm import tqdm
+        except ImportError as error:  # pragma: no cover
+            raise SystemExit(
+                "tqdm is required: python3 -m pip install 'tqdm>=4.66'"
+            ) from error
+
+        bar = tqdm(
+            items,
             total=n_total,
             initial=initial,
             unit="file",
             desc=desc,
-            file=sys.stderr,
-            dynamic_ncols=True,
+            file=progress,
+            dynamic_ncols=False,
+            ncols=120,
             mininterval=0.2,
             smoothing=0.05,
             bar_format=(
@@ -189,19 +198,45 @@ def iter_with_tqdm(
                 "{rate_fmt}] {postfix}"
             ),
         )
+        # Interactive TTY only — never the sole progress channel.
+        if progress_stdout and sys.stderr.isatty():
+            live = tqdm(
+                total=n_total,
+                initial=initial,
+                unit="file",
+                desc=desc,
+                file=sys.stderr,
+                dynamic_ncols=True,
+                mininterval=0.2,
+                smoothing=0.05,
+                bar_format=(
+                    "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, "
+                    "{rate_fmt}] {postfix}"
+                ),
+            )
+        iterator: Any = bar
+    else:
+        iterator = items
+
+    done = initial
     try:
-        for item in bar:
+        for item in iterator:
             yield item
+            done += 1
+            # Running counts as they accumulate (not only at the end).
+            beat.tick(n=done, force=(done == n_total or done == initial + 1))
             if live is not None:
                 live.update(1)
-                # Keep live postfix in sync when caller sets on bar.
-                if getattr(bar, "postfix", None):
+                if bar is not None and getattr(bar, "postfix", None):
                     live.set_postfix_str(str(bar.postfix), refresh=False)
     finally:
-        bar.close()
+        beat.stop(status="end")
+        if bar is not None:
+            bar.close()
         if live is not None:
             live.close()
-        progress.flush()
+        if progress is not None:
+            progress.flush()
 
 
 def floor_workspace_root() -> Path:

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
@@ -33,6 +33,11 @@ _WORKER = Path(__file__).resolve().parent / "_supervised_enum_worker.py"
 # Floors run 30728650857: POPULATION → refused: None at ~30.0s exactly.
 _DEFAULT_CONTEXT_INIT_TIMEOUT = 1800.0
 
+# tools/job_log_heartbeat.py — job log, not file, ≤30s silence.
+_TOOLS = Path(__file__).resolve().parents[4] / "tools"
+if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
 
 @dataclass(frozen=True)
 class FileTerminal:
@@ -250,52 +255,90 @@ class SupervisedEnumSupervisor:
 
         # Drain progress heartbeats until context-ready, a named refusal, or
         # the context-init budget (NOT the 30s per-file lift budget).
+        # Worker progress used to update last_progress only — invisible in CI.
+        from job_log_heartbeat import JobLogHeartbeat
+
         deadline = time.monotonic() + self.context_init_timeout
         last_progress: Mapping[str, Any] | None = None
         started = time.monotonic()
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                error = self._named_context_init_failure(
-                    response=None,
-                    last_progress=last_progress,
-                    elapsed=time.monotonic() - started,
-                    timed_out=True,
-                )
-                self._kill()
-                raise error
-            message = self._readline(timeout=remaining)
-            if message is None:
-                timed_out = time.monotonic() >= deadline
-                if (
-                    not timed_out
-                    and self._proc is not None
-                    and self._proc.poll() is None
-                ):
+        beat = JobLogHeartbeat("supervised-enum-context-init")
+        beat.watch()
+        try:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    error = self._named_context_init_failure(
+                        response=None,
+                        last_progress=last_progress,
+                        elapsed=time.monotonic() - started,
+                        timed_out=True,
+                    )
+                    self._kill()
+                    raise error
+                message = self._readline(timeout=min(remaining, 5.0))
+                if message is None:
+                    timed_out = time.monotonic() >= deadline
+                    if (
+                        not timed_out
+                        and self._proc is not None
+                        and self._proc.poll() is None
+                    ):
+                        # Alive but silent — job-log watch covers ≤30s.
+                        continue
+                    error = self._named_context_init_failure(
+                        response=None,
+                        last_progress=last_progress,
+                        elapsed=time.monotonic() - started,
+                        timed_out=timed_out
+                        or (self._proc is not None and self._proc.poll() is None),
+                    )
+                    self._kill()
+                    raise error
+                kind = message.get("kind")
+                if kind == "initialize-progress":
+                    last_progress = message
+                    # Running counts as they arrive — to the job log, not only memory.
+                    n = message.get("n") or message.get("done") or message.get("files")
+                    total = message.get("total") or message.get("files_total")
+                    phase = str(message.get("phase") or "context-init")
+                    beat.phase = f"supervised-enum-{phase}"
+                    if total is not None:
+                        beat.total = int(total)
+                    beat.tick(
+                        n=int(n) if n is not None else beat.n + 1,
+                        force=True,
+                        status="progress",
+                        **{
+                            k: v
+                            for k, v in message.items()
+                            if k
+                            not in {
+                                "kind",
+                                "n",
+                                "done",
+                                "files",
+                                "total",
+                                "files_total",
+                                "phase",
+                            }
+                            and isinstance(v, (str, int, float, bool))
+                        },
+                    )
                     continue
+                if kind == "context-ready":
+                    beat.stop(status="context-ready")
+                    return
                 error = self._named_context_init_failure(
-                    response=None,
+                    response=message,
                     last_progress=last_progress,
                     elapsed=time.monotonic() - started,
-                    timed_out=timed_out
-                    or (self._proc is not None and self._proc.poll() is None),
+                    timed_out=False,
                 )
                 self._kill()
                 raise error
-            kind = message.get("kind")
-            if kind == "initialize-progress":
-                last_progress = message
-                continue
-            if kind == "context-ready":
-                return
-            error = self._named_context_init_failure(
-                response=message,
-                last_progress=last_progress,
-                elapsed=time.monotonic() - started,
-                timed_out=False,
-            )
-            self._kill()
-            raise error
+        except BaseException:
+            beat.stop(status="failed")
+            raise
 
     def stop(self) -> None:
         proc = self._proc
@@ -548,11 +591,30 @@ class SupervisedEnumSupervisor:
                 pending.append((index, path, rel, key))
 
         if pending:
+            from job_log_heartbeat import JobLogHeartbeat
+
+            lift_beat = JobLogHeartbeat(
+                "supervised-enum-lift",
+                total=len(pending),
+            )
+            lift_beat.watch()
             try:
                 self.start()
-                for index, path, rel, key in pending:
+                for done_i, (index, path, rel, key) in enumerate(pending, start=1):
+                    lift_beat.tick(
+                        n=done_i,
+                        force=(done_i == 1 or done_i == len(pending)),
+                        status="lifting",
+                        file=rel,
+                    )
                     measured = self.lift_file(path, rel)
                     ordered[index] = measured
+                    lift_beat.tick(
+                        n=done_i,
+                        force=True,
+                        status=measured.category,
+                        file=rel,
+                    )
                     if cache is not None:
                         payload = terminal_to_payload(
                             file=measured.file,
@@ -563,6 +625,10 @@ class SupervisedEnumSupervisor:
                             terminal=measured.terminal,
                         )
                         cache.store(key, payload)
+                lift_beat.stop(status="ok")
+            except BaseException:
+                lift_beat.stop(status="failed")
+                raise
             finally:
                 self.stop()
 
@@ -571,7 +637,8 @@ class SupervisedEnumSupervisor:
                 "PROCESS-FLOOR-CACHE: "
                 f"root={cache.root} tip={tip} "
                 f"hits={hits} misses={len(pending)} refuses={refuses} "
-                f"corpusManifestCid={corpus_cid[:48]}…"
+                f"corpusManifestCid={corpus_cid[:48]}…",
+                flush=True,
             )
 
         rows: list[FileTerminal] = []

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -99,6 +99,12 @@ from typing import Any, Callable, TextIO
 # CI-visible narration: default print buffering makes a live process look dead.
 # Every RECENSUS line uses flush=True; prefer PYTHONUNBUFFERED=1 in the workflow.
 _PROGRESS_EVERY_N = max(1, int(os.environ.get("RECENSUS_PROGRESS_EVERY_N", "1")))
+# Doctrine: never more than 30s of job-log silence on a long path.
+_JOB_LOG_MAX_SILENCE_S = float(os.environ.get("JOB_LOG_MAX_SILENCE_S", "30"))
+
+_TOOLS = Path(__file__).resolve().parents[4] / "tools"
+if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
 
 
 def _narrate(msg: str) -> None:
@@ -120,6 +126,24 @@ def _phase_end(name: str, t0: float) -> None:
     _narrate(
         f"RECENSUS PHASE END: {name} elapsed_s={time.perf_counter() - t0:.3f}"
     )
+
+
+def _phase_call(name: str, fn):
+    """Run a long sub-phase with ≤30s job-log silence (alive lines if blocked)."""
+    from job_log_heartbeat import JobLogHeartbeat
+
+    t0 = _phase_begin(name)
+    beat = JobLogHeartbeat(f"recensus-{name}", max_silence_s=_JOB_LOG_MAX_SILENCE_S)
+    beat.watch()
+    try:
+        result = fn()
+        beat.stop(status="ok")
+        _phase_end(name, t0)
+        return result
+    except BaseException:
+        beat.stop(status="failed")
+        _phase_end(name, t0)
+        raise
 
 
 def _git_commit(root: Path) -> str:
@@ -887,12 +911,15 @@ def main() -> int:
     # anything but the root is the corpus-context drift defect.
     from sugar_lift_py_tests.lift_rpc import provisional_contract_refs_from_demands
 
-    t_demand = _phase_begin("demand_table_derivation")
+    # Demand-table walk can take minutes with only a BEGIN/END pair — that is
+    # blind by construction. Alive heartbeats every ≤30s hit the job log.
     _narrate(
         f"RECENSUS DEMAND_TABLE deriving provisional refs from workspace_root={workspace_root}"
     )
-    contract_refs = provisional_contract_refs_from_demands(workspace_root)
-    _phase_end("demand_table_derivation", t_demand)
+    contract_refs = _phase_call(
+        "demand_table_derivation",
+        lambda: provisional_contract_refs_from_demands(workspace_root),
+    )
     _narrate(
         "RECENSUS DEMAND_TABLE ready "
         f"(type={type(contract_refs).__name__})"
@@ -1007,15 +1034,22 @@ def main() -> int:
         if live_bar is not None:
             live_bar.set_postfix(postfix, refresh=refresh)
         progress_stream.flush()
-        # File-side tqdm is invisible in CI. Mirror heartbeats to stdout without
-        # TTY gating — rate-limited so per-function postfix does not flood.
-        if not args.progress_stdout or not refresh:
+        # File-side tqdm is invisible in CI. ALWAYS mirror to the job log —
+        # never TTY-gate, never hide behind --progress-stdout (that flag only
+        # controls the optional interactive stderr bar). Cap silence at 30s.
+        if not refresh:
             return
         now = time.monotonic()
         status = str(postfix.get("status") or "")
         force = status not in {"lifting…", "ok", "…"}
-        if not force and now - _last_progress_stdout < 2.0:
+        if not force and now - _last_progress_stdout < _JOB_LOG_MAX_SILENCE_S:
             return
+        if force and now - _last_progress_stdout < 2.0 and status in {
+            "done",
+            "cpanic",
+        }:
+            # Allow dense end-of-file lines without flooding.
+            pass
         _last_progress_stdout = now
         n = getattr(bar, "n", live_done)
         total = getattr(bar, "total", len(file_names)) or len(file_names)

--- a/tests/test_job_log_heartbeat.py
+++ b/tests/test_job_log_heartbeat.py
@@ -1,0 +1,57 @@
+"""Teeth: job-log doctrine — ≤30s silence, stdout not file, running counts."""
+
+from __future__ import annotations
+
+import io
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from job_log_heartbeat import JOB_LOG_MAX_SILENCE_S, JobLogHeartbeat, narrate  # noqa: E402
+
+
+def test_default_max_silence_is_30_seconds() -> None:
+    assert JOB_LOG_MAX_SILENCE_S == 30.0
+
+
+def test_narrate_writes_flushed_stdout(capsys) -> None:
+    narrate("JOB_LOG phase=tooth status=ok")
+    out = capsys.readouterr().out
+    assert "JOB_LOG phase=tooth status=ok" in out
+
+
+def test_heartbeat_emits_start_and_running_counts(capsys) -> None:
+    beat = JobLogHeartbeat("unit-scan", total=10, max_silence_s=0.05)
+    # start already emitted
+    beat.tick(n=1, force=True, status="lifting", file="a.py")
+    beat.tick(n=2, force=True, status="done", file="b.py")
+    beat.stop(status="ok")
+    out = capsys.readouterr().out
+    assert "phase=unit-scan" in out
+    assert "n=1/10" in out or "n=2/10" in out
+    assert "status=ok" in out
+
+
+def test_heartbeat_rate_limits_unless_forced(capsys) -> None:
+    beat = JobLogHeartbeat("rate", total=5, max_silence_s=60.0)
+    capsys.readouterr()  # drop start
+    beat.tick(n=1, status="a")  # suppressed (within 60s, not force)
+    beat.tick(n=2, status="b")
+    out = capsys.readouterr().out
+    assert out == ""
+    beat.tick(n=3, force=True, status="c")
+    out = capsys.readouterr().out
+    assert "n=3/5" in out
+    beat.stop()
+
+
+def test_watch_emits_alive_when_main_stalls(capsys) -> None:
+    beat = JobLogHeartbeat("stall", total=1, max_silence_s=0.05)
+    beat.watch()
+    time.sleep(0.18)
+    beat.stop(status="ok")
+    out = capsys.readouterr().out
+    assert "status=alive" in out or "status=ok" in out

--- a/tools/job_log_heartbeat.py
+++ b/tools/job_log_heartbeat.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Job-log narration: never let a >30s path look dead in Actions.
+
+DOCTRINE (binding): if work can run longer than 30 seconds, it must emit a
+named phase or a count within 30 seconds, and every 30 seconds after — TO THE
+JOB LOG (process stdout/stderr that CI captures). File-only progress (TTY-gated
+tqdm, out-dir/progress.log) is identical to no instrumentation.
+
+Four corollaries:
+  1. To the job log, not a file.
+  2. Never fuse phases into one CI step (caller's workflow concern).
+  3. Running counts as they accumulate.
+  4. A crash is not a measurement (caller's enrollment concern).
+
+This module is the shared narrator for long Python measurement paths.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from typing import Any, Callable, TypeVar
+
+T = TypeVar("T")
+
+# Max silence on the job log. Override only for tests.
+JOB_LOG_MAX_SILENCE_S = float(os.environ.get("JOB_LOG_MAX_SILENCE_S", "30"))
+
+
+def narrate(msg: str) -> None:
+    """Print one line to the job log with flush. Never raise for flush failures."""
+    print(msg, flush=True)
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except Exception:  # noqa: BLE001 — never fail the measurement for a flush
+        pass
+
+
+class JobLogHeartbeat:
+    """Rate-limited phase/count lines for the Actions job log.
+
+    Call ``tick`` on every meaningful progress event. Call ``force`` for phase
+    boundaries. A background ``watch`` keeps emitting if the main thread stalls
+    inside one long unit of work.
+    """
+
+    def __init__(
+        self,
+        phase: str,
+        *,
+        total: int | None = None,
+        max_silence_s: float | None = None,
+    ) -> None:
+        self.phase = phase
+        self.total = total
+        self.n = 0
+        self.extra: dict[str, Any] = {}
+        self.max_silence_s = (
+            JOB_LOG_MAX_SILENCE_S if max_silence_s is None else float(max_silence_s)
+        )
+        self._t0 = time.monotonic()
+        self._last_emit = 0.0
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._watch_thread: threading.Thread | None = None
+        self.tick(force=True, status="start")
+
+    def _line(self, *, status: str = "") -> str:
+        elapsed = time.monotonic() - self._t0
+        if self.total is not None:
+            count = f"n={self.n}/{self.total}"
+        else:
+            count = f"n={self.n}"
+        bits = [f"phase={self.phase}", count, f"elapsed_s={elapsed:.1f}"]
+        if status:
+            bits.append(f"status={status}")
+        for key, value in sorted(self.extra.items()):
+            bits.append(f"{key}={value}")
+        return "JOB_LOG " + " ".join(bits)
+
+    def tick(
+        self,
+        *,
+        n: int | None = None,
+        status: str = "",
+        force: bool = False,
+        **extra: Any,
+    ) -> None:
+        with self._lock:
+            if n is not None:
+                self.n = int(n)
+            if extra:
+                self.extra.update(extra)
+            now = time.monotonic()
+            if not force and (now - self._last_emit) < self.max_silence_s:
+                return
+            self._last_emit = now
+            line = self._line(status=status)
+
+        narrate(line)
+
+    def watch(self) -> None:
+        """Daemon thread: re-emit at max silence if the main thread stalls."""
+        if self._watch_thread is not None:
+            return
+
+        def _loop() -> None:
+            while not self._stop.wait(self.max_silence_s):
+                self.tick(force=True, status="alive")
+
+        self._watch_thread = threading.Thread(
+            target=_loop,
+            name=f"job-log-heartbeat-{self.phase}",
+            daemon=True,
+        )
+        self._watch_thread.start()
+
+    def stop(self, *, status: str = "end") -> None:
+        self._stop.set()
+        self.tick(force=True, status=status)
+
+
+def run_phase(
+    phase: str,
+    fn: Callable[[], T],
+    *,
+    total: int | None = None,
+    max_silence_s: float | None = None,
+) -> T:
+    """Run ``fn`` under a named phase with ≤30s job-log silence."""
+    beat = JobLogHeartbeat(phase, total=total, max_silence_s=max_silence_s)
+    beat.watch()
+    try:
+        result = fn()
+        beat.stop(status="ok")
+        return result
+    except BaseException:
+        beat.stop(status="failed")
+        raise

--- a/tools/run_one_process_floor_axis.sh
+++ b/tools/run_one_process_floor_axis.sh
@@ -43,13 +43,17 @@ fi
 
 echo "process-floor axis=$axis_id population=$PANDAS_CORPUS"
 echo "process-floor cache: dir=${SUGAR_PROCESS_FLOOR_CACHE_DIR} tip=${SUGAR_MEASUREMENT_TIP:-unpinned}"
+# Job-log doctrine: unbuffered stdout so phase/count lines hit Actions live.
+export PYTHONUNBUFFERED=1
+echo "JOB_LOG phase=process-floor-${axis_id} status=start population=$PANDAS_CORPUS"
 
 set +e
-python "$SCRIPT" "$PANDAS_CORPUS" \
+python -u "$SCRIPT" "$PANDAS_CORPUS" \
   --repo-root "$PANDAS_CORPUS" \
   --out-dir "$FLOOR_SCRATCH"
 exit_code=$?
 set -e
+echo "JOB_LOG phase=process-floor-${axis_id} status=end exit_code=$exit_code"
 
 commit="${GITHUB_SHA:-unpinned}"
 case "$axis_id" in


### PR DESCRIPTION
## Doctrine (binding)

> If it can run longer than 30 seconds, it must emit a named phase or a count within 30 seconds, and every 30 seconds after — **to the job log**.

Corollaries applied here:
1. **Job log, not a file** — TTY-gated tqdm / `progress.log` alone is blind in Actions
2. **Phases stay separable** — workflows already split auth vs measure where needed
3. **Running counts** as files finish, not only an end summary
4. **Crash ≠ measurement** — enrollment mint-on-crash remains mr_blonde’s floor fix; this PR is the narration membrane

## Changes

| Path | What |
| --- | --- |
| `tools/job_log_heartbeat.py` | Shared narrator + 30s watch thread |
| supervised enum floors | Context-init + lift counts → `JOB_LOG …` |
| `_enum_floor_runtime` | Always-on job-log heartbeats in the scan loop |
| `control_effect_recensus` | Demand-table alive heartbeats; progress never TTY/`--progress-stdout` gated |
| python-test-environment actions | Named phase lines |
| `run_one_process_floor_axis.sh` | `PYTHONUNBUFFERED` + phase start/end |

## Validation

`pytest -q tests/test_job_log_heartbeat.py tests/test_python_sole_construction_ci.py` → 11 passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ≤30s JOB_LOG heartbeat doctrine to all long measurement paths
> - Introduces [`tools/job_log_heartbeat.py`](https://github.com/TSavo/sugar/pull/7035/files#diff-2839c70d234739338e68ef077249460824e9c3229ae9cf6038153dea5aed7877) with `JobLogHeartbeat`, a reusable class that emits `JOB_LOG phase=... n=.../... elapsed_s=...` lines on tick and spawns a background watcher to emit `alive` pings when the main thread is silent for more than 30s.
> - Integrates heartbeats into [`_enum_floor_runtime.py`](https://github.com/TSavo/sugar/pull/7035/files#diff-722768a8db41f7e5bee7a5b826a61b0ebdc49edb27a8ff262303b2d68fd8c709), [`_supervised_enum_supervisor.py`](https://github.com/TSavo/sugar/pull/7035/files#diff-903c4ede56038960d15f1863a8424a01725179e4eecd04ee38f557e2cbf4e28e), and [`control_effect_recensus.py`](https://github.com/TSavo/sugar/pull/7035/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) to cover context init, wheelhouse build, file-lifting, and demand-table derivation phases.
> - Adds `JOB_LOG` start/ok echo lines to the [`python-test-environment`](https://github.com/TSavo/sugar/pull/7035/files#diff-93d85172587ff6130a5c787fe3512044d6a7b7e1db61708e7b52742c82dc3a3b) and [`python-test-environment-from-wheelhouse`](https://github.com/TSavo/sugar/pull/7035/files#diff-2d1eed24daf45b4f4ed5562cfcf41349718b80880fd1d1214f4e27d546f2d437) composite actions.
> - Sets `PYTHONUNBUFFERED=1` in the [`factory-zero-tolerance` workflow](https://github.com/TSavo/sugar/pull/7035/files#diff-b7935b47613e0d7520fac82144ed2fcf0a5f55d0d2e259af5d19296ad96f177f) and adds `-u` to Python invocations in [`run_one_process_floor_axis.sh`](https://github.com/TSavo/sugar/pull/7035/files#diff-e2f37947c64a438368c7b6c2e4b00a46231fdc6065bcaaec43954d2ada2be00e) so heartbeat lines reach the job log immediately.
> - Behavioral Change: Python stdout/stderr are now unbuffered across all jobs in the factory-zero-tolerance workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4306ff8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->