### PR TITLE
With census: effective resolution tally (Class B conservation stays loud)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -321,21 +321,79 @@ def _cm_resolution_bucket(resolution) -> str:
     return f"gap:{parsed.value}"
 
 
+# Conservation identity (Class B refusal law — do not paper this raise):
+# every synchronous AST with-item is either constructed or one typed gap.
+WITH_CENSUS_CONSERVATION_IDENTITY = (
+    "site:with-item (AST sync With items) "
+    "== constructed (derived-contract / authenticated CM refs) "
+    "+ typed_gaps (gap:* kinds on the same use-sites); "
+    "every sync with-item appears exactly once as constructed or a typed gap"
+)
+
+
+def _effective_cm_resolutions_for_source(context, *, source_cid: str) -> dict:
+    """Resolutions With construction will see for one source unit.
+
+    Same precedence as ``With._prebound_manager_resolution``: source-derived
+    overwrites ``contract_refs``. Filter by ``source_cid`` so a shared corpus
+    provisional table is counted once per site, not once per file walk.
+    """
+    effective: dict = {}
+    refs = getattr(context, "contract_refs", None)
+    by_use = getattr(refs, "by_use_site", None) or {}
+    for coordinate, resolution in by_use.items():
+        if getattr(coordinate, "source_cid", None) != source_cid:
+            continue
+        effective[coordinate] = resolution
+    derived = getattr(context, "source_derived_contract_refs", None) or {}
+    for coordinate, resolution in derived.items():
+        if getattr(coordinate, "source_cid", None) != source_cid:
+            continue
+        # Derived wins — identical to With construction.
+        effective[coordinate] = resolution
+    return effective
+
+
 def _tally_cm_resolutions(
     context,
+    *,
+    source_cid: str,
 ) -> tuple[Counter[str], Counter[str]]:
-    """Count derived-table rows by structural resolution kind."""
+    """Count effective prebound resolutions for one source unit by kind.
+
+    Measurement defect class (Class A if ignored): tallying only
+    ``source_derived_contract_refs`` under-counts the provisional / authenticated
+    ``contract_refs`` table that With falls back to — producing
+    constructed=0, typed_gaps≪with_items, and an honest conservation refusal.
+    """
     from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerContractRefV1,
         ContextManagerResolutionGapV1,
         SourceDerivedContextManagerRefV1,
+        SourceDerivedGeneratorResourceRefV1,
     )
     from sugar_source_tree.panic import WithConstructionGapKind
 
+    if not source_cid:
+        raise ValueError(
+            "cm resolution tally requires source_cid so shared contract_refs "
+            "are not multiplied across every file in the census"
+        )
+
     buckets: Counter[str] = Counter()
     unrecognized_kinds: Counter[str] = Counter()
-    refs = getattr(context, "source_derived_contract_refs", None) or {}
-    for resolution in refs.values():
-        if isinstance(resolution, SourceDerivedContextManagerRefV1):
+    for resolution in _effective_cm_resolutions_for_source(
+        context, source_cid=source_cid
+    ).values():
+        if isinstance(
+            resolution,
+            (
+                SourceDerivedContextManagerRefV1,
+                SourceDerivedGeneratorResourceRefV1,
+                ContextManagerContractRefV1,
+            ),
+        ):
+            # Constructed manager testimony (source-derived or authenticated bind).
             buckets["derived-contract"] += 1
             continue
         if isinstance(resolution, ContextManagerResolutionGapV1):
@@ -348,7 +406,7 @@ def _tally_cm_resolutions(
             continue
         raise TypeError(
             "With resolution table contains a value outside the closed "
-            f"derived-contract | ContextManagerResolutionGapV1 union: "
+            "constructed-ref | ContextManagerResolutionGapV1 union: "
             f"{type(resolution).__name__}"
         )
     return buckets, unrecognized_kinds
@@ -359,7 +417,12 @@ def _with_census_partition(
     ast_sites: Counter[str],
     unrecognized_kinds: Counter[str] | None = None,
 ) -> dict[str, Any]:
-    """Conserve every synchronous With item into constructed or one typed gap."""
+    """Conserve every synchronous With item into constructed or one typed gap.
+
+    Conservation identity (binding):
+    ``site:with-item == constructed + typed_gaps`` over the same use-site set.
+    Refusal when this fails is Class B honest accounting — never suppress it.
+    """
     from sugar_source_tree.panic import WithConstructionGapKind
 
     vocabulary = tuple(member.value for member in WithConstructionGapKind)
@@ -394,23 +457,31 @@ def _with_census_partition(
         )
     total = int(ast_sites.get("site:with-item", 0))
     constructed = int(cm_resolutions.get("derived-contract", 0))
-    accounted = constructed + sum(typed_gaps.values())
+    typed_gap_total = sum(typed_gaps.values())
+    accounted = constructed + typed_gap_total
     if accounted != total:
+        unaccounted = total - accounted
         raise ValueError(
-            "With census does not conserve: "
-            f"with_items_total={total} constructed={constructed} "
-            f"typed_gaps={sum(typed_gaps.values())} accounted={accounted}"
+            "With census does not conserve. "
+            f"LAW: {WITH_CENSUS_CONSERVATION_IDENTITY}. "
+            f"REFUSED: with_items_total={total} constructed={constructed} "
+            f"typed_gaps={typed_gap_total} accounted={accounted} "
+            f"unaccounted={unaccounted} "
+            f"(unaccounted>0 ⇒ residual/table miss; unaccounted<0 ⇒ overcount). "
+            "Do not suppress this raise; fix the partition or name residual."
         )
     return {
+        "conservationIdentity": WITH_CENSUS_CONSERVATION_IDENTITY,
         "with_items_total": total,
         "constructed": constructed,
         "typed_gap_kinds_total": len(vocabulary),
         "typed_gaps": typed_gaps,
         "unrecognized_resolution_kinds": dict(sorted(unrecognized_kinds.items())),
         "accounted": accounted,
+        "unaccounted": 0,
         "reconciliation": (
             f"{total} = {constructed} constructed + "
-            f"{sum(typed_gaps.values())} typed gaps"
+            f"{typed_gap_total} typed gaps"
         ),
         "conserves": True,
     }
@@ -596,10 +667,12 @@ def _measure_file(
             # Derivation can hit a real missing sugar before any function walk.
             tally_construction(type(gap).__name__, line=0)
             return reporter
-        # Resolution partition from the derived table (manager-expression
-        # sites, not functions-blocked), keyed by authenticated gap kind.
+        # Effective resolution set for THIS source unit only: source-derived
+        # over contract_refs (same door as With construction). Never tally the
+        # whole shared provisional table without source_cid — that multiplies.
         file_cm_resolutions, file_unrecognized_kinds = _tally_cm_resolutions(
-            construction_context
+            construction_context,
+            source_cid=source_file.unit.source_cid,
         )
         cm_resolutions.update(file_cm_resolutions)
         unrecognized_cm_kinds.update(file_unrecognized_kinds)

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
@@ -1,0 +1,205 @@
+"""With census conservation: Class B refusal + measurement partition teeth.
+
+Conservation identity (binding):
+  site:with-item == constructed + typed_gaps
+  over the effective use-site set With construction sees.
+
+Landmine class A (fixed elsewhere): families rebind.
+This module: Class B honest refusal when the identity fails, and teeth that
+discriminate measurement defect (wrong table) from product residual.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+SCRIPT = _SCRIPTS / "control_effect_recensus.py"
+
+
+def _load():
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    spec = importlib.util.spec_from_file_location("control_effect_recensus", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_conservation_identity_is_stated_on_partition_and_refusal():
+    module = _load()
+    law = module.WITH_CENSUS_CONSERVATION_IDENTITY
+    assert "site:with-item" in law
+    assert "constructed" in law
+    assert "typed_gaps" in law
+
+    # Conserving case embeds the law.
+    ok = module._with_census_partition(
+        Counter({"derived-contract": 2, "gap:runtime-selected": 3}),
+        Counter({"site:with-item": 5}),
+    )
+    assert ok["conserves"] is True
+    assert ok["conservationIdentity"] == law
+    assert ok["unaccounted"] == 0
+
+    # Refusal names the law and which side is short.
+    with pytest.raises(ValueError, match="LAW:") as caught:
+        module._with_census_partition(
+            Counter({"gap:runtime-selected": 12}),
+            Counter({"site:with-item": 7915}),
+        )
+    msg = str(caught.value)
+    assert "with_items_total=7915" in msg
+    assert "constructed=0" in msg
+    assert "typed_gaps=12" in msg
+    assert "unaccounted=7903" in msg
+    assert "Do not suppress" in msg
+
+
+def test_known_constructed_with_item_shows_constructed_gt_zero(tmp_path: Path):
+    """Planted constructed testimony at a real with-item must tally constructed>0.
+
+    Without this tooth, constructed=0 on a corpus could be an off-by-everything
+    counter and still look like product residual. Plants SourceDerived at the
+    live use-site (same type With construction consumes) after opening a real
+    with-item file — derivation population is not required to validate the tally.
+    """
+    module = _load()
+    from types import SimpleNamespace
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        EnterResultContractV1,
+        ExitContractV1,
+        ImportSignatureV2,
+        ProtocolResourceSemanticsV1,
+        ReturnTruthinessDispositionV1,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceDerivedContextManagerRefV1,
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_lift_py_tests.ir import PrimitiveSort
+    from sugar_lift_py_tests.lift_rpc import (
+        open_source_file_for_construction,
+        provisional_contract_refs_from_demands,
+        tree_construction_context_for_workspace,
+    )
+    from sugar_lift_py_tests.outcome import Complete
+
+    path = tmp_path / "consumer.py"
+    path.write_text(
+        "def consume(mgr):\n"
+        "    with mgr:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    refs = provisional_contract_refs_from_demands(tmp_path)
+    ctx = tree_construction_context_for_workspace(tmp_path, contract_refs=refs)
+    source_file = open_source_file_for_construction(
+        path, root=tmp_path, construction_context=ctx, populate_derived=False
+    )
+    # Use-site coordinate from the provisional demand (same seat With uses).
+    assert len(refs.by_use_site) == 1
+    use_site = next(iter(refs.by_use_site))
+
+    class _Protocol:
+        def enter_resource_outcome(self, _ctx=None):
+            return Complete(SimpleNamespace(enter_value=None))
+
+        def exit_outcome_for(self, _entered, _ctx=None):
+            return Complete(False)
+
+    ctx.source_derived_contract_refs[use_site] = SourceDerivedContextManagerRefV1(
+        use_site=use_site,
+        summary_cid="blake3-512:" + ("a" * 128),
+        semantics=ProtocolResourceSemanticsV1(
+            enter=EnterResultContractV1(sort=PrimitiveSort("Value")),
+            exit=ExitContractV1(disposition=ReturnTruthinessDispositionV1()),
+        ),
+        import_signature=ImportSignatureV2(()),
+        protocol=_Protocol(),
+    )
+    buckets, _ = module._tally_cm_resolutions(
+        ctx, source_cid=source_file.unit.source_cid
+    )
+    sites = module._ast_site_prevalence(path)
+    assert sites.get("site:with-item", 0) == 1
+    assert buckets.get("derived-contract", 0) >= 1, (
+        f"known-constructed with must show constructed>0; got {dict(buckets)}"
+    )
+    partition = module._with_census_partition(buckets, sites)
+    assert partition["constructed"] >= 1
+    assert partition["conserves"] is True
+
+
+def test_unconstructed_with_item_appears_in_typed_gap_not_silent_drop(tmp_path: Path):
+    """Planted opaque with must land in residual (typed gap), never vanish."""
+    module = _load()
+    from sugar_lift_py_tests.lift_rpc import (
+        open_source_file_for_construction,
+        provisional_contract_refs_from_demands,
+        tree_construction_context_for_workspace,
+    )
+
+    path = tmp_path / "opaque.py"
+    path.write_text(
+        "def run():\n"
+        "    with mystery():\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    refs = provisional_contract_refs_from_demands(tmp_path)
+    ctx = tree_construction_context_for_workspace(tmp_path, contract_refs=refs)
+    source_file = open_source_file_for_construction(
+        path, root=tmp_path, construction_context=ctx, populate_derived=True
+    )
+    buckets, _ = module._tally_cm_resolutions(
+        ctx, source_cid=source_file.unit.source_cid
+    )
+    sites = module._ast_site_prevalence(path)
+    assert sites.get("site:with-item", 0) == 1
+    typed = sum(v for k, v in buckets.items() if k.startswith("gap:"))
+    assert typed >= 1, f"unconstructed with must residual; got {dict(buckets)}"
+    assert buckets.get("derived-contract", 0) == 0
+    partition = module._with_census_partition(buckets, sites)
+    assert partition["constructed"] == 0
+    assert sum(partition["typed_gaps"].values()) == 1
+    assert partition["conserves"] is True
+
+
+def test_effective_tally_includes_contract_refs_not_only_source_derived(
+    tmp_path: Path,
+):
+    """Measurement defect class: source_derived-only under-counts provisional table."""
+    module = _load()
+    from sugar_lift_py_tests.lift_rpc import (
+        open_source_file_for_construction,
+        provisional_contract_refs_from_demands,
+        tree_construction_context_for_workspace,
+    )
+
+    path = tmp_path / "opaque.py"
+    path.write_text(
+        "def run():\n"
+        "    with mystery():\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    refs = provisional_contract_refs_from_demands(tmp_path)
+    ctx = tree_construction_context_for_workspace(tmp_path, contract_refs=refs)
+    source_file = open_source_file_for_construction(
+        path, root=tmp_path, construction_context=ctx, populate_derived=True
+    )
+    # Old defect shape: derived empty, provisional has the gap.
+    assert len(ctx.source_derived_contract_refs) == 0
+    assert len(refs.by_use_site) == 1
+    buckets, _ = module._tally_cm_resolutions(
+        ctx, source_cid=source_file.unit.source_cid
+    )
+    assert sum(buckets.values()) == 1, dict(buckets)


### PR DESCRIPTION
## Classification (advisor order)

**Class B — honest conservation refusal** on run 30735773901 was **correct**. Do not suppress it.

**Root cause of the numbers:** **MEASUREMENT DEFECT** in the partition counter (not product residual mass, not landmine-three rot).

| Field | Value | Meaning after diagnosis |
| --- | --- | --- |
| with_items_total | 7915 | AST `site:with-item` (truthful prevalence) |
| constructed | 0 | counted only `source_derived_contract_refs` |
| typed_gaps | 12 | only the sparse derived table |
| accounted | 12 | under-count |
| unaccounted | 7903 | **missing contract_refs / provisional table** |

With construction resolves: **source-derived if present, else `contract_refs.require`**. The census only tallied source-derived → under-count. That is a **wrong bucket**, not “every with is non-constructed with only 12 gaps.”

## Conservation identity (one sentence)

**Every synchronous AST with-item appears exactly once as either constructed (derived-contract / authenticated CM ref) or a typed gap (`gap:*`) on the same use-site set.**

Stated on the refusal message (`LAW: …`) and on successful `withCensus.conservationIdentity`.

## Fix (authorised)

- `_tally_cm_resolutions(context, source_cid=…)` builds the **effective** map: `contract_refs` for that `source_cid`, then source-derived overwrites (With precedence).
- Requires `source_cid` so a shared provisional table is not multiplied across files.
- **Still refuses** when conservation fails — Class B stays Class B.

## Teeth (required before either reading is trusted)

1. Refusal states law + unaccounted  
2. Planted constructed testimony → `constructed > 0` and conserves  
3. Planted opaque with → typed gap residual, never silent drop  
4. Effective tally includes provisional `contract_refs` when derived is empty  

## Explicitly not done

- No product drain on 7903  
- No defaultdict-style papering of conservation  
- No assumption this is criterion-1/3 residual mass until a conserved board is banked  

## Aggregation-path rot census (owed, restated)

Crash-class rebind/arity residual: **none** after #7044.  
This failure was **Class B conservation** + **measurement under-count**, not Class A rot.

After merge: re-fire S0.1; expect conserved `withCensus` (likely large typed_gaps under provisional table — product residual then named in sealed fields, not unaccounted).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tally context manager resolutions per-file using effective (derived-overrides-provisional) resolution set
> - `_tally_cm_resolutions` now requires a `source_cid` keyword argument and filters resolutions to the effective set for that source (derived refs override provisional `contract_refs` at matching coordinates), preventing shared-table multiplication across files.
> - Constructed counts now include `ContextManagerContractRefV1` and `SourceDerivedGeneratorResourceRefV1` in addition to `SourceDerivedContextManagerRefV1`.
> - `_with_census_partition` outputs now include `conservationIdentity` (a new module-level constant) and `unaccounted: 0` on success; conservation failures raise `ValueError` with the law string and an `unaccounted` value.
> - Tests in [test_with_census_conservation.py](https://github.com/TSavo/sugar/pull/7047/files#diff-ad74fd1e5a9b313c7e8b6aaae9ee7a6982d6b3d43ddeb0536de5c1e1b305058e) assert conservation identity presence, correct constructed/gap tallies, and provisional-only fallback behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dff6db4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->