### PR TITLE
Path smoke discrimination: re-prove each tooth bites every commit

### DIFF
--- a/.github/workflows/recensus-path-smoke.yml
+++ b/.github/workflows/recensus-path-smoke.yml
@@ -89,6 +89,17 @@ jobs:
           )
           PY
 
+      # Positive arm alone is decoration. Negative arms re-prove each tooth bites.
+      # crash_mid must be PATH_UNMEASURED (not green, not PATH_RED) — the
+      # crash-banks-measured / crash-prints-zero class already bit this campaign.
+      - name: "Phase: path-smoke discrimination (four one-fault arms)"
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "path-smoke phase=discrimination status=start commit=$GITHUB_SHA"
+          python -u implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke_discrimination.py
+          echo "path-smoke phase=discrimination status=done"
+
       - name: Upload path-smoke seal
         if: always()
         uses: actions/upload-artifact@v4

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
@@ -479,6 +479,36 @@ def main(argv: list[str] | None = None) -> int:
         typed_gaps = int(sum(partition.get("typed_gaps", {}).values()))
         conserves = bool(partition.get("conserves"))
 
+        # Discrimination lies (optional): one fault at a time so negative arms
+        # are OBSERVED, not reasoned. Env RECENSUS_PATH_SMOKE_LIE=
+        #   constructed_zero | swallow_panic | drop_opaque | crash_mid
+        # A tooth only ever seen GREEN is decoration, not an instrument.
+        lie = (os.environ.get("RECENSUS_PATH_SMOKE_LIE") or "").strip()
+        if lie == "constructed_zero":
+            _narrate("PATH_SMOKE LIE planted=constructed_zero")
+            constructed = 0
+        elif lie == "swallow_panic":
+            _narrate("PATH_SMOKE LIE planted=swallow_panic")
+            cpanic = 0
+            construction_panics = []
+            families.pop("ConstructionPanic", None)
+        elif lie == "drop_opaque":
+            _narrate("PATH_SMOKE LIE planted=drop_opaque")
+            # Vanish typed-gap residual; residual tooth must PATH_RED.
+            typed_gaps = 0
+            partition = dict(partition)
+            partition["typed_gaps"] = {
+                k: 0 for k in (partition.get("typed_gaps") or {})
+            }
+            partition["constructed"] = constructed
+        elif lie == "crash_mid":
+            _narrate("PATH_SMOKE LIE planted=crash_mid phase=after-conservation")
+            raise RuntimeError(
+                "planted crash mid-phase (discrimination arm: PATH_UNMEASURED)"
+            )
+        elif lie:
+            raise RuntimeError(f"unknown RECENSUS_PATH_SMOKE_LIE={lie!r}")
+
         smoke_counts = {
             "note": (
                 "smoke-scoped only — not R_construction_panics; "

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke_discrimination.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke_discrimination.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Negative-arm discrimination for recensus-path-smoke teeth.
+
+A tooth that has only ever been seen GREEN is not known to bite. This runner
+plants one fault at a time via RECENSUS_PATH_SMOKE_LIE and OBSERVES the sealed
+path verdict — not reasoned, not asserted from positive-arm silence.
+
+Arms (binding):
+  1. constructed_zero -> PATH_RED, failedTooth=known_constructed
+  2. swallow_panic    -> PATH_RED, failedTooth=known_panic
+  3. drop_opaque      -> PATH_RED, failedTooth=unconstructed_residual
+  4. crash_mid        -> PATH_UNMEASURED, failedTooth=crash_not_green
+     (NOT green, NOT PATH_RED — crash-banks-measured / crash-prints-zero class)
+
+Exit 0 only when every arm bites with the named tooth. CI must re-run this on
+every commit; one-time human observation is not enrollment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+_SCRIPTS = Path(__file__).resolve().parent
+_SMOKE = _SCRIPTS / "recensus_path_smoke.py"
+
+# (lie, expected_verdict, expected_failed_tooth, expected_exit)
+ARMS: list[tuple[str, str, str, int]] = [
+    ("constructed_zero", "PATH_RED", "known_constructed", 1),
+    ("swallow_panic", "PATH_RED", "known_panic", 1),
+    ("drop_opaque", "PATH_RED", "unconstructed_residual", 1),
+    ("crash_mid", "PATH_UNMEASURED", "crash_not_green", 2),
+]
+
+
+def _run_arm(lie: str, out_dir: Path) -> tuple[int, dict[str, Any], float]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["RECENSUS_PATH_SMOKE_LIE"] = lie
+    env["RECENSUS_PATH_SMOKE_OUT"] = str(out_dir)
+    env["PYTHONUNBUFFERED"] = "1"
+    started = time.time()
+    proc = subprocess.run(
+        [sys.executable, "-u", str(_SMOKE)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    elapsed = time.time() - started
+    # Always surface the smoke log so a failed arm is debuggable in CI.
+    if proc.stdout:
+        print(proc.stdout, end="" if proc.stdout.endswith("\n") else "\n", flush=True)
+    if proc.stderr:
+        print(proc.stderr, end="" if proc.stderr.endswith("\n") else "\n", file=sys.stderr, flush=True)
+    seal = out_dir / "path_verdict.json"
+    body: dict[str, Any] = {}
+    if seal.is_file():
+        body = json.loads(seal.read_text(encoding="utf-8"))
+    return proc.returncode, body, elapsed
+
+
+def main() -> int:
+    print(
+        "PATH_SMOKE_DISC START arms="
+        + ",".join(a[0] for a in ARMS)
+        + " (negative arms must bite; green-only teeth are decoration)",
+        flush=True,
+    )
+    rows: list[dict[str, Any]] = []
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="recensus-path-smoke-disc-") as tmp:
+        base = Path(tmp)
+        for lie, want_verdict, want_tooth, want_exit in ARMS:
+            out = base / lie
+            print(f"PATH_SMOKE_DISC arm={lie} status=start", flush=True)
+            code, body, elapsed = _run_arm(lie, out)
+            got_verdict = body.get("pathVerdict")
+            got_tooth = body.get("failedTooth")
+            row = {
+                "lie": lie,
+                "exit": code,
+                "pathVerdict": got_verdict,
+                "failedTooth": got_tooth,
+                "elapsed_s": round(elapsed, 3),
+                "want_verdict": want_verdict,
+                "want_tooth": want_tooth,
+                "want_exit": want_exit,
+            }
+            rows.append(row)
+            ok = (
+                code == want_exit
+                and got_verdict == want_verdict
+                and got_tooth == want_tooth
+            )
+            if ok:
+                print(
+                    f"PATH_SMOKE_DISC arm={lie} status=BITE "
+                    f"verdict={got_verdict} tooth={got_tooth} "
+                    f"exit={code} elapsed_s={elapsed:.2f}",
+                    flush=True,
+                )
+            else:
+                msg = (
+                    f"arm={lie} expected verdict={want_verdict} tooth={want_tooth} "
+                    f"exit={want_exit}; got verdict={got_verdict!r} tooth={got_tooth!r} "
+                    f"exit={code} body_keys={sorted(body.keys())}"
+                )
+                failures.append(msg)
+                print(f"PATH_SMOKE_DISC arm={lie} status=MISS {msg}", flush=True)
+
+    # Bankable table (also lands in CI log as the discrimination evidence).
+    print("", flush=True)
+    print("| Arm | exit | pathVerdict | failedTooth | elapsed_s |", flush=True)
+    print("| --- | --- | --- | --- | --- |", flush=True)
+    for r in rows:
+        print(
+            f"| `{r['lie']}` | {r['exit']} | **{r['pathVerdict']}** | "
+            f"**{r['failedTooth']}** | {r['elapsed_s']} |",
+            flush=True,
+        )
+    print("", flush=True)
+
+    if failures:
+        print("PATH_SMOKE_DISC FAIL teeth did not all bite:", flush=True)
+        for f in failures:
+            print(f"  - {f}", flush=True)
+        return 1
+
+    print(
+        "PATH_SMOKE_DISC PASS all four negative arms observed "
+        "(PATH_RED x3 + PATH_UNMEASURED crash)",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/recensus_path_smoke.sh
+++ b/tests/recensus_path_smoke.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 repo="${1:?usage: recensus_path_smoke.sh REPO_ROOT}"
 script="$repo/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py"
+disc="$repo/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke_discrimination.py"
 wf="$repo/.github/workflows/recensus-path-smoke.yml"
 fixtures="$repo/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke"
 cm="$repo/tools/commit_measurement.py"
@@ -10,6 +11,7 @@ cm="$repo/tools/commit_measurement.py"
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
 [[ -f "$script" ]] || fail "missing $script"
+[[ -f "$disc" ]] || fail "missing discrimination runner $disc"
 [[ -f "$wf" ]] || fail "missing workflow $wf"
 [[ -d "$fixtures" ]] || fail "missing fixtures"
 
@@ -23,15 +25,29 @@ if grep -E '^\s*"R_construction_panics"\s*:' "$script"; then
   fail 'smoke script must not construct R_construction_panics product field'
 fi
 
+# Plantable lies — without these the negative arm cannot be re-run in CI.
+grep -Fq 'RECENSUS_PATH_SMOKE_LIE' "$script" || fail 'smoke must accept RECENSUS_PATH_SMOKE_LIE for discrimination'
+for lie in constructed_zero swallow_panic drop_opaque crash_mid; do
+  grep -Fq "$lie" "$script" || fail "smoke must plant lie=$lie"
+  grep -Fq "$lie" "$disc" || fail "discrimination runner must name arm=$lie"
+done
+grep -Fq 'known_constructed' "$disc" || fail 'disc must expect known_constructed tooth'
+grep -Fq 'known_panic' "$disc" || fail 'disc must expect known_panic tooth'
+grep -Fq 'unconstructed_residual' "$disc" || fail 'disc must expect unconstructed_residual tooth'
+grep -Fq 'crash_not_green' "$disc" || fail 'disc must expect crash_not_green tooth'
+grep -Fq 'PATH_UNMEASURED' "$disc" || fail 'disc must expect PATH_UNMEASURED for crash_mid'
+
 # Fixtures (mr_blue plants + panic host)
 for f in planted_constructed_with.py planted_opaque_with.py planted_clean.py planted_panic_host.py; do
   [[ -f "$fixtures/$f" ]] || fail "missing plant $f"
 done
 
-# Workflow honesty + enrollment
+# Workflow honesty + enrollment + discrimination phase (every commit re-proves bite)
 grep -Fq 'recensus-path-smoke' "$wf" || fail 'workflow must name recensus-path-smoke'
 grep -Fq 'NOT measure Class B' "$wf" || grep -Fq 'Does NOT measure' "$wf" \
   || fail 'workflow header must state coverage honesty'
+grep -Fq 'recensus_path_smoke_discrimination.py' "$wf" \
+  || fail 'workflow must run discrimination runner (green-only teeth are decoration)'
 grep -Fq 'control-effect-recensus' "$wf" || true  # may appear in prose as "not that"
 # Live job name must not be bare control-effect-recensus
 if grep -E 'name: control-effect recensus' "$wf"; then
@@ -42,4 +58,4 @@ fi
 grep -Fq 'recensus-path-smoke' "$cm" || fail 'commit_measurement must know recensus-path-smoke'
 grep -Fq 'recensus-path-smoke-verdict' "$cm" || fail 'commit_measurement must refuse smoke kind'
 
-echo 'PASS: recensus-path-smoke walls (static)'
+echo 'PASS: recensus-path-smoke walls (static + discrimination enrollment)'


### PR DESCRIPTION
## Why (instrument vs decoration)

#7048 merged with only the **positive** arm observed (`PATH_OK`). A tooth that has only ever been seen GREEN is not known to bite. That is a claim, not an instrument — the self-sealing class this campaign already has a law against.

Fix-forward: plantable one-fault lies + a CI discrimination runner so **every commit re-proves the teeth bite**.

## Observed discrimination (local, then enrolled in CI)

Runner: `recensus_path_smoke_discrimination.py` under managed checkout PYTHONPATH.
Positive control remains the existing PATH_OK phase; these are the four **negative** arms.

| Arm | Planted fault | exit | `pathVerdict` | `failedTooth` | elapsed_s |
| --- | --- | --- | --- | --- | --- |
| `constructed_zero` | constructed→0 | 1 | **PATH_RED** | **known_constructed** | 1.60 |
| `swallow_panic` | cpanic→0 + drop ConstructionPanic | 1 | **PATH_RED** | **known_panic** | 0.69 |
| `drop_opaque` | typed_gaps→0 | 1 | **PATH_RED** | **unconstructed_residual** | 0.71 |
| `crash_mid` | raise after conservation | 2 | **PATH_UNMEASURED** | **crash_not_green** | 0.72 |

Arm 4 is the one that matters most: **PATH_UNMEASURED**, not green and not red — crash-banks-measured / crash-prints-zero class, observed.

```
PATH_SMOKE_DISC PASS all four negative arms observed (PATH_RED x3 + PATH_UNMEASURED crash)
```

## What lands

| File | Role |
| --- | --- |
| `recensus_path_smoke.py` | `RECENSUS_PATH_SMOKE_LIE={constructed_zero,swallow_panic,drop_opaque,crash_mid}` |
| `recensus_path_smoke_discrimination.py` | spawns each lie, asserts verdict+tooth+exit, prints bankable table |
| `recensus-path-smoke.yml` | phase after PATH_OK: run discrimination (CI re-proves every commit) |
| `tests/recensus_path_smoke.sh` | static enrollment of lies + workflow discrimination phase |

## PR accounting

| | |
| --- | --- |
| **R** | teeth with only-green evidence → teeth with observed negative bite + CI re-proof |
| **εR** | four PATH_RED/UNMEASURED arms banked; workflow fails if any tooth stops biting |
| **Floors** | positive PATH_OK still required; SCOREBOARD_AUTHORITY/smoke class walls unchanged |
| **Shell deleted** | "we reason the crash path is UNMEASURED" / "teeth would catch X" without observation |

## Local reproduce

```bash
export PYTHONPATH="$(python tools/managed_checkout_pythonpath.py --repo-root .)"
python -u implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke_discrimination.py
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add path-smoke discrimination phase that validates each fault arm bites on every commit
> - Adds [`recensus_path_smoke_discrimination.py`](https://github.com/TSavo/sugar/pull/7050/files#diff-fdbd42a3de525cd7306d2456c608b6be777c1a4f98013e476f50193342e4ab7a), a script that runs `recensus_path_smoke.py` four times, each with a different planted fault (`constructed_zero`, `swallow_panic`, `drop_opaque`, `crash_mid`), and asserts that each arm produces the expected verdict, failed tooth, and exit code.
> - Extends [`recensus_path_smoke.py`](https://github.com/TSavo/sugar/pull/7050/files#diff-419ffb7c8217e7e524f04dca798335ee64add79efdc1d1a2b5a824686a4d0933) to accept a `RECENSUS_PATH_SMOKE_LIE` environment variable that perturbs measurement outputs or raises a mid-run `RuntimeError` (`crash_mid`) to simulate faults.
> - Adds the discrimination phase as a CI step in the [`recensus-path-smoke` workflow](https://github.com/TSavo/sugar/pull/7050/files#diff-2a88259228967a6b7e859fad9905325fb0cbae94c94c10bfa0296a50978b5751), running between measurement and artifact upload; the job fails if any arm does not bite as expected.
> - Extends [`tests/recensus_path_smoke.sh`](https://github.com/TSavo/sugar/pull/7050/files#diff-33271766001fdd084c2774a198cd6487eb049c0781370e6fcf1ca8f2c0bfeffd) with static-wall checks verifying the discrimination runner exists, the smoke script supports all four lies, and the workflow invokes the runner.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 288b24a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->