### PR TITLE
IfExp+spread arm: SugarNotWritten, not TypeError

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -21,10 +21,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field as dataclass_field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import (
-    ConstructedTermSugar,
-    require_constructed_term_sugar,
-)
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.witnesses import _call_return_pair
 from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
 
@@ -41,9 +38,31 @@ class IfExpSugar(ConstructedTermSugar):
     branch_slot: object = None
 
     def __post_init__(self) -> None:
-        require_constructed_term_sugar(self.test, owner="IfExpSugar.test")
-        require_constructed_term_sugar(self.body, owner="IfExpSugar.body")
-        require_constructed_term_sugar(self.orelse, owner="IfExpSugar.orelse")
+        # Defense in depth: construction door is IfExp._construct_sugar, which
+        # raises SugarNotWritten for non-term arms. If anything bypasses that
+        # door, refuse the same way — never TypeError.
+        from sugar_source_tree.panic import SugarNotWritten
+
+        for arm_name, arm in (
+            ("test", self.test),
+            ("body", self.body),
+            ("orelse", self.orelse),
+        ):
+            if isinstance(arm, ConstructedTermSugar):
+                continue
+            raise SugarNotWritten(
+                blame=self.site,
+                owner=f"IfExpSugar.{arm_name}",
+                observed=(
+                    f"IfExpSugar.{arm_name} is {type(arm).__name__}, not "
+                    "ConstructedTermSugar"
+                ),
+                requested="ConstructedTermSugar arms for to_term / distribute",
+                fix=(
+                    "construct only through IfExp._construct_sugar, which names "
+                    "the missing arm sugar; do not bypass with a raw type assert"
+                ),
+            )
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-lift-py-tests/tests/test_ifexp_spread_arm_refusal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_ifexp_spread_arm_refusal.py
@@ -1,0 +1,47 @@
+"""IfExp + spread collection arm: named gap, never raw TypeError.
+
+Product shapes like ``[a, *xs] if c else ys`` construct SpreadCollectionSugar
+for an arm. IfExpSugar requires ConstructedTermSugar for to_term. Until that
+composition is written, the coordinate must refuse with SugarNotWritten —
+not surprise the constructor with a TypeError.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
+from sugar_source_tree.nodes import IfExp
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _cid(source: str) -> str:
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+
+def test_ifexp_spread_list_arm_is_sugar_not_written_not_typeerror() -> None:
+    """`[1, *xs] if flag else ys` must not raise TypeError at construction."""
+    source = "x = [1, *xs] if flag else ys\n"
+    sf = SourceFile((source, "ifexp_spread.py", _cid(source)))
+    node = next(n for n in sf.root.walk() if isinstance(n, IfExp))
+    with pytest.raises(SugarNotWritten) as caught:
+        node.sugar()
+    err = caught.value
+    assert type(err).__name__ == "SugarNotWritten"
+    observed = str(getattr(err, "observed", err))
+    assert "SpreadCollectionSugar" in observed
+    assert getattr(err, "owner", "") == "IfExp._construct_sugar"
+    fix = str(getattr(err, "fix", ""))
+    assert "TypeError" in fix or "ConstructedTermSugar" in fix
+
+
+def test_ifexp_plain_arms_still_construct() -> None:
+    """Ordinary IfExp arms remain ConstructedTermSugar and construct."""
+    source = "x = a if flag else b\n"
+    sf = SourceFile((source, "ifexp_plain.py", _cid(source)))
+    node = next(n for n in sf.root.walk() if isinstance(n, IfExp))
+    sugar = node.sugar()
+    assert isinstance(sugar, IfExpSugar)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -9320,13 +9320,46 @@ class IfExp(Expression):
         conditional VALUE the phi produces. It desugars to a GuardedValue that
         DISTRIBUTES (a return/equality splits into per-arm implications, each arm
         resolved per-atom), so the conditional never becomes a single mixed-sort
-        term; the compiler stays Python-ignorant and only ever sees ir.eq."""
-        from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
+        term; the compiler stays Python-ignorant and only ever sees ir.eq.
 
+        Arms must be ConstructedTermSugar so IfExpSugar can project to_term.
+        A spread collection arm (``[a, *xs] if c else ys``) is a real Python
+        shape but is NOT yet a term construction — refuse with SugarNotWritten,
+        never a raw TypeError from a type assertion.
+        """
+        from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
+        from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+        from sugar_source_tree.panic import SugarNotWritten
+
+        test = self.test.sugar()
+        body = self.body.sugar()
+        orelse = self.orelse.sugar()
+        for arm_name, arm in (("test", test), ("body", body), ("orelse", orelse)):
+            if isinstance(arm, ConstructedTermSugar):
+                continue
+            raise SugarNotWritten(
+                blame=self.fragment,
+                owner="IfExp._construct_sugar",
+                observed=(
+                    f"IfExp.{arm_name} constructed {type(arm).__name__}, which is "
+                    "not ConstructedTermSugar (e.g. SpreadCollectionSugar for "
+                    "`[a, *xs] if c else ys`)"
+                ),
+                requested=(
+                    "IfExp arms that are ordinary constructed terms so "
+                    "IfExpSugar can project to_term and distribute"
+                ),
+                fix=(
+                    f"write IfExp+{type(arm).__name__} construction (promote the "
+                    "arm sugar to ConstructedTermSugar with to_term), or keep "
+                    "this coordinate loud until that sugar exists — never a "
+                    "bare TypeError from a type assertion"
+                ),
+            )
         return IfExpSugar(
-            test=self.test.sugar(),
-            body=self.body.sugar(),
-            orelse=self.orelse.sugar(),
+            test=test,
+            body=body,
+            orelse=orelse,
             site=self.fragment,
             branch_slot=branch_result_slot(self.test),
         )


### PR DESCRIPTION
## Product gap

```
TypeError: IfExpSugar.body requires ConstructedTermSugar, got SpreadCollectionSugar
```

Raw TypeError = constructor surprised. That case was never written.

## Answers

1. **Should IfExp+SpreadCollection construct?** Not yet. Meaning may be expressible at desugar later, but IfExpSugar needs ConstructedTermSugar for `to_term`. That composition is not written.
2. **Refuse properly:** `SugarNotWritten` at `IfExp._construct_sugar` naming the arm sugar class and the missing `IfExp+SpreadCollectionSugar` work — not a TypeError from `require_constructed_term_sugar`.

## Fix

- `IfExp._construct_sugar`: check arms; raise `SugarNotWritten` with owner/observed/fix
- `IfExpSugar.__post_init__`: same refusal if anything bypasses the door
- Twin: plain IfExp still constructs; spread arm raises SNW not TypeError

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `SugarNotWritten` instead of `TypeError` when an `IfExp` arm is not a `ConstructedTermSugar`
> - `IfExp._construct_sugar` now sugars each arm first, then validates each is a `ConstructedTermSugar`; if not (e.g. a `SpreadCollectionSugar` from `[1, *xs]`), it raises `SugarNotWritten` with blame, owner, and fix details.
> - `IfExpSugar.__post_init__` mirrors this by raising `SugarNotWritten` directly instead of delegating to `require_constructed_term_sugar`.
> - Two new tests in [`test_ifexp_spread_arm_refusal.py`](https://github.com/TSavo/sugar/pull/7074/files#diff-d22d1a036f950bddc2435b8237d0a6e68b94265fd1c65e9b1c67ba42ed21715a) cover the spread-arm refusal and the happy path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5a8648.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->