### PR TITLE
Roster-floor law: bank SourceFile N before populate (close #7062 class)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -215,6 +215,13 @@ def open_source_file_for_construction(
     omitted, this door mints one session for the population so multi-receipt
     amortization is real; multi-file owners should pass one shared session so
     the same dependency definition is not re-projected per consumer file.
+
+    Roster-floor law: after SourceFile construction succeeds, N =
+    ``len(functions())`` is banked on the open as ``function_roster_floor``.
+    Any subsequent populate ``Exception`` is residualized and the SourceFile is
+    returned — the board may not undercut N without naming why. Open failure
+    *before* SourceFile still raises (empty denominator). Process-control
+    exceptions (``BaseException`` outside ``Exception``) still halt.
     """
     from sugar_lift_python_source.resolution_session import session_or_new
     from sugar_lift_python_source.source_oracle import workspace_path_source
@@ -234,6 +241,14 @@ def open_source_file_for_construction(
         reporter=reporter,
         construction_context=construction_context,
     )
+    # ROSTER FLOOR LAW (#7062 class close, #7075 second costume generalized):
+    # If SourceFile produced N functions, the board may never report fewer
+    # than N without naming why. Bank N *before* populate. Populate failure
+    # becomes a residual; it cannot erase the denominator. Open-path failure
+    # *before* this line still raises — correctly empty. A third costume is
+    # not another allowlist entry: any Exception after the bank is residual.
+    _bank_function_roster_floor(source_file)
+
     if populate_derived:
         from sugar_lift_python_source.manager_summary_derivation import (
             populate_source_derived_resource_refs,
@@ -242,57 +257,72 @@ def open_source_file_for_construction(
         # File-open is a multi-resolve owner: one session for every receipt in
         # this population. session_or_new keeps an explicit shared session.
         session = session_or_new(resolution_session)
-        # After SourceFile succeeds, populate must never erase the function
-        # roster. Per-receipt doors cite SugarNotWritten and TypeError (#7063
-        # + TypeError costume of #7062). This outer belt catches either if it
-        # still escapes — residual stays loud, roster stays. Open-path failure
-        # before SourceFile still raises — correctly empty denominator.
-        # Named classes only: never bare except (panics stay loud).
-        from sugar_source_tree.panic import SugarNotWritten
-
+        # Catch Exception, not BaseException: KeyboardInterrupt / SystemExit /
+        # GeneratorExit still halt the process. Do not enumerate SNW/TypeError
+        # here — that was the two-costume allowlist that left the class open.
         try:
             populate_source_derived_resource_refs(
                 source_file, root=root, path=path, session=session
             )
-        except (SugarNotWritten, TypeError) as populate_gap:
+        except Exception as populate_gap:  # noqa: BLE001 — floor law; see above
             _record_populate_path_residual(source_file, populate_gap)
     return source_file
 
 
-def _record_populate_path_residual(
-    source_file, error: BaseException
-) -> None:
-    """Keep a populate-path gap loud without discarding the open roster.
+def _bank_function_roster_floor(source_file) -> int:
+    """Bank N = len(SourceFile.functions()) as load-bearing open state.
 
-    Named residual on the construction context when present so boards can see
-    the gap; absence of a context still returns the SourceFile (denominator
-    law). Never a silent swallow.
+    The floor is the proof that construction already succeeded. Callers and
+    residual paths read it; populate cannot lower it. Returning the open after
+    a residual keeps ``functions()`` live; the banked floor is the invariant
+    pin when a board path would otherwise invent zero.
+    """
+    n = len(tuple(source_file.functions()))
+    try:
+        object.__setattr__(source_file, "function_roster_floor", n)
+    except (AttributeError, TypeError):
+        # If the SourceFile type forbids attributes, the live functions()
+        # roster still carries the denominator after residual return.
+        pass
+    unit = getattr(source_file, "unit", None) or getattr(
+        getattr(source_file, "root", None), "unit", None
+    )
+    context = getattr(unit, "construction_context", None) if unit is not None else None
+    if context is not None:
+        try:
+            object.__setattr__(context, "function_roster_floor", n)
+        except (AttributeError, TypeError):
+            pass
+    return n
+
+
+def _record_populate_path_residual(source_file, error: BaseException) -> None:
+    """Name a populate-path failure without discarding the banked roster floor.
+
+    Residual is always typed by the *actual* exception class name — no allowlist
+    of costumes. SugarNotWritten keeps its structured owner/observed/fix fields
+    when present; every other Exception is residualized generically so a third
+    costume cannot reintroduce the zero-function lie.
     """
     from sugar_source_tree.panic import SugarNotWritten
 
+    err_type = type(error).__name__
     if isinstance(error, SugarNotWritten):
-        err_type = "SugarNotWritten"
         owner = str(getattr(error, "owner", None) or err_type)
         observed = str(getattr(error, "observed", None) or error)
         requested = str(getattr(error, "requested", None) or "")
         fix = str(getattr(error, "fix", None) or "")
-    elif isinstance(error, TypeError):
-        err_type = "TypeError"
+    else:
         owner = "open_source_file_for_construction.populate"
-        observed = str(error)
+        observed = str(error) if str(error) else err_type
         requested = (
-            "per-receipt cite of construction TypeError inside populate "
-            "(source-body-type-error); outer belt must not erase SourceFile"
+            "populate residual after successful SourceFile; function_roster_floor "
+            f"preserved at {getattr(source_file, 'function_roster_floor', '?')}"
         )
         fix = (
-            "catch TypeError beside SugarNotWritten at resolve_source_visible_frame "
-            "and related populate doors; keep the enrolled function roster"
+            "cite this residual; never discard the banked SourceFile function "
+            "roster. The floor law forbids empty denominators after construction"
         )
-    else:
-        raise TypeError(
-            f"_record_populate_path_residual got unexpected {type(error).__name__}; "
-            f"callers must catch only SugarNotWritten and TypeError"
-        ) from error
 
     unit = getattr(source_file, "unit", None) or getattr(
         getattr(source_file, "root", None), "unit", None
@@ -305,6 +335,7 @@ def _record_populate_path_residual(
         "observed": observed,
         "requested": requested,
         "fix": fix,
+        "functionRosterFloor": getattr(source_file, "function_roster_floor", None),
     }
     if context is None:
         return

--- a/implementations/python/sugar-lift-python-source/tests/test_function_roster_floor_law.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_function_roster_floor_law.py
@@ -1,0 +1,158 @@
+"""Roster-floor law: SourceFile N is a floor the board may not undercut silently.
+
+#7062 fixed the SugarNotWritten arm. #7075 fixed the TypeError arm. Both are
+costumes of one defect: a populate-path failure after a successful SourceFile
+erased construction that already succeeded and banked functionsTotal=0 / fns=-1.
+
+A third costume is whatever exception nobody listed. This instrument does not
+extend an allowlist. It plants a failure *outside* the historical pair and
+demands the open still returns the banked roster, with the failure named as a
+populate residual.
+
+Invariant (enforced at open_source_file_for_construction):
+
+  If SourceFile produced N functions, the returned open may never lose those
+  N functions because populate failed. Populate failure after the bank is a
+  residual, not an empty denominator. Open-path failure *before* SourceFile
+  still raises — correctly empty.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.lift_rpc import (
+    open_source_file_for_construction,
+    tree_construction_context_for_workspace,
+)
+from sugar_source_tree.reporter import CollectingReporter
+
+
+class _UnlistedPopulateDefect(Exception):
+    """Third costume by construction: neither SugarNotWritten nor TypeError."""
+
+
+def _write_three_functions(path: Path) -> None:
+    path.write_text(
+        "def one():\n"
+        "    return 1\n"
+        "\n"
+        "def two():\n"
+        "    return 2\n"
+        "\n"
+        "def three():\n"
+        "    return 3\n",
+        encoding="utf-8",
+    )
+
+
+def _open(tmp_path: Path, path: Path):
+    ctx = tree_construction_context_for_workspace(tmp_path, contract_refs={})
+    return open_source_file_for_construction(
+        path,
+        root=tmp_path,
+        reporter=CollectingReporter(),
+        construction_context=ctx,
+        populate_derived=True,
+    )
+
+
+def test_unlisted_populate_exception_preserves_roster_floor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure outside the historical allowlist still keeps N and names why."""
+    path = tmp_path / "target.py"
+    _write_three_functions(path)
+
+    def boom_populate(source_file, **_k):
+        del source_file
+        raise _UnlistedPopulateDefect(
+            "third costume: not SNW, not TypeError — allowlist cannot see me"
+        )
+
+    monkeypatch.setattr(
+        "sugar_lift_python_source.manager_summary_derivation."
+        "populate_source_derived_resource_refs",
+        boom_populate,
+    )
+
+    source_file = _open(tmp_path, path)
+    assert len(tuple(source_file.functions())) == 3
+    # Floor is banked as load-bearing state, not inferred after the fact.
+    assert getattr(source_file, "function_roster_floor", None) == 3
+
+    ctx = source_file.root.unit.construction_context
+    residuals = list(getattr(ctx, "populate_residuals", None) or [])
+    assert residuals, "populate failure must stay loud as a named residual"
+    assert residuals[-1]["phase"] == "populate"
+    assert residuals[-1]["type"] == "_UnlistedPopulateDefect"
+    assert "third costume" in residuals[-1]["observed"]
+
+
+def test_runtime_error_and_value_error_also_preserve_floor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two more unlisted Exception subclasses — the door is not a pair of arms."""
+    path = tmp_path / "target.py"
+    _write_three_functions(path)
+
+    for exc in (
+        RuntimeError("populate runtime residual"),
+        ValueError("populate value residual"),
+    ):
+        def make_boom(planted):
+            def boom(source_file, **_k):
+                del source_file
+                raise planted
+
+            return boom
+
+        monkeypatch.setattr(
+            "sugar_lift_python_source.manager_summary_derivation."
+            "populate_source_derived_resource_refs",
+            make_boom(exc),
+        )
+        source_file = _open(tmp_path, path)
+        assert len(tuple(source_file.functions())) == 3
+        assert source_file.function_roster_floor == 3
+
+
+def test_open_path_failure_before_sourcefile_still_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Floor law does not invent a denominator when SourceFile never built."""
+    from sugar_source_tree.panic import SugarNotWritten
+    import sugar_source_tree.tree as tree_mod
+
+    path = tmp_path / "broken.py"
+    path.write_text("def a():\n    return 1\n", encoding="utf-8")
+    seed = tmp_path / "seed.py"
+    seed.write_text("x = 1\n", encoding="utf-8")
+    blame = tree_mod.SourceFile.from_path(seed).root.fragment
+
+    def boom_init(self, *_a, **_k):
+        raise SugarNotWritten(
+            blame=blame,
+            owner="open-path-gap",
+            observed="SourceFile never constructed",
+            requested="a constructed module",
+            fix="repair open",
+        )
+
+    monkeypatch.setattr(tree_mod.SourceFile, "__init__", boom_init)
+    with pytest.raises(SugarNotWritten):
+        _open(tmp_path, path)
+
+
+def test_successful_open_banks_floor_matching_functions(
+    tmp_path: Path,
+) -> None:
+    """Happy path: floor equals the live function roster."""
+    path = tmp_path / "target.py"
+    _write_three_functions(path)
+    source_file = _open(tmp_path, path)
+    n = len(tuple(source_file.functions()))
+    assert n == 3
+    assert source_file.function_roster_floor == n


### PR DESCRIPTION
## Summary

Closes the **class** that #7062 (SNW) and #7075 (TypeError) each fixed as a costume.

**Invariant:** If SourceFile produced N functions, the board may never report fewer than N without naming why.

**Enforcement at the door** (`open_source_file_for_construction`):
1. After SourceFile construction succeeds, bank `N = len(functions())` as `function_roster_floor` **before** populate.
2. Any populate `Exception` is residualized by its **actual** type name and the SourceFile is returned.
3. Open failure **before** SourceFile still raises (empty denominator correct).
4. Catch `Exception`, not `BaseException` — process-control still halts. Not an allowlist of SNW/TypeError; the next unlisted costume cannot reintroduce the lie.

## Instrument

`test_function_roster_floor_law.py` plants:
- `_UnlistedPopulateDefect` (neither SNW nor TypeError — third costume by construction)
- `RuntimeError` / `ValueError`
- open-path failure still raises
- happy path floor == live roster

## Epsilon R

Class of post-SourceFile roster-erasure lies → unrepresentable at the open door.

**Shell deleted:** exception-class allowlist as the protection mechanism (retired by the floor).

## Test plan

- [x] `test_function_roster_floor_law.py`
- [x] Prior #7075 tests still pass
- [x] `tests/frame/test_block_internals.py` still OK fns=26

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bank `function_roster_floor` on `SourceFile` before populate and broaden populate error handling
> - Adds a new `_bank_function_roster_floor` helper that computes `N = len(SourceFile.functions())` immediately after `SourceFile` construction and sets `function_roster_floor` on the instance (and construction context when available).
> - Broadens populate error handling in `open_source_file_for_construction` to catch any `Exception` (not just `SugarNotWritten` and `TypeError`), recording all failures as residuals via `_record_populate_path_residual` and returning the `SourceFile`; process-control exceptions still propagate.
> - `_record_populate_path_residual` now dynamically computes residual type names, includes `functionRosterFloor` in the payload, and no longer raises on unlisted exception types.
> - Adds [test_function_roster_floor_law.py](https://github.com/TSavo/sugar/pull/7076/files#diff-5869c3b77287085b632cf56e6db7b32f06249f6d2ace9210e1ab6233ff5473ba) covering floor banking on success, residualization of arbitrary populate exceptions, and pre-construction failures still raising.
> - Behavioral Change: exceptions other than `SugarNotWritten` and `TypeError` during populate were previously unhandled and would propagate; they are now caught and recorded as residuals.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c512f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->