### PR TITLE
Populate cites body gaps; keep open function roster

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -846,7 +846,15 @@ def prefix_has_completed_fallthrough(
         # Cite path: admit static export without off-population construction.
         return True
 
-    exits = _module_prefix_outcome(module, locus, graph=graph, session=session)
+    from sugar_source_tree.panic import SugarNotWritten
+
+    # Prefix sugar can SNW (e.g. decorated FunctionDef without publication).
+    # That is not "fallthrough completed"; it is incomplete prefix — cite as
+    # dynamic-export at the export door, never abort the open's population.
+    try:
+        exits = _module_prefix_outcome(module, locus, graph=graph, session=session)
+    except SugarNotWritten:
+        return False
     if len(exits.exits) != 1:
         return False
     face = exits.exits[0]

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1288,32 +1288,56 @@ def populate_source_derived_resource_refs(
         # function's intentionally empty ordinary body only manufactures the
         # misleading residual ``non-manager-result:BlockValue``.  The generator
         # transition remains independently loud when its steps are opaque.
+        from sugar_source_tree.panic import SugarNotWritten
+
         from .manager_construction import (
             ManagerConstructionGapV1,
             _install_source_call_frame,
             resolve_source_visible_frame,
         )
 
-        frame_result = resolve_source_visible_frame(
-            resolved,
-            graph=graph,
-            dependency_graphs=graphs,
-            session=session,
-        )
-        if not isinstance(frame_result, ManagerConstructionGapV1):
-            frame, generator_target = frame_result
-            if frame.generator_steps is not None:
-                _install_source_call_frame(context, call, frame)
-                # Seat the provider Call at the manager-use coordinate so a
-                # bare-Name With head resolves through its reaching binding
-                # rather than by spelling.  Direct Call heads already key the
-                # frame by their own span; the use-site seat is what carries
-                # assigned multi-manager projection.
-                context.source_manager_provider_calls[coordinate] = call
-                # Closed generator-backed resource contract: generator frame +
-                # native enter/exit definitions → one typed source-derived ref.
-                # Coordinates alone cannot construct the ref; non-generator
-                # frames refuse. No ObjectValue fabrication.
+        # CITE, never abort: frame projection can SNW deep in a dependency
+        # (decorated FunctionDef, incomplete body).  Failure already parks a
+        # gap; success must not discard the open's function roster for the
+        # recensus.  One receipt's body gap is not the enrolled file's zero.
+        try:
+            frame_result = resolve_source_visible_frame(
+                resolved,
+                graph=graph,
+                dependency_graphs=graphs,
+                session=session,
+            )
+        except SugarNotWritten as exc:
+            observed = getattr(exc, "observed", None) or str(exc)
+            _install_derivation_gap(
+                context,
+                coordinate,
+                receipt,
+                "source-body-gap",
+                str(observed),
+            )
+            continue
+        if isinstance(frame_result, ManagerConstructionGapV1):
+            # Membrane / export gap: cite the same way failure does.  Do NOT
+            # fall through into construct_manager_behavior (that re-resolves
+            # and re-MaterializeModule the dependency).
+            kind, detail = _gap_kind_and_detail(frame_result)
+            _install_derivation_gap(context, coordinate, receipt, kind, detail)
+            continue
+        frame, generator_target = frame_result
+        if frame.generator_steps is not None:
+            _install_source_call_frame(context, call, frame)
+            # Seat the provider Call at the manager-use coordinate so a
+            # bare-Name With head resolves through its reaching binding
+            # rather than by spelling.  Direct Call heads already key the
+            # frame by their own span; the use-site seat is what carries
+            # assigned multi-manager projection.
+            context.source_manager_provider_calls[coordinate] = call
+            # Closed generator-backed resource contract: generator frame +
+            # native enter/exit definitions → one typed source-derived ref.
+            # Coordinates alone cannot construct the ref; non-generator
+            # frames refuse. No ObjectValue fabrication.
+            try:
                 _publish_generator_backed_resource_contract(
                     context,
                     coordinate,
@@ -1327,7 +1351,16 @@ def populate_source_derived_resource_refs(
                     distribution_index=distribution_index,
                     resolved_cid=resolved.cid,
                 )
-                continue
+            except SugarNotWritten as exc:
+                observed = getattr(exc, "observed", None) or str(exc)
+                _install_derivation_gap(
+                    context,
+                    coordinate,
+                    receipt,
+                    "source-body-gap",
+                    str(observed),
+                )
+            continue
         from sugar_lift_py_tests.context.reduce_context import ReduceContext
         from sugar_lift_py_tests.temporal import builtin_name_temporal
 
@@ -1345,10 +1378,7 @@ def populate_source_derived_resource_refs(
                 "category",
             }
         )
-        frame_parameters = ()
-        if not isinstance(frame_result, ManagerConstructionGapV1):
-            _frame_for_params, _ = frame_result
-            frame_parameters = tuple(getattr(_frame_for_params, "parameters", ()) or ())
+        frame_parameters = tuple(getattr(frame, "parameters", ()) or ())
 
         def _actual_outcome(node, *, formal_name: str | None = None):
             # Substitution has already replaced every reaching lexical binding.
@@ -1501,14 +1531,25 @@ def populate_source_derived_resource_refs(
                 context, coordinate, receipt, "incomplete-call-actuals"
             )
             continue
-        behavior = construct_manager_behavior(
-            resolved,
-            graph=graph,
-            actuals=tuple(actuals),
-            keyword_actuals=tuple(keyword_actuals),
-            call_site=call.fragment,
-            session=session,
-        )
+        try:
+            behavior = construct_manager_behavior(
+                resolved,
+                graph=graph,
+                actuals=tuple(actuals),
+                keyword_actuals=tuple(keyword_actuals),
+                call_site=call.fragment,
+                session=session,
+            )
+        except SugarNotWritten as exc:
+            observed = getattr(exc, "observed", None) or str(exc)
+            _install_derivation_gap(
+                context,
+                coordinate,
+                receipt,
+                "source-body-gap",
+                str(observed),
+            )
+            continue
         from .manager_construction import ConstructedManagerBehaviorV1
         from .manager_protocol_construction import ConstructedManagerProtocolV1
 
@@ -1519,7 +1560,18 @@ def populate_source_derived_resource_refs(
             kind, detail = _gap_kind_and_detail(behavior)
             _install_derivation_gap(context, coordinate, receipt, kind, detail)
             continue
-        protocol = construct_manager_protocol(behavior, exit_face_id=exit_face_id)
+        try:
+            protocol = construct_manager_protocol(behavior, exit_face_id=exit_face_id)
+        except SugarNotWritten as exc:
+            observed = getattr(exc, "observed", None) or str(exc)
+            _install_derivation_gap(
+                context,
+                coordinate,
+                receipt,
+                "source-body-gap",
+                str(observed),
+            )
+            continue
         if not isinstance(protocol, ConstructedManagerProtocolV1):
             kind, detail = _gap_kind_and_detail(protocol)
             _install_derivation_gap(context, coordinate, receipt, kind, detail)


### PR DESCRIPTION
## Problem

SourceFile alone: **49 functions in ~0.5–1s**.  
`populate_source_derived_resource_refs` was ~13s of rebuild, then SNW on a transitive module **aborted** — recensus discarded all 49 and banked zero.

## Cite, do not rebuild-or-die

Populate was missing the failure cite path that import-call seating already has:

| Site | Before | After |
| --- | --- | --- |
| `resolve_source_visible_frame` SNW | abort populate | derivation gap, **continue** |
| frame `ManagerConstructionGap` | fall through → `construct_manager_behavior` (re-resolve) | **cite and continue** |
| `construct_manager_behavior` / protocol SNW | abort | gap, continue |
| prefix fallthrough SNW | abort export/open | return False → dynamic-export cite |

## Outcome (post-#7061 tip + this)

| | before | after |
| --- | --- | --- |
| full open | SNW, fns=None | **ok, fns=49** |
| alone | 49 in ~0.5s | unchanged |

In-pop multi-SourceFile of `config.py` remains white's memo; this PR is the **cite boundary** so populate cannot zero the enrolled file's roster.

## Hand to merge_dog

Standing order: take on sight.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Convert `SugarNotWritten` exceptions to derivation gaps in source body processing
> - [`manager_summary_derivation.py`](https://github.com/TSavo/sugar/pull/7063/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c): wraps frame resolution, generator contract publishing, behavior construction, and protocol construction in `try/except SugarNotWritten`, converting exceptions into `"source-body-gap"` derivation gaps and continuing to the next receipt instead of propagating.
> - Also stops falling through to `construct_manager_behavior` when frame resolution returns a `ManagerConstructionGapV1`, installing the gap immediately.
> - [`manager_construction.py`](https://github.com/TSavo/sugar/pull/7063/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1): `prefix_has_completed_fallthrough` now returns `False` instead of raising when `_module_prefix_outcome` throws `SugarNotWritten`.
> - Behavioral Change: callers that previously received exceptions on incomplete/unwritten source bodies now receive gaps, allowing processing to continue across all receipts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0637137.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->