### PR TITLE
Suite LPT prior: Path import, loud degrade, report survives prior failure

### DIFF
--- a/tests/test_suite_report_lpt_prior_import.py
+++ b/tests/test_suite_report_lpt_prior_import.py
@@ -1,16 +1,35 @@
-"""Tooth: suite sessionfinish LPT prior must not NameError on Path.
+"""Teeth: LPT prior must not kill suite-report; degrade must be loud.
 
-A NameError in pytest_sessionfinish after tests pass still kills suite-report.json
-and the package-suite class fails to speak. #7040 introduced Path without import.
+A NameError / any exception in pytest_sessionfinish after tests pass still
+killed suite-report.json (#7040 Path without import). The prior is a cost
+optimisation; the suite report is testimony — testimony must not be hostage.
 """
 
 from __future__ import annotations
 
 import ast
+import importlib.util
+import json
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 ROOT = Path(__file__).resolve().parents[1]
 PLUGIN = ROOT / "tools" / "python_package_suite_report.py"
+TOOLS = ROOT / "tools"
+
+
+def _load_suite_report():
+    if str(TOOLS) not in sys.path:
+        sys.path.insert(0, str(TOOLS))
+    spec = importlib.util.spec_from_file_location(
+        "python_package_suite_report_tooth", PLUGIN
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
 
 
 def test_suite_report_imports_pathlib_path() -> None:
@@ -34,29 +53,116 @@ def test_suite_report_imports_pathlib_path() -> None:
 
 
 def test_write_lpt_prior_name_is_defined_with_path() -> None:
-    """Static: body of _write_lpt_prior references Path and file defines Path."""
     src = PLUGIN.read_text(encoding="utf-8")
     assert "def _write_lpt_prior" in src
     assert "Path(self.config.rootpath)" in src
-    # Compile executes import graph enough to bind names used at function def time;
-    # Path is needed at runtime of _write_lpt_prior.
-    ns: dict = {}
-    compile(src, str(PLUGIN), "exec")  # syntax
-    # Runtime bind check: exec module top-level imports only
-    import importlib.util
-
-    spec = importlib.util.spec_from_file_location(
-        "python_package_suite_report_tooth", PLUGIN
-    )
-    assert spec and spec.loader
-    mod = importlib.util.module_from_spec(spec)
-    # tools/ on path for siblings
-    import sys
-
-    tools = str(ROOT / "tools")
-    if tools not in sys.path:
-        sys.path.insert(0, tools)
-    spec.loader.exec_module(mod)
-    assert hasattr(mod, "Path") or "Path" in dir(__import__("pathlib"))
-    # Callability: method exists on SuiteReporter
+    mod = _load_suite_report()
     assert hasattr(mod.SuiteReporter, "_write_lpt_prior")
+
+
+class _FakeConfig:
+    def __init__(self, options: dict, *, rootpath: Path):
+        self._options = options
+        self.rootpath = rootpath
+
+    def getoption(self, name: str):
+        key = name.lstrip("-").replace("-", "_")
+        return self._options.get(key)
+
+
+def test_sessionfinish_writes_suite_report_when_lpt_prior_raises(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Shell: sessionfinish LPT prior can fail closed for report — unrepresentable.
+
+    Plant an exception in the prior writer; suite-report.json must still land.
+    """
+    mod = _load_suite_report()
+    identity_path = tmp_path / "environment-identity.json"
+    identity_path.write_text(
+        json.dumps(
+            {
+                "environmentIdentityHash": "a" * 64,
+                "sourceStamp": {"value": "stamp"},
+                "dependencyAuthority": {"testExtraInputHash": "b" * 64},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    report_path = tmp_path / "suite-report.json"
+    config = _FakeConfig(
+        {
+            "suite_identity": str(identity_path),
+            "suite_commit": "deadbeef" * 5,
+            "suite_report": str(report_path),
+            "suite_order": "canonical",
+            "suite_label": "tooth",
+            "suite_shuffle_seed": None,
+            "suite_binary_stamp": None,
+            "suite_shard_index": 0,
+            "suite_shard_count": 8,
+        },
+        rootpath=tmp_path,
+    )
+    reporter = mod.SuiteReporter(config)
+    reporter.collected = ["pkg/tests/test_x.py::test_one"]
+    reporter.executed_order = list(reporter.collected)
+    reporter.passed = list(reporter.collected)
+    reporter._seen_outcome = set(reporter.collected)
+    reporter._file_duration_s = {"pkg/tests/test_x.py": 1.25}
+
+    def _boom(self) -> None:
+        raise RuntimeError("planted LPT prior failure")
+
+    monkeypatch.setattr(mod.SuiteReporter, "_write_lpt_prior", _boom)
+    # sessionfinish must not raise; report must exist
+    reporter.pytest_sessionfinish(SimpleNamespace(), exitstatus=0)
+    assert report_path.is_file(), (
+        "suite-report.json must be written even when _write_lpt_prior raises — "
+        "cost optimisation must never destroy measurement testimony"
+    )
+    body = json.loads(report_path.read_text(encoding="utf-8"))
+    assert body["measuredCommit"] == "deadbeef" * 5
+    assert body["counts"]["passed"] == 1
+    assert body["passedNodeIds"] == ["pkg/tests/test_x.py::test_one"]
+
+
+def test_write_lpt_prior_announces_disabled_shelf(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Silent no-op when prior disabled is forbidden — must name the mode."""
+    mod = _load_suite_report()
+    monkeypatch.setenv("SUGAR_LPT_PRIOR_DIR", "off")
+    identity_path = tmp_path / "environment-identity.json"
+    identity_path.write_text(
+        json.dumps(
+            {
+                "environmentIdentityHash": "a" * 64,
+                "sourceStamp": {"value": "stamp"},
+                "dependencyAuthority": {"testExtraInputHash": "b" * 64},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config = _FakeConfig(
+        {
+            "suite_identity": str(identity_path),
+            "suite_commit": "c" * 40,
+            "suite_report": None,
+            "suite_order": "canonical",
+            "suite_label": None,
+            "suite_shuffle_seed": None,
+            "suite_binary_stamp": None,
+            "suite_shard_index": None,
+            "suite_shard_count": None,
+        },
+        rootpath=tmp_path,
+    )
+    reporter = mod.SuiteReporter(config)
+    reporter._file_duration_s = {"x.py": 0.5}
+    reporter._write_lpt_prior()
+    combined = capsys.readouterr().out + capsys.readouterr().err
+    assert "lpt-prior-write" in combined
+    assert "prior-disabled" in combined or "degraded=equal-count" in combined

--- a/tests/test_suite_report_lpt_prior_import.py
+++ b/tests/test_suite_report_lpt_prior_import.py
@@ -1,0 +1,62 @@
+"""Tooth: suite sessionfinish LPT prior must not NameError on Path.
+
+A NameError in pytest_sessionfinish after tests pass still kills suite-report.json
+and the package-suite class fails to speak. #7040 introduced Path without import.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN = ROOT / "tools" / "python_package_suite_report.py"
+
+
+def test_suite_report_imports_pathlib_path() -> None:
+    src = PLUGIN.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    has_path = False
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == "pathlib":
+            names = {a.name for a in node.names}
+            if "Path" in names:
+                has_path = True
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                if a.name == "pathlib":
+                    has_path = True
+    assert has_path, (
+        "tools/python_package_suite_report.py must import Path from pathlib — "
+        "_write_lpt_prior uses Path at sessionfinish; missing import kills "
+        "suite-report.json after a green test run"
+    )
+
+
+def test_write_lpt_prior_name_is_defined_with_path() -> None:
+    """Static: body of _write_lpt_prior references Path and file defines Path."""
+    src = PLUGIN.read_text(encoding="utf-8")
+    assert "def _write_lpt_prior" in src
+    assert "Path(self.config.rootpath)" in src
+    # Compile executes import graph enough to bind names used at function def time;
+    # Path is needed at runtime of _write_lpt_prior.
+    ns: dict = {}
+    compile(src, str(PLUGIN), "exec")  # syntax
+    # Runtime bind check: exec module top-level imports only
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "python_package_suite_report_tooth", PLUGIN
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    # tools/ on path for siblings
+    import sys
+
+    tools = str(ROOT / "tools")
+    if tools not in sys.path:
+        sys.path.insert(0, tools)
+    spec.loader.exec_module(mod)
+    assert hasattr(mod, "Path") or "Path" in dir(__import__("pathlib"))
+    # Callability: method exists on SuiteReporter
+    assert hasattr(mod.SuiteReporter, "_write_lpt_prior")

--- a/tools/lpt_file_shards.py
+++ b/tools/lpt_file_shards.py
@@ -254,6 +254,7 @@ def assign_files(
     costs: dict[str, float] = {}
     hits = 0
     misses = len(ordered)
+    prior_disabled = not prior.enabled
     if path_resolver is not None and prior.enabled and ordered:
         costs, hits, misses = prior.costs_for_paths(
             {f: path_resolver[f] for f in ordered if f in path_resolver}
@@ -266,9 +267,11 @@ def assign_files(
     if hits == 0:
         bins = equal_count_bins(sorted(ordered), shard_count)
         loads = [float(len(b)) for b in bins]  # unit cost under equal-count
+        # Tag mode so callers can narrate shelf-disabled vs empty shelf.
+        mode = "equal-count-prior-disabled" if prior_disabled else "equal-count"
         return ShardAssignment(
             bins=bins,
-            mode="equal-count",
+            mode=mode,
             prior_hits=0,
             prior_misses=misses if ordered else 0,
             shard_count=shard_count,
@@ -299,10 +302,23 @@ def narrate_assignment(assignment: ShardAssignment, *, population: str) -> None:
     """
     line = assignment.job_log_line(population=population)
     print(line, file=sys.stderr, flush=True)
-    if assignment.mode == "equal-count":
+    if assignment.mode in {"equal-count", "equal-count-prior-disabled"}:
+        if assignment.mode == "equal-count-prior-disabled":
+            reason = (
+                "prior-shelf-disabled (SUGAR_LPT_PRIOR_DIR=off or no root); "
+                "equal-count is the only packer — not LPT"
+            )
+        else:
+            reason = (
+                "no prior hits for this population; degraded=equal-count "
+                "(next run is LPT only if a prior write succeeds this campaign)"
+            )
         print(
-            "JOB_LOG phase=lpt-shard-assign status=no-prior "
-            "degraded=equal-count (will write prior during this run for next)",
+            f"JOB_LOG phase=lpt-shard-assign status=degraded "
+            f"mode={assignment.mode} population={population} "
+            f"prior_hits={assignment.prior_hits} "
+            f"prior_misses={assignment.prior_misses} "
+            f"reason={reason}",
             file=sys.stderr,
             flush=True,
         )

--- a/tools/python_package_suite_report.py
+++ b/tools/python_package_suite_report.py
@@ -471,19 +471,42 @@ class SuiteReporter:
         return commit
 
     def _write_lpt_prior(self) -> None:
-        """Persist per-file pytest call seconds into the CA LPT cost shelf."""
+        """Persist per-file pytest call seconds into the CA LPT cost shelf.
+
+        LOUD on every outcome. Silent no-op is forbidden: a disabled shelf, a
+        failed write, or zero files resolved must announce mode=degraded so LPT
+        cold equal-count is visible (not a clean pretend that the prior exists).
+        """
+        measured = len(self._file_duration_s)
         if not self._file_duration_s:
+            narrate(
+                "JOB_LOG phase=lpt-prior-write population=suite-pytest "
+                "status=skipped reason=no-file-durations mode=no-write "
+                "degraded=equal-count-next-run"
+            )
             return
         try:
             from lpt_file_shards import ContentAddressedCostPrior
-        except ImportError:
+        except ImportError as error:
+            narrate(
+                "JOB_LOG phase=lpt-prior-write population=suite-pytest "
+                f"status=unavailable reason=ImportError:{error!s} "
+                "mode=no-write degraded=equal-count-next-run"
+            )
             return
         prior = ContentAddressedCostPrior()
         if not prior.enabled:
+            narrate(
+                "JOB_LOG phase=lpt-prior-write population=suite-pytest "
+                "status=prior-disabled root=None mode=no-write "
+                "degraded=equal-count-next-run "
+                "(SUGAR_LPT_PRIOR_DIR=off or no writable prior root)"
+            )
             return
         # nodeid file keys are usually relative to pytest rootdir (cwd).
         root = Path(self.config.rootpath)
         written = 0
+        unresolved = 0
         for file_key, cost in self._file_duration_s.items():
             candidates = [
                 root / file_key,
@@ -496,6 +519,7 @@ class SuiteReporter:
                 )
             path = next((p for p in candidates if p.is_file()), None)
             if path is None:
+                unresolved += 1
                 continue
             if prior.put_for_path(
                 path,
@@ -504,9 +528,18 @@ class SuiteReporter:
                 path_hint=file_key,
             ):
                 written += 1
+        if written == 0:
+            narrate(
+                "JOB_LOG phase=lpt-prior-write population=suite-pytest "
+                f"status=zero-files-written files_measured={measured} "
+                f"unresolved_paths={unresolved} prior_root={prior.root} "
+                "mode=no-write degraded=equal-count-next-run"
+            )
+            return
         narrate(
-            f"JOB_LOG phase=lpt-prior-write population=suite-pytest "
-            f"files_written={written} files_measured={len(self._file_duration_s)}"
+            "JOB_LOG phase=lpt-prior-write population=suite-pytest "
+            f"status=ok files_written={written} files_measured={measured} "
+            f"unresolved_paths={unresolved} prior_root={prior.root} mode=write-through"
         )
 
 

--- a/tools/python_package_suite_report.py
+++ b/tools/python_package_suite_report.py
@@ -35,6 +35,7 @@ import platform
 import random
 import sys
 import time
+from pathlib import Path
 
 # Phase of a report that failed decides failure-vs-error, the same split the
 # terminal summary shows: a call-phase failure is a FAILED test, a setup- or
@@ -310,7 +311,18 @@ class SuiteReporter:
             self._beat = None
         # Write content-addressed LPT prior so the NEXT run packs by measured
         # cost (cold equal-count seeds the shelf; second run is LPT).
-        self._write_lpt_prior()
+        # Never let prior write fail the suite report — missing import or shelf
+        # IO must not kill suite-report.json (freeze tip: NameError on Path).
+        try:
+            self._write_lpt_prior()
+        except Exception as error:  # noqa: BLE001 — report is load-bearing
+            try:
+                narrate(
+                    f"JOB_LOG phase=lpt-prior-write status=failed "
+                    f"error={type(error).__name__}:{error!s}"
+                )
+            except Exception:  # noqa: BLE001
+                pass
         path = self.config.getoption("--suite-report")
         if not path:
             return


### PR DESCRIPTION
## Summary

`_write_lpt_prior` used `Path` without importing it (#7040). When the CA prior shelf is **enabled** (GHA default), `pytest_sessionfinish` NameError'd **after** green tests and **before** `suite-report.json` — package-suite never spoke.

Also: prior write had been a silent no-op when disabled, so cold equal-count looked fine for weeks.

## Changes

1. `from pathlib import Path`
2. **try/except** around prior write — cost optimisation cannot destroy suite-report testimony
3. **Loud degrade** — every prior-write outcome named on job log; assign tags `equal-count-prior-disabled` vs empty-shelf equal-count
4. **Teeth** — import Path; plant exception in prior → sessionfinish still writes suite-report.json

## Validation

```
pytest tests/test_suite_report_lpt_prior_import.py tests/test_lpt_file_shards.py -q
# 9 passed
```

## Queue

Land **after** #7051 (floor residual emission). No heavy jobs from this PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden LPT prior path import, loud degradation narration, and suite-report resilience to prior failure
> - [`python_package_suite_report.py`](https://github.com/TSavo/sugar/pull/7052/files#diff-3411b9f5ad80bc5885a1bb8107067510f62372210ed5e8dac63f162e2dbe4af4) adds `from pathlib import Path` and wraps `_write_lpt_prior()` in a try/except so exceptions no longer block suite-report writing; a `phase=lpt-prior-write status=failed` JOB_LOG line is emitted on failure.
> - `SuiteReporter._write_lpt_prior` now narrates all outcomes explicitly (skipped, import unavailable, prior disabled, zero files written, successful write) instead of silently returning.
> - [`lpt_file_shards.py`](https://github.com/TSavo/sugar/pull/7052/files#diff-a8360708a4131eb96fd754a94e07ab71a39edcb310f70cc99b391b04f65881cf) distinguishes `equal-count-prior-disabled` from `equal-count` in `ShardAssignment.mode` and emits richer JOB_LOG degradation lines with mode, counts, and reason.
> - New tests in [`test_suite_report_lpt_prior_import.py`](https://github.com/TSavo/sugar/pull/7052/files#diff-dcf747616e334e1bcb01dab3abaf2b509a398f237f913f41542730f94126dafe) cover Path import presence, `_write_lpt_prior` definition, report survival when prior raises, and loud narration on disabled shelf.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93d9376.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->