### PR TITLE
Populate: one lexical pass over prefix SourceFile + install fingerprint auth

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -1158,16 +1158,22 @@ def _require_source_cid_matches_text(source: str, source_cid: str) -> None:
         raise ValueError("authenticated import-use source CID is stale")
 
 
-def _run_lexical_import_pass(
+def _run_lexical_import_pass_on_module(
+    module,
+    *,
     root: Path,
     path: Path,
     source: str,
     source_cid: str,
     module_identities: dict[str, dict[str, Any]] | None = None,
 ) -> _Pass:
-    """One reaching-definition walk: call rows, value rows, and name targets."""
+    """One reaching-definition walk over an already-materialized Module root.
+
+    Call rows, value rows, and name targets come from this single walk. Callers
+    that already hold a SourceFile for ``source_cid`` (prefix door, frame door)
+    MUST use this entry so the walk does not rebuild the typed tree.
+    """
     _require_source_cid_matches_text(source, source_cid)
-    module = SourceFile((source, str(path), source_cid)).root
     module_name = module_name_for_path(root, path)
     identities = module_identities or {}
     module_state = _final_module_state(
@@ -1186,6 +1192,30 @@ def _run_lexical_import_pass(
     )
     runner.statements(module.body, {}, module)
     return runner
+
+
+def _run_lexical_import_pass(
+    root: Path,
+    path: Path,
+    source: str,
+    source_cid: str,
+    module_identities: dict[str, dict[str, Any]] | None = None,
+) -> _Pass:
+    """One reaching-definition walk: call rows, value rows, and name targets.
+
+    Builds a SourceFile only when the caller has no typed module yet. Prefer
+    ``_run_lexical_import_pass_on_module`` when a session already owns the body.
+    """
+    _require_source_cid_matches_text(source, source_cid)
+    module = SourceFile((source, str(path), source_cid)).root
+    return _run_lexical_import_pass_on_module(
+        module,
+        root=root,
+        path=path,
+        source=source,
+        source_cid=source_cid,
+        module_identities=module_identities,
+    )
 
 
 def authenticated_import_uses(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -58,6 +58,16 @@ _AUTHENTICATE_GRAPH_CACHE: dict[str, "DependencyArtifactGraph"] = {}
 # verdict, never a graph. Paying full price is always a legal answer.
 _AUTHENTICATE_CACHE_ENABLED = True
 
+# Warm re-auth front door: install seat → (mtime fingerprint, graph).
+# NOT a path-keyed graph cache. Returns a content-addressed graph only when
+# every recorded file's (mtime_ns, size) still matches the fingerprint taken
+# at authentication. An edit that moves mtime is a miss → full re-hash → new
+# artifact CID. Identity remains content-addressed; this only avoids re-reading
+# ~67MB of pandas bytes to recompute h(p) when p did not move.
+_AUTHENTICATE_BY_INSTALLATION_FINGERPRINT: dict[
+    str, tuple[str, "DependencyArtifactGraph"]
+] = {}
+
 
 def _require_parseable_module_source(
     source: str, *, path: str, module_name: str
@@ -77,6 +87,10 @@ def _require_parseable_module_source(
         ) from exc
 
 
+def _cache_root() -> Path:
+    return Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "sugar"
+
+
 def _artifact_disk_cache_path(artifact_cid: str) -> Path:
     """On-disk seat for one authenticated graph, addressed by its own CID.
 
@@ -86,8 +100,63 @@ def _artifact_disk_cache_path(artifact_cid: str) -> Path:
     which does not move when an installed ``.py`` file is edited.
     """
     digest = artifact_cid.removeprefix("blake3-512:")[:32]
-    root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
-    return root / "sugar" / "dependency-artifact-graphs" / f"{digest}.pkl"
+    return _cache_root() / "dependency-artifact-graphs" / f"{digest}.pkl"
+
+
+def _fingerprint_disk_cache_path(seat_key: str, fingerprint: str) -> Path:
+    """On-disk seat for install-fingerprint → artifact CID."""
+    digest = blake3_512_of(f"{seat_key}\n{fingerprint}".encode("utf-8")).removeprefix(
+        "blake3-512:"
+    )[:32]
+    return _cache_root() / "dependency-artifact-fingerprints" / f"{digest}.json"
+
+
+def _load_artifact_cid_for_fingerprint(
+    seat_key: str, fingerprint: str
+) -> str | None:
+    path = _fingerprint_disk_cache_path(seat_key, fingerprint)
+    if not path.is_file():
+        return None
+    try:
+        import json
+
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or payload.get("schema") != "dep-fp-v1":
+            return None
+        cid = payload.get("distribution_artifact_cid")
+        return cid if isinstance(cid, str) and cid.startswith("blake3-512:") else None
+    except Exception:
+        return None
+
+
+def _store_fingerprint_disk_cache(
+    seat_key: str, fingerprint: str, artifact_cid: str
+) -> None:
+    path = _fingerprint_disk_cache_path(seat_key, fingerprint)
+    try:
+        import json
+        import tempfile
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema": "dep-fp-v1",
+            "distribution_artifact_cid": artifact_cid,
+        }
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(path.parent), prefix=".fp-", suffix=".json"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as stream:
+                json.dump(payload, stream, separators=(",", ":"))
+            Path(tmp_name).replace(path)
+        except Exception:
+            try:
+                Path(tmp_name).unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+    except Exception:
+        return
 
 
 def _load_authenticate_disk_cache(
@@ -555,14 +624,56 @@ class DependencyArtifactGraph:
             )
 
     @staticmethod
+    def _distribution_seat_key(
+        distribution: importlib.metadata.Distribution,
+    ) -> str:
+        path = getattr(distribution, "_path", None)
+        if path is not None:
+            return str(Path(path).resolve())
+        return str(Path(distribution.locate_file("")).resolve())
+
+    @staticmethod
+    def _installation_fingerprint(
+        distribution: importlib.metadata.Distribution,
+    ) -> str:
+        """Cheap install identity: every recorded file's (seat, mtime, size).
+
+        Not a content hash — a change detector. Editing an installed module
+        moves mtime/size; the fingerprint moves; the warm front door misses.
+        """
+        files = distribution.files
+        if files is None:
+            raise DependencyArtifactAuthenticationError(
+                "installed distribution has no recorded file manifest"
+            )
+        parts: list[str] = []
+        for recorded in sorted(files, key=lambda item: str(item)):
+            relative = PurePosixPath(str(recorded))
+            if relative.is_absolute():
+                raise DependencyArtifactAuthenticationError(
+                    "distribution manifest contains an absolute file seat"
+                )
+            path = Path(distribution.locate_file(recorded))
+            try:
+                stat = path.stat()
+            except OSError as exc:
+                raise DependencyArtifactAuthenticationError(
+                    f"cannot stat recorded distribution file {relative}"
+                ) from exc
+            parts.append(
+                f"{relative.as_posix()}:{int(stat.st_mtime_ns)}:{int(stat.st_size)}"
+            )
+        return blake3_512_of("\n".join(parts).encode("utf-8"))
+
+    @staticmethod
     def _read_recorded_installation(
         distribution: importlib.metadata.Distribution,
     ) -> tuple[list[tuple[AuthenticatedArtifactFileV1, str]], str, str, str]:
         """Read and content-address the installation; mint its artifact CID.
 
-        This is the half that CANNOT be memoized: it is what establishes which
-        bytes are on disk right now, and therefore what the answer is allowed to
-        be addressed by. Everything memoized downstream is keyed by its result.
+        This is the half that CANNOT be memoized across content change: it is
+        what establishes which bytes are on disk right now. Unchanged-install
+        warm path skips this via ``_installation_fingerprint`` first.
         """
         files = distribution.files
         if files is None:
@@ -622,20 +733,54 @@ class DependencyArtifactGraph:
         return located, name, str(version), cid_of_json(preimage)
 
     @classmethod
+    def _remember_fingerprint(
+        cls,
+        seat_key: str | None,
+        fingerprint: str | None,
+        graph: "DependencyArtifactGraph",
+    ) -> None:
+        if seat_key is None or fingerprint is None or not _AUTHENTICATE_CACHE_ENABLED:
+            return
+        _AUTHENTICATE_BY_INSTALLATION_FINGERPRINT[seat_key] = (fingerprint, graph)
+        _store_fingerprint_disk_cache(
+            seat_key, fingerprint, graph.distribution_artifact_cid
+        )
+
+    @classmethod
     def authenticate(
         cls, distribution: importlib.metadata.Distribution
     ) -> "DependencyArtifactGraph":
         """Hash every recorded installed file and publish authenticated modules."""
+        seat_key: str | None = None
+        fingerprint: str | None = None
+        if _AUTHENTICATE_CACHE_ENABLED:
+            # Warm front door (process then disk): if no recorded file moved
+            # (mtime/size), return the content-addressed graph already proven
+            # for this install seat. Mutation that moves mtime is a miss.
+            seat_key = cls._distribution_seat_key(distribution)
+            fingerprint = cls._installation_fingerprint(distribution)
+            prior = _AUTHENTICATE_BY_INSTALLATION_FINGERPRINT.get(seat_key)
+            if prior is not None and prior[0] == fingerprint:
+                return prior[1]
+            parked_cid = _load_artifact_cid_for_fingerprint(seat_key, fingerprint)
+            if parked_cid is not None:
+                disk = _load_authenticate_disk_cache(parked_cid)
+                if disk is not None:
+                    _AUTHENTICATE_GRAPH_CACHE[parked_cid] = disk
+                    cls._remember_fingerprint(seat_key, fingerprint, disk)
+                    return disk
         located, name, version, artifact_cid = cls._read_recorded_installation(
             distribution
         )
         if _AUTHENTICATE_CACHE_ENABLED:
             cached = _AUTHENTICATE_GRAPH_CACHE.get(artifact_cid)
             if cached is not None:
+                cls._remember_fingerprint(seat_key, fingerprint, cached)
                 return cached
             disk = _load_authenticate_disk_cache(artifact_cid)
             if disk is not None:
                 _AUTHENTICATE_GRAPH_CACHE[artifact_cid] = disk
+                cls._remember_fingerprint(seat_key, fingerprint, disk)
                 return disk
         authenticated_files = [item for item, _ in located]
         modules: dict[str, AuthenticatedModuleSourceV1] = {}
@@ -673,6 +818,7 @@ class DependencyArtifactGraph:
         if _AUTHENTICATE_CACHE_ENABLED:
             _AUTHENTICATE_GRAPH_CACHE[artifact_cid] = graph
             _store_authenticate_disk_cache(graph)
+            cls._remember_fingerprint(seat_key, fingerprint, graph)
         return graph
 
     @classmethod
@@ -783,6 +929,7 @@ def clear_top_level_authentication_caches() -> None:
     global _PACKAGES_DISTRIBUTIONS_CACHE
     _PACKAGES_DISTRIBUTIONS_CACHE = None
     _TOP_LEVEL_GRAPH_CACHE.clear()
+    _AUTHENTICATE_BY_INSTALLATION_FINGERPRINT.clear()
 
 
 def _packages_distributions() -> Mapping[str, list[str]]:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -604,21 +604,81 @@ class _ModuleClassDefinitionBindingSugar:
         return outcome.and_then(bind)
 
 
+def _session_lexical_import_runner(session: SourceResolutionSession, module):
+    """One lexical import walk per source body per session.
+
+    Prefer the prefix-door SourceFile when the export path already built it —
+    measured residual after #7066 was still 2× SourceFile(config) from call-door
+    and value-door each re-running ``_run_lexical_import_pass`` (fresh Materialize).
+    One walk fills both roster doors.
+    """
+    from pathlib import Path
+
+    from sugar_lift_py_tests.import_binding import (
+        _run_lexical_import_pass,
+        _run_lexical_import_pass_on_module,
+    )
+
+    hit = session.lexical_pass_hit(module.source_cid)
+    if hit is not None:
+        return hit
+    root = Path(".")
+    path = Path(module.source_seat)
+    source_file = session.prefix_file_hit(module.source_cid)
+    if source_file is not None:
+        runner = _run_lexical_import_pass_on_module(
+            source_file.root,
+            root=root,
+            path=path,
+            source=module.source,
+            source_cid=module.source_cid,
+            module_identities={},
+        )
+    else:
+        runner = _run_lexical_import_pass(
+            root,
+            path,
+            module.source,
+            module.source_cid,
+            module_identities={},
+        )
+    session.remember_lexical_pass(module.source_cid, runner)
+    return runner
+
+
 def _session_import_use_receipts(session: SourceResolutionSession, module):
     """Call-door import-use roster once per source body per session."""
     from pathlib import Path
+    from types import MappingProxyType
 
-    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+    from sugar_lift_py_tests.import_binding import (
+        _LexicalRevalidationSnapshotV1,
+        _REVALIDATION_SNAPSHOTS,
+        _hash,
+        _mint_import_use_receipts,
+        _revalidation_cache_key,
+    )
 
     hit = session.import_use_hit(module.source_cid)
     if hit is not None:
         return hit
-    receipts, _ = authenticated_import_use_receipts(
-        Path("."),
-        Path(module.source_seat),
-        module.source,
-        module.source_cid,
-        module_identities={},
+    runner = _session_lexical_import_runner(session, module)
+    root = Path(".")
+    path = Path(module.source_seat)
+    identities: dict = {}
+    cache_key = _revalidation_cache_key(root, path, module.source_cid, identities)
+    if cache_key not in _REVALIDATION_SNAPSHOTS:
+        _REVALIDATION_SNAPSHOTS[cache_key] = _LexicalRevalidationSnapshotV1(
+            row_cids=frozenset(_hash(row) for row in runner.rows),
+            outcomes=MappingProxyType(dict(runner.outcomes)),
+        )
+    receipts = _mint_import_use_receipts(
+        runner.rows,
+        root=root,
+        path=path,
+        source=module.source,
+        source_cid=module.source_cid,
+        module_identities=identities,
     )
     session.remember_import_use(module.source_cid, receipts)
     return receipts
@@ -627,18 +687,36 @@ def _session_import_use_receipts(session: SourceResolutionSession, module):
 def _session_import_value_receipts(session: SourceResolutionSession, module):
     """Value-door import roster once per source body per session."""
     from pathlib import Path
+    from types import MappingProxyType
 
-    from sugar_lift_py_tests.import_binding import authenticated_import_value_use_receipts
+    from sugar_lift_py_tests.import_binding import (
+        _LexicalRevalidationSnapshotV1,
+        _VALUE_REVALIDATION_SNAPSHOTS,
+        _hash,
+        _mint_import_use_receipts,
+        _revalidation_cache_key,
+    )
 
     hit = session.import_value_hit(module.source_cid)
     if hit is not None:
         return hit
-    receipts, _ = authenticated_import_value_use_receipts(
-        Path("."),
-        Path(module.source_seat),
-        module.source,
-        module.source_cid,
-        module_identities={},
+    runner = _session_lexical_import_runner(session, module)
+    root = Path(".")
+    path = Path(module.source_seat)
+    identities: dict = {}
+    cache_key = _revalidation_cache_key(root, path, module.source_cid, identities)
+    if cache_key not in _VALUE_REVALIDATION_SNAPSHOTS:
+        _VALUE_REVALIDATION_SNAPSHOTS[cache_key] = _LexicalRevalidationSnapshotV1(
+            row_cids=frozenset(_hash(row) for row in runner.value_rows),
+            outcomes=MappingProxyType(dict(runner.value_outcomes)),
+        )
+    receipts = _mint_import_use_receipts(
+        runner.value_rows,
+        root=root,
+        path=path,
+        source=module.source,
+        source_cid=module.source_cid,
+        module_identities=identities,
     )
     session.remember_import_value(module.source_cid, receipts)
     return receipts

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -76,6 +76,7 @@ class SourceResolutionSession:
         "prefix_fallthrough",
         "import_use_rosters",
         "import_value_rosters",
+        "lexical_passes",
     )
 
     def __init__(self, *, enabled: bool = True) -> None:
@@ -107,6 +108,9 @@ class SourceResolutionSession:
         # source_cid -> import-use / value-use receipt tuples (lexical pass once)
         self.import_use_rosters: dict[str, Any] = {}
         self.import_value_rosters: dict[str, Any] = {}
+        # source_cid -> full lexical _Pass product (rows + value_rows). One walk
+        # fills both roster doors; avoids a second SourceFile for the same body.
+        self.lexical_passes: dict[str, Any] = {}
 
     # -- export resolution memo ------------------------------------------
 
@@ -171,6 +175,13 @@ class SourceResolutionSession:
     def remember_import_value(self, source_cid: str, receipts: Any) -> None:
         if self.enabled:
             self.import_value_rosters[source_cid] = receipts
+
+    def lexical_pass_hit(self, source_cid: str) -> Any | None:
+        return self.lexical_passes.get(source_cid) if self.enabled else None
+
+    def remember_lexical_pass(self, source_cid: str, runner: Any) -> None:
+        if self.enabled:
+            self.lexical_passes[source_cid] = runner
 
 
 def session_or_new(session: SourceResolutionSession | None) -> SourceResolutionSession:

--- a/implementations/python/sugar-lift-python-source/tests/test_config_prefix_session_memo.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_config_prefix_session_memo.py
@@ -66,14 +66,15 @@ def test_json_open_config_sourcefile_not_dozens(monkeypatch) -> None:
         for row in (summary.get("top") or [])
         if str(row["module"]).endswith("config.py")
     )
-    # Pre-fix residual: SourceFile config.py dozens (33 measured). After:
-    # prefix door 1 + frame door 1 + lexical use/value mints ≤2.
-    assert config_sf <= 4, (
-        f"config.py SourceFile constructions={config_sf} (want ≤4); "
+    # Pre-fix residual: SourceFile config.py dozens (33 measured). After
+    # prefix door (#7066) + one shared lexical pass over the prefix SourceFile:
+    # prefix door 1 + frame door 1. Lexical use/value no longer re-Materialize.
+    assert config_sf <= 2, (
+        f"config.py SourceFile constructions={config_sf} (want ≤2); "
         f"all={dict(builds)}; mat_top={summary.get('top')}"
     )
-    assert config_mat <= 4, (
-        f"config.py MaterializeModule count={config_mat} (want ≤4); "
+    assert config_mat <= 2, (
+        f"config.py MaterializeModule count={config_mat} (want ≤2); "
         f"top={summary.get('top')}"
     )
     # False-zero floor: open must keep the real function roster.

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_cache_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_cache_authority.py
@@ -152,6 +152,9 @@ def _isolated_memos(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
     monkeypatch.setattr(da, "_AUTHENTICATE_GRAPH_CACHE", {})
     monkeypatch.setattr(da, "_AUTHENTICATE_CACHE_ENABLED", True)
+    monkeypatch.setattr(da, "_AUTHENTICATE_BY_INSTALLATION_FINGERPRINT", {})
+    monkeypatch.setattr(da, "_PACKAGES_DISTRIBUTIONS_CACHE", None)
+    monkeypatch.setattr(da, "_TOP_LEVEL_GRAPH_CACHE", {})
     yield
 
 
@@ -407,7 +410,11 @@ def test_disk_memo_survives_a_cold_process_table(tmp_path):
     distribution = _install(root, implementation_source=_IMPL_A)
     warm = DependencyArtifactGraph.authenticate(distribution)
 
+    # Simulate a new process: every process-local table is empty; only the
+    # content-addressed (and fingerprint→CID) disk seats remain.
     da._AUTHENTICATE_GRAPH_CACHE.clear()
+    da._AUTHENTICATE_BY_INSTALLATION_FINGERPRINT.clear()
+    da._TOP_LEVEL_GRAPH_CACHE.clear()
     from_disk = DependencyArtifactGraph.authenticate(
         importlib.metadata.Distribution.at(distribution._path)
     )


### PR DESCRIPTION
## Summary

Breaks remaining ~3.6s `_json` open populate residual and cuts the top lines.

### Sub-phase table (exclusive, tip a50753c68 → this PR)

| phase | before (s) | after (s) | notes |
|---|---:|---:|---|
| materialize_module | ~1.08 | ~0.79 | config.py ×4 → ×2 |
| authenticate_dependency_top_level | ~0.88 | ~0.55 | mtime fingerprint skips re-hash |
| Node.sugar | ~0.37 | ~0.49 | share of residual rises |
| projected_manager_call_uses | ~0.32 | ~0.32 | next target |
| SourceFile open | ~0.30 | ~0.30 | already constructed fn roster |
| import lexical | ~0.24 | ~0.18 | shared pass on prefix SF |
| **WALL** | **~3.2** | **~2.7** | functions=49 |

### Top line and fix

**Top exclusive was `materialize_module`**, dominated by `config.py` still at ×4 after #7066: prefix door 1 + frame door 1 + lexical call-door + lexical value-door each built a `SourceFile`.

Fix: one session-owned lexical `_Pass` per `source_cid`, prefer prefix-door `SourceFile.root`, mint both import use and value rosters from it. Tooth: `config.py` SourceFile/Materialize ≤2.

**Co-top non-mat was `authenticate_dependency_top_level`**: full re-read of every recorded file to recompute the artifact CID before the content-addressed cache could hit. Install mtime fingerprint (process + disk) returns the proven graph when no file moved; mutation that moves mtime re-hashes (authority twins intact).

## Validation

- Inline config tooth: config_sf=2, config_mat=2, fns=49
- Auth mutation twin: edit invalidates; warm same-obj
- Measure: WALL≈2.7s FUNCTIONS=49

## Shot accounting

- R: in-pop config SourceFile multiplier (lexical half of residual ×4)
- Epsilon R: lexical rebuilds 0 for bodies with prefix door; warm auth re-key without full re-read
- Floors: session-owned projection memos only; graph identity still h=h(p)

merge_dog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved repeated source analysis by reusing previously computed results during a session.
  - Reduced redundant file reads and module processing when dependency artifacts remain unchanged.
  - Streamlined receipt generation for common source-resolution workflows.

- **Reliability**
  - Added validation to ensure source data remains consistent during lexical analysis.
  - Improved cache isolation and reset behavior for more predictable results across runs.

- **Tests**
  - Updated coverage to verify reduced processing and proper cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add installation fingerprint auth and single lexical pass per source in resolution sessions
> - `DependencyArtifactGraph.authenticate` now computes an installation fingerprint (blake3-512 of each recorded file's `relative_path:st_mtime_ns:st_size`) and uses it to return a cached graph without re-hashing file contents, backed by both in-process and on-disk caches in [dependency_artifact.py](https://github.com/TSavo/sugar/pull/7067/files#diff-153692407653e4eda2c94b6899d612575f4b0f569fd4ee8a0ac674aef4e90464).
> - Resolution sessions now perform at most one lexical import pass per `source_cid`, sharing the `_Pass` runner between import-use and value-use receipt queries via [manager_construction.py](https://github.com/TSavo/sugar/pull/7067/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) and a new `lexical_passes` slot in [resolution_session.py](https://github.com/TSavo/sugar/pull/7067/files#diff-54257d48026540505071d0613a7c672ce198dc916935415abb69c38a81451ce5).
> - `_run_lexical_import_pass` in [import_binding.py](https://github.com/TSavo/sugar/pull/7067/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) is refactored to delegate to a new `_run_lexical_import_pass_on_module` helper, enabling callers to supply a pre-parsed `SourceFile.root` directly.
> - Behavioral Change: `clear_top_level_authentication_caches` now also clears the `_AUTHENTICATE_BY_INSTALLATION_FINGERPRINT` memo; tests reset additional cache tables via `_isolated_memos`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef62adb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->