### PR TITLE
Emit floor residual mass when full summary conservation fails

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -178,11 +178,15 @@ def main() -> int:
 
     offenders = tuple(row.offender for row in rows if row.offender is not None)
     if args.json is not None:
-        from pandas_floor_summary import floor_summary, relative_files, write_json
+        from pandas_floor_summary import relative_files, write_floor_summary_or_residual
 
         files = relative_files(paths, args.repo_root)
-        payload = floor_summary(
+        residual_count = len(offenders)
+        write_floor_summary_or_residual(
+            args.json,
             floor="bare-exception",
+            residual_key="R_bare_exceptions",
+            residual_count=residual_count,
             files=files,
             rows=[
                 {
@@ -193,7 +197,7 @@ def main() -> int:
                 for row in rows
             ],
             totals={
-                "R_bare_exceptions": len(offenders),
+                "R_bare_exceptions": residual_count,
                 "completed": sum(
                     row.category == OUTCOME_COMPLETED for row in rows
                 ),
@@ -207,7 +211,6 @@ def main() -> int:
             },
             measured=True,
         )
-        write_json(args.json, payload)
     print(
         "BARE-EXCEPTION SURFACE: "
         f"discovered={len(rows)} "

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -221,11 +221,15 @@ def main() -> int:
         progress_path=progress_path,
     )
     if args.json is not None:
-        from pandas_floor_summary import floor_summary, relative_files, write_json
+        from pandas_floor_summary import relative_files, write_floor_summary_or_residual
 
         files = relative_files(paths, args.repo_root)
-        payload = floor_summary(
+        residual_count = len(summary.offenders)
+        write_floor_summary_or_residual(
+            args.json,
             floor="native-crash",
+            residual_key="R_native_crashes",
+            residual_count=residual_count,
             files=files,
             rows=[
                 {
@@ -237,14 +241,13 @@ def main() -> int:
                 for row in summary.rows
             ],
             totals={
-                "R_native_crashes": len(summary.offenders),
+                "R_native_crashes": residual_count,
                 "completed": summary.completed,
                 "timeouts": summary.timeouts,
                 "nonNativeRed": summary.non_native_red,
             },
             measured=True,
         )
-        write_json(args.json, payload)
     print(
         "NATIVE-CRASH SURFACE: "
         f"discovered={summary.discovered} completed={summary.completed} "

--- a/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
@@ -59,3 +59,70 @@ def write_json(path: Path, value: Mapping[str, Any]) -> None:
     path.write_text(
         json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
+
+
+def write_floor_residual_v1(
+    path: Path,
+    *,
+    residual_key: str,
+    residual_count: int,
+    floor: str,
+    emission_fallback: str | None = None,
+) -> None:
+    """Minimal residual body for enrollment mint when full summary cannot seal.
+
+    Enrollment cites residualCount under residualKey — never invents from exit.
+    """
+    if type(residual_count) is not int or residual_count < 0:
+        raise ValueError(
+            f"residual_count must be non-negative int; got {residual_count!r}"
+        )
+    body: dict[str, Any] = {
+        "kind": "floor-residual-v1",
+        "floor": floor,
+        "residualKey": residual_key,
+        "residualCount": residual_count,
+    }
+    if emission_fallback:
+        body["emissionFallback"] = emission_fallback
+    write_json(path, body)
+
+
+def write_floor_summary_or_residual(
+    path: Path,
+    *,
+    floor: str,
+    residual_key: str,
+    residual_count: int,
+    files: Sequence[str],
+    rows: Sequence[Mapping[str, Any]],
+    totals: Mapping[str, int],
+    measured: bool = True,
+    unmeasurable_reasons: Sequence[str] = (),
+) -> str:
+    """Always emit residual magnitude for mint; full summary when conservation holds.
+
+    Product residual is already computed (residual_count). A conservation failure
+    in floor_summary must not erase that mass — fall back to floor-residual-v1
+    so enrollment can cite residualCount (freeze night: exit=1 + no summary).
+    """
+    try:
+        payload = floor_summary(
+            floor=floor,
+            files=files,
+            rows=rows,
+            totals=totals,
+            measured=measured,
+            unmeasurable_reasons=unmeasurable_reasons,
+        )
+        write_json(path, payload)
+        return "full"
+    except ValueError as error:
+        write_floor_residual_v1(
+            path,
+            residual_key=residual_key,
+            residual_count=residual_count,
+            floor=floor,
+            emission_fallback=f"{type(error).__name__}: {error}",
+        )
+        return "residual-only"

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -449,11 +449,15 @@ def main() -> int:
         progress_stdout=args.progress_stdout,
     )
     if args.json is not None:
-        from pandas_floor_summary import floor_summary, relative_files, write_json
+        from pandas_floor_summary import relative_files, write_floor_summary_or_residual
 
         files = relative_files(paths, args.repo_root)
-        payload = floor_summary(
+        residual_count = r_silent(summary.offenders)
+        write_floor_summary_or_residual(
+            args.json,
             floor="silent",
+            residual_key="R_silent",
+            residual_count=residual_count,
             files=files,
             rows=[
                 {
@@ -465,7 +469,7 @@ def main() -> int:
                 for row in summary.rows
             ],
             totals={
-                "R_silent": r_silent(summary.offenders),
+                "R_silent": residual_count,
                 "completed": summary.completed,
                 "constructionPanics": summary.construction_panics,
                 "nativeCrashes": summary.native_crashes,
@@ -475,7 +479,6 @@ def main() -> int:
             measured=len(summary.rows) == len(files),
             unmeasurable_reasons=(),
         )
-        write_json(args.json, payload)
     print(
         "SILENT SURFACE: "
         f"files_discovered={summary.discovered} files_completed={summary.completed} "

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -164,11 +164,15 @@ def main() -> int:
     rows = summary.rows
     offenders = summary.offenders
     if args.json is not None:
-        from pandas_floor_summary import floor_summary, relative_files, write_json
+        from pandas_floor_summary import relative_files, write_floor_summary_or_residual
 
         files = relative_files(paths, args.repo_root)
-        payload = floor_summary(
+        residual_count = len(offenders)
+        write_floor_summary_or_residual(
+            args.json,
             floor="timeout",
+            residual_key="R_timeouts",
+            residual_count=residual_count,
             files=files,
             rows=[
                 {
@@ -181,7 +185,7 @@ def main() -> int:
                 for row in rows
             ],
             totals={
-                "R_timeouts": len(offenders),
+                "R_timeouts": residual_count,
                 "completed": sum(row.category == "completed" for row in rows),
                 "typedGaps": sum(row.category == "typed-gap" for row in rows),
                 "nativeCrashes": sum(row.category == "native-crash" for row in rows),
@@ -189,7 +193,6 @@ def main() -> int:
             },
             measured=True,
         )
-        write_json(args.json, payload)
     print(
         "TIMEOUT SURFACE: "
         f"discovered={len(rows)} "

--- a/tests/test_floor_summary_residual_emission.py
+++ b/tests/test_floor_summary_residual_emission.py
@@ -1,0 +1,78 @@
+"""Emission: residual mass must land even when full floor_summary conservation fails."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "implementations/python/sugar-lift-py-tests/scripts"
+TOOLS = ROOT / "tools"
+
+
+def _load(name: str, path: Path):
+    if str(path.parent) not in sys.path:
+        sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_conservation_failure_still_emits_residual_v1(tmp_path: Path) -> None:
+    pfs = _load("pandas_floor_summary", SCRIPTS / "pandas_floor_summary.py")
+    out = tmp_path / "floor-summary.json"
+    # rows missing a file → conservation fails
+    mode = pfs.write_floor_summary_or_residual(
+        out,
+        floor="native-crash",
+        residual_key="R_native_crashes",
+        residual_count=47,
+        files=["a.py", "b.py"],
+        rows=[{"file": "a.py", "category": "native-crash"}],
+        totals={"R_native_crashes": 47},
+        measured=True,
+    )
+    assert mode == "residual-only"
+    body = json.loads(out.read_text(encoding="utf-8"))
+    assert body["kind"] == "floor-residual-v1"
+    assert body["residualKey"] == "R_native_crashes"
+    assert body["residualCount"] == 47
+    assert "emissionFallback" in body
+
+    enr = _load(
+        "sole_construction_floor_enrollment",
+        TOOLS / "sole_construction_floor_enrollment.py",
+    )
+    assert (
+        enr.load_residual_count_from_floor_summary(
+            out, residual_key="R_native_crashes"
+        )
+        == 47
+    )
+
+
+def test_full_summary_when_conservation_holds(tmp_path: Path) -> None:
+    pfs = _load("pandas_floor_summary", SCRIPTS / "pandas_floor_summary.py")
+    out = tmp_path / "floor-summary.json"
+    mode = pfs.write_floor_summary_or_residual(
+        out,
+        floor="timeout",
+        residual_key="R_timeouts",
+        residual_count=2,
+        files=["a.py", "b.py"],
+        rows=[
+            {"file": "a.py", "category": "timeout"},
+            {"file": "b.py", "category": "completed"},
+        ],
+        totals={"R_timeouts": 2, "completed": 1},
+        measured=True,
+    )
+    assert mode == "full"
+    body = json.loads(out.read_text(encoding="utf-8"))
+    assert body["kind"] == "pandas-floor-summary-v1"
+    assert body["totals"]["R_timeouts"] == 2


### PR DESCRIPTION
## Summary

After exit=1 residual scans, `floor-summary.json` was often **absent**, so #7046 mint sealed honest UNMEASURED (`floor-summary.json absent after exit=1`) instead of mass. Residual was already computed (`len(offenders)` / stdout `R_* = N`); **emission** failed when `floor_summary` conservation raised.

## Fix (emission only)

`write_floor_summary_or_residual`:
1. Try full `pandas-floor-summary-v1`
2. On conservation `ValueError` → write `floor-residual-v1` with `residualCount` / `residualKey` (mint already loads this)

Does not change residual definition. Does not invent R from exit code.

## Validation

```
pytest tests/test_floor_summary_residual_emission.py tests/test_sole_construction_floor_enrollment_measured.py -q
# 10 passed
```

Queue order: **this PR first**, then suite Path/LPT prior (`suite-path-import-fix`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resilient measurement reporting that emits either a complete floor summary or a residual-only report when full summary generation is unavailable.
  * Preserved residual counts, totals, file details, and measurement status in generated reports.
* **Bug Fixes**
  * Prevented conservation failures from blocking JSON report generation.
* **Tests**
  * Added coverage for both residual-only output and complete summaries when conservation succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->