### PR TITLE
Suite plugin: job-log heartbeats during pytest sweep

### DIFF
--- a/tests/test_suite_pytest_job_log_heartbeat.py
+++ b/tests/test_suite_pytest_job_log_heartbeat.py
@@ -1,0 +1,108 @@
+"""Teeth: suite plugin emits job-log heartbeats (not TTY-gated pytest -q bars)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOLS = ROOT / "tools"
+
+
+def _identity(path: Path) -> Path:
+    """Minimal identity blob that SuiteReporter will accept."""
+    stamp = "blake3-512_" + ("ab" * 64)
+    extras = "cd" * 32
+    identity = {
+        "environmentIdentityHash": "ee" * 32,
+        "sourceStamp": {"value": stamp},
+        "dependencyAuthority": {
+            "testExtraInputHash": extras,
+            "declared": {"optional-dependencies": {"test": ["pytest"]}},
+        },
+    }
+    path.write_text(json.dumps(identity) + "\n", encoding="utf-8")
+    return path
+
+
+def test_suite_plugin_job_log_emits_running_counts(tmp_path: Path) -> None:
+    """Live pytest load of the plugin: JOB_LOG lines with pass/fail as tests finish."""
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_sample.py").write_text(
+        textwrap.dedent(
+            """\
+            def test_one():
+                assert True
+
+            def test_two():
+                assert True
+
+            def test_three():
+                assert False
+            """
+        ),
+        encoding="utf-8",
+    )
+    identity = _identity(tmp_path / "identity.json")
+    report = tmp_path / "suite-report.json"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(TOOLS), env.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+    env["SUITE_JOB_LOG_EVERY_N"] = "1"
+    env["JOB_LOG_MAX_SILENCE_S"] = "60"
+    env["GITHUB_SHA"] = "deadbeef" * 5
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-u",
+            "-m",
+            "pytest",
+            str(tests),
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            "-p",
+            "python_package_suite_report",
+            f"--suite-report={report}",
+            f"--suite-identity={identity}",
+            "--suite-order=canonical",
+            "--suite-commit=deadbeef",
+            "--suite-binary-stamp=blake3-512_" + ("ab" * 64),
+            "--suite-label=tooth",
+            "--suite-shard-index=6",
+            "--suite-shard-count=8",
+        ],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    out = proc.stdout + proc.stderr
+    assert "JOB_LOG" in out, out
+    assert "suite-pytest-shard-06-of-8" in out or "suite-pytest" in out, out
+    assert "collection_done" in out, out
+    # Running counts accumulate (not only an end summary).
+    assert "passed=" in out, out
+    assert "failed=" in out, out
+    assert report.is_file(), (proc.returncode, out)
+    body = json.loads(report.read_text(encoding="utf-8"))
+    assert body["counts"]["passed"] == 2
+    assert body["counts"]["failed"] == 1
+
+
+def test_plugin_source_wires_heartbeat_hooks() -> None:
+    """Structural tooth: the plugin owns logstart + logreport heartbeats."""
+    src = (TOOLS / "python_package_suite_report.py").read_text(encoding="utf-8")
+    assert "JobLogHeartbeat" in src
+    assert "pytest_runtest_logstart" in src
+    assert "_heartbeat_after_outcome" in src
+    assert "SUITE_JOB_LOG_EVERY_N" in src
+    # Never the TTY-only progress path as the sole channel.
+    assert "isatty" not in src

--- a/tools/python_package_suite_report.py
+++ b/tools/python_package_suite_report.py
@@ -41,11 +41,25 @@ import time
 # teardown-phase failure is an ERROR.
 _ERROR_PHASES = ("setup", "teardown")
 
+# Job-log doctrine: pytest -q's TTY progress bar does not flush in CI — a
+# 200s silence after "[15%]" is blind by construction. Heartbeat every ≤30s
+# (and every N finished tests) with running counts so a hard kill still leaves
+# what the shard found in the Actions log.
+_JOB_LOG_EVERY_N = max(1, int(os.environ.get("SUITE_JOB_LOG_EVERY_N", "25")))
+
 # One owner for "is this field an excuse rather than a value".
 from python_suite_identity_gate import (  # noqa: E402
     IDENTITY_FIELDS,
     unavailable_marker as _unavailable_marker,
 )
+
+try:
+    from job_log_heartbeat import JobLogHeartbeat, narrate  # noqa: E402
+except ImportError:  # pragma: no cover — tools/ not on path in exotic launches
+    JobLogHeartbeat = None  # type: ignore[misc, assignment]
+
+    def narrate(msg: str) -> None:
+        print(msg, flush=True)
 
 
 class SuiteIdentityUnresolved(Exception):
@@ -154,6 +168,8 @@ class SuiteReporter:
         self._wall_start = time.perf_counter()
         self._cpu_start = os.times()
         self.shuffle_seed = None
+        self._beat: object | None = None
+        self._current_nodeid: str | None = None
         # Resolved NOW, so an unresolvable identity costs zero measurement.
         self.identity = self._identity()
         self.measured_commit = self._measured_commit()
@@ -174,6 +190,7 @@ class SuiteReporter:
             self.shuffle_seed = seed
             random.Random(seed).shuffle(items)
         self.executed_order = [item.nodeid for item in items]
+        self._start_job_log_heartbeat()
 
     def pytest_collectreport(self, report):
         # A collection failure is an error with no test node behind it; it is
@@ -183,6 +200,12 @@ class SuiteReporter:
 
     # -- execution ----------------------------------------------------------
 
+    def pytest_runtest_logstart(self, nodeid, location):
+        """Current test — so a 30s alive line names what is blocking."""
+        del location
+        self._current_nodeid = nodeid
+        self._heartbeat(force=False, status="running")
+
     def pytest_runtest_logreport(self, report):
         nodeid = report.nodeid
         if report.failed:
@@ -191,18 +214,73 @@ class SuiteReporter:
             else:
                 self._record(self.failed, nodeid)
             self._seen_outcome.add(nodeid)
+            self._heartbeat_after_outcome(nodeid)
         elif report.skipped:
             if getattr(report, "wasxfail", None) is not None:
                 self._record(self.xfailed, nodeid)
             else:
                 self._record(self.skipped, nodeid)
             self._seen_outcome.add(nodeid)
+            self._heartbeat_after_outcome(nodeid)
         elif report.when == "call":
             if getattr(report, "wasxfail", None) is not None:
                 self._record(self.xpassed, nodeid)
             else:
                 self._record(self.passed, nodeid)
             self._seen_outcome.add(nodeid)
+            self._heartbeat_after_outcome(nodeid)
+
+    def _heartbeat_after_outcome(self, nodeid: str) -> None:
+        done = len(self._seen_outcome)
+        total = len(self.executed_order) or len(self.collected) or 0
+        force = (
+            done == 1
+            or done == total
+            or (done % _JOB_LOG_EVERY_N == 0)
+        )
+        self._current_nodeid = nodeid
+        self._heartbeat(force=force, status="outcome")
+
+    def _start_job_log_heartbeat(self) -> None:
+        total = len(self.executed_order) or len(self.collected)
+        shard_i = self.config.getoption("--suite-shard-index")
+        shard_n = self.config.getoption("--suite-shard-count")
+        label = self.config.getoption("--suite-label") or "suite"
+        if shard_i is not None and shard_n is not None:
+            phase = f"suite-pytest-shard-{int(shard_i):02d}-of-{int(shard_n)}"
+        else:
+            phase = f"suite-pytest-{label}"
+        narrate(
+            f"JOB_LOG phase={phase} status=collection_done "
+            f"collected={len(self.collected)} to_run={total} "
+            f"order={self.config.getoption('--suite-order')}"
+        )
+        if JobLogHeartbeat is None or total <= 0:
+            return
+        self._beat = JobLogHeartbeat(phase, total=total)
+        # Watch keeps ≤30s silence if one test hangs without logreport.
+        self._beat.watch()
+
+    def _heartbeat(self, *, force: bool, status: str) -> None:
+        beat = self._beat
+        if beat is None:
+            return
+        done = len(self._seen_outcome)
+        extra = {
+            "passed": len(self.passed),
+            "failed": len(self.failed),
+            "error": len(self.errored),
+            "skipped": len(self.skipped),
+            "xfailed": len(self.xfailed),
+            "xpassed": len(self.xpassed),
+        }
+        if self._current_nodeid:
+            # Keep nodeid short enough for log grepping without multi-line mess.
+            node = self._current_nodeid
+            if len(node) > 160:
+                node = node[:157] + "..."
+            extra["nodeid"] = node
+        beat.tick(n=done, force=force, status=status, **extra)
 
     @staticmethod
     def _record(bucket, nodeid):
@@ -212,6 +290,15 @@ class SuiteReporter:
     # -- report -------------------------------------------------------------
 
     def pytest_sessionfinish(self, session, exitstatus):
+        # Stop heartbeat first so the last line carries final running counts
+        # even if report write fails or the process is about to die.
+        if self._beat is not None:
+            self._heartbeat(force=True, status="sessionfinish")
+            try:
+                self._beat.stop(status=f"exit={int(exitstatus)}")
+            except Exception:  # noqa: BLE001 — never fail report for narration
+                pass
+            self._beat = None
         path = self.config.getoption("--suite-report")
         if not path:
             return


### PR DESCRIPTION
## Problem

mr_pink measured **206s of job-log silence** on suite shard 6 after `[15%]`. `pytest -q` draws a progress bar that does not flush in Actions — the job-log doctrine failed exactly where the real work runs.

## Fix

Heartbeat lives in **`python_package_suite_report`** (already loaded as `-p`):

- After collection: `JOB_LOG … collection_done collected=N`
- On each finished test: running `passed` / `failed` / `error` / `skipped` / …
- Every **≤30s** (watch thread) and every **N tests** (`SUITE_JOB_LOG_EVERY_N`, default 25)
- Current `nodeid` so a hang names the blocker
- **Not** a progress bar, **not** TTY-gated, always flushed

If a shard hard-kills before the report is written, the job log still carries accumulated counts.

## Validation

`pytest -q tests/test_suite_pytest_job_log_heartbeat.py` → 2 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added periodic job-log heartbeat updates while test suites are running.
  * Progress updates now include the current test, pass/fail counts, status, and shard information when applicable.
  * Heartbeat reporting begins after test collection and stops when the suite finishes.
  * Reporting continues gracefully when heartbeat functionality is unavailable or encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add job-log heartbeats during pytest sweep in the suite plugin
> - Adds `JobLogHeartbeat` integration to [`tools/python_package_suite_report.py`](https://github.com/TSavo/sugar/pull/7037/files#diff-3411b9f5ad80bc5885a1bb8107067510f62372210ed5e8dac63f162e2dbe4af4), emitting periodic `JOB_LOG` lines during test runs to prevent silence gaps exceeding 30s.
> - After collection, emits a `collection_done` narration with phase label (including shard info when present), collected count, and test order.
> - During the run, heartbeats fire on the first, last, and every `SUITE_JOB_LOG_EVERY_N` tests (default 25), including running pass/fail/error counters and a truncated nodeid.
> - Falls back to a `print`-based `narrate()` shim when `job_log_heartbeat` is not installed.
> - Adds tests in [`tests/test_suite_pytest_job_log_heartbeat.py`](https://github.com/TSavo/sugar/pull/7037/files#diff-320280876c30cc0b16747acfd9064da71110a96edba7ff3cc2bec92007042715) covering both integration behavior and structural source checks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70de8bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->