### PR TITLE
Walk-scoped SourceResolutionSession for census/re-open (~15%, not 6×)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -212,9 +212,9 @@ def open_source_file_for_construction(
     hold a frozen context (shared demand table across a census) may pass it.
 
     ``resolution_session`` owns every source-resolution memo for this open. When
-    omitted, this door mints one session for the population so multi-receipt
-    amortization is real; multi-file owners should pass one shared session so
-    the same dependency definition is not re-projected per consumer file.
+    omitted, this door uses the walk-scoped session for ``root`` so multi-file
+    census / re-open of the same content amortize projection under one workspace
+    authority (see ``walk_session_for``). Pass an explicit session to isolate.
 
     Roster-floor law: after SourceFile construction succeeds, N =
     ``len(functions())`` is banked on the open as ``function_roster_floor``.
@@ -223,7 +223,7 @@ def open_source_file_for_construction(
     *before* SourceFile still raises (empty denominator). Process-control
     exceptions (``BaseException`` outside ``Exception``) still halt.
     """
-    from sugar_lift_python_source.resolution_session import session_or_new
+    from sugar_lift_python_source.resolution_session import walk_session_for
     from sugar_lift_python_source.source_oracle import workspace_path_source
     from sugar_source_tree.reporter import NULL_REPORTER
     from sugar_source_tree.tree import SourceFile
@@ -254,9 +254,13 @@ def open_source_file_for_construction(
             populate_source_derived_resource_refs,
         )
 
-        # File-open is a multi-resolve owner: one session for every receipt in
-        # this population. session_or_new keeps an explicit shared session.
-        session = session_or_new(resolution_session)
+        # Multi-resolve owner: walk-scoped session when none given so census
+        # and same-content re-open share projection memos under one root.
+        session = (
+            resolution_session
+            if resolution_session is not None
+            else walk_session_for(root)
+        )
         # Catch Exception, not BaseException: KeyboardInterrupt / SystemExit /
         # GeneratorExit still halt the process. Do not enumerate SNW/TypeError
         # here — that was the two-costume allowlist that left the class open.
@@ -1910,11 +1914,9 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
             construction_context = TreeConstructionContextV1(_BOUND_CONTRACT_REFS)
             # One session for the whole package walk: the same dependency
             # definition projected for many consumer files amortizes once.
-            from sugar_lift_python_source.resolution_session import (
-                SourceResolutionSession,
-            )
+            from sugar_lift_python_source.resolution_session import walk_session_for
 
-            package_session = SourceResolutionSession()
+            package_session = walk_session_for(root)
             for source_path in sorted(root.rglob("*.py")):
                 identity = path_source(str(source_path))
                 source_file = _TreeSourceFile(
@@ -2160,16 +2162,15 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 from sugar_lift_python_source.manager_summary_derivation import (
                     populate_source_derived_resource_refs,
                 )
-                from sugar_lift_python_source.resolution_session import (
-                    SourceResolutionSession,
-                )
+                from sugar_lift_python_source.resolution_session import walk_session_for
 
-                # Single-file multi-resolve owner: one session for every receipt.
+                # Walk-scoped multi-resolve owner: same session as other opens
+                # under this workspace root (census / re-open amortization).
                 populate_source_derived_resource_refs(
                     tree_file,
                     root=root,
                     path=full_path,
-                    session=SourceResolutionSession(),
+                    session=walk_session_for(root),
                 )
                 nodes = []
                 for fn in tree_file.functions():

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1201,9 +1201,17 @@ def populate_source_derived_resource_refs(
     """Preconstruct imported resource managers and freeze exact use-site rows.
 
     ``session`` owns every resolution memo for this population. Multi-resolve
-    owners (file-open, package enumeration) must pass one shared session so
-    export/frame amortization is real across receipts and consumer files. The
-    default opens one bounded to this single population call only.
+    owners (file-open, package enumeration, census walk via ``walk_session_for``)
+    must pass one shared session so export/frame amortization is real across
+    receipts, consumer files, and same-content re-open under one workspace.
+
+    Second open of the same content (after §4 SourceFile + lexical residency):
+    prepare and lexical walks are free; this loop still re-seats into a fresh
+    consumer ``construction_context``. Frame/export projection is free only
+    when the same session is threaded (walk session). Live frame Nodes and
+    protocol-bearing CM refs are session-bound — they must not be parked under
+    a process-global content CID (same law as ``resolve_source_visible_frame``).
+    Pure gap rows alone would be content-CID-able; they are not the residual wall.
     """
     from pathlib import Path
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -55,11 +55,43 @@ definition. The session is the boundary that makes that amortization safe.
 ``session_or_new(None)`` remains the honest single-shot leaf: slower, always
 correct, never process-global. It is not permission for a multi-resolve owner to
 drop the session.
+
+Walk-scoped multi-resolve owner (``walk_session_for``)
+------------------------------------------------------
+A census / package walk is ONE workspace root under ONE pin authority. Production
+doors that open many files under that root (``open_source_file_for_construction``,
+``sugar.enumerate`` functions/facts for a corpus) are multi-resolve owners in the
+sense of the decision of record above: they must thread ONE session so projection
+memos survive file-to-file and re-open of the same content.
+
+Legitimacy (why this is not process-global free-for-all):
+
+* Key is the resolved workspace root — the authority locus of the walk, not a
+  content CID. Different roots mint different sessions; one project cannot warm
+  another's answers.
+* Values remain session-bound live Nodes (frame / module materialize). They are
+  never parked under a process-global content map. §4 residency covers pure
+  content-derived prep (SourceFile body, lexical import pass); visible-frame
+  projection stays on the session object the walk owns.
+* Measured (orange, tip #7078): cross-file shared session is ~15% on a mixed
+  20-file lib sample (frame_results after 20 files ≈ 1 — almost no shared
+  definitions). Same-content re-open under the same walk session is the
+  amortization that is real (identical definition coordinates hit). Do not bet
+  a 6× census cut on walk session alone.
+
+``walk_session_for(root)`` is the small production default for multi-file doors.
+Callers that need isolation pass an explicit ``SourceResolutionSession()`` or
+``session_or_new(None)``.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
+
+# Resolved workspace root path -> walk-owned session. Not content-keyed; not a
+# substitute for §4 residency. Cleared only by tests (clear_walk_sessions).
+_WALK_SESSIONS: dict[str, "SourceResolutionSession"] = {}
 
 
 class SourceResolutionSession:
@@ -217,8 +249,29 @@ def session_or_new(session: SourceResolutionSession | None) -> SourceResolutionS
     (cycle detection and within-tree amortization stay real). The memo dies with
     the call tree -- slower across independent top-level calls, always correct.
 
-    Multi-resolve owners (populate, package enumeration, file-open) must pass an
-    explicit session so amortization reaches every receipt they own. Do not call
-    this at those doors and throw the result away between receipts.
+    Multi-resolve owners (populate, package enumeration, file-open, census walk)
+    must pass an explicit session — or use ``walk_session_for(workspace_root)``
+    — so amortization reaches every receipt they own. Do not call this at those
+    doors and throw the result away between receipts.
     """
     return SourceResolutionSession() if session is None else session
+
+
+def walk_session_for(workspace_root: Path | str) -> SourceResolutionSession:
+    """Return the multi-resolve session owned by one workspace walk.
+
+    One resolved root → one session for the life of the process (or until
+    ``clear_walk_sessions``). Legitimate because a corpus walk is one authority
+    locus; not process-global free-for-all (see module docstring).
+    """
+    key = str(Path(workspace_root).resolve())
+    session = _WALK_SESSIONS.get(key)
+    if session is None:
+        session = SourceResolutionSession()
+        _WALK_SESSIONS[key] = session
+    return session
+
+
+def clear_walk_sessions() -> None:
+    """Test door: drop walk-owned sessions so teeth start cold."""
+    _WALK_SESSIONS.clear()

--- a/implementations/python/sugar-lift-python-source/tests/test_walk_session.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_walk_session.py
@@ -1,0 +1,95 @@
+"""Walk-scoped SourceResolutionSession — multi-resolve owner for one workspace.
+
+Orange measured cross-file shared session ~15% (frame_results after 20 files = 1).
+This tooth pins the authority owner and same-content re-open amortization under
+one root — not a 6× claim.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_python_source.resolution_session import (
+    SourceResolutionSession,
+    clear_walk_sessions,
+    walk_session_for,
+)
+
+
+def setup_function() -> None:
+    clear_walk_sessions()
+
+
+def teardown_function() -> None:
+    clear_walk_sessions()
+
+
+def test_walk_session_same_root_is_one_session(tmp_path: Path) -> None:
+    a = walk_session_for(tmp_path)
+    b = walk_session_for(tmp_path / ".")
+    assert a is b
+    assert isinstance(a, SourceResolutionSession)
+
+
+def test_walk_session_different_roots_are_isolated(tmp_path: Path) -> None:
+    left = walk_session_for(tmp_path / "left")
+    right = walk_session_for(tmp_path / "right")
+    (tmp_path / "left").mkdir()
+    (tmp_path / "right").mkdir()
+    left2 = walk_session_for(tmp_path / "left")
+    right2 = walk_session_for(tmp_path / "right")
+    assert left2 is left
+    assert right2 is right
+    assert left is not right
+
+
+def test_open_default_uses_walk_session(tmp_path: Path, monkeypatch) -> None:
+    """Production open without resolution_session takes the walk owner for root."""
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+    from sugar_lift_python_source import manager_summary_derivation as msd
+
+    root = tmp_path / "ws"
+    root.mkdir()
+    path = root / "consumer.py"
+    path.write_text("x = 1\n", encoding="utf-8")
+
+    seen: list[object] = []
+    original = msd.populate_source_derived_resource_refs
+
+    def capture(source_file, *, root, path, session=None, **kwargs):
+        seen.append(session)
+        return original(source_file, root=root, path=path, session=session, **kwargs)
+
+    monkeypatch.setattr(msd, "populate_source_derived_resource_refs", capture)
+
+    open_source_file_for_construction(path, root=root)
+    open_source_file_for_construction(path, root=root)
+    assert len(seen) == 2
+    assert seen[0] is seen[1] is walk_session_for(root), (
+        "two opens under the same root must share the walk session so same-content "
+        "re-open and census multi-file amortize projection memos"
+    )
+
+
+def test_open_explicit_session_bypasses_walk(tmp_path: Path, monkeypatch) -> None:
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+    from sugar_lift_python_source import manager_summary_derivation as msd
+
+    root = tmp_path / "ws"
+    root.mkdir()
+    path = root / "consumer.py"
+    path.write_text("x = 1\n", encoding="utf-8")
+
+    seen: list[object] = []
+    original = msd.populate_source_derived_resource_refs
+
+    def capture(source_file, *, root, path, session=None, **kwargs):
+        seen.append(session)
+        return original(source_file, root=root, path=path, session=session, **kwargs)
+
+    monkeypatch.setattr(msd, "populate_source_derived_resource_refs", capture)
+
+    isolated = SourceResolutionSession()
+    open_source_file_for_construction(path, root=root, resolution_session=isolated)
+    assert seen == [isolated]
+    assert isolated is not walk_session_for(root)


### PR DESCRIPTION
## Summary

Small multi-resolve owner for one workspace walk: `walk_session_for(root)` threads one `SourceResolutionSession` across production opens and enumerate populate under that resolved root.

- **Legitimacy:** a corpus walk is one workspace, one pin authority. Session is keyed by resolved root, not content CID. Different roots stay isolated. Live frame/module projection Nodes remain session-bound — never process-global under a content address (orange's boundary after #7078).
- **Wiring:** `open_source_file_for_construction` defaults to the walk session when `resolution_session` is omitted; enumerate package walk + functions populate use the same door. Explicit `resolution_session=` still isolates.
- **Teeth:** `test_walk_session.py` — same root identity, different-root isolation, open default shares, explicit bypass.

## What this is not (orange measured, tip 3d44b0aa8)

| sample | shared/fresh | note |
| --- | ---: | --- |
| b20 lib mix | 0.85 (−15%) | export/module grows a bit |
| heavy20 | 1.18 (no win) | noise + uneven |
| frame_results after 20 files | **1** | almost no cross-file frame hits |

Extrapolated census: **~12 min → ~10.2 min**, not 2 min. Projection work is mostly per-file unique use-sites. Do not bet the 6× target on walk session alone.

## Second-open residual after #7071 / #7078 (the other lever)

On re-open of the **same content**:

| step | process-CID resident? | notes |
| --- | --- | --- |
| SourceFile prepare | yes (#7071) | free |
| lexical import pass | yes (#7078) | free |
| `resolve_source_visible_frame` / module materialize | **no** — session-bound | free only if same walk session |
| populate seating (`source_derived_contract_refs`, frames, provider calls) | **no** as full product | live protocol/frame Nodes; process-global would violate session law |
| pure gap rows alone | content-CID-able | not the residual wall |

So the re-walk / resumed-shard lever is **walk session lifetime** for frame amortization, not a new content-CID frame table. Full populate-product process residency is refused for green paths that carry live protocol testimony.

Parallelism (or a pure seating product that excludes live frames, if one is ever designed) remains the path toward 2 min.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | no construction formula change |
| `mandatory_panics` | 0 | |
| `suppressed_descendants` | 0 | |
| `typed_effects` | 0 | |
| `silent` | 0 | floor: must stay 0 |

## Validation

- Inline teeth: walk_session same-root identity, different-root isolation, open default shares, explicit session bypass — ALL GREEN (v312).
- Orange's separate-process measure of shared vs fresh is the wall claim (above).

## Floors preserved

data_loss=0, no secret commit, no test deleted for green, silent=0. No process-global live frame tables.

@merge_dog

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add walk-scoped `SourceResolutionSession` cache per workspace root to reduce session creation overhead
> - Introduces a module-level `_WALK_SESSIONS` dict in [resolution_session.py](https://github.com/TSavo/sugar/pull/7081/files#diff-54257d48026540505071d0613a7c672ce198dc916935415abb69c38a81451ce5) keyed by resolved workspace root path, with new `walk_session_for` and `clear_walk_sessions` functions.
> - Updates `open_source_file_for_construction` and `_handle_enumerate` in [lift_rpc.py](https://github.com/TSavo/sugar/pull/7081/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) to call `walk_session_for(root)` instead of creating a new `SourceResolutionSession` per call, reusing one session per root across a walk.
> - Behavioral Change: repeated file opens and enumerations under the same workspace root now share a single resolution session rather than constructing a fresh one each time; an explicit `resolution_session` argument still bypasses the cache.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4cb134f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->