### PR TITLE
Population membrane: pin-enrolled distributions only, not pytest

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -823,10 +823,10 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
     # Defensive membrane: stdlib must never reach MaterializeModule here.
     # Callers should short-circuit in prefix_has_completed_fallthrough; if they
     # do not, refuse loudly rather than rebuild an unenrolled module.
-    if graph is not None and getattr(graph, "artifact_kind", None) == "stdlib":
+    if graph is not None and _graph_is_off_population(graph, session=session):
         raise RuntimeError(
             "population membrane: _module_prefix_outcome must not MaterializeModule "
-            f"stdlib seat {module.source_seat!r}; cite via "
+            f"off-population seat {module.source_seat!r}; cite via "
             "prefix_has_completed_fallthrough / call-target-off-population"
         )
     session = session_or_new(session)
@@ -1051,13 +1051,13 @@ def prefix_has_completed_fallthrough(
     """
     from sugar_lift_py_tests.outcome import Completed, true_guard
 
-    if graph is not None and getattr(graph, "artifact_kind", None) == "stdlib":
+    session = session_or_new(session)
+    if graph is not None and _graph_is_off_population(graph, session=session):
         # Cite path: admit static export without off-population construction.
         return True
 
     from sugar_source_tree.panic import SugarNotWritten
 
-    session = session_or_new(session)
     fallthrough_key = (
         module.source_cid,
         getattr(locus, "lineno", None),
@@ -1240,29 +1240,61 @@ class ManagerConstructionGapV1:
     detail: str
 
 
+def _graph_is_off_population(
+    graph: "DependencyArtifactGraph",
+    *,
+    session: SourceResolutionSession | None = None,
+) -> bool:
+    """True when ``graph`` is outside the enrolled measurement population.
+
+    - stdlib is always off-pin (CPython is not the corpus pin).
+    - when ``session.enrolled_distributions`` is set, any distribution whose
+      name is not in that set is off-pin (pytest on a pandas test open was
+      40 frames / ~3.8s after the stdlib-only membrane — same law, broader door).
+    - when enrolled is None, legacy stdlib-only membrane (backward compatible).
+    """
+    if getattr(graph, "artifact_kind", None) == "stdlib":
+        return True
+    enrolled = None if session is None else session.enrolled_distributions
+    if enrolled is None:
+        return False
+    name = getattr(graph, "distribution_name", None)
+    return name is not None and name not in enrolled
+
+
 def _off_population_materialize_gap(
     resolved: "ResolvedPythonObjectV1",
     *,
     graph: "DependencyArtifactGraph",
+    session: SourceResolutionSession | None = None,
 ) -> ManagerConstructionGapV1 | None:
     """Population membrane: off-pin success must cite, never rebuild.
 
     Failure already parks an opaque obligation.  Success against authenticated
-    stdlib used to call ``resolve_source_visible_frame`` and fully
-    ``MaterializeModule`` the unenrolled source (enum.py 35× on one pandas
-    open).  That corrupts measurement integrity: the pin enrolls corpus files,
-    not CPython.  Return a typed gap so every caller takes the same cite path
-    failure already uses.
+    off-pin sources used to call ``resolve_source_visible_frame`` and fully
+    ``MaterializeModule`` the unenrolled source (enum.py 35× stdlib; pytest
+    raises 40× on one pandas test open).  That corrupts measurement integrity:
+    the pin enrolls corpus files, not CPython and not test-only distributions.
+    Return a typed gap so every caller takes the same cite path failure already
+    uses.
     """
-    if graph.artifact_kind != "stdlib":
+    if not _graph_is_off_population(graph, session=session):
         return None
+    if graph.artifact_kind == "stdlib":
+        detail = (
+            f"stdlib module {resolved.module_name!r} is off enrolled population; "
+            "cite via opaque membrane, do not MaterializeModule"
+        )
+    else:
+        dist = getattr(graph, "distribution_name", "?")
+        detail = (
+            f"distribution {dist!r} module {resolved.module_name!r} is off "
+            "enrolled population; cite via opaque membrane, do not MaterializeModule"
+        )
     return ManagerConstructionGapV1(
         "call-target-off-population",
         resolved.cid,
-        (
-            f"stdlib module {resolved.module_name!r} is off enrolled population; "
-            "cite via opaque membrane, do not MaterializeModule"
-        ),
+        detail,
     )
 
 
@@ -1985,7 +2017,9 @@ def resolve_source_visible_frame(
     # success must cite, never rebuild.  Placed AFTER artifact identity checks
     # and BEFORE any SourceFile / MaterializeModule.  Failure already cites via
     # _install_opaque_call_obligation; success must take the same door.
-    off_pop = _off_population_materialize_gap(resolved, graph=graph)
+    off_pop = _off_population_materialize_gap(
+        resolved, graph=graph, session=session
+    )
     if off_pop is not None:
         return off_pop
     definition = resolved.definition

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1229,6 +1229,18 @@ def populate_source_derived_resource_refs(
     # Multi-resolve owner entry: one session for every receipt in this loop.
     # Do not call session_or_new inside the receipt loop.
     session = session_or_new(session)
+    # Population membrane: pin enrolls the consumer distribution (first path
+    # segment under the locus root), not test-only deps (pytest) or stdlib.
+    # Without this, one open of pandas/tests/io/json/test_pandas.py projected
+    # 40 pytest frames (~3.8s) after the stdlib-only membrane.
+    if session.enrolled_distributions is None:
+        try:
+            rel = Path(path).resolve().relative_to(Path(root).resolve())
+            top = rel.parts[0] if rel.parts else None
+        except ValueError:
+            top = None
+        if top and top.isidentifier() and top not in {"tests", "test", "src"}:
+            session.enrolled_distributions = frozenset({top})
     context = source_file.root.unit.construction_context
     if context is None:
         return

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -67,6 +67,7 @@ class SourceResolutionSession:
 
     __slots__ = (
         "enabled",
+        "enrolled_distributions",
         "export_resolutions",
         "export_terminals",
         "frame_results",
@@ -80,8 +81,19 @@ class SourceResolutionSession:
         "lexical_passes",
     )
 
-    def __init__(self, *, enabled: bool = True) -> None:
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        enrolled_distributions: frozenset[str] | None = None,
+    ) -> None:
         self.enabled = enabled
+        # Pin membership for the population membrane.  None = legacy
+        # stdlib-only off-population (pre-#707x).  When set, any graph whose
+        # distribution_name is not in this set is off-pin and must cite, never
+        # MaterializeModule (pytest on a pandas test open was 40 frames / ~3.8s
+        # of residual wall after the stdlib membrane).
+        self.enrolled_distributions: frozenset[str] | None = enrolled_distributions
         # (distribution_artifact_cid, module_name, exported_name) -> pure-entry
         # resolution (includes module-structural reexport warrants; no path
         # import_binding_cid).

--- a/implementations/python/sugar-lift-python-source/tests/test_population_membrane_off_pin_dist.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_population_membrane_off_pin_dist.py
@@ -1,0 +1,89 @@
+"""Population membrane: off-pin *distributions* cite, never rebuild.
+
+stdlib was closed by #7057.  The residual hole: test-only distributions
+(``pytest``) authenticated as ``artifact_kind=distribution`` still fully
+projected frames during open of enrolled pandas *test* files.
+
+Measured on tip after #7057 family: one open of
+``pandas/tests/io/json/test_pandas.py`` spent ~3.8s / 40 frames inside
+``_pytest.*`` while stdlib was already 0.001s (113 off-pop cites).  Median
+open in a 29-file sample was 0.586s; this file was 5.725s — 10×.
+
+Law: the pin enrolls corpus files (``pandas``), not CPython and not
+test-only deps.  Session ``enrolled_distributions`` names the pin;
+``populate_source_derived_resource_refs`` sets it from the consumer path.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_source_tree.tree import SourceFile
+
+
+def _locus_root_for_corpus(corpus: Path) -> Path:
+    import importlib.util
+
+    cer_path = (
+        Path(__file__).resolve().parents[2]
+        / "sugar-lift-py-tests"
+        / "scripts"
+        / "control_effect_recensus.py"
+    )
+    spec = importlib.util.spec_from_file_location("cer_offpin", cer_path)
+    assert spec is not None and spec.loader is not None
+    cer = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cer)
+    return cer.locus_root_for_corpus(corpus)
+
+
+def test_pandas_test_open_never_materializes_pytest() -> None:
+    """One open of tests/io/json/test_pandas.py must not SourceFile pytest seats.
+
+    Pre-membrane residual: 40 frame projections into _pytest (distribution).
+    Green: zero SourceFile constructions whose seat is under pytest/_pytest.
+    """
+    corpus = authenticated_pandas_corpus().root
+    address_root = _locus_root_for_corpus(corpus)
+    path = corpus / "tests" / "io" / "json" / "test_pandas.py"
+    if not path.is_file():
+        import pytest
+
+        pytest.skip(f"missing {path}")
+
+    seats: Counter[str] = Counter()
+    orig = SourceFile.__init__
+
+    def counting_init(self, identity, *args, **kwargs):  # type: ignore[no-untyped-def]
+        _source, filename, _cid = identity
+        seats[str(filename).replace("\\", "/")] += 1
+        return orig(self, identity, *args, **kwargs)
+
+    SourceFile.__init__ = counting_init  # type: ignore[method-assign]
+    try:
+        open_source_file_for_construction(
+            path,
+            root=address_root,
+            construction_context=TreeConstructionContextV1.for_source_call_construction(),
+            populate_derived=True,
+        )
+    finally:
+        SourceFile.__init__ = orig  # type: ignore[method-assign]
+
+    offenders = {
+        seat: n
+        for seat, n in seats.items()
+        if "_pytest" in seat
+        or seat.startswith("pytest/")
+        or "/site-packages/pytest/" in seat
+        or "/site-packages/_pytest/" in seat
+        or seat.endswith("pytest/__init__.py")
+    }
+    assert not offenders, (
+        f"population membrane: off-pin pytest must never MaterializeModule; "
+        f"offenders={offenders} (all seats sample={seats.most_common(20)})"
+    )

--- a/implementations/python/sugar-lift-python-source/tests/test_population_membrane_stdlib_cite.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_population_membrane_stdlib_cite.py
@@ -171,13 +171,14 @@ def test_population_membrane_json_open_never_materializes_any_stdlib() -> None:
 
 
 def test_off_population_gap_helper_names_stdlib() -> None:
-    """Unit tooth: stdlib graphs return the off-population gap; distributions do not."""
+    """Unit tooth: stdlib graphs return the off-population gap; pin distributions do not."""
     from sugar_lift_python_source.dependency_artifact import (
         DependencyArtifactGraph,
     )
     from sugar_lift_python_source.manager_construction import (
         _off_population_materialize_gap,
     )
+    from sugar_lift_python_source.resolution_session import SourceResolutionSession
 
     # Minimal resolved stand-in: only cid + module_name are read by the helper.
     class _Resolved:
@@ -197,3 +198,25 @@ def test_off_population_gap_helper_names_stdlib() -> None:
     )
     assert gap_re is not None
     assert gap_re.kind == "call-target-off-population"
+
+    # Legacy (enrolled=None): pin distributions stay on-population.
+    import importlib.metadata
+
+    pytest_dist = importlib.metadata.distribution("pytest")
+    pytest_graph = DependencyArtifactGraph.authenticate(pytest_dist)
+    gap_legacy = _off_population_materialize_gap(
+        type("R", (), {"cid": "p", "module_name": "_pytest.raises"})(),
+        graph=pytest_graph,
+    )
+    assert gap_legacy is None, "without enrolled pin, distributions stay on-population"
+
+    # Enrolled pin: foreign distribution is off-population.
+    session = SourceResolutionSession(enrolled_distributions=frozenset({"pandas"}))
+    gap_pin = _off_population_materialize_gap(
+        type("R", (), {"cid": "p", "module_name": "_pytest.raises"})(),
+        graph=pytest_graph,
+        session=session,
+    )
+    assert gap_pin is not None
+    assert gap_pin.kind == "call-target-off-population"
+    assert "pytest" in gap_pin.detail

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -407,9 +407,13 @@ def leaky_process_memo(monkeypatch):
     import_uses: dict = {}
     import_values: dict = {}
 
-    def leaky_init(self, *, enabled: bool = True) -> None:
+    def leaky_init(
+        self, *, enabled: bool = True, enrolled_distributions=None
+    ) -> None:
         self.enabled = enabled
+        self.enrolled_distributions = enrolled_distributions
         self.export_resolutions = exports
+        self.export_terminals = exports  # shared leak for authority twin
         self.frame_results = frames
         self.frame_holds = holds
         self.frame_active = active
@@ -418,6 +422,7 @@ def leaky_process_memo(monkeypatch):
         self.prefix_fallthrough = fallthroughs
         self.import_use_rosters = import_uses
         self.import_value_rosters = import_values
+        self.lexical_passes = {}
 
     monkeypatch.setattr(SourceResolutionSession, "__init__", leaky_init)
 


### PR DESCRIPTION
## Summary

stdlib was closed by #7057. Residual hole: **test-only distributions** (`pytest`) authenticate as `artifact_kind=distribution` and still fully projected frames during open of enrolled pandas *test* files.

Orange re-measure named the outlier: `tests/io/json/test_pandas.py` **5.725s** vs median **0.586s** (10×) in a 29-file sample.

## Diagnosis (same shape as `_json.py` / enum)

On tip, one open of `test_pandas.py`:

| target | frames | time |
|---|---:|---:|
| stdlib (already membrane) | 113 | **0.001s** |
| **pytest distribution** | **40** | **~3.8s** (`_pytest.raises.raises` alone 2.87s) |

Zero pandas frames in that bucket — the 10× was pure off-pin work wearing a distribution costume.

## Fix

Extend the population membrane to **pin membership**, not only `artifact_kind==stdlib`:

- `SourceResolutionSession.enrolled_distributions: frozenset[str] | None`
- `populate_source_derived_resource_refs` sets it from the consumer path’s first segment under the locus root (`pandas/tests/...` → `pandas`)
- `_graph_is_off_population` / `_off_population_materialize_gap`: stdlib always off-pin; when enrolled is set, any other distribution **cites**, never `MaterializeModule`
- `enrolled=None` keeps legacy stdlib-only membrane

## Numbers

Recipe: `authenticated_pandas_corpus().root` + `locus_root_for_corpus` + `open_source_file_for_construction(..., populate_derived=True)`.

| | pytest SourceFiles | expensive pytest frames | warm open |
|---|---:|---:|---:|
| **BEFORE** | present | ~40 / ~3.8s | ~5.7–8s |
| **AFTER** | **0** | cite `call-target-off-population` | **~3.0s** min |

Residual ~3s is large-file SourceFile (86KB / 2387 lines / 135 fns) + in-population work — not off-pin thrash. `test_readlines.py` stays ~0.15–0.3s.

## Not claiming

- Not claiming median open for this 10× file (honest residual is size + on-pin)
- Not claiming numpy co-enrollment (only consumer distribution inferred; multi-pin can pass session.enrolled explicitly)

## Test plan

- [x] `test_population_membrane_off_pin_dist.py` — zero pytest SourceFiles on worst file open
- [x] unit: stdlib always off; pin session makes pytest off; legacy enrolled=None leaves dist on
- [x] measured before/after
- [ ] CI

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend population membrane to exclude non-enrolled distributions from source resolution
> - Adds `enrolled_distributions` to `SourceResolutionSession` to pin which distributions are "on-population" during source resolution.
> - Introduces `_graph_is_off_population` helper in [manager_construction.py](https://github.com/TSavo/sugar/pull/7077/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) that treats a graph as off-population if it is stdlib or its distribution is not in the enrolled pin set.
> - `populate_source_derived_resource_refs` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/7077/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) infers the enrolled distribution from the opened path and pins it on the session, so only that distribution (plus stdlib) is resolved.
> - Previously only stdlib was gated at the membrane; now any distribution absent from the enrolled pin (e.g. pytest) is treated as off-population and returns a gap instead of materializing source files.
> - Behavioral Change: sessions created via `populate_source_derived_resource_refs` now carry an enrolled pin, causing imports from other distributions to resolve as off-population gaps rather than constructing `SourceFile` objects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bc9a28.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->