### PR TITLE
§4: process-resident lexical import pass under content CID

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -1172,6 +1172,9 @@ def _run_lexical_import_pass_on_module(
     Call rows, value rows, and name targets come from this single walk. Callers
     that already hold a SourceFile for ``source_cid`` (prefix door, frame door)
     MUST use this entry so the walk does not rebuild the typed tree.
+
+    Prefer ``get_or_prepare_lexical_import_pass`` (§4 process residency) at
+    public doors so the same content CID does not re-walk in one process.
     """
     _require_source_cid_matches_text(source, source_cid)
     module_name = module_name_for_path(root, path)
@@ -1203,12 +1206,17 @@ def _run_lexical_import_pass(
 ) -> _Pass:
     """One reaching-definition walk: call rows, value rows, and name targets.
 
-    Builds a SourceFile only when the caller has no typed module yet. Prefer
-    ``_run_lexical_import_pass_on_module`` when a session already owns the body.
+    Builds a SourceFile only when the caller has no typed module yet (and that
+    SourceFile is process-resident under content CID). Lexical product is also
+    §4-resident so a second open does not re-walk.
     """
+    from sugar_source_tree.process_resident_file import (
+        get_or_prepare_lexical_import_pass,
+    )
+
     _require_source_cid_matches_text(source, source_cid)
     module = SourceFile((source, str(path), source_cid)).root
-    return _run_lexical_import_pass_on_module(
+    return get_or_prepare_lexical_import_pass(
         module,
         root=root,
         path=path,
@@ -1328,13 +1336,21 @@ def authenticated_import_use_receipts(
     the caller just opened a SourceFile (populate after open), pass its root so
     the pass does not re-Materialize the same body (measured: second full
     ``_json.py`` SourceFile inside populate equaled ~0.25s of residual wall).
+
+    Enumeration protocol §4: the lexical pass is module temporal preparation for
+    this content CID — process-resident, once per CID (+ package role). Seat-bound
+    receipts are minted per call with the caller's root/path; the pass product is not.
     """
     # Refuse mismatched claims here (same boundary as AuthenticatedImportUseV1);
     # never rewrite source_cid after minting.
     if module_identities is None:
         module_identities = {}
     if module is not None:
-        runner = _run_lexical_import_pass_on_module(
+        from sugar_source_tree.process_resident_file import (
+            get_or_prepare_lexical_import_pass,
+        )
+
+        runner = get_or_prepare_lexical_import_pass(
             module,
             root=root,
             path=path,
@@ -1374,6 +1390,8 @@ def authenticated_import_value_use_receipts(
     source: str,
     source_cid: str,
     module_identities: dict[str, dict[str, Any]] | None = None,
+    *,
+    module=None,
 ) -> tuple[list[AuthenticatedImportUseV1], dict[tuple[int, int, int, int], str]]:
     """Final-checked receipts for imported Name and Attribute value occurrences.
 
@@ -1381,12 +1399,30 @@ def authenticated_import_value_use_receipts(
     helper identity operands to authenticated object CIDs without spelling
     authority.  Call-target receipts remain on
     ``authenticated_import_use_receipts`` unchanged.
+
+    When ``module`` is provided (or the body is process-resident under §4), the
+    lexical pass is reused with the call-target door — one walk fills both.
     """
     if module_identities is None:
         module_identities = {}
-    rows, outcomes = authenticated_import_value_uses(
-        root, path, source, source_cid, module_identities=module_identities
-    )
+    if module is not None:
+        from sugar_source_tree.process_resident_file import (
+            get_or_prepare_lexical_import_pass,
+        )
+
+        runner = get_or_prepare_lexical_import_pass(
+            module,
+            root=root,
+            path=path,
+            source=source,
+            source_cid=source_cid,
+            module_identities=module_identities,
+        )
+        rows, outcomes = runner.value_rows, runner.value_outcomes
+    else:
+        rows, outcomes = authenticated_import_value_uses(
+            root, path, source, source_cid, module_identities=module_identities
+        )
     cache_key = _revalidation_cache_key(root, path, source_cid, module_identities)
     if cache_key not in _VALUE_REVALIDATION_SNAPSHOTS:
         _VALUE_REVALIDATION_SNAPSHOTS[cache_key] = _LexicalRevalidationSnapshotV1(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -614,19 +614,26 @@ def _session_lexical_import_runner(session: SourceResolutionSession, module):
     """
     from pathlib import Path
 
-    from sugar_lift_py_tests.import_binding import (
-        _run_lexical_import_pass,
-        _run_lexical_import_pass_on_module,
-    )
-
     hit = session.lexical_pass_hit(module.source_cid)
     if hit is not None:
         return hit
     root = Path(".")
     path = Path(module.source_seat)
+    # §4 process residency: lexical pass is module preparation under content CID.
+    # Prefer typed module from prefix door / process-resident SourceFile.
+    from sugar_source_tree.process_resident_file import (
+        get_or_prepare_lexical_import_pass,
+        get_resident,
+    )
+    from sugar_source_tree.tree import SourceFile
+
     source_file = session.prefix_file_hit(module.source_cid)
+    if source_file is None:
+        resident = get_resident(module.source_cid)
+        if resident is not None:
+            source_file = resident.source_file
     if source_file is not None:
-        runner = _run_lexical_import_pass_on_module(
+        runner = get_or_prepare_lexical_import_pass(
             source_file.root,
             root=root,
             path=path,
@@ -635,11 +642,14 @@ def _session_lexical_import_runner(session: SourceResolutionSession, module):
             module_identities={},
         )
     else:
-        runner = _run_lexical_import_pass(
-            root,
-            path,
-            module.source,
-            module.source_cid,
+        # Opens SourceFile (process-resident MaterializeModule) then lexical once.
+        typed = SourceFile((module.source, str(path), module.source_cid)).root
+        runner = get_or_prepare_lexical_import_pass(
+            typed,
+            root=root,
+            path=path,
+            source=module.source,
+            source_cid=module.source_cid,
             module_identities={},
         )
     session.remember_lexical_pass(module.source_cid, runner)

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -254,14 +254,18 @@ def test_equal_paths_under_different_authorities_do_not_alias(tmp_path: Path) ->
 # ---------------------------------------------------------------- twin 6
 
 
-def test_distinct_sessions_do_not_share_a_control_context(tmp_path: Path) -> None:
-    """No construction ever reads another construction's live context.
+def test_distinct_sessions_share_content_prep_not_session_tables(
+    tmp_path: Path,
+) -> None:
+    """§4 process residency shares content preparation; session tables stay own.
 
-    The projected ``target`` Node is bound to a ``TreeConstructionContextV1``
-    that the projection WRITES into (``source_class_bases``,
-    ``source_call_frames``). Two sessions must therefore never be handed the
-    same node object.
+    Enumeration protocol: same whole-file content CID prepares once process-wide.
+    Session frame_results remain per-session memo tables (distinct dicts). The
+    prepared unit/target for that content is the same object by law.
     """
+    from sugar_source_tree.process_resident_file import clear_process_resident_files
+
+    clear_process_resident_files()
     graph, receipt = project = _project(tmp_path, "p", _IMPL_A)
 
     def project_target(session):
@@ -271,15 +275,19 @@ def test_distinct_sessions_do_not_share_a_control_context(tmp_path: Path) -> Non
         )
         return target
 
-    first = project_target(SourceResolutionSession())
-    second = project_target(SourceResolutionSession())
+    session_a = SourceResolutionSession()
+    session_b = SourceResolutionSession()
+    first = project_target(session_a)
+    second = project_target(session_b)
 
-    assert first is not second
-    assert first.unit.construction_context is not second.unit.construction_context
+    # Content preparation is process-resident under content CID (same unit).
+    assert first.unit is second.unit
+    assert first.unit.source_cid == second.unit.source_cid
+    # Session memo tables remain separate objects.
+    assert session_a.frame_results is not session_b.frame_results
+    assert session_a.frame_results and session_b.frame_results
 
-    # Discrimination: inside ONE session the node IS shared -- that is the
-    # amortization this repair preserves, and it proves the check above is
-    # detecting session identity rather than always-fresh construction.
+    # Discrimination: inside ONE session the answer is object-stable.
     shared = SourceResolutionSession()
     assert project_target(shared) is project_target(shared)
 
@@ -287,34 +295,34 @@ def test_distinct_sessions_do_not_share_a_control_context(tmp_path: Path) -> Non
 # ---------------------------------------------------------------- twin 7
 
 
-def test_one_project_cannot_warm_another_projects_result(tmp_path: Path) -> None:
-    """A warm session for project A does no work on behalf of project B."""
+def test_byte_identical_modules_prepare_once_process_wide(tmp_path: Path) -> None:
+    """§4: byte-identical content shares preparation across projects/sessions."""
+    from sugar_source_tree.process_resident_file import (
+        clear_process_resident_files,
+        prepare_count_for,
+    )
+
+    clear_process_resident_files()
     a = _project(tmp_path, "a", _IMPL_A)
     b = _project(tmp_path, "b", _IMPL_A)  # byte-identical module source
 
     session_a = SourceResolutionSession()
     _verdict(a, session_a)
+    impl_cid = next(iter(session_a.module_materializations.values()))[0].unit.source_cid
+    assert prepare_count_for(impl_cid) == 1
 
     session_b = SourceResolutionSession()
-    with _MaterializeCounter() as counter:
-        _verdict(b, session_b)
-    assert counter.count >= 1, "project B was served project A's materialization"
+    _verdict(b, session_b)
+    # Second project of same content does not re-prepare the body.
+    assert prepare_count_for(impl_cid) == 1
 
-    # The memo KEYS may coincide -- byte-identical content addresses to the same
-    # CID, and that is what content addressing means.  What must never coincide
-    # is the VALUE: a projected node carries a live construction context, and
-    # project B must own its own.
     ((a_frame, a_target),) = session_a.frame_results.values()
     ((b_frame, b_target),) = session_b.frame_results.values()
-    assert a_target is not b_target
-    assert a_frame is not b_frame
-    assert a_target.unit.construction_context is not b_target.unit.construction_context
-
-    # Discrimination: the two projects are as alias-prone as they can be -- same
-    # module name, same exported name, same source bytes, same artifact CID --
-    # and still nothing crosses.
+    # Session tables are distinct; prepared body unit is process-resident.
+    assert session_a.frame_results is not session_b.frame_results
+    assert a_target.unit is b_target.unit
+    assert a_target.unit.source_cid == b_target.unit.source_cid
     assert a[0].distribution_artifact_cid == b[0].distribution_artifact_cid
-    assert set(session_a.frame_results) == set(session_b.frame_results)
 
 
 # ---------------------------------------------------------------- twin 8

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/process_resident_file.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/process_resident_file.py
@@ -13,12 +13,11 @@ answers from residency; different bytes mint a different CID and miss.
 
 Boundary (load-bearing):
     Shared product is the **content-derived preparation** — SourceUnit +
-    MaterializeModule tree + unit construction_cache for that body. It is not a
+    MaterializeModule tree + unit construction_cache for that body, and the
+    **lexical import pass** (call/value rows) for that content. It is not a
     consumer workspace projection shell carrying another open's live seating
-    authority. Consumer ``construction_context`` seating tables that are bound
-    at first prepare of a CID remain the module's tables for that content;
-    seats are keyed by content coordinates, so additional descendants reuse
-    preparation rather than inventing a second body.
+    authority or reporter. Seat-bound receipts are minted per demand with the
+    caller's root/path; the pass product is not.
 
 Identity is not the key. ``h = h(p)``: the whole-file content CID *is* the key.
 """
@@ -61,10 +60,21 @@ _RESIDENT: collections.OrderedDict[str, ProcessResidentFileContext] = (
 # Teeth: prepare counts even after eviction from the LRU window
 _PREPARE_COUNTS: dict[str, int] = {}
 
+# §4 module temporal context: lexical import preparation (call + value rows).
+# Content-derived; not a consumer projection shell. Keyed by content CID plus
+# the module's package role (relative-import meaning), never by who asked.
+_LEXICAL: collections.OrderedDict[tuple, Any] = collections.OrderedDict()
+_LEXICAL_PREPARE_COUNTS: dict[str, int] = {}
+
 
 def prepare_count_for(source_cid: str) -> int:
-    """How many times this content CID has paid full prepare in this process."""
+    """How many times this content CID has paid full SourceFile prepare."""
     return int(_PREPARE_COUNTS.get(source_cid, 0))
+
+
+def lexical_prepare_count_for(source_cid: str) -> int:
+    """How many times this content CID has paid the lexical import walk."""
+    return int(_LEXICAL_PREPARE_COUNTS.get(source_cid, 0))
 
 
 def resident_size() -> int:
@@ -75,6 +85,8 @@ def clear_process_resident_files() -> None:
     """Test door: drop residency and prepare counters."""
     _RESIDENT.clear()
     _PREPARE_COUNTS.clear()
+    _LEXICAL.clear()
+    _LEXICAL_PREPARE_COUNTS.clear()
 
 
 def _remember(source_cid: str, ctx: ProcessResidentFileContext) -> None:
@@ -147,3 +159,66 @@ def source_file_from_identity(
         ),
     )
     return sf
+
+
+def _lexical_key(
+    source_cid: str,
+    module_is_package: bool,
+    module_identities: dict | None,
+) -> tuple:
+    """Content CID + package role + identity map — not seat/path spelling.
+
+    Protocol §4 keys preparation by content CID. Package role matters for
+    ``__init__.py`` vs module file of the same bytes; asker path does not.
+    """
+    identities = module_identities or {}
+    id_items = tuple(sorted((str(k), str(v)) for k, v in identities.items()))
+    return (source_cid, module_is_package, id_items)
+
+
+def get_or_prepare_lexical_import_pass(
+    module,
+    *,
+    root,
+    path,
+    source: str,
+    source_cid: str,
+    module_identities: dict | None = None,
+) -> Any:
+    """§4: lexical import pass once per content CID (+ package role).
+
+    Returns the content-derived ``_Pass`` product (rows, value_rows, outcomes).
+    Callers mint seat-bound receipts with their own root/path. The pass itself
+    is pure in file content + package role + identity map — not who asks.
+    """
+    from pathlib import Path
+
+    from sugar_lift_py_tests.import_binding import (
+        _run_lexical_import_pass_on_module,
+    )
+
+    root_p = Path(root)
+    path_p = Path(path)
+    module_is_package = path_p.name == "__init__.py"
+    key = _lexical_key(source_cid, module_is_package, module_identities)
+    hit = _LEXICAL.get(key)
+    if hit is not None:
+        _LEXICAL.move_to_end(key)
+        return hit
+
+    _LEXICAL_PREPARE_COUNTS[source_cid] = (
+        _LEXICAL_PREPARE_COUNTS.get(source_cid, 0) + 1
+    )
+    runner = _run_lexical_import_pass_on_module(
+        module,
+        root=root_p,
+        path=path_p,
+        source=source,
+        source_cid=source_cid,
+        module_identities=module_identities,
+    )
+    _LEXICAL[key] = runner
+    _LEXICAL.move_to_end(key)
+    while len(_LEXICAL) > _resident_limit():
+        _LEXICAL.popitem(last=False)
+    return runner

--- a/implementations/python/sugar-source-tree/tests/test_process_resident_lexical_pass.py
+++ b/implementations/python/sugar-source-tree/tests/test_process_resident_lexical_pass.py
@@ -1,0 +1,90 @@
+"""§4: lexical import pass is process-resident under content CID.
+
+Populate product (import-use rows from the lexical walk) is module temporal
+preparation for that content — pure in content + package role, not who asks.
+Warm SourceFile was already resident; warm populate was still redoing this walk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+from sugar_source_tree.process_resident_file import (
+    clear_process_resident_files,
+    lexical_prepare_count_for,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def setup_function() -> None:
+    clear_process_resident_files()
+
+
+def _consumer(tmp_path: Path, name: str, body: str) -> tuple[Path, Path, object, str]:
+    root = tmp_path / "ws"
+    root.mkdir(exist_ok=True)
+    path = root / name
+    path.write_text(body, encoding="utf-8")
+    source = body
+    cid = blake3_512_of(source.encode("utf-8"))
+    sf = SourceFile((source, str(path), cid))
+    return root, path, sf, cid
+
+
+def test_lexical_pass_runs_once_for_two_opens_of_same_content(tmp_path: Path) -> None:
+    """Open same body twice with populate-shaped receipt mint → walk once."""
+    body = (
+        "from contextlib import contextmanager\n"
+        "@contextmanager\n"
+        "def cm():\n"
+        "    yield\n"
+        "with cm() as x:\n"
+        "    pass\n"
+    )
+    root1, path1, sf1, cid = _consumer(tmp_path, "a.py", body)
+    authenticated_import_use_receipts(
+        root1, path1, sf1.unit.source, cid, module_identities={}, module=sf1.root
+    )
+    assert lexical_prepare_count_for(cid) == 1
+
+    root2, path2, sf2, cid2 = _consumer(tmp_path, "b.py", body)
+    assert cid2 == cid
+    authenticated_import_use_receipts(
+        root2, path2, sf2.unit.source, cid, module_identities={}, module=sf2.root
+    )
+    assert lexical_prepare_count_for(cid) == 1
+
+
+def test_changed_bytes_re_run_lexical_pass(tmp_path: Path) -> None:
+    v1 = "import os\nos.getcwd()\n"
+    v2 = "import os\nos.getcwd()\nos.listdir()\n"
+    r1, p1, s1, c1 = _consumer(tmp_path, "v1.py", v1)
+    authenticated_import_use_receipts(
+        r1, p1, s1.unit.source, c1, module_identities={}, module=s1.root
+    )
+    r2, p2, s2, c2 = _consumer(tmp_path, "v2.py", v2)
+    assert c1 != c2
+    authenticated_import_use_receipts(
+        r2, p2, s2.unit.source, c2, module_identities={}, module=s2.root
+    )
+    assert lexical_prepare_count_for(c1) == 1
+    assert lexical_prepare_count_for(c2) == 1
+
+
+def test_second_pass_same_file_does_not_re_walk(tmp_path: Path) -> None:
+    """Orange warm-populate regression: second open of same path → lexical once."""
+    body = (
+        "from contextlib import nullcontext\n"
+        "with nullcontext() as a:\n"
+        "    pass\n"
+        "with nullcontext() as b:\n"
+        "    pass\n"
+    )
+    root, path, sf, cid = _consumer(tmp_path, "frame.py", body)
+    for _ in range(2):
+        authenticated_import_use_receipts(
+            root, path, sf.unit.source, cid, module_identities={}, module=sf.root
+        )
+    assert lexical_prepare_count_for(cid) == 1


### PR DESCRIPTION
## Uncovered door after #7071

Orange on `core/frame.py` (warm):

| path | wall |
|------|-----:|
| populate=False | **0.005s** (SourceFile fully resident) |
| populate=True | **4.54s** |
| materialize_module warm | **0** |

99.9% of warm wall was **re-done populate** — `authenticated_import_use_receipts` / `_run_lexical_import_pass_on_module` / statements — against a body already resident.

## Law

`protocol/specs/2026-07-08-enumeration-protocol.md` §4: prepare **module temporal context** once for the whole-file content CID. The lexical import pass **is** that preparation: pure in content + package role + identity map, not who asks.

## Fix

Extend process residency (`process_resident_file.py`) with lexical product:

- `get_or_prepare_lexical_import_pass` — key `(source_cid, is_package, identities)`
- Share pass rows/outcomes; mint seat-bound receipts per demand with caller root/path
- Wire `authenticated_import_use_receipts` + session lexical runner
- **Not** shared: live consumer projection / reporter shells

## Teeth

- two opens same content → `lexical_prepare_count == 1`
- changed bytes → new CID → second run  
- second pass same file → still 1 (orange warm-populate regression)
- authority twins: process shares content unit; session tables stay distinct

## Validation

```
22 passed (lexical + file residency + authority + amortize)
```

merge_dog: merge on sight. Foundation for black's enumerate-driven census.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved lexical import processing by reusing prepared results across repeated analyses and identical source content.
  * Reduced redundant parsing and traversal when the same modules are processed across files or sessions.

* **Reliability**
  * Preserved separate session-specific results while safely sharing reusable prepared content.

* **Documentation**
  * Clarified process residency and shared traversal behavior for lexical import processing.

* **Tests**
  * Added coverage for caching, content changes, repeated processing, and cross-session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add process-resident LRU cache for lexical import pass runners keyed by content CID
> - Introduces `get_or_prepare_lexical_import_pass` in [`process_resident_file.py`](https://github.com/TSavo/sugar/pull/7078/files#diff-a419340dc11cf32686609067b2bf24ffcd464e3969e9df67f4a68d4d53559041), a process-wide LRU cache for lexical import pass runners keyed by content CID, package role, and module identities.
> - Updates `_session_lexical_import_runner` and `authenticated_import_use_receipts` to use the new cached API instead of calling `_run_lexical_import_pass_on_module` directly, enabling cross-session reuse for identical content.
> - Adds `lexical_prepare_count_for` to expose a counter for how many times the lexical walk has been executed per CID, and extends `clear_process_resident_files` to also reset the lexical cache and counters.
> - Adds `module` parameter to `authenticated_import_value_use_receipts` to optionally route through the cached runner.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ea55d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->