### PR TITLE
Retire serial recensus seal: LPT compose door + dual-belt attendance

### DIFF
--- a/.github/workflows/control-effect-recensus.yml
+++ b/.github/workflows/control-effect-recensus.yml
@@ -2,11 +2,11 @@ name: Control-effect recensus (authoritative scoreboard)
 
 # THE DEFECT THIS FIXES
 #
-# scripts/control_effect_recensus.py declares SCOREBOARD_AUTHORITY = True. It
-# is THE authoritative scoreboard -- every other instrument in the kit declares
-# False, and tests/test_one_authoritative_scoreboard.py pins that there is
-# exactly one. It is the sole producer of R_construction_panics and of the
-# desugar board that every drain is ranked against.
+# scripts/compose_control_effect_board.py declares SCOREBOARD_AUTHORITY = True
+# (sole seal door). The walk script control_effect_recensus.py is SCOREBOARD
+# False and always seals through compose (k=1 or LPT N). It is the sole
+# producer of R_construction_panics and of the desugar board that every drain
+# is ranked against.
 #
 # It appeared in NO WORKFLOW. Searching the repo for it returns docs, ledgers,
 # and two tests -- nothing that runs it. It was a hand-run tool.
@@ -104,24 +104,39 @@ jobs:
             --out-dir "$GITHUB_WORKSPACE/.sugar/pandas-control-effect"
           echo "recensus phase=measure status=done"
 
-      # Phase 3 — attendance body only after a completed measure step.
-      - name: "Phase: write attendance measurement body"
+      # Phase 3 — dual-belt attendance: only a sealed board (status=sealed,
+      # measured=true, bodyCid) credits control-effect-recensus. Do NOT write a
+      # thin measurement.json with measurementClass alone (that zeros R_attendance
+      # while the board is unmeasured — #7049 smoke shape).
+      - name: "Phase: verify sealed board for attendance"
         if: success()
         shell: bash
         run: |
           set -euo pipefail
           echo "recensus phase=attendance status=start"
           python -u -c "
-          import json, os
+          import json, sys
           from pathlib import Path
-          body = {
-              'schemaVersion': 1,
-              'measurementClass': 'control-effect-recensus',
-              'measuredCommit': os.environ.get('GITHUB_SHA'),
-              'status': 'completed',
-          }
-          Path('.sugar/pandas-control-effect/measurement.json').parent.mkdir(parents=True, exist_ok=True)
-          Path('.sugar/pandas-control-effect/measurement.json').write_text(json.dumps(body, indent=2)+chr(10))
+          p = Path('.sugar/pandas-control-effect/recensus.json')
+          if not p.is_file():
+              print('::error::sealed board missing at', p, file=sys.stderr)
+              sys.exit(1)
+          body = json.loads(p.read_text())
+          ok = (
+              body.get('measurementClass') == 'control-effect-recensus'
+              and body.get('status') == 'sealed'
+              and body.get('measured') is True
+              and body.get('bodyCid')
+          )
+          if not ok:
+              print('::error::board not sealed for attendance', {
+                  'measurementClass': body.get('measurementClass'),
+                  'status': body.get('status'),
+                  'measured': body.get('measured'),
+                  'bodyCid': bool(body.get('bodyCid')),
+              }, file=sys.stderr)
+              sys.exit(1)
+          print('recensus attendance sealed bodyCid=', body.get('bodyCid')[:24], '...')
           "
           echo "recensus phase=attendance status=done"
 

--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -1,0 +1,784 @@
+#!/usr/bin/env python3
+"""Sole seal door for the control-effect recensus board.
+
+SCOREBOARD_AUTHORITY = True lives HERE only. Workers
+(``control_effect_recensus.py``) are SCOREBOARD_AUTHORITY = False and emit
+partials (or a k=1 full-bin journal) that this module alone may mint as
+``measurementClass=control-effect-recensus``.
+
+Law (banked): R1–R6, dual-belt attendance, serial seal retired.
+  compose_control_effect_board(plan, partials) → SealedBoard | UnmeasuredEnvelope
+
+Partials: measurementClass=control-effect-recensus-shard; never top-level
+R_construction_panics. UNMEASURED envelope omits measurementClass entirely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+# Sole True declaration for the kit (test_one_authoritative_scoreboard).
+SCOREBOARD_AUTHORITY = True
+
+MEASUREMENT_CLASS_BOARD = "control-effect-recensus"
+MEASUREMENT_CLASS_SHARD = "control-effect-recensus-shard"
+KIND_SEALED = "control-effect-construction-recensus"
+KIND_UNMEASURED = "control-effect-recensus-unmeasured/v1"
+KIND_PARTIAL = "control-effect-recensus-shard-partial/v1"
+KIND_PLAN = "control-effect-recensus-shard-plan/v1"
+COMPOSE_SCHEMA = "control-effect-recensus-compose/v1"
+PARTIAL_SCHEMA = "control-effect-recensus-shard-partial/v1"
+PLAN_SCHEMA = "control-effect-recensus-shard-plan/v1"
+
+_PANDAS_3_0_3_AGGREGATE_HASH = (
+    "bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c"
+)
+_PANDAS_3_0_3_MANIFEST_SHAPE_CID = (
+    "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0"
+)
+
+_TOOLS = Path(__file__).resolve().parents[4] / "tools"
+if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
+
+def _blake3_512(data: bytes) -> str:
+    try:
+        import blake3  # type: ignore
+
+        return "blake3-512:" + blake3.blake3(data, max_threads=1).digest(64).hex()
+    except Exception:  # noqa: BLE001
+        return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def canonical_cid(obj: Mapping[str, Any]) -> str:
+    """Content id of a JSON-stable object (sort_keys, no host noise)."""
+    rendered = json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
+    return _blake3_512(rendered.encode("utf-8"))
+
+
+def shard_file_set_cid(files: Sequence[str]) -> str:
+    return _blake3_512("\n".join(sorted(files)).encode("utf-8"))
+
+
+def build_plan(
+    *,
+    enrolled_files: Sequence[str],
+    shard_count: int,
+    measured_commit: str,
+    aggregate_hash: str,
+    manifest_shape_cid: str,
+    bins: Sequence[Sequence[str]],
+    split_mode: str,
+    prior_hits: int,
+    prior_misses: int,
+    estimated_loads: Sequence[float],
+) -> dict[str, Any]:
+    enrolled = sorted(enrolled_files)
+    bin_lists = [list(b) for b in bins]
+    if len(bin_lists) != shard_count:
+        raise ValueError(
+            f"plan bins length {len(bin_lists)} != shard_count {shard_count}"
+        )
+    flat: list[str] = []
+    for b in bin_lists:
+        flat.extend(b)
+    if sorted(flat) != enrolled:
+        raise ValueError(
+            "plan bins must partition enrolledFiles (union equality failed)"
+        )
+    if len(flat) != len(set(flat)):
+        raise ValueError("plan bins must be pairwise disjoint (duplicate file)")
+    plan: dict[str, Any] = {
+        "schema": PLAN_SCHEMA,
+        "kind": KIND_PLAN,
+        "measuredCommit": measured_commit,
+        "aggregateHash": aggregate_hash,
+        "manifestShapeCid": manifest_shape_cid,
+        "shardCount": shard_count,
+        "splitMode": split_mode,
+        "priorHits": prior_hits,
+        "priorMisses": prior_misses,
+        "enrolledFiles": enrolled,
+        "bins": bin_lists,
+        "estimatedLoadS": [float(x) for x in estimated_loads],
+    }
+    plan["planCid"] = canonical_cid({k: v for k, v in plan.items() if k != "planCid"})
+    return plan
+
+
+def mint_partial(
+    *,
+    plan: Mapping[str, Any],
+    shard_index: int,
+    terminal_rows: Sequence[tuple[str, Mapping[str, Any]]],
+    measured_commit: str | None = None,
+    status: str = "completed",
+    unmeasured_reason: str | None = None,
+) -> dict[str, Any]:
+    """Mint a shard partial. Never includes R_construction_panics top-level."""
+    shard_count = int(plan["shardCount"])
+    if shard_index < 0 or shard_index >= shard_count:
+        raise ValueError(f"shard_index {shard_index} out of range for k={shard_count}")
+    assigned = list(plan["bins"][shard_index])
+    assigned_set = set(assigned)
+    terminals = [(f, dict(r)) for f, r in terminal_rows]
+    terminal_files = [f for f, _ in terminals]
+    missing = sorted(assigned_set - set(terminal_files))
+    extra = sorted(set(terminal_files) - assigned_set)
+    dups = sorted({f for f in terminal_files if terminal_files.count(f) > 1})
+    malformed = [
+        f
+        for f, raw in terminals
+        if not isinstance(raw, dict) or not raw.get("category")
+    ]
+    files_complete = (
+        not missing
+        and not extra
+        and not dups
+        and not malformed
+        and len(terminal_files) == len(assigned)
+    )
+    fn_total = sum(int((r or {}).get("functionsTotal") or 0) for _, r in terminals)
+    fn_clean = sum(int((r or {}).get("functionsClean") or 0) for _, r in terminals)
+
+    panics: list[dict[str, Any]] = []
+    families: Counter[str] = Counter()
+    instrument_defects: list[dict[str, Any]] = []
+    for file, raw in terminals:
+        cat = str(raw.get("category") or "")
+        families.update(raw.get("families") or {})
+        if cat == "construction-panic":
+            panic = raw.get("panic")
+            if isinstance(panic, dict):
+                panics.append(dict(panic))
+            elif "ConstructionPanic" not in (raw.get("families") or {}):
+                families["ConstructionPanic"] += 1
+        elif cat not in {"completed", ""}:
+            defect = raw.get("defect")
+            instrument_defects.append(
+                dict(defect)
+                if isinstance(defect, dict)
+                else {"file": file, "type": cat, "message": cat}
+            )
+
+    measured = status == "completed" and files_complete and unmeasured_reason is None
+    if not measured and unmeasured_reason is None:
+        unmeasured_reason = (
+            f"sub-population incomplete missing={missing} extra={extra} "
+            f"dups={dups} malformed={malformed}"
+        )
+        status = "unmeasured"
+
+    body: dict[str, Any] = {
+        "schema": PARTIAL_SCHEMA,
+        "kind": KIND_PARTIAL,
+        "measurementClass": MEASUREMENT_CLASS_SHARD,
+        "SCOREBOARD_AUTHORITY": False,
+        "measuredCommit": measured_commit or plan.get("measuredCommit"),
+        "planCid": plan["planCid"],
+        "aggregateHash": plan.get("aggregateHash"),
+        "manifestShapeCid": plan.get("manifestShapeCid"),
+        "shardIndex": shard_index,
+        "shardCount": shard_count,
+        "populationScope": {
+            "kind": "shard-bin",
+            "assignedFiles": assigned,
+            "assignedFileCount": len(assigned),
+        },
+        "shardFileSetCid": shard_file_set_cid(assigned),
+        "terminalFiles": terminal_files,
+        "terminalRows": [
+            {"file": f, "result": r} for f, r in terminals
+        ],
+        "subDenominator": {
+            "files": {
+                "enrolled": len(assigned),
+                "terminal": len(terminal_files),
+                "complete": files_complete,
+                "missingFiles": missing,
+                "extraFiles": extra,
+                "duplicateFiles": dups,
+                "malformedRows": malformed,
+            },
+            "functions": {
+                "total": fn_total,
+                "clean": fn_clean,
+                "unit": "construction-function-locus",
+            },
+        },
+        "shardResiduals": {
+            "constructionPanics": panics,
+            "families": dict(families),
+            "instrumentDefects": instrument_defects,
+            "R_construction_panics_shard": len(panics),
+        },
+        "status": status,
+        "measured": measured,
+        "unmeasuredReason": unmeasured_reason,
+    }
+    # Forbidden fields must never appear:
+    assert "R_construction_panics" not in body
+    body["partialCid"] = canonical_cid(
+        {k: v for k, v in body.items() if k != "partialCid"}
+    )
+    return body
+
+
+def aggregate_terminal_rows(
+    measured_rows: Sequence[tuple[str, Mapping[str, Any]]],
+    *,
+    enrolled_files: Sequence[str],
+    manifest_cid: str | None = None,
+) -> dict[str, Any]:
+    """Aggregate checkpoint-style (file, result) rows into residual counters.
+
+    Does not mint measurementClass or seal fields — compose does that.
+    """
+    file_names = list(enrolled_files)
+    terminal_files = [file for file, _ in measured_rows]
+    missing_files = sorted(set(file_names) - set(terminal_files))
+    duplicate_files = sorted(
+        {file for file in terminal_files if terminal_files.count(file) > 1}
+    )
+    malformed_rows = sorted(
+        file
+        for file, raw in measured_rows
+        if not isinstance(raw, dict) or not raw.get("category")
+    )
+
+    families: Counter[str] = Counter()
+    desugar_families: Counter[str] = Counter()
+    desugar_categories: Counter[str] = Counter()
+    desugar_by_category_owner: Counter[str] = Counter()
+    backend_defects: Counter[str] = Counter()
+    cm_resolutions: Counter[str] = Counter()
+    unrecognized_cm_kinds: Counter[str] = Counter()
+    ast_sites: Counter[str] = Counter()
+    desugar_construction_panics: list[dict[str, Any]] = []
+    desugar_defects: list[dict[str, Any]] = []
+    desugar_designed_gaps: list[dict[str, Any]] = []
+    unresolvable_dispatch: list[dict[str, Any]] = []
+    construction_panics: list[dict[str, Any]] = []
+    defects: list[dict[str, Any]] = []
+    floor_rows: list[dict[str, Any]] = []
+    files_completed = 0
+    functions_total = 0
+    functions_clean = 0
+
+    for file, raw in measured_rows:
+        row = dict(raw)
+        category = str(row.get("category"))
+        floor_rows.append({"file": file, "category": category})
+        functions_total += int(row.get("functionsTotal") or 0)
+        functions_clean += int(row.get("functionsClean") or 0)
+        families.update(row.get("families") or {})
+        desugar_families.update(row.get("desugarFamilies") or {})
+        desugar_categories.update(row.get("desugarCategories") or {})
+        desugar_by_category_owner.update(row.get("desugarByCategoryOwner") or {})
+        backend_defects.update(row.get("backendDefects") or {})
+        cm_resolutions.update(row.get("cmResolutions") or {})
+        unrecognized_cm_kinds.update(row.get("unrecognizedCmResolutionKinds") or {})
+        ast_sites.update(row.get("astSites") or {})
+        desugar_construction_panics.extend(row.get("desugarConstructionPanics") or [])
+        desugar_defects.extend(row.get("desugarDefects") or [])
+        desugar_designed_gaps.extend(row.get("desugarDesignedGaps") or [])
+        if category == "completed":
+            files_completed += 1
+        elif category == "construction-panic":
+            panic = row.get("panic")
+            if isinstance(panic, dict):
+                construction_panics.append(dict(panic))
+            if "ConstructionPanic" not in (row.get("families") or {}):
+                families["ConstructionPanic"] = (
+                    int(families.get("ConstructionPanic") or 0) + 1
+                )
+        elif category == "instrument-defect-unresolvable-dispatch":
+            defect = row.get("defect")
+            if isinstance(defect, dict):
+                unresolvable_dispatch.append(dict(defect))
+            defects.append(
+                dict(defect)
+                if isinstance(defect, dict)
+                else {"file": file, "type": category, "message": category}
+            )
+        else:
+            defect = row.get("defect")
+            defects.append(
+                dict(defect)
+                if isinstance(defect, dict)
+                else {"file": file, "type": category, "message": category}
+            )
+
+    files_complete = (
+        len(measured_rows) == len(file_names)
+        and not missing_files
+        and not duplicate_files
+        and not malformed_rows
+    )
+    return {
+        "families": families,
+        "desugar_families": desugar_families,
+        "desugar_categories": desugar_categories,
+        "desugar_by_category_owner": desugar_by_category_owner,
+        "backend_defects": backend_defects,
+        "cm_resolutions": cm_resolutions,
+        "unrecognized_cm_kinds": unrecognized_cm_kinds,
+        "ast_sites": ast_sites,
+        "desugar_construction_panics": desugar_construction_panics,
+        "desugar_defects": desugar_defects,
+        "desugar_designed_gaps": desugar_designed_gaps,
+        "unresolvable_dispatch": unresolvable_dispatch,
+        "construction_panics": construction_panics,
+        "defects": defects,
+        "floor_rows": floor_rows,
+        "files_completed": files_completed,
+        "functions_total": functions_total,
+        "functions_clean": functions_clean,
+        "missing_files": missing_files,
+        "duplicate_files": duplicate_files,
+        "malformed_rows": malformed_rows,
+        "files_complete": files_complete,
+        "enrolled_files": file_names,
+        "terminal_count": len(measured_rows),
+        "manifest_cid": manifest_cid,
+    }
+
+
+def seal_board_from_aggregate(
+    agg: Mapping[str, Any],
+    *,
+    plan: Mapping[str, Any] | None,
+    per_shard_cids: Mapping[str, str] | None,
+    compose_cid: str | None,
+    measured_commit: str,
+    corpus: str | None = None,
+    corpus_root: str | None = None,
+    corpus_pin_summary: Mapping[str, Any] | None = None,
+    aggregate_hash: str | None = None,
+    manifest_shape_cid: str | None = None,
+    paths: Mapping[str, str] | None = None,
+    elapsed_seconds: float | None = None,
+    source_stamp: Mapping[str, Any] | None = None,
+    with_census: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Mint the sealed authoritative board body. Sole mint of the class."""
+    file_names = list(agg["enrolled_files"])
+    families = Counter(agg["families"])
+    desugar_families = Counter(agg["desugar_families"])
+    desugar_categories = Counter(agg["desugar_categories"])
+    backend_defects = Counter(agg["backend_defects"])
+    construction_panics = list(agg["construction_panics"])
+    defects = list(agg["defects"])
+    r_construction = sum(families.values())
+    r_desugar = sum(desugar_families.values())
+    r_backend = sum(backend_defects.values())
+
+    body: dict[str, Any] = {
+        "schemaVersion": 1,
+        "kind": KIND_SEALED,
+        "measurementClass": MEASUREMENT_CLASS_BOARD,
+        "status": "sealed",
+        "measured": True,
+        "SCOREBOARD_AUTHORITY": True,
+        "measuredCommit": measured_commit,
+        "authority": (
+            "sole authoritative Python corpus scoreboard; every other census "
+            "output is non-authoritative; sole seal door is compose_control_effect_board"
+        ),
+        "composeMode": "lpt-enrollment-v1" if plan else "k1-compose-v1",
+        "corpusAuthentication": {
+            "aggregateHash": aggregate_hash
+            or (plan or {}).get("aggregateHash")
+            or "",
+            "requiredAggregateHash": _PANDAS_3_0_3_AGGREGATE_HASH,
+            "manifestShapeCid": manifest_shape_cid
+            or (plan or {}).get("manifestShapeCid")
+            or "",
+            "requiredManifestShapeCid": _PANDAS_3_0_3_MANIFEST_SHAPE_CID,
+        },
+        "commit": measured_commit,
+        "corpus": corpus,
+        "corpusRoot": corpus_root,
+        "corpusPin": dict(corpus_pin_summary) if corpus_pin_summary else None,
+        "door": "enum:path_source→SourceFile→functions→sugar→desugar",
+        "isolation": "in-process",
+        "paths": dict(paths or {}),
+        # Dual unit denominator — files and functions NEVER share a slot.
+        "denominator": {
+            "files": {
+                "enrolled": len(file_names),
+                "terminalRows": int(agg["terminal_count"]),
+                "completed": int(agg["files_completed"]),
+                "corpusManifestCid": agg.get("manifest_cid"),
+                "enrolledFiles": list(file_names),
+                "missingFiles": list(agg["missing_files"]),
+                "duplicateFiles": list(agg["duplicate_files"]),
+                "malformedRows": list(agg["malformed_rows"]),
+                "complete": bool(agg["files_complete"]),
+            },
+            "functions": {
+                "total": int(agg["functions_total"]),
+                "clean": int(agg["functions_clean"]),
+                "unit": "construction-function-locus",
+            },
+            # Back-compat flat keys (file unit only) for older readers.
+            "enrolled": len(file_names),
+            "terminalRows": int(agg["terminal_count"]),
+            "completed": int(agg["files_completed"]),
+            "corpusManifestCid": agg.get("manifest_cid"),
+            "enrolledFiles": list(file_names),
+            "missingFiles": list(agg["missing_files"]),
+            "duplicateFiles": list(agg["duplicate_files"]),
+            "malformedRows": list(agg["malformed_rows"]),
+            "complete": bool(agg["files_complete"]),
+        },
+        "filesTotal": len(file_names),
+        "filesCompleted": int(agg["files_completed"]),
+        "enrolledFiles": len(file_names),
+        "populationSize": len(file_names),
+        "defects": defects,
+        "instrumentDefects": list(defects),
+        "R_instrument_defects": len(defects),
+        "constructionPanics": construction_panics,
+        "R_construction_panics": len(construction_panics),
+        "functionsTotal": int(agg["functions_total"]),
+        "functionsConstructClean": int(agg["functions_clean"]),
+        "R": r_construction,
+        "R_construction": r_construction,
+        "families": dict(
+            sorted(families.items(), key=lambda item: (-item[1], item[0]))
+        ),
+        "R_desugar": r_desugar,
+        "desugarCategories": dict(
+            sorted(desugar_categories.items(), key=lambda item: (-item[1], item[0]))
+        ),
+        "R_desugar_owed_work": int(desugar_categories.get("typed-refusal", 0)),
+        "R_desugar_accounted_semantics": int(
+            desugar_categories.get("constructed-effect", 0)
+        ),
+        "desugarByCategoryOwner": dict(
+            sorted(
+                Counter(agg["desugar_by_category_owner"]).items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        ),
+        "desugarFamilies": dict(
+            sorted(desugar_families.items(), key=lambda item: (-item[1], item[0]))
+        ),
+        "R_backend_defects": r_backend,
+        "backendDefects": dict(
+            sorted(backend_defects.items(), key=lambda item: (-item[1], item[0]))
+        ),
+        "cmResolutions": dict(
+            sorted(
+                Counter(agg["cm_resolutions"]).items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        ),
+        "R_cm_derived_contract": int(
+            Counter(agg["cm_resolutions"]).get("derived-contract", 0)
+        ),
+        "withCensus": with_census,
+        "astSitePrevalence": dict(
+            sorted(
+                Counter(agg["ast_sites"]).items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        ),
+        "desugarConstructionPanics": list(agg["desugar_construction_panics"]),
+        "R_desugar_construction_panics": len(agg["desugar_construction_panics"]),
+        "desugarDefects": list(agg["desugar_defects"]),
+        "R_desugar_defects": len(agg["desugar_defects"]),
+        "desugarDesignedGaps": list(agg["desugar_designed_gaps"]),
+        "R_desugar_designed_gaps": len(agg["desugar_designed_gaps"]),
+        "unresolvableDispatchTargets": list(agg["unresolvable_dispatch"]),
+        "R_unresolvable_dispatch_targets": len(agg["unresolvable_dispatch"]),
+        "elapsedSeconds": elapsed_seconds,
+        "planCid": (plan or {}).get("planCid"),
+        "perShardCids": dict(sorted((per_shard_cids or {}).items())),
+        "composeSchema": COMPOSE_SCHEMA,
+    }
+    if source_stamp is not None:
+        body["sourceStamp"] = dict(source_stamp)
+        # Host/load noise stays in sourceStamp; bodyCid excludes it.
+    if compose_cid is not None:
+        body["composeCid"] = compose_cid
+    # bodyCid over seal-domain fields (exclude host-volatile sourceStamp).
+    seal_domain = {
+        k: v
+        for k, v in body.items()
+        if k not in {"sourceStamp", "bodyCid", "paths", "elapsedSeconds"}
+    }
+    body["bodyCid"] = canonical_cid(seal_domain)
+    return body
+
+
+def unmeasured_envelope(
+    *,
+    plan: Mapping[str, Any] | None,
+    missing_shards: Sequence[str],
+    unmeasured_reasons: Mapping[str, str],
+    measured_commit: str | None = None,
+) -> dict[str, Any]:
+    """Attendance testimony only. NEVER measurementClass=control-effect-recensus."""
+    env: dict[str, Any] = {
+        "schemaVersion": 1,
+        "kind": KIND_UNMEASURED,
+        # measurementClass OMITTED — dual belt A
+        "status": "unmeasured",
+        "measured": False,
+        "measuredCommit": measured_commit
+        or (plan or {}).get("measuredCommit"),
+        "planCid": (plan or {}).get("planCid"),
+        "missingShards": list(missing_shards),
+        "unmeasuredReasons": dict(unmeasured_reasons),
+        "denominator": {"complete": False},
+    }
+    assert "measurementClass" not in env
+    assert "R_construction_panics" not in env
+    assert "bodyCid" not in env
+    return env
+
+
+def compose_from_partials(
+    plan: Mapping[str, Any],
+    partials: Sequence[Mapping[str, Any]],
+    *,
+    corpus: str | None = None,
+    corpus_root: str | None = None,
+    corpus_pin_summary: Mapping[str, Any] | None = None,
+    paths: Mapping[str, str] | None = None,
+    elapsed_seconds: float | None = None,
+    source_stamp: Mapping[str, Any] | None = None,
+    with_census_fn=None,
+) -> tuple[str, dict[str, Any]]:
+    """Sole compose door. Returns (\"sealed\"|\"unmeasured\", body)."""
+    k = int(plan["shardCount"])
+    by_index: dict[int, Mapping[str, Any]] = {}
+    missing: list[str] = []
+    reasons: dict[str, str] = {}
+
+    for p in partials:
+        try:
+            idx = int(p["shardIndex"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        by_index[idx] = p
+
+    for i in range(k):
+        seat = f"s{i:02d}"
+        p = by_index.get(i)
+        if p is None:
+            missing.append(seat)
+            reasons[seat] = "receipt absent"
+            continue
+        if p.get("planCid") != plan.get("planCid"):
+            missing.append(seat)
+            reasons[seat] = f"planCid mismatch got={p.get('planCid')!r}"
+            continue
+        if p.get("measurementClass") != MEASUREMENT_CLASS_SHARD:
+            missing.append(seat)
+            reasons[seat] = (
+                f"wrong measurementClass {p.get('measurementClass')!r} "
+                f"(want {MEASUREMENT_CLASS_SHARD})"
+            )
+            continue
+        if p.get("status") == "unmeasured" or not p.get("measured"):
+            missing.append(seat)
+            reasons[seat] = str(
+                p.get("unmeasuredReason") or "partial status=unmeasured"
+            )
+            continue
+        assigned = list(plan["bins"][i])
+        if p.get("shardFileSetCid") != shard_file_set_cid(assigned):
+            missing.append(seat)
+            reasons[seat] = "shardFileSetCid mismatch vs plan bin"
+            continue
+        sub = (p.get("subDenominator") or {}).get("files") or {}
+        if not sub.get("complete"):
+            missing.append(seat)
+            reasons[seat] = "subDenominator.files.complete is false"
+            continue
+        if "R_construction_panics" in p:
+            missing.append(seat)
+            reasons[seat] = "partial carries forbidden top-level R_construction_panics"
+            continue
+
+    if missing:
+        return "unmeasured", unmeasured_envelope(
+            plan=plan,
+            missing_shards=missing,
+            unmeasured_reasons=reasons,
+            measured_commit=str(plan.get("measuredCommit") or ""),
+        )
+
+    # Concat terminals in enrolled order for determinism.
+    row_by_file: dict[str, Mapping[str, Any]] = {}
+    per_shard_cids: dict[str, str] = {}
+    for i in range(k):
+        p = by_index[i]
+        per_shard_cids[f"s{i:02d}"] = str(p.get("partialCid") or "")
+        for entry in p.get("terminalRows") or []:
+            if not isinstance(entry, dict):
+                continue
+            f = entry.get("file")
+            r = entry.get("result")
+            if isinstance(f, str) and isinstance(r, dict):
+                row_by_file[f] = r
+
+    enrolled = list(plan["enrolledFiles"])
+    measured_rows = [(f, row_by_file[f]) for f in enrolled if f in row_by_file]
+    agg = aggregate_terminal_rows(
+        measured_rows,
+        enrolled_files=enrolled,
+        manifest_cid=str(plan.get("manifestShapeCid") or ""),
+    )
+    if not agg["files_complete"]:
+        return "unmeasured", unmeasured_envelope(
+            plan=plan,
+            missing_shards=["compose"],
+            unmeasured_reasons={
+                "compose": (
+                    f"full concat incomplete missing={agg['missing_files']} "
+                    f"dups={agg['duplicate_files']} malformed={agg['malformed_rows']}"
+                )
+            },
+            measured_commit=str(plan.get("measuredCommit") or ""),
+        )
+
+    partial_cids_sorted = sorted(per_shard_cids.values())
+    compose_cid = canonical_cid(
+        {
+            "schema": COMPOSE_SCHEMA,
+            "planCid": plan.get("planCid"),
+            "partialCids": partial_cids_sorted,
+        }
+    )
+
+    with_census = None
+    if with_census_fn is not None:
+        with_census = with_census_fn(
+            Counter(agg["cm_resolutions"]),
+            Counter(agg["ast_sites"]),
+            Counter(agg["unrecognized_cm_kinds"]),
+        )
+
+    board = seal_board_from_aggregate(
+        agg,
+        plan=plan,
+        per_shard_cids=per_shard_cids,
+        compose_cid=compose_cid,
+        measured_commit=str(plan.get("measuredCommit") or ""),
+        corpus=corpus,
+        corpus_root=corpus_root,
+        corpus_pin_summary=corpus_pin_summary,
+        aggregate_hash=str(plan.get("aggregateHash") or ""),
+        manifest_shape_cid=str(plan.get("manifestShapeCid") or ""),
+        paths=paths,
+        elapsed_seconds=elapsed_seconds,
+        source_stamp=source_stamp,
+        with_census=with_census,
+    )
+    return "sealed", board
+
+
+def compose_k1_from_rows(
+    measured_rows: Sequence[tuple[str, Mapping[str, Any]]],
+    *,
+    enrolled_files: Sequence[str],
+    measured_commit: str,
+    aggregate_hash: str,
+    manifest_shape_cid: str,
+    corpus: str | None = None,
+    corpus_root: str | None = None,
+    corpus_pin_summary: Mapping[str, Any] | None = None,
+    paths: Mapping[str, str] | None = None,
+    elapsed_seconds: float | None = None,
+    source_stamp: Mapping[str, Any] | None = None,
+    with_census_fn=None,
+    manifest_cid: str | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """k=1 path: one full-bin partial + compose (serial observation, one seal door)."""
+    enrolled = sorted(enrolled_files)
+    plan = build_plan(
+        enrolled_files=enrolled,
+        shard_count=1,
+        measured_commit=measured_commit,
+        aggregate_hash=aggregate_hash,
+        manifest_shape_cid=manifest_shape_cid,
+        bins=[enrolled],
+        split_mode="k1",
+        prior_hits=0,
+        prior_misses=0,
+        estimated_loads=[0.0],
+    )
+    partial = mint_partial(
+        plan=plan,
+        shard_index=0,
+        terminal_rows=list(measured_rows),
+        measured_commit=measured_commit,
+    )
+    return compose_from_partials(
+        plan,
+        [partial],
+        corpus=corpus,
+        corpus_root=corpus_root,
+        corpus_pin_summary=corpus_pin_summary,
+        paths=paths,
+        elapsed_seconds=elapsed_seconds,
+        source_stamp=source_stamp,
+        with_census_fn=with_census_fn,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--plan",
+        type=Path,
+        required=True,
+        help="shard plan JSON (planCid identity)",
+    )
+    parser.add_argument(
+        "--partials-dir",
+        type=Path,
+        required=True,
+        help="directory of partial-*.json shard bodies",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="sealed board or unmeasured envelope path",
+    )
+    args = parser.parse_args(argv)
+    plan = json.loads(args.plan.read_text(encoding="utf-8"))
+    partials: list[dict[str, Any]] = []
+    for path in sorted(args.partials_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(data, dict) and data.get("kind") == KIND_PARTIAL:
+            partials.append(data)
+    status, body = compose_from_partials(plan, partials)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(
+        f"COMPOSE status={status} out={args.out} "
+        f"missing={body.get('missingShards')} bodyCid={body.get('bodyCid')}",
+        flush=True,
+    )
+    return 0 if status == "sealed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -81,9 +81,11 @@ debugging a named stall needs the full stack flood.
 
 from __future__ import annotations
 
-# The sole authoritative Python corpus scoreboard. Enforced by
-# tests/test_one_authoritative_scoreboard.py: exactly one module may say True.
-SCOREBOARD_AUTHORITY = True
+# Worker / walk only. Sole seal door is compose_control_effect_board.py
+# (SCOREBOARD_AUTHORITY = True). Serial seal retired: this module never mints
+# measurementClass=control-effect-recensus; it emits terminals (+ optional
+# partials) and always seals through compose (k=1 or LPT N).
+SCOREBOARD_AUTHORITY = False
 
 _PANDAS_3_0_3_AGGREGATE_HASH = (
     "bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c"
@@ -892,7 +894,32 @@ def main() -> int:
             "Use --no-progress-stdout only for interactive local quiet."
         ),
     )
+    parser.add_argument(
+        "--plan-json",
+        type=Path,
+        default=None,
+        help=(
+            "LPT shard plan (planCid). With --shard-index, measure only that bin "
+            "and emit a partial (never a sealed board)."
+        ),
+    )
+    parser.add_argument(
+        "--shard-index",
+        type=int,
+        default=None,
+        help="shard seat to measure (requires --plan-json); writes partial only",
+    )
+    parser.add_argument(
+        "--partial-out",
+        type=Path,
+        default=None,
+        help="where to write the shard partial JSON (default: <out-dir>/partial-sXX.json)",
+    )
     args = parser.parse_args()
+    if args.shard_index is not None and args.plan_json is None:
+        parser.error("--shard-index requires --plan-json")
+    if args.plan_json is not None and args.shard_index is None:
+        parser.error("--plan-json requires --shard-index for worker mode")
 
     if not args.corpus.exists():
         parser.error(f"corpus not found: {args.corpus}")
@@ -1030,6 +1057,30 @@ def main() -> int:
         parser.error(
             f"enumeration produced {len(paths)} paths but "
             f"{len(file_names)} distinct identities — duplicate enrolled file"
+        )
+    # Shard worker mode: measure only plan.bins[shard_index]; never seal here.
+    shard_plan: dict[str, Any] | None = None
+    if args.plan_json is not None:
+        shard_plan = json.loads(args.plan_json.read_text(encoding="utf-8"))
+        assert args.shard_index is not None
+        k = int(shard_plan["shardCount"])
+        if args.shard_index < 0 or args.shard_index >= k:
+            parser.error(
+                f"--shard-index {args.shard_index} out of range for plan k={k}"
+            )
+        assigned = list(shard_plan["bins"][args.shard_index])
+        unknown = sorted(set(assigned) - set(file_names))
+        if unknown:
+            parser.error(
+                f"plan bin contains files not in this walk: {unknown[:5]}"
+            )
+        file_names = [f for f in file_names if f in set(assigned)]
+        by_file = {f: by_file[f] for f in file_names}
+        _narrate(
+            "RECENSUS SHARD WORKER "
+            f"shard={args.shard_index}/{k} assigned={len(assigned)} "
+            f"planCid={shard_plan.get('planCid')} "
+            f"(partial only — seal is compose_control_effect_board)"
         )
     pending: list[str] = list(file_names)
 
@@ -1554,136 +1605,57 @@ def main() -> int:
 
     from pandas_floor_summary import floor_summary
 
-    r_construction = sum(families.values())
-    r_desugar = sum(desugar_families.values())
-    r_backend = sum(backend_defects.values())
-    with_census = _with_census_partition(
-        cm_resolutions, ast_sites, unrecognized_cm_kinds
-    )
-    result: dict[str, Any] = {
-        "kind": "control-effect-construction-recensus",
-        "corpusAuthentication": {
-            "aggregateHash": observed_pin.aggregate_hash,
-            "requiredAggregateHash": _PANDAS_3_0_3_AGGREGATE_HASH,
-            "manifestShapeCid": manifest_shape_cid,
-            "requiredManifestShapeCid": _PANDAS_3_0_3_MANIFEST_SHAPE_CID,
-        },
-        "authority": (
-            "sole authoritative Python corpus scoreboard; every other census "
-            "output is non-authoritative"
-        ),
-        "commit": args.commit or _git_commit(args.repo),
-        "corpus": str(corpus),
-        "corpusRoot": str(corpus_root),
-        # WHICH corpus — version, manifest length, one aggregate hash. Two runs
-        # are comparable iff these aggregate hashes are equal. The 1,415-file
-        # ledger is a different pandas and is NOT comparable to this board.
-        "corpusPin": observed_pin.summary(),
-        "door": "enum:path_source→SourceFile→functions→sugar→desugar",
-        "isolation": "in-process",
-        "paths": {
+    # Sole seal door — never mint measurementClass=control-effect-recensus here.
+    from compose_control_effect_board import compose_k1_from_rows, mint_partial
+
+    tip_commit = args.commit or _git_commit(args.repo) or "unpinned"
+
+    # Shard worker: emit PARTIAL only (SCOREBOARD False). Compose is a separate step.
+    if shard_plan is not None:
+        assert args.shard_index is not None
+        partial = mint_partial(
+            plan=shard_plan,
+            shard_index=args.shard_index,
+            terminal_rows=measured_rows,
+            measured_commit=tip_commit,
+        )
+        partial_path = args.partial_out or (
+            out / f"partial-s{args.shard_index:02d}.json"
+        )
+        partial_path.parent.mkdir(parents=True, exist_ok=True)
+        partial_path.write_text(
+            json.dumps(partial, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _narrate(
+            "RECENSUS PARTIAL WRITTEN "
+            f"shard={args.shard_index} measured={partial.get('measured')} "
+            f"status={partial.get('status')} partialCid={partial.get('partialCid')} "
+            f"path={partial_path}"
+        )
+        # Exit 0/1 = scan completed (measured residual may be red later at compose);
+        # exit 2 = unmeasured seat.
+        return 0 if partial.get("measured") else 2
+
+    # Default k=1: one full-bin partial + compose (serial observation, one seal path).
+    seal_status, result = compose_k1_from_rows(
+        measured_rows,
+        enrolled_files=file_names,
+        measured_commit=tip_commit,
+        aggregate_hash=observed_pin.aggregate_hash,
+        manifest_shape_cid=manifest_shape_cid,
+        corpus=str(corpus),
+        corpus_root=str(corpus_root),
+        corpus_pin_summary=observed_pin.summary(),
+        paths={
             "engineLog": str(engine_path.resolve()),
             "progress": str(progress_path.resolve()),
             "checkpoint": str(checkpoint_path.resolve()),
             "result": str(result_path.resolve()),
         },
-        # THE DENOMINATOR — stated, with exact identities, before any rate.
-        "denominator": {
-            "enrolled": len(file_names),
-            "terminalRows": len(measured_rows),
-            "completed": files_completed,
-            "corpusManifestCid": checkpoint.manifest_cid,
-            "enrolledFiles": list(file_names),
-            "missingFiles": missing_files,
-            "duplicateFiles": duplicate_files,
-            "malformedRows": malformed_rows,
-            "complete": (
-                len(measured_rows) == len(file_names)
-                and not missing_files
-                and not duplicate_files
-                and not malformed_rows
-            ),
-        },
-        "filesTotal": len(file_names),
-        "filesCompleted": files_completed,
-        "defects": defects,
-        "constructionPanics": construction_panics,
-        "R_construction_panics": len(construction_panics),
-        "functionsTotal": functions_total,
-        "functionsConstructClean": functions_clean,
-        # Axis 1 — construction totality (tree owned). Occurrence-deduped.
-        # Never merge with R_desugar. Never double-count catch+reporter.
-        "R": r_construction,
-        "R_construction": r_construction,
-        "families": dict(
-            sorted(families.items(), key=lambda item: (-item[1], item[0]))
-        ),
-        # Axis 2 — desugar refusals + typed red (#6243). Separate quantity.
-        # R_desugar is MIXED. Read the split, never the total: a typed refusal
-        # owes work, a constructed effect IS the correct output of a reduction
-        # that succeeded. Publishing the sum as work remaining overstated the
-        # earlier board 7.6x.
-        "R_desugar": r_desugar,
-        "desugarCategories": dict(
-            sorted(desugar_categories.items(), key=lambda item: (-item[1], item[0]))
-        ),
-        "R_desugar_owed_work": int(desugar_categories.get("typed-refusal", 0)),
-        "R_desugar_accounted_semantics": int(
-            desugar_categories.get("constructed-effect", 0)
-        ),
-        "desugarByCategoryOwner": dict(
-            sorted(
-                desugar_by_category_owner.items(),
-                key=lambda item: (-item[1], item[0]),
-            )
-        ),
-        "desugarFamilies": dict(
-            sorted(desugar_families.items(), key=lambda item: (-item[1], item[0]))
-        ),
-        # Table hygiene — not residual mass (probe: 2 BackendDefect files).
-        "R_backend_defects": r_backend,
-        "backendDefects": dict(
-            sorted(backend_defects.items(), key=lambda item: (-item[1], item[0]))
-        ),
-        # With residual partition, keyed by AUTHENTICATED resolution kind.
-        # Structural, not spelling: no vendor name table decides these buckets.
-        "cmResolutions": dict(
-            sorted(cm_resolutions.items(), key=lambda item: (-item[1], item[0]))
-        ),
-        "R_cm_derived_contract": int(cm_resolutions.get("derived-contract", 0)),
-        "withCensus": with_census,
-        # AST SITE PREVALENCE — a denominator, NEVER R. Different question,
-        # different number: prevalence counts shapes present, R counts
-        # authenticated occurrences that failed to construct. Quoting one as
-        # the other is exactly the confusion this board was repaired to end.
-        "astSitePrevalence": dict(
-            sorted(ast_sites.items(), key=lambda item: (-item[1], item[0]))
-        ),
-        # Neither of these is semantic R. A construction-law None arm during
-        # desugar is a construction gap; an ordinary exception is an
-        # implementation defect. Both are red, separately.
-        "desugarConstructionPanics": desugar_construction_panics,
-        "R_desugar_construction_panics": len(desugar_construction_panics),
-        "desugarDefects": desugar_defects,
-        "R_desugar_defects": len(desugar_defects),
-        # Correct output from a named mechanism. Disjoint from desugarDefects
-        # (not a bug), from R_desugar (not a typed refusal) and from the panic
-        # collection. Never added to any of them, and never a red reason.
-        "desugarDesignedGaps": desugar_designed_gaps,
-        "R_desugar_designed_gaps": len(desugar_designed_gaps),
-        "desugarDesignedGapOwners": dict(
-            Counter(str(gap.get("owner", "?")) for gap in desugar_designed_gaps)
-        ),
-        # #6329 -- an arm reaching a dispatch target that does not exist. Its
-        # own axis: never semantic R, never quietly a backend defect.
-        "unresolvableDispatchTargets": unresolvable_dispatch,
-        "R_unresolvable_dispatch_targets": len(unresolvable_dispatch),
-        "elapsedSeconds": time.time() - started,
-        "python": sys.version,
-        # WHERE and WHEN this was measured. A board row without its stamp
-        # cannot be re-run, and a number nobody can re-run is not evidence.
-        "sourceStamp": {
-            "commit": args.commit or _git_commit(args.repo),
+        elapsed_seconds=time.time() - started,
+        source_stamp={
+            "commit": tip_commit,
             "repo": str(args.repo.resolve()),
             "python": sys.version,
             "platform": platform.platform(),
@@ -1691,24 +1663,56 @@ def main() -> int:
             "loadAverage": list(os.getloadavg()) if hasattr(os, "getloadavg") else [],
             "measuredAtUnix": time.time(),
         },
-        "floorSummary": floor_summary(
-            floor="control-effect",
-            files=file_names,
-            rows=floor_rows,
-            totals={
-                "R_control_effect": r_construction + len(defects),
-                "R_desugar": r_desugar,
-                "R_backend_defects": r_backend,
-                "R_cm_derived_contract": int(cm_resolutions.get("derived-contract", 0)),
-                "desugarConstructionPanics": len(desugar_construction_panics),
-                "desugarDefects": len(desugar_defects),
-                "constructionPanics": len(construction_panics),
-                "backendDefectsOrProcessTerminals": len(defects),
-            },
-            measured=len(floor_rows) == len(file_names),
-            unmeasurable_reasons=(),
-        ),
-    }
+        with_census_fn=_with_census_partition,
+        manifest_cid=checkpoint.manifest_cid,
+    )
+    if seal_status != "sealed":
+        _narrate(
+            "RECENSUS COMPOSE UNMEASURED "
+            f"missing={result.get('missingShards')} "
+            f"reasons={result.get('unmeasuredReasons')}"
+        )
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        result_path.write_text(json.dumps(result, indent=2) + "\n")
+        return 2
+
+    r_construction = int(result.get("R_construction") or 0)
+    r_desugar = int(result.get("R_desugar") or 0)
+    r_backend = int(result.get("R_backend_defects") or 0)
+    construction_panics = list(result.get("constructionPanics") or [])
+    defects = list(result.get("defects") or [])
+    desugar_construction_panics = list(result.get("desugarConstructionPanics") or [])
+    desugar_defects = list(result.get("desugarDefects") or [])
+    unresolvable_dispatch = list(result.get("unresolvableDispatchTargets") or [])
+    families = Counter(result.get("families") or {})
+    desugar_families = Counter(result.get("desugarFamilies") or {})
+    files_completed = int(result.get("filesCompleted") or 0)
+    result["python"] = sys.version
+    result["floorSummary"] = floor_summary(
+        floor="control-effect",
+        files=file_names,
+        rows=floor_rows,
+        totals={
+            "R_control_effect": r_construction + len(defects),
+            "R_desugar": r_desugar,
+            "R_backend_defects": r_backend,
+            "R_cm_derived_contract": int(
+                (result.get("cmResolutions") or {}).get("derived-contract", 0)
+            ),
+            "desugarConstructionPanics": len(desugar_construction_panics),
+            "desugarDefects": len(desugar_defects),
+            "constructionPanics": len(construction_panics),
+            "backendDefectsOrProcessTerminals": len(defects),
+        },
+        measured=len(floor_rows) == len(file_names),
+        unmeasurable_reasons=(),
+    )
+    result["desugarDesignedGapOwners"] = dict(
+        Counter(
+            str(gap.get("owner", "?"))
+            for gap in (result.get("desugarDesignedGaps") or [])
+        )
+    )
     # stableZero -- RULING ON PLACEMENT.
     #
     # This is a ONE-FLOOR term and is deliberately named

--- a/implementations/python/sugar-lift-py-tests/tests/test_one_authoritative_scoreboard.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_one_authoritative_scoreboard.py
@@ -98,9 +98,9 @@ def test_exactly_one_module_claims_to_be_the_authority() -> None:
         for path, declared in _board_producers().items()
         if declared is True
     )
-    assert claimants == ["scripts/control_effect_recensus.py"], (
-        "the Python corpus board has exactly one authority; claimants were "
-        f"{claimants}"
+    assert claimants == ["scripts/compose_control_effect_board.py"], (
+        "the Python corpus board has exactly one authority (the compose seal "
+        f"door); claimants were {claimants}"
     )
 
 

--- a/tests/test_control_effect_recensus_compose.py
+++ b/tests/test_control_effect_recensus_compose.py
@@ -1,0 +1,213 @@
+"""Teeth for recensus LPT compose seal (banked law R1–R6 + dual-belt attendance)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = (
+    ROOT
+    / "implementations/python/sugar-lift-py-tests/scripts"
+)
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+COMPOSE = _load(
+    "compose_control_effect_board",
+    SCRIPTS / "compose_control_effect_board.py",
+)
+ATTEND = _load(
+    "heavy_measurement_attendance",
+    ROOT / "tools/heavy_measurement_attendance.py",
+)
+
+
+def _row(file: str, *, category: str = "completed", fn: int = 1, panic: bool = False):
+    if panic:
+        return (
+            file,
+            {
+                "category": "construction-panic",
+                "functionsTotal": 0,
+                "functionsClean": 0,
+                "families": {"ConstructionPanic": 1},
+                "panic": {"file": file, "type": "ConstructionPanic", "message": "x"},
+            },
+        )
+    return (
+        file,
+        {
+            "category": category,
+            "functionsTotal": fn,
+            "functionsClean": fn if category == "completed" else 0,
+            "families": {},
+        },
+    )
+
+
+def _plan(files: list[str], *, k: int = 1, bins: list[list[str]] | None = None):
+    if bins is None:
+        if k == 1:
+            bins = [list(files)]
+        else:
+            raise ValueError("bins required for k>1")
+    return COMPOSE.build_plan(
+        enrolled_files=files,
+        shard_count=k,
+        measured_commit="deadbeef",
+        aggregate_hash="agg",
+        manifest_shape_cid="cid",
+        bins=bins,
+        split_mode="test",
+        prior_hits=0,
+        prior_misses=0,
+        estimated_loads=[1.0] * k,
+    )
+
+
+def test_compose_scoreboard_authority_true_only_here() -> None:
+    assert COMPOSE.SCOREBOARD_AUTHORITY is True
+    worker = (SCRIPTS / "control_effect_recensus.py").read_text(encoding="utf-8")
+    assert "SCOREBOARD_AUTHORITY = False" in worker
+    assert "SCOREBOARD_AUTHORITY = True" not in worker.split("compose_control_effect_board")[0]
+
+
+def test_k1_compose_seals_with_dual_denom_and_body_cid() -> None:
+    files = ["pandas/a.py", "pandas/b.py"]
+    rows = [_row("pandas/a.py", fn=3), _row("pandas/b.py", fn=2, panic=True)]
+    status, body = COMPOSE.compose_k1_from_rows(
+        rows,
+        enrolled_files=files,
+        measured_commit="deadbeef",
+        aggregate_hash="agg",
+        manifest_shape_cid="cid",
+    )
+    assert status == "sealed"
+    assert body["measurementClass"] == "control-effect-recensus"
+    assert body["status"] == "sealed"
+    assert body["measured"] is True
+    assert body["bodyCid"]
+    assert body["R_construction_panics"] == 1
+    assert body["denominator"]["files"]["enrolled"] == 2
+    # Panic fixture rows declare functionsTotal=0; only a.py contributes 3.
+    assert body["denominator"]["functions"]["total"] == 3
+    assert body["denominator"]["functions"]["unit"] == "construction-function-locus"
+    # Dual units: file enrolled count is not the function total slot.
+    assert "files" in body["denominator"] and "functions" in body["denominator"]
+
+
+def test_missing_shard_emits_unmeasured_without_class() -> None:
+    files = ["a.py", "b.py", "c.py", "d.py"]
+    bins = [["a.py", "b.py"], ["c.py", "d.py"]]
+    plan = _plan(files, k=2, bins=bins)
+    partial0 = COMPOSE.mint_partial(
+        plan=plan,
+        shard_index=0,
+        terminal_rows=[_row("a.py"), _row("b.py")],
+    )
+    # Only s00 present — s01 missing.
+    status, body = COMPOSE.compose_from_partials(plan, [partial0])
+    assert status == "unmeasured"
+    assert body["kind"] == COMPOSE.KIND_UNMEASURED
+    assert "measurementClass" not in body
+    assert "R_construction_panics" not in body
+    assert "bodyCid" not in body
+    assert "s01" in body["missingShards"]
+    assert body["measured"] is False
+    assert body["status"] == "unmeasured"
+
+
+def test_unmeasured_envelope_does_not_attend_heavy_roster(tmp_path: Path) -> None:
+    env = COMPOSE.unmeasured_envelope(
+        plan={"planCid": "p", "measuredCommit": "deadbeef"},
+        missing_shards=["s03"],
+        unmeasured_reasons={"s03": "receipt absent"},
+        measured_commit="deadbeef",
+    )
+    # Even if a buggy caller re-adds the class, sealed triple is required.
+    spoof = dict(env)
+    spoof["measurementClass"] = "control-effect-recensus"
+    path = tmp_path / "pandas-control-effect" / "unmeasured.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(spoof), encoding="utf-8")
+    attended, _ = ATTEND.receipts_attendance(tmp_path)
+    assert "control-effect-recensus" not in attended
+    assert ATTEND._class_from_payload(path, spoof) is None
+
+
+def test_sealed_board_attends_heavy_roster(tmp_path: Path) -> None:
+    files = ["a.py"]
+    status, body = COMPOSE.compose_k1_from_rows(
+        [_row("a.py", fn=1)],
+        enrolled_files=files,
+        measured_commit="deadbeef",
+        aggregate_hash="agg",
+        manifest_shape_cid="cid",
+    )
+    assert status == "sealed"
+    path = tmp_path / "pandas-control-effect" / "recensus.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(body), encoding="utf-8")
+    attended, _ = ATTEND.receipts_attendance(tmp_path)
+    assert "control-effect-recensus" in attended
+
+
+def test_partial_never_attends_as_board(tmp_path: Path) -> None:
+    plan = _plan(["a.py", "b.py"], k=1)
+    partial = COMPOSE.mint_partial(
+        plan=plan,
+        shard_index=0,
+        terminal_rows=[_row("a.py"), _row("b.py")],
+    )
+    assert partial["measurementClass"] == "control-effect-recensus-shard"
+    assert "R_construction_panics" not in partial
+    path = tmp_path / "pandas-control-effect" / "partial-s00.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(partial), encoding="utf-8")
+    attended, _ = ATTEND.receipts_attendance(tmp_path)
+    assert "control-effect-recensus" not in attended
+
+
+def test_two_partials_compose_stable_compose_cid() -> None:
+    files = ["a.py", "b.py"]
+    bins = [["a.py"], ["b.py"]]
+    plan = _plan(files, k=2, bins=bins)
+    p0 = COMPOSE.mint_partial(plan=plan, shard_index=0, terminal_rows=[_row("a.py", fn=2)])
+    p1 = COMPOSE.mint_partial(plan=plan, shard_index=1, terminal_rows=[_row("b.py", fn=3)])
+    s1, b1 = COMPOSE.compose_from_partials(plan, [p0, p1])
+    s2, b2 = COMPOSE.compose_from_partials(plan, [p1, p0])  # order independent
+    assert s1 == s2 == "sealed"
+    assert b1["composeCid"] == b2["composeCid"]
+    assert b1["R_construction_panics"] == 0
+    assert b1["denominator"]["functions"]["total"] == 5
+    assert b1["perShardCids"]["s00"] == p0["partialCid"]
+    assert b1["perShardCids"]["s01"] == p1["partialCid"]
+
+
+def test_partial_with_top_level_panics_refused() -> None:
+    plan = _plan(["a.py"], k=1)
+    partial = COMPOSE.mint_partial(
+        plan=plan, shard_index=0, terminal_rows=[_row("a.py")]
+    )
+    # Corrupt: inject forbidden C2 field.
+    bad = dict(partial)
+    bad["R_construction_panics"] = 1
+    bad["partialCid"] = COMPOSE.canonical_cid(
+        {k: v for k, v in bad.items() if k != "partialCid"}
+    )
+    status, body = COMPOSE.compose_from_partials(plan, [bad])
+    assert status == "unmeasured"
+    assert "s00" in body["missingShards"]

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -157,11 +157,17 @@ def test_the_two_cadences_are_never_summed():
 
 def test_the_authoritative_scoreboard_is_on_the_roster():
     module = _attendance_module()
+    # Sole seal door (serial seal retired from the walk script).
     authority = (
+        ROOT
+        / "implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py"
+    )
+    worker = (
         ROOT
         / "implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py"
     )
     assert "SCOREBOARD_AUTHORITY = True" in authority.read_text()
+    assert "SCOREBOARD_AUTHORITY = False" in worker.read_text()
     assert "control-effect-recensus" in module.HEAVY_ROSTER
     assert module.HEAVY_CADENCE["control-effect-recensus"] == module.NIGHTLY_WINDOW
 

--- a/tools/heavy_measurement_attendance.py
+++ b/tools/heavy_measurement_attendance.py
@@ -86,12 +86,32 @@ def _is_recensus_path_smoke(path: Path, payload: dict) -> bool:
     return False
 
 
+def _control_effect_recensus_sealed(payload: dict) -> bool:
+    """Dual belt B: class credit requires sealed + measured + bodyCid.
+
+    UNMEASURED envelopes (and any incomplete body) must not zero R_attendance.
+    Same lie class as recensus-path-smoke under PATH_HINTS (#7049 / banked law).
+    """
+    return (
+        payload.get("status") == "sealed"
+        and payload.get("measured") is True
+        and bool(payload.get("bodyCid"))
+    )
+
+
 def _class_from_payload(path: Path, payload: dict) -> str | None:
     # BEFORE roster / path hints: smoke never maps to control-effect-recensus.
     if _is_recensus_path_smoke(path, payload):
         return None
     mc = payload.get("measurementClass")
+    # Shard partials never attend as the board.
+    if mc == "control-effect-recensus-shard":
+        return None
     if isinstance(mc, str) and mc in HEAVY_ROSTER:
+        if mc == "control-effect-recensus" and not _control_effect_recensus_sealed(
+            payload
+        ):
+            return None
         return mc
     # Identity-bound body markers (suite report, etc.)
     identity_bound = bool(
@@ -108,6 +128,10 @@ def _class_from_payload(path: Path, payload: dict) -> str | None:
     text = str(path).replace("\\", "/")
     for cls, hints in PATH_HINTS.items():
         if any(h in text for h in hints):
+            if cls == "control-effect-recensus" and not _control_effect_recensus_sealed(
+                payload
+            ):
+                return None
             return cls
     return None
 

--- a/tools/plan_control_effect_recensus_shards.py
+++ b/tools/plan_control_effect_recensus_shards.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Plan LPT file shards for control-effect recensus (banked law R1).
+
+Does not measure. Writes a content-addressed plan JSON that workers and
+compose_control_effect_board consume. SCOREBOARD_AUTHORITY = False.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCOREBOARD_AUTHORITY = False
+
+_TOOLS = Path(__file__).resolve().parent
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
+_SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "implementations/python/sugar-lift-py-tests/scripts"
+)
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from lpt_file_shards import (  # noqa: E402
+    ContentAddressedCostPrior,
+    DEFAULT_SHARD_COUNT,
+    assign_files,
+)
+from compose_control_effect_board import build_plan  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--enrolled-files",
+        type=Path,
+        required=True,
+        help="JSON list of enrolled relative paths (corpus pin order or any)",
+    )
+    parser.add_argument(
+        "--corpus-root",
+        type=Path,
+        required=True,
+        help="filesystem root for content-addressed prior lookups",
+    )
+    parser.add_argument("--shard-count", type=int, default=DEFAULT_SHARD_COUNT)
+    parser.add_argument("--measured-commit", required=True)
+    parser.add_argument("--aggregate-hash", required=True)
+    parser.add_argument("--manifest-shape-cid", required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    enrolled = json.loads(args.enrolled_files.read_text(encoding="utf-8"))
+    if not isinstance(enrolled, list) or not all(isinstance(x, str) for x in enrolled):
+        parser.error("--enrolled-files must be a JSON list of strings")
+    enrolled = sorted(enrolled)
+    root = args.corpus_root.resolve()
+    path_resolver = {rel: root / rel for rel in enrolled}
+    # Also try package-stripped keys (pandas/foo.py vs foo.py).
+    for rel in list(enrolled):
+        if "/" in rel:
+            path_resolver.setdefault(rel.split("/", 1)[1], root / rel.split("/", 1)[1])
+
+    assignment = assign_files(
+        enrolled,
+        shard_count=args.shard_count,
+        path_resolver={rel: path_resolver[rel] for rel in enrolled if rel in path_resolver and path_resolver[rel].is_file()},
+        prior=ContentAddressedCostPrior(),
+    )
+    # If path resolver empty for all, equal-count still works via assign_files.
+    plan = build_plan(
+        enrolled_files=enrolled,
+        shard_count=args.shard_count,
+        measured_commit=args.measured_commit,
+        aggregate_hash=args.aggregate_hash,
+        manifest_shape_cid=args.manifest_shape_cid,
+        bins=assignment.bins,
+        split_mode=assignment.mode,
+        prior_hits=assignment.prior_hits,
+        prior_misses=assignment.prior_misses,
+        estimated_loads=assignment.estimated_loads,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(
+        f"PLAN mode={assignment.mode} k={args.shard_count} "
+        f"prior_hits={assignment.prior_hits} prior_misses={assignment.prior_misses} "
+        f"planCid={plan['planCid']} out={args.out}",
+        flush=True,
+    )
+    print(assignment.job_log_line(population="control-effect-recensus"), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Priority 3 (advisor): recensus LPT k=8 + compose seal — **symptom treatment for the serial pole**, not the population-boundary root fix.

Banked law (R1–R6, Law of One, serial seal retired, dual-belt attendance):

- **Sole seal door:** `compose_control_effect_board.py` (`SCOREBOARD_AUTHORITY = True`) is the only mint of `measurementClass=control-effect-recensus`.
- **Worker:** `control_effect_recensus.py` is `SCOREBOARD_AUTHORITY = False`. Default path is k=1 partial + compose (serial *observation*, one seal). `--plan-json` + `--shard-index` emits **partial only**.
- **UNMEASURED:** missing/failed seat → envelope **omits** `measurementClass`; no `bodyCid`; no top-level `R_construction_panics`.
- **Dual-belt attendance:** class credit requires `status=sealed` AND `measured=true` AND `bodyCid` (closes #7049-shaped spoof via incomplete board).
- **Plan:** `tools/plan_control_effect_recensus_shards.py` LPT over content-addressed prior (recensus running-counts ingest path; not suite CA prior).
- Workflow: drop thin `measurement.json` stub; verify sealed `recensus.json` for attendance.

## Shell deleted

Serial seal on the walk script — board complete fields no longer self-declared by the file walker.

## Validation

```
pytest tests/test_control_effect_recensus_compose.py  # 8 passed
pytest tests/test_heavy_measurement_concurrency_topology.py::test_the_authoritative_scoreboard_is_on_the_roster
pytest tests/test_heavy_measurement_concurrency_topology.py::test_smoke_body_under_path_hint_does_not_attend_control_effect_recensus
```

Does **not** fire full recensus / heavy measurement.

## Not in this PR

- Population membrane / dep-seat memo (white)
- Attribution / R_instrument_blind
- CI matrix for k=8 workers (compose + plan ready; wire matrix as follow-up)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add authoritative compose-and-seal door for control-effect-recensus with LPT shard support
> - Introduces [compose_control_effect_board.py](https://github.com/TSavo/sugar/pull/7055/files#diff-74e790a1f60d3814877eedd08ed5ab4d88fa6c54e5d483d8fec41180cd0f0915) as the sole `SCOREBOARD_AUTHORITY` for minting sealed `control-effect-recensus` boards; [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/7055/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) is demoted to a walk-only worker (`SCOREBOARD_AUTHORITY = False`).
> - The compose module supports both k=1 serial sealing (`compose_k1_from_rows`) and k>1 LPT sharded composition (`compose_from_partials`), with strict validation of shard receipts before sealing.
> - When shards are missing or incomplete, the compose path returns an explicit unmeasured envelope (no `measurementClass`, no `bodyCid`) instead of a sealed board.
> - Attendance logic in [heavy_measurement_attendance.py](https://github.com/TSavo/sugar/pull/7055/files#diff-488ea1f5082769971d9377e07807b0fef693e2d67727f202b2a8c34ba0963556) now requires `status=="sealed"`, `measured==True`, and a truthy `bodyCid` for `control-effect-recensus` payloads; shard partials and unmeasured envelopes are ignored.
> - Adds [plan_control_effect_recensus_shards.py](https://github.com/TSavo/sugar/pull/7055/files#diff-40acc7752917334e258a0eaf7260e5a69d41d72acc4decde821929fdeb0570c9) CLI to produce a validated shard plan with `planCid` for driving sharded measurement in CI.
> - Behavioral Change: attendance now requires a sealed board — unmeasured envelopes and shard partials will no longer count toward attendance or inflate `R_attendance`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7317a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->