### PR TITLE
Recensus: default engine TRACE off; keep WARNING heartbeats

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -65,10 +65,18 @@ No subprocess. No process pool. Construction context is required: bare
 defect). The real lift pipeline injects the same door via lift_rpc.
 
 I/O split (never mixed):
-  --engine-log   sugar engine JSONL (construction telemetry)
+  --engine-log   sugar engine JSONL (WARNING heartbeats by default)
+  --engine-trace opt-in full per-span DEBUG enter/exit flood
   --progress     tqdm bar only
   --json         final result summary
   --checkpoint-jsonl  per-file durable journal
+
+Engine log default is SUGAR_ENGINE_TRACE_EVENTS=0: WARNING heartbeats,
+cycle_suspected, and errors only — enough to name a stall. Per-span DEBUG
+enter/exit is write-only for this board (R comes from construction/desugar
+axes, not engine.jsonl) and costs json.dumps+FileHandler on every sugar
+enter/exit on the reduction hot path. Pass --engine-trace only when
+debugging a named stall needs the full stack flood.
 """
 
 from __future__ import annotations
@@ -227,11 +235,22 @@ class _EngineStdoutHeartbeat(logging.Handler):
             self.handleError(record)
 
 
-def _configure_engine_log(path: Path) -> None:
-    """Engine JSONL on disk + rate-limited stdout heartbeat for CI job logs."""
+def _configure_engine_log(path: Path, *, engine_trace: bool = False) -> None:
+    """Engine JSONL on disk + rate-limited stdout heartbeat for CI job logs.
+
+    Default is WARNING-only (``SUGAR_ENGINE_TRACE_EVENTS=0``): heartbeats,
+    cycle_suspected, and errors — enough to name a stall. Per-span DEBUG
+    enter/exit is opt-in via ``engine_trace=True`` / ``--engine-trace``; the
+    scoreboard path does not read those events for R, and they cost
+    ``json.dumps(sort_keys=...)`` plus a FileHandler write on every sugar
+    enter/exit on the reduction hot path (~1 MB/file, write-only).
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     # Prefer the kit's own sink; also pin env so late imports see it.
     os.environ["SUGAR_ENGINE_LOG"] = str(path.resolve())
+    # Force the scoreboard default: do not inherit ambient TRACE=1 from a
+    # parent shell. Full span flood is explicit --engine-trace only.
+    os.environ["SUGAR_ENGINE_TRACE_EVENTS"] = "1" if engine_trace else "0"
     from sugar_lift_py_tests import engine_log
 
     # Drop any prior live handler (e.g. wrong path from env at import time).
@@ -241,9 +260,14 @@ def _configure_engine_log(path: Path) -> None:
     engine_log._LIVE_HANDLER = None  # type: ignore[attr-defined]
     engine_log.configure_live_log(str(path.resolve()))
     logger.propagate = False
-    logger.setLevel(logging.DEBUG)
+    # configure_live_log already set logger level from TRACE. Do not re-raise
+    # to DEBUG here — that re-enables hot-path json.dumps even when the file
+    # handler filters at WARNING.
+    logger.setLevel(logging.DEBUG if engine_trace else logging.WARNING)
     # SCOREBOARD_AUTHORITY: never leave engine heartbeats file-only in CI.
+    # WARNING floor: job log names stalls; never mirror per-span DEBUG flood.
     heartbeat = _EngineStdoutHeartbeat(min_interval_s=2.0)
+    heartbeat.setLevel(logging.WARNING)
     heartbeat.setFormatter(logging.Formatter("%(message)s"))
     logger.addHandler(heartbeat)
 
@@ -749,6 +773,17 @@ def main() -> int:
         help="sugar engine JSONL only (default: <out-dir>/engine.jsonl)",
     )
     parser.add_argument(
+        "--engine-trace",
+        action="store_true",
+        default=False,
+        help=(
+            "opt-in full per-span DEBUG enter/exit JSONL (SUGAR_ENGINE_TRACE_EVENTS=1). "
+            "Default is WARNING-only heartbeats/cycles/errors for stall naming — "
+            "the board does not consume per-span events for R, and the flood is "
+            "serialisation on the reduction hot path."
+        ),
+    )
+    parser.add_argument(
         "--progress",
         type=Path,
         default=None,
@@ -854,7 +889,7 @@ def main() -> int:
     running_counts_path = out / "running-counts.jsonl"
 
     _silence_console_logging()
-    _configure_engine_log(engine_path)
+    _configure_engine_log(engine_path, engine_trace=bool(args.engine_trace))
     if args.write_corpus_pin is not None:
         write_pin(observed_pin, args.write_corpus_pin)
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/engine_log.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/engine_log.py
@@ -175,7 +175,17 @@ def _emit(level: int, event: str, frame: _Frame, **fields) -> None:
 
 
 def configure_live_log(path: str | None = None) -> None:
-    """Attach an immediate JSONL file sink outside pytest's log capture."""
+    """Attach an immediate JSONL file sink outside pytest's log capture.
+
+    ``SUGAR_ENGINE_TRACE_EVENTS`` defaults to on (``"1"``) for diagnostic
+    callers that opt into a live sink. Measurement drivers that attach a
+    sink for stall-naming only must set it to ``0`` / ``false`` / ``off``
+    *before* calling this — then DEBUG enter/exit spans never reach
+    ``json.dumps`` (``LOGGER.isEnabledFor`` short-circuits). WARNING
+    heartbeats, cycle_suspected, and ERROR terminals still write so a stall
+    stays nameable. Raising only the FileHandler level while leaving the
+    logger at DEBUG still pays serialisation on the reduction hot path.
+    """
     global _LIVE_HANDLER
     selected = path or os.environ.get("SUGAR_ENGINE_LOG")
     if not selected or _LIVE_HANDLER is not None:
@@ -184,10 +194,13 @@ def configure_live_log(path: str | None = None) -> None:
     trace_events = os.environ.get(
         "SUGAR_ENGINE_TRACE_EVENTS", "1"
     ).strip().lower() not in {"0", "false", "no", "off"}
-    handler.setLevel(logging.DEBUG if trace_events else logging.WARNING)
+    # Handler *and* logger level must follow TRACE. Handler-only WARNING still
+    # runs json.dumps on every DEBUG enter/exit before the record is dropped.
+    level = logging.DEBUG if trace_events else logging.WARNING
+    handler.setLevel(level)
     handler.setFormatter(logging.Formatter("%(message)s"))
     LOGGER.addHandler(handler)
-    LOGGER.setLevel(logging.DEBUG)
+    LOGGER.setLevel(level)
     _LIVE_HANDLER = handler
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_engine_logging.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_engine_logging.py
@@ -108,14 +108,30 @@ def test_heartbeat_only_live_log_omits_high_volume_debug_spans(
     previous = engine_log._LIVE_HANDLER
     engine_log._LIVE_HANDLER = None
     monkeypatch.setenv("SUGAR_ENGINE_TRACE_EVENTS", "0")
+    dumps_calls: list[object] = []
+    real_dumps = engine_log.json.dumps
+
+    def counting_dumps(*args, **kwargs):
+        dumps_calls.append(1)
+        return real_dumps(*args, **kwargs)
+
+    monkeypatch.setattr(engine_log.json, "dumps", counting_dumps)
     try:
         engine_log.configure_live_log(str(path))
+        # TRACE=0 must raise logger level so DEBUG enter/exit never reach
+        # json.dumps — handler-only filtering still pays serialisation.
+        assert engine_log.LOGGER.level == logging.WARNING
+        assert not engine_log.LOGGER.isEnabledFor(logging.DEBUG)
         with engine_log.reduction_span(sugar="NameSugar", role="term", site="t.py:1:0"):
+            # enter+exit are DEBUG: zero dumps on the hot path
+            assert dumps_calls == []
             engine_log._emit_heartbeats(
                 now=time.monotonic() + 1.0, minimum_seconds=0.01
             )
         payloads = [json.loads(line) for line in path.read_text().splitlines()]
         assert [payload["event"] for payload in payloads] == ["heartbeat"]
+        # Only the WARNING heartbeat paid serialisation.
+        assert len(dumps_calls) == 1
     finally:
         if engine_log._LIVE_HANDLER is not None:
             engine_log.LOGGER.removeHandler(engine_log._LIVE_HANDLER)


### PR DESCRIPTION
## Summary

Scoreboard recensus was paying ~1 MB/file of **write-only** per-span DEBUG telemetry on the reduction hot path (`json.dumps(sort_keys=...)` + FileHandler on every sugar enter/exit). The board never reads `engine.jsonl` for R — it is stall-diagnosis I/O that defaulted ON.

- **Default** `SUGAR_ENGINE_TRACE_EVENTS=0` for recensus (forced; no ambient TRACE=1 inheritance).
- **Keep** WARNING heartbeats / cycle_suspected / ERROR terminals so a stall stays nameable (doctrine).
- **Opt-in** full flood via `--engine-trace`.
- **Real short-circuit:** `configure_live_log` now sets **logger** level from TRACE, not only the FileHandler. Handler-only WARNING still serialised every DEBUG span before drop — that was the invisible cost.

Does **not** touch any in-flight recensus run. Lands for the next measurement.

### Confirm: other measurement paths default TRACE on?

| Path | Sets `SUGAR_ENGINE_LOG` | Sets `TRACE_EVENTS` | Effective |
| --- | --- | --- | --- |
| **recensus** (this PR) | yes | **0** (default) | WARNING only |
| **pandas/numpy walls** | yes (workflow env) | **unset** → engine_log default `"1"` | **full DEBUG flood** |
| **enum floors** (`_enum_floor_runtime`) | yes | unset → default `"1"`, then **`logger.setLevel(DEBUG)`** | **full DEBUG flood** |
| **census.py** CLI | optional | unset → default `"1"` if log attached | full if log on |
| **classify_loud_timeouts** | yes | **setdefault 0** | already WARNING |

Walls and floors inherit the same shape: engine sink attached, TRACE default ON, floors also re-raise logger to DEBUG (same bug recensus had). Nobody has audited that cost. Follow-up if next wall/floor run is I/O-bound the same way.

## Test plan

- [x] Manual: TRACE=0 → `LOGGER.isEnabledFor(DEBUG)` false; enter/exit pay 0 `json.dumps`; heartbeat only in file
- [x] Manual: TRACE=1 → enter/exit still written
- [x] Unit assertions extended in `test_engine_logging.py` (dumps call count)
- [ ] Next recensus run: engine.jsonl should be heartbeat-scale, not ~1 MB/file

## Shell deleted

None — no R axis. Cost kill only: scoreboard path no longer pays write-only hot-path serialisation. Instrument that exposed it (running counts) stays.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default engine logger to WARNING level and add `--engine-trace` flag to suppress per-span DEBUG events
> - [`configure_live_log`](https://github.com/TSavo/sugar/pull/7039/files#diff-1a6f9aa0cd868c391bf02bb380de9a8dadbf0840aabb98eb8c1074ac07162a19) now sets both the logger and file handler to WARNING when `SUGAR_ENGINE_TRACE_EVENTS=0`, preventing DEBUG enter/exit spans from being created or serialized.
> - [`_configure_engine_log`](https://github.com/TSavo/sugar/pull/7039/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) defaults to WARNING level and sets `SUGAR_ENGINE_TRACE_EVENTS=0` unless called with `engine_trace=True`; the stdout heartbeat handler is explicitly set to WARNING.
> - A new `--engine-trace` CLI flag on the recensus script opts into full per-span DEBUG JSONL tracing; without it, only WARNING heartbeats and errors are emitted.
> - Behavioral Change: previously DEBUG trace events were always serialized; they are now suppressed by default and require `--engine-trace` to enable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 372f2bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->