### PR TITLE
Session owns dependency top-level graphs (auth once per content)

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/external_exception_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/external_exception_construction.py
@@ -268,6 +268,10 @@ def construct_provider_exception_attribute(
         return None
     top_level = module_name.split(".", 1)[0]
     graph = graph_cache.get(top_level)
+    if graph is None and session.enabled:
+        graph = session.dependency_graphs.get(top_level)
+        if graph is not None:
+            graph_cache[top_level] = graph
     if graph is None:
         from .dependency_artifact import authenticate_dependency_top_level
 
@@ -280,6 +284,8 @@ def construct_provider_exception_attribute(
                 f"provider artifact source absent: {module_name}"
             ) from exc
         graph_cache[top_level] = graph
+        if session.enabled:
+            session.dependency_graphs[top_level] = graph
     return AuthenticatedProviderExceptionTypeV1.construct(
         graph=graph,
         binding_cid=binding_cid,
@@ -391,11 +397,17 @@ def _reaching_provider_module(
         return None, None
     callee_top = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
     callee_graph = graph_cache.get(callee_top)
+    if callee_graph is None and session.enabled:
+        callee_graph = session.dependency_graphs.get(callee_top)
+        if callee_graph is not None:
+            graph_cache[callee_top] = callee_graph
     if callee_graph is None:
         callee_graph = authenticate_dependency_top_level(
             callee_top, distribution_index=distribution_index
         )
         graph_cache[callee_top] = callee_graph
+        if session.enabled:
+            session.dependency_graphs[callee_top] = callee_graph
     resolved = resolve_import_binding(receipt, graph=callee_graph, session=session)
     if not isinstance(resolved, ResolvedPythonObjectV1):
         return None, None

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -65,6 +65,55 @@ class ImportValueUseSeatingGap(ValueError):
         super().__init__(f"{kind}: {detail}")
 
 
+def _bind_dependency_graphs(
+    session: SourceResolutionSession,
+    dependency_graphs: dict[str, DependencyArtifactGraph] | None,
+) -> dict[str, DependencyArtifactGraph]:
+    """Local graph map seeded from the session so auth tops are asked once.
+
+    Frame projection used to mint ``dependency_graphs={}`` per definition,
+    re-entering ``authenticate_dependency_top_level`` for the same warnings/re/
+    inspect tops (21× each on one test_pandas open). Session owns the map;
+    local overlays seed from it and write through on first auth. Walk-scoped
+    sessions (#7081) extend the once-ask across multi-file open/enumerate.
+    """
+    if dependency_graphs is None:
+        if session.enabled:
+            return session.dependency_graphs
+        return {}
+    if session.enabled:
+        for top, graph in session.dependency_graphs.items():
+            dependency_graphs.setdefault(top, graph)
+    return dependency_graphs
+
+
+def _dependency_graph_for_top(
+    top_level: str,
+    *,
+    session: SourceResolutionSession,
+    dependency_graphs: dict[str, DependencyArtifactGraph],
+    distribution_index=None,
+) -> DependencyArtifactGraph:
+    """Authenticate ``top_level`` once per session (and local map)."""
+    hit = dependency_graphs.get(top_level)
+    if hit is not None:
+        return hit
+    if session.enabled:
+        hit = session.dependency_graphs.get(top_level)
+        if hit is not None:
+            dependency_graphs[top_level] = hit
+            return hit
+    from .dependency_artifact import authenticate_dependency_top_level
+
+    graph = authenticate_dependency_top_level(
+        top_level, distribution_index=distribution_index
+    )
+    dependency_graphs[top_level] = graph
+    if session.enabled:
+        session.dependency_graphs[top_level] = graph
+    return graph
+
+
 def _project_metaclass_final_class(value: FloorValue, *, blame) -> FloorValue:
     """Select the sole authenticated returned class for module publication."""
     from sugar_lift_py_tests.floor.source_return_projection import (
@@ -770,12 +819,9 @@ def _enroll_imported_decorator_frames(
             continue
         receipt.revalidate()
         top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
-        graph = dependency_graphs.get(top_level)
-        if graph is None:
-            from .dependency_artifact import authenticate_dependency_top_level
-
-            graph = authenticate_dependency_top_level(top_level)
-            dependency_graphs[top_level] = graph
+        graph = _dependency_graph_for_top(
+            top_level, session=session, dependency_graphs=dependency_graphs
+        )
         resolved_decorator = resolve_import_binding(
             receipt, graph=graph, session=session
         )
@@ -897,9 +943,12 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
                 definition.fragment.seal().cid
             ] = tuple(bases)
 
-    dependency_graphs = {}
+    dependency_graphs = _bind_dependency_graphs(session, {})
     if graph is not None:
-        dependency_graphs[module.module_name.split(".", 1)[0]] = graph
+        top = module.module_name.split(".", 1)[0]
+        dependency_graphs[top] = graph
+        if session.enabled:
+            session.dependency_graphs[top] = graph
         for definition in prefix_classes:
             _seat_import_value_use_receipts(
                 source_file=source_file,
@@ -2123,8 +2172,13 @@ def _resolve_source_visible_frame_uncached(
     )
     from sugar_source_tree.reporter import NULL_REPORTER
 
-    dependency_graphs = dict(dependency_graphs or {})
-    dependency_graphs[resolved.module_name.split(".", 1)[0]] = graph
+    dependency_graphs = _bind_dependency_graphs(
+        session, dict(dependency_graphs or {})
+    )
+    top = resolved.module_name.split(".", 1)[0]
+    dependency_graphs[top] = graph
+    if session.enabled:
+        session.dependency_graphs[top] = graph
     module_key = _module_materialize_key(
         graph=graph, module=module, dependency_graphs=dependency_graphs
     )
@@ -2353,23 +2407,21 @@ def _resolve_source_visible_frame_uncached(
             )
 
         top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
-        dependency_graph = dependency_graphs.get(top_level)
-        if dependency_graph is None:
-            from .dependency_artifact import (
-                DependencyArtifactAuthenticationError,
-                authenticate_dependency_top_level,
+        try:
+            dependency_graph = _dependency_graph_for_top(
+                top_level, session=session, dependency_graphs=dependency_graphs
             )
+        except Exception as exc:
+            from .dependency_artifact import DependencyArtifactAuthenticationError
 
-            try:
-                dependency_graph = authenticate_dependency_top_level(top_level)
-            except DependencyArtifactAuthenticationError:
-                _install_opaque_call_obligation(
-                    context,
-                    call,
-                    obligation("call-target-source-absent"),
-                )
-                continue
-            dependency_graphs[top_level] = dependency_graph
+            if not isinstance(exc, DependencyArtifactAuthenticationError):
+                raise
+            _install_opaque_call_obligation(
+                context,
+                call,
+                obligation("call-target-source-absent"),
+            )
+            continue
         imported = resolve_import_binding(
             receipt, graph=dependency_graph, session=session
         )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1271,6 +1271,11 @@ def populate_source_derived_resource_refs(
             if value[0] in selected_coordinates
         }
     graphs = {} if artifact_graph_cache is None else artifact_graph_cache
+    # Seed from session so tops already resolved in frame/prefix projection
+    # are not re-asked (warnings/re/inspect ×21 on test_pandas).
+    if session.enabled:
+        for top, graph in session.dependency_graphs.items():
+            graphs.setdefault(top, graph)
     for receipt in receipts:
         raw_site = receipt.use["useSite"]
         key = (
@@ -1285,6 +1290,10 @@ def populate_source_derived_resource_refs(
         coordinate, call, exit_face_id = selected
         top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
         graph = graphs.get(top_level)
+        if graph is None and session.enabled:
+            graph = session.dependency_graphs.get(top_level)
+            if graph is not None:
+                graphs[top_level] = graph
         if graph is None:
             from .dependency_artifact import (
                 DependencyArtifactAuthenticationError,
@@ -1301,6 +1310,8 @@ def populate_source_derived_resource_refs(
                 )
                 continue
             graphs[top_level] = graph
+            if session.enabled:
+                session.dependency_graphs[top_level] = graph
         resolved = resolve_import_binding(receipt, graph=graph, session=session)
         if not isinstance(resolved, ResolvedPythonObjectV1):
             kind = getattr(resolved, "kind", None) or "no-derived-contract"
@@ -2464,7 +2475,14 @@ def _construct_decorator_function(
     if graph is not None:
         graphs.append(graph)
     top_level = module_name.split(".", 1)[0]
-    authenticated_dependency = (dependency_graphs or {}).get(top_level)
+    local_graphs = dependency_graphs if dependency_graphs is not None else {}
+    authenticated_dependency = local_graphs.get(top_level)
+    if authenticated_dependency is None and session is not None and session.enabled:
+        authenticated_dependency = session.dependency_graphs.get(top_level)
+        if authenticated_dependency is not None:
+            local_graphs[top_level] = authenticated_dependency
+            if dependency_graphs is not None:
+                dependency_graphs[top_level] = authenticated_dependency
     if authenticated_dependency is None:
         try:
             authenticated_dependency = authenticate_dependency_top_level(
@@ -2473,22 +2491,24 @@ def _construct_decorator_function(
         except DependencyArtifactAuthenticationError:
             authenticated_dependency = None
         else:
+            local_graphs[top_level] = authenticated_dependency
             if dependency_graphs is not None:
                 dependency_graphs[top_level] = authenticated_dependency
+            if session is not None and session.enabled:
+                session.dependency_graphs[top_level] = authenticated_dependency
     if authenticated_dependency is not None and authenticated_dependency not in graphs:
         graphs.append(authenticated_dependency)
     if not any(module_name in candidate.modules for candidate in graphs):
-        from .dependency_artifact import (
-            DependencyArtifactAuthenticationError,
-            authenticate_dependency_top_level,
-        )
-
         try:
             authenticated_dependency = authenticate_dependency_top_level(
                 top_level, distribution_index=distribution_index
             )
         except DependencyArtifactAuthenticationError:
             return None
+        if session is not None and session.enabled:
+            session.dependency_graphs[top_level] = authenticated_dependency
+        if dependency_graphs is not None:
+            dependency_graphs[top_level] = authenticated_dependency
         if authenticated_dependency not in graphs:
             graphs.append(authenticated_dependency)
     resolved = None

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -111,6 +111,7 @@ class SourceResolutionSession:
         "import_use_rosters",
         "import_value_rosters",
         "lexical_passes",
+        "dependency_graphs",
     )
 
     def __init__(
@@ -161,6 +162,16 @@ class SourceResolutionSession:
         # source_cid -> full lexical _Pass product (rows + value_rows). One walk
         # fills both roster doors; avoids a second SourceFile for the same body.
         self.lexical_passes: dict[str, Any] = {}
+        # top_level -> DependencyArtifactGraph for this session (and walk). Call
+        # sites used to mint a fresh ``dependency_graphs={}`` per frame /
+        # prefix / populate path, re-entering authenticate_dependency_top_level
+        # 21× for the same warnings/re/inspect tops on one test_pandas open
+        # (65 total across 5 unique tops). Process cache makes each hit cheap;
+        # session ownership makes the ask once per content under the walk.
+        # Graphs are content-addressed install facts (no live construction
+        # context) — process-resident top-level cache remains legal; this
+        # table deletes the path-local re-ask disease.
+        self.dependency_graphs: dict[str, Any] = {}
 
     # -- export resolution memo ------------------------------------------
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
@@ -66,6 +66,9 @@ def populate_source_visible_call_frames(
     calls_by_span = {_span_key(node): node for node in calls}
     constructor_targets = {}
     graphs = {} if artifact_graph_cache is None else artifact_graph_cache
+    if session.enabled:
+        for top, graph in session.dependency_graphs.items():
+            graphs.setdefault(top, graph)
     for receipt in receipts:
         raw = receipt.use["useSite"]
         key = (raw["startLine"], raw["startCol"], raw["endLine"], raw["endCol"])
@@ -75,6 +78,10 @@ def populate_source_visible_call_frames(
         coordinate = _coordinate(call)
         top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
         graph = graphs.get(top_level)
+        if graph is None and session.enabled:
+            graph = session.dependency_graphs.get(top_level)
+            if graph is not None:
+                graphs[top_level] = graph
         if graph is None:
             try:
                 from .dependency_artifact import authenticate_dependency_top_level
@@ -90,6 +97,8 @@ def populate_source_visible_call_frames(
                 )
                 continue
             graphs[top_level] = graph
+            if session.enabled:
+                session.dependency_graphs[top_level] = graph
         resolved = resolve_import_binding(receipt, graph=graph, session=session)
         if isinstance(resolved, PythonObjectResolutionGapV1):
             context.source_call_resolutions[coordinate] = (

--- a/implementations/python/sugar-lift-python-source/tests/test_auth_once_per_content.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_auth_once_per_content.py
@@ -1,0 +1,89 @@
+"""Session owns dependency top-level graphs — ask auth once per top.
+
+Cold test_pandas open called authenticate_dependency_top_level 65× across
+only 5 unique tops (warnings/re/inspect ×21 each). Process cache made each
+hit cheap; session ownership makes the ask once per construction session
+(and walk-scoped sessions share the map across multi-file open).
+"""
+
+from __future__ import annotations
+
+from sugar_lift_python_source.manager_construction import (
+    _bind_dependency_graphs,
+    _dependency_graph_for_top,
+)
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
+
+
+def test_dependency_graph_for_top_asks_auth_once(monkeypatch) -> None:
+    session = SourceResolutionSession()
+    local: dict = {}
+    calls: list[str] = []
+
+    class _FakeGraph:
+        def __init__(self, name: str) -> None:
+            self.distribution_name = name
+
+    def fake_auth(top_level, distribution_index=None):  # type: ignore[no-untyped-def]
+        calls.append(top_level)
+        return _FakeGraph(top_level)
+
+    monkeypatch.setattr(
+        "sugar_lift_python_source.dependency_artifact.authenticate_dependency_top_level",
+        fake_auth,
+    )
+
+    g1 = _dependency_graph_for_top(
+        "warnings", session=session, dependency_graphs=local
+    )
+    g2 = _dependency_graph_for_top(
+        "warnings", session=session, dependency_graphs=local
+    )
+    # Fresh local map still hits session (ask once per content, not path).
+    g3 = _dependency_graph_for_top(
+        "warnings", session=session, dependency_graphs={}
+    )
+    assert g1 is g2 is g3
+    assert calls == ["warnings"]
+    assert session.dependency_graphs["warnings"] is g1
+
+
+def test_bind_dependency_graphs_seeds_from_session() -> None:
+    session = SourceResolutionSession()
+    session.dependency_graphs["re"] = object()
+    bound = _bind_dependency_graphs(session, {})
+    assert bound["re"] is session.dependency_graphs["re"]
+    # None binds the session map itself (write-through).
+    direct = _bind_dependency_graphs(session, None)
+    assert direct is session.dependency_graphs
+
+
+def test_five_unique_tops_auth_once_each(monkeypatch) -> None:
+    """Black cold profile shape: 5 tops, path-local re-ask → 1 auth each."""
+    session = SourceResolutionSession()
+    calls: list[str] = []
+
+    class _FakeGraph:
+        def __init__(self, name: str) -> None:
+            self.distribution_name = name
+
+    def fake_auth(top_level, distribution_index=None):  # type: ignore[no-untyped-def]
+        calls.append(top_level)
+        return _FakeGraph(top_level)
+
+    monkeypatch.setattr(
+        "sugar_lift_python_source.dependency_artifact.authenticate_dependency_top_level",
+        fake_auth,
+    )
+
+    tops = ("warnings", "re", "inspect", "sys", "os")
+    # Simulate 21 path-local maps (as on one test_pandas open).
+    for _ in range(21):
+        local: dict = {}
+        for top in tops:
+            _dependency_graph_for_top(
+                top, session=session, dependency_graphs=local
+            )
+
+    assert calls == list(tops)
+    assert set(session.dependency_graphs) == set(tops)

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -431,6 +431,9 @@ def leaky_process_memo(monkeypatch):
         self.import_use_rosters = import_uses
         self.import_value_rosters = import_values
         self.lexical_passes = {}
+        # Content-addressed install graphs (not projection); empty per init so
+        # leaky twin still constructs after session.dependency_graphs lands.
+        self.dependency_graphs = {}
 
     monkeypatch.setattr(SourceResolutionSession, "__init__", leaky_init)
 


### PR DESCRIPTION
## Summary

Black cold profile on one test file: `authenticate_dependency_top_level` **x65** across only **5 unique tops** (warnings/re/inspect ×21 each). Process cache made each hit cheap; path-local `dependency_graphs={}` per frame/prefix/populate re-asked the same install fact by a different path — same disease as everything else tonight.

**Shell deleted:** path-local re-ask of content-addressed auth.

**Replacement:** `SourceResolutionSession.dependency_graphs` (top_level → graph). One door `_dependency_graph_for_top` / `_bind_dependency_graphs` seeds local maps from the session and write-throughs first auth. Walk-scoped sessions (#7081) extend the once-ask across multi-file open/enumerate.

Wired: `manager_construction`, `manager_summary_derivation`, `source_call_preconstruction`, `external_exception_construction`.

## Tooth

`test_auth_once_per_content.py`: 21 path-local maps × 5 tops → **5** `authenticate` calls (not 105).

## Epsilon R

- auth `ncalls` ≈ unique tops per walk (not × paths)
- **Not claimed:** full census wall 12 min → 2 min from this alone (revalidate volume is black's lane; LPT prior is #7082)

## Floors

- Process top-level / fingerprint caches remain (graphs are content-addressed install facts)
- No process-global projection memo of live Nodes
- Authority twin leaky fixture gains empty `dependency_graphs` so slots still construct

## Coordination

- mr_black: asked REVALIDATE vs AUTH; he owns `mr_black/revalidate-once-per-content` (lexical #7078 already on main) and is on LPT prior — **brown took AUTH only**
- Tip base: origin/main includes #7081 walk session + #7082 LPT prior

merge_dog: land when green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache dependency graphs on the session to authenticate each top-level content once per session
> - Adds a `dependency_graphs` dict slot to `SourceResolutionSession` as a session-scoped cache keyed by top-level module.
> - Introduces `_dependency_graph_for_top` and `_bind_dependency_graphs` helpers in [manager_construction.py](https://github.com/TSavo/sugar/pull/7083/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to centralize session-aware graph lookup and seeding.
> - Updates graph resolution across [manager_construction.py](https://github.com/TSavo/sugar/pull/7083/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1), [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/7083/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c), [external_exception_construction.py](https://github.com/TSavo/sugar/pull/7083/files#diff-41bbd498dc18ea7e4b478eccef54cc4953b94a7195456399cfed5c99da975acd), and [source_call_preconstruction.py](https://github.com/TSavo/sugar/pull/7083/files#diff-74b4be0d0a335267f0783561ba4419e3981f34d4d03f9d4d72678b66d4e94cbf) to read from and write back to the session cache.
> - Adds tests in [test_auth_once_per_content.py](https://github.com/TSavo/sugar/pull/7083/files#diff-641d52cb5bc8344f3a3efe40d3bd2721f85e2540405dcde125bbbe1f14eae1ba) asserting that `authenticate_dependency_top_level` is called at most once per top-level per session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7edc58e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->