### PR TITLE
Keep open function roster when session seating re-enters

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -3237,6 +3237,14 @@ def _seat_import_value_use_receipts(
             site["endLine"],
             site["endCol"],
         )
+        # Session-memoized module SourceFile is shared across definitions
+        # (#7064). The first definition that owns a use seats it; later
+        # definitions re-enter seating for the same unit. Re-seating a second
+        # mint of the same span raises BackendDefect and aborts the whole
+        # open — which discarded _json.py's 49-function roster (false zero).
+        # Already-seated spans are closed; leave them alone.
+        if unit.import_value_use_resolution(span_key) is not None:
+            continue
         use_start = (site["startLine"], site["startCol"])
         use_end = (site["endLine"], site["endCol"])
         if not any(
@@ -3334,6 +3342,9 @@ def _seat_import_value_use_receipts(
             return False
 
         def seat_receipt() -> None:
+            # Already seated on this unit (shared session module product): done.
+            if unit.import_value_use_resolution(span_key) is not None:
+                return
             transport_key = (
                 unit.filename,
                 module.source_cid,

--- a/implementations/python/sugar-lift-python-source/tests/test_open_keeps_function_roster.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_open_keeps_function_roster.py
@@ -1,0 +1,43 @@
+"""Open must not discard a successful SourceFile function roster.
+
+_json.py has ~49 real functions. Populate walking dependency CM derivation
+must not abort the open with BackendDefect and bank zero functions — that is
+a false refusal that made 708/1284 corpus rows look empty.
+
+#7063 already cites SugarNotWritten body gaps. Session module-materialize
+memo (#7064) shares one SourceFile across definitions; re-seating the same
+import-value span on that unit must be a no-op, not a BackendDefect that
+throws away the open.
+"""
+
+from __future__ import annotations
+
+from importlib import metadata
+from pathlib import Path
+
+import pytest
+
+
+def test_pandas_json_open_keeps_function_roster() -> None:
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+
+    pandas_distribution = metadata.distribution("pandas")
+    install_root = Path(pandas_distribution.locate_file("")).resolve()
+    path = install_root / "pandas" / "io" / "json" / "_json.py"
+    if not path.is_file():
+        pytest.skip(f"pandas _json.py not installed at {path}")
+
+    # Must not raise. Pre-fix: BackendDefect seat_import_value_use_resolution
+    # aborted open after ~9s and callers saw zero functions.
+    source_file = open_source_file_for_construction(
+        path,
+        root=install_root,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        populate_derived=True,
+    )
+    functions = tuple(source_file.functions())
+    assert len(functions) >= 40, (
+        f"_json.py has dozens of real functions; open banked {len(functions)}. "
+        f"names={[fn.name for fn in functions[:15]]}"
+    )


### PR DESCRIPTION
## Which of the three (answer first)

**#3 is the one that mattered: zero functions was a wrong answer.**

Measured on tip after #7057 membrane + #7063 cite-SNW + #7064 session module memo
(`c8a6b9a7b`), py3.12:

| door | wall | functions |
| --- | ---: | ---: |
| `SourceFile` alone | ~560ms | **49** |
| `open(populate=False)` | ~340ms | **49** |
| `open(populate=True)` **before this PR** | ~9s | **raises BackendDefect → 0 banked** |
| `open(populate=True)` **after this PR** | ~10s | **49, status=ok** |

`_json.py` is not an empty file. It constructs dozens of real functions. Banking
zero was the defect; the multi-second spend was the cost of **failing while
walking dependency CM derivation**, then throwing away a successful open.

## Q1 — If the open will refuse, why work first?

It **should not refuse the open**. Pre-fix, populate raised
`BackendDefect[SourceUnit.seat_import_value_use_resolution]` ("receipt conflicts
with occupied value-use occurrence"). That is not a file-level refusal of
`_json.py`; it is a seating state machine trip while walking
`option_context` inside `pandas/_config/config.py`.

#7063 already cites `SugarNotWritten` body gaps. This PR closes the sibling:
session-shared module SourceFile (#7064) re-enters seating for the same span
with a second receipt mint → BackendDefect → open aborts → zero functions.

## Q2 — Did materializing config contribute to the answer?

For the **function roster**: no. Functions exist after SourceFile alone.

For **CM derivation** on this file: populate matches **3** CM uses
(`option_context` ×2, `warnings.catch_warnings` ×1) and, after this fix, parks
**3 derivation gaps** and **0** frames. So the multi-second in-pop walk is still
expensive residual (config MaterializeModule still high via **prefix** door —
not this PR), but it is no longer allowed to erase the open's product.

## Q3 — Is zero correct?

**No.** False zero. Fixed.

## Fix

Idempotent import-value seating on a session-memoized module unit: if the span
is already seated, skip. No process-global cache.

## Numbers (same env)

```
BEFORE: open populate=True → BackendDefect, functions banked 0, wall ~9s
AFTER:  open populate=True → ok, functions=49, wall ~10s (populate residual remains)
```

Populate residual (config ×N via prefix fallthrough) is still real cost for 3
gap cites — separate from this false-zero bug. Orange membrane owns off-pop=0;
prefix-door in-pop multiplier is the remaining speed work.

## PR accounting

| | |
| --- | --- |
| **R** | false-zero-function open when seating re-enters shared module product |
| **εR** | that class 1→0 on `_json` open |
| **Shell deleted** | none yet (seating idempotence is the law; stronger type later) |
| **Floors** | no silent swallow of conflicts on *unseated* spans |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `_seat_import_value_use_receipts` to preserve function roster when session seating re-enters
> - Adds idempotency guards in [`_seat_import_value_use_receipts`](https://github.com/TSavo/sugar/pull/7065/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) so a span that has already been seated for a session-shared `SourceFile` is skipped on re-entry, rather than triggering a second mint/transport call.
> - Two checks are added: one before processing a site, and one inside the `seat_receipt()` closure, both keyed on `unit.import_value_use_resolution(span_key)`.
> - A new test in [`test_open_keeps_function_roster.py`](https://github.com/TSavo/sugar/pull/7065/files#diff-f01aa4c43ef5dcdd7468ed34b619212063cb72e5dbb9c3dd741b2c0474e759fe) verifies that opening a real file with `populate_derived=True` completes without error and returns a function roster of ≥40 functions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf32a4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->