### PR TITLE
Native carrier for SymbolicValue+str (unblinds enum.py:75 materialize SNW)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -462,7 +462,22 @@ class StringValue(GuardStableValue):
                     **runtime_effect_evidence("py.sequence_concat", other, site),
                 )
             )
-        if type(other) in (CallSiteValue, ImportAliasValue, SymbolicValue):
+        if type(other) is SymbolicValue:
+            # str + symbolic: same native-operation ExitSet carrier as
+            # SymbolicValue.add(StringValue). Do not re-enter as
+            # SymbolicValue(str_term).add(symbolic) — that pair SNWs and was
+            # the reverse face of enum.py:75-style materialize aborts.
+            from sugar_lift_py_tests.caller_parameter_contract import (
+                NativeOperationExitCarrierV1,
+            )
+
+            return NativeOperationExitCarrierV1.mint(
+                site=site,
+                operator="add",
+                operands=(self, other),
+                coordinates=(None, getattr(other, "formal_coordinate", None)),
+            )
+        if type(other) in (CallSiteValue, ImportAliasValue):
             return SymbolicValue(self.to_term(owner=str(site))).add(other, site)
         if other.denotes_value() and other.runtime_type_is_decided():
             from sugar_lift_py_tests.floor.ground_exit import ground_type_error

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -375,6 +375,7 @@ class SymbolicValue(FloorValue):
 
     def _runtime_binary_dispatch(self, other, site, operator):
         from sugar_lift_py_tests.floor.guarded_value import GuardedValue
+        from sugar_lift_py_tests.floor.string_value import StringValue
 
         owner = next(
             method
@@ -384,6 +385,25 @@ class SymbolicValue(FloorValue):
         left_coordinate = self.formal_coordinate
         right_coordinate = getattr(other, "formal_coordinate", None)
         if left_coordinate is not None or right_coordinate is not None:
+            from sugar_lift_py_tests.caller_parameter_contract import (
+                NativeOperationExitCarrierV1,
+            )
+
+            return NativeOperationExitCarrierV1.mint(
+                site=site,
+                operator=owner,
+                operands=(self, other),
+                coordinates=(left_coordinate, right_coordinate),
+            )
+        # Symbolic + str concat without a seated formal (NameSugar desugar of a
+        # parameter before FormalRef seating) used to SNW at
+        # binary_operation_exception_floor — enum.py:75 ``cls_name + '.' + …``.
+        # That abort escaped through dependency ClassDef/function force-floor
+        # during MaterializeModule of pandas files (e.g. io/json/_json.py) and
+        # returned functionsTotal=0 before any function walk. Mint the same
+        # native-operation ExitSet carrier formals already use; coordinates may
+        # be None. Do not invent Complete(SymbolicValue) concat (undecided-law).
+        if operator == "+" and type(other) is StringValue:
             from sugar_lift_py_tests.caller_parameter_contract import (
                 NativeOperationExitCarrierV1,
             )

--- a/implementations/python/sugar-lift-py-tests/tests/test_symbolic_string_concat_native_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_symbolic_string_concat_native_carrier.py
@@ -1,0 +1,98 @@
+"""Symbolic + str concat must not SNW at binary_operation_exception_floor.
+
+Recensus materialize of pandas files (e.g. io/json/_json.py) force-floors
+transitive stdlib (enum.py). Bare NameSugar desugar of a formal yields
+``SymbolicValue`` without ``formal_coordinate``; ``cls_name + '.'`` then raised
+``SugarNotWritten(owner=binary_operation_exception_floor)`` at enum.py:75:16
+and aborted SourceFile open with functionsTotal=0 before any function walk.
+
+Formal-seated formals already mint NativeOperationExitCarrierV1. This law
+extends the same carrier to formal-less SymbolicValue + StringValue (and the
+str + symbolic reverse) so materialize can complete and enumerate functions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.floor.string_value import StringValue
+from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.ir import make_var
+from sugar_source_tree.nodes import BinOp
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _tiny_binop_site():
+    """Minimal fragment — NativeOperationExitCarrier.mint needs line_col_span."""
+    from sugar_lift_python_source.canonical import blake3_512_of
+
+    src = "def f(cls_name):\n    return cls_name + '.'\n"
+    source = SourceFile(
+        (src, "tiny_concat.py", blake3_512_of(src.encode("utf-8"))),
+    )
+    return next(node for node in source.nodes() if isinstance(node, BinOp)).fragment
+
+
+def test_symbolic_plus_string_mints_native_operation_carrier() -> None:
+    site = _tiny_binop_site()
+    left = SymbolicValue(make_var("cls_name"))
+    right = StringValue(".")
+    assert left.formal_coordinate is None
+    outcome = left.add(right, site)
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    assert outcome.demand.operator == "add"
+
+
+def test_string_plus_symbolic_mints_native_operation_carrier() -> None:
+    site = _tiny_binop_site()
+    left = StringValue(".")
+    right = SymbolicValue(make_var("cls_name"))
+    outcome = left.add(right, site)
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    assert outcome.demand.operator == "add"
+
+
+def test_symbolic_plus_int_still_refuses_undecided() -> None:
+    """Discrimination: numeric undecided pair stays SNW (not string-concat door)."""
+    site = _tiny_binop_site()
+    with pytest.raises(SugarNotWritten) as raised:
+        SymbolicValue(make_var("n")).add(TermValue(2), site)
+    assert raised.value.owner == "binary_operation_exception_floor"
+
+
+def test_enum_py_line75_binop_desugar_does_not_snw() -> None:
+    """Live locus: enum._is_internal_class ``cls_name + '.' + getattr(...)``."""
+    enum_path = Path(__import__("enum").__file__)
+    source = SourceFile.from_path(enum_path)
+    binops = [
+        node
+        for node in source.nodes()
+        if isinstance(node, BinOp)
+        and node.line_col_span().start_line == 75
+        and node.line_col_span().start_col == 16
+    ]
+    assert binops, "expected enum.py:75:16 BinOp"
+    for node in binops:
+        sugar = node.sugar()
+        # Must not raise SugarNotWritten(binary_operation_exception_floor)
+        outcome = sugar.desugar(None)
+        assert outcome is not None
+        # Prefer carrier or Complete — never the old SNW abort.
+        if isinstance(outcome, Exception):
+            raise AssertionError(outcome)
+        # Nested left is NameSugar/formal-less path; carrier or nested Complete.
+        assert not isinstance(outcome, SugarNotWritten)
+
+
+def test_enum_is_internal_class_function_sugar_still_constructs() -> None:
+    enum_path = Path(__import__("enum").__file__)
+    source = SourceFile.from_path(enum_path)
+    function = next(fn for fn in source.functions() if fn.name == "_is_internal_class")
+    sugar = function.sugar()
+    outcome = sugar.desugar(None)
+    assert isinstance(outcome, NativeOperationExitCarrierV1) or outcome is not None


### PR DESCRIPTION
## Summary

**Why 708/1284 files had zero functions:** Materialize of in-corpus files (e.g. `pandas/io/json/_json.py`) force-floors transitive stdlib (`enum.py`). At `enum.py:75:16`, bare `NameSugar` desugar of formal `cls_name` yields `SymbolicValue` **without** `formal_coordinate`. Then:

```
cls_name + '.' + getattr(obj, '__name__', '')
```

raised `SugarNotWritten(owner=binary_operation_exception_floor, observed=SymbolicValue + StringValue)`. That abort hit SourceFile open / populate and returned `functionsTotal=0` before any function walk.

## Fix

- `SymbolicValue._runtime_binary_dispatch`: for `+` with `StringValue` and no seated formal, mint `NativeOperationExitCarrierV1` (same product as the formal-seated path). Do **not** invent `Complete(SymbolicValue)` concat.
- `StringValue.add(SymbolicValue)`: same carrier (reverse face); stop re-entering as `SymbolicValue(str_term).add(symbolic)` which SNWs.

## Validation

```
pytest tests/test_symbolic_string_concat_native_carrier.py -v --noconftest  # 5 passed
pytest tests/test_undecided_binary_operand_law.py -q --noconftest         # 70 passed
```

Env: v312 python as requested.

## Shell

Promotes string-concat native demand into the ExitSet carrier for formal-less symbolic+str. Undecided numeric pairs stay SNW.

Does not replace population membrane / dependency-seat memo (#1) — this only removes one high-mass SNW abort on the string-concat face that killed enumeration.

## Epsilon R

- Predicted: files that only died on this SNW become function-enumerable on next recensus.
- Does not claim full zero-function R→0 (other SNW owners remain).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native carrier for `SymbolicValue + str` and `str + SymbolicValue` to fix `SugarNotWritten` at `enum.py:75`
> - `SymbolicValue._runtime_binary_dispatch` now returns a `NativeOperationExitCarrierV1` (operator `add`) when the `+` operator is used with a `StringValue` and no formal coordinates are seated, instead of falling through to undecided dispatch that raised `SugarNotWritten`.
> - `StringValue.add` gains a dedicated branch for a `SymbolicValue` right operand that mints a `NativeOperationExitCarrierV1` directly, rather than re-entering via `SymbolicValue.add`.
> - A new test module [`test_symbolic_string_concat_native_carrier.py`](https://github.com/TSavo/sugar/pull/7060/files#diff-5527f3b15958e12c48abbfde01b638d00bc18a3ea4bd8a0129f0d866f1ba9b14) verifies both directions mint the carrier, that `SymbolicValue + int` still raises the named refusal, and that desugaring `enum.py:75:16` no longer raises `SugarNotWritten`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f01fff1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->