### PR TITLE
Session memos stay: multi-resolve owners must thread one session

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -203,13 +203,20 @@ def open_source_file_for_construction(
     call_contract_refs=None,
     construction_context=None,
     populate_derived: bool = True,
+    resolution_session=None,
 ):
     """Open a SourceFile the way production enumerate does — never bare context.
 
     Injects ``TreeConstructionContextV1`` (bound or provisional) and, by default,
     freezes source-derived manager refs at exact use-sites. Callers that already
     hold a frozen context (shared demand table across a census) may pass it.
+
+    ``resolution_session`` owns every source-resolution memo for this open. When
+    omitted, this door mints one session for the population so multi-receipt
+    amortization is real; multi-file owners should pass one shared session so
+    the same dependency definition is not re-projected per consumer file.
     """
+    from sugar_lift_python_source.resolution_session import session_or_new
     from sugar_lift_python_source.source_oracle import workspace_path_source
     from sugar_source_tree.reporter import NULL_REPORTER
     from sugar_source_tree.tree import SourceFile
@@ -232,7 +239,12 @@ def open_source_file_for_construction(
             populate_source_derived_resource_refs,
         )
 
-        populate_source_derived_resource_refs(source_file, root=root, path=path)
+        # File-open is a multi-resolve owner: one session for every receipt in
+        # this population. session_or_new keeps an explicit shared session.
+        session = session_or_new(resolution_session)
+        populate_source_derived_resource_refs(
+            source_file, root=root, path=path, session=session
+        )
     return source_file
 
 
@@ -1793,6 +1805,13 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
 
             rows = []
             construction_context = TreeConstructionContextV1(_BOUND_CONTRACT_REFS)
+            # One session for the whole package walk: the same dependency
+            # definition projected for many consumer files amortizes once.
+            from sugar_lift_python_source.resolution_session import (
+                SourceResolutionSession,
+            )
+
+            package_session = SourceResolutionSession()
             for source_path in sorted(root.rglob("*.py")):
                 identity = path_source(str(source_path))
                 source_file = _TreeSourceFile(
@@ -1803,7 +1822,10 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 )
 
                 populate_source_derived_resource_refs(
-                    source_file, root=root, path=source_path
+                    source_file,
+                    root=root,
+                    path=source_path,
+                    session=package_session,
                 )
                 for function in source_file.functions():
                     function_sugar = function.sugar()
@@ -2035,9 +2057,16 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 from sugar_lift_python_source.manager_summary_derivation import (
                     populate_source_derived_resource_refs,
                 )
+                from sugar_lift_python_source.resolution_session import (
+                    SourceResolutionSession,
+                )
 
+                # Single-file multi-resolve owner: one session for every receipt.
                 populate_source_derived_resource_refs(
-                    tree_file, root=root, path=full_path
+                    tree_file,
+                    root=root,
+                    path=full_path,
+                    session=SourceResolutionSession(),
                 )
                 nodes = []
                 for fn in tree_file.functions():

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1200,8 +1200,10 @@ def populate_source_derived_resource_refs(
 ) -> None:
     """Preconstruct imported resource managers and freeze exact use-site rows.
 
-    ``session`` owns every resolution memo for this population; the default
-    opens one bounded to this source file.
+    ``session`` owns every resolution memo for this population. Multi-resolve
+    owners (file-open, package enumeration) must pass one shared session so
+    export/frame amortization is real across receipts and consumer files. The
+    default opens one bounded to this single population call only.
     """
     from pathlib import Path
 
@@ -1224,6 +1226,8 @@ def populate_source_derived_resource_refs(
     from .manager_protocol_construction import construct_manager_protocol
     from .resolution_session import session_or_new
 
+    # Multi-resolve owner entry: one session for every receipt in this loop.
+    # Do not call session_or_new inside the receipt loop.
     session = session_or_new(session)
     context = source_file.root.unit.construction_context
     if context is None:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -32,6 +32,29 @@ this construction or the memo does not answer.
 
 ``enabled=False`` disables memoization entirely. That switch must change
 performance ONLY: never a formula, never a gap, never a verdict.
+
+Decision of record (session-memo liveness)
+------------------------------------------
+The memos on this class are real amortization, not decorative. They fire in two
+places:
+
+1. **Inside one call tree** -- even a single-shot ``session_or_new(None)`` entry
+   still needs ``frame_active`` (cycle detection) and nested export/frame hits
+   while that one top-level resolve walks reexports and nested callees.
+2. **Across top-level resolves** -- only when the *same* session object is
+   threaded. Multi-resolve owners (file-open population, package-level
+   enumeration that projects the same dependency definitions for many consumer
+   files) MUST mint one session and pass it through every resolve. Leaving
+   ``session=None`` at those doors re-opens a session per call and the across-
+   call amortization is gone -- correct isolation, wrong owner.
+
+Deletion of these memos is refused: the pandas megamodule wall was re-materializing
+SourceFile + class-base sugar once per call-site receipt of the same authenticated
+definition. The session is the boundary that makes that amortization safe.
+
+``session_or_new(None)`` remains the honest single-shot leaf: slower, always
+correct, never process-global. It is not permission for a multi-resolve owner to
+drop the session.
 """
 
 from __future__ import annotations
@@ -88,10 +111,15 @@ class SourceResolutionSession:
 
 
 def session_or_new(session: SourceResolutionSession | None) -> SourceResolutionSession:
-    """Resolve the caller's session, or open one bounded to this single call.
+    """Resolve the caller's session, or open one bounded to this single call tree.
 
     ``None`` never means "share the process": it means "this call is its own
-    session". The memo then dies with the call, which is slower and always
-    correct.
+    session". Nested resolves inside that call still share the returned object
+    (cycle detection and within-tree amortization stay real). The memo dies with
+    the call tree -- slower across independent top-level calls, always correct.
+
+    Multi-resolve owners (populate, package enumeration, file-open) must pass an
+    explicit session so amortization reaches every receipt they own. Do not call
+    this at those doors and throw the result away between receipts.
     """
     return SourceResolutionSession() if session is None else session

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
@@ -41,14 +41,16 @@ def populate_source_visible_call_frames(
 ) -> None:
     """Populate exact-use source frames and one closed classification row.
 
-    ``session`` owns every resolution memo for this population.  The default
-    opens one bounded to this source file, so no frame projected for one file
-    (or one project) can ever answer for another.
+    ``session`` owns every resolution memo for this population. Multi-resolve
+    owners must pass one shared session so amortization reaches every receipt.
+    The default opens one bounded to this single population call only — no
+    frame projected under that isolated session can answer for another call.
     """
     from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
 
     from .resolution_session import session_or_new
 
+    # Multi-resolve owner entry: one session for every receipt in this loop.
     session = session_or_new(session)
     context = source_file.unit.construction_context
     if context is None:

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -493,3 +493,111 @@ def test_authority_blind_key_aliases_two_distributions(
     )
     assert isinstance(projected, mc.ManagerConstructionGapV1)
     assert projected.kind == "artifact-mismatch"
+
+
+# -------------------------------- multi-resolve owner must thread session
+
+
+def test_shared_session_amortizes_across_two_consumer_files(tmp_path: Path) -> None:
+    """Multi-resolve owners must pass one session — memos are not decorative.
+
+    Decision of record: keep the session memos; make sessions reach every
+    multi-resolve owner. Two consumer files that project the same authenticated
+    definition under ONE package session must rematerialize once, not twice.
+    Two isolated session_or_new(None) trees rematerialize twice — isolation is
+    correct for leaves, wrong for package enumeration.
+    """
+    from sugar_lift_python_source.resolution_session import session_or_new
+
+    dist_root = tmp_path / "dist"
+    distribution = _install(dist_root, implementation_source=_IMPL_A)
+    graph = DependencyArtifactGraph.authenticate(distribution)
+
+    consumers = tmp_path / "consumers"
+    consumers.mkdir()
+    paths = []
+    for name in ("a.py", "b.py"):
+        path = consumers / name
+        path.write_text("import example_pkg\nexample_pkg.build(1)\n", encoding="utf-8")
+        paths.append(path)
+
+    def project_once(session):
+        for path in paths:
+            from sugar_lift_py_tests.import_binding import (
+                authenticated_import_use_receipts,
+            )
+
+            source = path.read_text(encoding="utf-8")
+            receipts, _ = authenticated_import_use_receipts(
+                consumers,
+                path,
+                source,
+                blake3_512_of(source.encode("utf-8")),
+                module_identities={},
+            )
+            assert len(receipts) == 1
+            resolved = resolve_import_binding(
+                receipts[0], graph=graph, session=session
+            )
+            assert isinstance(resolved, ResolvedPythonObjectV1)
+            projected = resolve_source_visible_frame(
+                resolved, graph=graph, session=session
+            )
+            assert isinstance(projected, tuple), projected
+
+    shared = SourceResolutionSession()
+    with _MaterializeCounter() as cold_counter:
+        project_once(shared)  # two consumers, one session
+    cold = cold_counter.count
+    assert cold >= 1, "shared session did no projection work"
+    assert len(shared.frame_results) == 1, shared.frame_results
+    # Second pass over the same two consumers must be free under the shared session.
+    with _MaterializeCounter() as warm_counter:
+        project_once(shared)
+    assert warm_counter.count == 0, (
+        f"shared multi-resolve session still rematerialized {warm_counter.count} "
+        f"times on the second pass; session memos are dead across consumers"
+    )
+
+    # Discrimination: isolated leaves (session_or_new(None) per project_once)
+    # do not share memos — correct isolation, and proves the warm zero is real.
+    with _MaterializeCounter() as isolated_counter:
+        project_once(session_or_new(None))
+        project_once(session_or_new(None))
+    assert isolated_counter.count >= cold * 2, (
+        f"isolated sessions only materialized {isolated_counter.count} times "
+        f"(cold shared was {cold}); the shared-session twin cannot bite"
+    )
+
+
+def test_file_open_door_threads_resolution_session(tmp_path: Path, monkeypatch) -> None:
+    """Production file-open is a multi-resolve owner and must pass a session."""
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+    from sugar_lift_python_source import manager_summary_derivation as msd
+    from sugar_lift_python_source.resolution_session import SourceResolutionSession
+
+    root = tmp_path / "ws"
+    root.mkdir()
+    path = root / "consumer.py"
+    path.write_text("x = 1\n", encoding="utf-8")
+
+    seen: list[object] = []
+    original = msd.populate_source_derived_resource_refs
+
+    def capture(source_file, *, root, path, session=None, **kwargs):
+        seen.append(session)
+        return original(source_file, root=root, path=path, session=session, **kwargs)
+
+    monkeypatch.setattr(msd, "populate_source_derived_resource_refs", capture)
+
+    open_source_file_for_construction(path, root=root)
+    assert len(seen) == 1
+    assert isinstance(seen[0], SourceResolutionSession), (
+        "file-open dropped the session; populate fell back to session_or_new and "
+        "the multi-resolve owner no longer owns amortization"
+    )
+
+    shared = SourceResolutionSession()
+    seen.clear()
+    open_source_file_for_construction(path, root=root, resolution_session=shared)
+    assert seen == [shared], "explicit package session must reach populate unchanged"


### PR DESCRIPTION
## Decision

White’s second defect: `SourceResolutionSession` is created fresh via `session_or_new(None)` (“slower and always correct”), so the class memos can look like dead caches.

**Keep the memos. Make sessions reach multi-resolve owners.**

Deletion is refused: the pandas megamodule wall was re-materializing SourceFile + class-base sugar once per call-site receipt of the same authenticated definition. Session-scoped export/frame memos are the amortization boundary that made that safe without process-global authority leaks (#6266).

`session_or_new(None)` remains the honest **single-shot leaf**: nested work inside that call tree still shares the session (cycle detection + within-tree hits). Across independent top-level calls, isolation is correct — but **populate / file-open / package enumeration must pass one explicit session** so amortization reaches every receipt they own.

## What changed

- Document the decision of record on `resolution_session.py`.
- Production multi-resolve doors thread a session:
  - `open_source_file_for_construction` mints/passes one session into populate (accepts `resolution_session=` for package owners).
  - Package CM-edge walk holds **one** `SourceResolutionSession` across all consumer files.
  - Functions-level enumerate passes an explicit session into populate.
- Authority teeth (13 green):
  - Shared session: second pass over two consumers of the same definition rematerializes **0** times.
  - Isolated `session_or_new(None)` trees rematerialize (discrimination).
  - File-open door threads a real `SourceResolutionSession` into populate.

## Out of scope

Does **not** touch `manager_construction.py` materialize path (~1739). White owns that memo.

## Epsilon R

- Axis: session-memo liveness (decorative-or-dead vs multi-resolve-owned).
- Predicted: decorative-or-dead **1 → 0** (owners thread session; teeth pin it).
- Floors: no process-global memo return; no verdict change.

## Validation

```text
pytest implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
# 13 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Thread a single `SourceResolutionSession` across multi-resolve owners to memoize session state
> - `open_source_file_for_construction` in [lift_rpc.py](https://github.com/TSavo/sugar/pull/7059/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) gains an optional `resolution_session` parameter and passes the resolved session into `populate_source_derived_resource_refs`, replacing per-call session creation.
> - The `_handle_enumerate` handler creates a single shared `SourceResolutionSession` for the context-manager edge enumeration branch, passing it to each file's derived-resource population.
> - `populate_source_derived_resource_refs` and `populate_source_visible_call_frames` gain comments clarifying that callers are multi-resolve owners responsible for session lifetime.
> - Two new tests in [test_resolution_session_authority.py](https://github.com/TSavo/sugar/pull/7059/files#diff-6b5c105a0d2ad119bca88016326d4132c5d6ec39fa3e1f68cdd8fdc3aaa00e43) verify cross-consumer amortization and that `open_source_file_for_construction` correctly threads an explicit session.
> - Behavioral Change: callers that previously got isolated sessions per call now share memoized state when a session is provided; callers passing `None` retain isolated behavior via `session_or_new`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b6fb6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->