### PR TITLE
resolve_export: terminal memo for reexport hops

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -40,10 +40,41 @@ def _bind() -> None:
         g[name] = getattr(da, name)
 
 
-def _restamp_export_result(result: Any, binding_cid: str) -> Any:
-    """Reuse a cached structural resolution under a new import-binding CID."""
+def _export_terminal_result(result: Any) -> Any:
+    """Definition/gap only — no path warrants or import-binding CID.
+
+    Reexport hops carry path warrants and cannot share the pure-entry memo
+    (that memo keeps module-structural reexport warrants).  The terminal memo
+    is the shared definition identity both doors restamp onto.
+    """
     if isinstance(result, ResolvedPythonObjectV1):
-        return replace(result, import_binding_cid=binding_cid, cid="")
+        return replace(
+            result,
+            import_binding_cid="",
+            reexport_warrants=(),
+            cid="",
+        )
+    if isinstance(result, PythonObjectResolutionGapV1):
+        return replace(result, import_binding_cid="")
+    return result
+
+
+def _restamp_export_result(
+    result: Any,
+    binding_cid: str,
+    *,
+    warrants: tuple[ReexportWarrantV1, ...] | None = None,
+) -> Any:
+    """Reuse a cached resolution under a new binding / warrant path."""
+    if isinstance(result, ResolvedPythonObjectV1):
+        return replace(
+            result,
+            import_binding_cid=binding_cid,
+            reexport_warrants=(
+                warrants if warrants is not None else result.reexport_warrants
+            ),
+            cid="",
+        )
     if isinstance(result, PythonObjectResolutionGapV1):
         return replace(result, import_binding_cid=binding_cid)
     return result
@@ -61,29 +92,48 @@ def resolve_export(
 ) -> PythonObjectResolutionV1:
     """Resolve one static export.
 
-    Structural export resolution is pure in (distribution_artifact_cid,
-    module_name, exported_name), and repeating the full-module static export
-    walk per receipt was the residual megamodule wall (see
-    docs/audits/pandas-recensus-latency-bisect.md).  So it is memoized -- but
-    the memo is owned by the caller's ``session``, never by module state: the
-    resolution names live ``ReexportWarrantV1``/definition objects whose
-    validity is bounded by the construction that asked for them.  ``None``
-    opens a session bounded to this single call.
+    Two session memos share the key (distribution_artifact_cid, module_name,
+    exported_name):
+
+    * **pure-entry** (``export_resolutions``): how THIS module exports the name,
+      including module-structural reexport warrants.  Filled only on pure entry
+      (no path warrants / empty seen).
+    * **terminal** (``export_terminals``): definition/gap only.  Filled on every
+      successful resolve so a reexport hop with path warrants can hit after a
+      pure resolve of the same symbol (or after another hop) without re-running
+      prefix fallthrough.  Measured on _json: pure-entry hit for repeats, but
+      reexport hops with warrants skipped the memo and re-paid ~0.8s prefix.
+
+    ``seen`` still owns cycle detection and is checked before either memo.
     """
     _bind()
     session = session_or_new(session)
-    # Only the entry form used by resolve_import_binding is memoizable:
-    # non-empty warrants/seen encode path context that must not be shared.
-    cacheable = not warrants and not seen
+    if (module_name, exported_name) in seen:
+        return _gap(
+            "reexport-cycle", binding_cid, graph, module_name, exported_name
+        )
     cache_key = (
         graph.distribution_artifact_cid,
         module_name,
         exported_name,
     )
-    if cacheable:
+    pure_entry = not warrants and not seen
+    if pure_entry:
         hit = session.export_hit(cache_key)
         if hit is not None:
             return _restamp_export_result(hit, binding_cid)
+        # A prior reexport hop may have filled the terminal memo for this
+        # symbol without a pure-entry row (hops do not write export_resolutions).
+        terminal = session.export_terminal_hit(cache_key)
+        if terminal is not None:
+            return _restamp_export_result(terminal, binding_cid, warrants=())
+    else:
+        # Reexport hop / path context: share definition identity only.
+        terminal = session.export_terminal_hit(cache_key)
+        if terminal is not None:
+            return _restamp_export_result(
+                terminal, binding_cid, warrants=warrants
+            )
 
     result = _resolve_export_uncached(
         graph,
@@ -94,8 +144,13 @@ def resolve_export(
         seen,
         session=session,
     )
-    if cacheable:
-        session.remember_export(cache_key, result)
+    # Terminal definition/gap: always, so the next hop can hit.
+    session.remember_export_terminal(cache_key, _export_terminal_result(result))
+    # Pure-entry form (keeps module-structural warrants): pure door only.
+    if pure_entry:
+        session.remember_export(
+            cache_key, _restamp_export_result(result, binding_cid="")
+        )
     return result
 
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -68,6 +68,7 @@ class SourceResolutionSession:
     __slots__ = (
         "enabled",
         "export_resolutions",
+        "export_terminals",
         "frame_results",
         "frame_holds",
         "frame_active",
@@ -81,8 +82,13 @@ class SourceResolutionSession:
 
     def __init__(self, *, enabled: bool = True) -> None:
         self.enabled = enabled
-        # (distribution_artifact_cid, module_name, exported_name) -> resolution
+        # (distribution_artifact_cid, module_name, exported_name) -> pure-entry
+        # resolution (includes module-structural reexport warrants; no path
+        # import_binding_cid).
         self.export_resolutions: dict[tuple[str, str, str], Any] = {}
+        # Same key -> definition/gap only (no warrants). Shared by reexport hops
+        # that carry path warrants and cannot use export_resolutions.
+        self.export_terminals: dict[tuple[str, str, str], Any] = {}
         # definition coordinate -> (frame, target) | ManagerConstructionGapV1
         self.frame_results: dict[tuple, Any] = {}
         # Keep the SourceFile that owns cached (frame, target) node identity
@@ -120,6 +126,13 @@ class SourceResolutionSession:
     def remember_export(self, key: tuple[str, str, str], result: Any) -> None:
         if self.enabled:
             self.export_resolutions[key] = result
+
+    def export_terminal_hit(self, key: tuple[str, str, str]) -> Any | None:
+        return self.export_terminals.get(key) if self.enabled else None
+
+    def remember_export_terminal(self, key: tuple[str, str, str], result: Any) -> None:
+        if self.enabled:
+            self.export_terminals[key] = result
 
     # -- source-visible frame memo ---------------------------------------
 

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -1000,6 +1000,85 @@ def test_resolve_export_amortizes_repeated_static_scans(tmp_path: Path) -> None:
     assert len({item.module_name for item in results}) == 1
 
 
+def test_resolve_export_reexport_hop_shares_structural_memo(tmp_path: Path) -> None:
+    """Reexport hops must hit the same structural memo as pure entry resolves.
+
+    Plant: package reexports ``build`` from implementation.  A pure resolve of
+    ``implementation.build`` then a reexport resolve of ``example_pkg.build``
+    (or the reverse) must not re-run the export-block walk on the terminal
+    module — warrants are path testimony restamped onto a shared structural
+    answer, not a second key.
+    """
+    from sugar_lift_python_source import dependency_export_adapter as de
+    from sugar_lift_python_source.resolution_session import SourceResolutionSession
+
+    distribution = _install_distribution(
+        tmp_path,
+        package_source="from example_pkg.implementation import build\n",
+        implementation_source="def build(value):\n    return value\n",
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    session = SourceResolutionSession()
+
+    scans = {"count": 0, "names": []}
+    # Production door uses _export_block_with_locus (not bare _export_block).
+    original_block = de._export_block_with_locus
+
+    def counting_export_block(statements, name, initial):
+        scans["count"] += 1
+        scans["names"].append(name)
+        return original_block(statements, name, initial)
+
+    de._export_block_with_locus = counting_export_block
+    try:
+        pure = de.resolve_export(
+            graph,
+            binding_cid="binding-pure",
+            module_name="example_pkg.implementation",
+            exported_name="build",
+            warrants=(),
+            seen=frozenset(),
+            session=session,
+        )
+        reexport = de.resolve_export(
+            graph,
+            binding_cid="binding-reexport",
+            module_name="example_pkg",
+            exported_name="build",
+            warrants=(),
+            seen=frozenset(),
+            session=session,
+        )
+        pure_again = de.resolve_export(
+            graph,
+            binding_cid="binding-pure-2",
+            module_name="example_pkg.implementation",
+            exported_name="build",
+            warrants=(),
+            seen=frozenset(),
+            session=session,
+        )
+    finally:
+        de._export_block_with_locus = original_block
+
+    assert isinstance(pure, ResolvedPythonObjectV1)
+    assert isinstance(reexport, ResolvedPythonObjectV1)
+    assert isinstance(pure_again, ResolvedPythonObjectV1)
+    assert pure.definition.fragment_cid == reexport.definition.fragment_cid
+    assert pure.definition.fragment_cid == pure_again.definition.fragment_cid
+    # pure: implementation.build once. reexport: package.build once + recursive
+    # hop to implementation.build must HIT structural memo (no second scan).
+    # pure_again: hit.  Total export-block scans == 2 (package + implementation).
+    assert scans["count"] == 2, (
+        f"export-block scans={scans['count']} names={scans['names']}; "
+        "reexport hop must share structural memo with pure entry resolve"
+    )
+    assert pure_again.import_binding_cid == "binding-pure-2"
+    assert pure.import_binding_cid == "binding-pure"
+    assert reexport.import_binding_cid == "binding-reexport"
+    assert len(reexport.reexport_warrants) == 1
+
+
 def test_resolve_source_visible_frame_amortizes_repeated_materialize(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

cProfile on tip (`63356a636`) put `resolve_export` at ~1.92s cum on one `_json.py` open. Probe of the session memo:

| | count |
|---|---|
| pure-entry **hit** | 7 |
| pure-entry **miss** | 6 (unique symbols) |
| reexport hop **uncacheable** | 2 (warrants/seen gate) |

Memo was **hitting for pure keys**. The over-specified gate was reexport hops: `cacheable = not warrants and not seen` skipped the memo, so a hop to a symbol already resolved (or resolvable as pure) re-ran prefix/export walk. Nested timing showed `pandas._config.config.option_context` reexport path ~0.77s inside the package miss.

### Fix
Two memos, same key `(distribution_artifact_cid, module_name, exported_name)`:

1. **pure-entry** (`export_resolutions`) — how this module exports the name, including module-structural reexport warrants. Pure door only.
2. **terminal** (`export_terminals`) — definition/gap only. Every resolve fills it; hops restamp path warrants onto a shared terminal.

Cycle detection via `seen` stays before either memo.

## Test plan
- [x] `test_resolve_export_amortizes_repeated_static_scans` still green
- [x] `test_resolve_export_reexport_hop_shares_structural_memo` — pure then reexport scans implementation once
- [x] reverse order: reexport then pure of terminal module does not rescan

## NOT claiming
- Single-file `_json` wall collapse: first-open unique misses still pay prefix once (1.9s class is expensive miss work, not thrash). This removes reexport **re**-work and multi-receipt thrash.
- Freeze vector numbers.

## Shell deleted
None — amortization only.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add terminal memo for reexport hops in `resolve_export`
> - Introduces a two-layer memoization scheme in `resolve_export`: a pure-entry memo (`export_resolutions`) and a new terminal memo (`export_terminals`) that stores definition/gap-only results stripped of path context and warrants.
> - Reexport hops now hit the same structural terminal memo as pure resolves, avoiding redundant export-block scans; results are restamped with the correct `import_binding_cid` and warrants on cache hit.
> - Adds an early cycle check using `seen` that returns a `reexport-cycle` gap immediately when the same `(module_name, exported_name)` pair is encountered again.
> - Extends `SourceResolutionSession` with `export_terminals` storage and `export_terminal_hit`/`remember_export_terminal` accessors in [resolution_session.py](https://github.com/TSavo/sugar/pull/7072/files#diff-54257d48026540505071d0613a7c672ce198dc916935415abb69c38a81451ce5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 234282d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->