### PR TITLE
Scale supervised context_init budget by population; unit tests fail in seconds

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
@@ -31,12 +31,71 @@ _WORKER = Path(__file__).resolve().parent / "_supervised_enum_worker.py"
 # shared demand table is supplied. Authenticated pandas (~1421 files) is
 # multi-minute work — never share the 30s per-file lift timeout.
 # Floors run 30728650857: POPULATION → refused: None at ~30.0s exactly.
-_DEFAULT_CONTEXT_INIT_TIMEOUT = 1800.0
+#
+# CRITICAL: unit tests must NOT inherit the corpus budget. Suite shard 3
+# hung 23+ minutes on a worker blocked in pipe-read because a tiny-population
+# test shared _CORPUS_CONTEXT_INIT_TIMEOUT (1800s). Corpus and test are
+# different obligations — scale the default with declared population size.
+_CORPUS_CONTEXT_INIT_TIMEOUT = 1800.0
+_CORPUS_POPULATION_FLOOR = 500  # ≥ this many .py files → corpus budget
+_SMALL_POP_INIT_FLOOR_S = 10.0
+_SMALL_POP_INIT_PER_FILE_S = 2.0
+_SMALL_POP_INIT_CAP_S = 60.0
+# Backward-compat alias (was the only default; now corpus-only).
+_DEFAULT_CONTEXT_INIT_TIMEOUT = _CORPUS_CONTEXT_INIT_TIMEOUT
 
 # tools/job_log_heartbeat.py — job log, not file, ≤30s silence.
 _TOOLS = Path(__file__).resolve().parents[4] / "tools"
 if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
+
+
+def count_python_population(root: Path) -> int:
+    """Declared scan population size: *.py under root (or 1 if root is a file)."""
+    root = root.resolve()
+    if root.is_file() and root.suffix == ".py":
+        return 1
+    if not root.is_dir():
+        return 0
+    n = 0
+    for path in root.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        if path.is_file():
+            n += 1
+    return n
+
+
+def context_init_timeout_for_population(population_file_count: int) -> float:
+    """Seconds for worker context init, scaled by declared population.
+
+    - Full corpus order-of-magnitude (≥500 .py, authenticated pandas ~1421):
+      multi-minute provisional demand derivation → 1800s.
+    - Tiny / fixture populations (unit tests): seconds-scale so a hung init
+      fails the suite fast instead of parking a shard for half an hour.
+    - Env ``SUGAR_SUPERVISED_CONTEXT_INIT_TIMEOUT`` overrides when set.
+    """
+    override = os.environ.get("SUGAR_SUPERVISED_CONTEXT_INIT_TIMEOUT")
+    if override is not None and override.strip():
+        value = float(override)
+        if value <= 0:
+            raise ValueError(
+                "SUGAR_SUPERVISED_CONTEXT_INIT_TIMEOUT must be positive; "
+                f"got {value!r}"
+            )
+        return value
+    if population_file_count >= _CORPUS_POPULATION_FLOOR:
+        return _CORPUS_CONTEXT_INIT_TIMEOUT
+    if population_file_count <= 0:
+        # Missing/empty root still needs a short named refuse, not 1800s.
+        return _SMALL_POP_INIT_FLOOR_S
+    return min(
+        _SMALL_POP_INIT_CAP_S,
+        max(
+            _SMALL_POP_INIT_FLOOR_S,
+            _SMALL_POP_INIT_PER_FILE_S * float(population_file_count) + 5.0,
+        ),
+    )
 
 
 @dataclass(frozen=True)
@@ -81,7 +140,7 @@ class SupervisedEnumSupervisor:
         self,
         *,
         file_timeout: float = 30.0,
-        context_init_timeout: float = _DEFAULT_CONTEXT_INIT_TIMEOUT,
+        context_init_timeout: float | None = None,
         python: str | None = None,
         env: Mapping[str, str] | None = None,
         corpus_root: Path,
@@ -90,10 +149,7 @@ class SupervisedEnumSupervisor:
     ) -> None:
         if file_timeout > 30:
             raise ValueError("per-file timeout may not exceed 30 seconds")
-        if context_init_timeout <= 0:
-            raise ValueError("context_init_timeout must be positive")
         self.file_timeout = float(file_timeout)
-        self.context_init_timeout = float(context_init_timeout)
         self.python = python or sys.executable
         self.env = dict(env or os.environ)
         self.env.setdefault("PYTHONFAULTHANDLER", "1")
@@ -102,6 +158,15 @@ class SupervisedEnumSupervisor:
             None if demand_table_path is None else demand_table_path.resolve()
         )
         self.allow_local_demand_derivation = allow_local_demand_derivation
+        self.population_file_count = count_python_population(self.corpus_root)
+        if context_init_timeout is None:
+            self.context_init_timeout = context_init_timeout_for_population(
+                self.population_file_count
+            )
+        else:
+            if context_init_timeout <= 0:
+                raise ValueError("context_init_timeout must be positive")
+            self.context_init_timeout = float(context_init_timeout)
         self._proc: subprocess.Popen[str] | None = None
         self.worker_restarts = 0
         self._current_file: str | None = None
@@ -157,6 +222,7 @@ class SupervisedEnumSupervisor:
             f"corpus_root={self.corpus_root}",
             f"demand_table_path={demand!r}",
             f"allow_local_demand_derivation={self.allow_local_demand_derivation}",
+            f"population_file_count={self.population_file_count}",
             f"context_init_timeout_s={self.context_init_timeout}",
             f"elapsed_s={elapsed:.1f}",
         ]
@@ -166,7 +232,8 @@ class SupervisedEnumSupervisor:
                 "fix=pass demand_table_path (shared python-demand-table) or "
                 "raise context_init_timeout; local provisional demand derivation "
                 "over authenticated pandas is multi-minute work and must not "
-                "share the 30s per-file lift timeout"
+                "share the 30s per-file lift timeout; unit tests must use a "
+                "population-scaled budget (tiny trees fail in seconds, not 1800s)"
             )
         elif rc is not None:
             parts.append("mode=worker-exited")
@@ -246,6 +313,16 @@ class SupervisedEnumSupervisor:
                 f"response={ready!r}; worker={_WORKER}"
             )
         assert self._proc.stdin is not None
+        # Job log (not file): budget is population-scaled — name it before wait.
+        print(
+            "supervised-enum-context-init: "
+            f"population_file_count={self.population_file_count} "
+            f"context_init_timeout_s={self.context_init_timeout} "
+            f"corpus_root={self.corpus_root} "
+            f"demand_table_path="
+            f"{self.demand_table_path if self.demand_table_path else None}",
+            flush=True,
+        )
         initialize = {"kind": "initialize", "corpus_root": str(self.corpus_root)}
         if self.demand_table_path is not None:
             initialize["demand_table_path"] = str(self.demand_table_path)
@@ -680,9 +757,14 @@ def scan_paths(
     *,
     root: Path,
     file_timeout: float = 30.0,
-    context_init_timeout: float = _DEFAULT_CONTEXT_INIT_TIMEOUT,
+    context_init_timeout: float | None = None,
     demand_table_path: Path | None = None,
 ) -> list[FileTerminal]:
+    """Scan paths under root.
+
+    ``context_init_timeout`` defaults to population-scaled budget (tiny trees
+    seconds; full corpus 1800s). Pass an explicit float only when you mean it.
+    """
     pairs = [(_p, _relative_to_root(_p, root)) for _p in paths]
     supervisor = SupervisedEnumSupervisor(
         file_timeout=file_timeout,

--- a/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
@@ -118,6 +118,18 @@ def test_worker_refuses_file_before_frozen_context_initialization(
         worker.wait(timeout=5)
 
 
+def test_context_init_timeout_for_population_scales() -> None:
+    """Corpus and unit-test populations are different obligations."""
+    assert _SUP.context_init_timeout_for_population(0) <= 60.0
+    assert _SUP.context_init_timeout_for_population(1) <= 60.0
+    assert _SUP.context_init_timeout_for_population(2) <= 60.0
+    assert _SUP.context_init_timeout_for_population(2) < 120.0
+    # Authenticated pandas order-of-magnitude → corpus budget.
+    assert _SUP.context_init_timeout_for_population(1421) == 1800.0
+    assert _SUP.context_init_timeout_for_population(500) == 1800.0
+    assert _SUP.context_init_timeout_for_population(499) < 1800.0
+
+
 def test_context_init_timeout_names_phase_not_none(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -144,6 +156,47 @@ def test_context_init_timeout_names_phase_not_none(
         assert f"corpus_root={tmp_path.resolve()}" in message
         assert "coordinate=supervised-enum-worker.construction-context" in message
         assert "context_init_timeout_s=1.0" in message
+    finally:
+        supervisor.stop()
+
+
+def test_tiny_population_init_hang_fails_in_seconds_not_corpus_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Suite hang class: tiny tree must not inherit 1800s corpus init budget.
+
+    Shard 3 job 91456853960: worker sat 23+ minutes under the corpus default.
+    Population-scaled default makes unit-spawned workers fail in seconds.
+    """
+    import time
+
+    _write(tmp_path, "clean.py", "def a(z):\n    return z\n")
+    monkeypatch.setenv("SUGAR_SUPERVISOR_PLANT_INIT_HANG", "1")
+    # No explicit context_init_timeout — must derive short budget from population.
+    supervisor = _SUP.SupervisedEnumSupervisor(
+        corpus_root=tmp_path,
+        file_timeout=30.0,
+        allow_local_demand_derivation=True,
+    )
+    assert supervisor.population_file_count == 1
+    assert supervisor.context_init_timeout <= 60.0
+    assert supervisor.context_init_timeout < 1800.0
+    try:
+        t0 = time.perf_counter()
+        with pytest.raises(RuntimeError) as raised:
+            supervisor.start()
+        elapsed = time.perf_counter() - t0
+        message = str(raised.value)
+        assert elapsed < 30.0, (
+            f"tiny-population init hang took {elapsed:.1f}s; "
+            "must fail in seconds, not the 1800s corpus budget"
+        )
+        assert "refused: None" not in message
+        assert "mode=timeout" in message
+        assert "population_file_count=1" in message
+        assert "last_phase='planted-init-hang'" in message
+        assert "context_init_timeout_s=1800" not in message
+        assert f"context_init_timeout_s={supervisor.context_init_timeout}" in message
     finally:
         supervisor.stop()
 


### PR DESCRIPTION
## Summary

Suite shard 3 (job 91456853960) hung **23+ minutes** on a child
`_supervised_enum_worker.py` blocked in a pipe read after pytest had finished
400/452 tests in 25s. #7027 correctly gave **corpus** context init an 1800s
budget; unit tests with a handful of planted files **inherited that budget**.

Corpus budget and test budget are different obligations.

## Fix

- Default `context_init_timeout=None` → **population-scaled**
  - ≥500 `.py` under corpus root → **1800s** (authenticated pandas)
  - tiny / fixture trees → **10–60s** (not half an hour)
- `count_python_population` / `context_init_timeout_for_population`
- Job-log line before init wait names `population_file_count` + budget
- Named timeout still includes phase / population / elapsed (never bare hang, never `refused: None`)
- Env override: `SUGAR_SUPERVISED_CONTEXT_INIT_TIMEOUT`

## Teeth

- Scale unit: 1–2 files ≪ 1800; 1421 → 1800
- Twin: plant init hang over a one-file tree fails in **&lt;30s** without explicit timeout, asserts budget ≠ 1800

Process floors over ~1421 files unchanged. No demand-derivation climb.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scale supervised `context_init_timeout` by Python file population so unit tests fail in seconds
> - Replaces the fixed 1800s `context_init_timeout` default with a population-aware scheme: small populations (< 500 `.py` files) get a short timeout (floor 10s, 2s/file, cap 60s); corpus-sized populations keep 1800s.
> - Adds `count_python_population` to count `.py` files under a root (skipping `__pycache__`) and `context_init_timeout_for_population` to derive the timeout, with an override via `SUGAR_SUPERVISED_CONTEXT_INIT_TIMEOUT`.
> - `SupervisedEnumSupervisor.__init__` now accepts `context_init_timeout=None` and derives the timeout from population when none is provided; startup logs population count and resolved timeout.
> - New tests in [test_supervised_enum_supervisor.py](https://github.com/TSavo/sugar/pull/7042/files#diff-dc89bf4a1089528bb2c9056872ee8654fef2ac316ce2d781747bbfee5b95b5fb) verify scaling behavior and confirm that a simulated init hang on a tiny population times out in under 30s rather than waiting 1800s.
> - Behavioral Change: `scan_paths` callers that omit `context_init_timeout` now get a population-scaled budget instead of always 1800s.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8870e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->