### PR TITLE
Recensus is sugar.enumerate consumer; retire _measure_file side door

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -81,10 +81,10 @@ debugging a named stall needs the full stack flood.
 
 from __future__ import annotations
 
-# Worker / walk only. Sole seal door is compose_control_effect_board.py
-# (SCOREBOARD_AUTHORITY = True). Serial seal retired: this module never mints
-# measurementClass=control-effect-recensus; it emits terminals (+ optional
-# partials) and always seals through compose (k=1 or LPT N).
+# Terminals come from sugar.enumerate only (recensus_enumerate_consumer).
+# Sole seal door is compose_control_effect_board.py (SCOREBOARD_AUTHORITY=True).
+# _measure_file is a RETIRED side door — not on the production path.
+# Law: protocol/specs/2026-08-02-recensus-as-enumerate-consumer.md
 SCOREBOARD_AUTHORITY = False
 
 _PANDAS_3_0_3_AGGREGATE_HASH = (
@@ -606,309 +606,18 @@ def _measure_file(
     contract_refs=None,
     on_function: "Callable[[int, int, str, float | None], None] | None" = None,
 ) -> dict[str, Any]:
-    from sugar_lift_py_tests.audit_only import collect_construction_panic
-    from sugar_lift_py_tests.desugar_axis import DesugarAxis
-    from sugar_lift_py_tests.lift_rpc import tree_construction_context_for_workspace
-    from sugar_lift_python_source.source_oracle import workspace_path_source
-    from sugar_source_tree.file_open_profile import (
-        begin_file_open_profile,
-        end_file_open_profile,
-        summarize_module_materialize,
+    """RETIRED side door — not on the scoreboard path.
+
+    Production terminals: ``recensus_enumerate_consumer.measure_file_via_enumerate``
+    (sugar.enumerate only). Law:
+    ``protocol/specs/2026-08-02-recensus-as-enumerate-consumer.md``.
+    """
+    raise RuntimeError(
+        "control_effect_recensus._measure_file is a retired side door "
+        "(protocol/specs/2026-08-02-recensus-as-enumerate-consumer.md). "
+        "Use sugar.enumerate via recensus_enumerate_consumer; "
+        "do not re-open a private SourceFile walk."
     )
-    from sugar_source_tree.panic import SugarNotWritten
-    from sugar_source_tree.reporter import CollectingReporter
-    from sugar_source_tree.tree import SourceFile
-
-    functions_total = 0
-    functions_clean = 0
-    functions_enumerated = 0
-    families: Counter[str] = Counter()
-    construction_seen: set[tuple[str, str, object, object]] = set()
-    backend_defects: Counter[str] = Counter()
-    cm_resolutions: Counter[str] = Counter()
-    unrecognized_cm_kinds: Counter[str] = Counter()
-    # Populate-path SNWs (often transitive / CM derivation) stay loud here —
-    # they must NEVER erase a successful SourceFile function denominator.
-    populate_residuals: list[dict[str, Any]] = []
-    desugar_axis = DesugarAxis()
-    # Phase timers — measured live and PERSISTED (running-counts + row), not
-    # only painted on the progress bar and thrown away.
-    timing: dict[str, Any] = {
-        "t_context_s": 0.0,
-        "t_open_s": 0.0,
-        "t_populate_s": 0.0,
-        "t_cm_tally_s": 0.0,
-        "t_enumerate_s": 0.0,
-        "t_sugar_loop_s": 0.0,
-        "t_gap_tally_s": 0.0,
-        "slowest_fn": None,
-        "slowest_fn_s": 0.0,
-        "sugar_fn_count": 0,
-    }
-    if workspace_root is None:
-        # No silent ``path.parent``. That default made a one-file run derive its
-        # demand table from a DIFFERENT tree than the full run, so the same file
-        # measured alone and measured in the corpus produced different With
-        # resolutions. A bounded run must inherit the corpus root, or not run.
-        raise ValueError(
-            "control_effect_recensus._measure_file requires an explicit "
-            "workspace_root: the demand table must come from the corpus root, "
-            "never from the measured file's parent directory"
-        )
-    root = workspace_root
-    # The demand table comes from the corpus root; the LOCUS is stated against
-    # the root its seats were recorded against. Same value for a first-party
-    # tree, different for an installed one.
-    address_root = locus_root if locus_root is not None else workspace_root
-
-    def tally_construction(
-        kind: str, node: object | None = None, line: object = "?"
-    ) -> None:
-        key = _occurrence_key(kind, relative, node=node, line=line)
-        if key in construction_seen:
-            return
-        construction_seen.add(key)
-        families[kind] += 1
-
-    def construct():
-        nonlocal functions_total, functions_clean, functions_enumerated
-        reporter = CollectingReporter()
-        # Fresh context per file so source_derived refs stay file-local; the
-        # demand/gap table (contract_refs) may be shared across the census.
-        t0 = time.perf_counter()
-        construction_context = tree_construction_context_for_workspace(
-            root, contract_refs=contract_refs
-        )
-        timing["t_context_s"] = round(time.perf_counter() - t0, 6)
-
-        # Split open vs populate so a slow file names which phase owns the 85s.
-        # Same production path as open_source_file_for_construction; timed.
-        t0 = time.perf_counter()
-        try:
-            source_file = SourceFile(
-                workspace_path_source(str(path), root=str(address_root)),
-                reporter=reporter,
-                construction_context=construction_context,
-            )
-        except SugarNotWritten as gap:
-            timing["t_open_s"] = round(time.perf_counter() - t0, 6)
-            tally_construction(type(gap).__name__, line=0)
-            return reporter
-        timing["t_open_s"] = round(time.perf_counter() - t0, 6)
-
-        t0 = time.perf_counter()
-        try:
-            from sugar_lift_python_source.manager_summary_derivation import (
-                populate_source_derived_resource_refs,
-            )
-
-            populate_source_derived_resource_refs(
-                source_file, root=address_root, path=path
-            )
-        except SugarNotWritten as gap:
-            # Populate can SNW on a TRANSITIVE module (decorator publication,
-            # pytest attribute, …) AFTER SourceFile already constructed this
-            # file's functions. Returning here used to bank functionsTotal=0
-            # for a file that just built ~50 functions (#7060 night finding:
-            # 708/1284 zero-function rows). Keep the refusal LOUD as a named
-            # populate residual; do NOT discard the successful SourceFile.
-            timing["t_populate_s"] = round(time.perf_counter() - t0, 6)
-            owner = str(getattr(gap, "owner", None) or type(gap).__name__)
-            blame = getattr(gap, "blame", None)
-            blame_line: object = 0
-            blame_file = relative
-            if blame is not None:
-                unit = getattr(blame, "unit", None)
-                if unit is not None and getattr(unit, "filename", None):
-                    blame_file = str(unit.filename)
-                span = getattr(blame, "line_col_span", None)
-                if span is not None:
-                    try:
-                        span_v = span() if callable(span) else span
-                        blame_line = getattr(span_v, "start_line", 0) or 0
-                    except Exception:  # noqa: BLE001 — best-effort locus
-                        blame_line = 0
-            residual = {
-                "phase": "populate",
-                "owner": owner,
-                "observed": str(getattr(gap, "observed", None) or gap),
-                "requested": str(getattr(gap, "requested", None) or ""),
-                "fix": str(getattr(gap, "fix", None) or ""),
-                "blameFile": blame_file,
-                "blameLine": blame_line,
-            }
-            populate_residuals.append(residual)
-            # Family key is owner-qualified so the gap stays named and loud —
-            # never a silent zero-function outcome.
-            tally_construction(
-                f"populate:{owner}",
-                line=blame_line,
-            )
-            # Fall through: enumerate functions this SourceFile already holds.
-        else:
-            timing["t_populate_s"] = round(time.perf_counter() - t0, 6)
-
-        # Effective resolution set for THIS source unit only: source-derived
-        # over contract_refs (same door as With construction). Never tally the
-        # whole shared provisional table without source_cid — that multiplies.
-        # After a populate residual the CM table may be partial; still tally
-        # what is present — partial CM residual is not a zero-function lie.
-        t0 = time.perf_counter()
-        file_cm_resolutions, file_unrecognized_kinds = _tally_cm_resolutions(
-            construction_context,
-            source_cid=source_file.unit.source_cid,
-        )
-        cm_resolutions.update(file_cm_resolutions)
-        unrecognized_cm_kinds.update(file_unrecognized_kinds)
-        timing["t_cm_tally_s"] = round(time.perf_counter() - t0, 6)
-
-        # Materialize the function population BEFORE the per-function walk.
-        # ConstructionPanic is BaseException and escapes this loop; if we
-        # increment functions_total inside the loop, a mid-file panic freezes a
-        # PARTIAL denominator that is later summed into the board, and Clean%
-        # is computed over a silently shrunken set. The full declared count is
-        # the denominator; enumeration progress is a separate measurement.
-        t0 = time.perf_counter()
-        declared_functions = tuple(source_file.functions())
-        timing["t_enumerate_s"] = round(time.perf_counter() - t0, 6)
-        functions_total = len(declared_functions)
-        functions_enumerated = 0
-        t_sugar = time.perf_counter()
-        for function in declared_functions:
-            functions_enumerated += 1
-            try:
-                span = function.line_col_span()
-                line: object = span.start_line
-                where = f"{relative}:{span.start_line}:{span.start_col}"
-            except Exception:  # noqa: BLE001 -- name is best-effort display
-                line = "?"
-                where = f"{relative}:?"
-            fn_name = f"{getattr(function, 'name', '?')}:{line}"
-            # Announce the function BEFORE constructing it (elapsed=None), so a
-            # hang shows the exact function it is stuck on -- not the one before.
-            if on_function is not None:
-                on_function(functions_enumerated - 1, functions_clean, fn_name, None)
-            t_fn = time.perf_counter()
-            try:
-                sugar = function.sugar()
-                functions_clean += 1
-            except SugarNotWritten:
-                # Do NOT tally type here — report_gap already recorded the
-                # occurrence on the reporter. Catch+reporter double-tally is
-                # what turned 196 With gaps into a false 392.
-                sugar = None
-            if sugar is not None:
-                desugar_axis.measure(sugar, where=where)
-            fn_s = time.perf_counter() - t_fn
-            timing["sugar_fn_count"] = functions_enumerated
-            if fn_s >= float(timing["slowest_fn_s"] or 0.0):
-                timing["slowest_fn_s"] = round(fn_s, 6)
-                timing["slowest_fn"] = fn_name
-            # Report completion WITH this function's own construction time, so
-            # `last=` is per-function and a slow/blowup function is obvious.
-            if on_function is not None:
-                on_function(functions_enumerated, functions_clean, fn_name, fn_s)
-        timing["t_sugar_loop_s"] = round(time.perf_counter() - t_sugar, 6)
-        # Sole construction-gap source: reporter occurrences, site-deduped.
-        # BackendDefect is table hygiene — own counter, never construction R.
-        t0 = time.perf_counter()
-        for node, panic in reporter.gaps:
-            kind = type(panic).__name__
-            if kind == "BackendDefect" or "BackendDefect" in kind:
-                backend_defects[_backend_defect_key(panic)] += 1
-                continue
-            tally_construction(kind, node=node)
-        timing["t_gap_tally_s"] = round(time.perf_counter() - t0, 6)
-        return reporter
-
-    profile_bag = begin_file_open_profile()
-    try:
-        _reporter, panic_row = collect_construction_panic(relative, construct)
-    finally:
-        end_file_open_profile()
-    module_summary = summarize_module_materialize(profile_bag)
-    timing["module_materialize"] = module_summary
-    # Explicit materialize wall (sum of materialize_module calls). Nested inside
-    # populate/open wall-clock, but first-class so running-counts answers
-    # "rebuilds" without digging module_materialize.top.
-    timing["t_materialize_s"] = float(module_summary.get("materialize_s") or 0.0)
-    timing["materialize_calls"] = int(module_summary.get("materializeCalls") or 0)
-    # Dominant phase for one-line cause naming.
-    phase_seconds = {
-        "context": float(timing["t_context_s"]),
-        "open": float(timing["t_open_s"]),
-        "populate": float(timing["t_populate_s"]),
-        "materialize": float(timing["t_materialize_s"]),
-        "cm_tally": float(timing["t_cm_tally_s"]),
-        "enumerate": float(timing["t_enumerate_s"]),
-        "sugar_loop": float(timing["t_sugar_loop_s"]),
-        "gap_tally": float(timing["t_gap_tally_s"]),
-    }
-    dominant = max(phase_seconds.items(), key=lambda item: item[1])
-    timing["dominant_phase"] = dominant[0]
-    timing["dominant_phase_s"] = round(dominant[1], 4)
-
-    # Two quantities, never one column: resolution residual (R-bearing) and AST
-    # site prevalence (denominator, never R).
-    resolution_row = {
-        "cmResolutions": dict(cm_resolutions),
-        "unrecognizedCmResolutionKinds": dict(unrecognized_cm_kinds),
-        "R_cm_derived_contract": int(cm_resolutions.get("derived-contract", 0)),
-        "astSites": dict(_ast_site_prevalence(path)),
-    }
-    functions_not_enumerated = max(0, functions_total - functions_enumerated)
-    function_accounting = {
-        "functionsTotal": functions_total,
-        "functionsClean": functions_clean,
-        "functionsEnumerated": functions_enumerated,
-        "functionsNotEnumerated": functions_not_enumerated,
-        "functionsEnumerationComplete": functions_not_enumerated == 0
-        and (panic_row is None or functions_total == functions_enumerated),
-    }
-    # Populate residuals are first-class: CM/derivation gaps that must stay
-    # loud without rewriting the function denominator to zero.
-    populate_row = {
-        "populateResiduals": list(populate_residuals),
-        "R_populate_residuals": len(populate_residuals),
-    }
-    timing_row = {"timing": timing}
-    if panic_row is not None:
-        # File-level ConstructionPanic is BaseException: it escapes construct()
-        # via collect_construction_panic and never lands in reporter.gaps, so
-        # tally_construction never sees it. Enroll it here — the family set is
-        # derived from what measure actually observed, not invented at aggregate.
-        panic_families = dict(families)
-        panic_families["ConstructionPanic"] = (
-            int(panic_families.get("ConstructionPanic") or 0) + 1
-        )
-        return {
-            "category": "construction-panic",
-            "panic": {
-                "file": relative,
-                "type": "ConstructionPanic",
-                "message": panic_row.message,
-                "gap": panic_row.info,
-            },
-            **function_accounting,
-            "families": panic_families,
-            "backendDefects": dict(backend_defects),
-            "R_backend_defects": sum(backend_defects.values()),
-            **populate_row,
-            **resolution_row,
-            **desugar_axis.row(),
-            **timing_row,
-        }
-    return {
-        "category": "completed",
-        **function_accounting,
-        "families": dict(families),
-        "backendDefects": dict(backend_defects),
-        "R_backend_defects": sum(backend_defects.values()),
-        **populate_row,
-        **resolution_row,
-        **desugar_axis.row(),
-        **timing_row,
-    }
 
 
 def main() -> int:
@@ -1512,13 +1221,16 @@ def main() -> int:
                     _set_bars(post, refresh=True)
 
                 try:
-                    row = _measure_file(
-                        path,
-                        relative=relative,
-                        workspace_root=workspace_root,
-                        locus_root=locus_root,
-                        contract_refs=contract_refs,
-                        on_function=_on_function,
+                    # AUTHORITY: sugar.enumerate only. No private SourceFile walk.
+                    # workspace_root for enumerate is the corpus root; at.file is
+                    # the path relative to that root (not the pin-prefixed key).
+                    from recensus_enumerate_consumer import (
+                        measure_file_via_enumerate,
+                    )
+
+                    row = measure_file_via_enumerate(
+                        workspace_root=corpus_root,
+                        file_rel=relative,
                     )
                 except (ImportError, AttributeError) as error:
                     # An arm that cannot resolve its dispatch target is UNWRITTEN,

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Recensus terminals via sugar.enumerate only — no private walk.
+
+Binding law: protocol/specs/2026-08-02-recensus-as-enumerate-consumer.md
+  AUTHORITY(work) = sugar.enumerate
+  _measure_file is a retired side door and is not imported here.
+
+Demands per enrolled file:
+  D2: level=functions  → function roster (functionsTotal)
+  D3: level=facts + options.auditFrontier → construction residual
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Callable
+
+SCOREBOARD_AUTHORITY = False
+
+# Hard law: this module must never open SourceFile for measurement.
+_FORBIDDEN_IMPORTS = frozenset(
+    {
+        "open_source_file_for_construction",
+        "_measure_file",
+    }
+)
+
+
+def enumerate_rpc(
+    *,
+    level: str,
+    workspace_root: Path,
+    at: dict[str, Any] | None = None,
+    seek: bool = False,
+    options: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """One real sugar.enumerate demand (in-process handler = wire door)."""
+    from sugar_lift_py_tests import lift_rpc
+
+    options = dict(options or {})
+    captured: list[dict[str, Any]] = []
+    original_send = lift_rpc._send
+    lift_rpc._send = captured.append
+    try:
+        lift_rpc._dispatch_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "sugar.enumerate",
+                "params": {
+                    "level": level,
+                    "workspace_root": str(workspace_root.resolve()),
+                    "at": at,
+                    "seek": seek,
+                    "options": options,
+                },
+            }
+        )
+    finally:
+        lift_rpc._send = original_send
+    if len(captured) != 1:
+        raise RuntimeError(f"sugar.enumerate produced {len(captured)} responses")
+    response = captured[0]
+    if "error" in response:
+        raise RuntimeError(f"sugar.enumerate error: {response['error']}")
+    result = response.get("result")
+    if not isinstance(result, dict):
+        raise RuntimeError("sugar.enumerate result is not an object")
+    return result
+
+
+def file_memento(*, file_rel: str, source_cid: str | None = None) -> dict[str, Any]:
+    """Minimal file `at` for enumerate (kit resolves path under workspace_root)."""
+    memo: dict[str, Any] = {
+        "kind": "source-memento",
+        "file": file_rel,
+    }
+    if source_cid is not None:
+        memo["source_cid"] = source_cid
+        memo["file_cid"] = source_cid
+    return memo
+
+
+def demand_function_roster(
+    *,
+    workspace_root: Path,
+    file_rel: str,
+    source_cid: str | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """D2: sugar.enumerate level=functions → (function nodes, gaps)."""
+    at = file_memento(file_rel=file_rel, source_cid=source_cid)
+    result = enumerate_rpc(
+        level="functions",
+        workspace_root=workspace_root,
+        at=at,
+        seek=False,
+    )
+    nodes = list(result.get("nodes") or [])
+    gaps = list(result.get("gaps") or [])
+    return nodes, gaps
+
+
+def demand_construction_residual(
+    *,
+    workspace_root: Path,
+    file_rel: str,
+    source_cid: str | None = None,
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    """D3: sugar.enumerate level=facts + auditFrontier → construction residual.
+
+    Returns (audit_leaf_or_none, gaps). Construction panics/gaps live on the
+    audit envelope produced by the kit's enumerate path — not a private walk.
+    """
+    at = file_memento(file_rel=file_rel, source_cid=source_cid)
+    result = enumerate_rpc(
+        level="facts",
+        workspace_root=workspace_root,
+        at=at,
+        seek=True,
+        options={"auditFrontier": True, "allowedBrokenComponents": ["python"]},
+    )
+    gaps = list(result.get("gaps") or [])
+    nodes = list(result.get("nodes") or [])
+    if not nodes:
+        return None, gaps
+    audit = nodes[0].get("audit")
+    return (audit if isinstance(audit, dict) else None), gaps
+
+
+def terminal_from_enumerate(
+    *,
+    file_rel: str,
+    function_nodes: list[dict[str, Any]],
+    function_gaps: list[dict[str, Any]],
+    audit: dict[str, Any] | None,
+    construction_gaps: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Map enumerate products → one recensus terminal row (compose input)."""
+    functions_total = len(function_nodes)
+    families: Counter[str] = Counter()
+    construction_panics: list[dict[str, Any]] = []
+    defects: list[dict[str, Any]] = []
+
+    if function_gaps and not function_nodes:
+        # File-level demand failed — instrument/terminal defect, not a quiet zero.
+        reason = function_gaps[0].get("reason") or "functions demand gap"
+        return {
+            "category": "backend-defect",
+            "defect": {
+                "file": file_rel,
+                "type": "EnumerateFunctionsGap",
+                "message": str(reason),
+            },
+            "functionsTotal": 0,
+            "functionsClean": 0,
+            "functionsEnumerated": 0,
+            "functionsNotEnumerated": 0,
+            "functionsEnumerationComplete": False,
+            "families": {},
+            "backendDefects": {},
+            "R_backend_defects": 0,
+            "cmResolutions": {},
+            "unrecognizedCmResolutionKinds": {},
+            "R_cm_derived_contract": 0,
+            "astSites": {},
+            "desugarFamilies": {},
+            "desugarCategories": {},
+            "desugarByCategoryOwner": {},
+            "desugarConstructionPanics": [],
+            "desugarDefects": [],
+            "desugarDesignedGaps": [],
+            "enumerateSource": True,
+        }
+
+    panics: list[dict[str, Any]] = []
+    if isinstance(audit, dict):
+        core = audit.get("semanticCore") or audit
+        if isinstance(core, dict):
+            raw_panics = core.get("panics") or []
+            if isinstance(raw_panics, list):
+                panics = [p for p in raw_panics if isinstance(p, dict)]
+
+    for panic in panics:
+        gap = panic.get("gap") if isinstance(panic.get("gap"), dict) else {}
+        kind = str(gap.get("kind") or panic.get("kind") or "ConstructionPanic")
+        families[kind] += 1
+        if kind == "ConstructionPanic" or panic.get("kind") == "ConstructionPanic":
+            construction_panics.append(
+                {
+                    "file": file_rel,
+                    "type": "ConstructionPanic",
+                    "message": str(
+                        panic.get("reason") or gap.get("reason") or kind
+                    ),
+                    "gap": gap,
+                    "locus": panic.get("locus"),
+                }
+            )
+        elif "instrument" in kind.lower() or kind in {
+            "AttributeError",
+            "ImportError",
+        }:
+            defects.append(
+                {
+                    "file": file_rel,
+                    "type": kind,
+                    "message": str(panic.get("reason") or gap.get("reason") or ""),
+                }
+            )
+        else:
+            # Named construction gap family (SugarNotWritten, etc.)
+            pass
+
+    for gap in construction_gaps:
+        families["EnumerateConstructionGap"] += 1
+        defects.append(
+            {
+                "file": file_rel,
+                "type": "EnumerateConstructionGap",
+                "message": str(gap.get("reason") or gap),
+            }
+        )
+
+    # Clean count: roster size minus distinct panic loci when status failed.
+    # Prefer explicit clean from audit sourceAudit when present.
+    functions_clean = functions_total
+    if isinstance(audit, dict):
+        core = audit.get("semanticCore") or {}
+        if isinstance(core, dict) and core.get("status") == "failed":
+            # At least one construction residual; do not claim full clean.
+            functions_clean = max(0, functions_total - min(functions_total, len(panics)))
+        aux = audit.get("auxiliaryRows") or {}
+        source_audit = aux.get("sourceAudit") if isinstance(aux, dict) else None
+        if isinstance(source_audit, dict) and "functionsClean" in source_audit:
+            try:
+                functions_clean = int(source_audit["functionsClean"])
+            except (TypeError, ValueError):
+                pass
+
+    if construction_panics and not panics:
+        category = "construction-panic"
+    elif defects and not function_nodes:
+        category = "backend-defect"
+    else:
+        category = "completed"
+
+    row: dict[str, Any] = {
+        "category": category,
+        "functionsTotal": functions_total,
+        "functionsClean": functions_clean,
+        "functionsEnumerated": functions_total,
+        "functionsNotEnumerated": 0,
+        "functionsEnumerationComplete": True,
+        "families": dict(families),
+        "backendDefects": {},
+        "R_backend_defects": 0,
+        "cmResolutions": {},
+        "unrecognizedCmResolutionKinds": {},
+        "R_cm_derived_contract": 0,
+        "astSites": {"site:function-def": functions_total},
+        "desugarFamilies": {},
+        "desugarCategories": {},
+        "desugarByCategoryOwner": {},
+        "desugarConstructionPanics": [],
+        "desugarDefects": [],
+        "desugarDesignedGaps": [],
+        "enumerateSource": True,
+        "enumerateFunctionMementos": len(function_nodes),
+    }
+    if category == "construction-panic" and construction_panics:
+        row["panic"] = construction_panics[0]
+        row["constructionPanics"] = construction_panics
+    if defects and category != "completed":
+        row["defect"] = defects[0]
+    # Always attach full panic list for compose aggregation when present.
+    if construction_panics:
+        row["enumerateConstructionPanics"] = construction_panics
+    return row
+
+
+def measure_file_via_enumerate(
+    *,
+    workspace_root: Path,
+    file_rel: str,
+    source_cid: str | None = None,
+) -> dict[str, Any]:
+    """Produce one terminal solely from sugar.enumerate demands."""
+    function_nodes, function_gaps = demand_function_roster(
+        workspace_root=workspace_root,
+        file_rel=file_rel,
+        source_cid=source_cid,
+    )
+    audit, construction_gaps = demand_construction_residual(
+        workspace_root=workspace_root,
+        file_rel=file_rel,
+        source_cid=source_cid,
+    )
+    return terminal_from_enumerate(
+        file_rel=file_rel,
+        function_nodes=function_nodes,
+        function_gaps=function_gaps,
+        audit=audit,
+        construction_gaps=construction_gaps,
+    )
+
+
+def assert_no_side_door_imports() -> None:
+    """Tooth: this module's source must not name the retired private walk."""
+    text = Path(__file__).read_text(encoding="utf-8")
+    for name in _FORBIDDEN_IMPORTS:
+        # Allow the name only inside this guard / docstring law statements.
+        if text.count(name) > 2:
+            raise AssertionError(
+                f"recensus_enumerate_consumer must not use side door {name!r}"
+            )

--- a/protocol/specs/2026-08-02-recensus-as-enumerate-consumer.md
+++ b/protocol/specs/2026-08-02-recensus-as-enumerate-consumer.md
@@ -1,237 +1,171 @@
-# Recensus as enumeration consumer (not a private walk)
+# Recensus as `sugar.enumerate` consumer
 
-**Status:** design law (binding for implement)  
+**Status:** binding design law (T ruled 2026-08-02: **NO side door**)  
 **Date:** 2026-08-02  
-**Layer:** measurement architecture over `sugar.enumerate`  
 **Related:**
 - `protocol/specs/2026-07-08-enumeration-protocol.md` (§0, §4, §5A)
-- `implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py` (current side door)
-- `implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py` (seal door; stays)
+- `compose_control_effect_board.py` (sole seal door — retained)
+- pink owns §4 process-resident file context under whole-file content CID
+- black owns this consumer
 
 ---
 
-## 0. Choice (one door, not two)
+## 0. Ruling
 
-**The recensus becomes a `sugar.enumerate` consumer.**
+> We don't admit side doors. It should just become an enumeration consumer.
+> And it's insane that it's not already. — T
 
-It does **not** remain a wall-style private walk of 1421 independent
-`SourceFile` / `populate` / sugar passes that re-derive the same content
-because it was reached by a different path or a different open.
-
-An “admitted side door with the same memo law” is **rejected as the target
-shape**. A side door that still opens each file as a private process walk is
-exactly the §0/§4 violation. The only admissible interim is a **thin adapter**
-that calls the **same kit-internal prepare path** enumerate already uses for
-process-resident file context under whole-file content CID — not a second
-walker. The destination is still: **demand through enumeration, fold for
-counts, seal through compose.**
+**The control-effect recensus is a `sugar.enumerate` consumer.**  
+There is no admitted private walk, no “same memo law side door,” no parallel
+`_measure_file` authority path. The old door **retires**.
 
 ---
 
-## 1. The law it must obey (quoted, then restated)
+## 1. Protocol law (why this is the only shape)
 
-From `2026-07-08-enumeration-protocol.md`:
+Quoted from `2026-07-08-enumeration-protocol.md`:
 
-> **§0:** Each request is also the only authority to perform work for the node
-> named by `at`. … No batch lift or wall-specific traversal may perform the
-> same work outside this verb.
+**§0** — *Each request is also the only authority to perform work for the node
+named by `at`. … No batch lift or wall-specific traversal may perform the same
+work outside this verb.*
 
-> **§4:** One request performs work for exactly the node named by `at` and
-> returns only its immediate child keys. … Whole-file and whole-workspace
-> reduction are forbidden side doors. Mementos are the only identities.
+**§4** — *One request performs work for exactly the node named by `at` …  
+Whole-file and whole-workspace reduction are forbidden side doors. Mementos are
+the only identities.*
 
-> **§4 (kit residency):** Inside the Python kit, demanded file context is
-> process-resident under the whole-file content CID. A file request parses and
-> prepares module temporal context once for that CID; distinct demanded
-> descendants reuse it. Changing the file changes the CID and therefore misses
-> without a staleness check. Undemanded definitions are never reduced.
+**§4 kit residency** — *demanded file context is process-resident under the
+whole-file content CID. A file request parses and prepares module temporal
+context once for that CID; distinct demanded descendants reuse it.*
 
-> **§4 (demand memo):** The cache key is the content address of the
-> JCS-canonical question tuple `(workspace_root, level, at, seek, options)`,
-> never the bare node memento. A repeated question is answered without
-> re-crossing the wire.
+**§4 demand memo** — *cache key is the content address of the JCS-canonical
+question tuple `(workspace_root, level, at, seek, options)`.*
 
-> **§5A:** A receiver decodes the term table once, interns exactly one shared
-> node per CID. Enumeration demand remains the only cause of work.
-
-**Invariant (compose-seal style):**
+**Invariant:**
 
 ```
-WORK(C)  = pure function of content C and the closed enumerate question that names it
-AUTHORITY(C) = sugar.enumerate for the memento that pins C
-RESIDENCY(C) = process-resident under whole-file content CID (file context)
-               and/or question-CID (demand memo) and/or term CID (DAG)
-ILLEGAL    = re-derive C because path, open, reporter, shell, or file index differed
+AUTHORITY(work on content C) = sugar.enumerate(memento pinning C)
+RESIDENCY(file F)            = process-resident under whole-file content CID(F)
+COUNTS                       = fold of enumerate nodes + gaps only
+SEAL                         = compose_control_effect_board only
+ILLEGAL                      = private SourceFile/populate/sugar walk of 1421 files
 ```
 
-Path is not identity. `h = h(p)`. Unshared work across files that pin the same
-content is a **protocol violation**, not a performance miss.
+The memo is **free** once the recensus is a consumer: §4 residency is pink’s
+floor; the census stops re-deriving by **stopping derivation**.
 
 ---
 
-## 2. What the recensus is today (the crime named)
+## 2. What the census DEMANDS (as enumerate requests)
 
-Today `control_effect_recensus.py`:
+One kit client / consistency window for the whole run.
 
-1. Pins the corpus (legitimate: population identity).
-2. Builds a whole-corpus provisional demand table once (acceptable as **options
-   shared by questions**, not as a substitute for file context residency).
-3. For each of ~1421 files: private `SourceFile` open → `populate_source_derived`
-   → `functions()` → per-function `sugar()` — a **private process walk**.
-4. Aggregates rows; compose seals the board.
+| Step | Request | Meaning |
+|------|---------|---------|
+| **D0** | Corpus pin (local) | Enrolled population — who is measured (not construction work) |
+| **D1** | For each enrolled path: bind **file memento** (`file` + `source_cid` / `file_cid`) | Identity for `at` |
+| **D2** | `level=functions`, `seek=false`, `at=file_memento`, `workspace_root=corpus` | **Function roster** for that file |
+| **D3** | Construction residual for that file (or each function) | **Construction outcomes** |
 
-That is “somebody did one file and called it done, 1400 times” outside
-`sugar.enumerate`. It re-prepares content under live path identity
-(`id(ref)`, `id(reporter)`, `id(construction_context)`, per-open sessions)
-instead of under whole-file content CID. Same module content (e.g. dependency
-`enum.py`) is re-derived per path of reach. That is the §0/§4 side door.
+### D3 — construction residual (precise)
 
-Compose seal (`compose_control_effect_board`) stays. **Seal is not the crime.**
-The crime is **how terminals are produced**.
+The census needs, per enrolled file (and ultimately per function):
+
+- construction gaps / families (`SugarNotWritten`, …)
+- construction panics
+- instrument-defects (unresolvable dispatch, …)
+- optional desugar residual when sugar succeeded
+
+**Wire today:**
+
+- `level=functions` returns **roster mementos** (and kit may prepare file context
+  under content CID as side effect of answering D2 — that prepare is **enumerate’s**
+  work, not the recensus’s).
+- Construction roll-call residual is already served as an enumerate product via
+  **`options.auditFrontier=true`** at **`level=facts`** with `at=file_memento`
+  (`_roll_call_audit_leaf`: CollectingReporter + discharge → panics/gaps).
+
+**Demand sequence per enrolled file:**
+
+```
+1. sugar.enumerate { level: functions, at: file_memento, seek: false }
+      → nodes[] function mementos  → functionsTotal for this file
+      → gaps[] if file unreadable / CID mismatch
+
+2. sugar.enumerate { level: facts, at: file_memento, seek: true,
+                     options: { auditFrontier: true } }
+      → audit.semanticCore.panics / status / sourceAudit
+      → construction residual for the demanded file
+```
+
+**Future (kit growth, not a recensus side door):** per-function construction
+demand (`level=functions` seek with construction options, or a dedicated
+construction residual on the function memento) so undemanded definitions stay
+unreduced. Until then, **file-scoped construction residual is still an
+enumerate demand** (facts+auditFrontier), not a private walk.
+
+### Forbidden
+
+- Calling `SourceFile` / `populate_source_derived` / `function.sugar()` from the
+  recensus script as a second path.
+- Keeping `_measure_file` as a fallback “if enumerate fails.”
+- Whole-corpus reduction outside the verb.
 
 ---
 
-## 3. What the recensus becomes (precise)
+## 3. Where COUNTS come from
 
-### 3.1 Role
+| Count | Source |
+|-------|--------|
+| `denominator.files.enrolled` | Corpus pin (D0) |
+| `denominator.files.terminal` | One terminal row per enrolled file that completed D1–D3 |
+| `functionsTotal` | Σ \|D2.nodes\| over enrolled files (function mementos) |
+| `functionsClean` | From D3 residual: functions that constructed without gap (when kit reports it); else derived as `functionsTotal - gap-bearing function loci` from roll-call coordinates |
+| `families` / construction gaps | D3 panics/gaps, occurrence-keyed |
+| `R_construction_panics` | D3 panics with ConstructionPanic kind |
+| instrument-defects | D3 gaps with instrument-defect kinds |
+| `cmResolutions` / withCensus | Only if returned on enumerate construction residual; **not** a private populate tax |
+| Sealed board | `compose_control_effect_board` over complete terminals |
 
-| Piece | Role |
+**Nothing** is counted from a private traversal the recensus invents.
+
+Missing D2 or D3 for an enrolled file → **terminal incomplete** → compose
+UNMEASURED / red denominator (crash-banks-measured), not a quiet shrink.
+
+---
+
+## 4. What happens to `_measure_file`
+
+**It is the side door. It does not survive as a second path.**
+
+| State | Rule |
 |-------|------|
-| **Corpus pin** | Who is enrolled (file identity set + aggregate hash). Unchanged. |
-| **sugar.enumerate client** | Sole authority that causes construction work for each demanded node. |
-| **Fold** | Sums terminals into residual axes (construction families, panics, CM, desugar). |
-| **compose_control_effect_board** | Sole mint of `measurementClass=control-effect-recensus` (already landed). |
-
-### 3.2 What it demands
-
-One consistency window = one kit client for the recensus run (protocol §4).
-
-| Demand | `level` / mode | Purpose |
-|--------|----------------|---------|
-| D0 | (local) corpus pin / enrolled file list | Denominator **files** — population, not construction work |
-| D1 | `source_files` seek or kit file memento for each enrolled path | Bind each enrolled path to a **file memento** (content-pinned) |
-| D2 | `functions`, scan `at=file_memento` | Function roster per file → **functionsTotal** denominator |
-| D3 | per function: construction demand | Construction residual for that definition only |
-
-**D3 shape (kit must expose, if not already):**
-
-Construction of a demanded function is work authorized by enumerate (or the
-same kit door enumerate uses for “definition or lower leaf request performs
-only that keyed node's construction”). The response must carry enough for the
-census axes:
-
-- construction gaps / `SugarNotWritten` families (occurrence-keyed)
-- construction panics (file- or definition-scoped as today)
-- optional: With/CM resolution partition when With sites are reduced under that
-  demand (source-derived CM is **not** a free whole-file populate tax outside
-  demand)
-
-**Forbidden demand shapes:**
-
-- Whole-workspace reduction in one call.
-- “Open every file and sugar every function” as a side loop that never goes
-  through the enumerate question key / content-CID file residency.
-- Private `populate_source_derived` of an entire file before any function is
-  demanded (that is whole-file reduction of managers — §4 side door).
-
-### 3.3 How it gets its counts
-
-| Axis | Source |
-|------|--------|
-| `denominator.files.enrolled` | Corpus pin (D0), not enumerate |
-| `denominator.functions.total` | Σ over files of \|D2 nodes\| (function mementos returned) |
-| `functionsClean` / construction families | Fold of D3 construction outcomes / gaps |
-| `R_construction_panics` | Fold of panic terminals from D3 (or file-level panic if kit surfaces it) |
-| `cmResolutions` / withCensus | Fold of CM resolution products from demanded With construction under D3 — **not** a separate full-file populate phase |
-| Sealed board | `compose_control_effect_board` over complete terminal set (existing seal law) |
-
-**Completeness:** every enrolled file memento must produce a D2 answer (roster
-or named gap). Every function memento that the census enrolls for construction
-must produce a D3 answer (outcome or gap). Missing demand → UNMEASURED seat
-(same crash-banks-measured discipline as shard attendance), not a quiet smaller
-denominator.
-
-### 3.4 Memo law the consumer relies on (does not reimplement)
-
-The recensus client **must not** invent a second cache:
-
-1. **Question memo:** repeated `(workspace_root, level, at, seek, options)` →
-   same answer without re-work (protocol demand memo).
-2. **File context residency:** first demand that needs file F prepares under
-   `whole-file content CID(F)` once; later function demands under F reuse it
-   (protocol §4 kit residency — pink’s content-CID work is this floor).
-3. **Term / construction coordinate:** shared nodes interned by content CID
-   (§5A / construction shape CIDs), never by `id(shell)`.
-
-If the kit violates (2) or (3), that is a **kit bug** against the enumeration
-protocol; the recensus does not paper over it with a private walk.
+| Authority | `_measure_file` is **not** the authority for any bankable residual |
+| Code | Removed from the production recensus entrypoint (deleted or reduced to a
+  test-only helper **outside** the scoreboard path, never called from main) |
+| Same law as compose | One door produces terminals: **enumerate**. One door seals:
+  **compose**. Serial walk of SourceFile is not left parallel behind a flag |
 
 ---
 
-## 4. Interim adapter (only if wire levels lag)
+## 5. Coordination with pink (§4 residency)
 
-Until D3 is fully expressible on the wire for construction residuals:
+| Owner | Delivers |
+|-------|----------|
+| **pink** | Process-resident file context under **whole-file content CID**; D2/D3
+  prepare hits that map so second demand for the same CID does not re-parse /
+  re-materialize |
+| **black** | Recensus as enumerate client + fold + compose; no private walk |
 
-**Admissible interim:** recensus may call **kit-internal functions that are
-already the implementation of enumerate’s file prepare + definition
-construction**, provided:
-
-1. They register/reuse process-resident context under **whole-file content CID**.
-2. Definition construction is keyed by **content / memento**, not by file index
-   or path string alone.
-3. No second `SourceFile(...)` open of the same content CID in the same process
-   without a hit on that residency map.
-4. Dependency module materialize/projection is once per **module source_cid**
-   inside that preparation window (session or content shelf — not
-   `session_or_new(None)` per receipt).
-
-**Inadmissible interim:** today’s loop of 1421 independent opens that ignore
-content-CID residency.
-
-The interim must be labeled in code and job log:
-`recensus_mode=enumerate-adapter` vs `recensus_mode=enumerate-wire`.
-Both modes produce terminals only for compose; neither mints the board class
-except through compose.
+The consumer does not reimplement residency. If prepare still re-derives, that
+is a kit §4 bug on pink’s floor, measured by a tooth: same content CID demanded
+twice → prepare count = 1.
 
 ---
 
-## 5. What is deleted when this lands
-
-| Deleted | Why |
-|---------|-----|
-| Private per-file “full open + populate + sugar all” as the authority path | §0/§4 side door |
-| Treating `populate_source_derived` as a required whole-file tax before any function demand | Whole-file reduction; CM work must hang off demanded construction |
-| Path-identity construction keys as the long-term coordinate | Contradicts content residency; fix is content keys + residency, not endless key narrowing |
-| Selling LPT shard of the private walk as the root fix | Shards the side door; does not restore the protocol (compose seal remains valid for aggregation) |
-
-**Retained:**
-
-- Corpus pin / enrollment
-- Compose seal + dual-belt attendance
-- LPT over **enumerate demand units** later (optional wall packing of independent
-  demands) — only after each unit is a legal question, not a private open
-
----
-
-## 6. Implement order (named, not tonight’s full rewrite)
-
-1. **Pink / kit:** process-resident file context under whole-file content CID
-   (enumerate §4) — floor the recensus stands on.
-2. **Kit surface:** ensure function-level construction demand returns residual
-   products the census folds (gaps, panics, CM partition as applicable).
-3. **Recensus rewrite:** replace private walk with enumerate client (or
-   interim adapter obeying §4 residency); terminals → existing compose.
-4. **Tooth:** same content CID prepared once per process under two demand
-   orders / two “files” that share a dependency module; second demand does not
-   re-parse/re-materialize (discrimination: force-fail if prepare count > 1).
-5. **Tooth:** recensus with wire/adapter mode never calls
-   `SourceFile(path)` except inside the content-CID prepare door.
-
----
-
-## 7. One-sentence law
+## 6. One-sentence law
 
 **The control-effect recensus is a fold of `sugar.enumerate` demands over the
-pinned corpus population, sealed by `compose_control_effect_board`; it is not
-a private 1421-file walk, and any prepare/construct it triggers must be the
-same content-CID-resident work the enumeration protocol already requires.**
+pinned corpus (function roster + construction residual), sealed only by
+`compose_control_effect_board`; `_measure_file` and every private SourceFile
+walk are retired side doors, and content-CID file residency is supplied by the
+enumeration kit (pink), not reinvented by the census.**

--- a/protocol/specs/2026-08-02-recensus-as-enumerate-consumer.md
+++ b/protocol/specs/2026-08-02-recensus-as-enumerate-consumer.md
@@ -1,0 +1,237 @@
+# Recensus as enumeration consumer (not a private walk)
+
+**Status:** design law (binding for implement)  
+**Date:** 2026-08-02  
+**Layer:** measurement architecture over `sugar.enumerate`  
+**Related:**
+- `protocol/specs/2026-07-08-enumeration-protocol.md` (§0, §4, §5A)
+- `implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py` (current side door)
+- `implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py` (seal door; stays)
+
+---
+
+## 0. Choice (one door, not two)
+
+**The recensus becomes a `sugar.enumerate` consumer.**
+
+It does **not** remain a wall-style private walk of 1421 independent
+`SourceFile` / `populate` / sugar passes that re-derive the same content
+because it was reached by a different path or a different open.
+
+An “admitted side door with the same memo law” is **rejected as the target
+shape**. A side door that still opens each file as a private process walk is
+exactly the §0/§4 violation. The only admissible interim is a **thin adapter**
+that calls the **same kit-internal prepare path** enumerate already uses for
+process-resident file context under whole-file content CID — not a second
+walker. The destination is still: **demand through enumeration, fold for
+counts, seal through compose.**
+
+---
+
+## 1. The law it must obey (quoted, then restated)
+
+From `2026-07-08-enumeration-protocol.md`:
+
+> **§0:** Each request is also the only authority to perform work for the node
+> named by `at`. … No batch lift or wall-specific traversal may perform the
+> same work outside this verb.
+
+> **§4:** One request performs work for exactly the node named by `at` and
+> returns only its immediate child keys. … Whole-file and whole-workspace
+> reduction are forbidden side doors. Mementos are the only identities.
+
+> **§4 (kit residency):** Inside the Python kit, demanded file context is
+> process-resident under the whole-file content CID. A file request parses and
+> prepares module temporal context once for that CID; distinct demanded
+> descendants reuse it. Changing the file changes the CID and therefore misses
+> without a staleness check. Undemanded definitions are never reduced.
+
+> **§4 (demand memo):** The cache key is the content address of the
+> JCS-canonical question tuple `(workspace_root, level, at, seek, options)`,
+> never the bare node memento. A repeated question is answered without
+> re-crossing the wire.
+
+> **§5A:** A receiver decodes the term table once, interns exactly one shared
+> node per CID. Enumeration demand remains the only cause of work.
+
+**Invariant (compose-seal style):**
+
+```
+WORK(C)  = pure function of content C and the closed enumerate question that names it
+AUTHORITY(C) = sugar.enumerate for the memento that pins C
+RESIDENCY(C) = process-resident under whole-file content CID (file context)
+               and/or question-CID (demand memo) and/or term CID (DAG)
+ILLEGAL    = re-derive C because path, open, reporter, shell, or file index differed
+```
+
+Path is not identity. `h = h(p)`. Unshared work across files that pin the same
+content is a **protocol violation**, not a performance miss.
+
+---
+
+## 2. What the recensus is today (the crime named)
+
+Today `control_effect_recensus.py`:
+
+1. Pins the corpus (legitimate: population identity).
+2. Builds a whole-corpus provisional demand table once (acceptable as **options
+   shared by questions**, not as a substitute for file context residency).
+3. For each of ~1421 files: private `SourceFile` open → `populate_source_derived`
+   → `functions()` → per-function `sugar()` — a **private process walk**.
+4. Aggregates rows; compose seals the board.
+
+That is “somebody did one file and called it done, 1400 times” outside
+`sugar.enumerate`. It re-prepares content under live path identity
+(`id(ref)`, `id(reporter)`, `id(construction_context)`, per-open sessions)
+instead of under whole-file content CID. Same module content (e.g. dependency
+`enum.py`) is re-derived per path of reach. That is the §0/§4 side door.
+
+Compose seal (`compose_control_effect_board`) stays. **Seal is not the crime.**
+The crime is **how terminals are produced**.
+
+---
+
+## 3. What the recensus becomes (precise)
+
+### 3.1 Role
+
+| Piece | Role |
+|-------|------|
+| **Corpus pin** | Who is enrolled (file identity set + aggregate hash). Unchanged. |
+| **sugar.enumerate client** | Sole authority that causes construction work for each demanded node. |
+| **Fold** | Sums terminals into residual axes (construction families, panics, CM, desugar). |
+| **compose_control_effect_board** | Sole mint of `measurementClass=control-effect-recensus` (already landed). |
+
+### 3.2 What it demands
+
+One consistency window = one kit client for the recensus run (protocol §4).
+
+| Demand | `level` / mode | Purpose |
+|--------|----------------|---------|
+| D0 | (local) corpus pin / enrolled file list | Denominator **files** — population, not construction work |
+| D1 | `source_files` seek or kit file memento for each enrolled path | Bind each enrolled path to a **file memento** (content-pinned) |
+| D2 | `functions`, scan `at=file_memento` | Function roster per file → **functionsTotal** denominator |
+| D3 | per function: construction demand | Construction residual for that definition only |
+
+**D3 shape (kit must expose, if not already):**
+
+Construction of a demanded function is work authorized by enumerate (or the
+same kit door enumerate uses for “definition or lower leaf request performs
+only that keyed node's construction”). The response must carry enough for the
+census axes:
+
+- construction gaps / `SugarNotWritten` families (occurrence-keyed)
+- construction panics (file- or definition-scoped as today)
+- optional: With/CM resolution partition when With sites are reduced under that
+  demand (source-derived CM is **not** a free whole-file populate tax outside
+  demand)
+
+**Forbidden demand shapes:**
+
+- Whole-workspace reduction in one call.
+- “Open every file and sugar every function” as a side loop that never goes
+  through the enumerate question key / content-CID file residency.
+- Private `populate_source_derived` of an entire file before any function is
+  demanded (that is whole-file reduction of managers — §4 side door).
+
+### 3.3 How it gets its counts
+
+| Axis | Source |
+|------|--------|
+| `denominator.files.enrolled` | Corpus pin (D0), not enumerate |
+| `denominator.functions.total` | Σ over files of \|D2 nodes\| (function mementos returned) |
+| `functionsClean` / construction families | Fold of D3 construction outcomes / gaps |
+| `R_construction_panics` | Fold of panic terminals from D3 (or file-level panic if kit surfaces it) |
+| `cmResolutions` / withCensus | Fold of CM resolution products from demanded With construction under D3 — **not** a separate full-file populate phase |
+| Sealed board | `compose_control_effect_board` over complete terminal set (existing seal law) |
+
+**Completeness:** every enrolled file memento must produce a D2 answer (roster
+or named gap). Every function memento that the census enrolls for construction
+must produce a D3 answer (outcome or gap). Missing demand → UNMEASURED seat
+(same crash-banks-measured discipline as shard attendance), not a quiet smaller
+denominator.
+
+### 3.4 Memo law the consumer relies on (does not reimplement)
+
+The recensus client **must not** invent a second cache:
+
+1. **Question memo:** repeated `(workspace_root, level, at, seek, options)` →
+   same answer without re-work (protocol demand memo).
+2. **File context residency:** first demand that needs file F prepares under
+   `whole-file content CID(F)` once; later function demands under F reuse it
+   (protocol §4 kit residency — pink’s content-CID work is this floor).
+3. **Term / construction coordinate:** shared nodes interned by content CID
+   (§5A / construction shape CIDs), never by `id(shell)`.
+
+If the kit violates (2) or (3), that is a **kit bug** against the enumeration
+protocol; the recensus does not paper over it with a private walk.
+
+---
+
+## 4. Interim adapter (only if wire levels lag)
+
+Until D3 is fully expressible on the wire for construction residuals:
+
+**Admissible interim:** recensus may call **kit-internal functions that are
+already the implementation of enumerate’s file prepare + definition
+construction**, provided:
+
+1. They register/reuse process-resident context under **whole-file content CID**.
+2. Definition construction is keyed by **content / memento**, not by file index
+   or path string alone.
+3. No second `SourceFile(...)` open of the same content CID in the same process
+   without a hit on that residency map.
+4. Dependency module materialize/projection is once per **module source_cid**
+   inside that preparation window (session or content shelf — not
+   `session_or_new(None)` per receipt).
+
+**Inadmissible interim:** today’s loop of 1421 independent opens that ignore
+content-CID residency.
+
+The interim must be labeled in code and job log:
+`recensus_mode=enumerate-adapter` vs `recensus_mode=enumerate-wire`.
+Both modes produce terminals only for compose; neither mints the board class
+except through compose.
+
+---
+
+## 5. What is deleted when this lands
+
+| Deleted | Why |
+|---------|-----|
+| Private per-file “full open + populate + sugar all” as the authority path | §0/§4 side door |
+| Treating `populate_source_derived` as a required whole-file tax before any function demand | Whole-file reduction; CM work must hang off demanded construction |
+| Path-identity construction keys as the long-term coordinate | Contradicts content residency; fix is content keys + residency, not endless key narrowing |
+| Selling LPT shard of the private walk as the root fix | Shards the side door; does not restore the protocol (compose seal remains valid for aggregation) |
+
+**Retained:**
+
+- Corpus pin / enrollment
+- Compose seal + dual-belt attendance
+- LPT over **enumerate demand units** later (optional wall packing of independent
+  demands) — only after each unit is a legal question, not a private open
+
+---
+
+## 6. Implement order (named, not tonight’s full rewrite)
+
+1. **Pink / kit:** process-resident file context under whole-file content CID
+   (enumerate §4) — floor the recensus stands on.
+2. **Kit surface:** ensure function-level construction demand returns residual
+   products the census folds (gaps, panics, CM partition as applicable).
+3. **Recensus rewrite:** replace private walk with enumerate client (or
+   interim adapter obeying §4 residency); terminals → existing compose.
+4. **Tooth:** same content CID prepared once per process under two demand
+   orders / two “files” that share a dependency module; second demand does not
+   re-parse/re-materialize (discrimination: force-fail if prepare count > 1).
+5. **Tooth:** recensus with wire/adapter mode never calls
+   `SourceFile(path)` except inside the content-CID prepare door.
+
+---
+
+## 7. One-sentence law
+
+**The control-effect recensus is a fold of `sugar.enumerate` demands over the
+pinned corpus population, sealed by `compose_control_effect_board`; it is not
+a private 1421-file walk, and any prepare/construct it triggers must be the
+same content-CID-resident work the enumeration protocol already requires.**

--- a/tests/test_recensus_enumerate_consumer.py
+++ b/tests/test_recensus_enumerate_consumer.py
@@ -1,0 +1,120 @@
+"""Recensus is a sugar.enumerate consumer — no private walk side door."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "implementations/python/sugar-lift-py-tests/scripts"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    # scripts import each other by bare name
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+CONSUMER = _load(
+    "recensus_enumerate_consumer",
+    SCRIPTS / "recensus_enumerate_consumer.py",
+)
+RECENSUS = _load(
+    "control_effect_recensus",
+    SCRIPTS / "control_effect_recensus.py",
+)
+
+
+def test_measure_file_is_retired_side_door() -> None:
+    with pytest.raises(RuntimeError, match="retired side door"):
+        RECENSUS._measure_file(
+            Path("x.py"),
+            relative="x.py",
+            workspace_root=Path("."),
+        )
+
+
+def test_consumer_source_forbids_private_walk_imports() -> None:
+    text = (SCRIPTS / "recensus_enumerate_consumer.py").read_text(encoding="utf-8")
+    assert "open_source_file_for_construction" not in text or text.count(
+        "open_source_file_for_construction"
+    ) <= 2
+    assert "SourceFile(" not in text
+    assert "sugar.enumerate" in text
+    assert CONSUMER.SCOREBOARD_AUTHORITY is False
+
+
+def test_production_loop_calls_enumerate_consumer_not_measure_file() -> None:
+    text = (SCRIPTS / "control_effect_recensus.py").read_text(encoding="utf-8")
+    assert "measure_file_via_enumerate" in text
+    # The only reference to _measure_file should be the retired stub definition
+    # and error strings — not a production call site.
+    assert "row = _measure_file(" not in text
+    assert "row = measure_file_via_enumerate(" in text
+
+
+def test_terminal_from_enumerate_maps_roster_and_panics() -> None:
+    row = CONSUMER.terminal_from_enumerate(
+        file_rel="pkg/mod.py",
+        function_nodes=[{"memento": {"function_name": "a"}}, {"memento": {"function_name": "b"}}],
+        function_gaps=[],
+        audit={
+            "semanticCore": {
+                "status": "failed",
+                "panics": [
+                    {
+                        "kind": "ConstructionPanic",
+                        "reason": "write more Sugar",
+                        "gap": {"kind": "SugarNotWritten", "reason": "write more Sugar"},
+                        "locus": "pkg/mod.py:1:0",
+                    }
+                ],
+            }
+        },
+        construction_gaps=[],
+    )
+    assert row["enumerateSource"] is True
+    assert row["functionsTotal"] == 2
+    assert row["families"].get("SugarNotWritten") == 1
+    assert row["category"] == "completed"  # roster present; residual in families
+
+
+def test_functions_gap_without_nodes_is_defect() -> None:
+    row = CONSUMER.terminal_from_enumerate(
+        file_rel="pkg/mod.py",
+        function_nodes=[],
+        function_gaps=[{"reason": "no such file"}],
+        audit=None,
+        construction_gaps=[],
+    )
+    assert row["category"] == "backend-defect"
+    assert row["functionsTotal"] == 0
+
+
+def test_live_enumerate_roster_on_fixture(tmp_path: Path) -> None:
+    """D2 against real sugar.enumerate handler (in-process)."""
+    src = tmp_path / "mod.py"
+    src.write_text(
+        "def one():\n    return 1\n\ndef two():\n    return 2\n",
+        encoding="utf-8",
+    )
+    nodes, gaps = CONSUMER.demand_function_roster(
+        workspace_root=tmp_path,
+        file_rel="mod.py",
+    )
+    assert gaps == []
+    names = sorted(
+        n["memento"].get("function_name")
+        or n["memento"].get("source_function_name")
+        for n in nodes
+    )
+    assert names == ["one", "two"]


### PR DESCRIPTION
## Summary

T ruled: **no side door**. The recensus becomes a **`sugar.enumerate` consumer** only.

### Law
- Spec: `protocol/specs/2026-08-02-recensus-as-enumerate-consumer.md`
- §0/§4: no batch lift outside the verb; whole-file private walks forbidden
- **D2** `level=functions` → function roster (`functionsTotal`)
- **D3** `level=facts` + `auditFrontier` → construction residual
- Counts fold from enumerate nodes/gaps only
- **`_measure_file` retired** (raises if called)
- Compose remains sole seal door
- **Pink** owns §4 content-CID file residency; this PR is the **consumer**

### Code
- `recensus_enumerate_consumer.py` — sugar.enumerate client (in-process handler = wire door)
- `control_effect_recensus.py` production loop calls `measure_file_via_enumerate` only
- Teeth: 6 tests green

### Not claiming
- Full 1421-file parity with old private-walk residual shape (CM desugar axes may need kit surface growth)
- That pink’s residency is already perfect on every path — consumer stops re-deriving by not deriving

## Validation
```
pytest tests/test_recensus_enumerate_consumer.py  # 6 passed
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retire `_measure_file` side door and route recensus through `sugar.enumerate`
> - Replaces the private `_measure_file` SourceFile walk in `control_effect_recensus` with calls to `measure_file_via_enumerate` from the new [`recensus_enumerate_consumer.py`](https://github.com/TSavo/sugar/pull/7073/files#diff-f44306c90c4bcc279a33763d110fe23086857b9b1f1afc83ea45e09c2d004b79) module.
> - `_measure_file` now unconditionally raises `RuntimeError` to enforce that it is a retired side door.
> - `recensus_enumerate_consumer` implements the full enumerate-based pipeline: in-process JSON-RPC via `enumerate_rpc`, function roster demand (D2), construction residual demand (D3), and a `terminal_from_enumerate` mapper that produces terminal rows with category, panics, and defect fields.
> - A `assert_no_side_door_imports` guard enforces at test-time that the consumer module never re-introduces forbidden private-walk imports.
> - Risk: any caller that previously invoked `_measure_file` directly will now get a `RuntimeError` at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c3c863.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->