### PR TITLE
LPT unknown degrade: p75 floor + size-bin median

### DIFF
--- a/tests/test_lpt_unknown_degrade.py
+++ b/tests/test_lpt_unknown_degrade.py
@@ -1,0 +1,108 @@
+"""Unknown-file LPT degrade: safe floor + size-bin proxy (not optimistic median).
+
+Census-200 evidence (open+populate on tip ba3c94fbf):
+  size↔cost Spearman ≈ 0.85; median under-prices heavies ≥1s by ~12–39×;
+  p75 cuts under-half rate 36% → 14%; size quintile medians rise with size.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lpt_file_shards import (
+    ContentAddressedCostPrior,
+    assign_files,
+    calibrate_size_cost_bins,
+    estimate_cost_from_size,
+    percentile,
+    safe_unknown_cost_floor,
+)
+
+
+def test_safe_floor_is_p75_not_median() -> None:
+    # Multiset polluted by tiny-file collisions (black's 0.039 trap).
+    known = [0.003] * 100 + [0.04] * 50 + [1.0, 2.0, 5.7]
+    med = sorted(known)[len(known) // 2]
+    floor = safe_unknown_cost_floor(known)
+    assert med < 0.05
+    assert floor == percentile(known, 0.75)
+    assert floor >= 0.04
+    assert floor > med
+
+
+def test_size_bins_monotone_on_synthetic() -> None:
+    pairs = [(i * 1000, float(i)) for i in range(1, 51)]
+    bins = calibrate_size_cost_bins(pairs, n_bins=5)
+    assert len(bins) == 5
+    meds = [b.median_cost_s for b in bins]
+    assert meds == sorted(meds), meds
+    # Large file lands in top band.
+    est = estimate_cost_from_size(10**9, bins, floor_s=0.5)
+    assert est >= meds[-1]
+    assert est >= 0.5
+
+
+def test_unknown_uses_size_proxy_not_constant_median(tmp_path: Path) -> None:
+    """With a prior on small files only, a large unknown must not score at ~median."""
+    prior_root = tmp_path / "prior"
+    prior = ContentAddressedCostPrior(root=prior_root)
+    # Three small measured files.
+    paths = {}
+    for i, cost in enumerate((0.05, 0.06, 0.07)):
+        p = tmp_path / f"small_{i}.py"
+        p.write_text("x = 1\n" * 10, encoding="utf-8")
+        prior.put_for_path(p, cost, source="test", path_hint=p.name)
+        paths[f"pkg/small_{i}.py"] = p
+    # One large unknown (no prior).
+    big = tmp_path / "big.py"
+    big.write_text("def f():\n    pass\n" * 5000, encoding="utf-8")
+    paths["pkg/big.py"] = big
+
+    assignment = assign_files(
+        list(paths.keys()),
+        shard_count=2,
+        path_resolver=paths,
+        prior=prior,
+    )
+    assert assignment.mode == "lpt"
+    assert assignment.prior_hits == 3
+    assert assignment.prior_misses == 1
+    # Estimated load for the bin containing big must include a cost >> small med.
+    # Find which bin has big.
+    big_bin = next(i for i, b in enumerate(assignment.bins) if "pkg/big.py" in b)
+    # Reconstruct: big's share ≈ load_big_bin - sum of smalls in that bin
+    # Easier: re-read via floor being p75 of {0.05,0.06,0.07}=0.07 and size band
+    # at least that. The assignment estimated_loads must be > 3*0.07 if big is heavy.
+    floor = safe_unknown_cost_floor([0.05, 0.06, 0.07])
+    assert floor >= 0.06
+    # Big file estimate at least floor; total load of its bin >= floor.
+    assert assignment.estimated_loads[big_bin] >= floor
+
+
+def test_equal_cost_unknowns_do_not_pile_in_one_bin(tmp_path: Path) -> None:
+    """Equal proxy costs still LPT-spread across lightest bins."""
+    prior_root = tmp_path / "prior"
+    prior = ContentAddressedCostPrior(root=prior_root)
+    paths: dict[str, Path] = {}
+    # One expensive known file.
+    heavy = tmp_path / "heavy.py"
+    heavy.write_text("h\n" * 100, encoding="utf-8")
+    prior.put_for_path(heavy, 10.0, source="test", path_hint="heavy")
+    paths["pkg/heavy.py"] = heavy
+    # Eight identical-size unknowns → same proxy cost.
+    for i in range(8):
+        p = tmp_path / f"u{i}.py"
+        p.write_text("u = 1\n" * 20, encoding="utf-8")
+        paths[f"pkg/u{i}.py"] = p
+    assignment = assign_files(
+        list(paths.keys()),
+        shard_count=4,
+        path_resolver=paths,
+        prior=prior,
+    )
+    # Unknowns should appear in multiple bins, not all with heavy or all in one.
+    unk_counts = [
+        sum(1 for f in b if f.startswith("pkg/u")) for b in assignment.bins
+    ]
+    assert max(unk_counts) <= 3, unk_counts
+    assert sum(1 for c in unk_counts if c > 0) >= 3, unk_counts

--- a/tools/lpt_file_shards.py
+++ b/tools/lpt_file_shards.py
@@ -179,6 +179,94 @@ class ContentAddressedCostPrior:
         return costs, hits, misses
 
 
+def percentile(values: Sequence[float], p: float) -> float:
+    """Linear-interpolation-free nearest-rank percentile on a non-empty sequence."""
+    if not values:
+        raise ValueError("percentile on empty sequence")
+    if p <= 0:
+        return float(min(values))
+    if p >= 1:
+        return float(max(values))
+    ordered = sorted(float(v) for v in values)
+    # nearest-rank: index = ceil(p * n) - 1
+    idx = min(len(ordered) - 1, max(0, int(p * len(ordered) + 0.999999999) - 1))
+    return ordered[idx]
+
+
+def safe_unknown_cost_floor(known_costs: Sequence[float]) -> float:
+    """Conservative constant floor for files with no prior and no usable proxy.
+
+    Measured census-200 (open+populate): median 0.147s under-prices heavies by
+    ~12× (median heavy ≥1s) to 39× (worst). p75 (~0.54s) cuts under-half rate
+    from 36% to 14%. Never use the median of hit costs when tiny content-CID
+    collisions dominate the hit multiset (that produced the optimistic 0.039s).
+    """
+    if not known_costs:
+        return 1.0  # no evidence — one second, not zero
+    return max(percentile(known_costs, 0.75), 0.0)
+
+
+@dataclass(frozen=True)
+class SizeCostBin:
+    """One size band → measured median cost (calibrated from prior hits)."""
+
+    max_size: int  # inclusive upper bound (last bin uses a huge sentinel)
+    median_cost_s: float
+
+
+def calibrate_size_cost_bins(
+    size_cost_pairs: Sequence[tuple[int, float]],
+    *,
+    n_bins: int = 5,
+) -> tuple[SizeCostBin, ...]:
+    """Build size→cost bins from measured (size_bytes, cost_s) pairs.
+
+    Spearman size↔cost on census-200 was ~0.85 (rank); linear R² only ~0.18.
+    Quintile medians capture the monotone lift without pretending linearity.
+    """
+    if n_bins < 1:
+        raise ValueError("n_bins must be >= 1")
+    pairs = [(int(s), float(c)) for s, c in size_cost_pairs if s >= 0 and c >= 0]
+    if not pairs:
+        return (SizeCostBin(max_size=2**62, median_cost_s=1.0),)
+    pairs.sort(key=lambda t: (t[0], t[1]))
+    n = len(pairs)
+    bins: list[SizeCostBin] = []
+    for i in range(n_bins):
+        lo = (i * n) // n_bins
+        hi = ((i + 1) * n) // n_bins
+        chunk = pairs[lo:hi]
+        if not chunk:
+            continue
+        costs = sorted(c for _, c in chunk)
+        med = costs[len(costs) // 2]
+        max_size = chunk[-1][0] if i < n_bins - 1 else 2**62
+        bins.append(SizeCostBin(max_size=max_size, median_cost_s=med))
+    if not bins:
+        return (SizeCostBin(max_size=2**62, median_cost_s=1.0),)
+    # Ensure last bin is open-ended.
+    last = bins[-1]
+    bins[-1] = SizeCostBin(max_size=2**62, median_cost_s=last.median_cost_s)
+    return tuple(bins)
+
+
+def estimate_cost_from_size(
+    size_bytes: int,
+    bins: Sequence[SizeCostBin],
+    *,
+    floor_s: float,
+) -> float:
+    """Proxy cost for an unknown file: size-bin median, floored at p75 known."""
+    if size_bytes < 0:
+        size_bytes = 0
+    est = floor_s
+    for band in bins:
+        if size_bytes <= band.max_size:
+            est = band.median_cost_s
+            break
+    return max(float(floor_s), float(est))
+
+
 def equal_count_bins(files: Sequence[str], shard_count: int) -> list[list[str]]:
     """Path-index % k on the given order (caller should sort for stability)."""
     if shard_count < 1:
@@ -248,6 +336,16 @@ def assign_files(
 
     ``path_resolver`` maps roster key → filesystem path for content cid.
     When omitted, equal-count only (no path bytes to hash).
+
+    Unknown-file degrade (no prior entry) — safety law from census-200:
+      * Floor at **p75 of known costs**, never the median of the hit multiset
+        (tiny content-CID collisions made median ≈ 0.039s while heavies are 1–5s).
+      * When a filesystem path is available, score the unknown at
+        ``max(floor, size-bin median)`` calibrated from hit (size, cost) pairs
+        (Spearman size↔cost ≈ 0.85; size quintile medians rise 0.015→0.88s).
+      * LPT then packs known + estimated unknowns together — equal-cost unknowns
+        naturally fan across lightest bins (not one pile). No separate RR pass
+        required when estimates differ by size.
     """
     ordered = list(files)
     prior = prior if prior is not None else ContentAddressedCostPrior()
@@ -255,10 +353,10 @@ def assign_files(
     hits = 0
     misses = len(ordered)
     prior_disabled = not prior.enabled
+    path_map: dict[str, Path] = {}
     if path_resolver is not None and prior.enabled and ordered:
-        costs, hits, misses = prior.costs_for_paths(
-            {f: path_resolver[f] for f in ordered if f in path_resolver}
-        )
+        path_map = {f: path_resolver[f] for f in ordered if f in path_resolver}
+        costs, hits, misses = prior.costs_for_paths(path_map)
         # Files without a resolvable path count as misses.
         for f in ordered:
             if f not in path_resolver and f not in costs:
@@ -279,11 +377,42 @@ def assign_files(
         )
 
     known = list(costs.values())
-    missing_cost = sorted(known)[len(known) // 2]  # median of known
-    bins = lpt_bins(ordered, costs, shard_count, missing_cost=missing_cost)
-    loads = [
-        sum(costs.get(p, missing_cost) for p in b) for b in bins
-    ]
+    floor_s = safe_unknown_cost_floor(known)
+    # Calibrate size bins from hits that still have a resolvable path.
+    size_pairs: list[tuple[int, float]] = []
+    for key, cost in costs.items():
+        path = path_map.get(key)
+        if path is None:
+            continue
+        try:
+            size_pairs.append((path.stat().st_size, float(cost)))
+        except OSError:
+            continue
+    size_bins = calibrate_size_cost_bins(size_pairs)
+
+    # Fill per-file estimates for misses (do not leave them on a single constant
+    # that both under-prices heavies and clusters equal-weight unknowns).
+    estimated = dict(costs)
+    for f in ordered:
+        if f in estimated:
+            continue
+        path = path_map.get(f) if path_map else None
+        if path is not None:
+            try:
+                size = path.stat().st_size
+            except OSError:
+                estimated[f] = floor_s
+            else:
+                estimated[f] = estimate_cost_from_size(
+                    size, size_bins, floor_s=floor_s
+                )
+        else:
+            estimated[f] = floor_s
+
+    # missing_cost is only a residual fallback inside lpt_bins for keys absent
+    # from ``estimated`` (should be none); keep it at the safe floor.
+    bins = lpt_bins(ordered, estimated, shard_count, missing_cost=floor_s)
+    loads = [sum(float(estimated.get(p, floor_s)) for p in b) for b in bins]
     return ShardAssignment(
         bins=bins,
         mode="lpt",


### PR DESCRIPTION
## Summary

LPT k=8 only buys ~8× when unknowns are not under-priced. 1221/1421 files have no prior. The old degrade used **median of hit costs** → **0.039s** after tiny content-CID collisions (black’s optimistic note), while measured heavies are **1–5.7s**.

## Evidence (census-200)

| proxy | Pearson | Spearman | top/bottom decile cost ratio |
|---|---:|---:|---:|
| size_bytes | 0.42 | **0.85** | 29× |
| lines | 0.41 | **0.85** | — |
| fn_approx | **0.63** | 0.82 | 28× |

- Linear size R² ≈ 0.18 — rank yes, linear no → **size quintile medians**, not a slope.
- const **median**: under-half rate **36%**, heavies true/pred worst **39×**.
- const **p75**: under-half **14%**, worst ~11×.

## Rule

```
floor = p75(known prior costs)          # never multiset median
cost  = max(floor, size_bin_median(bytes))  # when path exists
```

LPT then packs known + estimates. Equal-cost unknowns still spread across lightest bins (multiprocessor rule) — no separate RR required when size estimates differ.

## Not claiming

- Size predicts cost precisely (R² low); it ranks and floors safely.
- Full 1421 pole without more prior writes.
- Black’s seed work (already done).

## Test plan

- [x] `tests/test_lpt_unknown_degrade.py` (4 passed)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace constant-median unknown cost with p75 floor and size-bin median in LPT file sharding
> - Adds `safe_unknown_cost_floor` in [lpt_file_shards.py](https://github.com/TSavo/sugar/pull/7080/files#diff-a8360708a4131eb96fd754a94e07ab71a39edcb310f70cc99b391b04f65881cf) to compute the 75th percentile of known costs (instead of the median) as the floor for unknown file costs.
> - Adds `calibrate_size_cost_bins` and `estimate_cost_from_size` to build monotone size-to-cost bands from prior observations and look up a size-based proxy cost for unknown files.
> - Updates `assign_files` so that in LPT mode with prior hits, unknowns are scored at `max(p75 floor, size-bin median)` rather than a constant median, spreading equal-cost unknowns across shards and assigning larger unknowns higher estimated costs.
> - Adds four tests covering p75 floor correctness, bin monotonicity, size-proxy assignment, and distribution of equal-cost unknowns.
> - Behavioral Change: shard composition and `estimated_loads` in LPT mode will differ from before; the zero-hits equal-count path is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9371a3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->