### PR TITLE
getattr volume: walk once, share walk products

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -819,12 +819,14 @@ class _Pass:
                 if scope.kind == "ClassDef"
                 else state
             )
-            local_names = _function_locals(node)
+            # One tree visit: locals + global/nonlocal declarations.
+            # Previously _function_locals and _function_declarations each did a
+            # full recursive children() walk of the same immutable body.
+            local_names, globals_, _nonlocals = _function_scope_bindings(node)
             for name in local_names:
                 inner[name] = frozenset({_UNBOUND})
             for param in node.params:
                 inner[param.name] = frozenset({_NON_IMPORT})
-            globals_, _nonlocals = _function_declarations(node)
             for name in globals_:
                 inner[name] = self.module_state.get(name, frozenset({_UNBOUND}))
             self.statements(node.body, inner, node)
@@ -942,11 +944,16 @@ class _Pass:
         raise UnsupportedStatementVariant(type(node).__name__)
 
 
-def _function_locals(node: Node) -> set[str]:
-    """Collect lexical bindings from the adapter's typed tree.
+def _function_scope_bindings(
+    node: Node,
+) -> tuple[set[str], set[str], set[str]]:
+    """One visit: local bindings, global names, nonlocal names.
 
     Nested scopes are barriers.  Binding sites are read from their typed roles;
     identifier spelling is never treated as evidence that a read is a store.
+
+    Replaces the old dual walk (``_function_locals`` + ``_function_declarations``)
+    that each did a full recursive ``children()`` pass over the same immutable body.
     """
     globals_: set[str] = set()
     nonlocals: set[str] = set()
@@ -990,29 +997,19 @@ def _function_locals(node: Node) -> set[str]:
             visit(descendant)
 
     visit(node, root=True)
-    return names - globals_ - nonlocals
+    locals_ = names - globals_ - nonlocals
+    return locals_, globals_, nonlocals
+
+
+def _function_locals(node: Node) -> set[str]:
+    """Local names only — thin projection of the single scope walk."""
+    locals_, _globals, _nonlocals = _function_scope_bindings(node)
+    return locals_
 
 
 def _function_declarations(node: Node) -> tuple[set[str], set[str]]:
-    globals_: set[str] = set()
-    nonlocals: set[str] = set()
-
-    def visit(child: Node, *, root: bool = False) -> None:
-        if not root and child.kind in (
-            "FunctionDef",
-            "AsyncFunctionDef",
-            "ClassDef",
-            "Lambda",
-        ):
-            return
-        if child.kind == "Global":
-            globals_.update(child.names)
-        elif child.kind == "Nonlocal":
-            nonlocals.update(child.names)
-        for _, _, descendant in child.children():
-            visit(descendant)
-
-    visit(node, root=True)
+    """Global/nonlocal declarations — thin projection of the single scope walk."""
+    _locals, globals_, nonlocals = _function_scope_bindings(node)
     return globals_, nonlocals
 
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -708,29 +708,33 @@ class Backend:
             )
             raise AssertionError("unreachable")
 
-        # This is the sole completed traversal.  Every roster below is a
-        # projection of these exact constructed node objects, never a reread.
-        constructed_nodes = tuple(root.walk())
+        # ONE pre-order walk produces constructed_nodes AND parent_positions.
+        # The old shape did root.walk() then a second full getattr of every
+        # _child_fields for the parent map — rediscovering edges the walk just
+        # traversed (tens of thousands of Node.__getattr__ calls per module).
+        # The tree is immutable; parent is a fact of that walk, not a second pass.
+        constructed_nodes_list: list[Node] = []
+        parent_positions: list[int | None] = []
+        function_nodes_list: list[Node] = []
+        # (node, parent_position) — same pre-order as Node.walk().
+        walk_stack: list[tuple[Node, int | None]] = [(root, None)]
+        while walk_stack:
+            node, parent_position = walk_stack.pop()
+            position = len(constructed_nodes_list)
+            constructed_nodes_list.append(node)
+            parent_positions.append(parent_position)
+            if isinstance(node, (FunctionDef, AsyncFunctionDef)):
+                function_nodes_list.append(node)
+            # _child_edges: one getattr of fields + memo for later walk/children.
+            child_nodes = [child for _n, _i, child in node._child_edges()]
+            # Parent of each child is this position; reverse for left-first order.
+            for child in reversed(child_nodes):
+                walk_stack.append((child, position))
+        constructed_nodes = tuple(constructed_nodes_list)
+        function_nodes = tuple(function_nodes_list)
         positions = {
             id(node): position for position, node in enumerate(constructed_nodes)
         }
-        parent_positions: list[int | None] = [None] * len(constructed_nodes)
-        for position, node in enumerate(constructed_nodes):
-            for field_name in type(node)._child_fields:
-                child_value = getattr(node, field_name)
-                if child_value is None:
-                    continue
-                if isinstance(child_value, Node):
-                    parent_positions[positions[id(child_value)]] = position
-                else:
-                    for child in child_value:
-                        if child is not None:
-                            parent_positions[positions[id(child)]] = position
-        function_nodes = tuple(
-            node
-            for node in constructed_nodes
-            if isinstance(node, (FunctionDef, AsyncFunctionDef))
-        )
         unit.bind_typed_module(
             root,
             constructed_nodes=constructed_nodes,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2628,34 +2628,55 @@ class Node(Typed):
     def end_col_offset(self) -> int:
         return self.line_col_span().end_col
 
-    def children(self) -> Iterator[tuple[str, Optional[int], "Node"]]:
-        """Yield (field_name, index-or-None, child) in declared grammar order."""
+    def _child_edges(self) -> tuple[tuple[str, Optional[int], "Node"], ...]:
+        """Resolved child edges once per construction-cache key.
+
+        ``children()`` and ``walk()`` used to each re-getattr every ``_child_fields``
+        entry.  The tree is immutable after materialize; re-deriving the edge list
+        is pure recompute.  Memoize on the unit construction cache (same key as
+        field data) so the second consumer of a node pays zero field getattr.
+        """
+        cache = self._construction_cache()
+        key = cache.key(
+            self.ref,
+            self.reporter,
+            self.control_context,
+            self.unit.construction_context,
+        )
+        row = cache.fields.setdefault(key, {})
+        cached = row.get("__child_edges__")
+        if cached is not None:
+            return cached  # type: ignore[no-any-return]
+        edges: list[tuple[str, Optional[int], Node]] = []
         for name in type(self)._child_fields:
             value = getattr(self, name)
             if value is None:
                 continue
             if isinstance(value, Node):
-                yield name, None, value
+                edges.append((name, None, value))
             else:
                 for i, item in enumerate(value):
                     if item is not None:
-                        yield name, i, item
+                        edges.append((name, i, item))
+        frozen = tuple(edges)
+        row["__child_edges__"] = frozen
+        return frozen
+
+    def children(self) -> Iterator[tuple[str, Optional[int], "Node"]]:
+        """Yield (field_name, index-or-None, child) in declared grammar order."""
+        yield from self._child_edges()
 
     def walk(self) -> Iterator["Node"]:
-        """Pre-order walk over the constructed graph. Iterative — never recursive."""
+        """Pre-order walk over the constructed graph. Iterative — never recursive.
+
+        Expands each node via ``_child_edges()`` so a walk that follows a
+        ``children()`` consumer (or a second walk) does not re-getattr fields.
+        """
         stack: list[Node] = [self]
         while stack:
             node = stack.pop()
             yield node
-            children = []
-            for field_name in type(node)._child_fields:
-                value = getattr(node, field_name)
-                if value is None:
-                    continue
-                if isinstance(value, Node):
-                    children.append(value)
-                else:
-                    children.extend(child for child in value if child is not None)
+            children = [child for _name, _index, child in node._child_edges()]
             stack.extend(reversed(children))
 
     def __repr__(self) -> str:  # pragma: no cover


### PR DESCRIPTION
## Volume, not key

White owns the cache-key thrash. This PR owns **call volume**: the tree is immutable and was being re-walked ~six times per open.

## Three landings (separate commits)

### 1. Parent map during materialize walk
`materialize_module` did `root.walk()` then a second full field getattr for `parent_positions`. Parent is now recorded as children are expanded — one pass.

### 2. One import_binding scope visit
`_function_locals` + `_function_declarations` each did a full recursive `children()` walk. Combined into `_function_scope_bindings`; old names remain as thin wrappers.

### 3. Memo child edges for walk/children share
`children()` and `walk()` each re-getattred every field. Memo `__child_edges__` on the construction-cache key; second consumer of a node pays 0 field getattr.

## Numbers — `_json.py` open (`populate_derived=True`, light getattr counter)

| | before (main) | after |
| --- | --- | --- |
| **`Node.__getattr__`** | **374,118** | **203,485** (−46%) |
| **wall** | **10.50s** | **8.58s** |

Env: `/Users/tsavo/.claude/jobs/0bdf89c4/tmp/v312/bin/python`. Outcome still SNW (decorated FunctionDef) — volume only, not the SNW fix.

## Not this PR
- Cache key / `_child_control_context` (white)
- In-pop memo of config.py ×N (white)
- SNW decorated FunctionDef publication

## Equivalence checks
- One-pass parent map == two-pass on small fixture
- `_function_scope_bindings` == old dual walk for locals/globals/nonlocals

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache child edges in `Node._child_edges` to walk the AST once per node
> - Adds `Node._child_edges()` in [nodes.py](https://github.com/TSavo/sugar/pull/7061/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to compute and memoize `(field_name, index, child_node)` tuples via a single `getattr` pass over `_child_fields`, storing results in the construction cache.
> - Refactors `Node.children` and `Node.walk` to consume the cached edge list instead of recomputing children on each call.
> - Reworks `Backend.materialize_module` in [backend.py](https://github.com/TSavo/sugar/pull/7061/files#diff-ad498e547096dff0cc0a35d78feaa867418d745ad78531faf3f78b5e835414b8) to build `constructed_nodes`, `parent_positions`, and `function_nodes` in a single iterative traversal using `_child_edges()`.
> - Replaces two separate recursive passes in [import_binding.py](https://github.com/TSavo/sugar/pull/7061/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) (`_function_locals` and `_function_declarations`) with a single `_function_scope_bindings` helper that collects local names, globals, and nonlocals in one walk.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5aa672.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->