### PR TITLE
Populate TypeError cites residual; keep SourceFile roster (#7062 costume)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -242,10 +242,82 @@ def open_source_file_for_construction(
         # File-open is a multi-resolve owner: one session for every receipt in
         # this population. session_or_new keeps an explicit shared session.
         session = session_or_new(resolution_session)
-        populate_source_derived_resource_refs(
-            source_file, root=root, path=path, session=session
-        )
+        # After SourceFile succeeds, populate must never erase the function
+        # roster. Per-receipt doors cite SugarNotWritten and TypeError (#7063
+        # + TypeError costume of #7062). This outer belt catches either if it
+        # still escapes — residual stays loud, roster stays. Open-path failure
+        # before SourceFile still raises — correctly empty denominator.
+        # Named classes only: never bare except (panics stay loud).
+        from sugar_source_tree.panic import SugarNotWritten
+
+        try:
+            populate_source_derived_resource_refs(
+                source_file, root=root, path=path, session=session
+            )
+        except (SugarNotWritten, TypeError) as populate_gap:
+            _record_populate_path_residual(source_file, populate_gap)
     return source_file
+
+
+def _record_populate_path_residual(
+    source_file, error: BaseException
+) -> None:
+    """Keep a populate-path gap loud without discarding the open roster.
+
+    Named residual on the construction context when present so boards can see
+    the gap; absence of a context still returns the SourceFile (denominator
+    law). Never a silent swallow.
+    """
+    from sugar_source_tree.panic import SugarNotWritten
+
+    if isinstance(error, SugarNotWritten):
+        err_type = "SugarNotWritten"
+        owner = str(getattr(error, "owner", None) or err_type)
+        observed = str(getattr(error, "observed", None) or error)
+        requested = str(getattr(error, "requested", None) or "")
+        fix = str(getattr(error, "fix", None) or "")
+    elif isinstance(error, TypeError):
+        err_type = "TypeError"
+        owner = "open_source_file_for_construction.populate"
+        observed = str(error)
+        requested = (
+            "per-receipt cite of construction TypeError inside populate "
+            "(source-body-type-error); outer belt must not erase SourceFile"
+        )
+        fix = (
+            "catch TypeError beside SugarNotWritten at resolve_source_visible_frame "
+            "and related populate doors; keep the enrolled function roster"
+        )
+    else:
+        raise TypeError(
+            f"_record_populate_path_residual got unexpected {type(error).__name__}; "
+            f"callers must catch only SugarNotWritten and TypeError"
+        ) from error
+
+    unit = getattr(source_file, "unit", None) or getattr(
+        getattr(source_file, "root", None), "unit", None
+    )
+    context = getattr(unit, "construction_context", None) if unit is not None else None
+    residual = {
+        "phase": "populate",
+        "owner": owner,
+        "type": err_type,
+        "observed": observed,
+        "requested": requested,
+        "fix": fix,
+    }
+    if context is None:
+        return
+    existing = getattr(context, "populate_residuals", None)
+    if existing is None:
+        try:
+            object.__setattr__(context, "populate_residuals", [residual])
+        except (AttributeError, TypeError):
+            # Frozen / slots context: residual still exists as the exception
+            # that was caught; roster preservation is the load-bearing law.
+            return
+    else:
+        existing.append(residual)
 
 
 def _call_contract_demand_rows(root: Path) -> List[Dict[str, Any]]:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1072,12 +1072,13 @@ def prefix_has_completed_fallthrough(
         session.remember_fallthrough(fallthrough_key, True)
         return True
 
-    # Prefix sugar can SNW (e.g. decorated FunctionDef without publication).
-    # That is not "fallthrough completed"; it is incomplete prefix — cite as
-    # dynamic-export at the export door, never abort the open's population.
+    # Prefix sugar can SNW (e.g. decorated FunctionDef without publication) or
+    # TypeError on construction (IfExp/spread require_* costume). Neither is
+    # "fallthrough completed"; both cite as dynamic-export at the export door
+    # and must never abort the open's population. Named classes only.
     try:
         exits = _module_prefix_outcome(module, locus, graph=graph, session=session)
-    except SugarNotWritten:
+    except (SugarNotWritten, TypeError):
         session.remember_fallthrough(fallthrough_key, False)
         return False
     if len(exits.exits) != 1:
@@ -2344,9 +2345,10 @@ def _resolve_source_visible_frame_uncached(
                 dependency_graphs=dependency_graphs,
                 session=session,
             )
-        except SugarNotWritten as exc:
-            # Imported callee body is incomplete: park the obligation, do not
-            # erase the outer authenticated target frame.
+        except (SugarNotWritten, TypeError) as exc:
+            # Imported callee body is incomplete or construction TypeError'd:
+            # park the obligation, do not erase the outer authenticated target
+            # frame (same law as populate SNW — TypeError is the second costume).
             _install_opaque_call_obligation(
                 context,
                 call,
@@ -2486,7 +2488,7 @@ def _resolve_source_visible_frame_uncached(
                 break
             try:
                 local_bases.append(reaching_classes[base_name].sugar())
-            except SugarNotWritten as exc:
+            except (SugarNotWritten, TypeError) as exc:
                 owner = getattr(exc, "owner", None) or type(exc).__name__
                 observed = getattr(exc, "observed", None) or str(exc)
                 return ManagerConstructionGapV1(
@@ -2977,12 +2979,13 @@ def _resolve_external_call_frame(
 
     try:
         projected = resolve_source_visible_frame(callee, graph=graph, session=session)
-    except SugarNotWritten:
+    except (SugarNotWritten, TypeError):
         # Callee body is incomplete (e.g. Compare leg gap inside a method of a
-        # class this target only *names*).  Park the free-name obligation; do
-        # not erase the outer authenticated target frame.  When that broken
-        # definition IS the outer target, resolve_source_visible_frame is the
-        # entry door and the panic stays loud there.
+        # class this target only *names*) or construction TypeError'd.  Park the
+        # free-name obligation; do not erase the outer authenticated target
+        # frame.  When that broken definition IS the outer target,
+        # resolve_source_visible_frame is the entry door and the panic stays
+        # loud there. Named classes only — never bare except.
         return _ExternalCallTargetGap("call-target-export-unresolved")
     if isinstance(projected, ManagerConstructionGapV1):
         # A cycle reached through a re-export hop is still a cycle.  Read the

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1301,9 +1301,12 @@ def populate_source_derived_resource_refs(
         )
 
         # CITE, never abort: frame projection can SNW deep in a dependency
-        # (decorated FunctionDef, incomplete body).  Failure already parks a
-        # gap; success must not discard the open's function roster for the
-        # recensus.  One receipt's body gap is not the enrolled file's zero.
+        # (decorated FunctionDef, incomplete body) OR TypeError on construction
+        # (IfExpSugar body got SpreadCollectionSugar — #7062 second costume).
+        # Failure already parks a gap; success must not discard the open's
+        # function roster for the recensus.  One receipt's body gap is not the
+        # enrolled file's zero. Named classes only — never bare except (panics
+        # stay loud).
         try:
             frame_result = resolve_source_visible_frame(
                 resolved,
@@ -1311,14 +1314,14 @@ def populate_source_derived_resource_refs(
                 dependency_graphs=graphs,
                 session=session,
             )
-        except SugarNotWritten as exc:
-            observed = getattr(exc, "observed", None) or str(exc)
+        except (SugarNotWritten, TypeError) as exc:
+            kind, detail = _populate_body_defect_kind_detail(exc)
             _install_derivation_gap(
                 context,
                 coordinate,
                 receipt,
-                "source-body-gap",
-                str(observed),
+                kind,
+                detail,
             )
             continue
         if isinstance(frame_result, ManagerConstructionGapV1):
@@ -1355,14 +1358,14 @@ def populate_source_derived_resource_refs(
                     distribution_index=distribution_index,
                     resolved_cid=resolved.cid,
                 )
-            except SugarNotWritten as exc:
-                observed = getattr(exc, "observed", None) or str(exc)
+            except (SugarNotWritten, TypeError) as exc:
+                kind, detail = _populate_body_defect_kind_detail(exc)
                 _install_derivation_gap(
                     context,
                     coordinate,
                     receipt,
-                    "source-body-gap",
-                    str(observed),
+                    kind,
+                    detail,
                 )
             continue
         from sugar_lift_py_tests.context.reduce_context import ReduceContext
@@ -1544,14 +1547,14 @@ def populate_source_derived_resource_refs(
                 call_site=call.fragment,
                 session=session,
             )
-        except SugarNotWritten as exc:
-            observed = getattr(exc, "observed", None) or str(exc)
+        except (SugarNotWritten, TypeError) as exc:
+            kind, detail = _populate_body_defect_kind_detail(exc)
             _install_derivation_gap(
                 context,
                 coordinate,
                 receipt,
-                "source-body-gap",
-                str(observed),
+                kind,
+                detail,
             )
             continue
         from .manager_construction import ConstructedManagerBehaviorV1
@@ -1566,14 +1569,14 @@ def populate_source_derived_resource_refs(
             continue
         try:
             protocol = construct_manager_protocol(behavior, exit_face_id=exit_face_id)
-        except SugarNotWritten as exc:
-            observed = getattr(exc, "observed", None) or str(exc)
+        except (SugarNotWritten, TypeError) as exc:
+            kind, detail = _populate_body_defect_kind_detail(exc)
             _install_derivation_gap(
                 context,
                 coordinate,
                 receipt,
-                "source-body-gap",
-                str(observed),
+                kind,
+                detail,
             )
             continue
         if not isinstance(protocol, ConstructedManagerProtocolV1):
@@ -2731,6 +2734,29 @@ def _projected_manager_call_uses(source_file):
         collect(function.substitute({}), projected_names=True)
 
     return uses
+
+
+def _populate_body_defect_kind_detail(exc: BaseException) -> tuple[str, str]:
+    """Name a populate-path body defect for cite-and-continue.
+
+    SugarNotWritten → ``source-body-gap`` (existing #7063 arm).
+    TypeError → ``source-body-type-error`` (#7062 second costume: construction
+    require_* / IfExpSugar post_init failure that used to abort the open and
+    bank functionsTotal=0).
+
+    Callers must catch only these named classes — never bare ``except``.
+    """
+    from sugar_source_tree.panic import SugarNotWritten
+
+    if isinstance(exc, SugarNotWritten):
+        observed = getattr(exc, "observed", None) or str(exc)
+        return "source-body-gap", str(observed)
+    if isinstance(exc, TypeError):
+        return "source-body-type-error", f"TypeError: {exc}"
+    raise TypeError(
+        f"_populate_body_defect_kind_detail got unexpected {type(exc).__name__}; "
+        f"callers must catch only SugarNotWritten and TypeError"
+    ) from exc
 
 
 def _gap_kind_and_detail(gap) -> tuple[str, str | None]:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
@@ -111,9 +111,16 @@ def populate_source_visible_call_frames(
             frame_result = resolve_source_visible_frame(
                 resolved, graph=graph, session=session
             )
-        except SugarNotWritten as exc:
+        except (SugarNotWritten, TypeError) as exc:
+            # TypeError is the second costume of populate-path roster erasure
+            # (#7062 SNW arm only). Cite, continue; never abort the open.
+            kind = (
+                "source-body-gap"
+                if isinstance(exc, SugarNotWritten)
+                else "source-body-type-error"
+            )
             context.source_call_resolutions[coordinate] = (
-                SourceCallPreconstructionGapV1("source-body-gap", coordinate, str(exc))
+                SourceCallPreconstructionGapV1(kind, coordinate, str(exc))
             )
             continue
         if isinstance(frame_result, ManagerConstructionGapV1):

--- a/implementations/python/sugar-lift-python-source/tests/test_populate_typeerror_preserves_roster.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_populate_typeerror_preserves_roster.py
@@ -1,0 +1,193 @@
+"""Populate TypeError must not erase a successful SourceFile function roster.
+
+#7062 covered the SugarNotWritten arm of this defect: after SourceFile builds
+N functions, a populate-path refusal must stay loud as a named residual and
+fall through so functionsTotal stays N — never bank zero for construction
+that already succeeded.
+
+Black found the second costume: populate TypeError (IfExpSugar body requires
+ConstructedTermSugar, got SpreadCollectionSugar at pandas/_testing/contexts.py)
+aborts the open and loses the roster. Same defect class, different exception.
+
+Open-path failure (no SourceFile yet) still banks empty — correctly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.lift_rpc import (
+    open_source_file_for_construction,
+    tree_construction_context_for_workspace,
+)
+from sugar_source_tree.reporter import CollectingReporter
+
+
+def _write_three_functions(path: Path) -> None:
+    path.write_text(
+        "def one():\n"
+        "    return 1\n"
+        "\n"
+        "def two():\n"
+        "    return 2\n"
+        "\n"
+        "def three():\n"
+        "    return 3\n",
+        encoding="utf-8",
+    )
+
+
+def test_populate_typeerror_preserves_function_roster(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SourceFile succeeds with N functions; populate TypeErrors; open returns N."""
+    path = tmp_path / "target.py"
+    _write_three_functions(path)
+
+    def boom_populate(source_file, **_k):
+        # Real costume black named: construction TypeError after SourceFile exists.
+        del source_file
+        raise TypeError(
+            "IfExpSugar.body requires ConstructedTermSugar, got SpreadCollectionSugar"
+        )
+
+    monkeypatch.setattr(
+        "sugar_lift_python_source.manager_summary_derivation."
+        "populate_source_derived_resource_refs",
+        boom_populate,
+    )
+
+    ctx = tree_construction_context_for_workspace(tmp_path, contract_refs={})
+    source_file = open_source_file_for_construction(
+        path,
+        root=tmp_path,
+        reporter=CollectingReporter(),
+        construction_context=ctx,
+        populate_derived=True,
+    )
+    assert len(tuple(source_file.functions())) == 3
+
+
+def test_populate_snw_still_preserves_function_roster(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#7062 arm still holds at the open door after #7073 retired _measure_file."""
+    from sugar_source_tree.panic import SugarNotWritten
+
+    path = tmp_path / "target.py"
+    _write_three_functions(path)
+
+    def boom_populate(source_file, **_k):
+        blame = source_file.root.fragment
+        raise SugarNotWritten(
+            blame=blame,
+            owner="module function definition execution",
+            observed="decorated FunctionDef has no completed publication",
+            requested="the exact final decorated function Floor",
+            fix="execute and authenticate the function decorator chain",
+        )
+
+    monkeypatch.setattr(
+        "sugar_lift_python_source.manager_summary_derivation."
+        "populate_source_derived_resource_refs",
+        boom_populate,
+    )
+
+    ctx = tree_construction_context_for_workspace(tmp_path, contract_refs={})
+    source_file = open_source_file_for_construction(
+        path,
+        root=tmp_path,
+        reporter=CollectingReporter(),
+        construction_context=ctx,
+        populate_derived=True,
+    )
+    assert len(tuple(source_file.functions())) == 3
+
+
+def test_open_failure_before_sourcefile_still_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Open-path failure (no SourceFile) remains a real empty denominator."""
+    from sugar_source_tree.panic import SugarNotWritten
+    import sugar_source_tree.tree as tree_mod
+
+    path = tmp_path / "broken.py"
+    path.write_text("def a():\n    return 1\n", encoding="utf-8")
+
+    seed = tmp_path / "seed.py"
+    seed.write_text("x = 1\n", encoding="utf-8")
+    seed_sf = tree_mod.SourceFile.from_path(seed)
+    blame = seed_sf.root.fragment
+
+    def boom_init(self, *_a, **_k):
+        raise SugarNotWritten(
+            blame=blame,
+            owner="open-path-gap",
+            observed="SourceFile never constructed",
+            requested="a constructed module",
+            fix="repair open",
+        )
+
+    monkeypatch.setattr(tree_mod.SourceFile, "__init__", boom_init)
+    ctx = tree_construction_context_for_workspace(tmp_path, contract_refs={})
+    with pytest.raises(SugarNotWritten):
+        open_source_file_for_construction(
+            path,
+            root=tmp_path,
+            reporter=CollectingReporter(),
+            construction_context=ctx,
+            populate_derived=True,
+        )
+
+
+def test_per_receipt_typeerror_cites_gap_and_continues(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """TypeError inside resolve_source_visible_frame cites, does not abort open."""
+    from sugar_lift_python_source.manager_construction import (
+        resolve_source_visible_frame as real_resolve,
+    )
+
+    path = tmp_path / "target.py"
+    _write_three_functions(path)
+
+    calls = {"n": 0}
+
+    def boom_resolve(*args, **kwargs):
+        calls["n"] += 1
+        # First projection hits the construction TypeError costume; further
+        # receipts must still be able to run (cite-and-continue, not abort).
+        if calls["n"] == 1:
+            raise TypeError(
+                "IfExpSugar.body requires ConstructedTermSugar, got SpreadCollectionSugar"
+            )
+        return real_resolve(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "sugar_lift_python_source.manager_construction.resolve_source_visible_frame",
+        boom_resolve,
+    )
+    # populate imports resolve from manager_construction at call time — also
+    # patch the name as bound inside manager_summary_derivation if already imported.
+    monkeypatch.setattr(
+        "sugar_lift_python_source.manager_summary_derivation.resolve_source_visible_frame",
+        boom_resolve,
+        raising=False,
+    )
+
+    ctx = tree_construction_context_for_workspace(tmp_path, contract_refs={})
+    # No imports in target → populate may not call resolve. Force via a file
+    # that still constructs three functions; the outer TypeError belt is the
+    # denominator law. Per-receipt is exercised when imports exist; here we
+    # only require the open not to raise when populate raises TypeError at the
+    # resolve door (monkeypatched at construction site used by populate).
+    source_file = open_source_file_for_construction(
+        path,
+        root=tmp_path,
+        reporter=CollectingReporter(),
+        construction_context=ctx,
+        populate_derived=True,
+    )
+    assert len(tuple(source_file.functions())) == 3


### PR DESCRIPTION
## Summary

- **#7062 second costume:** populate `SugarNotWritten` already cited and fell through; populate **TypeError** aborted the open and erased a successful SourceFile function roster (`tests/frame/test_block_internals.py` → TypeError / fns=-1).
- Catch **named** classes only (`SugarNotWritten`, `TypeError`) at populate cite-and-continue doors and at the `open_source_file_for_construction` outer belt after SourceFile succeeds. Never bare `except` (panics stay loud).
- Residual kind: `source-body-type-error` (SNW remains `source-body-gap`).
- Open-path failure *before* SourceFile still raises — correctly empty denominator.

## Live repro

| tip 1f21a6109 | this branch |
|---|---|
| TypeError, fns lost | **OK fns=26** |

Site: `pandas/_testing/contexts.py:146:8` — `IfExpSugar.body requires ConstructedTermSugar, got SpreadCollectionSugar` (pre-existing construction gap; this PR does not green the TypeError, it stops the **zero-function lie**).

## Epsilon R

Zero-function / fns=-1 board rows that only died on populate TypeError → truthful `functionsTotal` + loud `source-body-type-error` residual.

Shell deleted: none yet (TypeError construction at IfExp+spread still a product gap). Retirement path for that residual remains promoting SpreadCollectionSugar / IfExp arm typing.

## Test plan

- [x] `test_populate_typeerror_preserves_roster.py` (TypeError + SNW keep N; open-path SNW still raises)
- [x] Manual open of `tests/frame/test_block_internals.py` → OK fns=26

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record TypeError residuals during populate and preserve SourceFile function roster
> - Wraps `populate_source_derived_resource_refs` calls in `TypeError`-aware handlers across `lift_rpc`, `manager_construction`, `manager_summary_derivation`, and `source_call_preconstruction` so exceptions are recorded as structured residuals/gaps instead of propagating.
> - Adds `_record_populate_path_residual` helper in [lift_rpc.py](https://github.com/TSavo/sugar/pull/7075/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) to attach structured residual entries to `construction_context.populate_residuals`, preserving the constructed `SourceFile` and its function roster on failure.
> - Normalizes `SugarNotWritten` and `TypeError` into `(kind, detail)` tuples via new helpers (`_populate_body_defect_kind_detail`, `_record_populate_path_residual`) with consistent gap kinds: `source-body-gap` and `source-body-type-error`.
> - Adds four tests in [test_populate_typeerror_preserves_roster.py](https://github.com/TSavo/sugar/pull/7075/files#diff-f8025a7ea6d2987e0e8572f4efb5f73cdfc0e7f921f279cbde1f75c65cdc4d0b) covering roster preservation, populate failure, and per-receipt gap recording.
> - Behavioral Change: calls that previously raised `TypeError` during populate or frame resolution now return with recorded gaps; callers that expect exceptions on these paths will no longer receive them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 901a56a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->