### PR TITLE
Floors and walls: default engine TRACE off; fix setLevel(DEBUG) noop

### DIFF
--- a/.github/workflows/numpy-wall.yml
+++ b/.github/workflows/numpy-wall.yml
@@ -49,6 +49,9 @@ jobs:
         shell: bash
         env:
           SUGAR_ENGINE_LOG: ${{ github.workspace }}/.sugar/numpy-wall-logs/engine.jsonl
+          # WARNING heartbeats only — per-span DEBUG is write-only hot-path
+          # serialisation. Same cut as recensus #7039. Opt in: TRACE_EVENTS=1.
+          SUGAR_ENGINE_TRACE_EVENTS: "0"
           SUGAR_ENGINE_HEARTBEAT_SECONDS: "5"
           SUGAR_ENGINE_CYCLE_THRESHOLD: "8"
           SUGAR_KIT_LOG: ${{ github.workspace }}/.sugar/numpy-wall-logs/transport.jsonl

--- a/.github/workflows/pandas-wall.yml
+++ b/.github/workflows/pandas-wall.yml
@@ -49,6 +49,10 @@ jobs:
         shell: bash
         env:
           SUGAR_ENGINE_LOG: ${{ github.workspace }}/.sugar/pandas-wall-logs/engine.jsonl
+          # WARNING heartbeats only — per-span DEBUG is write-only hot-path
+          # serialisation (~1 MB/file). Same cut as recensus #7039 (43% faster).
+          # Opt in full flood: SUGAR_ENGINE_TRACE_EVENTS=1.
+          SUGAR_ENGINE_TRACE_EVENTS: "0"
           SUGAR_ENGINE_HEARTBEAT_SECONDS: "5"
           SUGAR_ENGINE_CYCLE_THRESHOLD: "8"
           SUGAR_KIT_LOG: ${{ github.workspace }}/.sugar/pandas-wall-logs/transport.jsonl

--- a/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
@@ -5,10 +5,18 @@ One process. One door:
     path_source → SourceFile → functions → sugar
 
 I/O never mixed:
-  engine log  → JSONL file (sugar construction telemetry)
+  engine log  → JSONL file (WARNING heartbeats by default; see TRACE)
   progress    → optional tqdm file (local tail)
   job log     → ALWAYS: named phase + running counts (≤30s silence)
   result/print → floor summary lines only
+
+Engine log default is SUGAR_ENGINE_TRACE_EVENTS=0: WARNING heartbeats,
+cycle_suspected, and errors only — enough to name a stall. Per-span DEBUG
+enter/exit is write-only for floor R (R is the floor axis, not engine.jsonl)
+and costs json.dumps+FileHandler on every sugar enter/exit on the reduction
+hot path. Set engine_trace=True / SUGAR_ENGINE_TRACE_EVENTS=1 only when
+debugging a named stall needs the full flood. Never re-raise the logger to
+DEBUG after configure — that made TRACE=0 a no-op (#7039 recensus lesson).
 
 DOCTRINE: if it can run >30s, emit a named phase or count to the JOB LOG
 within 30s and every 30s after. TTY-gated tqdm and file-only progress are
@@ -42,9 +50,25 @@ def silence_console_logging() -> None:
     logging.lastResort = None  # type: ignore[assignment]
 
 
-def configure_engine_log(path: Path) -> None:
+def configure_engine_log(path: Path, *, engine_trace: bool = False) -> None:
+    """Attach engine JSONL for stall-naming; default TRACE off.
+
+    Default is WARNING-only (``SUGAR_ENGINE_TRACE_EVENTS=0``): heartbeats,
+    cycle_suspected, and errors. Per-span DEBUG enter/exit is opt-in via
+    ``engine_trace=True`` — floor axes do not read those events for R, and
+    they pay ``json.dumps`` on the reduction hot path.
+
+    Critical: do **not** re-raise ``LOGGER`` to DEBUG after
+    ``configure_live_log``. Handler-only WARNING still serialises every
+    DEBUG span before the record is dropped; logger level must follow TRACE
+    so ``isEnabledFor(DEBUG)`` short-circuits. Same lesson as recensus #7039
+    (43% wall-time cut on scoreboard from killing this flood).
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     os.environ["SUGAR_ENGINE_LOG"] = str(path.resolve())
+    # Force measurement default: do not inherit ambient TRACE=1. Full span
+    # flood is explicit engine_trace only.
+    os.environ["SUGAR_ENGINE_TRACE_EVENTS"] = "1" if engine_trace else "0"
     from sugar_lift_py_tests import engine_log
 
     logger = engine_log.LOGGER
@@ -53,7 +77,9 @@ def configure_engine_log(path: Path) -> None:
     engine_log._LIVE_HANDLER = None  # type: ignore[attr-defined]
     engine_log.configure_live_log(str(path.resolve()))
     logger.propagate = False
-    logger.setLevel(logging.DEBUG)
+    # configure_live_log already set level from TRACE. Pin it again so a
+    # future editor cannot reintroduce setLevel(DEBUG) and re-enable the flood.
+    logger.setLevel(logging.DEBUG if engine_trace else logging.WARNING)
 
 
 def python_paths(roots: Sequence[Path]) -> list[Path]:

--- a/implementations/python/sugar-lift-py-tests/tests/test_floor_measurement_integrity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_floor_measurement_integrity.py
@@ -102,6 +102,63 @@ def test_format_unmeasured_never_serializes_r_equals_zero() -> None:
     assert " = 0" not in text
 
 
+def test_configure_engine_log_defaults_trace_off_and_does_not_re_raise_debug(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """TRACE=0 must short-circuit DEBUG enter/exit before json.dumps.
+
+    The pre-#7039 floor bug: setLevel(DEBUG) after configure made TRACE=0 a
+    no-op — FileHandler filtered, but every span still serialised.
+    """
+    import json
+    import logging
+    import os
+    import time
+
+    # Kit path for engine_log import inside configure_engine_log.
+    kit_src = _KIT / "src"
+    monkeypatch.syspath_prepend(str(kit_src))
+
+    from sugar_lift_py_tests import engine_log
+
+    path = tmp_path / "engine.jsonl"
+    previous = engine_log._LIVE_HANDLER
+    engine_log._LIVE_HANDLER = None
+    engine_log.LOGGER.handlers.clear()
+    # Ambient TRACE=1 must not win over the floor default.
+    monkeypatch.setenv("SUGAR_ENGINE_TRACE_EVENTS", "1")
+    dumps_calls: list[int] = []
+    real_dumps = engine_log.json.dumps
+
+    def counting_dumps(*args, **kwargs):
+        dumps_calls.append(1)
+        return real_dumps(*args, **kwargs)
+
+    monkeypatch.setattr(engine_log.json, "dumps", counting_dumps)
+    try:
+        _RT.configure_engine_log(path)
+        assert os.environ["SUGAR_ENGINE_TRACE_EVENTS"] == "0"
+        assert engine_log.LOGGER.level == logging.WARNING
+        assert not engine_log.LOGGER.isEnabledFor(logging.DEBUG)
+        with engine_log.reduction_span(
+            sugar="NameSugar", role="term", site="floor.py:1:0"
+        ):
+            assert dumps_calls == []
+            engine_log._emit_heartbeats(
+                now=time.monotonic() + 1.0, minimum_seconds=0.01
+            )
+        events = [json.loads(line)["event"] for line in path.read_text().splitlines()]
+        assert events == ["heartbeat"]
+        assert len(dumps_calls) == 1
+    finally:
+        if engine_log._LIVE_HANDLER is not None:
+            engine_log.LOGGER.removeHandler(engine_log._LIVE_HANDLER)
+            engine_log._LIVE_HANDLER.close()
+        engine_log._LIVE_HANDLER = previous
+        engine_log.json.dumps = real_dumps
+        engine_log.LOGGER.handlers.clear()
+
+
 def test_format_completed_zero_only_when_measurement_finished() -> None:
     """Completed measurement with zero findings may print = 0; that is honest."""
     text = _RT.format_completed_axis_report("R_silent", 0)

--- a/tests/wall_workflow_prerequisites_test.py
+++ b/tests/wall_workflow_prerequisites_test.py
@@ -37,6 +37,9 @@ def test_wall_workflows_preserve_structured_wall_evidence() -> None:
         upload = re.search(r"(?m)^\s*- name: Upload .+ wall artifacts\s*$", workflow)
         required_before_mint = (
             f"SUGAR_ENGINE_LOG: ${{{{ github.workspace }}}}/{log_dir}/engine.jsonl",
+            # Measurement path: WARNING heartbeats only. TRACE=1 re-enables
+            # per-span json.dumps on the reduction hot path (recensus #7039).
+            'SUGAR_ENGINE_TRACE_EVENTS: "0"',
             'SUGAR_ENGINE_HEARTBEAT_SECONDS: "5"',
             'SUGAR_ENGINE_CYCLE_THRESHOLD: "8"',
             f"SUGAR_KIT_LOG: ${{{{ github.workspace }}}}/{log_dir}/transport.jsonl",


### PR DESCRIPTION
## Summary

Recensus went **7699s → 4395s (−43%)** purely from defaulting `SUGAR_ENGINE_TRACE_EVENTS=0` (#7039). Walls and enum floors still paid the same write-only hot-path flood: `json.dumps(sort_keys=...)` + FileHandler on every sugar enter/exit. R does not read `engine.jsonl`.

Worse: floors called `logger.setLevel(DEBUG)` **after** `configure_live_log`, so even TRACE=0 only raised the FileHandler level — serialisation still ran because `LOGGER.isEnabledFor(DEBUG)` stayed true.

### Changes
- **`_enum_floor_runtime.configure_engine_log`**: force TRACE=0 by default; set logger WARNING (not DEBUG); opt-in via `engine_trace=True`
- **pandas/numpy wall workflows**: `SUGAR_ENGINE_TRACE_EVENTS: "0"`
- **prerequisites test**: pin TRACE=0 on both walls
- **unit test**: ambient TRACE=1 loses; enter/exit pay 0 dumps; heartbeat only

WARNING heartbeats / cycle_suspected / ERROR stay — stall naming doctrine unchanged.

## Test plan
- [x] Manual: floors configure → TRACE forced 0, ambient 1 loses, logger WARNING, enter/exit 0 dumps, heartbeat only
- [x] Manual: `engine_trace=True` still writes enter/exit
- [x] Wall prerequisites evidence test includes TRACE=0
- [ ] Next wall/floor run: engine.jsonl heartbeat-scale, not ~1 MB/file

## Shell deleted
None — cost kill only. Same class as #7039, remaining measurement surfaces.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default engine TRACE off and fix `setLevel(DEBUG)` noop in floor/wall test infrastructure
> - `configure_engine_log` in [_enum_floor_runtime.py](https://github.com/TSavo/sugar/pull/7045/files#diff-722768a8db41f7e5bee7a5b826a61b0ebdc49edb27a8ff262303b2d68fd8c709) now defaults `engine_trace=False`, sets `SUGAR_ENGINE_TRACE_EVENTS=0`, and sets the logger to WARNING unless explicitly opted in, fixing a bug where DEBUG was always set regardless of trace intent.
> - The numpy and pandas wall workflows now explicitly set `SUGAR_ENGINE_TRACE_EVENTS: "0"` in the mint step env, ensuring per-span DEBUG serialization is suppressed in CI by default.
> - A new test verifies that `configure_engine_log` defaults TRACE off even when the ambient environment has `SUGAR_ENGINE_TRACE_EVENTS=1`, and that no `json.dumps` calls occur during a `reduction_span`.
> - Behavioral Change: engine logging now defaults to WARNING-level heartbeats only; full trace requires passing `engine_trace=True` to `configure_engine_log`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d9a1d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->