### PR TITLE
Recensus path smoke: micro-population PATH integrity (not product R)

### DIFF
--- a/.github/workflows/recensus-path-smoke.yml
+++ b/.github/workflows/recensus-path-smoke.yml
@@ -1,0 +1,98 @@
+# Recensus PATH smoke — production-path integrity over a planted micro-population.
+#
+# COVERAGE HONESTY (binding):
+#   This job measures the RECENSUS PRODUCTION PATH (per_file_lift → aggregation
+#   → with-census conservation → sealed path body) over ~4 planted files in
+#   under 60s. It retires the SERIAL ROT TAX that made path defects cost one
+#   full 73-minute corpus walk each.
+#
+#   It does NOT measure Class B corpus scale (thousands of with-items).
+#   It does NOT mint authoritative R_construction_panics.
+#   Smoke PASS is NOT S0.1 / full recensus PASS.
+#   Smoke FAIL is still CI red for the path-integrity class.
+#
+# ENROLLMENT: measurementClass = recensus-path-smoke only.
+#   Never control-effect-recensus. The roll call / CommitMeasurement must not
+#   accept smoke as the authoritative board speaking.
+#
+# SCOREBOARD_AUTHORITY: unchanged. Sole bankable panics producer remains
+# control_effect_recensus on the authenticated pandas corpus (nightly/dispatch).
+
+name: Recensus path smoke
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  recensus-path-smoke:
+    name: recensus-path-smoke (PATH integrity)
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 15
+    env:
+      PYTHONUNBUFFERED: "1"
+      RECENSUS_PATH_SMOKE_OUT: ${{ github.workspace }}/.sugar/recensus-path-smoke
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare immutable Python test environment
+        uses: ./.github/actions/python-test-environment
+
+      - name: "Phase: recensus-path-smoke (planted micro-population)"
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "path-smoke phase=measure status=start commit=$GITHUB_SHA"
+          # Same production doors as the full recensus; tiny enrolled population.
+          python -u implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
+          echo "path-smoke phase=measure status=done"
+          # Refuse product-shaped keys on the sealed body (advisor wall 1).
+          python -u - <<'PY'
+          import json, sys
+          from pathlib import Path
+          p = Path(".sugar/recensus-path-smoke/path_verdict.json")
+          body = json.loads(p.read_text(encoding="utf-8"))
+          banned = [
+              "R_construction_panics",
+              "R_construction",
+              "R_desugar",
+              "controlEffectStableZero",
+              "floorSummary",
+          ]
+          bad = [k for k in banned if k in body]
+          if bad:
+              print(f"PATH_RED: product keys present on smoke body: {bad}", file=sys.stderr)
+              sys.exit(1)
+          if body.get("measurementClass") != "recensus-path-smoke":
+              print(
+                  f"PATH_RED: wrong measurementClass {body.get('measurementClass')!r}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          if body.get("pathVerdict") != "PATH_OK":
+              print(
+                  f"PATH_RED: pathVerdict={body.get('pathVerdict')!r} "
+                  f"failedTooth={body.get('failedTooth')!r}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          print(
+              f"path-smoke gate PATH_OK teeth="
+              f"{sorted(k for k,v in body.get('teeth',{}).items() if v.get('pass'))}"
+          )
+          PY
+
+      - name: Upload path-smoke seal
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: recensus-path-smoke
+          path: .sugar/recensus-path-smoke/**
+          if-no-files-found: warn

--- a/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/README.md
+++ b/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/README.md
@@ -1,0 +1,18 @@
+# recensus_path_smoke planted micro-population
+
+**Not a product scoreboard.** These files exercise the recensus *production
+path* (per-file lift → aggregation → with-census conservation → sealed path
+body) in seconds. They do not mint authoritative `R_construction_panics`.
+
+Planted teeth (mr_blue conservation fixtures + panic):
+
+| File | Known answer |
+| --- | --- |
+| `planted_constructed_with.py` | one with-item; inject SourceDerived → constructed≥1 |
+| `planted_opaque_with.py` | one with-item; typed gap residual, not silent drop |
+| `planted_clean.py` | no with; completed row |
+| panic plant | ConstructionPanic enrolled as cpanic=1 (harness inject) |
+
+Smoke retires the serial rot tax of full-corpus walks for *path integrity*
+defects. It does **not** retire the full pandas walk or Class B aggregation
+scale (thousands of with-items).

--- a/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/planted_clean.py
+++ b/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/planted_clean.py
@@ -1,0 +1,5 @@
+"""Clean function plant — completed row, no with-items."""
+
+
+def ok():
+    return 1

--- a/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/planted_constructed_with.py
+++ b/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/planted_constructed_with.py
@@ -1,0 +1,11 @@
+"""Known-constructed with-item plant (mr_blue conservation tooth).
+
+The smoke harness injects SourceDerivedContextManagerRef at the live use-site
+after open — same type With construction consumes — so constructed>0 is a real
+tally, not a hardcoded scoreboard number.
+"""
+
+
+def consume(mgr):
+    with mgr:
+        pass

--- a/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/planted_opaque_with.py
+++ b/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/planted_opaque_with.py
@@ -1,0 +1,6 @@
+"""Unconstructed with-item plant: must residual (typed gap), never vanish."""
+
+
+def run():
+    with mystery():  # noqa: F821 — intentional unresolved manager
+        pass

--- a/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/planted_panic_host.py
+++ b/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/planted_panic_host.py
@@ -1,0 +1,10 @@
+"""Host file for the known-panic plant.
+
+The smoke harness measures this file under a ConstructionPanic inject at
+SourceFile construction so cpanic=1 is projected through the production
+_measure_file door (not invented at board compose).
+"""
+
+
+def a():
+    return 1

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+"""Recensus PATH smoke — micro-population integrity, NOT product R.
+
+WALLS (advisor, binding):
+  1. PATH verdict only: PATH_OK | PATH_RED | PATH_UNMEASURED.
+     Never emit R_construction_panics, desugar board, or SCOREBOARD_AUTHORITY
+     product fields. Smoke-scoped counts (if any) are nested under smokeCounts
+     and refuse CommitMeasurement panics ingestion by construction.
+  2. SCOREBOARD_AUTHORITY stays False here. Sole bankable panics producer is
+     control_effect_recensus on the authenticated pandas corpus.
+  3. Teeth are the instrument: constructed>0, cpanic=1, residual not vanish,
+     conservation closes, sealed body on PATH_OK. Crash → PATH_UNMEASURED.
+  4. Coverage honesty: five planted files retire serial path-rot discovery,
+     not Class B corpus scale (thousands of with-items) or the full walk.
+  5. measurementClass = recensus-path-smoke — never control-effect-recensus.
+
+Planted fixtures (mr_blue conservation teeth + panic host):
+  fixtures/recensus_path_smoke/
+"""
+
+from __future__ import annotations
+
+# Explicit: never the sole authoritative scoreboard.
+SCOREBOARD_AUTHORITY = False
+
+import importlib.util
+import json
+import os
+import sys
+import time
+import traceback
+from collections import Counter
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+_SCRIPTS = Path(__file__).resolve().parent
+_PKG = _SCRIPTS.parent
+_FIXTURES = _PKG / "fixtures" / "recensus_path_smoke"
+_REPO = _PKG.parents[2]
+
+MEASUREMENT_CLASS = "recensus-path-smoke"
+KIND = "recensus-path-smoke-verdict"
+
+# Forbidden product-shaped keys — presence alone is PATH_RED (unrepresentable
+# as a green path body).
+_FORBIDDEN_PRODUCT_KEYS = frozenset(
+    {
+        "R_construction_panics",
+        "R_construction",
+        "R_desugar",
+        "controlEffectStableZero",
+        "floorSummary",
+        "SCOREBOARD_AUTHORITY",
+    }
+)
+
+
+def _narrate(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def _load_recensus():
+    path = _SCRIPTS / "control_effect_recensus.py"
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    spec = importlib.util.spec_from_file_location("control_effect_recensus", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    # Path smoke must never promote the recensus module's authority flag.
+    assert getattr(module, "SCOREBOARD_AUTHORITY", None) is True, (
+        "control_effect_recensus must remain SCOREBOARD_AUTHORITY=True; "
+        "this smoke module is False and separate"
+    )
+    return module
+
+
+def _seal_path(
+    *,
+    out_dir: Path,
+    path_verdict: str,
+    path_phase: str,
+    tooth: str | None,
+    teeth: dict[str, Any],
+    smoke_counts: dict[str, Any],
+    phases: list[str],
+    error: str | None = None,
+) -> Path:
+    body: dict[str, Any] = {
+        "schemaVersion": 1,
+        "kind": KIND,
+        "measurementClass": MEASUREMENT_CLASS,
+        # PATH verdict only — never product panics R.
+        "pathVerdict": path_verdict,
+        "pathPhase": path_phase,
+        "failedTooth": tooth,
+        "teeth": teeth,
+        "smokeCounts": smoke_counts,
+        "phasesCompleted": phases,
+        "scoreboardAuthority": False,
+        "coverageHonesty": (
+            "Measures recensus production PATH integrity over an enrolled "
+            "micro-population. Does NOT measure C2 R_construction_panics on "
+            "pandas. Does NOT retire the full corpus walk or Class B with-item "
+            "scale. Smoke-green is not corpus-clean."
+        ),
+    }
+    if error is not None:
+        body["error"] = error
+        body["status"] = "unmeasured"
+        body["unmeasuredReason"] = error
+    else:
+        body["status"] = "completed" if path_verdict == "PATH_OK" else "path-red"
+    # Unrepresentable: product keys must not appear on a path body.
+    for banned in _FORBIDDEN_PRODUCT_KEYS:
+        if banned in body:
+            raise RuntimeError(f"smoke path body must not carry product key {banned}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / "path_verdict.json"
+    path.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _measure_constructed(module, path: Path, workspace: Path) -> dict[str, Any]:
+    """mr_blue plant: SourceDerived at live use-site → derived-contract tally.
+
+    Isolate the plant in a single-file workspace so provisional demands see
+    exactly one use-site (same isolation as test_with_census_conservation).
+    """
+    import shutil
+    import tempfile
+
+    from sugar_lift_py_tests.context_manager_contract import (
+        EnterResultContractV1,
+        ExitContractV1,
+        ImportSignatureV2,
+        ProtocolResourceSemanticsV1,
+        ReturnTruthinessDispositionV1,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceDerivedContextManagerRefV1,
+    )
+    from sugar_lift_py_tests.ir import PrimitiveSort
+    from sugar_lift_py_tests.lift_rpc import (
+        open_source_file_for_construction,
+        provisional_contract_refs_from_demands,
+        tree_construction_context_for_workspace,
+    )
+    from sugar_lift_py_tests.outcome import Complete
+
+    iso = Path(tempfile.mkdtemp(prefix="recensus-path-smoke-constructed-"))
+    try:
+        plant = iso / path.name
+        shutil.copy2(path, plant)
+        refs = provisional_contract_refs_from_demands(iso)
+        ctx = tree_construction_context_for_workspace(iso, contract_refs=refs)
+        source_file = open_source_file_for_construction(
+            plant, root=iso, construction_context=ctx, populate_derived=False
+        )
+        if len(refs.by_use_site) != 1:
+            raise RuntimeError(
+                f"planted_constructed_with must have exactly one use-site; got "
+                f"{len(refs.by_use_site)}"
+            )
+        use_site = next(iter(refs.by_use_site))
+
+        class _Protocol:
+            def enter_resource_outcome(self, _ctx=None):
+                return Complete(SimpleNamespace(enter_value=None))
+
+            def exit_outcome_for(self, _entered, _ctx=None):
+                return Complete(False)
+
+        ctx.source_derived_contract_refs[use_site] = SourceDerivedContextManagerRefV1(
+            use_site=use_site,
+            summary_cid="blake3-512:" + ("a" * 128),
+            semantics=ProtocolResourceSemanticsV1(
+                enter=EnterResultContractV1(sort=PrimitiveSort("Value")),
+                exit=ExitContractV1(disposition=ReturnTruthinessDispositionV1()),
+            ),
+            import_signature=ImportSignatureV2(()),
+            protocol=_Protocol(),
+        )
+        buckets, unrecognized = module._tally_cm_resolutions(
+            ctx, source_cid=source_file.unit.source_cid
+        )
+        sites = module._ast_site_prevalence(plant)
+        return {
+            "category": "completed",
+            "cmResolutions": dict(buckets),
+            "unrecognizedCmResolutionKinds": dict(unrecognized),
+            "families": {},
+            "sites": dict(sites),
+            "relative": f"recensus_path_smoke/{path.name}",
+        }
+    finally:
+        shutil.rmtree(iso, ignore_errors=True)
+
+
+def _measure_opaque(module, path: Path, workspace: Path) -> dict[str, Any]:
+    """mr_blue plant: opaque with → typed gap residual (isolated workspace)."""
+    import shutil
+    import tempfile
+
+    from sugar_lift_py_tests.lift_rpc import (
+        open_source_file_for_construction,
+        provisional_contract_refs_from_demands,
+        tree_construction_context_for_workspace,
+    )
+
+    iso = Path(tempfile.mkdtemp(prefix="recensus-path-smoke-opaque-"))
+    try:
+        plant = iso / path.name
+        shutil.copy2(path, plant)
+        refs = provisional_contract_refs_from_demands(iso)
+        ctx = tree_construction_context_for_workspace(iso, contract_refs=refs)
+        source_file = open_source_file_for_construction(
+            plant, root=iso, construction_context=ctx, populate_derived=True
+        )
+        buckets, unrecognized = module._tally_cm_resolutions(
+            ctx, source_cid=source_file.unit.source_cid
+        )
+        sites = module._ast_site_prevalence(plant)
+        return {
+            "category": "completed",
+            "cmResolutions": dict(buckets),
+            "unrecognizedCmResolutionKinds": dict(unrecognized),
+            "families": {},
+            "sites": dict(sites),
+            "relative": f"recensus_path_smoke/{path.name}",
+        }
+    finally:
+        shutil.rmtree(iso, ignore_errors=True)
+
+
+def _measure_clean(module, path: Path, workspace: Path) -> dict[str, Any]:
+    """Production per-file lift door for a clean function (isolated workspace)."""
+    import shutil
+    import tempfile
+
+    from sugar_lift_py_tests.lift_rpc import provisional_contract_refs_from_demands
+
+    iso = Path(tempfile.mkdtemp(prefix="recensus-path-smoke-clean-"))
+    try:
+        plant = iso / path.name
+        shutil.copy2(path, plant)
+        refs = provisional_contract_refs_from_demands(iso)
+        row = module._measure_file(
+            plant,
+            relative=f"recensus_path_smoke/{path.name}",
+            workspace_root=iso,
+            contract_refs=refs,
+        )
+        row = dict(row)
+        row["sites"] = dict(module._ast_site_prevalence(plant))
+        row["relative"] = f"recensus_path_smoke/{path.name}"
+        return row
+    finally:
+        shutil.rmtree(iso, ignore_errors=True)
+
+
+def _measure_panic(module, path: Path, workspace: Path) -> dict[str, Any]:
+    """Known panic through production _measure_file + ConstructionPanic inject."""
+    import shutil
+    import tempfile
+
+    from sugar_lift_py_tests.gap.info import ConstructionGap
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    import sugar_source_tree.tree as tree_mod
+
+    iso = Path(tempfile.mkdtemp(prefix="recensus-path-smoke-panic-"))
+    original = tree_mod.SourceFile.__init__
+
+    def boom(self, *a, **k):
+        raise ConstructionPanic(
+            ConstructionGap(
+                owner="recensus-path-smoke-planted-panic",
+                blame=f"{path.name}:1:0",
+                observed="OpaqueValue",
+                requested="constructed value",
+                fix="smoke tooth: cpanic must count 1",
+            )
+        )
+
+    try:
+        plant = iso / path.name
+        shutil.copy2(path, plant)
+        tree_mod.SourceFile.__init__ = boom  # type: ignore[method-assign]
+        row = module._measure_file(
+            plant,
+            relative=f"recensus_path_smoke/{path.name}",
+            workspace_root=iso,
+        )
+    finally:
+        tree_mod.SourceFile.__init__ = original  # type: ignore[method-assign]
+        shutil.rmtree(iso, ignore_errors=True)
+    row = dict(row)
+    row["sites"] = dict(module._ast_site_prevalence(path))
+    row["relative"] = f"recensus_path_smoke/{path.name}"
+    return row
+
+
+def _run_teeth(
+    *,
+    constructed: int,
+    typed_gaps: int,
+    cpanic: int,
+    conserves: bool,
+    sealed_path: Path | None,
+    path_verdict_so_far: str,
+) -> tuple[dict[str, Any], str | None]:
+    """Return (teeth_report, first_failed_tooth_name)."""
+    teeth: dict[str, Any] = {}
+    failed: str | None = None
+
+    def fail(name: str, detail: str) -> None:
+        nonlocal failed
+        teeth[name] = {"pass": False, "detail": detail}
+        if failed is None:
+            failed = name
+
+    def ok(name: str, detail: str) -> None:
+        teeth[name] = {"pass": True, "detail": detail}
+
+    if constructed > 0:
+        ok("known_constructed", f"constructed={constructed}")
+    else:
+        fail("known_constructed", f"constructed={constructed} expected >0")
+
+    if cpanic == 1:
+        ok("known_panic", f"cpanic={cpanic}")
+    else:
+        fail("known_panic", f"cpanic={cpanic} expected 1")
+
+    if typed_gaps >= 1:
+        ok("unconstructed_residual", f"typed_gaps={typed_gaps}")
+    else:
+        fail("unconstructed_residual", f"typed_gaps={typed_gaps} expected >=1")
+
+    if conserves:
+        ok("conservation", "with census conserves")
+    else:
+        fail("conservation", "with census does not conserve")
+
+    if sealed_path is not None and sealed_path.is_file():
+        raw = sealed_path.read_text(encoding="utf-8")
+        body = json.loads(raw)
+        banned = [k for k in _FORBIDDEN_PRODUCT_KEYS if k in body]
+        if banned:
+            fail("no_product_r", f"forbidden product keys present: {banned}")
+        elif body.get("measurementClass") != MEASUREMENT_CLASS:
+            fail(
+                "enrollment_class",
+                f"measurementClass={body.get('measurementClass')!r} "
+                f"expected {MEASUREMENT_CLASS!r}",
+            )
+        elif body.get("kind") != KIND:
+            fail("enrollment_kind", f"kind={body.get('kind')!r}")
+        else:
+            ok("sealed_body", f"sealed {sealed_path}")
+            ok("no_product_r", "no forbidden product keys")
+            ok("enrollment_class", MEASUREMENT_CLASS)
+    else:
+        fail("sealed_body", "path_verdict.json missing")
+
+    if path_verdict_so_far == "PATH_UNMEASURED":
+        fail("crash_not_green", "path crashed — UNMEASURED, never green")
+    else:
+        ok("crash_not_green", "path completed without crash")
+
+    return teeth, failed
+
+
+def main(argv: list[str] | None = None) -> int:
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    started = time.time()
+    phases: list[str] = []
+    out_dir = Path(
+        os.environ.get(
+            "RECENSUS_PATH_SMOKE_OUT",
+            str(_REPO / ".sugar" / "recensus-path-smoke"),
+        )
+    )
+    # Isolate engine log under out-dir so smoke does not poison ambient state.
+    engine_log = out_dir / "engine.jsonl"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    os.environ["SUGAR_ENGINE_LOG"] = str(engine_log.resolve())
+    os.environ["SUGAR_ENGINE_TRACE_EVENTS"] = "0"
+
+    _narrate(
+        f"PATH_SMOKE START measurementClass={MEASUREMENT_CLASS} "
+        f"fixtures={_FIXTURES} out_dir={out_dir.resolve()}"
+    )
+
+    try:
+        phases.append("load_recensus_module")
+        _narrate("PATH_SMOKE phase=load_recensus_module")
+        module = _load_recensus()
+
+        phases.append("enroll_micro_population")
+        _narrate("PATH_SMOKE phase=enroll_micro_population")
+        workspace = _FIXTURES
+        constructed_path = workspace / "planted_constructed_with.py"
+        opaque_path = workspace / "planted_opaque_with.py"
+        clean_path = workspace / "planted_clean.py"
+        panic_path = workspace / "planted_panic_host.py"
+        for p in (constructed_path, opaque_path, clean_path, panic_path):
+            if not p.is_file():
+                raise FileNotFoundError(f"missing planted fixture: {p}")
+
+        # Cache / out-dir write seam (must be writable).
+        phases.append("cache_write")
+        _narrate("PATH_SMOKE phase=cache_write")
+        probe = out_dir / ".write-probe"
+        probe.write_text("ok\n", encoding="utf-8")
+        probe.unlink()
+
+        # Manifest / pin shape over micro population (content auth for smoke only).
+        phases.append("manifest_cid")
+        _narrate("PATH_SMOKE phase=manifest_cid")
+        from sugar_lift_py_tests.corpus_pin import pin_corpus
+        from pandas_floor_summary import corpus_cid as corpus_manifest_shape_cid
+
+        pin = pin_corpus(
+            workspace, distribution="recensus_path_smoke", version="smoke-0"
+        )
+        shape_cid = corpus_manifest_shape_cid(list(pin.paths))
+        _narrate(
+            f"PATH_SMOKE pin files={len(pin.paths)} "
+            f"aggregate={pin.aggregate_hash[:16]}… shape={shape_cid[:24]}…"
+        )
+
+        # Per-file lift (production doors) + panic plant.
+        phases.append("per_file_lift")
+        _narrate("PATH_SMOKE phase=per_file_lift")
+        rows: list[dict[str, Any]] = []
+        rows.append(_measure_constructed(module, constructed_path, workspace))
+        _narrate("PATH_SMOKE measured planted_constructed_with")
+        rows.append(_measure_opaque(module, opaque_path, workspace))
+        _narrate("PATH_SMOKE measured planted_opaque_with")
+        rows.append(_measure_clean(module, clean_path, workspace))
+        _narrate("PATH_SMOKE measured planted_clean")
+        rows.append(_measure_panic(module, panic_path, workspace))
+        _narrate("PATH_SMOKE measured planted_panic_host")
+
+        # Family counters + aggregation (board compose path pieces).
+        phases.append("aggregation")
+        _narrate("PATH_SMOKE phase=aggregation")
+        cm: Counter[str] = Counter()
+        sites: Counter[str] = Counter()
+        families: Counter[str] = Counter()
+        construction_panics: list[dict[str, Any]] = []
+        unrecognized: Counter[str] = Counter()
+        for row in rows:
+            cm.update({k: int(v) for k, v in (row.get("cmResolutions") or {}).items()})
+            sites.update({k: int(v) for k, v in (row.get("sites") or {}).items()})
+            families.update({k: int(v) for k, v in (row.get("families") or {}).items()})
+            if row.get("category") == "construction-panic":
+                panic = row.get("panic")
+                if isinstance(panic, dict):
+                    construction_panics.append(panic)
+                if "ConstructionPanic" not in (row.get("families") or {}):
+                    families["ConstructionPanic"] = (
+                        int(families.get("ConstructionPanic") or 0) + 1
+                    )
+            for k, v in (row.get("unrecognizedCmResolutionKinds") or {}).items():
+                unrecognized[k] += int(v)
+
+        cpanic = len(construction_panics)
+        if cpanic == 0 and families.get("ConstructionPanic", 0) > 0:
+            cpanic = int(families["ConstructionPanic"])
+
+        # With-census conservation identity (the Class B door).
+        phases.append("conservation")
+        _narrate("PATH_SMOKE phase=conservation")
+        partition = module._with_census_partition(cm, sites, unrecognized)
+        constructed = int(partition.get("constructed") or 0)
+        typed_gaps = int(sum(partition.get("typed_gaps", {}).values()))
+        conserves = bool(partition.get("conserves"))
+
+        smoke_counts = {
+            "note": (
+                "smoke-scoped only — not R_construction_panics; "
+                "CommitMeasurement must refuse these as panics terms"
+            ),
+            "filesMeasured": len(rows),
+            "constructed": constructed,
+            "typedGaps": typed_gaps,
+            "cpanic": cpanic,
+            "families": dict(sorted(families.items())),
+            "cmResolutions": dict(sorted(cm.items())),
+            "withCensus": {
+                "with_items_total": partition.get("with_items_total"),
+                "constructed": constructed,
+                "typed_gaps_sum": typed_gaps,
+                "conserves": conserves,
+                "conservationIdentity": partition.get("conservationIdentity"),
+            },
+            "pin": {
+                "fileCount": len(pin.paths),
+                "aggregateHashPrefix": pin.aggregate_hash[:32],
+                "manifestShapeCidPrefix": shape_cid[:40],
+            },
+        }
+
+        # Attendance-style sealed path body (NOT control-effect-recensus).
+        phases.append("seal_path_body")
+        _narrate("PATH_SMOKE phase=seal_path_body")
+        # Preliminary seal without teeth so sealed_body tooth can read the file;
+        # then re-seal with final teeth/verdict.
+        sealed = _seal_path(
+            out_dir=out_dir,
+            path_verdict="PATH_RED",  # provisional until teeth run
+            path_phase="teeth",
+            tooth=None,
+            teeth={},
+            smoke_counts=smoke_counts,
+            phases=list(phases),
+        )
+
+        phases.append("teeth")
+        _narrate("PATH_SMOKE phase=teeth")
+        teeth, failed = _run_teeth(
+            constructed=constructed,
+            typed_gaps=typed_gaps,
+            cpanic=cpanic,
+            conserves=conserves,
+            sealed_path=sealed,
+            path_verdict_so_far="PATH_OK",
+        )
+        path_verdict = "PATH_OK" if failed is None else "PATH_RED"
+        sealed = _seal_path(
+            out_dir=out_dir,
+            path_verdict=path_verdict,
+            path_phase="done",
+            tooth=failed,
+            teeth=teeth,
+            smoke_counts=smoke_counts,
+            phases=list(phases) + ["done"],
+        )
+        # Attendance body separate class.
+        attendance = {
+            "schemaVersion": 1,
+            "measurementClass": MEASUREMENT_CLASS,
+            "measuredCommit": os.environ.get("GITHUB_SHA"),
+            "status": "completed" if path_verdict == "PATH_OK" else "path-red",
+            "pathVerdict": path_verdict,
+        }
+        (out_dir / "measurement.json").write_text(
+            json.dumps(attendance, indent=2) + "\n", encoding="utf-8"
+        )
+
+        elapsed = time.time() - started
+        _narrate(
+            f"PATH_SMOKE DONE pathVerdict={path_verdict} failedTooth={failed} "
+            f"constructed={constructed} typed_gaps={typed_gaps} cpanic={cpanic} "
+            f"elapsed_s={elapsed:.1f} sealed={sealed}"
+        )
+        if elapsed > 60:
+            _narrate(
+                f"PATH_SMOKE WARNING elapsed_s={elapsed:.1f} exceeded 60s budget"
+            )
+        return 0 if path_verdict == "PATH_OK" else 1
+
+    except Exception as exc:  # noqa: BLE001 — crash is UNMEASURED path
+        err = f"{type(exc).__name__}: {exc}"
+        _narrate(f"PATH_SMOKE CRASH {err}")
+        traceback.print_exc()
+        phases.append("crash")
+        try:
+            _seal_path(
+                out_dir=out_dir,
+                path_verdict="PATH_UNMEASURED",
+                path_phase="crash",
+                tooth="crash_not_green",
+                teeth={
+                    "crash_not_green": {
+                        "pass": False,
+                        "detail": "crash is UNMEASURED path, never green",
+                    }
+                },
+                smoke_counts={},
+                phases=phases,
+                error=err,
+            )
+            (out_dir / "measurement.json").write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "measurementClass": MEASUREMENT_CLASS,
+                        "measuredCommit": os.environ.get("GITHUB_SHA"),
+                        "status": "unmeasured",
+                        "pathVerdict": "PATH_UNMEASURED",
+                        "unmeasuredReason": err,
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+        except Exception:  # noqa: BLE001
+            traceback.print_exc()
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/recensus_path_smoke.sh
+++ b/tests/recensus_path_smoke.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Static teeth for recensus-path-smoke walls (no full measure — CI runs that).
+set -euo pipefail
+repo="${1:?usage: recensus_path_smoke.sh REPO_ROOT}"
+script="$repo/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py"
+wf="$repo/.github/workflows/recensus-path-smoke.yml"
+fixtures="$repo/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke"
+cm="$repo/tools/commit_measurement.py"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[[ -f "$script" ]] || fail "missing $script"
+[[ -f "$wf" ]] || fail "missing workflow $wf"
+[[ -d "$fixtures" ]] || fail "missing fixtures"
+
+grep -Fq 'SCOREBOARD_AUTHORITY = False' "$script" || fail 'smoke must declare SCOREBOARD_AUTHORITY = False'
+grep -Fq 'recensus-path-smoke' "$script" || fail 'smoke must enroll as recensus-path-smoke'
+grep -Fq 'PATH_OK' "$script" || fail 'smoke must emit PATH_OK'
+grep -Fq 'PATH_UNMEASURED' "$script" || fail 'smoke must treat crash as PATH_UNMEASURED'
+grep -Fq 'R_construction_panics' "$script" || fail 'smoke must name forbidden product key to refuse it'
+# Must not assign product panics field onto path body construction.
+if grep -E '^\s*"R_construction_panics"\s*:' "$script"; then
+  fail 'smoke script must not construct R_construction_panics product field'
+fi
+
+# Fixtures (mr_blue plants + panic host)
+for f in planted_constructed_with.py planted_opaque_with.py planted_clean.py planted_panic_host.py; do
+  [[ -f "$fixtures/$f" ]] || fail "missing plant $f"
+done
+
+# Workflow honesty + enrollment
+grep -Fq 'recensus-path-smoke' "$wf" || fail 'workflow must name recensus-path-smoke'
+grep -Fq 'NOT measure Class B' "$wf" || grep -Fq 'Does NOT measure' "$wf" \
+  || fail 'workflow header must state coverage honesty'
+grep -Fq 'control-effect-recensus' "$wf" || true  # may appear in prose as "not that"
+# Live job name must not be bare control-effect-recensus
+if grep -E 'name: control-effect recensus' "$wf"; then
+  fail 'smoke workflow must not use control-effect recensus job name'
+fi
+
+# CommitMeasurement must refuse smoke as panics candidate
+grep -Fq 'recensus-path-smoke' "$cm" || fail 'commit_measurement must know recensus-path-smoke'
+grep -Fq 'recensus-path-smoke-verdict' "$cm" || fail 'commit_measurement must refuse smoke kind'
+
+echo 'PASS: recensus-path-smoke walls (static)'

--- a/tools/commit_measurement.py
+++ b/tools/commit_measurement.py
@@ -625,6 +625,10 @@ def _body_matches_spec(body: Mapping[str, Any], spec: TipAxisSpec) -> bool:
 
 
 def _is_candidate_body(payload: Mapping[str, Any]) -> bool:
+    # recensus-path-smoke is PATH integrity only — never a panics/board candidate.
+    cls = payload.get("measurementClass") or payload.get("leaseClass")
+    if cls == "recensus-path-smoke" or payload.get("kind") == "recensus-path-smoke-verdict":
+        return False
     if "totals" in payload or "failedNodeIds" in payload:
         return True
     if "R_construction_panics" in payload:


### PR DESCRIPTION
## What this measures (name it correctly)

**Recensus production path integrity** over an enrolled micro-population — the class of seven defects that each cost a full ~73-minute walk. **Not** C2 `R_construction_panics` on pandas.

Smoke PASS ≠ S0.1 PASS. Smoke FAIL is still CI red for the path class.

## Advisor walls (binding)

| Wall | How |
| --- | --- |
| 1. No product R | Sealed body is `kind=recensus-path-smoke-verdict`, `pathVerdict` only. Forbidden product keys. Nested `smokeCounts` are explicitly non-bankable. |
| 2. SCOREBOARD_AUTHORITY | `False` on smoke; recensus module remains `True` and sole panics producer. |
| 3. Teeth are the instrument | known-constructed→constructed>0; known-panic→cpanic=1; opaque→typed residual; conservation closes; sealed body; crash→PATH_UNMEASURED. |
| 4. Coverage honesty | Workflow + seal text: does not retire full walk / Class B scale. |
| 5. Enrollment | `measurementClass=recensus-path-smoke` only. `CommitMeasurement` refuses smoke as panics candidate. |

## Planted fixtures (mr_blue conservation + panic)

| Plant | Known answer |
| --- | --- |
| `planted_constructed_with.py` | SourceDerived inject → constructed≥1 |
| `planted_opaque_with.py` | typed gap residual |
| `planted_clean.py` | completed, no with |
| `planted_panic_host.py` | ConstructionPanic → cpanic=1 |

## PR accounting

| | |
| --- | --- |
| **R** | serial path-rot discovery latency → smoke red in seconds |
| **εR** | path class fails in <60s on commit; product R unrepresentable from smoke |
| **Floors** | panics authority unchanged; crash never mints green path |
| **Shell deleted** | full-walk-only exercise of pin/cache/lift/aggregate/conservation/seal seams |

## Local

```bash
PYTHONPATH=... RECENSUS_PATH_SMOKE_OUT=/tmp/smoke \
  python -u implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
# PATH_OK in ~1s with all teeth green
```


## Discrimination evidence (observed negative arms)

A tooth that has only ever been seen GREEN is not known to bite. Four separate
one-fault runs under `RECENSUS_PATH_SMOKE_LIE` (commit `5ea78be6d`, local
managed PYTHONPATH, ~0.6–1.0s each). Positive control first.

| Arm | Planted fault | exit | `pathVerdict` | `failedTooth` | key counts | Not |
| --- | --- | --- | --- | --- | --- | --- |
| **POSITIVE** | none | 0 | **PATH_OK** | None | constructed=1 typed_gaps=1 cpanic=1 | — |
| 1. `constructed_zero` | force constructed=0 | 1 | **PATH_RED** | **known_constructed** | constructed=0 | PATH_OK |
| 2. `swallow_panic` | force cpanic=0 + drop ConstructionPanic | 1 | **PATH_RED** | **known_panic** | cpanic=0 | green-with-cpanic=0 |
| 3. `drop_opaque` | force typed_gaps=0 | 1 | **PATH_RED** | **unconstructed_residual** | typed_gaps=0 | silent pass |
| 4. `crash_mid` | raise mid-phase after conservation | 2 | **PATH_UNMEASURED** | **crash_not_green** | smokeCounts={} status=unmeasured | green **or** PATH_RED |

Log seals under `/tmp/recensus-path-smoke-disc-51728/{POSITIVE,constructed_zero,swallow_panic,drop_opaque,crash_mid}/path_verdict.json`.

Reproduce:

```bash
export PYTHONPATH="$(python tools/managed_checkout_pythonpath.py --repo-root .)"
for lie in constructed_zero swallow_panic drop_opaque crash_mid; do
  out=/tmp/smoke-disc/$lie; mkdir -p "$out"
  RECENSUS_PATH_SMOKE_LIE=$lie RECENSUS_PATH_SMOKE_OUT=$out \
    python -u implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
  python -c "import json; print(json.load(open('$out/path_verdict.json'))['pathVerdict'],
    json.load(open('$out/path_verdict.json')).get('failedTooth'))"
done
```

This is what makes the smoke corpus bankable as an **instrument** rather than a claim.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add recensus-path-smoke CI job to validate PATH integrity over a planted micro-population
> - Adds a [GitHub Actions workflow](https://github.com/TSavo/sugar/pull/7048/files#diff-2a88259228967a6b7e859fad9905325fb0cbae94c94c10bfa0296a50978b5751) that runs a fast path-smoke measurement on push, PR, and manual dispatch using a self-hosted Linux runner.
> - Adds [recensus_path_smoke.py](https://github.com/TSavo/sugar/pull/7048/files#diff-419ffb7c8217e7e524f04dca798335ee64add79efdc1d1a2b5a824686a4d0933), which measures four planted fixture files (clean, constructed-with, opaque-with, panic-host), seals a `path_verdict.json`, and exits 0/1/2 for PATH_OK/PATH_RED/UNMEASURED.
> - Adds a [static bash test](https://github.com/TSavo/sugar/pull/7048/files#diff-33271766001fdd084c2774a198cd6487eb049c0781370e6fcf1ca8f2c0bfeffd) that asserts configuration guardrails (e.g. `SCOREBOARD_AUTHORITY=False`, fixture presence, forbidden product key refusal).
> - Updates `_is_candidate_body` in [commit_measurement.py](https://github.com/TSavo/sugar/pull/7048/files#diff-034ed16ba84c4a527a93fb4c6f2ee50b10a1a08d9cb122bd440105312d686c07) to exclude `recensus-path-smoke` class/kind bodies from scoreboard processing.
> - Behavioral Change: the smoke verdict JSON explicitly rejects product-shaped keys; any sealed body containing them fails the workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 661a59e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
