### PR TITLE
Expose t_materialize_s on recensus running-counts

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -787,12 +787,17 @@ def _measure_file(
         end_file_open_profile()
     module_summary = summarize_module_materialize(profile_bag)
     timing["module_materialize"] = module_summary
-    # Dominant phase for one-line cause naming (excludes nested module time
-    # which is already inside t_populate / t_open when materialize runs there).
+    # Explicit materialize wall (sum of materialize_module calls). Nested inside
+    # populate/open wall-clock, but first-class so running-counts answers
+    # "rebuilds" without digging module_materialize.top.
+    timing["t_materialize_s"] = float(module_summary.get("materialize_s") or 0.0)
+    timing["materialize_calls"] = int(module_summary.get("materializeCalls") or 0)
+    # Dominant phase for one-line cause naming.
     phase_seconds = {
         "context": float(timing["t_context_s"]),
         "open": float(timing["t_open_s"]),
         "populate": float(timing["t_populate_s"]),
+        "materialize": float(timing["t_materialize_s"]),
         "cm_tally": float(timing["t_cm_tally_s"]),
         "enumerate": float(timing["t_enumerate_s"]),
         "sugar_loop": float(timing["t_sugar_loop_s"]),
@@ -1567,6 +1572,8 @@ def main() -> int:
                     "fn_total": live_fns,
                     "phase": "per_file_lift",
                     "t_open_s": row_timing.get("t_open_s"),
+                    "t_materialize_s": row_timing.get("t_materialize_s"),
+                    "materialize_calls": row_timing.get("materialize_calls"),
                     "t_populate_s": row_timing.get("t_populate_s"),
                     "t_enumerate_s": row_timing.get("t_enumerate_s"),
                     "t_sugar_loop_s": row_timing.get("t_sugar_loop_s"),
@@ -1602,6 +1609,8 @@ def main() -> int:
                         f"dominant={row_timing.get('dominant_phase')}:"
                         f"{row_timing.get('dominant_phase_s')}s "
                         f"open={row_timing.get('t_open_s')}s "
+                        f"materialize={row_timing.get('t_materialize_s')}s "
+                        f"materialize_calls={row_timing.get('materialize_calls')} "
                         f"populate={row_timing.get('t_populate_s')}s "
                         f"enumerate={row_timing.get('t_enumerate_s')}s "
                         f"sugar_loop={row_timing.get('t_sugar_loop_s')}s "

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_file_open_profile.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_file_open_profile.py
@@ -33,6 +33,8 @@ def test_measure_file_persists_phase_timers(tmp_path: Path) -> None:
     timing = row["timing"]
     for key in (
         "t_open_s",
+        "t_materialize_s",
+        "materialize_calls",
         "t_populate_s",
         "t_enumerate_s",
         "t_sugar_loop_s",
@@ -82,7 +84,10 @@ def test_running_counts_line_includes_timing_fields(tmp_path: Path) -> None:
     assert lines, "running-counts.jsonl must have at least one file row"
     row = json.loads(lines[-1])
     assert "t_open_s" in row
+    assert "t_materialize_s" in row
+    assert "materialize_calls" in row
     assert "t_populate_s" in row
+    assert "t_enumerate_s" in row
     assert "t_sugar_loop_s" in row
     assert "dominant_phase" in row
     assert "module_materialize" in row


### PR DESCRIPTION
## Summary

Follow-up to **#7054** (already on main).

#7054 persists phase timers into `running-counts.jsonl`. This adds the requested **first-class** names:

- `t_materialize_s` — sum of `materialize_module` wall during the file open
- `materialize_calls` — how many times modules were rebuilt

Already on main from #7054: `t_open_s`, `t_populate_s`, `t_enumerate_s`, `t_sugar_loop_s`, `module_materialize.top[]` (per-module count+s), `dominant_phase`, `slowest_fn`.

## For merge_dog

Small, non-semantic instrumentation. No heavy fire required.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `t_materialize_s` and `materialize_calls` in recensus running-counts output
> - Adds `t_materialize_s` (summed wall time) and `materialize_calls` (count) from `module_summary` to the timing row returned by `_measure_file` in [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/7056/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d).
> - Includes `materialize` as a candidate phase when computing `dominant_phase` and `dominant_phase_s`, so the dominant phase reported may change for files where materialization dominates.
> - Extends the per-file running-counts JSONL payload and human-readable narration to include the two new fields.
> - Updates [test_recensus_file_open_profile.py](https://github.com/TSavo/sugar/pull/7056/files#diff-083e04b4f146b697a1a1667af4ead67518673b12dcf471dcd153b4d6979b0b2c) to assert presence of the new fields in both timing rows and running-counts output.
> - Behavioral Change: downstream consumers of running-counts JSONL and timing rows will see two new fields, and `dominant_phase` may now report `materialize` where it previously would not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 350fcb8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->