### PR TITLE
LPT file shards (k=8): measured prior, write-through, suite + floors

### DIFF
--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -18,6 +18,11 @@ permissions:
 #
 # JOB LOG DOCTRINE: long floors emit named phase/count to the job log ≤30s.
 # PYTHONUNBUFFERED so narration is not held in stdio buffers.
+#
+# LPT file shards (k=8): process axes × file-shard seats. Split key is
+# longest-processing-time packing on a content-addressed file cost prior;
+# equal-count only when no prior (JOB_LOG says so). Prior write-through
+# makes the second run fast. Do not raise k — env tax, max_file floor.
 
 env:
   PYTHONUNBUFFERED: "1"
@@ -40,7 +45,7 @@ jobs:
           if-no-files-found: error
 
   process-floor:
-    name: process-floor ${{ matrix.axis }}
+    name: process-floor ${{ matrix.axisSeat }}
     needs: [python-test-env-prepare]
     runs-on: [self-hosted, Linux, X64]
     # silent is the long pole (~11min today); others ~30s once cache warm.
@@ -52,17 +57,197 @@ jobs:
       matrix:
         include:
           - axis: silent
+            axisSeat: silent-s00
             script: silent_zero_tolerance.py
-            display: R_silent
+            display: R_silent[s00]
+            shard: 0
+            shardCount: 8
+          - axis: silent
+            axisSeat: silent-s01
+            script: silent_zero_tolerance.py
+            display: R_silent[s01]
+            shard: 1
+            shardCount: 8
+          - axis: silent
+            axisSeat: silent-s02
+            script: silent_zero_tolerance.py
+            display: R_silent[s02]
+            shard: 2
+            shardCount: 8
+          - axis: silent
+            axisSeat: silent-s03
+            script: silent_zero_tolerance.py
+            display: R_silent[s03]
+            shard: 3
+            shardCount: 8
+          - axis: silent
+            axisSeat: silent-s04
+            script: silent_zero_tolerance.py
+            display: R_silent[s04]
+            shard: 4
+            shardCount: 8
+          - axis: silent
+            axisSeat: silent-s05
+            script: silent_zero_tolerance.py
+            display: R_silent[s05]
+            shard: 5
+            shardCount: 8
+          - axis: silent
+            axisSeat: silent-s06
+            script: silent_zero_tolerance.py
+            display: R_silent[s06]
+            shard: 6
+            shardCount: 8
+          - axis: silent
+            axisSeat: silent-s07
+            script: silent_zero_tolerance.py
+            display: R_silent[s07]
+            shard: 7
+            shardCount: 8
           - axis: native-crash
+            axisSeat: native-crash-s00
             script: native_crash_zero_tolerance.py
-            display: R_native_crashes
+            display: R_native_crashes[s00]
+            shard: 0
+            shardCount: 8
+          - axis: native-crash
+            axisSeat: native-crash-s01
+            script: native_crash_zero_tolerance.py
+            display: R_native_crashes[s01]
+            shard: 1
+            shardCount: 8
+          - axis: native-crash
+            axisSeat: native-crash-s02
+            script: native_crash_zero_tolerance.py
+            display: R_native_crashes[s02]
+            shard: 2
+            shardCount: 8
+          - axis: native-crash
+            axisSeat: native-crash-s03
+            script: native_crash_zero_tolerance.py
+            display: R_native_crashes[s03]
+            shard: 3
+            shardCount: 8
+          - axis: native-crash
+            axisSeat: native-crash-s04
+            script: native_crash_zero_tolerance.py
+            display: R_native_crashes[s04]
+            shard: 4
+            shardCount: 8
+          - axis: native-crash
+            axisSeat: native-crash-s05
+            script: native_crash_zero_tolerance.py
+            display: R_native_crashes[s05]
+            shard: 5
+            shardCount: 8
+          - axis: native-crash
+            axisSeat: native-crash-s06
+            script: native_crash_zero_tolerance.py
+            display: R_native_crashes[s06]
+            shard: 6
+            shardCount: 8
+          - axis: native-crash
+            axisSeat: native-crash-s07
+            script: native_crash_zero_tolerance.py
+            display: R_native_crashes[s07]
+            shard: 7
+            shardCount: 8
           - axis: bare-exception
+            axisSeat: bare-exception-s00
             script: bare_exception_zero_tolerance.py
-            display: R_bare_exceptions
+            display: R_bare_exceptions[s00]
+            shard: 0
+            shardCount: 8
+          - axis: bare-exception
+            axisSeat: bare-exception-s01
+            script: bare_exception_zero_tolerance.py
+            display: R_bare_exceptions[s01]
+            shard: 1
+            shardCount: 8
+          - axis: bare-exception
+            axisSeat: bare-exception-s02
+            script: bare_exception_zero_tolerance.py
+            display: R_bare_exceptions[s02]
+            shard: 2
+            shardCount: 8
+          - axis: bare-exception
+            axisSeat: bare-exception-s03
+            script: bare_exception_zero_tolerance.py
+            display: R_bare_exceptions[s03]
+            shard: 3
+            shardCount: 8
+          - axis: bare-exception
+            axisSeat: bare-exception-s04
+            script: bare_exception_zero_tolerance.py
+            display: R_bare_exceptions[s04]
+            shard: 4
+            shardCount: 8
+          - axis: bare-exception
+            axisSeat: bare-exception-s05
+            script: bare_exception_zero_tolerance.py
+            display: R_bare_exceptions[s05]
+            shard: 5
+            shardCount: 8
+          - axis: bare-exception
+            axisSeat: bare-exception-s06
+            script: bare_exception_zero_tolerance.py
+            display: R_bare_exceptions[s06]
+            shard: 6
+            shardCount: 8
+          - axis: bare-exception
+            axisSeat: bare-exception-s07
+            script: bare_exception_zero_tolerance.py
+            display: R_bare_exceptions[s07]
+            shard: 7
+            shardCount: 8
           - axis: timeout
+            axisSeat: timeout-s00
             script: timeout_zero_tolerance.py
-            display: R_timeouts
+            display: R_timeouts[s00]
+            shard: 0
+            shardCount: 8
+          - axis: timeout
+            axisSeat: timeout-s01
+            script: timeout_zero_tolerance.py
+            display: R_timeouts[s01]
+            shard: 1
+            shardCount: 8
+          - axis: timeout
+            axisSeat: timeout-s02
+            script: timeout_zero_tolerance.py
+            display: R_timeouts[s02]
+            shard: 2
+            shardCount: 8
+          - axis: timeout
+            axisSeat: timeout-s03
+            script: timeout_zero_tolerance.py
+            display: R_timeouts[s03]
+            shard: 3
+            shardCount: 8
+          - axis: timeout
+            axisSeat: timeout-s04
+            script: timeout_zero_tolerance.py
+            display: R_timeouts[s04]
+            shard: 4
+            shardCount: 8
+          - axis: timeout
+            axisSeat: timeout-s05
+            script: timeout_zero_tolerance.py
+            display: R_timeouts[s05]
+            shard: 5
+            shardCount: 8
+          - axis: timeout
+            axisSeat: timeout-s06
+            script: timeout_zero_tolerance.py
+            display: R_timeouts[s06]
+            shard: 6
+            shardCount: 8
+          - axis: timeout
+            axisSeat: timeout-s07
+            script: timeout_zero_tolerance.py
+            display: R_timeouts[s07]
+            shard: 7
+            shardCount: 8
     steps:
       - uses: actions/checkout@v4
       - name: Download shared third-party wheelhouse
@@ -83,6 +268,24 @@ jobs:
       # under /home/runner/.cache on self-hosted (HOME not a safe cache root).
       # Fleet share is actions/cache restore/save, not host HOME — so use the
       # job workspace (always writable) as the local mount point.
+
+      - name: Resolve LPT file-cost prior path
+        id: lpt
+        shell: bash
+        run: |
+          set -euo pipefail
+          dir="${GITHUB_WORKSPACE}/.cache/sugar/lpt-file-costs"
+          mkdir -p "$dir"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+          echo "SUGAR_LPT_PRIOR_DIR=$dir" >> "$GITHUB_ENV"
+          echo "JOB_LOG phase=lpt-prior status=resolve dir=$dir"
+      - name: Restore LPT file-cost prior (content-addressed)
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.lpt.outputs.dir }}
+          key: lpt-file-costs-${{ github.sha }}
+          restore-keys: |
+            lpt-file-costs-
       - name: Resolve process-floor CA shelf path
         id: shelf
         shell: bash
@@ -119,7 +322,7 @@ jobs:
           set -uo pipefail
           chmod +x tools/run_one_process_floor_axis.sh
           set +e
-          bash tools/run_one_process_floor_axis.sh "${{ matrix.axis }}" "${{ matrix.script }}"
+          bash tools/run_one_process_floor_axis.sh "${{ matrix.axis }}" "${{ matrix.script }}" "${{ matrix.shard }}" "${{ matrix.shardCount }}"
           code=$?
           set -e
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
@@ -128,6 +331,13 @@ jobs:
           exit "$code"
       # Save after every attempt so partial fills warm peers / next runs.
       # Concurrent saves of the same key: first wins; content is CA so safe.
+
+      - name: Save LPT file-cost prior (content-addressed)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.lpt.outputs.dir }}
+          key: lpt-file-costs-${{ github.sha }}-${{ matrix.axisSeat }}
       - name: Save process-floor CA terminal shelf (fleet)
         if: always()
         uses: actions/cache/save@v4
@@ -138,7 +348,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: floor-axis-${{ matrix.axis }}
+          name: floor-axis-${{ matrix.axisSeat }}
           path: floor-axis-report.json
           if-no-files-found: error
 

--- a/.github/workflows/python-package-suite.yml
+++ b/.github/workflows/python-package-suite.yml
@@ -19,6 +19,10 @@ name: Python package suite (authoritative)
 # suite-report.json. Completeness is ENROLLMENT (roster + roll call), not merge
 # into a shared hub. Identity gate runs PER SHARD.
 #
+# Shard count k=8 lives in tools/python_package_suite_shards.py.
+# Split key is LPT on a content-addressed per-file cost prior (not
+# path-index%8). Live by-count k=8 showed 1115s vs 45s shards; LPT
+# targets T/k. No prior → equal-count + JOB_LOG; run writes prior.
 # Shard count lives in tools/python_package_suite_shards.py (SHARD_COUNT=8)
 # and is mirrored as the static matrix + SUITE_SHARD_COUNT env below.
 
@@ -106,6 +110,24 @@ jobs:
           name: python-test-environment-identity
           path: ${{ runner.temp }}/python-test-identity
 
+
+      - name: Resolve LPT file-cost prior path
+        id: lpt
+        shell: bash
+        run: |
+          set -euo pipefail
+          dir="${GITHUB_WORKSPACE}/.cache/sugar/lpt-file-costs"
+          mkdir -p "$dir"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+          echo "SUGAR_LPT_PRIOR_DIR=$dir" >> "$GITHUB_ENV"
+          echo "JOB_LOG phase=lpt-prior status=resolve dir=$dir"
+      - name: Restore LPT file-cost prior (content-addressed)
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.lpt.outputs.dir }}
+          key: lpt-file-costs-${{ github.sha }}
+          restore-keys: |
+            lpt-file-costs-
       - name: Install from shared wheelhouse (no network resolve)
         id: env
         uses: ./.github/actions/python-test-environment-from-wheelhouse
@@ -242,6 +264,14 @@ jobs:
             suite-node-ids/
             identity-gate.md
           if-no-files-found: warn
+
+
+      - name: Save LPT file-cost prior (content-addressed)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.lpt.outputs.dir }}
+          key: lpt-file-costs-${{ github.sha }}-suite-${{ matrix.shard }}
 
       - name: Report, do not gate on pytest verdict
         if: always()

--- a/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
@@ -88,6 +88,52 @@ def require_python_paths(roots: Sequence[Path]) -> list[Path]:
     return paths
 
 
+def add_lpt_shard_args(parser) -> None:
+    """CLI for LPT file sharding (k=8 default; same key as suite)."""
+    parser.add_argument(
+        "--shard-index",
+        type=int,
+        default=None,
+        help="0-based LPT/equal-count file shard (omit = full population)",
+    )
+    parser.add_argument(
+        "--shard-count",
+        type=int,
+        default=8,
+        help="file shard count k (default 8; do not raise without env evidence)",
+    )
+
+
+def apply_lpt_file_shard(
+    paths: Sequence[Path],
+    *,
+    root: Path,
+    shard_index: int | None,
+    shard_count: int,
+    population: str,
+) -> list[Path]:
+    """Filter paths to one LPT shard; no-op when shard_index is None."""
+    if shard_index is None:
+        return list(paths)
+    if not (0 <= shard_index < shard_count):
+        raise ValueError(
+            f"shard_index {shard_index} out of range for shard_count {shard_count}"
+        )
+    tools = Path(__file__).resolve().parents[4] / "tools"
+    if tools.is_dir() and str(tools) not in sys.path:
+        sys.path.insert(0, str(tools))
+    from lpt_file_shards import filter_paths_for_shard
+
+    return filter_paths_for_shard(
+        paths,
+        root=root,
+        shard_index=shard_index,
+        shard_count=shard_count,
+        population=population,
+        narrate=True,
+    )
+
+
 def require_explicit_scan_roots(roots: Sequence[Path]) -> list[Path]:
     """Refuse empty path sets so a floor cannot green on a defaulted population.
 

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
@@ -607,13 +607,32 @@ class SupervisedEnumSupervisor:
                         status="lifting",
                         file=rel,
                     )
+                    t_file = time.perf_counter()
                     measured = self.lift_file(path, rel)
+                    file_s = time.perf_counter() - t_file
                     ordered[index] = measured
+                    # Content-addressed LPT prior write-through (next run packs
+                    # by measured cost; cold equal-count seeds the shelf).
+                    try:
+                        _tools = Path(__file__).resolve().parents[4] / "tools"
+                        if _tools.is_dir() and str(_tools) not in sys.path:
+                            sys.path.insert(0, str(_tools))
+                        from lpt_file_shards import ContentAddressedCostPrior
+
+                        ContentAddressedCostPrior().put_for_path(
+                            path,
+                            file_s,
+                            source="process-floor-lift",
+                            path_hint=rel,
+                        )
+                    except Exception:  # noqa: BLE001 — prior must not kill scan
+                        pass
                     lift_beat.tick(
                         n=done_i,
                         force=True,
                         status=measured.category,
                         file=rel,
+                        file_s=f"{file_s:.3f}",
                     )
                     if cache is not None:
                         payload = terminal_to_payload(

--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -28,6 +28,8 @@ from _enum_floor_runtime import (  # noqa: E402
     production_roots,
     require_explicit_scan_roots,
     require_python_paths,
+    add_lpt_shard_args,
+    apply_lpt_file_shard,
 )
 from _production_lift_child import (  # noqa: E402
     NON_FAILURE_OUTCOMES,
@@ -116,6 +118,7 @@ def main() -> int:
     parser.add_argument("--out-dir", type=Path, default=None)
     parser.add_argument("--engine-log", type=Path, default=None)
     parser.add_argument("--progress", type=Path, default=None)
+    add_lpt_shard_args(parser)
     args = parser.parse_args()
 
     boot_error = production_lift_bootstrap_error()
@@ -127,6 +130,13 @@ def main() -> int:
         return 2
     try:
         paths = require_explicit_scan_roots(args.paths)
+        paths = apply_lpt_file_shard(
+            paths,
+            root=args.repo_root,
+            shard_index=args.shard_index,
+            shard_count=args.shard_count,
+            population="process-floor-bare-exception",
+        )
     except ValueError as error:
         print(f"BARE-EXCEPTION ZERO-TOLERANCE RED: {error}")
         return 2

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -29,6 +29,8 @@ from _enum_floor_runtime import (  # noqa: E402
     production_roots,
     require_explicit_scan_roots,
     require_python_paths,
+    add_lpt_shard_args,
+    apply_lpt_file_shard,
 )
 from _production_lift_child import production_lift_bootstrap_error  # noqa: E402
 from _supervised_enum_supervisor import FileTerminal, scan_paths  # noqa: E402
@@ -173,6 +175,7 @@ def main() -> int:
     parser.add_argument("--out-dir", type=Path, default=None)
     parser.add_argument("--engine-log", type=Path, default=None)
     parser.add_argument("--progress", type=Path, default=None)
+    add_lpt_shard_args(parser)
     args = parser.parse_args()
 
     boot_error = production_lift_bootstrap_error()
@@ -185,6 +188,13 @@ def main() -> int:
 
     try:
         paths = require_explicit_scan_roots(args.paths)
+        paths = apply_lpt_file_shard(
+            paths,
+            root=args.repo_root,
+            shard_index=args.shard_index,
+            shard_count=args.shard_count,
+            population="process-floor-native-crash",
+        )
     except ValueError as error:
         print(f"NATIVE-CRASH ZERO-TOLERANCE RED: {error}")
         return 2

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -88,6 +88,8 @@ from _enum_floor_runtime import (  # noqa: E402
     require_explicit_scan_roots,
     require_python_paths,
     with_file_timeout,
+    add_lpt_shard_args,
+    apply_lpt_file_shard,
 )
 
 
@@ -406,6 +408,7 @@ def main() -> int:
     parser.add_argument("--out-dir", type=Path, default=None)
     parser.add_argument("--engine-log", type=Path, default=None)
     parser.add_argument("--progress", type=Path, default=None)
+    add_lpt_shard_args(parser)
     parser.add_argument("--progress-stdout", action="store_true")
     args = parser.parse_args()
 
@@ -414,6 +417,13 @@ def main() -> int:
         # refuse empty args. Kit production_roots is never an implied default.
         roots = list(args.live_root) + list(args.paths)
         paths = require_explicit_scan_roots(roots)
+        paths = apply_lpt_file_shard(
+            paths,
+            root=args.repo_root,
+            shard_index=args.shard_index,
+            shard_count=args.shard_count,
+            population="process-floor-silent",
+        )
     except ValueError as error:
         print(f"SILENT ZERO-TOLERANCE RED: {error}")
         return 2

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -26,6 +26,8 @@ from _enum_floor_runtime import (  # noqa: E402
     production_roots,
     require_explicit_scan_roots,
     require_python_paths,
+    add_lpt_shard_args,
+    apply_lpt_file_shard,
 )
 from _production_lift_child import production_lift_bootstrap_error  # noqa: E402
 from _supervised_enum_supervisor import FileTerminal, scan_paths  # noqa: E402
@@ -115,6 +117,7 @@ def main() -> int:
     parser.add_argument("--out-dir", type=Path, default=None)
     parser.add_argument("--engine-log", type=Path, default=None)
     parser.add_argument("--progress", type=Path, default=None)
+    add_lpt_shard_args(parser)
     args = parser.parse_args()
 
     boot_error = production_lift_bootstrap_error()
@@ -126,6 +129,13 @@ def main() -> int:
         return 2
     try:
         paths = require_explicit_scan_roots(args.paths)
+        paths = apply_lpt_file_shard(
+            paths,
+            root=args.repo_root,
+            shard_index=args.shard_index,
+            shard_count=args.shard_count,
+            population="process-floor-timeout",
+        )
     except ValueError as error:
         print(f"TIMEOUT ZERO-TOLERANCE RED: {error}")
         return 2

--- a/tests/test_lpt_file_shards.py
+++ b/tests/test_lpt_file_shards.py
@@ -1,0 +1,83 @@
+"""Teeth: LPT packing + content-addressed prior + honest equal-count degrade."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from lpt_file_shards import (  # noqa: E402
+    ContentAddressedCostPrior,
+    assign_files,
+    equal_count_bins,
+    lpt_bins,
+)
+
+
+def test_lpt_assigns_heaviest_first_to_lightest_bin() -> None:
+    files = ["a", "b", "c", "d"]
+    costs = {"a": 100.0, "b": 90.0, "c": 10.0, "d": 5.0}
+    bins = lpt_bins(files, costs, 2, missing_cost=1.0)
+    # a->0, b->1, c->1 (10 on 90), d->0 (5 on 100) => loads 105 / 100
+    assert set(bins[0]) == {"a", "d"} or set(bins[0]) == {"a", "c"}
+    loads = [sum(costs[x] for x in b) for b in bins]
+    assert max(loads) <= 105.0
+    assert abs(loads[0] - loads[1]) <= 15.0
+
+
+def test_equal_count_is_index_mod_k() -> None:
+    files = [f"f{i}" for i in range(8)]
+    bins = equal_count_bins(files, 4)
+    assert bins[0] == ["f0", "f4"]
+    assert bins[3] == ["f3", "f7"]
+
+
+def test_no_prior_degrades_to_equal_count(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SUGAR_LPT_PRIOR_DIR", str(tmp_path / "prior"))
+    files = ["x.py", "y.py", "z.py", "w.py"]
+    # no files on disk → no cid hits
+    assignment = assign_files(files, shard_count=2, path_resolver={})
+    assert assignment.mode == "equal-count"
+    assert assignment.prior_hits == 0
+
+
+def test_prior_write_and_lpt_second_pass(tmp_path: Path, monkeypatch) -> None:
+    prior_root = tmp_path / "prior"
+    monkeypatch.setenv("SUGAR_LPT_PRIOR_DIR", str(prior_root))
+    root = tmp_path / "src"
+    root.mkdir()
+    paths = {}
+    costs = {"heavy.py": 100.0, "mid.py": 50.0, "light.py": 1.0, "tiny.py": 1.0}
+    for name, cost in costs.items():
+        p = root / name
+        p.write_text(f"# {name} {cost}\n" + ("x" * int(cost)), encoding="utf-8")
+        paths[name] = p
+    prior = ContentAddressedCostPrior(prior_root)
+    for name, cost in costs.items():
+        prior.put_for_path(paths[name], cost, source="test")
+    assignment = assign_files(
+        list(costs),
+        shard_count=2,
+        path_resolver=paths,
+        prior=prior,
+    )
+    assert assignment.mode == "lpt"
+    assert assignment.prior_hits == 4
+    loads = assignment.estimated_loads
+    # LPT packs 100+1 vs 50+1 — far better than dumping both heavies on one bin.
+    assert max(loads) < 120.0
+    assert min(loads) >= 50.0
+    assert sum(loads) == pytest.approx(152.0)
+
+
+
+def test_job_log_line_names_mode() -> None:
+    files = ["a", "b"]
+    a = assign_files(files, shard_count=2, path_resolver={})
+    line = a.job_log_line(population="suite-pytest")
+    assert "mode=equal-count" in line
+    assert "population=suite-pytest" in line

--- a/tests/test_python_package_suite_shards.py
+++ b/tests/test_python_package_suite_shards.py
@@ -39,16 +39,18 @@ def test_shard_assignment_is_deterministic_and_covers_every_file() -> None:
     assert count == 8, f"suite fan-out sized to 8 by measurement; got {count}"
     covered: list[str] = []
     for i in range(count):
-        covered.extend(mod.files_for_shard(files, i, count))
+        covered.extend(mod.files_for_shard(files, i, count, repo_root=ROOT))
 
     assert sorted(covered) == sorted(files)
-    # Same file always same shard across two pure calls.
-    assert mod.files_for_shard(files, 0, count) == mod.files_for_shard(
-        files, 0, count
+    # Same file always same shard across two pure calls (deterministic LPT/eq).
+    assert mod.files_for_shard(files, 0, count, repo_root=ROOT) == mod.files_for_shard(
+        files, 0, count, repo_root=ROOT
     )
-    # Spot-check: a middle file's seat is index % count.
+    # Spot-check: seat is stable for a middle file under the active assignment.
     mid = files[len(files) // 2]
-    assert mod.shard_index_for(mid, files, count) == files.index(mid) % count
+    seat = mod.shard_index_for(mid, files, count, repo_root=ROOT)
+    assert 0 <= seat < count
+    assert mid in mod.files_for_shard(files, seat, count, repo_root=ROOT)
 
 
 def test_missing_shard_makes_attendance_red_not_a_smaller_pass() -> None:

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -104,30 +104,30 @@ def test_enrollment_missing_axis_is_unmeasured(tmp_path: Path) -> None:
     mod = _enroll_mod()
     # Only one of five enrolled axes present.
     report = mod.mint_axis_report(
-        axis_id="silent",
-        display="R_silent",
+        axis_id="silent-s00",
+        display="R_silent[s00]",
         commit_sha="deadbeef",
         exit_code=0,
         kind="process",
     )
-    path = tmp_path / "floor-axis-silent" / mod.REPORT_FILENAME
+    path = tmp_path / "floor-axis-silent-s00" / mod.REPORT_FILENAME
     path.parent.mkdir(parents=True)
     path.write_text(json.dumps(report), encoding="utf-8")
     code, summary = mod.check_attendance(tmp_path, require_commit="deadbeef")
     assert code == 1
     assert summary["status"] == "UNMEASURED"
-    assert "native-crash" in summary["missing"]
-    assert "silent" in summary["attended"]
+    assert "native-crash-s00" in summary["missing"]
+    assert "silent-s00" in summary["attended"]
 
 
 def test_enrollment_complete_with_all_axes(tmp_path: Path) -> None:
     mod = _enroll_mod()
-    for axis in mod.ENROLLED:
+    for axis in mod.ENROLLED:  # process LPT seats + static
         report = mod.mint_axis_report(
             axis_id=axis.axis_id,
             display=axis.display,
             commit_sha="abc123",
-            exit_code=0 if axis.axis_id != "timeout" else 1,
+            exit_code=0 if not axis.axis_id.startswith("timeout-") else 1,
             kind=axis.kind,
         )
         path = tmp_path / f"floor-axis-{axis.axis_id}" / mod.REPORT_FILENAME
@@ -136,7 +136,7 @@ def test_enrollment_complete_with_all_axes(tmp_path: Path) -> None:
     code, summary = mod.check_attendance(tmp_path, require_commit="abc123")
     assert code == 0
     assert summary["status"] == "complete"
-    assert summary["residualRed"] == ["timeout"]
+    assert summary["residualRed"] == [f"timeout-s{i:02d}" for i in range(8)]
 
 
 def test_local_monolith_still_lists_process_axes_for_workstation() -> None:

--- a/tools/lpt_file_shards.py
+++ b/tools/lpt_file_shards.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""LPT file sharding on a content-addressed measured cost prior.
+
+Keep k fixed (suite/floors: 8). Change the SPLIT KEY:
+
+  equal-count (path-index % k)  →  up to ~25× wall imbalance on live suite
+  LPT on measured file_s prior →  wall ≈ T/k until the max-file floor
+
+Algorithm (classic multiprocessor LPT):
+  1. Sort files by prior cost descending (path asc on ties — deterministic).
+  2. Assign each file to the currently lightest shard (lowest index on ties).
+
+Prior:
+  Content-addressed by file bytes (same cid vocabulary as process-floor cache).
+  Unchanged files keep their cost forever. First cold run has no prior →
+  equal-count AND writes the prior so the second run is fast. No silent pretend.
+
+Job log:
+  Always print which mode ran (lpt vs equal-count) and prior hit rate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+
+DEFAULT_SHARD_COUNT = 8
+PRIOR_SCHEMA = "lpt-file-cost/v1"
+
+
+def _blake3_512(data: bytes) -> str:
+    try:
+        import blake3  # type: ignore
+
+        return "blake3-512:" + blake3.blake3(data, max_threads=1).digest(64).hex()
+    except Exception:  # noqa: BLE001
+        return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def file_content_cid(path: Path) -> str:
+    return _blake3_512(Path(path).read_bytes())
+
+
+def resolve_prior_root() -> Path | None:
+    """Durable prior root, or None to disable.
+
+    Prefer ``SUGAR_LPT_PRIOR_DIR``. Default: workspace
+    ``.cache/sugar/lpt-file-costs`` (writable in GHA; fleet-shared via
+    actions/cache). Disable: ``SUGAR_LPT_PRIOR_DIR=off``.
+    """
+    explicit = os.environ.get("SUGAR_LPT_PRIOR_DIR")
+    if explicit is not None:
+        text = explicit.strip()
+        if text in {"", "0", "off", "none", "disabled"}:
+            return None
+        return Path(text).expanduser().resolve()
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if workspace:
+        return Path(workspace).resolve() / ".cache" / "sugar" / "lpt-file-costs"
+    home = os.environ.get("HOME")
+    if home:
+        return Path(home).expanduser().resolve() / ".cache" / "sugar" / "lpt-file-costs"
+    return Path(".cache/sugar/lpt-file-costs").resolve()
+
+
+def _cid_filename(cid: str) -> str:
+    # Filesystem-safe: drop scheme punctuation.
+    return cid.replace(":", "_").replace("/", "_") + ".json"
+
+
+@dataclass(frozen=True)
+class PriorHit:
+    content_cid: str
+    cost_s: float
+    source: str
+
+
+class ContentAddressedCostPrior:
+    """Per-file-content cost shelf. Path is only a lookup handle for bytes."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root if root is not None else resolve_prior_root()
+
+    @property
+    def enabled(self) -> bool:
+        return self.root is not None
+
+    def _path_for_cid(self, cid: str) -> Path | None:
+        if self.root is None:
+            return None
+        return self.root / _cid_filename(cid)
+
+    def get_by_cid(self, cid: str) -> PriorHit | None:
+        path = self._path_for_cid(cid)
+        if path is None or not path.is_file():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        if data.get("schema") != PRIOR_SCHEMA:
+            return None
+        try:
+            cost = float(data["cost_s"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        if cost < 0:
+            return None
+        return PriorHit(
+            content_cid=str(data.get("contentCid") or cid),
+            cost_s=cost,
+            source=str(data.get("source") or "unknown"),
+        )
+
+    def get_for_path(self, path: Path) -> PriorHit | None:
+        try:
+            cid = file_content_cid(path)
+        except OSError:
+            return None
+        return self.get_by_cid(cid)
+
+    def put_for_path(
+        self,
+        path: Path,
+        cost_s: float,
+        *,
+        source: str,
+        path_hint: str | None = None,
+    ) -> str | None:
+        """Write/overwrite prior for this file's content. Returns cid or None."""
+        if self.root is None or cost_s < 0:
+            return None
+        try:
+            data = Path(path).read_bytes()
+        except OSError:
+            return None
+        cid = _blake3_512(data)
+        self.root.mkdir(parents=True, exist_ok=True)
+        out = self._path_for_cid(cid)
+        assert out is not None
+        payload = {
+            "schema": PRIOR_SCHEMA,
+            "contentCid": cid,
+            "cost_s": round(float(cost_s), 6),
+            "source": source,
+            "pathHint": path_hint or Path(path).as_posix(),
+        }
+        tmp = out.with_suffix(out.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        tmp.replace(out)
+        return cid
+
+    def costs_for_paths(
+        self, paths: Mapping[str, Path]
+    ) -> tuple[dict[str, float], int, int]:
+        """Map roster key → cost_s for keys with a prior.
+
+        Returns (costs, hits, misses).
+        """
+        costs: dict[str, float] = {}
+        hits = 0
+        misses = 0
+        for key, path in paths.items():
+            hit = self.get_for_path(path)
+            if hit is None:
+                misses += 1
+                continue
+            costs[key] = hit.cost_s
+            hits += 1
+        return costs, hits, misses
+
+
+def equal_count_bins(files: Sequence[str], shard_count: int) -> list[list[str]]:
+    """Path-index % k on the given order (caller should sort for stability)."""
+    if shard_count < 1:
+        raise ValueError("shard_count must be >= 1")
+    bins: list[list[str]] = [[] for _ in range(shard_count)]
+    for i, path in enumerate(files):
+        bins[i % shard_count].append(path)
+    return bins
+
+
+def lpt_bins(
+    files: Sequence[str],
+    costs: Mapping[str, float],
+    shard_count: int,
+    *,
+    missing_cost: float,
+) -> list[list[str]]:
+    """Longest-processing-time-first multiprocessor packing."""
+    if shard_count < 1:
+        raise ValueError("shard_count must be >= 1")
+    if missing_cost < 0:
+        raise ValueError("missing_cost must be >= 0")
+
+    def sort_key(path: str) -> tuple[float, str]:
+        cost = costs.get(path, missing_cost)
+        return (-float(cost), path)
+
+    ordered = sorted(files, key=sort_key)
+    bins: list[list[str]] = [[] for _ in range(shard_count)]
+    loads = [0.0] * shard_count
+    for path in ordered:
+        cost = float(costs.get(path, missing_cost))
+        # Lightest bin; lowest index on ties — deterministic.
+        target = min(range(shard_count), key=lambda i: (loads[i], i))
+        bins[target].append(path)
+        loads[target] += cost
+    return bins
+
+
+@dataclass(frozen=True)
+class ShardAssignment:
+    bins: list[list[str]]
+    mode: str  # "lpt" | "equal-count"
+    prior_hits: int
+    prior_misses: int
+    shard_count: int
+    estimated_loads: list[float]
+
+    def job_log_line(self, *, population: str) -> str:
+        loads = ",".join(f"{x:.1f}" for x in self.estimated_loads)
+        return (
+            f"JOB_LOG phase=lpt-shard-assign population={population} "
+            f"mode={self.mode} k={self.shard_count} "
+            f"prior_hits={self.prior_hits} prior_misses={self.prior_misses} "
+            f"est_load_s=[{loads}]"
+        )
+
+
+def assign_files(
+    files: Sequence[str],
+    *,
+    shard_count: int = DEFAULT_SHARD_COUNT,
+    path_resolver: Mapping[str, Path] | None = None,
+    prior: ContentAddressedCostPrior | None = None,
+) -> ShardAssignment:
+    """Assign files to shards: LPT when any prior exists, else equal-count.
+
+    ``path_resolver`` maps roster key → filesystem path for content cid.
+    When omitted, equal-count only (no path bytes to hash).
+    """
+    ordered = list(files)
+    prior = prior if prior is not None else ContentAddressedCostPrior()
+    costs: dict[str, float] = {}
+    hits = 0
+    misses = len(ordered)
+    if path_resolver is not None and prior.enabled and ordered:
+        costs, hits, misses = prior.costs_for_paths(
+            {f: path_resolver[f] for f in ordered if f in path_resolver}
+        )
+        # Files without a resolvable path count as misses.
+        for f in ordered:
+            if f not in path_resolver and f not in costs:
+                misses += 1
+
+    if hits == 0:
+        bins = equal_count_bins(sorted(ordered), shard_count)
+        loads = [float(len(b)) for b in bins]  # unit cost under equal-count
+        return ShardAssignment(
+            bins=bins,
+            mode="equal-count",
+            prior_hits=0,
+            prior_misses=misses if ordered else 0,
+            shard_count=shard_count,
+            estimated_loads=loads,
+        )
+
+    known = list(costs.values())
+    missing_cost = sorted(known)[len(known) // 2]  # median of known
+    bins = lpt_bins(ordered, costs, shard_count, missing_cost=missing_cost)
+    loads = [
+        sum(costs.get(p, missing_cost) for p in b) for b in bins
+    ]
+    return ShardAssignment(
+        bins=bins,
+        mode="lpt",
+        prior_hits=hits,
+        prior_misses=misses,
+        shard_count=shard_count,
+        estimated_loads=loads,
+    )
+
+
+def narrate_assignment(assignment: ShardAssignment, *, population: str) -> None:
+    """Emit assignment mode to the job log on stderr.
+
+    Suite path emission prints paths on stdout for ``mapfile``; mixing JOB_LOG
+    onto stdout would feed the log line into pytest as a fake test path.
+    """
+    line = assignment.job_log_line(population=population)
+    print(line, file=sys.stderr, flush=True)
+    if assignment.mode == "equal-count":
+        print(
+            "JOB_LOG phase=lpt-shard-assign status=no-prior "
+            "degraded=equal-count (will write prior during this run for next)",
+            file=sys.stderr,
+            flush=True,
+        )
+
+
+def load_costs_from_running_counts_jsonl(
+    path: Path,
+) -> dict[str, float]:
+    """Parse recensus running-counts.jsonl → relative file → file_s (last wins)."""
+    costs: dict[str, float] = {}
+    if not path.is_file():
+        return costs
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            file_key = row.get("file")
+            file_s = row.get("file_s")
+            if not isinstance(file_key, str) or file_s is None:
+                continue
+            try:
+                costs[file_key] = float(file_s)
+            except (TypeError, ValueError):
+                continue
+    return costs
+
+
+def ingest_running_counts_into_prior(
+    jsonl_path: Path,
+    *,
+    corpus_root: Path,
+    prior: ContentAddressedCostPrior | None = None,
+    source: str = "recensus-running-counts",
+) -> int:
+    """Materialize path-keyed running counts into content-addressed prior.
+
+    Returns number of files written.
+    """
+    prior = prior if prior is not None else ContentAddressedCostPrior()
+    if not prior.enabled:
+        return 0
+    costs = load_costs_from_running_counts_jsonl(jsonl_path)
+    written = 0
+    root = corpus_root.resolve()
+    for rel, cost in costs.items():
+        # running-counts may use "pandas/foo.py" or "foo.py"
+        candidates = [root / rel, root / Path(rel).name]
+        if "/" in rel:
+            # strip leading package dir if present
+            parts = rel.split("/", 1)
+            if len(parts) == 2:
+                candidates.append(root / parts[1])
+        path = next((p for p in candidates if p.is_file()), None)
+        if path is None:
+            continue
+        if prior.put_for_path(path, cost, source=source, path_hint=rel):
+            written += 1
+    return written
+
+
+def filter_paths_for_shard(
+    paths: Sequence[Path],
+    *,
+    root: Path,
+    shard_index: int,
+    shard_count: int = DEFAULT_SHARD_COUNT,
+    population: str = "corpus",
+    narrate: bool = True,
+) -> list[Path]:
+    """LPT/equal-count filter of absolute paths under ``root`` for one shard."""
+    root = root.resolve()
+    rels: list[str] = []
+    by_rel: dict[str, Path] = {}
+    for path in paths:
+        path = path.resolve()
+        rel = path.relative_to(root).as_posix()
+        rels.append(rel)
+        by_rel[rel] = path
+    assignment = assign_files(
+        rels,
+        shard_count=shard_count,
+        path_resolver=by_rel,
+        prior=ContentAddressedCostPrior(),
+    )
+    if narrate:
+        narrate_assignment(assignment, population=population)
+    chosen = assignment.bins[shard_index]
+    return [by_rel[rel] for rel in chosen]
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--demo-lpt", action="store_true")
+    args = parser.parse_args(argv)
+    if args.demo_lpt:
+        files = [f"f{i}" for i in range(10)]
+        costs = {f"f{i}": float(10 - i) for i in range(10)}
+        bins = lpt_bins(files, costs, 3, missing_cost=1.0)
+        print(json.dumps(bins))
+        return 0
+    parser.error("pass --demo-lpt or import as a library")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/python_package_suite_report.py
+++ b/tools/python_package_suite_report.py
@@ -170,6 +170,8 @@ class SuiteReporter:
         self.shuffle_seed = None
         self._beat: object | None = None
         self._current_nodeid: str | None = None
+        # Per-test-file wall seconds (sum of call durations) → LPT prior.
+        self._file_duration_s: dict[str, float] = {}
         # Resolved NOW, so an unresolvable identity costs zero measurement.
         self.identity = self._identity()
         self.measured_commit = self._measured_commit()
@@ -208,6 +210,13 @@ class SuiteReporter:
 
     def pytest_runtest_logreport(self, report):
         nodeid = report.nodeid
+        # Accumulate call-phase duration per test file for LPT prior write-through.
+        if report.when == "call":
+            duration = float(getattr(report, "duration", 0.0) or 0.0)
+            file_key = nodeid.split("::", 1)[0]
+            self._file_duration_s[file_key] = (
+                self._file_duration_s.get(file_key, 0.0) + duration
+            )
         if report.failed:
             if report.when in _ERROR_PHASES:
                 self._record(self.errored, nodeid)
@@ -299,6 +308,9 @@ class SuiteReporter:
             except Exception:  # noqa: BLE001 — never fail report for narration
                 pass
             self._beat = None
+        # Write content-addressed LPT prior so the NEXT run packs by measured
+        # cost (cold equal-count seeds the shelf; second run is LPT).
+        self._write_lpt_prior()
         path = self.config.getoption("--suite-report")
         if not path:
             return
@@ -445,6 +457,45 @@ class SuiteReporter:
                 "which commit it measured"
             )
         return commit
+
+    def _write_lpt_prior(self) -> None:
+        """Persist per-file pytest call seconds into the CA LPT cost shelf."""
+        if not self._file_duration_s:
+            return
+        try:
+            from lpt_file_shards import ContentAddressedCostPrior
+        except ImportError:
+            return
+        prior = ContentAddressedCostPrior()
+        if not prior.enabled:
+            return
+        # nodeid file keys are usually relative to pytest rootdir (cwd).
+        root = Path(self.config.rootpath)
+        written = 0
+        for file_key, cost in self._file_duration_s.items():
+            candidates = [
+                root / file_key,
+                Path(file_key),
+            ]
+            # Workflow runs with working-directory implementations/python.
+            if not file_key.startswith("implementations/"):
+                candidates.append(
+                    root / "implementations" / "python" / file_key
+                )
+            path = next((p for p in candidates if p.is_file()), None)
+            if path is None:
+                continue
+            if prior.put_for_path(
+                path,
+                float(cost),
+                source="suite-pytest-call-duration",
+                path_hint=file_key,
+            ):
+                written += 1
+        narrate(
+            f"JOB_LOG phase=lpt-prior-write population=suite-pytest "
+            f"files_written={written} files_measured={len(self._file_duration_s)}"
+        )
 
 
 _START_UNIX = time.time()

--- a/tools/python_package_suite_shards.py
+++ b/tools/python_package_suite_shards.py
@@ -8,11 +8,15 @@ one long hold of a shared resource. Parallel CI jobs each own one shard: each
 writes its own identity-bound report. Completeness is enrollment (all shards
 attended), not aggregation into a shared hub.
 
-SHARD LAW
----------
+SHARD LAW (LPT on measured prior)
+---------------------------------
 - Test *files* are the unit of assignment (not individual tests).
-- Assignment is pure: sort relative paths, then ``index % shard_count``.
-- The same file always lands in the same shard for a fixed ``shard_count``.
+- k stays 8 (env tax; raising k only hits the max-file floor).
+- Split key is LPT bin-packing on a content-addressed per-file cost prior
+  (measured pytest wall seconds). Live by-count k=8 showed 1115s vs 45s
+  shards (~25× imbalance) because 40 heavy files landed by path-index luck.
+- No prior → honest equal-count degrade + JOB_LOG line; the run still WRITES
+  the prior so the next is LPT.
 - Empty shards are legal: they still attend with collected=0.
 
 CANONICAL ORDER (stated, not silent)
@@ -36,11 +40,15 @@ import json
 import sys
 from pathlib import Path
 
-# 8 shards: measurement sized the fan-out. Pytest work is ~25s mean / ~71s max
-# per shard; 32-way paid 89–156s env prep N times and stampeded cold sugarbin.
-# Eight keeps the sweep in minutes while cutting env tax and stampede 4×.
-# Env is prepared once (shared wheelhouse artifact); shards install --no-index.
-SHARD_COUNT = 8
+from lpt_file_shards import (  # noqa: E402
+    DEFAULT_SHARD_COUNT,
+    ContentAddressedCostPrior,
+    assign_files,
+    narrate_assignment,
+)
+
+# 8 shards: env-sized fan-out. Split key is LPT, not path-index%8.
+SHARD_COUNT = DEFAULT_SHARD_COUNT
 
 # Relative to repo root. Collected pytest targets are files under this tree.
 TESTS_REL = Path("implementations/python/sugar-lift-py-tests/tests")
@@ -78,15 +86,54 @@ def list_suite_test_files(repo_root: Path) -> list[str]:
     return files
 
 
-def shard_index_for(path: str, files: list[str], shard_count: int) -> int:
-    try:
-        return files.index(path) % shard_count
-    except ValueError as exc:
-        raise SystemExit(f"path not in suite file roster: {path}") from exc
+def _path_resolver(repo_root: Path, files: list[str]) -> dict[str, Path]:
+    root = repo_root.resolve()
+    return {rel: root / rel for rel in files if (root / rel).is_file()}
+
+
+def assign_suite_shards(
+    files: list[str],
+    *,
+    repo_root: Path,
+    shard_count: int = SHARD_COUNT,
+    narrate: bool = True,
+):
+    """LPT (or equal-count degrade) assignment for the suite file roster."""
+    assignment = assign_files(
+        files,
+        shard_count=shard_count,
+        path_resolver=_path_resolver(repo_root, files),
+        prior=ContentAddressedCostPrior(),
+    )
+    if narrate:
+        narrate_assignment(assignment, population="suite-pytest")
+    return assignment
+
+
+def shard_index_for(
+    path: str,
+    files: list[str],
+    shard_count: int,
+    *,
+    repo_root: Path | None = None,
+) -> int:
+    root = repo_root if repo_root is not None else repo_root_from()
+    assignment = assign_suite_shards(
+        files, repo_root=root, shard_count=shard_count, narrate=False
+    )
+    for i, bucket in enumerate(assignment.bins):
+        if path in bucket:
+            return i
+    raise SystemExit(f"path not in suite file roster: {path}")
 
 
 def files_for_shard(
-    files: list[str], shard_index: int, shard_count: int
+    files: list[str],
+    shard_index: int,
+    shard_count: int,
+    *,
+    repo_root: Path | None = None,
+    narrate: bool = False,
 ) -> list[str]:
     if shard_count < 1:
         raise SystemExit("shard_count must be >= 1")
@@ -94,7 +141,11 @@ def files_for_shard(
         raise SystemExit(
             f"shard_index {shard_index} out of range for shard_count {shard_count}"
         )
-    return [path for i, path in enumerate(files) if i % shard_count == shard_index]
+    root = repo_root if repo_root is not None else repo_root_from()
+    assignment = assign_suite_shards(
+        files, repo_root=root, shard_count=shard_count, narrate=narrate
+    )
+    return list(assignment.bins[shard_index])
 
 
 def roster_ids(shard_count: int) -> list[str]:
@@ -285,7 +336,14 @@ def main(argv: list[str] | None = None) -> int:
     if args.print_paths or args.emit_paths_for_cwd:
         if args.shard_index is None:
             parser.error("--print-paths requires --shard-index")
-        chosen = files_for_shard(files, args.shard_index, args.shard_count)
+        # Narrate once per shard job: LPT vs equal-count + prior hit rate.
+        chosen = files_for_shard(
+            files,
+            args.shard_index,
+            args.shard_count,
+            repo_root=root,
+            narrate=True,
+        )
         prefix = "implementations/python/"
         for path in chosen:
             if args.emit_paths_for_cwd:

--- a/tools/run_one_process_floor_axis.sh
+++ b/tools/run_one_process_floor_axis.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Run exactly one Criterion-2 process floor axis; emit identity-bound report.
+# Run exactly one Criterion-2 process floor axis file-shard; emit identity-bound report.
 #
-# Usage: tools/run_one_process_floor_axis.sh <axis_id> <script_name>
+# Usage: tools/run_one_process_floor_axis.sh <axis_base> <script_name> <shard_index> <shard_count>
+#   axis_base: silent | native-crash | bare-exception | timeout
+#   seat id minted as ${axis_base}-s${shard_index:02d}
 #
 # Exit vocabulary (enrollment mint):
 #   0 — scan completed, residual green
@@ -10,8 +12,12 @@
 
 set -uo pipefail
 
-axis_id="${1:?axis_id}"
+axis_base="${1:?axis_base}"
 script_name="${2:?script}"
+shard_index="${3:?shard_index}"
+shard_count="${4:?shard_count}"
+
+axis_seat="$(printf '%s-s%02d' "$axis_base" "$shard_index")"
 
 TESTS=implementations/python/sugar-lift-py-tests
 SCRIPTS="$TESTS/scripts"
@@ -22,22 +28,31 @@ if [ ! -f "$SCRIPT" ]; then
   exit 2
 fi
 
+# LPT prior shelf — content-addressed; fleet-shared via actions/cache.
+if [ -z "${SUGAR_LPT_PRIOR_DIR+x}" ]; then
+  if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+    export SUGAR_LPT_PRIOR_DIR="${GITHUB_WORKSPACE}/.cache/sugar/lpt-file-costs"
+  else
+    export SUGAR_LPT_PRIOR_DIR="${HOME}/.cache/sugar/lpt-file-costs"
+  fi
+fi
+mkdir -p "${SUGAR_LPT_PRIOR_DIR}" 2>/dev/null || true
+
 PANDAS_CORPUS="$(
   python -c 'from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus; print(authenticated_pandas_corpus().root)'
 )" || {
-  echo "::error::cannot authenticate pandas corpus for process floor $axis_id"
-  # Auth failure is infrastructure UNMEASURED, not residual red.
+  echo "::error::cannot authenticate pandas corpus for process floor $axis_seat"
   commit="${GITHUB_SHA:-unpinned}"
-  case "$axis_id" in
-    silent) display=R_silent ;;
-    native-crash) display=R_native_crashes ;;
-    bare-exception) display=R_bare_exceptions ;;
-    timeout) display=R_timeouts ;;
-    *) display="R_${axis_id}" ;;
+  case "$axis_base" in
+    silent) display="R_silent[s$(printf '%02d' "$shard_index")]" ;;
+    native-crash) display="R_native_crashes[s$(printf '%02d' "$shard_index")]" ;;
+    bare-exception) display="R_bare_exceptions[s$(printf '%02d' "$shard_index")]" ;;
+    timeout) display="R_timeouts[s$(printf '%02d' "$shard_index")]" ;;
+    *) display="R_${axis_base}[s$(printf '%02d' "$shard_index")]" ;;
   esac
   python3 tools/sole_construction_floor_enrollment.py \
     --mint-report floor-axis-report.json \
-    --axis-id "$axis_id" \
+    --axis-id "$axis_seat" \
     --display "$display" \
     --kind process \
     --commit-sha "$commit" \
@@ -47,11 +62,9 @@ PANDAS_CORPUS="$(
   exit 2
 }
 
-FLOOR_SCRATCH="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}/.sugar/ci-floors/${axis_id}"
+FLOOR_SCRATCH="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}/.sugar/ci-floors/${axis_seat}"
 export SUGAR_FLOOR_WORKSPACE="${SUGAR_FLOOR_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP:-$(pwd)}}}"
 
-# Prefer workspace (writable in CI). HOME/.cache failed mkdir on self-hosted
-# (run 30731778056 Permission denied). Fleet share is actions/cache, not HOME.
 if [ -z "${SUGAR_PROCESS_FLOOR_CACHE_DIR+x}" ]; then
   if [ -n "${GITHUB_WORKSPACE:-}" ]; then
     export SUGAR_PROCESS_FLOOR_CACHE_DIR="${GITHUB_WORKSPACE}/.cache/sugar/process-floor-terminals"
@@ -63,33 +76,34 @@ if [ -z "${SUGAR_MEASUREMENT_TIP:-}" ] && [ -n "${GITHUB_SHA:-}" ]; then
   export SUGAR_MEASUREMENT_TIP="${GITHUB_SHA}"
 fi
 
-echo "process-floor axis=$axis_id population=$PANDAS_CORPUS"
+echo "process-floor seat=$axis_seat population=$PANDAS_CORPUS shard=$shard_index/$shard_count"
 echo "process-floor cache: dir=${SUGAR_PROCESS_FLOOR_CACHE_DIR} tip=${SUGAR_MEASUREMENT_TIP:-unpinned}"
-# Job-log doctrine: unbuffered stdout so phase/count lines hit Actions live.
+echo "process-floor lpt_prior: dir=${SUGAR_LPT_PRIOR_DIR}"
 export PYTHONUNBUFFERED=1
-echo "JOB_LOG phase=process-floor-${axis_id} status=start population=$PANDAS_CORPUS"
+echo "JOB_LOG phase=process-floor-${axis_seat} status=start population=$PANDAS_CORPUS"
 
 set +e
 python -u "$SCRIPT" "$PANDAS_CORPUS" \
   --repo-root "$PANDAS_CORPUS" \
-  --out-dir "$FLOOR_SCRATCH"
+  --out-dir "$FLOOR_SCRATCH" \
+  --shard-index "$shard_index" \
+  --shard-count "$shard_count"
 exit_code=$?
 set -e
-echo "JOB_LOG phase=process-floor-${axis_id} status=end exit_code=$exit_code"
+echo "JOB_LOG phase=process-floor-${axis_seat} status=end exit_code=$exit_code"
 
 commit="${GITHUB_SHA:-unpinned}"
-case "$axis_id" in
-  silent) display=R_silent ;;
-  native-crash) display=R_native_crashes ;;
-  bare-exception) display=R_bare_exceptions ;;
-  timeout) display=R_timeouts ;;
-  *) display="R_${axis_id}" ;;
+case "$axis_base" in
+  silent) display="R_silent[s$(printf '%02d' "$shard_index")]" ;;
+  native-crash) display="R_native_crashes[s$(printf '%02d' "$shard_index")]" ;;
+  bare-exception) display="R_bare_exceptions[s$(printf '%02d' "$shard_index")]" ;;
+  timeout) display="R_timeouts[s$(printf '%02d' "$shard_index")]" ;;
+  *) display="R_${axis_base}[s$(printf '%02d' "$shard_index")]" ;;
 esac
 
-# 0/1 = scan completed (green/red residual); >=2 = infrastructure UNMEASURED
 mint_args=(
   --mint-report floor-axis-report.json
-  --axis-id "$axis_id"
+  --axis-id "$axis_seat"
   --display "$display"
   --kind process
   --commit-sha "$commit"

--- a/tools/sole_construction_floor_enrollment.py
+++ b/tools/sole_construction_floor_enrollment.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 """Sole-construction floor enrollment — completeness by roll call, not sum of R.
 
-T: serializing floors on a multi-runner fleet is pure insanity. Each process
-axis is its own CI job; wall clock is max(axis), not sum(axes). Completeness
-is enrollment: a missing axis is UNMEASURED, never a smaller green set.
+T: serializing floors on a multi-runner fleet is pure insanity. Process axes
+run as a matrix; wall clock is max(job), not sum. Completeness is enrollment:
+a missing seat is UNMEASURED, never a smaller green set.
 
-Process axes (expensive, parallel matrix — one job each):
-  silent | native-crash | bare-exception | timeout
+Process population is file-sharded with LPT (k=8) on a measured cost prior —
+same key as the suite. Each (axis × file-shard) is an enrolled seat:
+  silent-s00..s07 | native-crash-s00.. | bare-exception-s00.. | timeout-s00..
 
 Static laws (cheap AST / discrimination): one parallel job that does not wait
 on the process matrix.
 
 Each job writes an identity-bound floor-axis-report.json. Attendance checks
-the enrolled roster; residual red is the axis job's own exit code.
+the enrolled roster; residual red is the seat job's own exit code.
 """
 
 from __future__ import annotations
@@ -31,6 +32,9 @@ REPORT_FILENAME = "floor-axis-report.json"
 CAMPAIGN_CLASS = "python-sole-construction-floors"
 CAMPAIGN_BODY = "floor-measurement.json"
 
+# File-shard k — keep with suite. Split key is LPT, not raising k.
+PROCESS_FILE_SHARD_COUNT = 8
+
 
 @dataclass(frozen=True, slots=True)
 class FloorAxis:
@@ -40,7 +44,7 @@ class FloorAxis:
     script: str | None = None  # process floors only
 
 
-PROCESS_AXES: tuple[FloorAxis, ...] = (
+PROCESS_AXIS_BASE: tuple[FloorAxis, ...] = (
     FloorAxis("silent", "R_silent", "process", "silent_zero_tolerance.py"),
     FloorAxis(
         "native-crash", "R_native_crashes", "process", "native_crash_zero_tolerance.py"
@@ -54,25 +58,54 @@ PROCESS_AXES: tuple[FloorAxis, ...] = (
     FloorAxis("timeout", "R_timeouts", "process", "timeout_zero_tolerance.py"),
 )
 
+# Back-compat alias: base axes without file-shard seats.
+PROCESS_AXES = PROCESS_AXIS_BASE
+
+
+def process_shard_seats(
+    shard_count: int = PROCESS_FILE_SHARD_COUNT,
+) -> tuple[FloorAxis, ...]:
+    seats: list[FloorAxis] = []
+    for axis in PROCESS_AXIS_BASE:
+        for shard in range(shard_count):
+            seats.append(
+                FloorAxis(
+                    f"{axis.axis_id}-s{shard:02d}",
+                    f"{axis.display}[s{shard:02d}]",
+                    "process",
+                    axis.script,
+                )
+            )
+    return tuple(seats)
+
+
 # One enrollment slot for the cheap static job (ownership, side doors, …).
 STATIC_AXIS = FloorAxis("static-laws", "R_static_sole_construction", "static")
 
-ENROLLED: tuple[FloorAxis, ...] = PROCESS_AXES + (STATIC_AXIS,)
+ENROLLED: tuple[FloorAxis, ...] = process_shard_seats() + (STATIC_AXIS,)
 
 
 def enrolled_ids() -> tuple[str, ...]:
     return tuple(a.axis_id for a in ENROLLED)
 
 
-def emit_process_matrix_json() -> str:
-    include = [
-        {
-            "axis": a.axis_id,
-            "display": a.display,
-            "script": a.script,
-        }
-        for a in PROCESS_AXES
-    ]
+def emit_process_matrix_json(
+    shard_count: int = PROCESS_FILE_SHARD_COUNT,
+) -> str:
+    """GitHub Actions matrix include: base axis × LPT file shard."""
+    include = []
+    for axis in PROCESS_AXIS_BASE:
+        for shard in range(shard_count):
+            include.append(
+                {
+                    "axis": axis.axis_id,
+                    "axisSeat": f"{axis.axis_id}-s{shard:02d}",
+                    "display": f"{axis.display}[s{shard:02d}]",
+                    "script": axis.script,
+                    "shard": shard,
+                    "shardCount": shard_count,
+                }
+            )
     return json.dumps({"include": include})
 
 


### PR DESCRIPTION
## Problem

Live suite under by-count **k=8** (run 30731778058): **1115s vs 45s** shards (**~25×** imbalance). Path-index%8 dumps heavy files together; 40 files carry ~75% of runtime. Raising k does not fix the key (k=16 only hits max_file floor while multiplying env tax).

## Fix

**Keep k=8. Change the split key to LPT** on a **content-addressed measured cost prior**.

1. Sort files by prior `cost_s` descending  
2. Assign each to the currently lightest shard (stable ties)  
3. **No prior** → equal-count and **say so** on the job log  
4. **Every measured run writes the prior** (file content cid → cost) so the cold first run seeds the second forever for unchanged files  

### Surfaces

| Surface | Change |
| --- | --- |
| Suite | `python_package_suite_shards` uses LPT; report plugin writes pytest call durations into the prior |
| Floors | Process matrix = base axis × file-shard seats (`silent-s00`…); same LPT filter; enum writes `file_s` into prior |
| Enrollment | Process seats expanded to 4×8 + static |
| Cache | `lpt-file-costs` restore/save (CA entries survive tips) |

## Validation

`PYTHONPATH=tools pytest -q tests/test_lpt_file_shards.py tests/test_python_package_suite_shards.py tests/test_python_sole_construction_ci.py` → **15 passed**

## Not a reversal of 32→8

Env evidence still owns **k**. This corrects the **key** under that k.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add LPT file sharding (k=8) with measured priors to process-floor and suite CI axes
> - Introduces [`tools/lpt_file_shards.py`](https://github.com/TSavo/sugar/pull/7040/files#diff-a8360708a4131eb96fd754a94e07ab71a39edcb310f70cc99b391b04f65881cf) implementing LPT and equal-count-fallback bin assignment, a content-addressed per-file cost prior (shelf-based), and `filter_paths_for_shard` used by floor scanners.
> - Expands the process-floor CI matrix from 4 axes to 32 seats (4 axes × 8 shards s00–s07); [`tools/run_one_process_floor_axis.sh`](https://github.com/TSavo/sugar/pull/7040/files#diff-e2f37947c64a438368c7b6c2e4b00a46231fdc6065bcaaec43954d2ada2be00e) now accepts shard index/count and mints per-seat enrollment reports.
> - Each floor scanner (`silent`, `native-crash`, `bare-exception`, `timeout`) gains `--shard-index` / `--shard-count` CLI args and filters its file list to the assigned shard.
> - [`tools/python_package_suite_shards.py`](https://github.com/TSavo/sugar/pull/7040/files#diff-9f48da58cabb30fcad1c04d290501b130d9268868644bca5c1fc5774b1aa7c90) replaces `index % k` assignment with LPT/equal-count via `assign_files`; suite jobs restore and save the cost prior cache keyed by `github.sha`.
> - Per-file wall-clock durations are recorded during floor lifts and suite runs and written to the content-addressed prior so subsequent runs use measured costs for LPT assignment.
> - Behavioral Change: shard seat assignment is no longer deterministic by list index alone — files move between seats once a prior exists, and any tooling asserting `index % k` bucket membership will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6536376.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->