### PR TITLE
CommitMeasurement: cite #7034 unmeasured mints as Unmeasured

### DIFF
--- a/tests/test_commit_measurement.py
+++ b/tests/test_commit_measurement.py
@@ -159,6 +159,88 @@ def test_empty_artifacts_partial_includes_panics_axis(tmp_path: Path) -> None:
     assert GATE.main(["--composition", str(path), "--require-complete"]) == 1
 
 
+def test_enrollment_unmeasured_body_is_not_measured(tmp_path: Path) -> None:
+    """#7034: crash mint banks UNMEASURED — compose must not cite totals.failed."""
+    body = {
+        "schemaVersion": 1,
+        "kind": "sole-construction-floor-axis-report",
+        "axisId": "native-crash",
+        "measurementClass": "python-sole-construction-floors",
+        "measuredCommit": "deadbeef",
+        "status": "unmeasured",
+        "exitCode": 2,
+        "identityResolved": True,
+        "measured": False,
+        "floorExitGreen": False,
+        "unmeasuredReason": (
+            "scan did not complete (exit=2); infrastructure/auth/init/crash "
+            "— not a residual reading"
+        ),
+        "totals": {"failed": 1, "unmeasured": 1},
+    }
+    (tmp_path / "native" / "floor-axis-report.json").parent.mkdir()
+    (tmp_path / "native" / "floor-axis-report.json").write_text(
+        json.dumps(body), encoding="utf-8"
+    )
+    # silent completed green so vector is partial on native + panics etc.
+    (tmp_path / "silent" / "floor-axis-report.json").parent.mkdir()
+    (tmp_path / "silent" / "floor-axis-report.json").write_text(
+        json.dumps(_floor_body("silent", failed=0)), encoding="utf-8"
+    )
+    v = CM.compose_tip_from_artifacts_dir("deadbeef", tmp_path)
+    assert isinstance(v, CM.PartialVector)
+    assert isinstance(v.axes["silent"], CM.Measured)
+    assert v.axes["silent"].value == 0
+    native = v.axes["native-crash"]
+    assert isinstance(native, CM.Unmeasured)
+    assert "scan did not complete" in native.reason
+    assert "not a residual" in native.reason
+    # Must not bank totals.failed=1 as Measured residual
+    assert not isinstance(native, CM.Measured)
+
+
+def test_no_total_while_any_axis_unmeasured() -> None:
+    v = CM.commit_measurement(
+        "sha",
+        "roster",
+        {
+            "silent": CM.measured(
+                0,
+                identity="silent",
+                unit=CM.UNIT_ASSERT_FUNCTION_LOCUS,
+                population_id="p",
+                population_size=1,
+                body=_body(0, 1),
+                value_field_path="totals.failed",
+                exit_code=0,
+            ),
+            "native-crash": CM.unmeasured("NeverFired: tip floors queued"),
+            "bare-exception": CM.unmeasured(
+                "EnrollmentUnmeasured: scan did not complete"
+            ),
+            "timeout": CM.unmeasured("WorkerRefusal: supervised-enum"),
+            "R_construction_panics": CM.unmeasured(
+                "NoBoard: recensus board absent"
+            ),
+        },
+    )
+    assert isinstance(v, CM.PartialVector)
+    with pytest.raises(AttributeError):
+        _ = v.total  # type: ignore[attr-defined]
+    payload = v.to_json()
+    assert "total" not in payload
+    reasons = {
+        name: payload["axes"][name]["reason"]
+        for name in payload["unmeasuredAxes"]
+    }
+    assert "NeverFired" in reasons["native-crash"]
+    assert "EnrollmentUnmeasured" in reasons["bare-exception"]
+    assert "WorkerRefusal" in reasons["timeout"]
+    assert "NoBoard" in reasons["R_construction_panics"]
+    # Four absences must not flatten to one identical string
+    assert len(set(reasons.values())) == 4
+
+
 def test_four_green_floors_without_panics_is_partial_not_complete(
     tmp_path: Path,
 ) -> None:

--- a/tools/commit_measurement.py
+++ b/tools/commit_measurement.py
@@ -638,6 +638,26 @@ def _is_candidate_body(payload: Mapping[str, Any]) -> bool:
     return False
 
 
+def _body_declares_unmeasured(body: Mapping[str, Any]) -> str | None:
+    """#7034: enrollment mints status=unmeasured / measured=False with a reason.
+
+    A body that declares unmeasured must not be cited as Measured merely because
+    totals.failed is present — that was the crash-as-residual lie.
+    """
+    measured_flag = body.get("measured")
+    status = body.get("status")
+    if measured_flag is False or status == "unmeasured":
+        reason = body.get("unmeasuredReason") or body.get("reason")
+        if isinstance(reason, str) and reason.strip():
+            return reason.strip()
+        return (
+            "EnrollmentUnmeasured: axis body declares measured=False "
+            f"status={status!r} exitCode={body.get('exitCode')!r} "
+            "(scan did not complete — not a residual reading)"
+        )
+    return None
+
+
 def compose_tip_from_artifacts_dir(
     commit_sha: str,
     artifacts_dir: Path,
@@ -649,6 +669,9 @@ def compose_tip_from_artifacts_dir(
 
     Missing any enrolled axis (including R_construction_panics) → Unmeasured
     for that axis → PartialVector. Four green floors alone never Complete.
+
+    #7034 bodies with status=unmeasured / measured=False cite as Unmeasured
+    with unmeasuredReason — never Measured from totals.failed alone.
     """
     sha = _require_nonempty_str("commit_sha", commit_sha)
     specs: Sequence[TipAxisSpec] = (
@@ -668,28 +691,41 @@ def compose_tip_from_artifacts_dir(
     for spec in specs:
         identity = spec.identity
         value_path = spec.value_field_path
-        chosen: Mapping[str, Any] | None = None
+        chosen_measured: Mapping[str, Any] | None = None
+        chosen_unmeasured: Mapping[str, Any] | None = None
         for _path, body in bodies:
             if not _body_matches_spec(body, spec):
+                continue
+            um_reason = _body_declares_unmeasured(body)
+            if um_reason is not None:
+                chosen_unmeasured = body
                 continue
             try:
                 _lookup_path(body, value_path)
             except KeyError:
                 continue
-            chosen = body
+            chosen_measured = body
             break
-        if chosen is None:
+        if chosen_measured is None and chosen_unmeasured is not None:
+            reason = _body_declares_unmeasured(chosen_unmeasured) or "EnrollmentUnmeasured"
             axes[identity] = unmeasured(
-                f"NoReport: no produced body artifact for identity {identity!r} "
-                f"(unit={spec.unit}) at commit {sha}"
-                + (
-                    " — control-effect recensus board is the sole producer; "
-                    "four green process floors do not measure this axis"
-                    if identity == "R_construction_panics"
-                    else ""
-                )
+                f"{reason} identity={identity!r} unit={spec.unit} commit={sha}"
             )
             continue
+        if chosen_measured is None:
+            if identity == "R_construction_panics":
+                axes[identity] = unmeasured(
+                    f"NoBoard: no control-effect recensus board body for "
+                    f"identity {identity!r} (unit={spec.unit}) at commit {sha} "
+                    f"— sole producer of R_construction_panics; floors do not measure it"
+                )
+            else:
+                axes[identity] = unmeasured(
+                    f"NoReport: no produced completed body for identity "
+                    f"{identity!r} (unit={spec.unit}) at commit {sha}"
+                )
+            continue
+        chosen = chosen_measured
         pop_size = 0
         pop_id = f"{identity}:undeclared"
         try:


### PR DESCRIPTION
## Summary

#7034 enrollment mints `status=unmeasured` / `measured=False` with `unmeasuredReason` when a scan does not complete. `compose_tip_from_artifacts_dir` still treated those bodies as **Measured** if `totals.failed` was present — the crash-as-residual lie one layer up.

- Prefer a completed (`measured=True`) body when both exist
- If only an unmeasured mint is present → **Unmeasured** with enrollment reason
- `R_construction_panics` absence uses **NoBoard** wording (distinct from floor **NoReport**)

## Tip vector (main `c35e044d9a06`)

Composed PartialVector: all five C2 axes Unmeasured; **no total**; gate `--require-complete` red.

| Axis | Reading | Kind |
|------|---------|------|
| silent | Unmeasured | **NoTipBoundCompletedBody** (Measured=0 not attributable without tip-bound completed body) |
| native/bare/timeout | Unmeasured | **NeverFired** (tip floors still queued) |
| R_construction_panics | Unmeasured | **NoBoard** (recensus not present) |

Receipts under worktree `.receipts/commit-measurement-live/` (not committed).

## Validation

```
python3.12 -m pytest tests/test_commit_measurement.py -q
# 14 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cite unmeasured mints as Unmeasured in `compose_tip_from_artifacts_dir`
> - Adds a `_body_declares_unmeasured` helper in [`commit_measurement.py`](https://github.com/TSavo/sugar/pull/7036/files#diff-034ed16ba84c4a527a93fb4c6f2ee50b10a1a08d9cb122bd440105312d686c07) that detects bodies with `measured=False` or `status='unmeasured'` and extracts or synthesizes a reason string.
> - `compose_tip_from_artifacts_dir` now tracks unmeasured candidates separately; bodies declaring unmeasured are emitted as `Unmeasured` axes with the body's reason rather than being treated as measured (e.g. via `totals.failed`).
> - Missing-body messaging is improved: `R_construction_panics` emits a `NoBoard` reason pointing to the control-effect recensus board; all other axes emit `NoReport: no produced completed body`.
> - Behavioral Change: axes with explicit unmeasured declarations are no longer counted as measured even when `totals.failed` is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 043ed9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->