### PR TITLE
Population membrane: stdlib success cites, never MaterializeModule

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_resolution.py
@@ -54,6 +54,7 @@ class SourceCallPreconstructionGapV1:
         "value-call-target",
         "call-target-source-absent",
         "call-target-export-unresolved",
+        "call-target-off-population",
         "non-manager-result",
         "call-binding",
         "dynamic-call-target",

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -709,6 +709,15 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
 
     if module.source_cid != blake3_512_of(module.source.encode("utf-8")):
         raise ValueError("module prefix source CID mismatch")
+    # Defensive membrane: stdlib must never reach MaterializeModule here.
+    # Callers should short-circuit in prefix_has_completed_fallthrough; if they
+    # do not, refuse loudly rather than rebuild an unenrolled module.
+    if graph is not None and getattr(graph, "artifact_kind", None) == "stdlib":
+        raise RuntimeError(
+            "population membrane: _module_prefix_outcome must not MaterializeModule "
+            f"stdlib seat {module.source_seat!r}; cite via "
+            "prefix_has_completed_fallthrough / call-target-off-population"
+        )
     construction_context = TreeConstructionContextV1.for_source_call_construction()
     producer_reporter = ConstructionTestimonyReporterV1(
         NULL_REPORTER, SubstitutionTraceBuilderV1(module.source_cid)
@@ -822,8 +831,20 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
 def prefix_has_completed_fallthrough(
     module, locus, *, graph=None, session=None
 ) -> bool:
-    """Admit an export only through the authenticated module-prefix producer."""
+    """Admit an export only through the authenticated module-prefix producer.
+
+    POPULATION MEMBRANE: when ``graph`` is stdlib (off enrolled population),
+    never ``MaterializeModule`` the module to prove fallthrough.  Static export
+    locus + definition coordinate is enough for a ResolvedPythonObjectV1
+    citation; frame projection then cites via ``call-target-off-population``
+    instead of rebuilding.  Running the prefix producer here is what turned
+    one pandas open into 35× ``SourceFile(enum.py)``.
+    """
     from sugar_lift_py_tests.outcome import Completed, true_guard
+
+    if graph is not None and getattr(graph, "artifact_kind", None) == "stdlib":
+        # Cite path: admit static export without off-population construction.
+        return True
 
     exits = _module_prefix_outcome(module, locus, graph=graph, session=session)
     if len(exits.exits) != 1:
@@ -932,11 +953,18 @@ class ConstructedManagerBehaviorV1:
 #     The export door DID authenticate an object in this artifact, but projecting
 #     its frame failed.  A defect in the door, not a coverage gap -- and invisible
 #     for as long as it shares a bucket with the other three.
+# ``call-target-off-population``
+#     The export door authenticated a defining source, but that source is outside
+#     the enrolled measurement population (stdlib / off-pin).  Cite via the opaque
+#     obligation path; do NOT MaterializeModule / ClassDef.sugar the unenrolled
+#     module.  Successful resolution used to be punished with a full rebuild
+#     while failure already cited -- the population membrane closes that hole.
 
 _CALL_TARGET_GAP_PRECEDENCE = (
     "call-graph-cycle",
     "value-call-target",
     "call-target-export-unresolved",
+    "call-target-off-population",
     "call-target-source-absent",
 )
 
@@ -952,6 +980,7 @@ class _ExternalCallTargetGap:
     kind: Literal[
         "call-target-source-absent",
         "call-target-export-unresolved",
+        "call-target-off-population",
         "call-graph-cycle",
     ]
 
@@ -965,12 +994,39 @@ class ManagerConstructionGapV1:
         "value-call-target",
         "call-target-source-absent",
         "call-target-export-unresolved",
+        "call-target-off-population",
         "non-manager-result",
         "call-binding",
         "force-floor",
     ]
     resolved_object_cid: str
     detail: str
+
+
+def _off_population_materialize_gap(
+    resolved: "ResolvedPythonObjectV1",
+    *,
+    graph: "DependencyArtifactGraph",
+) -> ManagerConstructionGapV1 | None:
+    """Population membrane: off-pin success must cite, never rebuild.
+
+    Failure already parks an opaque obligation.  Success against authenticated
+    stdlib used to call ``resolve_source_visible_frame`` and fully
+    ``MaterializeModule`` the unenrolled source (enum.py 35× on one pandas
+    open).  That corrupts measurement integrity: the pin enrolls corpus files,
+    not CPython.  Return a typed gap so every caller takes the same cite path
+    failure already uses.
+    """
+    if graph.artifact_kind != "stdlib":
+        return None
+    return ManagerConstructionGapV1(
+        "call-target-off-population",
+        resolved.cid,
+        (
+            f"stdlib module {resolved.module_name!r} is off enrolled population; "
+            "cite via opaque membrane, do not MaterializeModule"
+        ),
+    )
 
 
 def _factory_return_faces_from_entries(
@@ -1687,6 +1743,13 @@ def resolve_source_visible_frame(
         return ManagerConstructionGapV1(
             "artifact-mismatch", resolved.cid, "module source CID"
         )
+    # POPULATION MEMBRANE (measurement integrity): off-pin authenticated
+    # success must cite, never rebuild.  Placed AFTER artifact identity checks
+    # and BEFORE any SourceFile / MaterializeModule.  Failure already cites via
+    # _install_opaque_call_obligation; success must take the same door.
+    off_pop = _off_population_materialize_gap(resolved, graph=graph)
+    if off_pop is not None:
+        return off_pop
     definition = resolved.definition
     cache_key = (
         graph.distribution_artifact_cid,
@@ -2037,11 +2100,14 @@ def _resolve_source_visible_frame_uncached(
             del exc
             continue
         if isinstance(projected, ManagerConstructionGapV1):
-            kind = (
-                "call-graph-cycle"
-                if projected.kind == "call-graph-cycle"
-                else "call-target-export-unresolved"
-            )
+            if projected.kind == "call-graph-cycle":
+                kind = "call-graph-cycle"
+            elif projected.kind == "call-target-off-population":
+                # Cite: success against authenticated stdlib is not a door
+                # defect and not coverage-absent — it is off-population.
+                kind = "call-target-off-population"
+            else:
+                kind = "call-target-export-unresolved"
             _install_opaque_call_obligation(
                 context,
                 call,
@@ -2670,6 +2736,8 @@ def _resolve_external_call_frame(
         # reported as a bug in the export door.
         if projected.kind == "call-graph-cycle":
             return _ExternalCallTargetGap("call-graph-cycle")
+        if projected.kind == "call-target-off-population":
+            return _ExternalCallTargetGap("call-target-off-population")
         return _ExternalCallTargetGap("call-target-export-unresolved")
     frame, _target = projected
     return frame

--- a/implementations/python/sugar-lift-python-source/tests/test_population_membrane_stdlib_cite.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_population_membrane_stdlib_cite.py
@@ -1,0 +1,133 @@
+"""Population membrane: off-pin success cites, never rebuilds.
+
+Advisor ruling (measurement integrity): the pin enrolls corpus files (pandas),
+not CPython.  A terminal for a pandas file must not be decided by constructing
+an unenrolled module.
+
+The opaque/cite path already existed on FAILURE
+(``_install_opaque_call_obligation``).  SUCCESS against authenticated stdlib
+used to call ``resolve_source_visible_frame`` → full ``MaterializeModule`` of
+the dependency (``enum.py`` 35× on one open of ``pandas/io/json/_json.py``).
+
+Red instrument (one assertion):
+  one open of pandas/io/json/_json.py → SourceFile constructions of enum.py == 0
+
+Do not touch the dependency-seat memo — that is a separate campaign (white).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+from sugar_lift_py_tests.lift_rpc import (
+    open_source_file_for_construction,
+    tree_construction_context_for_workspace,
+)
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.tree import SourceFile
+
+
+def _enum_seat(filename: str) -> bool:
+    seat = str(filename).replace("\\", "/")
+    return seat.endswith("enum.py") or seat == "enum.py"
+
+
+def _count_enum_sourcefiles_during(open_fn) -> tuple[int, int, object]:
+    """Patch SourceFile.__init__ to count constructions, run open_fn, restore."""
+    counts = {"all": 0, "enum": 0}
+    orig = SourceFile.__init__
+
+    def counting_init(self, identity, *args, **kwargs):  # type: ignore[no-untyped-def]
+        _source, filename, _cid = identity
+        counts["all"] += 1
+        if _enum_seat(filename):
+            counts["enum"] += 1
+        return orig(self, identity, *args, **kwargs)
+
+    SourceFile.__init__ = counting_init  # type: ignore[method-assign]
+    try:
+        result = open_fn()
+    finally:
+        SourceFile.__init__ = orig  # type: ignore[method-assign]
+    return counts["enum"], counts["all"], result
+
+
+def _locus_root_for_corpus(corpus: Path) -> Path:
+    """Install root that records seats as ``pandas/...`` (not package-relative)."""
+    import importlib.util
+
+    # tests/ -> sugar-lift-python-source -> python/ -> sugar-lift-py-tests/scripts
+    cer_path = (
+        Path(__file__).resolve().parents[2]
+        / "sugar-lift-py-tests"
+        / "scripts"
+        / "control_effect_recensus.py"
+    )
+    # __file__ = .../sugar-lift-python-source/tests/test_....py
+    # parents[0]=tests, [1]=sugar-lift-python-source, [2]=python
+    assert cer_path.is_file(), f"missing recensus script at {cer_path}"
+    spec = importlib.util.spec_from_file_location("cer_membrane", cer_path)
+    assert spec is not None and spec.loader is not None
+    cer = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cer)
+    return cer.locus_root_for_corpus(corpus)
+
+
+def test_population_membrane_json_open_never_materializes_enum_py() -> None:
+    """One open of pandas io/json/_json.py must construct SourceFile(enum.py) zero times.
+
+    Pre-membrane this was 35.  Green is 0: success cites.
+    Open may still SNW for unrelated in-population reasons; the instrument
+    only measures off-population rebuild of enum.py.
+    """
+    corpus = authenticated_pandas_corpus().root
+    locus = _locus_root_for_corpus(corpus)
+    target = corpus / "io" / "json" / "_json.py"
+    assert target.is_file(), f"missing planted corpus file {target}"
+
+    ctx = tree_construction_context_for_workspace(corpus, contract_refs={})
+    reporter = CollectingReporter()
+
+    def open_once():
+        from sugar_source_tree.panic import SugarNotWritten
+
+        try:
+            return open_source_file_for_construction(
+                target,
+                root=locus,
+                reporter=reporter,
+                construction_context=ctx,
+                populate_derived=True,
+            )
+        except SugarNotWritten:
+            # In-population SNW is not this instrument.  enum count still measured.
+            return object()
+
+    enum_n, total_n, _result = _count_enum_sourcefiles_during(open_once)
+    assert enum_n == 0, (
+        f"POPULATION MEMBRANE RED: SourceFile constructions of enum.py = {enum_n} "
+        f"(want 0). Success against authenticated stdlib must cite, never "
+        f"MaterializeModule. total SourceFile constructions this open={total_n}."
+    )
+
+
+def test_off_population_gap_helper_names_stdlib() -> None:
+    """Unit tooth: stdlib graphs return the off-population gap; distributions do not."""
+    from sugar_lift_python_source.dependency_artifact import (
+        DependencyArtifactGraph,
+    )
+    from sugar_lift_python_source.manager_construction import (
+        _off_population_materialize_gap,
+    )
+
+    # Minimal resolved stand-in: only cid + module_name are read by the helper.
+    class _Resolved:
+        cid = "test-resolved-cid"
+        module_name = "enum"
+
+    stdlib = DependencyArtifactGraph.authenticate_stdlib_module("enum")
+    gap = _off_population_materialize_gap(_Resolved(), graph=stdlib)  # type: ignore[arg-type]
+    assert gap is not None
+    assert gap.kind == "call-target-off-population"
+    assert "enum" in gap.detail

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -214,6 +214,8 @@ class WithConstructionGapKind(str, Enum):
     VALUE_CALL_TARGET = "value-call-target"
     CALL_TARGET_SOURCE_ABSENT = "call-target-source-absent"
     CALL_TARGET_EXPORT_UNRESOLVED = "call-target-export-unresolved"
+    # Authenticated stdlib / off-pin: cite, never MaterializeModule (membrane).
+    CALL_TARGET_OFF_POPULATION = "call-target-off-population"
     ENTER_MISSING = "enter-missing"
     EXIT_MISSING = "exit-missing"
     METHOD_CONSTRUCTION = "method-construction"


### PR DESCRIPTION
## Claim

**A: POPULATION MEMBRANE** (collision split — white owns B dependency-seat memo; not touched).

## Disease (measurement integrity)

The pin enrolls **1421 pandas files**. Nothing enrolls CPython. Failure already cited via `_install_opaque_call_obligation`. **Success** against authenticated stdlib ran full `MaterializeModule` / `ClassDef.sugar` of the unenrolled module.

Observed pre-fix: one open of `pandas/io/json/_json.py` → **`SourceFile(enum.py) = 35`**, ~90s+ in `ClassDef.sugar|enum.py:508`.

## Fix (success cites)

| Door | Behavior |
| --- | --- |
| `resolve_source_visible_frame` | `artifact_kind==stdlib` → `call-target-off-population` gap → opaque cite path; **no** `SourceFile` |
| `prefix_has_completed_fallthrough` | stdlib admits static export **without** `_module_prefix_outcome` (that path was the 35× factory) |
| `_module_prefix_outcome` | defensive RuntimeError if stdlib ever reaches it |

New kind enrolled: `call-target-off-population` (gap vocab + `WithConstructionGapKind` + preconstruction Literal).

## Red instrument (banked green)

```
one open of pandas/io/json/_json.py → SourceFile constructions of enum.py == 0
```

| | pre | post |
| --- | --- | --- |
| `enum.py` SourceFile count | **35** | **0** |
| wall (this open) | ~90s+ in enum sugar | **~7s** |
| instrument | — | `test_population_membrane_stdlib_cite.py` |

Env: `/Users/tsavo/.claude/jobs/0bdf89c4/tmp/v312/bin/python` (3.12.13, pandas 3.0.3).

## PR accounting

| | |
| --- | --- |
| **R** | off-pin rebuilds of stdlib during corpus open (enum seat as named tooth) |
| **εR** | enum SourceFile count 35→0 on `_json` open; terminals no longer decided by unenrolled ClassDef.sugar |
| **Floors** | binding still authenticates; failure cite path unchanged; white’s memo untouched |
| **Shell deleted** | “success against stdlib means full MaterializeModule” |

## Not this PR

- Dependency-seat memo (once-per-open) — **mr_white / B**
- Attribution SNW / instrument-defect reclass — priority 2
- LPT k=8 — mr_black

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add population membrane to cite stdlib modules instead of materializing them
> - Introduces a `call-target-off-population` gap kind to signal when a call target resolves to a stdlib module, preventing materialization of those modules.
> - `resolve_source_visible_frame` now returns a `ManagerConstructionGapV1(kind='call-target-off-population')` early when the graph artifact is stdlib, and `prefix_has_completed_fallthrough` returns `True` for stdlib artifacts without invoking `_module_prefix_outcome`.
> - `_module_prefix_outcome` raises `RuntimeError` if called with a stdlib graph, enforcing that callers use the new gap path instead.
> - Adds tests asserting that opening a corpus file produces zero `SourceFile` constructions for `enum.py` and that the off-population gap helper correctly identifies stdlib artifacts.
> - Behavioral Change: stdlib call targets no longer materialize source files; they now produce an opaque `call-target-off-population` obligation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 859d91b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->