### PR TITLE
Construction cache: control stacks only for Break/Continue/Raise

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -66,8 +66,9 @@ def materialize(
 
     Constructs a Node shell for this backend ref (source or shadow). Field
     *data* is memoized on the unit's ConstructionCache — slots resolve once
-    per (ref, reporter, control_context) into a shared row; shells may be
-    built freely over that row. Registration runs in the constructor.
+    per construction coordinate into a shared row; shells may be built freely
+    over that row. Control stacks enter the coordinate only for
+    Break/Continue/Raise. Registration runs in the constructor.
 
     ``unit`` is the unit to construct UNDER, which is the parent's for a child
     slot. A ref that was parsed out of a specific source overrides it with that
@@ -85,11 +86,14 @@ def materialize(
     if cache is None:
         cache = ConstructionCache()
         object.__setattr__(unit, "construction_cache", cache)
-    # Ensure the field row exists (filled lazily on first accessor).
-    key = cache.key(ref, reporter, ctx, unit.construction_context)
+    cls = ref.resolve_type()
+    # Ensure the field row exists (filled lazily on first accessor). Kind
+    # selects whether the control stack is part of the coordinate.
+    key = cache.key(
+        ref, reporter, ctx, unit.construction_context, kind=cls.__name__
+    )
     cache.fields.setdefault(key, {})
 
-    cls = ref.resolve_type()
     return cls(
         unit=unit,
         ref=ref,
@@ -865,6 +869,7 @@ class Backend:
                 node.value.reporter,
                 node.value.control_context,
                 node.value.unit.construction_context,
+                kind=type(node.value).__name__,
             )
             value_cache.sugar_results[value_key] = value_sugar
             node.value.reporter.present_fact(node.value)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
@@ -1,15 +1,49 @@
 """Work memoization for typed construction — field *data*, not Node shells.
 
-Each ``(ref, reporter, control_context)`` site owns a field row. Slots resolve
-at most once into that row on first need. ``materialize`` may construct Node
-shells freely; each shell reads the shared row. Source and shadow backends use
-the same map (different ``ref``).
+Each construction coordinate owns a field row. Slots resolve at most once into
+that row on first need. ``materialize`` may construct Node shells freely; each
+shell reads the shared row. Source and shadow backends use the same map
+(different ``ref``).
+
+Control context (enclosing loop / except stacks) is NOT part of every key.
+Only node kinds whose *resolved value* depends on that stack — Break,
+Continue, Raise — contribute a control fragment, and only the nearest binding
+they actually read. Name, Constant, Attribute, and the rest of the tree share
+one row per (ref, reporter, construction_context) regardless of nesting depth,
+so the key set converges with the ref set instead of growing with every loop.
 """
 
 from __future__ import annotations
 
 import weakref
 from typing import Any
+
+# Kinds whose constructed answer reads ControlConstructionContextV1.
+# Everyone else resolves identically inside or outside a loop/handler.
+CONTROL_SENSITIVE_KINDS: frozenset[str] = frozenset(
+    ("Break", "Continue", "Raise")
+)
+
+
+def control_key_fragment(
+    control_context: object,
+    kind: str | None,
+) -> tuple:
+    """The part of control context that belongs in a construction key.
+
+    Break/Continue need the nearest loop target only — not the full stack.
+    Raise needs the nearest exception slot only (bare raise; others tolerate
+    None). All other kinds contribute nothing: their field and sugar answers
+    do not depend on which loop encloses them.
+    """
+    if kind not in CONTROL_SENSITIVE_KINDS:
+        return ()
+    if kind in ("Break", "Continue"):
+        loops = getattr(control_context, "loop_targets", ()) or ()
+        return ("loop", loops[-1] if loops else None)
+    # Raise
+    slots = getattr(control_context, "exception_slots", ()) or ()
+    return ("exc", slots[-1] if slots else None)
 
 # The construction-shape CID is a CATEGORY of content-addressed work: a pure
 # function of a backend ref (fragment + subtree preimage). It is NOT unit-scoped
@@ -150,7 +184,12 @@ def remember_constructed_value_cid_v2(value: object, cid: str) -> None:
 
 
 class ConstructionCache:
-    """Shared field rows keyed by backend site + reporter + control context."""
+    """Shared field rows keyed by construction coordinate.
+
+    Control stacks enter the key only for control-sensitive kinds (see
+    ``control_key_fragment``). Non-sensitive kinds share one row across every
+    enclosing loop/handler so the key population converges with the ref set.
+    """
 
     __slots__ = ("fields", "sugar_results", "sugar_panics", "_pinned")
 
@@ -178,9 +217,10 @@ class ConstructionCache:
         # the coordinate rule -- the reporter testifies each coordinate once,
         # whether it answers present or absent.
         self.sugar_panics: dict[tuple, BaseException] = {}
-        # key -> ref, or (ref, construction_context). The cache key embeds
-        # both live identities; pin every non-None participant so neither ID
-        # can be recycled underneath a retained row.
+        # key -> pin bag. The cache key embeds live identities (ref,
+        # construction_context, and for control-sensitive kinds the nearest
+        # loop/exception binding); pin every participant so IDs cannot be
+        # recycled underneath a retained row.
         # Shadow refs minted
         # during substitution are transient: once a rewritten shadow is GC'd its
         # address is reused by the NEXT shadow (e.g. one loop-unroll iteration's
@@ -196,17 +236,29 @@ class ConstructionCache:
         reporter: object,
         control_context: object,
         construction_context: object = None,
+        *,
+        kind: str | None = None,
     ) -> tuple:
-        loop_targets = getattr(control_context, "loop_targets", ())
-        exception_slots = getattr(control_context, "exception_slots", ())
+        """Construction coordinate for field rows and sugar memoization.
+
+        ``kind`` selects whether control context contributes. Pass the node
+        class name (``Break``, ``Name``, …). Omitting ``kind`` is treated as
+        non-sensitive — no control fragment — which is correct for pin tests
+        and any caller that is not a control-sensitive node.
+        """
+        control = control_key_fragment(control_context, kind)
         computed = (
             id(ref),
             id(reporter),
             id(construction_context),
-            loop_targets,
-            exception_slots,
+            control,
         )
-        self._pinned[computed] = (
-            ref if construction_context is None else (ref, construction_context)
-        )
+        # Pin every identity-bearing participant so a GC'd address cannot be
+        # recycled into a live key. Control fragment is pinned when present so
+        # a nearest-loop target object stays unique for the row's lifetime.
+        if construction_context is None and not control:
+            pin: object = ref
+        else:
+            pin = (ref, construction_context, control)
+        self._pinned[computed] = pin
         return computed

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1861,8 +1861,10 @@ class Node(Typed):
     """Abstract base of every node. The hierarchy is the grammar.
 
     Shell over memoized field *data* on the unit ConstructionCache. Accessors
-    resolve each backend slot at most once per (ref, reporter, control_context)
-    into that shared row; re-reads hit the row. Shells are free to construct.
+    resolve each backend slot at most once per construction coordinate into
+    that shared row; re-reads hit the row. Control stacks enter the coordinate
+    only for Break/Continue/Raise (nearest binding); other kinds share one row
+    across every enclosing loop/handler. Shells are free to construct.
     Shadow rewrite uses the same door with a shadow backend ref.
     """
 
@@ -1949,6 +1951,7 @@ class Node(Typed):
             self.reporter,
             self.control_context,
             self.unit.construction_context,
+            kind=type(self).__name__,
         )
         row = cache.fields.setdefault(key, {})
         if name in row:
@@ -2518,6 +2521,7 @@ class Node(Typed):
             self.reporter,
             self.control_context,
             self.unit.construction_context,
+            kind=type(self).__name__,
         )
         remembered_panic = cache.sugar_panics.get(key)
         if remembered_panic is not None:
@@ -2642,6 +2646,7 @@ class Node(Typed):
             self.reporter,
             self.control_context,
             self.unit.construction_context,
+            kind=type(self).__name__,
         )
         row = cache.fields.setdefault(key, {})
         cached = row.get("__child_edges__")

--- a/implementations/python/sugar-source-tree/tests/test_construction_cache_pin.py
+++ b/implementations/python/sugar-source-tree/tests/test_construction_cache_pin.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 import gc
 import weakref
 
-from sugar_source_tree.construction_cache import ConstructionCache
+from sugar_source_tree.construction_cache import (
+    CONTROL_SENSITIVE_KINDS,
+    ConstructionCache,
+    control_key_fragment,
+)
 
 
 class _Ctx:
-    loop_targets = ()
-    exception_slots = ()
+    def __init__(self, loop_targets=(), exception_slots=()):
+        self.loop_targets = loop_targets
+        self.exception_slots = exception_slots
 
 
 def test_cache_pins_keyed_refs_against_id_reuse():
@@ -49,12 +54,76 @@ def test_cache_pins_non_none_construction_context_and_keeps_none_shape():
     gc.collect()
 
     assert context_ref() is not None
-    assert cache._pinned[key] == (ref, context_ref())
+    pinned = cache._pinned[key]
+    assert pinned[0] is ref
+    assert pinned[1] is context_ref()
     foreign = _Ctx()
     foreign_key = cache.key(ref, reporter, control, foreign)
     assert foreign_key != key
     assert cache.fields.get(foreign_key) is None
 
     none_key = cache.key(ref, reporter, control)
-    assert none_key == (id(ref), id(reporter), id(None), (), ())
+    assert none_key == (id(ref), id(reporter), id(None), ())
     assert cache._pinned[none_key] is ref
+
+
+def test_control_key_fragment_empty_for_non_sensitive_kinds():
+    deep = _Ctx(loop_targets=("outer", "inner"), exception_slots=("h1",))
+    for kind in ("Name", "Constant", "Attribute", "BinOp", "For", "Call", None):
+        assert control_key_fragment(deep, kind) == ()
+
+
+def test_control_key_fragment_nearest_only_for_sensitive_kinds():
+    outer, inner = object(), object()
+    deep = _Ctx(loop_targets=(outer, inner), exception_slots=("h0", "h1"))
+    assert control_key_fragment(deep, "Break") == ("loop", inner)
+    assert control_key_fragment(deep, "Continue") == ("loop", inner)
+    assert control_key_fragment(deep, "Raise") == ("exc", "h1")
+    assert CONTROL_SENSITIVE_KINDS == frozenset(("Break", "Continue", "Raise"))
+
+
+def test_non_sensitive_kind_shares_key_across_control_stacks():
+    """Name under two different loop nestings is ONE field row — the cache
+    converges. Only Break/Continue/Raise split by nearest control binding."""
+    cache = ConstructionCache()
+    reporter = object()
+    ref = object()
+    outer, inner = object(), object()
+    shallow = _Ctx(loop_targets=(outer,))
+    deep = _Ctx(loop_targets=(outer, inner), exception_slots=("h",))
+
+    k_name_shallow = cache.key(ref, reporter, shallow, kind="Name")
+    k_name_deep = cache.key(ref, reporter, deep, kind="Name")
+    assert k_name_shallow == k_name_deep
+
+    k_break_shallow = cache.key(ref, reporter, shallow, kind="Break")
+    k_break_deep = cache.key(ref, reporter, deep, kind="Break")
+    assert k_break_shallow != k_break_deep
+    assert k_break_shallow == (
+        id(ref),
+        id(reporter),
+        id(None),
+        ("loop", outer),
+    )
+    assert k_break_deep == (
+        id(ref),
+        id(reporter),
+        id(None),
+        ("loop", inner),
+    )
+
+
+def test_nested_breaks_keep_distinct_nearest_loop_keys():
+    """Correctness tooth: break in outer and break in inner must not share."""
+    cache = ConstructionCache()
+    reporter = object()
+    break_ref = object()
+    loop_a, loop_b = object(), object()
+    outer_only = _Ctx(loop_targets=(loop_a,))
+    nested = _Ctx(loop_targets=(loop_a, loop_b))
+
+    outer_key = cache.key(break_ref, reporter, outer_only, kind="Break")
+    inner_key = cache.key(break_ref, reporter, nested, kind="Break")
+    assert outer_key != inner_key
+    assert outer_key[3] == ("loop", loop_a)
+    assert inner_key[3] == ("loop", loop_b)

--- a/implementations/python/sugar-source-tree/tests/test_control_key_cache_converge.py
+++ b/implementations/python/sugar-source-tree/tests/test_control_key_cache_converge.py
@@ -1,0 +1,62 @@
+"""Control stacks belong in the construction key only for control-sensitive kinds.
+
+A Name under two loop depths shares one field row. A Break under two nearest
+loops keeps two rows. Nested-loop construction still resolves each break to
+its own target.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+from sugar_lift_python_source.source_oracle import path_source
+from sugar_source_tree.construction_cache import ConstructionCache
+from sugar_source_tree.nodes import ControlConstructionContextV1
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(source)
+        path = handle.name
+    return next(SourceFile(path_source(path)).functions())
+
+
+def test_nested_breaks_sugar_targets_nearest_loop_with_shared_field_cache():
+    function = _function(
+        "def f(xs, ys):\n"
+        "    for x in xs:\n"
+        "        for y in ys:\n"
+        "            if y:\n"
+        "                break\n"
+        "        if x:\n"
+        "            break\n"
+    )
+    breaks = [n for n in function.walk() if n.kind == "Break"]
+    assert len(breaks) == 2
+    targets = [br.sugar().target_cid for br in breaks]
+    assert targets[0] != targets[1], (
+        "inner and outer break must not share a loop target "
+        f"(got {targets!r})"
+    )
+    cache = function.unit.construction_cache
+    assert cache is not None
+    control_bearing = sum(1 for key in cache.fields if key[3])
+    plain = sum(1 for key in cache.fields if not key[3])
+    # Non-sensitive kinds dominate; control fragments are rare (breaks).
+    assert plain > control_bearing
+    assert control_bearing >= 1
+
+
+def test_name_field_key_ignores_loop_stack():
+    cache = ConstructionCache()
+    ref, reporter = object(), object()
+    outer = object()
+    a = ControlConstructionContextV1().enter_loop(outer)
+    b = a.enter_loop(object())
+    assert cache.key(ref, reporter, a, kind="Name") == cache.key(
+        ref, reporter, b, kind="Name"
+    )
+    assert cache.key(ref, reporter, a, kind="Break") != cache.key(
+        ref, reporter, b, kind="Break"
+    )


### PR DESCRIPTION
## Summary

`ControlConstructionContextV1` is two stacks: enclosing loops and except handlers. Only **Break/Continue** (nearest loop target) and **Raise** (nearest exception slot) read those stacks for their resolved value. Every other node kind was still keyed on the full stack, so nested loops/handlers split field and sugar rows for Names, Constants, Attributes, etc. that resolve identically under any nesting.

**Fix (option b):** construction keys include a control fragment only for control-sensitive kinds, and only the **nearest** binding:
- `Break` / `Continue` → `("loop", nearest_loop_target)`
- `Raise` → `("exc", nearest_exception_slot)`
- everything else → `()`

Shells still receive the full stack via `materialize` / `_child_control_context` so sugar for break/raise stays correct. Nested breaks cannot share a nearest-loop key.

## Numbers — one open of `pandas/io/json/_json.py`

Recipe: `open_source_file_for_construction(..., construction_context=TreeConstructionContextV1.for_source_call_construction(), populate_derived=True)` on tip after #7066.

| | getattr | hit | miss | distinct_keys | wall |
|---|---:|---:|---:|---:|---:|
| **BEFORE** | 79760 | 57670 | 22090 | 11626 | 3.834s |
| **AFTER** | 79787 | 57697 | 22090 | 11626 | 3.803s (clean uninstrumented 3.366s) |

Main-unit field rows after: **3899** total, **33** control-bearing (Break/Continue/Raise only).

**Honest read:** on this open path each ref already appears under one control stack, so content-addressed full stacks were not multiplying keys much either — keys track refs (~2 miss/ref first-touch). The change is still the right coordinate law: non-sensitive kinds can no longer split when the same ref is reached under different nestings (substitution / re-materialize / multi-path), and the key set cannot grow with nesting depth for the 99% of nodes that ignore control.

The remaining 7–17s / 80k getattr volume is call volume + first-touch resolve, not dead-cache thrash from control stacks on this path. That is a separate shot (eager fields / shell-local row / less walk during populate).

## Tooth

- `test_control_key_cache_converge.py` — nested breaks → distinct nearest-loop targets; Name shares key across two loop depths
- `test_construction_cache_pin.py` — fragment rules + non-sensitive share / sensitive split
- Existing `test_loop_control_construction.py::test_nested_controls_target_the_nearest_structural_loop`

## Test plan

- [x] focused construction-cache + loop-control tests
- [x] nested break sugar targets differ
- [x] measured _json open before/after
- [ ] CI

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope construction cache control stack keying to Break, Continue, and Raise nodes only
> - Introduces `CONTROL_SENSITIVE_KINDS` in [`construction_cache.py`](https://github.com/TSavo/sugar/pull/7069/files#diff-fec1dbfe7718a35848f37642330b8df50429df86eae284a72524c6bf8352972f) as a frozenset of `{'Break', 'Continue', 'Raise'}` — only these node kinds factor the nearest loop/exception binding into their cache key.
> - Adds `control_key_fragment(kind)` to compute a compact control-context fragment, replacing the previous approach of embedding full `loop_targets`/`exception_slots` tuples in every key.
> - Updates `ConstructionCache.key` to accept a `kind` argument and produce keys of the form `(id(ref), id(reporter), id(construction_context), control_fragment)`, with pinning extended to include the control fragment for sensitive kinds.
> - Call sites in [`nodes.py`](https://github.com/TSavo/sugar/pull/7069/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) and [`backend.py`](https://github.com/TSavo/sugar/pull/7069/files#diff-ad498e547096dff0cc0a35d78feaa867418d745ad78531faf3f78b5e835414b8) now pass `kind=type(node).__name__` to `cache.key`.
> - Behavioral Change: nodes of kinds other than Break/Continue/Raise now share cache entries across different control stacks, where previously they would have diverged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 297c347.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->