### PR TITLE
Process-resident file context under content CID (enumeration §4)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/process_resident_file.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/process_resident_file.py
@@ -1,0 +1,149 @@
+"""Enumeration protocol §4 — process-resident file context under content CID.
+
+Law (``protocol/specs/2026-07-08-enumeration-protocol.md`` §4):
+
+    Inside the Python kit, demanded file context is process-resident under the
+    whole-file content CID. A file request parses and prepares module temporal
+    context once for that CID; distinct demanded descendants reuse it. Changing
+    the file changes the CID and therefore misses without a staleness check.
+
+This is not a new invention and not an optional cache. The protocol makes
+re-deriving the same content for every consumer **unrepresentable**: same CID
+answers from residency; different bytes mint a different CID and miss.
+
+Boundary (load-bearing):
+    Shared product is the **content-derived preparation** — SourceUnit +
+    MaterializeModule tree + unit construction_cache for that body. It is not a
+    consumer workspace projection shell carrying another open's live seating
+    authority. Consumer ``construction_context`` seating tables that are bound
+    at first prepare of a CID remain the module's tables for that content;
+    seats are keyed by content coordinates, so additional descendants reuse
+    preparation rather than inventing a second body.
+
+Identity is not the key. ``h = h(p)``: the whole-file content CID *is* the key.
+"""
+
+from __future__ import annotations
+
+import collections
+import os
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+
+def _resident_limit() -> int:
+    raw = os.environ.get("SUGAR_PROCESS_RESIDENT_FILE_LIMIT", "512")
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 512
+
+
+@dataclass
+class ProcessResidentFileContext:
+    """One whole-file content CID's prepared body, process-resident.
+
+    ``prepare_count`` is the number of times this CID paid MaterializeModule
+    in this process (protocol: must be 1 after first demand).
+    """
+
+    source_cid: str
+    source: str
+    filename: str
+    source_file: Any  # SourceFile — structural shell after prepare
+    prepare_count: int
+
+
+# content CID -> resident context (LRU by access)
+_RESIDENT: collections.OrderedDict[str, ProcessResidentFileContext] = (
+    collections.OrderedDict()
+)
+# Teeth: prepare counts even after eviction from the LRU window
+_PREPARE_COUNTS: dict[str, int] = {}
+
+
+def prepare_count_for(source_cid: str) -> int:
+    """How many times this content CID has paid full prepare in this process."""
+    return int(_PREPARE_COUNTS.get(source_cid, 0))
+
+
+def resident_size() -> int:
+    return len(_RESIDENT)
+
+
+def clear_process_resident_files() -> None:
+    """Test door: drop residency and prepare counters."""
+    _RESIDENT.clear()
+    _PREPARE_COUNTS.clear()
+
+
+def _remember(source_cid: str, ctx: ProcessResidentFileContext) -> None:
+    _RESIDENT[source_cid] = ctx
+    _RESIDENT.move_to_end(source_cid)
+    while len(_RESIDENT) > _resident_limit():
+        _RESIDENT.popitem(last=False)
+
+
+def get_resident(source_cid: str) -> ProcessResidentFileContext | None:
+    hit = _RESIDENT.get(source_cid)
+    if hit is not None:
+        _RESIDENT.move_to_end(source_cid)
+    return hit
+
+
+def source_file_from_identity(
+    identity: Tuple[str, str, str],
+    *,
+    backend: Any = None,
+    reporter: Any = None,
+    construction_context: object | None = None,
+) -> Any:
+    """Return SourceFile for identity, preparing at most once per content CID.
+
+    Implements §4 at the construction door every demand already walks.
+    """
+    from .reporter import NULL_REPORTER
+    from .tree import SourceFile, _default_backend
+
+    source, filename, source_cid = identity
+    if not source_cid:
+        # No content address → no residency (cannot key). Pay full prepare.
+        return SourceFile._prepare_uncached(
+            identity,
+            backend=backend,
+            reporter=NULL_REPORTER if reporter is None else reporter,
+            construction_context=construction_context,
+        )
+
+    hit = get_resident(source_cid)
+    if hit is not None:
+        # Protocol: distinct demanded descendants reuse preparation.
+        # Rebind consumer construction_context when provided so seating writes
+        # land on the caller's tables when this open owns seating — without
+        # re-running MaterializeModule. structural tree + construction_cache stay.
+        sf = hit.source_file
+        if construction_context is not None:
+            object.__setattr__(sf.unit, "construction_context", construction_context)
+        if reporter is not None:
+            sf.reporter = reporter
+        return sf
+
+    # Miss: content CID not prepared. Pay once; changing bytes → new CID → miss.
+    _PREPARE_COUNTS[source_cid] = _PREPARE_COUNTS.get(source_cid, 0) + 1
+    sf = SourceFile._prepare_uncached(
+        identity,
+        backend=backend if backend is not None else _default_backend(),
+        reporter=NULL_REPORTER if reporter is None else reporter,
+        construction_context=construction_context,
+    )
+    _remember(
+        source_cid,
+        ProcessResidentFileContext(
+            source_cid=source_cid,
+            source=source,
+            filename=filename,
+            source_file=sf,
+            prepare_count=_PREPARE_COUNTS[source_cid],
+        ),
+    )
+    return sf

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
@@ -13,11 +13,14 @@ the SourceOracle's identity triple ``(source, filename, content CID)``
 file, never hashes text, never owns an address. There is no raw-string
 door and no ``read_text`` anywhere in the parser.
 
-A ``SourceFile`` parses at construction and holds its own tree. That is
-not a cache — it IS the file. There is no pool, no keyed store, no
-registry, no memo: enumerate a ``SourceTree`` and each ``SourceFile`` is
-built, yielded, and dropped when the caller lets go of it, so peak RSS is
-bounded by the largest file, not the corpus.
+A ``SourceFile`` parses at construction and holds its own tree. Enumeration
+protocol §4 makes that preparation **process-resident under the whole-file
+content CID**: the same content is prepared once; distinct demanded
+descendants reuse it; changing the file changes the CID and therefore
+misses. That is the law, not an optional memo — see
+``process_resident_file.py``. Peak RSS is bounded by the residency limit
+(``SUGAR_PROCESS_RESIDENT_FILE_LIMIT``), not by re-deriving every shared
+module once per consumer.
 
 Each enumeration is a QUERY into the backend: a ``SourceFile`` asking
 for its nodes, a node asking for its children — answered per access,
@@ -70,8 +73,41 @@ class SourceFile:
         reporter: AuditReporter = NULL_REPORTER,
         construction_context: object | None = None,
     ) -> None:
+        # Enumeration protocol §4: process-resident under whole-file content CID.
+        # Construction goes through residency so the same CID never pays
+        # MaterializeModule twice in one process.
+        from .process_resident_file import source_file_from_identity
+
+        # Always adopt the resident (or first-prepare) shell. Callers hold a
+        # view; the process holds the preparation under content CID.
+        resident = source_file_from_identity(
+            identity,
+            backend=backend,
+            reporter=reporter,
+            construction_context=construction_context,
+        )
+        self.unit = resident.unit
+        self.backend = resident.backend
+        self.reporter = resident.reporter
+        self.constructed_module = resident.constructed_module
+        self.root = resident.root
+        self.closed_roll_call = resident.closed_roll_call
+        self.provider_member_rows = resident.provider_member_rows
+        self.construction_event_receipt_cid = resident.construction_event_receipt_cid
+
+    @classmethod
+    def _prepare_uncached(
+        cls,
+        identity: Tuple[str, str, str],
+        *,
+        backend: Optional[Backend] = None,
+        reporter: AuditReporter = NULL_REPORTER,
+        construction_context: object | None = None,
+    ) -> "SourceFile":
+        """Full parse + MaterializeModule — only the residency miss path calls this."""
         from sugar_lift_py_tests.engine_log import reduction_span
 
+        self = object.__new__(cls)
         source, filename, source_cid = identity
         site = filename
         with reduction_span(sugar="SourceFile", role="file", site=site):
@@ -84,9 +120,6 @@ class SourceFile:
                 )
             with reduction_span(sugar="BackendSelect", role="file", site=site):
                 self.backend = backend if backend is not None else _default_backend()
-            # The reporter enters the whole tree here: the root carries it and
-            # hands it to every child it resolves. An audit walk passes a
-            # CollectingReporter; everyone else takes the do-nothing default.
             self.reporter = reporter
             with reduction_span(sugar="MaterializeModule", role="file", site=site):
                 constructed_module = self.backend.materialize_module(self.unit, reporter)
@@ -97,6 +130,7 @@ class SourceFile:
             self.construction_event_receipt_cid = (
                 constructed_module.construction_event_receipt_cid
             )
+        return self
 
     @classmethod
     def from_path(

--- a/implementations/python/sugar-source-tree/tests/test_process_resident_file_cid.py
+++ b/implementations/python/sugar-source-tree/tests/test_process_resident_file_cid.py
@@ -1,0 +1,94 @@
+"""Enumeration protocol §4 — process-resident file context under content CID.
+
+Law: prepare once per whole-file content CID; descendants reuse; changing
+bytes changes the CID and misses. The tooth that made the violation
+unrepresentable: two consumers of the same module content prepare ONCE.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.process_resident_file import (
+    clear_process_resident_files,
+    prepare_count_for,
+    resident_size,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _identity(source: str, filename: str = "mod.py") -> tuple[str, str, str]:
+    return (source, filename, blake3_512_of(source.encode("utf-8")))
+
+
+def setup_function() -> None:
+    clear_process_resident_files()
+
+
+def test_same_content_cid_prepares_once_from_two_consumer_seats() -> None:
+    """§4 tooth: two different seats, same content CID → MaterializeModule once."""
+    body = "def shared(value):\n    return value\n"
+    cid = blake3_512_of(body.encode("utf-8"))
+    a = SourceFile(_identity(body, "consumer_a/dep.py"))
+    b = SourceFile(_identity(body, "consumer_b/dep.py"))
+    assert a.unit.source_cid == b.unit.source_cid == cid
+    assert a.unit is b.unit  # same preparation
+    assert a.root is b.root
+    assert prepare_count_for(cid) == 1
+    assert resident_size() == 1
+
+
+def test_changed_bytes_change_cid_and_miss() -> None:
+    """Changing the file changes the CID and therefore misses."""
+    v1 = "def f():\n    return 1\n"
+    v2 = "def f():\n    return 2\n"
+    c1 = blake3_512_of(v1.encode("utf-8"))
+    c2 = blake3_512_of(v2.encode("utf-8"))
+    assert c1 != c2
+    SourceFile(_identity(v1, "m.py"))
+    SourceFile(_identity(v2, "m.py"))
+    assert prepare_count_for(c1) == 1
+    assert prepare_count_for(c2) == 1
+    assert resident_size() == 2
+
+
+def test_second_pass_over_same_files_does_not_reprepare() -> None:
+    """Orange experiment as regression: open the same set twice; prepare once each."""
+    files = [
+        _identity(f"def f{i}():\n    return {i}\n", f"pkg/m{i}.py") for i in range(8)
+    ]
+    for identity in files:
+        SourceFile(identity)
+    counts_after_p1 = {identity[2]: prepare_count_for(identity[2]) for identity in files}
+    assert all(c == 1 for c in counts_after_p1.values()), counts_after_p1
+
+    for identity in files:
+        SourceFile(identity)
+    counts_after_p2 = {identity[2]: prepare_count_for(identity[2]) for identity in files}
+    assert counts_after_p2 == counts_after_p1
+    assert all(c == 1 for c in counts_after_p2.values())
+
+
+def test_prefix_and_frame_doors_share_one_prepare() -> None:
+    """Dual-door collapse: two SourceFile constructions of one body → one prepare."""
+    body = (
+        "x = 1\n"
+        "def alpha(v):\n"
+        "    return v\n"
+        "def beta(v):\n"
+        "    return v + 1\n"
+    )
+    cid = blake3_512_of(body.encode("utf-8"))
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+    # Prefix-style and frame-style contexts — both walk SourceFile(identity).
+    SourceFile(
+        _identity(body, "pandas/_config/config.py"),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+    SourceFile(
+        _identity(body, "pandas/_config/config.py"),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(
+            frame_projection=True
+        ),
+    )
+    assert prepare_count_for(cid) == 1


### PR DESCRIPTION
## Protocol violation, not a missing optimization

**Law** (`protocol/specs/2026-07-08-enumeration-protocol.md` §4):

> demanded file context is process-resident under the whole-file content CID.
> A file request parses and prepares module temporal context **once** for that
> CID; distinct demanded descendants reuse it. Changing the file changes the
> CID and therefore misses without a staleness check.

T: *Why is no work shared? The whole point of the enumeration protocol is it was supposed to make that impossible.*

Orange measured P2/P1 ≈ 1.04 on 20 files twice — zero durable sharing. Census mean unchanged vs historical 73 min walk. Per-file caches looked healthy; across the corpus the law was broken.

## Fix

Restore §4 at `SourceFile` construction (every demand already walks this door):

- `process_resident_file.py` — process-resident map keyed by **whole-file content CID**
- Miss → pay MaterializeModule once; hit → reuse unit + tree + construction_cache
- Staleness: new bytes → new CID → miss (unrepresentable to serve stale content)
- Boundary: shared product is **content-derived preparation**, not a live consumer projection shell

## Teeth (make violation unrepresentable)

| test | asserts |
|------|---------|
| `test_same_content_cid_prepares_once_from_two_consumer_seats` | two seats, one CID → prepare 1 |
| `test_changed_bytes_change_cid_and_miss` | edit → new CID → second prepare |
| `test_second_pass_over_same_files_does_not_reprepare` | orange P2 regression |
| `test_prefix_and_frame_doors_share_one_prepare` | dual door → one prepare |

## Coordination

Black owns recensus-as-enumerate-consumer. This residency is the foundation that walk stands on: when 1421 files become enumerate demands, shared modules prepare once per content CID in the process.

## Validation

```
pytest implementations/python/sugar-source-tree/tests/test_process_resident_file_cid.py  # 4 passed
# + construction_cache / module amortize / enumerate bound: 11 passed
```

merge_dog: merge on sight.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add process-resident `SourceFile` caching keyed by content CID with LRU eviction
> - Introduces [process_resident_file.py](https://github.com/TSavo/sugar/pull/7071/files#diff-a419340dc11cf32686609067b2bf24ffcd464e3969e9df67f4a68d4d53559041) implementing an LRU cache of prepared `SourceFile` objects keyed by whole-file content CID, bounded by `SUGAR_PROCESS_RESIDENT_FILE_LIMIT` (default 512).
> - `SourceFile.__init__` in [tree.py](https://github.com/TSavo/sugar/pull/7071/files#diff-e33b77d801acbf485d8cb82851d1ff628c33612bb042ea7949e645d8b1bdc82a) now delegates to `source_file_from_identity`, which runs `MaterializeModule` at most once per content CID per process window; cache hits return the shared shell with per-call `reporter` and `construction_context` rebound.
> - Exposes `prepare_count_for`, `resident_size`, and `clear_process_resident_files` for observability and test isolation.
> - Behavioral Change: constructing a `SourceFile` with the same content CID twice no longer re-runs the full parse pipeline; callers sharing a content CID share the same prepared unit and root objects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2ef6ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->