### PR TITLE
Recensus: persist file-open phase timers and module materialize counts

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -606,12 +606,16 @@ def _measure_file(
 ) -> dict[str, Any]:
     from sugar_lift_py_tests.audit_only import collect_construction_panic
     from sugar_lift_py_tests.desugar_axis import DesugarAxis
-    from sugar_lift_py_tests.lift_rpc import (
-        open_source_file_for_construction,
-        tree_construction_context_for_workspace,
+    from sugar_lift_py_tests.lift_rpc import tree_construction_context_for_workspace
+    from sugar_lift_python_source.source_oracle import workspace_path_source
+    from sugar_source_tree.file_open_profile import (
+        begin_file_open_profile,
+        end_file_open_profile,
+        summarize_module_materialize,
     )
     from sugar_source_tree.panic import SugarNotWritten
     from sugar_source_tree.reporter import CollectingReporter
+    from sugar_source_tree.tree import SourceFile
 
     functions_total = 0
     functions_clean = 0
@@ -622,6 +626,20 @@ def _measure_file(
     cm_resolutions: Counter[str] = Counter()
     unrecognized_cm_kinds: Counter[str] = Counter()
     desugar_axis = DesugarAxis()
+    # Phase timers — measured live and PERSISTED (running-counts + row), not
+    # only painted on the progress bar and thrown away.
+    timing: dict[str, Any] = {
+        "t_context_s": 0.0,
+        "t_open_s": 0.0,
+        "t_populate_s": 0.0,
+        "t_cm_tally_s": 0.0,
+        "t_enumerate_s": 0.0,
+        "t_sugar_loop_s": 0.0,
+        "t_gap_tally_s": 0.0,
+        "slowest_fn": None,
+        "slowest_fn_s": 0.0,
+        "sugar_fn_count": 0,
+    }
     if workspace_root is None:
         # No silent ``path.parent``. That default made a one-file run derive its
         # demand table from a DIFFERENT tree than the full run, so the same file
@@ -652,39 +670,67 @@ def _measure_file(
         reporter = CollectingReporter()
         # Fresh context per file so source_derived refs stay file-local; the
         # demand/gap table (contract_refs) may be shared across the census.
+        t0 = time.perf_counter()
         construction_context = tree_construction_context_for_workspace(
             root, contract_refs=contract_refs
         )
+        timing["t_context_s"] = round(time.perf_counter() - t0, 6)
+
+        # Split open vs populate so a slow file names which phase owns the 85s.
+        # Same production path as open_source_file_for_construction; timed.
+        t0 = time.perf_counter()
         try:
-            source_file = open_source_file_for_construction(
-                path,
-                root=address_root,
+            source_file = SourceFile(
+                workspace_path_source(str(path), root=str(address_root)),
                 reporter=reporter,
                 construction_context=construction_context,
-                populate_derived=True,
+            )
+        except SugarNotWritten as gap:
+            timing["t_open_s"] = round(time.perf_counter() - t0, 6)
+            tally_construction(type(gap).__name__, line=0)
+            return reporter
+        timing["t_open_s"] = round(time.perf_counter() - t0, 6)
+
+        t0 = time.perf_counter()
+        try:
+            from sugar_lift_python_source.manager_summary_derivation import (
+                populate_source_derived_resource_refs,
+            )
+
+            populate_source_derived_resource_refs(
+                source_file, root=address_root, path=path
             )
         except SugarNotWritten as gap:
             # Derivation can hit a real missing sugar before any function walk.
+            timing["t_populate_s"] = round(time.perf_counter() - t0, 6)
             tally_construction(type(gap).__name__, line=0)
             return reporter
+        timing["t_populate_s"] = round(time.perf_counter() - t0, 6)
+
         # Effective resolution set for THIS source unit only: source-derived
         # over contract_refs (same door as With construction). Never tally the
         # whole shared provisional table without source_cid — that multiplies.
+        t0 = time.perf_counter()
         file_cm_resolutions, file_unrecognized_kinds = _tally_cm_resolutions(
             construction_context,
             source_cid=source_file.unit.source_cid,
         )
         cm_resolutions.update(file_cm_resolutions)
         unrecognized_cm_kinds.update(file_unrecognized_kinds)
+        timing["t_cm_tally_s"] = round(time.perf_counter() - t0, 6)
+
         # Materialize the function population BEFORE the per-function walk.
         # ConstructionPanic is BaseException and escapes this loop; if we
         # increment functions_total inside the loop, a mid-file panic freezes a
         # PARTIAL denominator that is later summed into the board, and Clean%
         # is computed over a silently shrunken set. The full declared count is
         # the denominator; enumeration progress is a separate measurement.
+        t0 = time.perf_counter()
         declared_functions = tuple(source_file.functions())
+        timing["t_enumerate_s"] = round(time.perf_counter() - t0, 6)
         functions_total = len(declared_functions)
         functions_enumerated = 0
+        t_sugar = time.perf_counter()
         for function in declared_functions:
             functions_enumerated += 1
             try:
@@ -711,21 +757,49 @@ def _measure_file(
             if sugar is not None:
                 desugar_axis.measure(sugar, where=where)
             fn_s = time.perf_counter() - t_fn
+            timing["sugar_fn_count"] = functions_enumerated
+            if fn_s >= float(timing["slowest_fn_s"] or 0.0):
+                timing["slowest_fn_s"] = round(fn_s, 6)
+                timing["slowest_fn"] = fn_name
             # Report completion WITH this function's own construction time, so
             # `last=` is per-function and a slow/blowup function is obvious.
             if on_function is not None:
                 on_function(functions_enumerated, functions_clean, fn_name, fn_s)
+        timing["t_sugar_loop_s"] = round(time.perf_counter() - t_sugar, 6)
         # Sole construction-gap source: reporter occurrences, site-deduped.
         # BackendDefect is table hygiene — own counter, never construction R.
+        t0 = time.perf_counter()
         for node, panic in reporter.gaps:
             kind = type(panic).__name__
             if kind == "BackendDefect" or "BackendDefect" in kind:
                 backend_defects[_backend_defect_key(panic)] += 1
                 continue
             tally_construction(kind, node=node)
+        timing["t_gap_tally_s"] = round(time.perf_counter() - t0, 6)
         return reporter
 
-    _reporter, panic_row = collect_construction_panic(relative, construct)
+    profile_bag = begin_file_open_profile()
+    try:
+        _reporter, panic_row = collect_construction_panic(relative, construct)
+    finally:
+        end_file_open_profile()
+    module_summary = summarize_module_materialize(profile_bag)
+    timing["module_materialize"] = module_summary
+    # Dominant phase for one-line cause naming (excludes nested module time
+    # which is already inside t_populate / t_open when materialize runs there).
+    phase_seconds = {
+        "context": float(timing["t_context_s"]),
+        "open": float(timing["t_open_s"]),
+        "populate": float(timing["t_populate_s"]),
+        "cm_tally": float(timing["t_cm_tally_s"]),
+        "enumerate": float(timing["t_enumerate_s"]),
+        "sugar_loop": float(timing["t_sugar_loop_s"]),
+        "gap_tally": float(timing["t_gap_tally_s"]),
+    }
+    dominant = max(phase_seconds.items(), key=lambda item: item[1])
+    timing["dominant_phase"] = dominant[0]
+    timing["dominant_phase_s"] = round(dominant[1], 4)
+
     # Two quantities, never one column: resolution residual (R-bearing) and AST
     # site prevalence (denominator, never R).
     resolution_row = {
@@ -743,6 +817,7 @@ def _measure_file(
         "functionsEnumerationComplete": functions_not_enumerated == 0
         and (panic_row is None or functions_total == functions_enumerated),
     }
+    timing_row = {"timing": timing}
     if panic_row is not None:
         # File-level ConstructionPanic is BaseException: it escapes construct()
         # via collect_construction_panic and never lands in reporter.gaps, so
@@ -766,6 +841,7 @@ def _measure_file(
             "R_backend_defects": sum(backend_defects.values()),
             **resolution_row,
             **desugar_axis.row(),
+            **timing_row,
         }
     return {
         "category": "completed",
@@ -775,6 +851,7 @@ def _measure_file(
         "R_backend_defects": sum(backend_defects.values()),
         **resolution_row,
         **desugar_axis.row(),
+        **timing_row,
     }
 
 
@@ -1418,6 +1495,11 @@ def main() -> int:
 
                 # Durable running counts — crash at file 900 still leaves 899 rows
                 # on checkpoint AND a jsonl tail of counts on stdout-equivalent disk.
+                # Phase timers + module materialize counts PERSIST here (not only
+                # on the progress bar — that was measured, displayed, thrown away).
+                row_timing = row.get("timing") if isinstance(row, dict) else None
+                if not isinstance(row_timing, dict):
+                    row_timing = {}
                 running = {
                     "schema": "control-effect-recensus-running-v1",
                     "index": live_done,
@@ -1433,6 +1515,18 @@ def main() -> int:
                     "fn_clean": live_clean,
                     "fn_total": live_fns,
                     "phase": "per_file_lift",
+                    "t_open_s": row_timing.get("t_open_s"),
+                    "t_populate_s": row_timing.get("t_populate_s"),
+                    "t_enumerate_s": row_timing.get("t_enumerate_s"),
+                    "t_sugar_loop_s": row_timing.get("t_sugar_loop_s"),
+                    "t_context_s": row_timing.get("t_context_s"),
+                    "t_cm_tally_s": row_timing.get("t_cm_tally_s"),
+                    "t_gap_tally_s": row_timing.get("t_gap_tally_s"),
+                    "dominant_phase": row_timing.get("dominant_phase"),
+                    "dominant_phase_s": row_timing.get("dominant_phase_s"),
+                    "slowest_fn": row_timing.get("slowest_fn"),
+                    "slowest_fn_s": row_timing.get("slowest_fn_s"),
+                    "module_materialize": row_timing.get("module_materialize"),
                 }
                 with running_counts_path.open("a", encoding="utf-8") as rc_stream:
                     rc_stream.write(
@@ -1440,15 +1534,31 @@ def main() -> int:
                         + "\n"
                     )
                     rc_stream.flush()
+                # One-line cause for slow files (always for first/last/every-N,
+                # and always when wall exceeds 5s so a long open names its phase).
+                slow = file_s >= 5.0
                 if (
                     live_done == 1
                     or live_done % _PROGRESS_EVERY_N == 0
                     or live_done == len(file_names)
+                    or slow
                 ):
+                    mm = row_timing.get("module_materialize") or {}
                     _narrate(
                         "RECENSUS FILE END "
                         f"{live_done}/{len(file_names)} file={relative} "
                         f"category={cat} file_s={file_s:.3f} "
+                        f"dominant={row_timing.get('dominant_phase')}:"
+                        f"{row_timing.get('dominant_phase_s')}s "
+                        f"open={row_timing.get('t_open_s')}s "
+                        f"populate={row_timing.get('t_populate_s')}s "
+                        f"enumerate={row_timing.get('t_enumerate_s')}s "
+                        f"sugar_loop={row_timing.get('t_sugar_loop_s')}s "
+                        f"slowest_fn={row_timing.get('slowest_fn')}:"
+                        f"{row_timing.get('slowest_fn_s')}s "
+                        f"mod_mat_calls={mm.get('materializeCalls')} "
+                        f"mod_mat_s={mm.get('materialize_s')} "
+                        f"mod_top={mm.get('top')} "
                         f"elapsed_s={time.time() - started:.1f} "
                         f"snw={live_snw} other_gaps={live_other_gaps} "
                         f"cpanic={live_panic} defect={live_defect} "

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_file_open_profile.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_file_open_profile.py
@@ -1,0 +1,89 @@
+"""File-open phase timers persist — not only painted then thrown away."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+SCRIPT = _SCRIPTS / "control_effect_recensus.py"
+
+
+def _load():
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    spec = importlib.util.spec_from_file_location("control_effect_recensus", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_measure_file_persists_phase_timers(tmp_path: Path) -> None:
+    module = _load()
+    path = tmp_path / "mod.py"
+    path.write_text(
+        "def a():\n    return 1\n\ndef b():\n    return 2\n",
+        encoding="utf-8",
+    )
+    row = module._measure_file(path, relative="mod.py", workspace_root=tmp_path)
+    assert row["category"] == "completed"
+    timing = row["timing"]
+    for key in (
+        "t_open_s",
+        "t_populate_s",
+        "t_enumerate_s",
+        "t_sugar_loop_s",
+        "dominant_phase",
+        "module_materialize",
+    ):
+        assert key in timing, timing
+    assert timing["sugar_fn_count"] == 2
+    assert timing["module_materialize"]["materializeCalls"] >= 0
+    # Phase seconds are non-negative and finite.
+    assert float(timing["t_open_s"]) >= 0.0
+    assert float(timing["t_sugar_loop_s"]) >= 0.0
+
+
+def test_running_counts_line_includes_timing_fields(tmp_path: Path) -> None:
+    """End-to-end: running-counts.jsonl carries phase breakdown for each file."""
+    module = _load()
+    from pandas_floor_summary import corpus_cid
+    from sugar_lift_py_tests.corpus_pin import pin_corpus
+
+    root = tmp_path / "pkg"
+    root.mkdir()
+    (root / "a.py").write_text("def a():\n    return 1\n", encoding="utf-8")
+    observed = pin_corpus(root, distribution=root.name, version="test-pin")
+    module._PANDAS_3_0_3_AGGREGATE_HASH = observed.aggregate_hash
+    module._PANDAS_3_0_3_MANIFEST_SHAPE_CID = corpus_cid(list(observed.paths))
+    out = tmp_path / "out"
+    saved = sys.argv
+    sys.argv = [
+        "control_effect_recensus.py",
+        str(root),
+        "--corpus-root",
+        str(root),
+        "--corpus-version",
+        "test-pin",
+        "--commit",
+        "profile-tip",
+        "--out-dir",
+        str(out),
+    ]
+    try:
+        code = module.main()
+    finally:
+        sys.argv = saved
+    assert code in (0, 1)
+    lines = (out / "running-counts.jsonl").read_text(encoding="utf-8").splitlines()
+    assert lines, "running-counts.jsonl must have at least one file row"
+    row = json.loads(lines[-1])
+    assert "t_open_s" in row
+    assert "t_populate_s" in row
+    assert "t_sugar_loop_s" in row
+    assert "dominant_phase" in row
+    assert "module_materialize" in row
+    assert row["file_s"] is not None

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -663,6 +663,27 @@ class Backend:
         reporter: AuditReporter = NULL_REPORTER,
     ) -> _ConstructedModuleV1:
         """Construct and close one module product in one eager traversal."""
+        from .file_open_profile import _TimedModuleMaterialize, current_file_open_profile
+
+        # Profile only when a file-open instrument is active (recensus etc.).
+        profile = current_file_open_profile()
+        if profile is not None:
+            # Prefer human path; fall back to content address.
+            module_key = str(
+                getattr(unit, "filename", None)
+                or getattr(unit, "path", None)
+                or getattr(unit, "source_cid", "unknown")
+            )
+            with _TimedModuleMaterialize(module_key):
+                return self._materialize_module_body(unit, reporter)
+        return self._materialize_module_body(unit, reporter)
+
+    def _materialize_module_body(
+        self,
+        unit: SourceUnit,
+        reporter: AuditReporter = NULL_REPORTER,
+    ) -> _ConstructedModuleV1:
+        """Inner materialize_module body (timed when profile is active)."""
         from .nodes import (
             Assert,
             Assign,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/file_open_profile.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/file_open_profile.py
@@ -1,0 +1,97 @@
+"""Optional per-file-open profile for construction cost attribution.
+
+Enabled only while a recensus (or other instrument) holds the contextvar.
+Default is off — zero cost when unset. materialize_module records count+time
+per module identity so a slow open names which dependency rebuilds dominate.
+"""
+
+from __future__ import annotations
+
+import time
+from contextvars import ContextVar
+from typing import Any
+
+# None = profiling off (production default).
+_PROFILE: ContextVar[dict[str, Any] | None] = ContextVar(
+    "sugar_source_tree_file_open_profile", default=None
+)
+
+
+def begin_file_open_profile() -> dict[str, Any]:
+    """Start a profile bag for one file open; return it for the caller to fill."""
+    bag: dict[str, Any] = {
+        "module_materialize": {},  # module_key -> {count, s}
+    }
+    _PROFILE.set(bag)
+    return bag
+
+
+def current_file_open_profile() -> dict[str, Any] | None:
+    return _PROFILE.get()
+
+
+def end_file_open_profile() -> dict[str, Any] | None:
+    """Clear the contextvar; return the bag (or None if never begun)."""
+    bag = _PROFILE.get()
+    _PROFILE.set(None)
+    return bag
+
+
+def record_module_materialize(module_key: str, elapsed_s: float) -> None:
+    """Accumulate one materialize_module completion into the active profile."""
+    bag = _PROFILE.get()
+    if bag is None:
+        return
+    table = bag.setdefault("module_materialize", {})
+    row = table.get(module_key)
+    if row is None:
+        table[module_key] = {"count": 1, "s": round(elapsed_s, 6)}
+    else:
+        row["count"] = int(row["count"]) + 1
+        row["s"] = round(float(row["s"]) + elapsed_s, 6)
+
+
+def summarize_module_materialize(bag: dict[str, Any] | None) -> dict[str, Any]:
+    """Compact top offenders for running-counts (not the full map)."""
+    if not bag:
+        return {
+            "modulesDistinct": 0,
+            "materializeCalls": 0,
+            "materialize_s": 0.0,
+            "top": [],
+        }
+    table = bag.get("module_materialize") or {}
+    total_calls = 0
+    total_s = 0.0
+    ranked: list[tuple[str, int, float]] = []
+    for key, row in table.items():
+        c = int(row.get("count") or 0)
+        s = float(row.get("s") or 0.0)
+        total_calls += c
+        total_s += s
+        ranked.append((str(key), c, s))
+    ranked.sort(key=lambda item: (-item[2], -item[1], item[0]))
+    top = [
+        {"module": key, "count": c, "s": round(s, 4)} for key, c, s in ranked[:8]
+    ]
+    return {
+        "modulesDistinct": len(table),
+        "materializeCalls": total_calls,
+        "materialize_s": round(total_s, 4),
+        "top": top,
+    }
+
+
+class _TimedModuleMaterialize:
+    """Context manager: time one materialize_module and record it."""
+
+    def __init__(self, module_key: str) -> None:
+        self.module_key = module_key
+        self._t0 = 0.0
+
+    def __enter__(self) -> "_TimedModuleMaterialize":
+        self._t0 = time.perf_counter()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        record_module_materialize(self.module_key, time.perf_counter() - self._t0)


### PR DESCRIPTION
## Problem

Recensus already computed per-function timing and showed it on the live bar, then persisted **only** `file_s`. An 85s file open could not say whether the cost was open, populate, sugar_loop, or repeated module materialize without another full investigation day.

## Fix

Phase timers **persist** to `running-counts.jsonl` and the per-file result `timing` object:

| Field | Meaning |
| --- | --- |
| `t_open_s` | SourceFile construction |
| `t_populate_s` | `populate_source_derived_resource_refs` |
| `t_enumerate_s` | `tuple(functions())` |
| `t_sugar_loop_s` | per-function sugar + desugar |
| `t_context_s` / `t_cm_tally_s` / `t_gap_tally_s` | context + CM tally + gap pass |
| `dominant_phase` / `dominant_phase_s` | max phase for one-line cause |
| `slowest_fn` / `slowest_fn_s` | kept, not discarded |
| `module_materialize` | `{modulesDistinct, materializeCalls, materialize_s, top[]}` |

Source-tree: optional `file_open_profile` contextvar records each `materialize_module` (count + time per module key). Off by default — zero cost when recensus is not profiling.

Narration: FILE END always includes the breakdown for first/last/every-N and for any file with `file_s >= 5`.

## Not this PR

- Population membrane / dependency-seat memo (priority #1 campaign)
- clean% attribution / R_instrument_blind
- No heavy job fire

## Test plan

- [x] `_measure_file` returns timing phases
- [x] `running-counts.jsonl` carries phase fields after a tiny recensus

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist per-phase timers and module materialize counts in recensus file processing
> - Adds a new `file_open_profile` module with a `ContextVar`-based API to track and summarize module materialization timings per file-open operation.
> - Instruments `_measure_file` in [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/7054/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) to time each processing phase (context creation, file open, populate, cm tally, function enumeration, sugar loop, gap tally) and return results in a `"timing"` key.
> - Wraps `Backend.materialize_module` in [backend.py](https://github.com/TSavo/sugar/pull/7054/files#diff-ad498e547096dff0cc0a35d78feaa867418d745ad78531faf3f78b5e835414b8) with a timed context manager when a file-open profile is active, recording per-module materialization counts and durations.
> - Persists timing fields (dominant phase, slowest function, module materialize summary, etc.) into each `running-counts.jsonl` entry and includes them in `RECENSUS FILE END` log lines for slow files (≥5s).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f6505b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->