### PR TITLE
Refuse recensus-path-smoke false enrollment via PATH_HINTS

### DIFF
--- a/tests/test_commit_measurement.py
+++ b/tests/test_commit_measurement.py
@@ -404,3 +404,43 @@ def test_partial_has_no_total() -> None:
     assert isinstance(partial, CM.PartialVector)
     with pytest.raises(AttributeError):
         _ = partial.total  # type: ignore[attr-defined]
+
+
+def test_smoke_body_with_forbidden_product_key_does_not_measure_panics(tmp_path):
+    """Smoke seal carrying R_construction_panics must not Measure panics.
+
+    _is_candidate_body already refuses smoke class/kind. _body_matches_spec must
+    also refuse before match_field short-circuit so a stripped/malformed smoke
+    body that still has the board field cannot compose as Measured.
+    """
+    smoke = {
+        "schemaVersion": 1,
+        "kind": "recensus-path-smoke-verdict",
+        "measurementClass": "recensus-path-smoke",
+        "pathVerdict": "PATH_OK",
+        # Forbidden product key — if present, still must not Measure panics.
+        "R_construction_panics": 0,
+        "measuredCommit": "deadbeef",
+    }
+    # Four green floors so only panics would complete the vector.
+    for axis in ("silent", "native-crash", "bare-exception", "timeout"):
+        (tmp_path / f"floor-{axis}.json").write_text(
+            json.dumps(_floor_body(axis, failed=0)), encoding="utf-8"
+        )
+    # Spoof path carries PATH_HINTS fragment for attendance class of bug.
+    spoof_dir = tmp_path / "pandas-control-effect"
+    spoof_dir.mkdir()
+    (spoof_dir / "smoke.json").write_text(json.dumps(smoke), encoding="utf-8")
+
+    panics_spec = next(
+        s for s in CM.TIP_AXIS_SPECS if s.identity == "R_construction_panics"
+    )
+    assert CM._body_matches_spec(smoke, panics_spec) is False
+    assert CM._is_candidate_body(smoke) is False
+
+    v = CM.compose_tip_from_artifacts_dir("deadbeef", tmp_path)
+    assert "R_construction_panics" in v.unmeasured_axes(), (
+        f"smoke with product key Measured panics: {v.axes!r}"
+    )
+    reading = v.axes["R_construction_panics"]
+    assert not isinstance(reading, CM.Measured), reading

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -204,3 +204,53 @@ def test_process_floor_matrix_restores_and_saves_ca_terminal_shelf():
     assert "process-floor-term-${{ github.sha }}" in text
     assert "process-floor-terminals" in text
     assert "SUGAR_PROCESS_FLOOR_CACHE_DIR" in text
+
+
+def test_smoke_body_under_path_hint_does_not_attend_control_effect_recensus(tmp_path):
+    """False-enrollment spoof: smoke under PATH_HINTS path must not attend the board.
+
+    measurementClass recensus-path-smoke is not on HEAVY_ROSTER, so classification
+    used to fall through to PATH_HINTS. A path containing 'pandas-control-effect'
+    then marked control-effect-recensus ATTENDED from a 0.7s path seal.
+    """
+    module = _attendance_module()
+    # Plant under a path that carries the authoritative PATH_HINT fragment.
+    spoof = tmp_path / "pandas-control-effect" / "smoke_seal.json"
+    spoof.parent.mkdir(parents=True)
+    body = {
+        "schemaVersion": 1,
+        "kind": "recensus-path-smoke-verdict",
+        "measurementClass": "recensus-path-smoke",
+        "pathVerdict": "PATH_OK",
+        "measuredCommit": "deadbeef",
+        # Even with identity-bound markers, smoke must not attend.
+        "environmentIdentityHash": "blake3-512_fake",
+        "totals": {"failed": 0},
+    }
+    spoof.write_text(__import__("json").dumps(body), encoding="utf-8")
+    attended, testimony = module.receipts_attendance(tmp_path)
+    assert "control-effect-recensus" not in attended, (
+        f"smoke under PATH_HINT path attended the board: {attended}"
+    )
+    assert module._class_from_payload(spoof, body) is None
+    # Kind alone under spoof path is also refused.
+    body_kind_only = {
+        "kind": "recensus-path-smoke-verdict",
+        "measuredCommit": "deadbeef",
+        "totals": {"failed": 0},
+    }
+    spoof2 = tmp_path / "control-effect-recensus" / "kind_only.json"
+    spoof2.parent.mkdir(parents=True, exist_ok=True)
+    spoof2.write_text(__import__("json").dumps(body_kind_only), encoding="utf-8")
+    attended2, _ = module.receipts_attendance(tmp_path)
+    assert "control-effect-recensus" not in attended2
+
+
+def test_smoke_workflow_artifact_path_avoids_path_hints():
+    """Defense in depth: smoke seals live under recensus-path-smoke/ only."""
+    text = _text("recensus-path-smoke.yml")
+    assert "recensus-path-smoke" in text
+    # Must not write smoke under PATH_HINTS fragments for the board.
+    assert "pandas-control-effect" not in text
+    # control-effect-recensus as class name in comments is ok; artifact path is not.
+    assert ".sugar/recensus-path-smoke" in text or "RECENSUS_PATH_SMOKE_OUT" in text

--- a/tools/commit_measurement.py
+++ b/tools/commit_measurement.py
@@ -601,6 +601,16 @@ TIP_AXIS_SPECS: tuple[TipAxisSpec, ...] = CRITERION2_AXIS_SPECS
 
 
 def _body_matches_spec(body: Mapping[str, Any], spec: TipAxisSpec) -> bool:
+    # Refuse recensus-path-smoke BEFORE match_field short-circuit. A smoke seal
+    # that still carries R_construction_panics (stripped/malformed) must not
+    # Measure panics — _is_candidate_body already refuses, but match_field alone
+    # used to return True first.
+    smoke_cls = body.get("measurementClass") or body.get("leaseClass")
+    if (
+        smoke_cls == "recensus-path-smoke"
+        or body.get("kind") == "recensus-path-smoke-verdict"
+    ):
+        return False
     if spec.match_axis_id is not None:
         if body.get("axisId") == spec.match_axis_id:
             return True

--- a/tools/heavy_measurement_attendance.py
+++ b/tools/heavy_measurement_attendance.py
@@ -62,7 +62,34 @@ def owed(cadence):
     return [c for c in HEAVY_ROSTER if HEAVY_CADENCE[c] == cadence]
 
 
+# Path-smoke is PATH integrity only (#7048). It must never attend as the
+# authoritative control-effect-recensus board via PATH_HINTS fall-through.
+RECENSUS_PATH_SMOKE_CLASS = "recensus-path-smoke"
+RECENSUS_PATH_SMOKE_KIND = "recensus-path-smoke-verdict"
+RECENSUS_PATH_SMOKE_PATH_MARKER = "recensus-path-smoke"
+
+
+def _is_recensus_path_smoke(path: Path, payload: dict) -> bool:
+    """True for smoke class/kind or a body under the smoke path prefix.
+
+    Defense in depth: class alone is not enough — a smoke seal planted under a
+    path that carries PATH_HINTS fragments must still refuse to attend.
+    """
+    mc = payload.get("measurementClass")
+    if mc == RECENSUS_PATH_SMOKE_CLASS:
+        return True
+    if payload.get("kind") == RECENSUS_PATH_SMOKE_KIND:
+        return True
+    text = str(path).replace("\\", "/")
+    if RECENSUS_PATH_SMOKE_PATH_MARKER in text:
+        return True
+    return False
+
+
 def _class_from_payload(path: Path, payload: dict) -> str | None:
+    # BEFORE roster / path hints: smoke never maps to control-effect-recensus.
+    if _is_recensus_path_smoke(path, payload):
+        return None
     mc = payload.get("measurementClass")
     if isinstance(mc, str) and mc in HEAVY_ROSTER:
         return mc


### PR DESCRIPTION
## Summary

Advisor: `_class_from_payload` returned `measurementClass` only when on `HEAVY_ROSTER`. `recensus-path-smoke` (#7048) is correctly not on the roster, then **fell through to `PATH_HINTS`**, which maps any path containing `pandas-control-effect` or `control-effect-recensus` to the **authoritative** board.

A smoke seal under such a path made **control-effect-recensus ATTENDED** from a ~0.7s path check — silence-as-clean inverted.

## Fix

1. **Attendance:** refuse smoke class/kind/`recensus-path-smoke` path marker **before** roster and path hints.
2. **Paths:** workflow already uses `.sugar/recensus-path-smoke/`; tooth asserts no `pandas-control-effect` artifact path in smoke workflow.
3. **CommitMeasurement:** refuse smoke inside `_body_matches_spec` **before** `match_field` short-circuit (`R_construction_panics` present).
4. **Teeth (observed):**
   - smoke body under `pandas-control-effect/` → board stays **UNATTENDED**
   - smoke body with `R_construction_panics` → tip compose does **not** Measure panics

Coordinates with mr_orange (smoke instrument teeth); this PR owns attendance + CommitMeasurement refusal only.

## Validation

```bash
python3 -m pytest -q \
  tests/test_heavy_measurement_concurrency_topology.py::test_smoke_body_under_path_hint_does_not_attend_control_effect_recensus \
  tests/test_heavy_measurement_concurrency_topology.py::test_smoke_workflow_artifact_path_avoids_path_hints \
  tests/test_commit_measurement.py::test_smoke_body_with_forbidden_product_key_does_not_measure_panics
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse recensus-path-smoke bodies from enrollment via PATH_HINTS
> - `_body_matches_spec` in [commit_measurement.py](https://github.com/TSavo/sugar/pull/7049/files#diff-034ed16ba84c4a527a93fb4c6f2ee50b10a1a08d9cb122bd440105312d686c07) now returns `False` early for any body with `recensus-path-smoke` or `recensus-path-smoke-verdict` class/kind, preventing smoke bodies from matching tip axis specs.
> - `_class_from_payload` in [heavy_measurement_attendance.py](https://github.com/TSavo/sugar/pull/7049/files#diff-488ea1f5082769971d9377e07807b0fef693e2d67727f202b2a8c34ba0963556) early-returns `None` for smoke payloads identified by class, kind, or path marker, blocking PATH_HINTS-based attendance classification.
> - A new `_is_recensus_path_smoke` helper centralizes smoke detection by checking payload fields and normalized file paths for the `recensus-path-smoke` marker.
> - New tests cover that smoke bodies cannot satisfy axis matching, candidate checks, or attend the `control-effect-recensus` board, and that workflow artifact paths stay under `recensus-path-smoke` rather than PATH_HINTS fragments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ea3ac1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->