### PR TITLE
Recensus: bank functions after populate SNW (stop zero-function lie)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -627,6 +627,9 @@ def _measure_file(
     backend_defects: Counter[str] = Counter()
     cm_resolutions: Counter[str] = Counter()
     unrecognized_cm_kinds: Counter[str] = Counter()
+    # Populate-path SNWs (often transitive / CM derivation) stay loud here —
+    # they must NEVER erase a successful SourceFile function denominator.
+    populate_residuals: list[dict[str, Any]] = []
     desugar_axis = DesugarAxis()
     # Phase timers — measured live and PERSISTED (running-counts + row), not
     # only painted on the progress bar and thrown away.
@@ -703,15 +706,53 @@ def _measure_file(
                 source_file, root=address_root, path=path
             )
         except SugarNotWritten as gap:
-            # Derivation can hit a real missing sugar before any function walk.
+            # Populate can SNW on a TRANSITIVE module (decorator publication,
+            # pytest attribute, …) AFTER SourceFile already constructed this
+            # file's functions. Returning here used to bank functionsTotal=0
+            # for a file that just built ~50 functions (#7060 night finding:
+            # 708/1284 zero-function rows). Keep the refusal LOUD as a named
+            # populate residual; do NOT discard the successful SourceFile.
             timing["t_populate_s"] = round(time.perf_counter() - t0, 6)
-            tally_construction(type(gap).__name__, line=0)
-            return reporter
-        timing["t_populate_s"] = round(time.perf_counter() - t0, 6)
+            owner = str(getattr(gap, "owner", None) or type(gap).__name__)
+            blame = getattr(gap, "blame", None)
+            blame_line: object = 0
+            blame_file = relative
+            if blame is not None:
+                unit = getattr(blame, "unit", None)
+                if unit is not None and getattr(unit, "filename", None):
+                    blame_file = str(unit.filename)
+                span = getattr(blame, "line_col_span", None)
+                if span is not None:
+                    try:
+                        span_v = span() if callable(span) else span
+                        blame_line = getattr(span_v, "start_line", 0) or 0
+                    except Exception:  # noqa: BLE001 — best-effort locus
+                        blame_line = 0
+            residual = {
+                "phase": "populate",
+                "owner": owner,
+                "observed": str(getattr(gap, "observed", None) or gap),
+                "requested": str(getattr(gap, "requested", None) or ""),
+                "fix": str(getattr(gap, "fix", None) or ""),
+                "blameFile": blame_file,
+                "blameLine": blame_line,
+            }
+            populate_residuals.append(residual)
+            # Family key is owner-qualified so the gap stays named and loud —
+            # never a silent zero-function outcome.
+            tally_construction(
+                f"populate:{owner}",
+                line=blame_line,
+            )
+            # Fall through: enumerate functions this SourceFile already holds.
+        else:
+            timing["t_populate_s"] = round(time.perf_counter() - t0, 6)
 
         # Effective resolution set for THIS source unit only: source-derived
         # over contract_refs (same door as With construction). Never tally the
         # whole shared provisional table without source_cid — that multiplies.
+        # After a populate residual the CM table may be partial; still tally
+        # what is present — partial CM residual is not a zero-function lie.
         t0 = time.perf_counter()
         file_cm_resolutions, file_unrecognized_kinds = _tally_cm_resolutions(
             construction_context,
@@ -824,6 +865,12 @@ def _measure_file(
         "functionsEnumerationComplete": functions_not_enumerated == 0
         and (panic_row is None or functions_total == functions_enumerated),
     }
+    # Populate residuals are first-class: CM/derivation gaps that must stay
+    # loud without rewriting the function denominator to zero.
+    populate_row = {
+        "populateResiduals": list(populate_residuals),
+        "R_populate_residuals": len(populate_residuals),
+    }
     timing_row = {"timing": timing}
     if panic_row is not None:
         # File-level ConstructionPanic is BaseException: it escapes construct()
@@ -846,6 +893,7 @@ def _measure_file(
             "families": panic_families,
             "backendDefects": dict(backend_defects),
             "R_backend_defects": sum(backend_defects.values()),
+            **populate_row,
             **resolution_row,
             **desugar_axis.row(),
             **timing_row,
@@ -856,6 +904,7 @@ def _measure_file(
         "families": dict(families),
         "backendDefects": dict(backend_defects),
         "R_backend_defects": sum(backend_defects.values()),
+        **populate_row,
         **resolution_row,
         **desugar_axis.row(),
         **timing_row,

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_preserve_fns_on_populate_snw.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_preserve_fns_on_populate_snw.py
@@ -1,0 +1,122 @@
+"""Populate SNW must not erase a successful SourceFile function denominator.
+
+Night finding: _json.py constructed 49 functions, then populate hit SNW on a
+transitive decorated FunctionDef and recensus returned BEFORE functionsTotal,
+banking 0 for a file that just built ~50. 14/14 sampled SNW files had fns>0
+after SourceFile. The refusal stays loud; the zero-function board answer dies.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from sugar_source_tree.panic import SugarNotWritten
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load(name: str):
+    path = _SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_populate_snw_preserves_function_denominator(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """SourceFile succeeds with N functions; populate SNWs; bank N + residual."""
+    module = _load("control_effect_recensus")
+    path = tmp_path / "target.py"
+    path.write_text(
+        "def one():\n"
+        "    return 1\n"
+        "\n"
+        "def two():\n"
+        "    return 2\n"
+        "\n"
+        "def three():\n"
+        "    return 3\n",
+        encoding="utf-8",
+    )
+
+    def boom_populate(source_file, **_k):
+        # Real coordinate required by SugarNotWritten — use the constructed root.
+        blame = source_file.root.fragment
+        raise SugarNotWritten(
+            blame=blame,
+            owner="module function definition execution",
+            observed="decorated FunctionDef has no completed publication",
+            requested="the exact final decorated function Floor",
+            fix="execute and authenticate the function decorator chain",
+        )
+
+    monkeypatch.setattr(
+        "sugar_lift_python_source.manager_summary_derivation."
+        "populate_source_derived_resource_refs",
+        boom_populate,
+    )
+
+    row = module._measure_file(
+        path,
+        relative="target.py",
+        workspace_root=tmp_path,
+        contract_refs={},
+    )
+
+    assert row["category"] == "completed"
+    # Successful construction survives.
+    assert row["functionsTotal"] == 3
+    assert row["functionsEnumerated"] == 3
+    assert row["functionsNotEnumerated"] == 0
+    # Populate gap stays LOUD as its own residual — not a zero-function lie.
+    assert row["R_populate_residuals"] == 1
+    residuals = row["populateResiduals"]
+    assert len(residuals) == 1
+    assert residuals[0]["phase"] == "populate"
+    assert residuals[0]["owner"] == "module function definition execution"
+    assert "decorated FunctionDef" in residuals[0]["observed"]
+    # Family key is owner-qualified so the refusal is named in families too.
+    assert row["families"].get(
+        "populate:module function definition execution", 0
+    ) >= 1
+
+
+def test_open_snw_still_zero_functions_when_sourcefile_never_builds(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Open-path SNW (no SourceFile) remains a true empty denominator."""
+    module = _load("control_effect_recensus")
+    path = tmp_path / "broken.py"
+    path.write_text("def a():\n    return 1\n", encoding="utf-8")
+
+    # Plant a real fragment via a tiny successful SourceFile first, then
+    # make SourceFile.__init__ raise with that coordinate as blame.
+    seed = tmp_path / "seed.py"
+    seed.write_text("x = 1\n", encoding="utf-8")
+    from sugar_source_tree.tree import SourceFile as SF
+
+    seed_sf = SF.from_path(seed)
+    blame = seed_sf.root.fragment
+
+    def boom_init(self, *_a, **_k):
+        raise SugarNotWritten(
+            blame=blame,
+            owner="open-path-gap",
+            observed="SourceFile never constructed",
+            requested="a constructed module",
+            fix="repair open",
+        )
+
+    import sugar_source_tree.tree as tree_mod
+
+    monkeypatch.setattr(tree_mod.SourceFile, "__init__", boom_init)
+    row = module._measure_file(
+        path, relative="broken.py", workspace_root=tmp_path, contract_refs={}
+    )
+    assert row["functionsTotal"] == 0
+    assert row["R_populate_residuals"] == 0
+    assert row["families"].get("SugarNotWritten", 0) >= 1


### PR DESCRIPTION
## Summary

**Finding of the night:** `_json.py` constructs **49 functions in ~0.8s**, then `populate_source_derived_resource_refs` hits SNW on a **transitive** incomplete door (`@contextlib.contextmanager rewrite_exception`). Recensus returned **before** `functions_total = len(source_file.functions())`, banking **`functionsTotal=0`**. Sample: **14/14** SNW-populate files had `fns>0` after SourceFile. 708/1284 zero-function rows share this measurement shape.

## Fix

On populate `SugarNotWritten` after successful `SourceFile`:

1. **Do not return** without enumerating.
2. Append a **named** `populateResiduals[]` residual (`owner`, `observed`, `blameFile`/`blameLine`, `fix`).
3. Tally family `populate:<owner>` so the refusal stays loud.
4. **Fall through** to `functions()` + sugar walk; bank truthful `functionsTotal`.

Open-path SNW (SourceFile never builds) still banks zero — that is a true empty denominator.

The decorator publication door remains incomplete and loud. What dies is only the board lie that successful construction produced nothing.

## Validation

```
pytest tests/test_recensus_preserve_fns_on_populate_snw.py -v --noconftest
# 2 passed
```

## Epsilon R

- Predicted: files that only failed populate bank `functionsTotal = N` + `R_populate_residuals ≥ 1` instead of `functionsTotal = 0`.
- Does not complete decorator publication or pytest membrane — those stay named residuals.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `_measure_file` to preserve function counts when `populate_source_derived_resource_refs` raises `SugarNotWritten`
> - Previously, a `SugarNotWritten` during the populate phase caused `_measure_file` to return early, reporting zero functions even though `SourceFile` had already been constructed with valid function data.
> - Now, populate-phase `SugarNotWritten` is caught and recorded as a structured residual in `populateResiduals`, and the function continues to return the true `functionsTotal`/`functionsEnumerated` counts from the already-built `SourceFile`.
> - A `populate:{owner}` family key is tallied for blame attribution, and `R_populate_residuals` is included in the returned row alongside existing accounting fields.
> - A new test module [`test_recensus_preserve_fns_on_populate_snw.py`](https://github.com/TSavo/sugar/pull/7062/files#diff-b7d5ea5c67e2a0678f6928f9aeb81fe243735a65eb1d96b653ff691159b7e58f) covers both the populate-phase and open-path (pre-construction) `SugarNotWritten` cases.
> - Behavioral Change: files that previously produced a silent zero-function `completed` row on populate SNW now return the real function count with a non-empty `populateResiduals` array.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e6d7e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->