### PR TITLE
Fix FunctionDef-as-ClassDef allocation AttributeError (unblinds recensus)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1049,39 +1049,17 @@ class SourceUnit:
             ):
                 return None
 
-            # Nested definitions are owned by the containing function, not by
-            # module_direct_bindings.  Resolve only an earlier same-name
-            # definition in this exact lexical body; foreign scopes and
-            # post-call definitions remain loud.
-            owner_span = owner.line_col_span()
-            nested = [
-                candidate
-                for candidate in self.function_nodes
-                if candidate.name == call.func.id
-                and (
-                    candidate.line_col_span().start_line,
-                    candidate.line_col_span().start_col,
-                )
-                >= (owner_span.start_line, owner_span.start_col)
-                and (
-                    candidate.line_col_span().end_line,
-                    candidate.line_col_span().end_col,
-                )
-                <= (owner_span.end_line, owner_span.end_col)
-                and (
-                    candidate.line_col_span().start_line,
-                    candidate.line_col_span().start_col,
-                )
-                < (span.start_line, span.start_col)
-            ]
-            if nested:
-                return max(
-                    nested,
-                    key=lambda item: (
-                        item.line_col_span().start_line,
-                        item.line_col_span().start_col,
-                    ),
-                )
+            # Do NOT resolve "nested" names from function_nodes here.
+            # function_nodes is FunctionDef/AsyncFunctionDef only — never ClassDef.
+            # Returning a FunctionDef as an allocation definition made
+            # source_class_has_authenticated_default_attribute_behavior call
+            # ClassDef._authenticated_new_constructor_shape on a FunctionDef
+            # (recursive Name-calls: def f: f(...) — the enclosing FunctionDef
+            # matched as a "prior nested" same-name definition). That AttributeError
+            # blinded recensus (instrument-defect) and factory_walk auditor-errors
+            # on real pandas (e.g. io/json/_normalize.py recursive normalize).
+            # Nested ClassDef allocation is not enrolled via function_nodes; module
+            # ClassDef bindings below remain the sole allocation door.
 
         bindings = (self.module_direct_bindings or {}).get(call.func.id, ())
         if len(bindings) != 1 or not isinstance(bindings[0], ClassDef):
@@ -1186,6 +1164,10 @@ class SourceUnit:
         definition: "ClassDef",
     ) -> bool:
         """Whether ordinary attribute storage/lookup is source-constructed."""
+        # Defense in depth: allocation definition must be ClassDef. A FunctionDef
+        # here is not "no default attributes" — it is not an allocation at all.
+        if not isinstance(definition, ClassDef):
+            return False
         if definition._authenticated_new_constructor_shape() is not None:
             return True
         forbidden_methods = {

--- a/implementations/python/sugar-source-tree/tests/test_allocation_definition_not_functiondef.py
+++ b/implementations/python/sugar-source-tree/tests/test_allocation_definition_not_functiondef.py
@@ -1,0 +1,142 @@
+"""Allocation definitions are ClassDef only — never FunctionDef.
+
+Regression: recursive Name-calls (def f: ... f(...)) used to make
+``source_allocation_definition_for_call`` return the enclosing FunctionDef from
+``function_nodes``. Callers then invoked ClassDef-only
+``_authenticated_new_constructor_shape`` → AttributeError, blinding recensus
+(instrument-defect) and factory_walk on real pandas (e.g. _normalize.py:267).
+"""
+
+from __future__ import annotations
+
+from sugar_source_tree.nodes import Call, ClassDef, FunctionDef, Name
+from sugar_source_tree.tree import SourceFile
+
+
+def _source_file(source: str) -> SourceFile:
+    from sugar_lift_python_source.canonical import blake3_512_of
+
+    return SourceFile(
+        (source, "allocation_fixture.py", blake3_512_of(source.encode("utf-8"))),
+    )
+
+
+def test_recursive_name_call_is_not_an_allocation_definition() -> None:
+    """Recursive self-call must not resolve as a ClassDef allocation."""
+    source = _source_file(
+        "def f(n):\n"
+        "    if n:\n"
+        "        return f(n - 1)\n"
+        "    return 0\n"
+        "\n"
+        "f(2)\n"
+    )
+    recursive_calls = [
+        node
+        for node in source.nodes()
+        if isinstance(node, Call)
+        and isinstance(node.func, Name)
+        and node.func.id == "f"
+    ]
+    assert recursive_calls, "expected Name-call(s) to f"
+    for call in recursive_calls:
+        definition = call.unit.source_allocation_definition_for_call(call)
+        assert definition is None, (
+            f"allocation must not return FunctionDef for recursive call; "
+            f"got {type(definition).__name__} "
+            f"name={getattr(definition, 'name', None)!r}"
+        )
+        assert not isinstance(definition, FunctionDef)
+
+
+def test_source_allocation_definition_never_returns_functiondef() -> None:
+    """Codomain law: allocation door is ClassDef | None, never FunctionDef."""
+    source = _source_file(
+        "def helper(x):\n"
+        "    return helper(x) if x else 0\n"
+        "\n"
+        "class Box:\n"
+        "    def __init__(self, value):\n"
+        "        self.value = value\n"
+        "\n"
+        "def outer():\n"
+        "    return Box(1)\n"
+        "\n"
+        "helper(1)\n"
+        "outer()\n"
+        "Box(2)\n"
+    )
+    for call in (node for node in source.nodes() if isinstance(node, Call)):
+        definition = call.unit.source_allocation_definition_for_call(call)
+        assert definition is None or isinstance(definition, ClassDef)
+        assert not isinstance(definition, FunctionDef)
+
+
+def test_module_class_call_still_resolves_classdef_allocation() -> None:
+    """Truthful twin: ordinary module ClassDef call remains authenticated."""
+    source = _source_file(
+        "class Box:\n"
+        "    def __init__(self, value):\n"
+        "        self.value = value\n"
+        "\n"
+        "Box(11)\n"
+    )
+    call = next(
+        node
+        for node in source.nodes()
+        if isinstance(node, Call)
+        and isinstance(node.func, Name)
+        and node.func.id == "Box"
+    )
+    definition = call.unit.source_allocation_definition_for_call(call)
+    assert isinstance(definition, ClassDef)
+    assert definition.name == "Box"
+    assert call.unit.source_class_has_authenticated_default_attribute_behavior(
+        definition
+    )
+
+
+def test_recursive_name_call_sugar_does_not_raise_authenticated_new_shape() -> None:
+    """Integration: Call.sugar on recursive Name-call must not AttributeError.
+
+    This is the path recensus/factory_walk hit (Call.sugar|construction|...).
+    Full Module.sugar may still be incomplete for other reasons; the forbidden
+    signal is AttributeError: _authenticated_new_constructor_shape.
+    """
+    source = _source_file(
+        "def f(n):\n"
+        "    if n:\n"
+        "        return f(n - 1)\n"
+        "    return 0\n"
+        "\n"
+        "f(2)\n"
+    )
+    recursive_calls = [
+        node
+        for node in source.nodes()
+        if isinstance(node, Call)
+        and isinstance(node.func, Name)
+        and node.func.id == "f"
+    ]
+    assert recursive_calls
+    for call in recursive_calls:
+        try:
+            call.sugar()
+        except AttributeError as exc:
+            assert str(exc) != "_authenticated_new_constructor_shape", (
+                "recursive Name-call must not trip ClassDef-only method on FunctionDef"
+            )
+            raise
+
+
+def test_functiondef_is_not_authenticated_default_attribute_class() -> None:
+    """Defense: source_class_has_* refuses non-ClassDef without AttributeError."""
+    source = _source_file("def f():\n    return 1\n")
+    function = next(node for node in source.nodes() if isinstance(node, FunctionDef))
+    # Would AttributeError before the isinstance guard.
+    assert (
+        function.unit.source_class_has_authenticated_default_attribute_behavior(
+            function  # type: ignore[arg-type]
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary

Recursive Name-calls (`def f: ... f(...)`) made `source_allocation_definition_for_call` return a **FunctionDef** from `function_nodes`. Callers then invoked ClassDef-only `_authenticated_new_constructor_shape` → `AttributeError`, recorded as recensus `instrument-defect-unresolvable-dispatch` (counter ~74) and factory_walk auditor-errors on real pandas (exact site: `io/json/_normalize.py:267` `Call.sugar|construction`).

## Fix

- Stop resolving allocation from `function_nodes` (FunctionDef only; never ClassDef).
- `isinstance(definition, ClassDef)` guard on `source_class_has_authenticated_default_attribute_behavior`.
- Focused twins: recursive call is not allocation; never returns FunctionDef; module ClassDef still authenticates; Call.sugar on recursive call does not AttributeError; FunctionDef refused by guard.

## Shell deleted

This promotes “allocation definition is ClassDef” into the resolution door + isinstance guard. The AttributeError symptom for this cause becomes unrepresentable for the FunctionDef misroute. Does not yet seal full `R_instrument_blind` for all defect families.

## Validation

```
pytest implementations/python/sugar-source-tree/tests/test_allocation_definition_not_functiondef.py -v --noconftest
# 5 passed
```

No heavy measurement fired (recensus still walking).

## Epsilon R

- Predicted: instrument-defect rows caused by `_authenticated_new_constructor_shape` on recursive Name-calls → 0 after next recensus on a tip that includes this.
- Does not claim population membrane or LPT.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AttributeError` when a `FunctionDef` is resolved as an allocation definition
> - `SourceUnit.source_allocation_definition_for_call` no longer looks up same-name nested definitions in `function_nodes`; that set only tracks `FunctionDef`/`AsyncFunctionDef`, never `ClassDef`, so using it to resolve allocation definitions was incorrect. The method now only considers `module_direct_bindings`.
> - `SourceUnit.source_class_has_authenticated_default_attribute_behavior` adds an `isinstance` guard so non-`ClassDef` inputs return `False` instead of raising `AttributeError` on a `ClassDef`-only method call.
> - Regression tests in [`test_allocation_definition_not_functiondef.py`](https://github.com/TSavo/sugar/pull/7053/files#diff-71eaf8603d3099af47723c8389d9584c0a1128b300eff74d679fdd3f0a3e8cc5) cover recursive Name-calls, the `ClassDef`-or-`None` codomain law, and the `AttributeError` fix.
> - Behavioral Change: recursive or nested function Name-calls now return `None` from `source_allocation_definition_for_call` instead of resolving to the enclosing `FunctionDef`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 974e1d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->