### PR TITLE
Enrollment mint: residual COUNT from floor summary (S1.1 mass)

### DIFF
--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -384,13 +384,22 @@ jobs:
           code=$?
           set -e
           echo "static_floors phase=mint_report exit=$code"
-          python3 -u tools/sole_construction_floor_enrollment.py \
-            --mint-report floor-axis-report.json \
-            --axis-id static-laws \
-            --display R_static_sole_construction \
-            --kind static \
-            --commit-sha "${GITHUB_SHA}" \
+          mint_args=(
+            --mint-report floor-axis-report.json
+            --axis-id static-laws
+            --display R_static_sole_construction
+            --kind static
+            --commit-sha "${GITHUB_SHA}"
             --exit-code "$code"
+          )
+          if [ "$code" -ge 2 ]; then
+            mint_args+=(--no-scan-completed --unmeasured-reason "static floors exit=${code} (crash — not residual)")
+          elif [ -s floor-static-residual.json ]; then
+            mint_args+=(--residual-from-summary floor-static-residual.json)
+          else
+            mint_args+=(--no-scan-completed --unmeasured-reason "static residual summary missing after exit=${code}")
+          fi
+          python3 -u tools/sole_construction_floor_enrollment.py "${mint_args[@]}"
           exit "$code"
       - name: Upload static axis report
         if: always()

--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -118,6 +118,12 @@ def main() -> int:
     parser.add_argument("--out-dir", type=Path, default=None)
     parser.add_argument("--engine-log", type=Path, default=None)
     parser.add_argument("--progress", type=Path, default=None)
+    parser.add_argument(
+        "--json",
+        type=Path,
+        default=None,
+        help="Write pandas-floor-summary-v1 with R_bare_exceptions magnitude.",
+    )
     add_lpt_shard_args(parser)
     args = parser.parse_args()
 
@@ -171,6 +177,37 @@ def main() -> int:
             progress.write(f"{t.file}\t{t.category}\trestarts={t.worker_restarts}\n")
 
     offenders = tuple(row.offender for row in rows if row.offender is not None)
+    if args.json is not None:
+        from pandas_floor_summary import floor_summary, relative_files, write_json
+
+        files = relative_files(paths, args.repo_root)
+        payload = floor_summary(
+            floor="bare-exception",
+            files=files,
+            rows=[
+                {
+                    "file": row.file,
+                    "category": row.category,
+                    "returncode": None,
+                }
+                for row in rows
+            ],
+            totals={
+                "R_bare_exceptions": len(offenders),
+                "completed": sum(
+                    row.category == OUTCOME_COMPLETED for row in rows
+                ),
+                "typedGaps": sum(
+                    row.category == OUTCOME_TYPED_GAP for row in rows
+                ),
+                "timeouts": sum(row.category == "timeout" for row in rows),
+                "nativeCrashes": sum(
+                    row.category == "native-crash" for row in rows
+                ),
+            },
+            measured=True,
+        )
+        write_json(args.json, payload)
     print(
         "BARE-EXCEPTION SURFACE: "
         f"discovered={len(rows)} "

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -109,6 +109,7 @@ def test_enrollment_missing_axis_is_unmeasured(tmp_path: Path) -> None:
         commit_sha="deadbeef",
         exit_code=0,
         kind="process",
+        residual_count=0,
     )
     path = tmp_path / "floor-axis-silent-s00" / mod.REPORT_FILENAME
     path.parent.mkdir(parents=True)
@@ -123,12 +124,15 @@ def test_enrollment_missing_axis_is_unmeasured(tmp_path: Path) -> None:
 def test_enrollment_complete_with_all_axes(tmp_path: Path) -> None:
     mod = _enroll_mod()
     for axis in mod.ENROLLED:  # process LPT seats + static
+        is_timeout = axis.axis_id.startswith("timeout-")
         report = mod.mint_axis_report(
             axis_id=axis.axis_id,
             display=axis.display,
             commit_sha="abc123",
-            exit_code=0 if not axis.axis_id.startswith("timeout-") else 1,
+            exit_code=0 if not is_timeout else 1,
             kind=axis.kind,
+            # Magnitude from floor summary identity — not invented from exit.
+            residual_count=3 if is_timeout else 0,
         )
         path = tmp_path / f"floor-axis-{axis.axis_id}" / mod.REPORT_FILENAME
         path.parent.mkdir(parents=True)

--- a/tests/test_sole_construction_floor_enrollment_measured.py
+++ b/tests/test_sole_construction_floor_enrollment_measured.py
@@ -1,4 +1,4 @@
-"""Teeth: enrollment mint must not bank crash as measured residual."""
+"""Teeth: enrollment mint residual magnitude from floor summary, not exit invent."""
 
 from __future__ import annotations
 
@@ -6,6 +6,8 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 _SPEC = importlib.util.spec_from_file_location(
@@ -18,11 +20,15 @@ sys.modules[_SPEC.name] = ENR
 _SPEC.loader.exec_module(ENR)
 
 
+def _seat(base: str, shard: int = 0) -> str:
+    return f"{base}-s{shard:02d}"
+
+
 def test_crash_before_scan_mints_unmeasured_not_completed() -> None:
     """Plant infrastructure death (exit 2): body must be UNMEASURED, not residual."""
     report = ENR.mint_axis_report(
-        axis_id="silent",
-        display="R_silent",
+        axis_id=_seat("silent"),
+        display="R_silent[s00]",
         commit_sha="deadbeef",
         exit_code=2,
         kind="process",
@@ -32,73 +38,178 @@ def test_crash_before_scan_mints_unmeasured_not_completed() -> None:
     assert report["status"] == "unmeasured"
     assert report["floorExitGreen"] is False
     assert report["unmeasuredReason"]
-    assert "auth" in report["unmeasuredReason"].lower() or "planted" in report["unmeasuredReason"].lower()
-    # Must not look like a measured residual red (status=completed measured=True exit=1).
+    assert "auth" in report["unmeasuredReason"].lower() or "planted" in report[
+        "unmeasuredReason"
+    ].lower()
     assert report["status"] != "completed"
     assert report.get("totals", {}).get("unmeasured") == 1
+    assert report.get("residualCount") is None
 
 
-def test_genuine_nonzero_residual_is_measured_not_unmeasured() -> None:
-    """Plant residual red (exit 1 after completed scan): measured with residual."""
+def test_genuine_nonzero_residual_requires_count_not_exit_invent() -> None:
+    """Measured residual must carry magnitude from floor summary — not exit=1 invent."""
+    with pytest.raises(ValueError, match="residual_count|floor summary|invent"):
+        ENR.mint_axis_report(
+            axis_id=_seat("native-crash"),
+            display="R_native_crashes[s00]",
+            commit_sha="deadbeef",
+            exit_code=1,
+            kind="process",
+        )
     report = ENR.mint_axis_report(
-        axis_id="native-crash",
-        display="R_native_crashes",
+        axis_id=_seat("native-crash"),
+        display="R_native_crashes[s00]",
         commit_sha="deadbeef",
         exit_code=1,
         kind="process",
+        residual_count=47,
+        residual_source="floor-summary.json",
+        residual_key="R_native_crashes",
     )
     assert report["measured"] is True
     assert report["status"] == "completed"
     assert report["floorExitGreen"] is False
     assert report["exitCode"] == 1
+    assert report["residualCount"] == 47
+    assert report["totals"]["failed"] == 47
+    assert report["totals"]["residual"] == 47
     assert report.get("unmeasuredReason") is None
 
 
-def test_green_residual_is_measured() -> None:
+def test_green_residual_is_measured_with_zero_count() -> None:
     report = ENR.mint_axis_report(
-        axis_id="timeout",
-        display="R_timeouts",
+        axis_id=_seat("timeout"),
+        display="R_timeouts[s00]",
         commit_sha="deadbeef",
         exit_code=0,
         kind="process",
+        residual_count=0,
+        residual_source="floor-summary.json",
     )
     assert report["measured"] is True
     assert report["status"] == "completed"
     assert report["floorExitGreen"] is True
+    assert report["residualCount"] == 0
+    assert report["totals"]["failed"] == 0
+
+
+def test_load_residual_from_pandas_floor_summary(tmp_path: Path) -> None:
+    summary = {
+        "kind": "pandas-floor-summary-v1",
+        "floor": "native-crash",
+        "totals": {"R_native_crashes": 12, "completed": 100},
+    }
+    path = tmp_path / "floor-summary.json"
+    path.write_text(json.dumps(summary), encoding="utf-8")
+    assert (
+        ENR.load_residual_count_from_floor_summary(
+            path, residual_key="R_native_crashes"
+        )
+        == 12
+    )
+
+
+def test_load_residual_from_floor_residual_v1(tmp_path: Path) -> None:
+    path = tmp_path / "static.json"
+    path.write_text(
+        json.dumps(
+            {
+                "kind": "floor-residual-v1",
+                "residualKey": "R_static_sole_construction",
+                "residualCount": 3,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert (
+        ENR.load_residual_count_from_floor_summary(
+            path, residual_key="R_static_sole_construction"
+        )
+        == 3
+    )
 
 
 def test_crash_and_residual_never_look_alike() -> None:
     crash = ENR.mint_axis_report(
-        axis_id="bare-exception",
-        display="R_bare_exceptions",
+        axis_id=_seat("bare-exception"),
+        display="R_bare_exceptions[s00]",
         commit_sha="c",
         exit_code=2,
         kind="process",
     )
     residual = ENR.mint_axis_report(
-        axis_id="bare-exception",
-        display="R_bare_exceptions",
+        axis_id=_seat("bare-exception"),
+        display="R_bare_exceptions[s00]",
         commit_sha="c",
         exit_code=1,
         kind="process",
+        residual_count=9,
     )
-    # The distinction enrollment exists to make:
-    assert (crash["measured"], crash["status"]) != (residual["measured"], residual["status"])
+    assert (crash["measured"], crash["status"]) != (
+        residual["measured"],
+        residual["status"],
+    )
     assert crash["measured"] is False and residual["measured"] is True
+    assert residual["residualCount"] == 9
+    assert residual["totals"]["failed"] == 9
 
 
 def test_enrollment_roll_call_unmeasured_not_residual_red(tmp_path: Path) -> None:
     """UNMEASURED axis fails completeness; must not be counted as residualRed."""
-    # Four axes measured green; silent is crash-unmeasured.
     for axis in ENR.ENROLLED:
-        if axis.axis_id == "silent":
+        if axis.axis_id == _seat("silent") or axis.axis_id.startswith("silent-"):
+            if axis.axis_id != _seat("silent"):
+                # only plant unmeasured on silent-s00; other silent seats green
+                report = ENR.mint_axis_report(
+                    axis_id=axis.axis_id,
+                    display=axis.display,
+                    commit_sha="tip",
+                    exit_code=0,
+                    kind=axis.kind,
+                    residual_count=0,
+                )
+            else:
+                report = ENR.mint_axis_report(
+                    axis_id=axis.axis_id,
+                    display=axis.display,
+                    commit_sha="tip",
+                    exit_code=2,
+                    kind=axis.kind,
+                    unmeasured_reason="planted crash before measurement",
+                )
+        else:
             report = ENR.mint_axis_report(
                 axis_id=axis.axis_id,
                 display=axis.display,
                 commit_sha="tip",
-                exit_code=2,
+                exit_code=0,
                 kind=axis.kind,
-                unmeasured_reason="planted crash before measurement",
+                residual_count=0,
+            )
+        path = tmp_path / f"floor-axis-{axis.axis_id}" / ENR.REPORT_FILENAME
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps(report), encoding="utf-8")
+    code, summary = ENR.check_attendance(tmp_path, require_commit="tip")
+    assert code == 1
+    assert summary["status"] == "UNMEASURED"
+    assert _seat("silent") in summary["unresolved"]
+    assert _seat("silent") not in summary["residualRed"]
+    assert _seat("silent") not in summary["attended"]
+
+
+def test_residual_magnitude_drives_residual_red_not_exit_alone(
+    tmp_path: Path,
+) -> None:
+    """residualCount>0 is residual red even if someone mints exit=0 wrongly."""
+    for axis in ENR.ENROLLED:
+        if axis.axis_id == _seat("native-crash"):
+            report = ENR.mint_axis_report(
+                axis_id=axis.axis_id,
+                display=axis.display,
+                commit_sha="tip",
+                exit_code=0,  # exit lies; magnitude is authority
+                kind=axis.kind,
+                residual_count=5,
             )
         else:
             report = ENR.mint_axis_report(
@@ -107,13 +218,12 @@ def test_enrollment_roll_call_unmeasured_not_residual_red(tmp_path: Path) -> Non
                 commit_sha="tip",
                 exit_code=0,
                 kind=axis.kind,
+                residual_count=0,
             )
         path = tmp_path / f"floor-axis-{axis.axis_id}" / ENR.REPORT_FILENAME
         path.parent.mkdir(parents=True)
         path.write_text(json.dumps(report), encoding="utf-8")
     code, summary = ENR.check_attendance(tmp_path, require_commit="tip")
-    assert code == 1
-    assert summary["status"] == "UNMEASURED"
-    assert "silent" in summary["unresolved"]
-    assert "silent" not in summary["residualRed"]
-    assert "silent" not in summary["attended"]
+    assert code == 0
+    assert summary["status"] == "complete"
+    assert _seat("native-crash") in summary["residualRed"]

--- a/tools/run_one_process_floor_axis.sh
+++ b/tools/run_one_process_floor_axis.sh
@@ -9,6 +9,9 @@
 #   0 — scan completed, residual green
 #   1 — scan completed, residual red
 #   2+ — scan did not complete (auth/init/crash) → report UNMEASURED
+#
+# Residual *magnitude* is never invented from exit code. Completed scans write
+# floor-summary.json; mint cites totals[R_*] under identity into residualCount.
 
 set -uo pipefail
 
@@ -82,10 +85,14 @@ echo "process-floor lpt_prior: dir=${SUGAR_LPT_PRIOR_DIR}"
 export PYTHONUNBUFFERED=1
 echo "JOB_LOG phase=process-floor-${axis_seat} status=start population=$PANDAS_CORPUS"
 
+FLOOR_SUMMARY="${FLOOR_SCRATCH}/floor-summary.json"
+mkdir -p "$FLOOR_SCRATCH"
+
 set +e
 python -u "$SCRIPT" "$PANDAS_CORPUS" \
   --repo-root "$PANDAS_CORPUS" \
   --out-dir "$FLOOR_SCRATCH" \
+  --json "$FLOOR_SUMMARY" \
   --shard-index "$shard_index" \
   --shard-count "$shard_count"
 exit_code=$?
@@ -111,6 +118,14 @@ mint_args=(
 )
 if [ "$exit_code" -ge 2 ]; then
   mint_args+=(--no-scan-completed --unmeasured-reason "process floor exit=${exit_code} (auth/init/bootstrap/crash — not residual)")
+else
+  # Completed scan: residual magnitude from floor summary under identity.
+  if [ ! -s "$FLOOR_SUMMARY" ]; then
+    echo "::error::floor summary missing after completed scan: $FLOOR_SUMMARY"
+    mint_args+=(--no-scan-completed --unmeasured-reason "floor-summary.json absent after exit=${exit_code}; residual magnitude not cited")
+  else
+    mint_args+=(--residual-from-summary "$FLOOR_SUMMARY")
+  fi
 fi
 
 python3 tools/sole_construction_floor_enrollment.py "${mint_args[@]}"

--- a/tools/run_static_sole_construction_floors.sh
+++ b/tools/run_static_sole_construction_floors.sh
@@ -92,6 +92,30 @@ axis "R_bare_construction_door = 0" \
 echo
 echo "static_floors phase=end green=${#green_axes[@]} red=${#red_axes[@]}"
 echo "static sole-construction floors: ${#green_axes[@]} green, ${#red_axes[@]} red"
+# Residual magnitude for enrollment mint — count of red static axes, not exit invent.
+residual_json="${SUGAR_STATIC_FLOOR_RESIDUAL_JSON:-floor-static-residual.json}"
+python3 -u -c "
+import json
+from pathlib import Path
+path = Path('''${residual_json}''')
+red = ${#red_axes[@]}
+path.write_text(
+    json.dumps(
+        {
+            'kind': 'floor-residual-v1',
+            'residualKey': 'R_static_sole_construction',
+            'residualCount': red,
+            'greenAxes': ${#green_axes[@]},
+            'redAxes': red,
+        },
+        indent=2,
+        sort_keys=True,
+    )
+    + '\n',
+    encoding='utf-8',
+)
+print(f'static_floors residual_written path={path} residualCount={red}', flush=True)
+"
 if [ ${#red_axes[@]} -gt 0 ]; then
   echo "RED AXES:"
   printf '  - %s\n' "${red_axes[@]}"

--- a/tools/sole_construction_floor_enrollment.py
+++ b/tools/sole_construction_floor_enrollment.py
@@ -113,7 +113,90 @@ def emit_process_matrix_json(
 #   0 — scan completed; residual green (R=0)
 #   1 — scan completed; residual red (R>0)
 #   2+ — scan did NOT complete (auth/init/crash/IO); UNMEASURED, not residual
+#
+# Residual *magnitude* is never invented from exit code. Measured mints require
+# residual_count cited from the floor's own summary under residual_key identity.
 SCAN_COMPLETED_EXITS = frozenset({0, 1})
+
+# Floor summary totals keys (pandas-floor-summary-v1) keyed by base axis id.
+RESIDUAL_KEY_BY_BASE: dict[str, str] = {
+    "silent": "R_silent",
+    "native-crash": "R_native_crashes",
+    "bare-exception": "R_bare_exceptions",
+    "timeout": "R_timeouts",
+    "static-laws": "R_static_sole_construction",
+}
+
+
+def base_axis_id(axis_id: str) -> str:
+    """Map seat id (silent-s03) to base axis (silent)."""
+    if axis_id == "static-laws":
+        return axis_id
+    # Seats: {base}-sNN
+    if "-s" in axis_id:
+        head, _, tail = axis_id.rpartition("-s")
+        if len(tail) == 2 and tail.isdigit():
+            return head
+    return axis_id
+
+
+def residual_key_for_axis(axis_id: str) -> str:
+    base = base_axis_id(axis_id)
+    key = RESIDUAL_KEY_BY_BASE.get(base)
+    if key is None:
+        raise ValueError(f"no residual key for axis_id {axis_id!r} (base={base!r})")
+    return key
+
+
+def load_residual_count_from_floor_summary(
+    summary_path: Path, *, residual_key: str
+) -> int:
+    """Cite residual magnitude from a floor summary body — never invent.
+
+    Accepts:
+      - pandas-floor-summary-v1 with totals[residual_key]
+      - floor-residual-v1 with residualKey + residualCount
+    """
+    try:
+        payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValueError(
+            f"cannot read floor summary {summary_path}: {exc}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"floor summary {summary_path} is not a JSON object")
+    kind = payload.get("kind")
+    if kind == "floor-residual-v1":
+        if payload.get("residualKey") != residual_key:
+            raise ValueError(
+                f"floor-residual-v1 residualKey={payload.get('residualKey')!r} "
+                f"!= expected {residual_key!r}"
+            )
+        raw = payload.get("residualCount")
+        if type(raw) is not int or raw < 0:
+            raise ValueError(
+                f"floor-residual-v1 residualCount must be non-negative int; "
+                f"got {type(raw).__name__}={raw!r}"
+            )
+        return raw
+    totals = payload.get("totals")
+    if not isinstance(totals, dict):
+        raise ValueError(
+            f"floor summary {summary_path} missing totals object "
+            f"(need residual key {residual_key!r} under identity)"
+        )
+    if residual_key not in totals:
+        raise ValueError(
+            f"floor summary {summary_path} totals missing residual key "
+            f"{residual_key!r}; present={sorted(totals)!r}"
+        )
+    raw = totals[residual_key]
+    if type(raw) is not int or raw < 0:
+        raise ValueError(
+            f"floor summary residual {residual_key!r} must be a non-negative "
+            f"int; got {type(raw).__name__}={raw!r}"
+        )
+    return raw
 
 
 def mint_axis_report(
@@ -125,12 +208,18 @@ def mint_axis_report(
     kind: str,
     scan_completed: bool | None = None,
     unmeasured_reason: str | None = None,
+    residual_count: int | None = None,
+    residual_source: str | None = None,
+    residual_key: str | None = None,
 ) -> dict:
     """Mint an identity-bound axis body.
 
-    ``measured=True`` only when the scan completed with a body (exit 0 or 1 by
-    default). Auth/init/crash (exit >= 2, or scan_completed=False) mints
-    UNMEASURED with a named reason — never banked as attended residual green.
+    ``measured=True`` only when the scan completed (exit 0 or 1 by default)
+    **and** residual_count is cited from the floor summary. Auth/init/crash
+    (exit >= 2, or scan_completed=False) mints UNMEASURED with a named reason.
+
+    Do **not** invent residual magnitude from exit code: exit 1 only says
+    R>0; the count lives in the floor's own summary under residual_key.
     """
     if axis_id not in enrolled_ids():
         raise ValueError(f"axis_id {axis_id!r} is not enrolled")
@@ -138,6 +227,17 @@ def mint_axis_report(
     if scan_completed is None:
         scan_completed = code in SCAN_COMPLETED_EXITS
     if scan_completed:
+        if residual_count is None:
+            raise ValueError(
+                f"measured mint for {axis_id!r} requires residual_count from "
+                f"the floor summary (do not invent R from exit code={code})"
+            )
+        if type(residual_count) is not int or residual_count < 0:
+            raise ValueError(
+                f"residual_count must be a non-negative int; got "
+                f"{type(residual_count).__name__}={residual_count!r}"
+            )
+        rkey = residual_key or residual_key_for_axis(axis_id)
         return {
             "schemaVersion": 1,
             "kind": REPORT_KIND,
@@ -150,9 +250,17 @@ def mint_axis_report(
             "exitCode": code,
             "identityResolved": True,
             "measured": True,
-            "floorExitGreen": code == 0,
+            # Green iff residual count is zero — count is authoritative, not exit.
+            "floorExitGreen": residual_count == 0,
             "unmeasuredReason": None,
-            "totals": {"failed": 0 if code == 0 else 1},
+            "residualCount": residual_count,
+            "residualKey": rkey,
+            "residualSource": residual_source or "floor-summary",
+            # totals.failed carries magnitude for CommitMeasurement cite path.
+            "totals": {
+                "failed": residual_count,
+                "residual": residual_count,
+            },
         }
     reason = unmeasured_reason or (
         f"scan did not complete (exit={code}); infrastructure/auth/init/crash "
@@ -172,6 +280,7 @@ def mint_axis_report(
         "measured": False,
         "floorExitGreen": False,
         "unmeasuredReason": reason,
+        "residualCount": None,
         "totals": {"failed": 1, "unmeasured": 1},
     }
 
@@ -314,16 +423,25 @@ def check_attendance(
             continue
         attended.append(axis.axis_id)
         exit_code = int(row.get("exitCode", 1))
-        if exit_code != 0:
+        # Prefer residualCount magnitude when present (S1.1 mass ranking).
+        residual_count = row.get("residualCount")
+        if type(residual_count) is int:
+            residual_n = residual_count
+        else:
+            # Legacy bodies without magnitude: exit only proves red/green, not R.
+            residual_n = 1 if exit_code != 0 else 0
+        if residual_n > 0:
             residual_red.append(axis.axis_id)
             _log(
                 f"floor_enrollment result index={index}/{len(ENROLLED)} "
-                f"axis={axis.axis_id} spoke=yes residual=RED exit={exit_code}"
+                f"axis={axis.axis_id} spoke=yes residual=RED "
+                f"residualCount={residual_n} exit={exit_code}"
             )
         else:
             _log(
                 f"floor_enrollment result index={index}/{len(ENROLLED)} "
-                f"axis={axis.axis_id} spoke=yes residual=green exit=0"
+                f"axis={axis.axis_id} spoke=yes residual=green "
+                f"residualCount={residual_n} exit={exit_code}"
             )
 
     complete = not missing and not unresolved and not wrong_commit
@@ -395,6 +513,29 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=None,
         help="Named reason when minting UNMEASURED (auth/init/crash).",
     )
+    parser.add_argument(
+        "--residual-count",
+        type=int,
+        default=None,
+        help=(
+            "Residual magnitude from the floor summary (required for measured "
+            "mints). Do not invent from exit code."
+        ),
+    )
+    parser.add_argument(
+        "--residual-from-summary",
+        type=Path,
+        default=None,
+        help=(
+            "pandas-floor-summary-v1 JSON; residual_count is read from "
+            "totals[residual_key] under identity (preferred over --residual-count)."
+        ),
+    )
+    parser.add_argument(
+        "--residual-key",
+        default=None,
+        help="totals key in floor summary (default: residual_key_for_axis(axis-id)).",
+    )
     parser.add_argument("--check-attendance", type=Path)
     parser.add_argument("--require-commit", default="")
     parser.add_argument("--write-campaign-body", type=Path)
@@ -427,9 +568,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 0
     if args.mint_report is not None:
+        residual_count = args.residual_count
+        residual_source = None
+        residual_key = args.residual_key
+        if args.residual_from_summary is not None:
+            rkey = residual_key or residual_key_for_axis(args.axis_id)
+            residual_count = load_residual_count_from_floor_summary(
+                args.residual_from_summary, residual_key=rkey
+            )
+            residual_source = str(args.residual_from_summary.resolve())
+            residual_key = rkey
         _log(
             f"floor_enrollment phase=mint_report axis={args.axis_id} "
-            f"exit={args.exit_code} commit={args.commit_sha}"
+            f"exit={args.exit_code} residual_count={residual_count!r} "
+            f"commit={args.commit_sha}"
         )
         report = mint_axis_report(
             axis_id=args.axis_id,
@@ -439,6 +591,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             kind=args.kind,
             scan_completed=args.scan_completed,
             unmeasured_reason=args.unmeasured_reason,
+            residual_count=residual_count,
+            residual_source=residual_source,
+            residual_key=residual_key,
         )
         args.mint_report.parent.mkdir(parents=True, exist_ok=True)
         args.mint_report.write_text(


### PR DESCRIPTION
## Summary

Advisor: enrollment mint recorded residual as **binary** red/green from exit code, so we know native/bare/timeout are R>0 but not **R=what**. That blocks S1.1 ranking by mass.

**Constraint:** do not invent R from exit code — count comes from the floor’s own summary under identity.

### Changes

| Surface | Behavior |
|---------|----------|
| `mint_axis_report` | Measured path **requires** `residual_count`; writes `residualCount` + `totals.failed` = magnitude |
| `load_residual_count_from_floor_summary` | Cites `totals[R_*]` or `floor-residual-v1` |
| `run_one_process_floor_axis.sh` | Always `--json floor-summary.json`; mint `--residual-from-summary` |
| bare_exception | `--json` writes `R_bare_exceptions` count |
| static floors | Writes `floor-residual-v1` with red-axis count; workflow mints from it |

Unmeasured (exit ≥ 2) unchanged: still no residual magnitude (scan never completed).

### Validation

```
python3.12 -m pytest tests/test_sole_construction_floor_enrollment_measured.py \
  tests/test_python_sole_construction_ci.py -q
# 14 passed
```

Unblocks ranking once measured floor seats land with real counts on sealed bodies.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Source enrollment mint residual count from floor summary JSON
> - `mint_axis_report` in [`sole_construction_floor_enrollment.py`](https://github.com/TSavo/sugar/pull/7046/files#diff-97da7ddf4a53542ab183832c1fedf5e3201fc8f4395b58fc71155d4040db58db) now requires an explicit `residual_count` for measured mints; `floorExitGreen` is derived from `residual_count==0` rather than the process exit code.
> - Adds `load_residual_count_from_floor_summary` to read residual magnitude from `pandas-floor-summary-v1` or `floor-residual-v1` JSON files, with CLI flags `--residual-from-summary` and `--residual-count`.
> - [`run_one_process_floor_axis.sh`](https://github.com/TSavo/sugar/pull/7046/files#diff-e2f37947c64a438368c7b6c2e4b00a46231fdc6065bcaaec43954d2ada2be00e) and [`run_static_sole_construction_floors.sh`](https://github.com/TSavo/sugar/pull/7046/files#diff-fe37c87c9dc044d5189f871624437d0fd0857b8ffb2f70af355c37ed02d4ff2b) now write floor summary JSONs and pass them to the enrollment mint; runs with missing summaries after a completed scan are minted as UNMEASURED.
> - `check_attendance` classifies `residualRed` using `residualCount` from the report when present, falling back to exit code for legacy reports.
> - Risk: measured mints without a `residual_count` now raise `ValueError`, breaking any caller that previously omitted it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c01c2ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->