### PR TITLE
LPT prior: CI pin-keyed cache + recensus file_s write-through

### DIFF
--- a/.github/workflows/control-effect-recensus.yml
+++ b/.github/workflows/control-effect-recensus.yml
@@ -55,6 +55,9 @@ jobs:
       root: ${{ steps.population.outputs.root }}
       plan_cid: ${{ steps.plan.outputs.plan_cid }}
       shard_count: ${{ steps.plan.outputs.shard_count }}
+      # Pin-keyed LPT shelf: different corpus pin must not restore as exact key.
+      aggregate_hash: ${{ steps.pin.outputs.aggregate_hash }}
+      lpt_dir: ${{ steps.lpt.outputs.dir }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -76,8 +79,10 @@ jobs:
           echo "recensus population: authenticated pandas corpus at $PANDAS_CORPUS"
           echo "root=$PANDAS_CORPUS" >> "$GITHUB_OUTPUT"
 
-      - name: "Phase: pin + LPT plan (no measure)"
-        id: plan
+      # Pin first so the LPT cache key includes aggregateHash — empty CI runners
+      # otherwise plan with an empty shelf and degrade to equal-count (1.87× pole).
+      - name: "Phase: pin enrolled files (no measure)"
+        id: pin
         shell: bash
         env:
           PANDAS_CORPUS: ${{ steps.population.outputs.root }}
@@ -86,9 +91,6 @@ jobs:
           set -euo pipefail
           OUT="$GITHUB_WORKSPACE/.sugar/pandas-control-effect"
           mkdir -p "$OUT"
-          # Emit enrolled file identities matching the worker's by_file keys:
-          #   {corpus_root.name}/{rel_posix}
-          # and pin aggregate / manifest shape for plan bind.
           python -u - <<'PY'
           import json, os, sys
           from pathlib import Path
@@ -107,7 +109,6 @@ jobs:
           pin = pin_corpus(corpus_root)
           paths = list(SourceTree(corpus_root).paths())
           if subtree:
-              # Bounded dispatch: keep only files under optional subtree.
               sub = (corpus_root / subtree).resolve()
               paths = [p for p in paths if sub == p.resolve() or sub in p.resolve().parents]
           enrolled = sorted(
@@ -118,7 +119,6 @@ jobs:
               print("::error::no enrolled files after pin/subtree filter", file=sys.stderr)
               sys.exit(1)
           manifest_shape_cid = corpus_manifest_shape_cid(list(pin.paths))
-          # Install root seats are recorded against (pandas/foo.py under site-packages).
           installed = install_root_for(str(corpus_root))
           locus_root = corpus_root if installed is None else Path(installed)
           (out / "enrolled-files.json").write_text(
@@ -145,13 +145,49 @@ jobs:
               f"manifest={manifest_shape_cid[:24]}… locus_root={locus_root}",
               flush=True,
           )
+          # Expose pin aggregate for cache key (pin identity, not tip).
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as gh:
+              gh.write(f"aggregate_hash={pin.aggregate_hash}\n")
           PY
+
+      # Workspace-writable shelf (HOME/.cache may be unwritable on self-hosted).
+      # Keyed by corpus pin aggregate so a different pin cannot be the exact hit;
+      # entries themselves are content-addressed by file bytes (#7040).
+      - name: Resolve LPT file-cost prior path
+        id: lpt
+        shell: bash
+        run: |
+          set -euo pipefail
+          dir="${GITHUB_WORKSPACE}/.cache/sugar/lpt-file-costs"
+          mkdir -p "$dir"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+          echo "SUGAR_LPT_PRIOR_DIR=$dir" >> "$GITHUB_ENV"
+          echo "JOB_LOG phase=lpt-prior status=resolve dir=$dir population=control-effect-recensus"
+
+      - name: Restore LPT file-cost prior (pin-keyed)
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.lpt.outputs.dir }}
+          key: lpt-recensus-file-costs-${{ steps.pin.outputs.aggregate_hash }}-${{ github.run_id }}-plan
+          restore-keys: |
+            lpt-recensus-file-costs-${{ steps.pin.outputs.aggregate_hash }}-
+            lpt-recensus-file-costs-
+
+      - name: "Phase: LPT plan (no measure; uses restored prior)"
+        id: plan
+        shell: bash
+        env:
+          PANDAS_CORPUS: ${{ steps.population.outputs.root }}
+        run: |
+          set -euo pipefail
+          OUT="$GITHUB_WORKSPACE/.sugar/pandas-control-effect"
           META="$OUT/pin-meta.json"
+          test -f "$META" || { echo "::error::pin-meta.json missing"; exit 1; }
           AGG="$(python -c 'import json,sys; print(json.load(open(sys.argv[1]))["aggregateHash"])' "$META")"
           MANIFEST="$(python -c 'import json,sys; print(json.load(open(sys.argv[1]))["manifestShapeCid"])' "$META")"
-          # LPT prior resolves enrolled keys as <locus_root>/<enrolled> so
-          # pandas/core/frame.py lands under site-packages/pandas/core/...
           LOCUS="$(python -c 'import json,sys; print(json.load(open(sys.argv[1]))["locusRoot"])' "$META")"
+          PRIOR_N="$(find "${SUGAR_LPT_PRIOR_DIR}" -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"
+          echo "JOB_LOG phase=lpt-prior status=pre-plan entries=${PRIOR_N} dir=${SUGAR_LPT_PRIOR_DIR} aggregate=${AGG:0:16}"
           python -u tools/plan_control_effect_recensus_shards.py \
             --enrolled-files "$OUT/enrolled-files.json" \
             --corpus-root "$LOCUS" \
@@ -162,9 +198,10 @@ jobs:
             --out "$OUT/plan.json"
           PLAN_CID="$(python -c 'import json,sys; print(json.load(open(sys.argv[1]))["planCid"])' "$OUT/plan.json")"
           K="$(python -c 'import json,sys; print(json.load(open(sys.argv[1]))["shardCount"])' "$OUT/plan.json")"
+          MODE="$(python -c 'import json,sys; print(json.load(open(sys.argv[1])).get("splitMode") or json.load(open(sys.argv[1])).get("mode") or "?")' "$OUT/plan.json")"
           echo "plan_cid=$PLAN_CID" >> "$GITHUB_OUTPUT"
           echo "shard_count=$K" >> "$GITHUB_OUTPUT"
-          echo "recensus phase=plan status=done planCid=$PLAN_CID k=$K"
+          echo "recensus phase=plan status=done planCid=$PLAN_CID k=$K mode=$MODE prior_entries=$PRIOR_N"
 
       - name: Upload plan artifacts
         uses: actions/upload-artifact@v4
@@ -202,6 +239,28 @@ jobs:
           name: control-effect-recensus-plan
           path: .sugar/pandas-control-effect
 
+      # Restore pin-keyed LPT shelf so write-through appends to fleet prior,
+      # not an empty local dir that dies when the runner is recycled.
+      - name: Resolve LPT file-cost prior path
+        id: lpt
+        shell: bash
+        run: |
+          set -euo pipefail
+          dir="${GITHUB_WORKSPACE}/.cache/sugar/lpt-file-costs"
+          mkdir -p "$dir"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+          echo "SUGAR_LPT_PRIOR_DIR=$dir" >> "$GITHUB_ENV"
+          echo "JOB_LOG phase=lpt-prior status=resolve dir=$dir seat=s$(printf '%02d' '${{ matrix.shard }}')"
+
+      - name: Restore LPT file-cost prior (pin-keyed)
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.lpt.outputs.dir }}
+          key: lpt-recensus-file-costs-${{ needs.plan.outputs.aggregate_hash }}-${{ github.run_id }}-s${{ matrix.shard }}
+          restore-keys: |
+            lpt-recensus-file-costs-${{ needs.plan.outputs.aggregate_hash }}-
+            lpt-recensus-file-costs-
+
       - name: "Phase: measure shard partial only"
         shell: bash
         env:
@@ -219,6 +278,7 @@ jobs:
           fi
           echo "recensus phase=measure-shard status=start shard=$SHARD/$K corpus_root=$PANDAS_CORPUS commit=$GITHUB_SHA"
           # Worker: --plan-json + --shard-index → PARTIAL only (never seals).
+          # control_effect_recensus write-throughs each file_s → LPT shelf.
           python -u implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py \
             "$PANDAS_CORPUS" \
             --corpus-root "$PANDAS_CORPUS" \
@@ -230,6 +290,8 @@ jobs:
             --partial-out "$OUT/partial-s$(printf '%02d' "$SHARD").json"
           echo "recensus phase=measure-shard status=done shard=$SHARD"
           ls -la "$OUT"/partial-s*.json || true
+          PRIOR_N="$(find "${SUGAR_LPT_PRIOR_DIR}" -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"
+          echo "JOB_LOG phase=lpt-prior-write status=post-shard entries=${PRIOR_N} seat=s$(printf '%02d' "$SHARD")"
 
       - name: Upload shard partial
         if: always()
@@ -237,6 +299,23 @@ jobs:
         with:
           name: control-effect-recensus-partial-s${{ matrix.shard }}
           path: .sugar/pandas-control-effect/partial-s*.json
+          if-no-files-found: warn
+
+      # Per-seat save: concurrent first-wins; content-addressed entries merge
+      # safely across seats. Compose also merges all seats into one fleet key.
+      - name: Save LPT file-cost prior (pin-keyed, per seat)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.lpt.outputs.dir }}
+          key: lpt-recensus-file-costs-${{ needs.plan.outputs.aggregate_hash }}-${{ github.run_id }}-s${{ matrix.shard }}
+
+      - name: Upload LPT prior delta (for compose union)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: control-effect-recensus-lpt-prior-s${{ matrix.shard }}
+          path: ${{ steps.lpt.outputs.dir }}
           if-no-files-found: warn
 
   # ---------------------------------------------------------------- compose
@@ -267,6 +346,49 @@ jobs:
           pattern: control-effect-recensus-partial-*
           path: .sugar/pandas-control-effect/partials-raw
           merge-multiple: true
+
+      # Union all seat write-throughs into one shelf, then save under the pin
+      # key so the NEXT plan restores a complete prior (not equal-count degrade).
+      - name: Resolve LPT file-cost prior path
+        id: lpt
+        shell: bash
+        run: |
+          set -euo pipefail
+          dir="${GITHUB_WORKSPACE}/.cache/sugar/lpt-file-costs"
+          mkdir -p "$dir"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+          echo "SUGAR_LPT_PRIOR_DIR=$dir" >> "$GITHUB_ENV"
+
+      - name: Download all shard LPT prior deltas
+        if: always()
+        uses: actions/download-artifact@v4
+        with:
+          pattern: control-effect-recensus-lpt-prior-*
+          path: .sugar/pandas-control-effect/lpt-prior-raw
+          merge-multiple: true
+
+      - name: "Phase: union LPT prior from all seats (self-maintaining shelf)"
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEST="${{ steps.lpt.outputs.dir }}"
+          mkdir -p "$DEST"
+          RAW=".sugar/pandas-control-effect/lpt-prior-raw"
+          if [[ -d "$RAW" ]]; then
+            # Content-addressed filenames: last write of same cid wins; union is free.
+            find "$RAW" -type f -name '*.json' -print0 2>/dev/null \
+              | xargs -0 -I{} cp -f {} "$DEST/" 2>/dev/null || true
+          fi
+          N="$(find "$DEST" -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"
+          echo "JOB_LOG phase=lpt-prior-union status=done entries=${N} dir=${DEST} pin=${{ needs.plan.outputs.aggregate_hash }}"
+
+      - name: Save LPT file-cost prior (pin-keyed, fleet merge)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.lpt.outputs.dir }}
+          key: lpt-recensus-file-costs-${{ needs.plan.outputs.aggregate_hash }}-${{ github.run_id }}-merged
 
       - name: "Phase: compose board (UNMEASURED if any seat missing)"
         shell: bash

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1353,6 +1353,22 @@ def main() -> int:
                         + "\n"
                     )
                     rc_stream.flush()
+                # Content-addressed LPT prior write-through (#7040 law for
+                # recensus). Every measured file_s must land on the shelf so
+                # the next plan is LPT, not equal-count. Hand-seed is not a
+                # standing property; this is. Prior must never kill the walk.
+                # ``path`` is the filesystem seat; ``file`` is the enrolled key.
+                try:
+                    from lpt_file_shards import ContentAddressedCostPrior
+
+                    ContentAddressedCostPrior().put_for_path(
+                        path,
+                        file_s,
+                        source="control-effect-recensus",
+                        path_hint=relative,
+                    )
+                except Exception:  # noqa: BLE001 — prior must not kill scan
+                    pass
                 # One-line cause for slow files (always for first/last/every-N,
                 # and always when wall exceeds 5s so a long open names its phase).
                 slow = file_s >= 5.0

--- a/tests/test_control_effect_recensus_lpt_ci_matrix.py
+++ b/tests/test_control_effect_recensus_lpt_ci_matrix.py
@@ -53,3 +53,40 @@ def test_compose_unmeasured_law_still_named_in_workflow() -> None:
     # Attendance dual-belt only on sealed board.
     assert "measurementClass" in text
     assert "bodyCid" in text
+
+
+def test_lpt_prior_shelf_is_actions_cached_and_pin_keyed() -> None:
+    """CI runners start clean — without actions/cache the shelf dies every run.
+
+    Key must include corpus pin aggregate so a different pin is not the exact
+    restore hit. Entries remain content-addressed by file bytes (#7040).
+    """
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "actions/cache/restore@v4" in text
+    assert "actions/cache/save@v4" in text
+    assert "SUGAR_LPT_PRIOR_DIR" in text
+    assert ".cache/sugar/lpt-file-costs" in text
+    assert "lpt-recensus-file-costs-" in text
+    # Pin identity in the key (not tip-only).
+    assert "aggregate_hash" in text
+    assert "lpt-recensus-file-costs-${{ steps.pin.outputs.aggregate_hash }}" in text or (
+        "lpt-recensus-file-costs-${{ needs.plan.outputs.aggregate_hash }}" in text
+    )
+    # Compose unions seat deltas so one full run fills the fleet shelf.
+    assert "lpt-prior-union" in text or "union LPT prior" in text
+    assert "control-effect-recensus-lpt-prior-" in text
+
+
+def test_recensus_write_through_file_s_to_lpt_prior() -> None:
+    """Every measured file_s must land on the CA prior — not only a hand-seed."""
+    recensus = (
+        ROOT
+        / "implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py"
+    )
+    src = recensus.read_text(encoding="utf-8")
+    assert "ContentAddressedCostPrior" in src
+    assert "put_for_path" in src
+    assert "control-effect-recensus" in src
+    assert "file_s" in src
+    # Write-through sits after running-counts persist (same durability belt).
+    assert src.index("running-counts") < src.index("put_for_path")

--- a/tests/test_recensus_lpt_prior_write_through.py
+++ b/tests/test_recensus_lpt_prior_write_through.py
@@ -1,0 +1,52 @@
+"""Recensus write-through: measured file_s → content-addressed LPT prior.
+
+Without this, CI plans degrade to equal-count forever after a hand-seed dies
+on a clean runner. #7040 defined the shelf; process-floor enum already
+write-throughs; recensus must too.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from lpt_file_shards import ContentAddressedCostPrior, assign_files  # noqa: E402
+
+
+def test_put_for_path_then_assign_is_lpt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    prior_root = tmp_path / "prior"
+    monkeypatch.setenv("SUGAR_LPT_PRIOR_DIR", str(prior_root))
+    corpus = tmp_path / "pandas"
+    corpus.mkdir()
+    costs = {
+        "heavy.py": 12.0,
+        "mid.py": 5.0,
+        "light_a.py": 0.2,
+        "light_b.py": 0.2,
+    }
+    paths: dict[str, Path] = {}
+    for name, cost in costs.items():
+        p = corpus / name
+        p.write_text(f"# {name}\n" + ("x" * int(cost * 10)), encoding="utf-8")
+        paths[name] = p
+    prior = ContentAddressedCostPrior(prior_root)
+    for name, cost in costs.items():
+        cid = prior.put_for_path(
+            paths[name], cost, source="control-effect-recensus", path_hint=name
+        )
+        assert cid is not None
+    assignment = assign_files(
+        list(costs),
+        shard_count=2,
+        path_resolver=paths,
+        prior=prior,
+    )
+    assert assignment.mode == "lpt"
+    assert assignment.prior_hits == 4
+    # Heaviest alone or with lights — pole not both mid+heavy.
+    assert max(assignment.estimated_loads) < 13.0


### PR DESCRIPTION
## Summary

Closes the two gaps that made the measured LPT win (pole 12.79s vs equal-count 23.94s, 1.00× ideal) **die on the next CI run**:

1. **CI `actions/cache` for the LPT shelf** — restore before plan and each shard; per-seat save; compose unions all seat deltas and saves a pin-keyed fleet merge. Path is workspace `.cache/sugar/lpt-file-costs` (writable on self-hosted). Cache key includes **corpus pin `aggregateHash`** so a different pin is not the exact restore hit; entries remain content-addressed by file bytes (#7040).

2. **Recensus write-through `file_s` → `ContentAddressedCostPrior`** — same law as process-floor enum. Every measured file lands on the shelf; after **one** full k=8 walk the shelf is complete and self-maintaining (no permanent hand-seed).

## Why

- Local hand-seed of 200 files proved LPT; CI starts clean → empty shelf → equal-count → 1.87× pole.
- Recensus measures 1421 real costs and was throwing them away.

## Validation

```
python3 -m pytest -q tests/test_control_effect_recensus_lpt_ci_matrix.py \
  tests/test_recensus_lpt_prior_write_through.py tests/test_lpt_file_shards.py
# 10 passed
```

## Numbers (prior work, not re-claimed here)

- 200-file walk: wall 102.3s, mean 0.511s, median 0.147s, worst 5.71s → ~12 min full serial.
- LPT k=8 on measured prior: pole **12.79s** vs equal-count **23.94s** (1.00× ideal LPT).

## Not claiming

- 2-minute full-corpus wall in this PR (needs a live CI run with filled shelf).
- Revalidate x1011 / auth spam (mr_black revalidate track; stashed separately).
- Pink’s populate product residency under content CID.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pin-keyed CI cache and write-through for LPT file-cost prior in recensus workflow
> - The CI workflow now maintains a content-addressed LPT file-cost prior shelf at `.cache/sugar/lpt-file-costs`, keyed by the corpus pin `aggregate_hash`, across plan, shard, and compose jobs in [control-effect-recensus.yml](https://github.com/TSavo/sugar/pull/7082/files#diff-7e202e700aa9f13d566241432324fdcbab9681d436e4227693482c2c51b3acd0).
> - The plan job restores the prior before planning and logs entry counts; shard jobs restore, execute, and save per-seat deltas as artifacts.
> - The compose job downloads all per-seat delta artifacts, unions them into the shelf, and saves a merged cache snapshot under the pin key.
> - [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/7082/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) now calls `ContentAddressedCostPrior.put_for_path` after each file measurement to write `file_s` into the prior; exceptions are swallowed so measurement is unaffected.
> - New tests in [test_control_effect_recensus_lpt_ci_matrix.py](https://github.com/TSavo/sugar/pull/7082/files#diff-3f07c56e07aabe2d33f863573800d121da9aaf1248b541d3601c6247ab8b0d11) and [test_recensus_lpt_prior_write_through.py](https://github.com/TSavo/sugar/pull/7082/files#diff-472fc4bc638b3521f4b4bf4a8e6d00ba9e442aed4475e647c88494cfbf835aa5) cover the cache wiring and the write-through behavior end-to-end.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 440bf8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->