### PR TITLE
Session-memo module materialize: N definitions → 1 SourceFile

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1729,8 +1729,9 @@ def resolve_source_visible_frame(
 
     The projection is memoized on ``session``: the same authenticated
     definition is projected once per repeated call-site receipt in pandas
-    megamodules, and re-materializing SourceFile + class base sugar each time
-    was the residual wall after export/revalidation amortization.
+    megamodules. Module SourceFile materialize is also session-memoized
+    (per source CID, not per definition): without it, in-population modules
+    like ``pandas/_config/config.py`` rebuild N times for N definitions.
 
     The memo may NOT be process-global even though its key is a content
     address.  ``_resolve_source_visible_frame_uncached`` mints a fresh
@@ -1807,6 +1808,33 @@ def resolve_source_visible_frame(
     return result
 
 
+def _module_materialize_key(
+    *,
+    graph: DependencyArtifactGraph,
+    module,
+    dependency_graphs: dict[str, DependencyArtifactGraph] | None,
+) -> tuple:
+    """Session key for one authenticated module's SourceFile materialize.
+
+    Per-definition frame projection still keys on the definition coordinate.
+    Materializing the whole module per definition is what multiplied
+    in-population megamodules (``pandas/_config/config.py`` ×18). Key is
+    artifact + dependency seats + source CID + module name — never process
+    state; the session is the authority boundary.
+    """
+    return (
+        graph.distribution_artifact_cid,
+        tuple(
+            sorted(
+                (name, dependency.distribution_artifact_cid)
+                for name, dependency in (dependency_graphs or {}).items()
+            )
+        ),
+        module.source_cid,
+        module.module_name,
+    )
+
+
 def _resolve_source_visible_frame_uncached(
     resolved: ResolvedPythonObjectV1,
     *,
@@ -1822,45 +1850,54 @@ def _resolve_source_visible_frame_uncached(
     )
     from sugar_source_tree.reporter import NULL_REPORTER
 
-    # frame_projection: dual-mode factories may nest With only on non-CM
-    # branches; soft-require those so call-frame projection can complete.
-    context = TreeConstructionContextV1.for_source_call_construction(
-        frame_projection=True
+    dependency_graphs = dict(dependency_graphs or {})
+    dependency_graphs[resolved.module_name.split(".", 1)[0]] = graph
+    module_key = _module_materialize_key(
+        graph=graph, module=module, dependency_graphs=dependency_graphs
     )
-    source_file = SourceFile(
-        (module.source, module.source_seat, module.source_cid),
-        construction_context=context,
-    )
-    producer_reporter = ConstructionTestimonyReporterV1(
-        NULL_REPORTER, SubstitutionTraceBuilderV1(module.source_cid)
-    )
-    producer_root = materialize(
-        source_file.unit, source_file.root.ref, producer_reporter
-    )
-    from sugar_lift_python_source.value_pins import scan_module_value_pins
-    from sugar_lift_py_tests.source_call_frame import MutableGlobalBindingV1
-
-    pin_scan = scan_module_value_pins(
-        source_file.root, source=module.source, source_path=module.source_seat
-    )
-    mutable_global_bindings = tuple(
-        MutableGlobalBindingV1(
-            source_cid=pin.source_cid,
-            binding_occurrence=pin.binding_occurrence,
-            name=pin.name,
-            kind=pin.kind,
-            term=pin.term,
-            line=pin.line,
-            col=pin.col,
+    module_product = session.module_materialize_hit(module_key)
+    if module_product is None:
+        # frame_projection: dual-mode factories may nest With only on non-CM
+        # branches; soft-require those so call-frame projection can complete.
+        context = TreeConstructionContextV1.for_source_call_construction(
+            frame_projection=True
         )
-        for pin in pin_scan.mutable_global_pins
-    )
+        source_file = SourceFile(
+            (module.source, module.source_seat, module.source_cid),
+            construction_context=context,
+        )
+        producer_reporter = ConstructionTestimonyReporterV1(
+            NULL_REPORTER, SubstitutionTraceBuilderV1(module.source_cid)
+        )
+        producer_root = materialize(
+            source_file.unit, source_file.root.ref, producer_reporter
+        )
+        from sugar_lift_python_source.value_pins import scan_module_value_pins
+        from sugar_lift_py_tests.source_call_frame import MutableGlobalBindingV1
+
+        pin_scan = scan_module_value_pins(
+            source_file.root, source=module.source, source_path=module.source_seat
+        )
+        mutable_global_bindings = tuple(
+            MutableGlobalBindingV1(
+                source_cid=pin.source_cid,
+                binding_occurrence=pin.binding_occurrence,
+                name=pin.name,
+                kind=pin.kind,
+                term=pin.term,
+                line=pin.line,
+                col=pin.col,
+            )
+            for pin in pin_scan.mutable_global_pins
+        )
+        module_product = (source_file, producer_root, mutable_global_bindings)
+        session.remember_module_materialize(module_key, module_product)
+    source_file, producer_root, mutable_global_bindings = module_product
+    context = source_file.unit.construction_context
 
     def with_mutable_globals(frame):
         return replace(frame, mutable_global_bindings=mutable_global_bindings)
 
-    dependency_graphs = dict(dependency_graphs or {})
-    dependency_graphs[resolved.module_name.split(".", 1)[0]] = graph
     definitions = tuple(
         item for item in producer_root.body if isinstance(item, (FunctionDef, ClassDef))
     )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -71,6 +71,7 @@ class SourceResolutionSession:
         "frame_results",
         "frame_holds",
         "frame_active",
+        "module_materializations",
     )
 
     def __init__(self, *, enabled: bool = True) -> None:
@@ -87,6 +88,12 @@ class SourceResolutionSession:
         # typed-loud exactly like the local recursive case, and never loops.
         # Re-entrancy is a property of THIS traversal, so it is session state.
         self.frame_active: set[tuple] = set()
+        # Module SourceFile + producer root + pin roster for one authenticated
+        # module under this session. Frame projection is per-definition, but
+        # materializing the whole module per definition multiplied in-population
+        # megamodules (pandas/_config/config.py ×18 in one _json.py open). The
+        # value is live context-bound, so it lives here — never process-global.
+        self.module_materializations: dict[tuple, Any] = {}
 
     # -- export resolution memo ------------------------------------------
 
@@ -108,6 +115,15 @@ class SourceResolutionSession:
         if hold is not None:
             self.frame_holds[key] = hold
         self.frame_results[key] = result
+
+    # -- module materialize memo (shared across definitions in one module) --
+
+    def module_materialize_hit(self, key: tuple) -> Any | None:
+        return self.module_materializations.get(key) if self.enabled else None
+
+    def remember_module_materialize(self, key: tuple, product: Any) -> None:
+        if self.enabled:
+            self.module_materializations[key] = product
 
 
 def session_or_new(session: SourceResolutionSession | None) -> SourceResolutionSession:

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -1060,3 +1060,113 @@ def test_resolve_source_visible_frame_amortizes_repeated_materialize(
         f"{materializations['count']} times for {n_sites} receipts of one "
         f"definition; amortize source-visible frame projection"
     )
+
+
+def test_session_module_materialize_amortizes_across_definitions(
+    tmp_path: Path,
+) -> None:
+    """In-population modules materialize once per session, not once per def.
+
+    Frame memo is per definition coordinate. Without a module materialize
+    memo, projecting N definitions from one authenticated module rebuilds
+    SourceFile N times — ``pandas/_config/config.py`` ×18 in one ``_json.py``
+    open. Session owns the module product (live context-bound); process-
+    global is forbidden. TARGET: N definitions → 1 SourceFile under one
+    session; distinct sessions still isolate.
+    """
+    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+    from sugar_lift_python_source import manager_construction as mc
+    from sugar_lift_python_source.manager_construction import (
+        resolve_source_visible_frame,
+    )
+    from sugar_lift_python_source.resolution_session import SourceResolutionSession
+    from sugar_source_tree.tree import SourceFile
+
+    implementation = (
+        "def alpha(value):\n"
+        "    return value\n"
+        "def beta(value):\n"
+        "    return value + 1\n"
+        "def gamma(value):\n"
+        "    return value + 2\n"
+        "def delta(value):\n"
+        "    return value + 3\n"
+    )
+    distribution = _install_distribution(
+        tmp_path,
+        package_source=(
+            "from example_pkg.implementation import alpha, beta, gamma, delta\n"
+        ),
+        implementation_source=implementation,
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    session = SourceResolutionSession()
+
+    consumer = (
+        "from example_pkg.implementation import alpha, beta, gamma, delta\n"
+        "alpha(1)\n"
+        "beta(1)\n"
+        "gamma(1)\n"
+        "delta(1)\n"
+    )
+    path = tmp_path / "consumer_multi_def.py"
+    path.write_text(consumer, encoding="utf-8")
+    source_cid = blake3_512_of(consumer.encode("utf-8"))
+    receipts, _ = authenticated_import_use_receipts(
+        tmp_path, path, consumer, source_cid, module_identities={}
+    )
+    # One receipt per call site; four distinct definitions.
+    resolved = [
+        resolve_import_binding(receipt, graph=graph, session=session)
+        for receipt in receipts
+    ]
+    resolved = [item for item in resolved if isinstance(item, ResolvedPythonObjectV1)]
+    names = {item.definition.name for item in resolved}
+    assert names >= {"alpha", "beta", "gamma", "delta"}, names
+    assert len(resolved) >= 4
+
+    materializations = {"count": 0, "paths": []}
+    original_sf = SourceFile
+
+    class CountingSourceFile(original_sf):
+        def __init__(self, *args, **kwargs):
+            materializations["count"] += 1
+            identity = args[0] if args else None
+            if isinstance(identity, tuple) and len(identity) >= 2:
+                materializations["paths"].append(identity[1])
+            super().__init__(*args, **kwargs)
+
+    mc.SourceFile = CountingSourceFile  # type: ignore[misc, assignment]
+    try:
+        frames = [
+            resolve_source_visible_frame(item, graph=graph, session=session)
+            for item in resolved
+        ]
+    finally:
+        mc.SourceFile = original_sf  # type: ignore[misc, assignment]
+
+    assert all(isinstance(item, tuple) for item in frames)
+    # Only the implementation module should materialize for these projections;
+    # package __init__ reexport may also appear — count implementation seats.
+    impl_hits = sum(
+        1 for p in materializations["paths"] if str(p).endswith("implementation.py")
+    )
+    assert impl_hits == 1, (
+        f"implementation module SourceFile count={impl_hits} (total "
+        f"{materializations['count']}, paths={materializations['paths']}); "
+        f"expected 1 under one session for {len(resolved)} definitions"
+    )
+    assert len(session.module_materializations) >= 1
+
+    # Discrimination: a fresh session re-materializes (isolation, not process memo).
+    other = SourceResolutionSession()
+    materializations["count"] = 0
+    materializations["paths"] = []
+    mc.SourceFile = CountingSourceFile  # type: ignore[misc, assignment]
+    try:
+        resolve_source_visible_frame(resolved[0], graph=graph, session=other)
+    finally:
+        mc.SourceFile = original_sf  # type: ignore[misc, assignment]
+    assert materializations["count"] >= 1, (
+        "fresh session paid zero materialize; process-global memo returned"
+    )

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -400,6 +400,7 @@ def leaky_process_memo(monkeypatch):
     frames: dict = {}
     holds: dict = {}
     active: set = set()
+    modules: dict = {}
 
     def leaky_init(self, *, enabled: bool = True) -> None:
         self.enabled = enabled
@@ -407,6 +408,7 @@ def leaky_process_memo(monkeypatch):
         self.frame_results = frames
         self.frame_holds = holds
         self.frame_active = active
+        self.module_materializations = modules
 
     monkeypatch.setattr(SourceResolutionSession, "__init__", leaky_init)
 


### PR DESCRIPTION
## Problem

`pandas/_config/config.py` is **in-population**, so the stdlib membrane cannot touch it. Frame projection keys per definition, so one open of `_json.py` rebuilt that module’s `SourceFile` once per projected definition (~18×). Multiplies against walks and fields.

## Fix

Session-owned **module materialize** memo at `_resolve_source_visible_frame_uncached`:

- Key: artifact CID + dependency seats + `source_cid` + module name (not definition span).
- Value: `(SourceFile, producer_root, mutable_global_bindings)` — live context-bound, so it lives on `SourceResolutionSession`, never process-global.
- Multi-resolve owners already thread one session through file-open (#7059); this is the third amplifier (white/key, orange/walks, this/module product).

## Teeth

- `test_session_module_materialize_amortizes_across_definitions`: 4 defs → 1 implementation `SourceFile`; fresh session rematerializes.
- Existing same-definition amortize + authority twins still green (leaky fixture updated for new table).

## Epsilon R

- Axis: in-population module materialize multiplier per open.
- Predicted: config-class **18 → 1** under one session open.
- Floors: no process-global projection memo.

## Validation

```
pytest test_session_module_materialize_amortizes_across_definitions \
       test_resolve_source_visible_frame_amortizes_repeated_materialize \
       test_resolution_session_authority.py
# 15 passed
```

merge_dog: merge on sight.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Memoize module SourceFile materialization per session to amortize cost across definitions
> - Previously, each call to `resolve_source_visible_frame` for a different definition in the same module would rebuild the `SourceFile` and its materialization products from scratch.
> - Adds `_module_materialize_key` in [manager_construction.py](https://github.com/TSavo/sugar/pull/7064/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to produce a deterministic cache key from artifact CID and module identity, and caches the `(source_file, producer_root, mutable_global_bindings)` tuple in `SourceResolutionSession.module_materializations`.
> - Cache is session-scoped only — no cross-session or process-global sharing occurs, enforced by the existing `leaky_process_memo` test fixture extended in [test_resolution_session_authority.py](https://github.com/TSavo/sugar/pull/7064/files#diff-6b5c105a0d2ad119bca88016326d4132c5d6ec39fa3e1f68cdd8fdc3aaa00e43).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cba0ed3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->