### PR TITLE
Recensus LPT prior: batch write-through at end of lift

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1098,6 +1098,7 @@ def main() -> int:
             bits = " ".join(f"{k}={v}" for k, v in postfix.items())
             _narrate(f"RECENSUS PROGRESS {n}/{total} {bits}")
 
+        lpt_prior_rows: list[tuple[Path, float, str]] = []
         try:
             bar = tqdm(
                 pending,
@@ -1353,22 +1354,14 @@ def main() -> int:
                         + "\n"
                     )
                     rc_stream.flush()
-                # Content-addressed LPT prior write-through (#7040 law for
-                # recensus). Every measured file_s must land on the shelf so
-                # the next plan is LPT, not equal-count. Hand-seed is not a
-                # standing property; this is. Prior must never kill the walk.
-                # ``path`` is the filesystem seat; ``file`` is the enrolled key.
-                try:
-                    from lpt_file_shards import ContentAddressedCostPrior
-
-                    ContentAddressedCostPrior().put_for_path(
-                        path,
-                        file_s,
-                        source="control-effect-recensus",
-                        path_hint=relative,
-                    )
-                except Exception:  # noqa: BLE001 — prior must not kill scan
-                    pass
+                # Buffer LPT prior rows — flush once at shard end (not per file).
+                # put_for_path re-reads full source bytes for the content CID and
+                # does an atomic json write; doing that on the lift hot path under
+                # k=8 concurrent seats interleaved disk with Materialize. No
+                # flock/fsync, but the re-read+write storm is real volume. Law
+                # is unchanged: every file_s still lands on the shelf before the
+                # process exits the lift phase.
+                lpt_prior_rows.append((path, file_s, relative))
                 # One-line cause for slow files (always for first/last/every-N,
                 # and always when wall exceeds 5s so a long open names its phase).
                 slow = file_s >= 5.0
@@ -1407,7 +1400,38 @@ def main() -> int:
                 live_bar.close()
             bar.close()
         finally:
+            # LPT prior write-through: once per shard/process, not per file.
+            # #7040 law — every measured file_s on the shelf; #7082 put the door
+            # on the hot path; batch so concurrent seats do not re-read source
+            # + write-write mid-lift (blonde 3.26× inflation suspect). Flush in
+            # finally so a mid-walk abort still banks what was measured.
+            if lpt_prior_rows:
+                try:
+                    from lpt_file_shards import ContentAddressedCostPrior
+
+                    prior = ContentAddressedCostPrior()
+                    written = 0
+                    for pth, cost, hint in lpt_prior_rows:
+                        if prior.put_for_path(
+                            pth,
+                            cost,
+                            source="control-effect-recensus",
+                            path_hint=hint,
+                        ):
+                            written += 1
+                    _narrate(
+                        "JOB_LOG phase=lpt-prior-write population=control-effect-recensus "
+                        f"status=ok files_written={written} files_buffered={len(lpt_prior_rows)} "
+                        f"mode=batch-end-of-lift prior_root={prior.root}"
+                    )
+                except Exception as exc:  # noqa: BLE001 — prior must not kill scan
+                    _narrate(
+                        "JOB_LOG phase=lpt-prior-write population=control-effect-recensus "
+                        f"status=failed reason={type(exc).__name__}:{exc} "
+                        "mode=batch-end-of-lift degraded=shelf-stale-next-plan"
+                    )
             progress_stream.close()
+
 
 
     # Tripwire: the lift loop must never rebind `families` to a row dict.

--- a/tests/test_control_effect_recensus_lpt_ci_matrix.py
+++ b/tests/test_control_effect_recensus_lpt_ci_matrix.py
@@ -88,5 +88,9 @@ def test_recensus_write_through_file_s_to_lpt_prior() -> None:
     assert "put_for_path" in src
     assert "control-effect-recensus" in src
     assert "file_s" in src
-    # Write-through sits after running-counts persist (same durability belt).
-    assert src.index("running-counts") < src.index("put_for_path")
+    # Buffer during the lift; flush once at end (not per-file on hot path).
+    assert "lpt_prior_rows" in src
+    assert "mode=batch-end-of-lift" in src
+    assert "lpt_prior_rows.append" in src
+    # One put_for_path call site (the batch flush), not a per-file call.
+    assert src.count("prior.put_for_path(") == 1


### PR DESCRIPTION
## Summary

Follow-up to #7082. Per-file `put_for_path` on the lift hot path re-reads full source bytes (content CID) and atomic-writes a JSON prior entry every file. Under k=8 concurrent seats that interleaves disk with Materialize — a prime suspect for blonde’s **3.26× work inflation**.

**Change:** buffer `(path, file_s, hint)` during the walk; flush once in `finally` at end of lift (still banks partials on abort). Law unchanged: every measured `file_s` still lands on the CA shelf before the process exits the lift phase.

## Topology finding (separate report)

The ~25 online self-hosted runners are **25 Docker containers on one host (Battleaxe, 32 CPU / 62 GiB)**, not 25 machines. Runner name suffix = container short id. CI k=8 therefore hits the **same single-box contention** blonde measured (~1.8× wall, not ~8×). Multi-host is required for near-linear LPT wall.

## Validation

```
python3 -m pytest -q tests/test_control_effect_recensus_lpt_ci_matrix.py \
  tests/test_recensus_lpt_prior_write_through.py tests/test_lpt_file_shards.py
# 10 passed
```

## Not claiming

- That batching alone recovers the full 3.26× (CPU/RAM contention still dominates on one box).
- Multi-host runner fleet redesign.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Batch LPT prior writes at end of lift in `control_effect_recensus`
> - Replaces per-file `ContentAddressedCostPrior.put_for_path()` calls with a buffer (`lpt_prior_rows`) that collects tuples during the file loop, then flushes in a single batch after the progress bars close.
> - Adds JOB_LOG narration summarizing batch write success (`files_written`, `files_buffered`, `mode=batch-end-of-lift`, `prior_root`) or failure with exception details.
> - Exceptions during prior writes are now logged rather than silently suppressed, but still do not abort the scan.
> - Updates assertions in [test_control_effect_recensus_lpt_ci_matrix.py](https://github.com/TSavo/sugar/pull/7084/files#diff-3f07c56e07aabe2d33f863573800d121da9aaf1248b541d3601c6247ab8b0d11) to verify the buffered batch pattern and single `put_for_path` call site.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e55367.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->