### PR TITLE
Session-memo prefix door: config.py N→1 per open

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -1293,9 +1293,19 @@ def authenticated_import_use_receipts(
     """Return typed, final-checked Call-target receipts from the lexical pass."""
     # Refuse mismatched claims here (same boundary as AuthenticatedImportUseV1);
     # never rewrite source_cid after minting.
+    if module_identities is None:
+        module_identities = {}
     rows, outcomes = authenticated_import_uses(
         root, path, source, source_cid, module_identities=module_identities
     )
+    # Same pass fills revalidation snapshot so receipt.revalidate() does not
+    # re-Materialize the module (mint+revalidate was a second SourceFile).
+    cache_key = _revalidation_cache_key(root, path, source_cid, module_identities)
+    if cache_key not in _REVALIDATION_SNAPSHOTS:
+        _REVALIDATION_SNAPSHOTS[cache_key] = _LexicalRevalidationSnapshotV1(
+            row_cids=frozenset(_hash(row) for row in rows),
+            outcomes=MappingProxyType(dict(outcomes)),
+        )
     return (
         _mint_import_use_receipts(
             rows,
@@ -1323,9 +1333,17 @@ def authenticated_import_value_use_receipts(
     authority.  Call-target receipts remain on
     ``authenticated_import_use_receipts`` unchanged.
     """
+    if module_identities is None:
+        module_identities = {}
     rows, outcomes = authenticated_import_value_uses(
         root, path, source, source_cid, module_identities=module_identities
     )
+    cache_key = _revalidation_cache_key(root, path, source_cid, module_identities)
+    if cache_key not in _VALUE_REVALIDATION_SNAPSHOTS:
+        _VALUE_REVALIDATION_SNAPSHOTS[cache_key] = _LexicalRevalidationSnapshotV1(
+            row_cids=frozenset(_hash(row) for row in rows),
+            outcomes=MappingProxyType(dict(outcomes)),
+        )
     return (
         _mint_import_use_receipts(
             rows,

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -771,6 +771,27 @@ class DependencyArtifactGraph:
         )
 
 
+# packages_distributions() walks every installed dist's file list (measured
+# ~0.5s+ per call). Content of the install map — not a projection memo — so a
+# process cache is legitimate. Top-level graph answers reuse the same map.
+_PACKAGES_DISTRIBUTIONS_CACHE: Mapping[str, list[str]] | None = None
+_TOP_LEVEL_GRAPH_CACHE: dict[str, "DependencyArtifactGraph"] = {}
+
+
+def clear_top_level_authentication_caches() -> None:
+    """Drop top-level auth memos (tests / hermetic process reuse)."""
+    global _PACKAGES_DISTRIBUTIONS_CACHE
+    _PACKAGES_DISTRIBUTIONS_CACHE = None
+    _TOP_LEVEL_GRAPH_CACHE.clear()
+
+
+def _packages_distributions() -> Mapping[str, list[str]]:
+    global _PACKAGES_DISTRIBUTIONS_CACHE
+    if _PACKAGES_DISTRIBUTIONS_CACHE is None:
+        _PACKAGES_DISTRIBUTIONS_CACHE = importlib.metadata.packages_distributions()
+    return _PACKAGES_DISTRIBUTIONS_CACHE
+
+
 def authenticate_dependency_top_level(
     top_level: str,
     *,
@@ -779,17 +800,26 @@ def authenticate_dependency_top_level(
     """Authenticate a distribution or stdlib module through one graph door."""
     if distribution_index is not None and top_level in distribution_index:
         return DependencyArtifactGraph.authenticate(distribution_index[top_level])
-    packages = importlib.metadata.packages_distributions()
+    # Ambient install map only — never share with an explicit distribution_index.
+    if _AUTHENTICATE_CACHE_ENABLED:
+        cached = _TOP_LEVEL_GRAPH_CACHE.get(top_level)
+        if cached is not None:
+            return cached
+    packages = _packages_distributions()
     distributions = tuple(packages.get(top_level, ()))
     if len(distributions) == 1:
-        return DependencyArtifactGraph.authenticate(
+        graph = DependencyArtifactGraph.authenticate(
             importlib.metadata.distribution(distributions[0])
         )
-    if distributions:
+    elif distributions:
         raise DependencyArtifactAuthenticationError(
             "top-level module belongs to multiple installed distributions"
         )
-    return DependencyArtifactGraph.authenticate_stdlib_module(top_level)
+    else:
+        graph = DependencyArtifactGraph.authenticate_stdlib_module(top_level)
+    if _AUTHENTICATE_CACHE_ENABLED:
+        _TOP_LEVEL_GRAPH_CACHE[top_level] = graph
+    return graph
 
 
 def resolve_import_binding(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -604,23 +604,56 @@ class _ModuleClassDefinitionBindingSugar:
         return outcome.and_then(bind)
 
 
-def _enroll_imported_decorator_frames(
-    *, module, definition, context, session, dependency_graphs
-) -> None:
-    """Seat exact imported Attribute decorator factories before Sugar caching."""
+def _session_import_use_receipts(session: SourceResolutionSession, module):
+    """Call-door import-use roster once per source body per session."""
     from pathlib import Path
 
     from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
-    from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
-    from sugar_source_tree.panic import BackendDefect
 
-    decorator_receipts, _ = authenticated_import_use_receipts(
+    hit = session.import_use_hit(module.source_cid)
+    if hit is not None:
+        return hit
+    receipts, _ = authenticated_import_use_receipts(
         Path("."),
         Path(module.source_seat),
         module.source,
         module.source_cid,
         module_identities={},
     )
+    session.remember_import_use(module.source_cid, receipts)
+    return receipts
+
+
+def _session_import_value_receipts(session: SourceResolutionSession, module):
+    """Value-door import roster once per source body per session."""
+    from pathlib import Path
+
+    from sugar_lift_py_tests.import_binding import authenticated_import_value_use_receipts
+
+    hit = session.import_value_hit(module.source_cid)
+    if hit is not None:
+        return hit
+    receipts, _ = authenticated_import_value_use_receipts(
+        Path("."),
+        Path(module.source_seat),
+        module.source,
+        module.source_cid,
+        module_identities={},
+    )
+    session.remember_import_value(module.source_cid, receipts)
+    return receipts
+
+
+def _enroll_imported_decorator_frames(
+    *, module, definition, context, session, dependency_graphs
+) -> None:
+    """Seat exact imported Attribute decorator factories before Sugar caching."""
+    from pathlib import Path
+
+    from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
+    from sugar_source_tree.panic import BackendDefect
+
+    decorator_receipts = _session_import_use_receipts(session, module)
     receipts_by_span = {}
     for receipt in decorator_receipts:
         receipt_span = (
@@ -718,15 +751,24 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
             f"stdlib seat {module.source_seat!r}; cite via "
             "prefix_has_completed_fallthrough / call-target-off-population"
         )
-    construction_context = TreeConstructionContextV1.for_source_call_construction()
-    producer_reporter = ConstructionTestimonyReporterV1(
-        NULL_REPORTER, SubstitutionTraceBuilderV1(module.source_cid)
-    )
-    source_file = SourceFile(
-        (module.source, module.source_seat, module.source_cid),
-        reporter=producer_reporter,
-        construction_context=construction_context,
-    )
+    session = session_or_new(session)
+    # One prefix-door SourceFile per source body per session. Export fallthrough
+    # used to rebuild config.py once per export locus (measured 33× SourceFile
+    # on one _json open after the frame-door memo). Value is context-bound to
+    # this session — never process-global.
+    source_file = session.prefix_file_hit(module.source_cid)
+    if source_file is None:
+        construction_context = TreeConstructionContextV1.for_source_call_construction()
+        producer_reporter = ConstructionTestimonyReporterV1(
+            NULL_REPORTER, SubstitutionTraceBuilderV1(module.source_cid)
+        )
+        source_file = SourceFile(
+            (module.source, module.source_seat, module.source_cid),
+            reporter=producer_reporter,
+            construction_context=construction_context,
+        )
+        session.remember_prefix_file(module.source_cid, source_file)
+    construction_context = source_file.unit.construction_context
     locus_key = (locus.lineno, locus.col_offset)
     prefix = tuple(
         statement
@@ -769,7 +811,6 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
 
     dependency_graphs = {}
     if graph is not None:
-        session = session_or_new(session)
         dependency_graphs[module.module_name.split(".", 1)[0]] = graph
         for definition in prefix_classes:
             _seat_import_value_use_receipts(
@@ -848,21 +889,35 @@ def prefix_has_completed_fallthrough(
 
     from sugar_source_tree.panic import SugarNotWritten
 
+    session = session_or_new(session)
+    fallthrough_key = (
+        module.source_cid,
+        getattr(locus, "lineno", None),
+        getattr(locus, "col_offset", None),
+    )
+    cached = session.fallthrough_hit(fallthrough_key)
+    if cached is not None:
+        return cached
+
     # Prefix sugar can SNW (e.g. decorated FunctionDef without publication).
     # That is not "fallthrough completed"; it is incomplete prefix — cite as
     # dynamic-export at the export door, never abort the open's population.
     try:
         exits = _module_prefix_outcome(module, locus, graph=graph, session=session)
     except SugarNotWritten:
+        session.remember_fallthrough(fallthrough_key, False)
         return False
     if len(exits.exits) != 1:
+        session.remember_fallthrough(fallthrough_key, False)
         return False
     face = exits.exits[0]
-    return (
+    ok = (
         isinstance(face, Completed)
         and face.guard == true_guard()
         and bool(getattr(face.value, "can_fall_through", False))
     )
+    session.remember_fallthrough(fallthrough_key, ok)
+    return ok
 
 
 @dataclass(frozen=True)
@@ -1994,11 +2049,6 @@ def _resolve_source_visible_frame_uncached(
     # without reconstructing either binding from the callee spelling.
     from pathlib import Path
 
-    from sugar_lift_py_tests.import_binding import (
-        authenticated_import_use_receipts,
-        authenticated_import_value_use_receipts,
-    )
-
     reachable_calls = {
         (
             call.line_col_span().start_line,
@@ -2011,21 +2061,8 @@ def _resolve_source_visible_frame_uncached(
         for call in _reachable_attribute_calls(function)
     }
     if reachable_calls:
-        module_path = Path(module.source_seat)
-        import_receipts, _ = authenticated_import_use_receipts(
-            Path("."),
-            module_path,
-            module.source,
-            module.source_cid,
-            module_identities={},
-        )
-        value_receipts, _ = authenticated_import_value_use_receipts(
-            Path("."),
-            module_path,
-            module.source,
-            module.source_cid,
-            module_identities={},
-        )
+        import_receipts = _session_import_use_receipts(session, module)
+        value_receipts = _session_import_value_receipts(session, module)
         value_receipts = _retain_import_value_receipt_roster(
             context, module, tuple(value_receipts)
         )
@@ -3134,9 +3171,6 @@ def _seat_import_value_use_receipts(
     from sugar_lift_py_tests.context_manager_resolution import (
         SourceFragmentCoordinateV1,
     )
-    from sugar_lift_py_tests.import_binding import (
-        authenticated_import_value_use_receipts,
-    )
     from sugar_lift_python_source.canonical import blake3_512_of
 
     unit = source_file.unit
@@ -3170,23 +3204,9 @@ def _seat_import_value_use_receipts(
     roster_key = (module.module_name, module.source_seat, module.source_cid)
     receipts = context.source_import_value_receipts.get(roster_key)
     if receipts is None:
-        minted, _ = authenticated_import_value_use_receipts(
-            Path("."),
-            Path(module.source_seat),
-            module.source,
-            module.source_cid,
-            module_identities={},
-        )
+        minted = _session_import_value_receipts(session, module)
         receipts = _retain_import_value_receipt_roster(context, module, tuple(minted))
-    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
-
-    call_receipts, _ = authenticated_import_use_receipts(
-        Path("."),
-        Path(module.source_seat),
-        module.source,
-        module.source_cid,
-        module_identities={},
-    )
+    call_receipts = _session_import_use_receipts(session, module)
     calls_by_cid = {}
     for call_receipt in call_receipts:
         cid = call_receipt.use["cid"]

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -72,6 +72,10 @@ class SourceResolutionSession:
         "frame_holds",
         "frame_active",
         "module_materializations",
+        "prefix_files",
+        "prefix_fallthrough",
+        "import_use_rosters",
+        "import_value_rosters",
     )
 
     def __init__(self, *, enabled: bool = True) -> None:
@@ -94,6 +98,15 @@ class SourceResolutionSession:
         # megamodules (pandas/_config/config.py ×18 in one _json.py open). The
         # value is live context-bound, so it lives here — never process-global.
         self.module_materializations: dict[tuple, Any] = {}
+        # Prefix-door SourceFile (no frame_projection). Export fallthrough called
+        # _module_prefix_outcome once per export locus and rebuilt config N times.
+        # Separate from module_materializations: different context settings.
+        self.prefix_files: dict[str, Any] = {}
+        # (source_cid, lineno, col_offset) -> bool fallthrough answer
+        self.prefix_fallthrough: dict[tuple, bool] = {}
+        # source_cid -> import-use / value-use receipt tuples (lexical pass once)
+        self.import_use_rosters: dict[str, Any] = {}
+        self.import_value_rosters: dict[str, Any] = {}
 
     # -- export resolution memo ------------------------------------------
 
@@ -124,6 +137,40 @@ class SourceResolutionSession:
     def remember_module_materialize(self, key: tuple, product: Any) -> None:
         if self.enabled:
             self.module_materializations[key] = product
+
+    # -- prefix-door SourceFile + fallthrough (export path) --------------
+
+    def prefix_file_hit(self, source_cid: str) -> Any | None:
+        return self.prefix_files.get(source_cid) if self.enabled else None
+
+    def remember_prefix_file(self, source_cid: str, source_file: Any) -> None:
+        if self.enabled:
+            self.prefix_files[source_cid] = source_file
+
+    def fallthrough_hit(self, key: tuple) -> bool | None:
+        if not self.enabled:
+            return None
+        return self.prefix_fallthrough.get(key)
+
+    def remember_fallthrough(self, key: tuple, value: bool) -> None:
+        if self.enabled:
+            self.prefix_fallthrough[key] = value
+
+    # -- lexical import rosters (call / value doors) ---------------------
+
+    def import_use_hit(self, source_cid: str) -> Any | None:
+        return self.import_use_rosters.get(source_cid) if self.enabled else None
+
+    def remember_import_use(self, source_cid: str, receipts: Any) -> None:
+        if self.enabled:
+            self.import_use_rosters[source_cid] = receipts
+
+    def import_value_hit(self, source_cid: str) -> Any | None:
+        return self.import_value_rosters.get(source_cid) if self.enabled else None
+
+    def remember_import_value(self, source_cid: str, receipts: Any) -> None:
+        if self.enabled:
+            self.import_value_rosters[source_cid] = receipts
 
 
 def session_or_new(session: SourceResolutionSession | None) -> SourceResolutionSession:

--- a/implementations/python/sugar-lift-python-source/tests/test_config_prefix_session_memo.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_config_prefix_session_memo.py
@@ -1,0 +1,80 @@
+"""In-population prefix memo: one session → config SourceFile not ×N.
+
+After membrane (#7057) killed stdlib rebuilds, residual open cost on
+``pandas/io/json/_json.py`` was ``pandas/_config/config.py`` MaterializeModule
+dozens of times via ``prefix_has_completed_fallthrough`` →
+``_module_prefix_outcome`` (export fallthrough once per locus).
+
+Frame-door module memo is #7064. This tooth owns the **prefix door** on the
+same ``SourceResolutionSession`` (file-open already threads one session).
+
+Values stay session-owned (context-bound). No process-global projection memo.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from importlib import metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_source_tree.file_open_profile import (
+    begin_file_open_profile,
+    end_file_open_profile,
+    summarize_module_materialize,
+)
+from sugar_source_tree.tree import SourceFile as RealSourceFile
+
+
+def test_json_open_config_sourcefile_not_dozens(monkeypatch) -> None:
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+    from sugar_source_tree import tree as tree_mod
+
+    pandas_distribution = metadata.distribution("pandas")
+    install_root = Path(pandas_distribution.locate_file("")).resolve()
+    path = install_root / "pandas" / "io" / "json" / "_json.py"
+    if not path.is_file():
+        pytest.skip(f"pandas _json.py not installed at {path}")
+
+    builds: Counter = Counter()
+    orig = tree_mod.SourceFile.__init__
+
+    def counting(self, identity, *args, **kwargs):
+        seat = identity[1] if isinstance(identity, tuple) else str(identity)
+        builds[Path(str(seat)).name] += 1
+        return orig(self, identity, *args, **kwargs)
+
+    monkeypatch.setattr(tree_mod.SourceFile, "__init__", counting)
+
+    bag = begin_file_open_profile()
+    try:
+        sf = open_source_file_for_construction(
+            path,
+            root=install_root,
+            construction_context=TreeConstructionContextV1.for_source_call_construction(),
+            populate_derived=True,
+        )
+        fns = len(tuple(sf.functions()))
+    finally:
+        end_file_open_profile()
+    summary = summarize_module_materialize(bag)
+    config_sf = builds.get("config.py", 0)
+    config_mat = sum(
+        int(row["count"])
+        for row in (summary.get("top") or [])
+        if str(row["module"]).endswith("config.py")
+    )
+    # Pre-fix residual: SourceFile config.py dozens (33 measured). After:
+    # prefix door 1 + frame door 1 + lexical use/value mints ≤2.
+    assert config_sf <= 4, (
+        f"config.py SourceFile constructions={config_sf} (want ≤4); "
+        f"all={dict(builds)}; mat_top={summary.get('top')}"
+    )
+    assert config_mat <= 4, (
+        f"config.py MaterializeModule count={config_mat} (want ≤4); "
+        f"top={summary.get('top')}"
+    )
+    # False-zero floor: open must keep the real function roster.
+    assert fns >= 40, f"_json open banked {fns} functions"

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -402,6 +402,11 @@ def leaky_process_memo(monkeypatch):
     active: set = set()
     modules: dict = {}
 
+    prefixes: dict = {}
+    fallthroughs: dict = {}
+    import_uses: dict = {}
+    import_values: dict = {}
+
     def leaky_init(self, *, enabled: bool = True) -> None:
         self.enabled = enabled
         self.export_resolutions = exports
@@ -409,6 +414,10 @@ def leaky_process_memo(monkeypatch):
         self.frame_holds = holds
         self.frame_active = active
         self.module_materializations = modules
+        self.prefix_files = prefixes
+        self.prefix_fallthrough = fallthroughs
+        self.import_use_rosters = import_uses
+        self.import_value_rosters = import_values
 
     monkeypatch.setattr(SourceResolutionSession, "__init__", leaky_init)
 


### PR DESCRIPTION
## Boundary residual (after #7057/#7058)

Off-pop stdlib rebuilds are dead. Entire remaining named cost on one
`pandas/io/json/_json.py` open was **in-population**:

`pandas/_config/config.py` **SourceFile ×33** (MaterializeModule ×33, ~3.9s)
via `prefix_has_completed_fallthrough` → `_module_prefix_outcome`.

Frame-door module memo is already #7064. This PR owns the **prefix door**.

## Constraint respected

`resolution_session.py`: projection values are live-context-bound. Memo lives
on `SourceResolutionSession` (file-open already threads one session via #7059).
**No process-global projection dict.**

`packages_distributions()` is install-map **content** (not a projection node);
process-caching that map is legitimate and removes a multi-second re-walk.

## What landed

| Session table | Purpose |
| --- | --- |
| `prefix_files[source_cid]` | one prefix SourceFile per body per open |
| `prefix_fallthrough[(cid,line,col)]` | fallthrough answer once per locus |
| `import_use_rosters` / `import_value_rosters` | one lexical pass per body |
| + revalidation snapshot filled at mint | revalidate does not re-Materialize |
| + `packages_distributions` / top-level graph cache | install content |

## Numbers (py3.12, same machine)

| | wall | config SourceFile | config MaterializeModule | functions |
| --- | ---: | ---: | ---: | ---: |
| **BEFORE** | **10.6s** | **33** | **33** | 49 |
| **AFTER cold** | **3.5s** | **4** | **4** | 49 |
| **AFTER warm** | **2.1s** | **4** | **4** | 49 |

Why 4 not 1: prefix door (1) + frame door (1, #7064) + lexical use mint (1) +
lexical value mint (1). Those doors use different construction contexts;
sharing one SourceFile across them would leak frame_projection authority.
Honest O(1) per door, not one global product.

Note: `_json.py` has **49 real functions** (~0.3–0.5s open alone). “Zero
functions” was a false bank (#7065). Residual seconds are populate CM
derivation for 3 uses (option_context / catch_warnings), not empty-file work.

## PR accounting

| | |
| --- | --- |
| **R** | in-pop prefix MaterializeModule multiplier on enrolled megamodules |
| **εR** | config SourceFile/Materialize 33→4 on `_json` open; wall 10.6s→2–3.5s |
| **Shell deleted** | none (session memo is the substrate; stronger type if doors unify) |
| **Floors** | no process-global projection memo; function roster preserved |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Memoize `config.py` SourceFile construction to once per session open
> - Adds per-session memo tables to `SourceResolutionSession` for prefix `SourceFile`s, fallthrough results, and import-use/value rosters, keyed by `source_cid`.
> - `_module_prefix_outcome` and `prefix_has_completed_fallthrough` in [manager_construction.py](https://github.com/TSavo/sugar/pull/7066/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) now reuse cached results instead of reconstructing on every call.
> - Import-use and import-value receipt lookups are routed through session-scoped helpers `_session_import_use_receipts` and `_session_import_value_receipts`, replacing repeated direct calls to the lexical pass functions.
> - Adds a process-level cache for `packages_distributions()` and `DependencyArtifactGraph` in [dependency_artifact.py](https://github.com/TSavo/sugar/pull/7066/files#diff-153692407653e4eda2c94b6899d612575f4b0f569fd4ee8a0ac674aef4e90464), with `clear_top_level_authentication_caches()` to reset them.
> - A new test in [test_config_prefix_session_memo.py](https://github.com/TSavo/sugar/pull/7066/files#diff-11d36489af0e06875180aff1098c33d370b0ab37d562f9023f5f1f4139054f53) asserts that `config.py` `SourceFile` and `MaterializeModule` counts stay ≤4 when opening `pandas/io/json/_json.py`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d7056f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->