### PR TITLE
Populate: reuse open SourceFile for lexical; skip packages_distributions when possible

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -1319,15 +1319,34 @@ def authenticated_import_use_receipts(
     source: str,
     source_cid: str,
     module_identities: dict[str, dict[str, Any]] | None = None,
+    *,
+    module=None,
 ) -> tuple[list[AuthenticatedImportUseV1], dict[tuple[int, int, int, int], str]]:
-    """Return typed, final-checked Call-target receipts from the lexical pass."""
+    """Return typed, final-checked Call-target receipts from the lexical pass.
+
+    ``module`` — already-materialized Module root for this ``source_cid``. When
+    the caller just opened a SourceFile (populate after open), pass its root so
+    the pass does not re-Materialize the same body (measured: second full
+    ``_json.py`` SourceFile inside populate equaled ~0.25s of residual wall).
+    """
     # Refuse mismatched claims here (same boundary as AuthenticatedImportUseV1);
     # never rewrite source_cid after minting.
     if module_identities is None:
         module_identities = {}
-    rows, outcomes = authenticated_import_uses(
-        root, path, source, source_cid, module_identities=module_identities
-    )
+    if module is not None:
+        runner = _run_lexical_import_pass_on_module(
+            module,
+            root=root,
+            path=path,
+            source=source,
+            source_cid=source_cid,
+            module_identities=module_identities,
+        )
+        rows, outcomes = runner.rows, runner.outcomes
+    else:
+        rows, outcomes = authenticated_import_uses(
+            root, path, source, source_cid, module_identities=module_identities
+        )
     # Same pass fills revalidation snapshot so receipt.revalidate() does not
     # re-Materialize the module (mint+revalidate was a second SourceFile).
     cache_key = _revalidation_cache_key(root, path, source_cid, module_identities)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -952,18 +952,28 @@ def authenticate_dependency_top_level(
         cached = _TOP_LEVEL_GRAPH_CACHE.get(top_level)
         if cached is not None:
             return cached
-    packages = _packages_distributions()
-    distributions = tuple(packages.get(top_level, ()))
-    if len(distributions) == 1:
+    # Fast path: many top-levels share the distribution name (pandas, numpy, …).
+    # ``packages_distributions()`` walks every installed dist (~0.2s measured);
+    # try the direct door first and only pay the install-map walk on miss
+    # (e.g. dateutil → python-dateutil) or multi-owner conflict.
+    graph: DependencyArtifactGraph | None = None
+    try:
         graph = DependencyArtifactGraph.authenticate(
-            importlib.metadata.distribution(distributions[0])
+            importlib.metadata.distribution(top_level)
         )
-    elif distributions:
-        raise DependencyArtifactAuthenticationError(
-            "top-level module belongs to multiple installed distributions"
-        )
-    else:
-        graph = DependencyArtifactGraph.authenticate_stdlib_module(top_level)
+    except importlib.metadata.PackageNotFoundError:
+        packages = _packages_distributions()
+        distributions = tuple(packages.get(top_level, ()))
+        if len(distributions) == 1:
+            graph = DependencyArtifactGraph.authenticate(
+                importlib.metadata.distribution(distributions[0])
+            )
+        elif distributions:
+            raise DependencyArtifactAuthenticationError(
+                "top-level module belongs to multiple installed distributions"
+            )
+        else:
+            graph = DependencyArtifactGraph.authenticate_stdlib_module(top_level)
     if _AUTHENTICATE_CACHE_ENABLED:
         _TOP_LEVEL_GRAPH_CACHE[top_level] = graph
     return graph

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1232,12 +1232,16 @@ def populate_source_derived_resource_refs(
     context = source_file.root.unit.construction_context
     if context is None:
         return
+    # Reuse the already-open typed module. A fresh lexical pass used to
+    # MaterializeModule the consumer body a second time (same source_cid,
+    # absolute vs relative seat in the profile) — residual ~0.25s on _json.
     receipts, _ = authenticated_import_use_receipts(
         Path(root),
         Path(path),
         source_file.unit.source,
         source_file.unit.source_cid,
         module_identities={},
+        module=source_file.root,
     )
     uses = _projected_manager_call_uses(source_file)
     if selected_coordinates is not None:

--- a/implementations/python/sugar-lift-python-source/tests/test_populate_reuses_open_sourcefile.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_populate_reuses_open_sourcefile.py
@@ -1,0 +1,58 @@
+"""Populate must not re-Materialize the consumer body just opened.
+
+After open, ``populate_source_derived_resource_refs`` used to call
+``authenticated_import_use_receipts`` which rebuilt a SourceFile for the same
+``source_cid`` (profile showed absolute + relative ``_json.py`` seats, ~0.25s).
+Pass the open module root into the lexical pass.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from importlib import metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_source_tree.file_open_profile import (
+    begin_file_open_profile,
+    end_file_open_profile,
+    summarize_module_materialize,
+)
+
+
+def test_json_open_plus_populate_materializes_consumer_once() -> None:
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+
+    pandas_distribution = metadata.distribution("pandas")
+    install_root = Path(pandas_distribution.locate_file("")).resolve()
+    path = install_root / "pandas" / "io" / "json" / "_json.py"
+    if not path.is_file():
+        pytest.skip(f"pandas _json.py not installed at {path}")
+
+    bag = begin_file_open_profile()
+    try:
+        sf = open_source_file_for_construction(
+            path,
+            root=install_root,
+            construction_context=TreeConstructionContextV1.for_source_call_construction(),
+            populate_derived=True,
+        )
+        fns = len(tuple(sf.functions()))
+    finally:
+        end_file_open_profile()
+
+    summary = summarize_module_materialize(bag)
+    json_rows = [
+        row
+        for row in (summary.get("top") or [])
+        if str(row.get("module", "")).endswith("_json.py")
+        or str(row.get("module", "")).endswith("/_json.py")
+    ]
+    json_calls = sum(int(row["count"]) for row in json_rows)
+    assert json_calls <= 1, (
+        f"_json.py MaterializeModule count={json_calls} (want ≤1); "
+        f"rows={json_rows}; top={summary.get('top')}"
+    )
+    assert fns >= 40, f"_json open banked {fns} functions"


### PR DESCRIPTION
## Populate sub-phase table (tip 3757a5e53, remaining ~2.0s after SourceFile open)

| group | excl s | %pop | @2.0s |
|---|---:|---:|---:|
| **authenticate_dependency_top_level** | 0.56 | 29% | 0.57 |
| Node.sugar | 0.36 | 19% | 0.38 |
| materialize_module (populate only) | 0.29 | 15% | 0.30 |
| projected_manager_call_uses | 0.25 | 13% | 0.26 |
| lexical / receipts | 0.18 | 9% | 0.18 |
| resolve_source_visible_frame residual | 0.15 | 8% | 0.16 |
| prefix residual | 0.11 | 6% | 0.11 |
| cid / export / binding residual | ~0.04 | 2% | 0.04 |

OPEN ~0.3s (SourceFile) + POPULATE ~1.9–2.1s → WALL ~2.2–2.5s; **functions=49**.

## Top lines taken

### 1. Consumer double-materialize (inside materialize residual)
Populate called `authenticated_import_use_receipts` which rebuilt a `SourceFile` for the body just opened (same `source_cid`, absolute vs relative seat in the profile).

**Fix:** `module=` on the receipt door; populate passes `source_file.root`.

### 2. Auth cold path (top exclusive of pure populate)
`packages_distributions()` ~0.2s every first top-level even when `distribution("pandas")` works.

**Fix:** try `importlib.metadata.distribution(top_level)` first; fall back to the install map (dateutil → python-dateutil still works).

## Validation
- Tooth: `_json.py` MaterializeModule count ≤1; fns ≥40
- dateutil fallback still authenticates

merge_dog

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reuse open SourceFile for lexical import pass and skip `packages_distributions` when possible
> - `populate_source_derived_resource_refs` now passes the already-open module root to `authenticated_import_use_receipts`, avoiding a second `MaterializeModule` call during population.
> - `authenticated_import_use_receipts` accepts a new `module=` keyword argument; when provided, it runs the lexical import pass directly on that module instead of re-materializing.
> - `authenticate_dependency_top_level` adds a fast path via `importlib.metadata.distribution()` to resolve top-levels that match a distribution name directly, falling back to the full `packages_distributions()` walk only on miss or conflict.
> - A new test verifies that opening a source file with `populate_derived=True` results in at most one `MaterializeModule` call for the consumer module.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3d0fbf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->