### PR TITLE
Fix process-floor CA shelf path: workspace-writable (30731778056)

### DIFF
--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -74,19 +74,33 @@ jobs:
         uses: ./.github/actions/python-test-environment-from-wheelhouse
         with:
           wheelhouse-path: ${{ runner.temp }}/python-test-wheelhouse
-      # Host path ($HOME/...) only shares when matrix jobs land the same
-      # self-hosted user. Fleet-wide: restore/save CA terminal shelf via
+      # Local path is workspace-writable (HOME/.cache is not always mkdir-able
+      # on self-hosted — run 30731778056). Fleet-wide: restore/save via
       # actions/cache. Key is tip; MeasurementKey still gates corpus/file
       # content so a restored shelf cannot serve wrong population.
+      # CA shelf path must be WRITABLE by the runner user.
+      # Run 30731778056: mkdir "${HOME}/.cache/sugar/..." → Permission denied
+      # under /home/runner/.cache on self-hosted (HOME not a safe cache root).
+      # Fleet share is actions/cache restore/save, not host HOME — so use the
+      # job workspace (always writable) as the local mount point.
       - name: Resolve process-floor CA shelf path
         id: shelf
         shell: bash
         run: |
           set -euo pipefail
-          dir="${HOME}/.cache/sugar/process-floor-terminals"
+          # Prefer explicit pin; else workspace-local (writable on every runner).
+          if [ -n "${SUGAR_PROCESS_FLOOR_CACHE_DIR:-}" ] && [ "${SUGAR_PROCESS_FLOOR_CACHE_DIR}" != "off" ]; then
+            dir="${SUGAR_PROCESS_FLOOR_CACHE_DIR}"
+          else
+            dir="${GITHUB_WORKSPACE}/.cache/sugar/process-floor-terminals"
+          fi
+          echo "process-floor shelf phase=resolve status=start dir=$dir home=${HOME:-} workspace=${GITHUB_WORKSPACE}"
           mkdir -p "$dir"
+          # Prove write (Permission denied surfaces here with a named phase, not later).
+          touch "$dir/.write-check" && rm -f "$dir/.write-check"
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
           echo "SUGAR_PROCESS_FLOOR_CACHE_DIR=$dir" >> "$GITHUB_ENV"
+          echo "process-floor shelf phase=resolve status=done dir=$dir"
       - name: Restore process-floor CA terminal shelf (fleet)
         uses: actions/cache/restore@v4
         with:
@@ -98,7 +112,7 @@ jobs:
         id: floor
         shell: bash
         env:
-          # Tip pins the CA terminal key. Dir from shelf step (HOME + GHA cache).
+          # Tip pins the CA terminal key. Dir from shelf step (workspace + GHA cache).
           SUGAR_MEASUREMENT_TIP: ${{ github.sha }}
           SUGAR_PROCESS_FLOOR_CACHE_DIR: ${{ steps.shelf.outputs.dir }}
         run: |

--- a/implementations/python/sugar-lift-py-tests/scripts/process_floor_measurement_cache.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/process_floor_measurement_cache.py
@@ -86,10 +86,10 @@ def resolve_cache_root() -> Path | None:
 
     Prefer explicit ``SUGAR_PROCESS_FLOOR_CACHE_DIR``.
 
-    Default is **host-durable** ``$HOME/.cache/sugar/process-floor-terminals`` so
-    parallel CI matrix jobs (separate workspaces) still share hits. A
-    workspace-local path is job-private on GitHub Actions and would force every
-    process-floor axis to cold-lift — slower under parallelization.
+    Default in GHA is **workspace-writable**
+    ``$GITHUB_WORKSPACE/.cache/sugar/process-floor-terminals`` (HOME/.cache is
+    not always mkdir-able on self-hosted runners). Fleet share is actions/cache
+    restore/save on that path, not host HOME.
 
     Disable: ``SUGAR_PROCESS_FLOOR_CACHE_DIR=off``.
     """
@@ -99,6 +99,16 @@ def resolve_cache_root() -> Path | None:
         if text in {"", "0", "off", "none", "disabled"}:
             return None
         return Path(text).expanduser().resolve()
+    # In GHA prefer workspace — always writable; fleet share is actions/cache.
+    # HOME/.cache is not mkdir-able on some self-hosted runners (30731778056).
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if workspace:
+        return (
+            Path(workspace).resolve()
+            / ".cache"
+            / "sugar"
+            / "process-floor-terminals"
+        )
     home = os.environ.get("HOME")
     if home:
         return (
@@ -107,10 +117,6 @@ def resolve_cache_root() -> Path | None:
             / "sugar"
             / "process-floor-terminals"
         )
-    # Last resort: workspace (job-local; poor for multi-job fan-out).
-    workspace = os.environ.get("GITHUB_WORKSPACE")
-    if workspace:
-        return Path(workspace).resolve() / ".cache" / "process-floor-terminals"
     return None
 
 

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -96,7 +96,8 @@ def test_process_one_axis_binds_corpus_and_host_cache() -> None:
     assert '"$PANDAS_CORPUS"' in text or "'$PANDAS_CORPUS'" in text
     assert "--out-dir" in text
     # Host-durable cache — not workspace-only (job-private under parallel jobs).
-    assert "HOME" in text and "process-floor-terminals" in text
+    assert "process-floor-terminals" in text
+    assert "GITHUB_WORKSPACE" in text or "HOME" in text
 
 
 def test_enrollment_missing_axis_is_unmeasured(tmp_path: Path) -> None:

--- a/tools/run_one_process_floor_axis.sh
+++ b/tools/run_one_process_floor_axis.sh
@@ -50,8 +50,14 @@ PANDAS_CORPUS="$(
 FLOOR_SCRATCH="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}/.sugar/ci-floors/${axis_id}"
 export SUGAR_FLOOR_WORKSPACE="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}"
 
+# Prefer workspace (writable in CI). HOME/.cache failed mkdir on self-hosted
+# (run 30731778056 Permission denied). Fleet share is actions/cache, not HOME.
 if [ -z "${SUGAR_PROCESS_FLOOR_CACHE_DIR+x}" ]; then
-  export SUGAR_PROCESS_FLOOR_CACHE_DIR="${HOME}/.cache/sugar/process-floor-terminals"
+  if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+    export SUGAR_PROCESS_FLOOR_CACHE_DIR="${GITHUB_WORKSPACE}/.cache/sugar/process-floor-terminals"
+  else
+    export SUGAR_PROCESS_FLOOR_CACHE_DIR="${HOME}/.cache/sugar/process-floor-terminals"
+  fi
 fi
 if [ -z "${SUGAR_MEASUREMENT_TIP:-}" ] && [ -n "${GITHUB_SHA:-}" ]; then
   export SUGAR_MEASUREMENT_TIP="${GITHUB_SHA}"


### PR DESCRIPTION
## Cause (run 30731778056)

All four `process-floor *` jobs failed **before scan** on step **Resolve process-floor CA shelf path**:

```
mkdir: cannot create directory '/home/runner/.cache/sugar/process-floor-terminals': Permission denied
```

Then restore skipped, run skipped, upload failed (no `floor-axis-report.json`).

**Not** actions/cache key logic. **Not** MeasurementKey. **Path pin**: `#7015`/`#7013` defaulted to `\$HOME/.cache/sugar/...`; on this self-hosted runner `HOME=/home/runner` cannot create that tree.

## Fix

| Layer | Change |
| --- | --- |
| Workflow resolve step | `\$GITHUB_WORKSPACE/.cache/sugar/process-floor-terminals` (+ write probe) |
| `run_one_process_floor_axis.sh` | same default when `GITHUB_WORKSPACE` set |
| `resolve_cache_root()` | prefer workspace over HOME in GHA |

`actions/cache` restore/save **key** stays `process-floor-term-\${{ github.sha }}` — fleet share unchanged; only the local mount is writable.

## Secondary (not fixed here)

`R_factory_walk_unclassified = 0` was ~88s silent then incomplete (150 auditor_errors / 459 files) — over 30s doctrine; separate logging follow-up.

## Validation

```
uv run --with pytest python -m pytest tests/test_python_sole_construction_ci.py -q
# 6 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix process-floor CA shelf cache path to use workspace-writable directory
> - Changes `resolve_cache_root` in [`process_floor_measurement_cache.py`](https://github.com/TSavo/sugar/pull/7038/files#diff-589f9b615cfb5f8907fd602c2fbc5529a0b2f849c3d3547993f5d16d1d4af8f0) and [`run_one_process_floor_axis.sh`](https://github.com/TSavo/sugar/pull/7038/files#diff-e2f37947c64a438368c7b6c2e4b00a46231fdc6065bcaaec43954d2ada2be00e) to prefer `${GITHUB_WORKSPACE}/.cache/sugar/process-floor-terminals` over `${HOME}/.cache/...` when `GITHUB_WORKSPACE` is set.
> - The workflow in [`.github/workflows/factory-zero-tolerance.yml`](https://github.com/TSavo/sugar/pull/7038/files#diff-b7935b47613e0d7520fac82144ed2fcf0a5f55d0d2e259af5d19296ad96f177f) also adopts the workspace-local path and adds an explicit write-check (`touch`/`remove`) before exporting the cache directory.
> - `SUGAR_PROCESS_FLOOR_CACHE_DIR`, if set to a non-disabling value, still takes precedence over both paths.
> - Behavioral Change: CI runs will now write the process-floor cache under the job workspace instead of `$HOME`, which avoids permission issues but changes where cached data lands between steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f5f693.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->