### PR TITLE
Static prefix fallthrough: pure-binding AST admits without sugar

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -947,10 +947,95 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
     return reduce_block_to_exitset(sugars)
 
 
+# Top-level statement kinds that always complete and fall through under Python
+# module semantics (bind or no-op; never exit the module body). Used so export
+# admit does not run ``_module_prefix_outcome`` (MaterializeModule + ClassDef
+# sugar of every earlier definition) when the AST prefix is pure bindings —
+# measured residual ~1.9s of prefix_has_completed_fallthrough on tip 63356a636
+# for one pandas/io/json/_json.py open after session memos landed.
+_STATIC_FALLTHROUGH_STMT_TYPES: frozenset[type] | None = None
+
+
+def _static_fallthrough_stmt_types() -> frozenset[type]:
+    global _STATIC_FALLTHROUGH_STMT_TYPES
+    if _STATIC_FALLTHROUGH_STMT_TYPES is not None:
+        return _STATIC_FALLTHROUGH_STMT_TYPES
+    import ast
+
+    kinds: set[type] = {
+        ast.Import,
+        ast.ImportFrom,
+        ast.FunctionDef,
+        ast.AsyncFunctionDef,
+        ast.ClassDef,
+        ast.Assign,
+        ast.AnnAssign,
+        ast.Pass,
+        ast.Expr,
+        ast.Delete,
+        ast.Global,
+        ast.Nonlocal,
+    }
+    type_alias = getattr(ast, "TypeAlias", None)
+    if type_alias is not None:
+        kinds.add(type_alias)
+    _STATIC_FALLTHROUGH_STMT_TYPES = frozenset(kinds)
+    return _STATIC_FALLTHROUGH_STMT_TYPES
+
+
+def _ast_stmt_always_falls_through(statement) -> bool:
+    """True when this top-level statement cannot prevent later bindings.
+
+    Decorated FunctionDef/ClassDef still bind (incomplete sugar is a Floor gap,
+    not a module exit).  Pure-branch Ifs (``if TYPE_CHECKING:`` and any If
+    whose every arm always falls through) fall through when both arms do.
+    Open control flow (Try/For/While/With/Match/Raise/Return/Assert) needs the
+    full prefix producer.
+    """
+    import ast
+
+    if type(statement) in _static_fallthrough_stmt_types():
+        return True
+    if isinstance(statement, ast.If):
+        body_ok = all(_ast_stmt_always_falls_through(s) for s in statement.body)
+        else_ok = all(_ast_stmt_always_falls_through(s) for s in statement.orelse)
+        return body_ok and else_ok
+    return False
+
+
+def _static_prefix_always_fallthrough(module, locus) -> bool:
+    """AST-only admit: pure-binding prefix needs no MaterializeModule/sugar.
+
+    Parses ``module.source`` once (stdlib ``ast``, not SourceFile).  When every
+    statement strictly before ``locus`` always falls through, export resolve
+    may admit without ``_module_prefix_outcome``.  That path re-sugared every
+    ClassDef before each export locus (prefix_has_completed_fallthrough ~1.9s
+    of a ~7s _json open on tip after SourceFile session memos).
+    """
+    import ast
+
+    from .canonical import blake3_512_of
+
+    if module.source_cid != blake3_512_of(module.source.encode("utf-8")):
+        raise ValueError("module prefix source CID mismatch")
+    try:
+        tree = ast.parse(module.source)
+    except SyntaxError:
+        return False
+    locus_key = (locus.lineno, locus.col_offset)
+    for statement in tree.body:
+        key = (statement.lineno, statement.col_offset)
+        if key >= locus_key:
+            break
+        if not _ast_stmt_always_falls_through(statement):
+            return False
+    return True
+
+
 def prefix_has_completed_fallthrough(
     module, locus, *, graph=None, session=None
 ) -> bool:
-    """Admit an export only through the authenticated module-prefix producer.
+    """Admit an export when the module prefix normally completes.
 
     POPULATION MEMBRANE: when ``graph`` is stdlib (off enrolled population),
     never ``MaterializeModule`` the module to prove fallthrough.  Static export
@@ -958,6 +1043,11 @@ def prefix_has_completed_fallthrough(
     citation; frame projection then cites via ``call-target-off-population``
     instead of rebuilding.  Running the prefix producer here is what turned
     one pandas open into 35× ``SourceFile(enum.py)``.
+
+    STATIC FALLTHROUGH: when the AST prefix is pure bindings (imports, defs,
+    classes, assigns, pure-branch Ifs such as TYPE_CHECKING), admit without
+    ``_module_prefix_outcome`` / ClassDef.sugar.  Full producer remains the
+    authority for open control flow (Try/For/Raise/…).
     """
     from sugar_lift_py_tests.outcome import Completed, true_guard
 
@@ -976,6 +1066,11 @@ def prefix_has_completed_fallthrough(
     cached = session.fallthrough_hit(fallthrough_key)
     if cached is not None:
         return cached
+
+    # Cheap door: pure-binding AST prefix always falls through — no sugar.
+    if _static_prefix_always_fallthrough(module, locus):
+        session.remember_fallthrough(fallthrough_key, True)
+        return True
 
     # Prefix sugar can SNW (e.g. decorated FunctionDef without publication).
     # That is not "fallthrough completed"; it is incomplete prefix — cite as

--- a/implementations/python/sugar-lift-python-source/tests/test_static_prefix_fallthrough.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_static_prefix_fallthrough.py
@@ -1,0 +1,122 @@
+"""Static prefix fallthrough: pure-binding AST admits without _module_prefix_outcome.
+
+``prefix_has_completed_fallthrough`` only needs whether control reaches the
+export locus.  Pure-binding prefixes (imports, defs, classes, assigns,
+TYPE_CHECKING-only Ifs) always fall through under Python module semantics —
+MaterializeModule + ClassDef.sugar of every earlier definition was residual
+wall (~1.9s of prefix_has_completed_fallthrough on tip 63356a636 for one
+pandas/io/json/_json.py open after session memos).
+
+Open-control prefixes (Try/For/Raise/…) still take the full producer.
+"""
+
+from __future__ import annotations
+
+import ast
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.manager_construction import (
+    _module_prefix_outcome,
+    _static_prefix_always_fallthrough,
+    prefix_has_completed_fallthrough,
+)
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
+
+
+def _module(source: str, seat: str = "mod.py"):
+    return SimpleNamespace(
+        source=source,
+        source_seat=seat,
+        source_cid=blake3_512_of(source.encode("utf-8")),
+        module_name="mod",
+    )
+
+
+def _locus_of(source: str, name: str) -> ast.stmt:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name == name:
+                return node
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name) and t.id == name:
+                    return node
+    raise AssertionError(f"no locus for {name!r} in source")
+
+
+def test_static_pure_binding_prefix_admits_without_outcome(monkeypatch) -> None:
+    source = (
+        "import os\n"
+        "from typing import TYPE_CHECKING\n"
+        "if TYPE_CHECKING:\n"
+        "    from collections.abc import Callable\n"
+        "X = 1\n"
+        "class C:\n"
+        "    pass\n"
+        "def export(value):\n"
+        "    return value\n"
+    )
+    module = _module(source)
+    locus = _locus_of(source, "export")
+    assert _static_prefix_always_fallthrough(module, locus) is True
+
+    calls = {"n": 0}
+    real = _module_prefix_outcome
+
+    def counting(module, locus, **kw):
+        calls["n"] += 1
+        return real(module, locus, **kw)
+
+    monkeypatch.setattr(
+        "sugar_lift_python_source.manager_construction._module_prefix_outcome",
+        counting,
+    )
+    session = SourceResolutionSession()
+    assert (
+        prefix_has_completed_fallthrough(module, locus, session=session) is True
+    )
+    assert calls["n"] == 0, (
+        f"pure-binding prefix must not run _module_prefix_outcome; n={calls['n']}"
+    )
+
+
+def test_static_open_control_prefix_declines_static_door() -> None:
+    source = (
+        "import os\n"
+        "try:\n"
+        "    setup()\n"
+        "except Exception:\n"
+        "    pass\n"
+        "def export(value):\n"
+        "    return value\n"
+    )
+    module = _module(source)
+    locus = _locus_of(source, "export")
+    assert _static_prefix_always_fallthrough(module, locus) is False
+
+
+def test_stdlib_graph_still_short_circuits(monkeypatch) -> None:
+    source = "def export():\n    return 1\n"
+    module = _module(source)
+    locus = _locus_of(source, "export")
+    graph = SimpleNamespace(artifact_kind="stdlib")
+    calls = {"n": 0}
+
+    def boom(*a, **k):
+        calls["n"] += 1
+        raise AssertionError("stdlib must not reach outcome")
+
+    monkeypatch.setattr(
+        "sugar_lift_python_source.manager_construction._module_prefix_outcome",
+        boom,
+    )
+    monkeypatch.setattr(
+        "sugar_lift_python_source.manager_construction._static_prefix_always_fallthrough",
+        boom,
+    )
+    assert prefix_has_completed_fallthrough(module, locus, graph=graph) is True
+    assert calls["n"] == 0


### PR DESCRIPTION
## Summary

`prefix_has_completed_fallthrough` only needs whether control reaches the export locus. On-pin exports still ran `_module_prefix_outcome` (MaterializeModule + ClassDef.sugar of every earlier definition) **once per export locus**. Session memos stopped rebuilding SourceFile N times; they did not stop re-sugaring pure-binding prefixes.

Brown profile tip `63356a636`: `prefix_has_completed_fallthrough` **1.885s** inside `populate_source_derived` (~5.9s).

## Fix

AST-only static door before the producer:

- Pure-binding prefix (Import*, FunctionDef/ClassDef, Assign/AnnAssign, Pass/Expr/Delete, pure-branch Ifs including `TYPE_CHECKING`) → admit `True` without sugar
- Open control flow (Try/For/While/With/Match/Raise/Return/Assert, non-pure If) → full `_module_prefix_outcome` as today
- Stdlib population membrane unchanged (still short-circuits before static)

Incomplete decorator sugar is a Floor gap, not a module exit — decorated FunctionDef still falls through (correct Python module semantics).

## Numbers — one open of `pandas/io/json/_json.py`

Recipe: `authenticated_pandas_corpus().root` + `locus_root_for_corpus` + `open_source_file_for_construction(..., populate_derived=True)` on tip + this change.

| | fallthrough total | `_module_prefix_outcome` | cold open wall (instrumented) |
|---|---:|---:|---:|
| **BEFORE** | ~3.22s (n=7) | ×4 (config.py:454 alone 2.89s) | ~9.5s |
| **AFTER** | **~0.029s** (n=9) | **×0** | **~4.6s** |

## Tooth

`test_static_prefix_fallthrough.py`: pure prefix never calls outcome; open-control declines static; stdlib still short-circuits.

## Not claiming

- Not claiming sub-second open wall (SourceFile + populate residual remain)
- Not claiming lexical-pass kill (already gone from top 30)
- Not claiming full producer retired for open-control prefixes

## Test plan

- [x] focused static fallthrough tooth (manual runner — pytest SIGTERM in this env)
- [x] measured _json open before/after
- [ ] CI

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add static prefix fallthrough fast-path to `prefix_has_completed_fallthrough`
> - Adds `_static_prefix_always_fallthrough` in [manager_construction.py](https://github.com/TSavo/sugar/pull/7070/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1), which parses the module AST and checks whether all statements before the export locus are pure-binding (imports, function/class defs, assignments, etc.) without constructing sugar.
> - Adds `_ast_stmt_always_falls_through`, a recursive predicate that handles `If` statements by checking both branches, and returns `False` for control-flow constructs like `Try`, `For`, `While`, `With`, `Match`, `Raise`, `Return`, and `Assert`.
> - When the fast-path returns `True`, `prefix_has_completed_fallthrough` short-circuits and stores `True` in the session cache without invoking `_module_prefix_outcome`.
> - Risk: if `module.source_cid` does not match the blake3_512 hash of `module.source`, the new fast-path raises `ValueError`, which may now propagate before the existing producer path is attempted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eafe192.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->