### PR TITLE
Revalidate once per demand content, not once per path

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -166,6 +166,9 @@ class AuthenticatedImportUseV1:
         repr=False, compare=False
     )
     _authority: object = dataclass_field(repr=False, compare=False)
+    # Content address of ``demand`` (the lexical row). Minted once; revalidate
+    # and snapshot membership use this instead of re-hashing the row per path.
+    demand_cid: str = dataclass_field(repr=False, compare=False, default="")
 
     def __post_init__(self) -> None:
         if self._authority is not _IMPORT_AUTHORITY:
@@ -203,6 +206,9 @@ class AuthenticatedImportUseV1:
         else:
             # call-contract-demand — closed call shape only.
             _require_call_contract_demand(self)
+        # Pin demand content address once (mint supplies it; forge path computes).
+        if not self.demand_cid:
+            object.__setattr__(self, "demand_cid", _hash(self.demand))
 
     def revalidate(self) -> None:
         """Demand byte identity against one shared #6090 snapshot per module.
@@ -215,7 +221,20 @@ class AuthenticatedImportUseV1:
         Call-target and value-use demands revalidate against their own
         row/outcome surfaces so Call receipts stay unchanged and neither
         surface can authorize the other.
+
+        Once-per-content (#7083 disease class): a demand that has already
+        proven membership under its content CID is not re-asked when reached
+        by a different path (manager seat, resolve_import_binding, floor,
+        sugar). Black cold profile: revalidate ×1011 on one test_pandas open
+        — answer cannot change; re-ask is design smell, not cost hygiene.
         """
+        if getattr(self, "_revalidated_ok", False):
+            return
+        surface = _revalidation_surface(self.demand)
+        memo_key = (self.demand_cid, surface)
+        if memo_key in _REVALIDATED_DEMANDS:
+            object.__setattr__(self, "_revalidated_ok", True)
+            return
         site = self.use["useSite"]
         key = (
             site["startLine"],
@@ -223,7 +242,7 @@ class AuthenticatedImportUseV1:
             site["endLine"],
             site["endCol"],
         )
-        if self.demand.get("kind") == "import-value-use-demand":
+        if surface == "value":
             snapshot = _lexical_value_revalidation_snapshot(
                 self.root,
                 self.path,
@@ -241,12 +260,14 @@ class AuthenticatedImportUseV1:
                 self.module_identities,
             )
             expected = "authenticated-import-use"
-        if snapshot.outcome_at(key) != expected or not (
-            snapshot.contains_row(self.demand)
+        if snapshot.outcome_at(key) != expected or not snapshot.contains_row_cid(
+            self.demand_cid
         ):
             raise ValueError(
                 "authenticated import use is not byte-identical to lexical revalidation"
             )
+        _REVALIDATED_DEMANDS.add(memo_key)
+        object.__setattr__(self, "_revalidated_ok", True)
 
 
 def _authenticated_binding_target_symbol(binding: ImportBindingV1) -> str:
@@ -1056,25 +1077,42 @@ class _LexicalRevalidationSnapshotV1:
         """Byte identity against the pass's rows, by content address."""
         return _hash(row) in self.row_cids
 
+    def contains_row_cid(self, row_cid: str) -> bool:
+        """Membership by precomputed row content address (no re-hash)."""
+        return row_cid in self.row_cids
+
     def outcome_at(self, site: tuple[int, int, int, int]) -> str | None:
         return self.outcomes.get(site)
 
 
 # Shared #6090 snapshot for revalidation only.  Keyed by consumer module
-# content + identities map so many receipts share one full-module pass.
-# See docs/audits/pandas-recensus-latency-bisect.md.
+# content + package role + identities (not asker path — same disease as
+# path-local auth re-ask). See docs/audits/pandas-recensus-latency-bisect.md
+# and process_resident_file §4 lexical key.
 _REVALIDATION_SNAPSHOTS: dict[
-    tuple[str, str, str, str], _LexicalRevalidationSnapshotV1
+    tuple[str, bool, str], _LexicalRevalidationSnapshotV1
 ] = {}
 _VALUE_REVALIDATION_SNAPSHOTS: dict[
-    tuple[str, str, str, str], _LexicalRevalidationSnapshotV1
+    tuple[str, bool, str], _LexicalRevalidationSnapshotV1
 ] = {}
+
+# Demand content CIDs already proven against their surface.  Pure content fact
+# (h = h(p)): once the demand is in the snapshot, every later path that holds
+# the same demand content is free.  Cleared with snapshots.
+_REVALIDATED_DEMANDS: set[tuple[str, str]] = set()
+
+
+def _revalidation_surface(demand: Mapping[str, Any]) -> str:
+    if demand.get("kind") == "import-value-use-demand":
+        return "value"
+    return "call"
 
 
 def clear_lexical_revalidation_snapshots() -> None:
     """Drop amortized revalidation snapshots (tests / hermetic process reuse)."""
     _REVALIDATION_SNAPSHOTS.clear()
     _VALUE_REVALIDATION_SNAPSHOTS.clear()
+    _REVALIDATED_DEMANDS.clear()
 
 
 def _revalidation_cache_key(
@@ -1082,11 +1120,17 @@ def _revalidation_cache_key(
     path: Path,
     source_cid: str,
     module_identities: dict[str, dict[str, Any]],
-) -> tuple[str, str, str, str]:
+) -> tuple[str, bool, str]:
+    """Content key for the revalidation snapshot (not path-local).
+
+    Same body under two seat spellings must share one snapshot — package role
+    and identities are the only open inputs beyond source_cid (§4 law).
+    ``root``/``path`` remain parameters so miss-path lexical runs still seat.
+    """
+    del root  # seat is not the key; miss path still receives path for package bit
     return (
-        str(root.resolve()),
-        str(path.resolve()),
         source_cid,
+        Path(path).name == "__init__.py",
         _hash(module_identities),
     )
 
@@ -1297,27 +1341,39 @@ def _mint_import_use_receipts(
     source: str,
     source_cid: str,
     module_identities: dict[str, dict[str, Any]] | None,
+    prevalidated: bool = False,
 ) -> list[AuthenticatedImportUseV1]:
+    """Mint seat-bound receipts.
+
+    ``prevalidated=True`` when the caller just installed these exact ``rows``
+    into the revalidation snapshot for this content — membership is proven by
+    construction; later ``revalidate()`` must not re-hash each demand per path.
+    """
     receipts: list[AuthenticatedImportUseV1] = []
     for row in rows:
         binding_value = row["importBinding"]
         binding = ImportBindingV1(
             binding_value, row["importBindingCid"], _IMPORT_AUTHORITY
         )
-        receipts.append(
-            AuthenticatedImportUseV1(
-                import_binding=binding,
-                target_symbol=row["targetSymbol"],
-                use=row["authenticatedImportUse"],
-                demand=row,
-                root=root,
-                path=path,
-                source=source,
-                source_cid=source_cid,
-                module_identities=dict(module_identities or {}),
-                _authority=_IMPORT_AUTHORITY,
-            )
+        demand_cid = _hash(row)
+        receipt = AuthenticatedImportUseV1(
+            import_binding=binding,
+            target_symbol=row["targetSymbol"],
+            use=row["authenticatedImportUse"],
+            demand=row,
+            root=root,
+            path=path,
+            source=source,
+            source_cid=source_cid,
+            module_identities=dict(module_identities or {}),
+            _authority=_IMPORT_AUTHORITY,
+            demand_cid=demand_cid,
         )
+        if prevalidated:
+            surface = _revalidation_surface(row)
+            _REVALIDATED_DEMANDS.add((demand_cid, surface))
+            object.__setattr__(receipt, "_revalidated_ok", True)
+        receipts.append(receipt)
     return receipts
 
 
@@ -1365,10 +1421,13 @@ def authenticated_import_use_receipts(
         )
     # Same pass fills revalidation snapshot so receipt.revalidate() does not
     # re-Materialize the module (mint+revalidate was a second SourceFile).
+    # Row CIDs are the demand content addresses — mint stamps them and marks
+    # prevalidated so multi-path revalidate is free (once per content).
     cache_key = _revalidation_cache_key(root, path, source_cid, module_identities)
+    row_cids = frozenset(_hash(row) for row in rows)
     if cache_key not in _REVALIDATION_SNAPSHOTS:
         _REVALIDATION_SNAPSHOTS[cache_key] = _LexicalRevalidationSnapshotV1(
-            row_cids=frozenset(_hash(row) for row in rows),
+            row_cids=row_cids,
             outcomes=MappingProxyType(dict(outcomes)),
         )
     return (
@@ -1379,6 +1438,7 @@ def authenticated_import_use_receipts(
             source=source,
             source_cid=source_cid,
             module_identities=module_identities,
+            prevalidated=True,
         ),
         outcomes,
     )
@@ -1424,9 +1484,10 @@ def authenticated_import_value_use_receipts(
             root, path, source, source_cid, module_identities=module_identities
         )
     cache_key = _revalidation_cache_key(root, path, source_cid, module_identities)
+    row_cids = frozenset(_hash(row) for row in rows)
     if cache_key not in _VALUE_REVALIDATION_SNAPSHOTS:
         _VALUE_REVALIDATION_SNAPSHOTS[cache_key] = _LexicalRevalidationSnapshotV1(
-            row_cids=frozenset(_hash(row) for row in rows),
+            row_cids=row_cids,
             outcomes=MappingProxyType(dict(outcomes)),
         )
     return (
@@ -1437,6 +1498,7 @@ def authenticated_import_value_use_receipts(
             source=source,
             source_cid=source_cid,
             module_identities=module_identities,
+            prevalidated=True,
         ),
         outcomes,
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_revalidate_once_per_content.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_revalidate_once_per_content.py
@@ -1,0 +1,118 @@
+"""Revalidate asks once per demand content, not once per path.
+
+Black cold profile on tests/io/json/test_pandas.py: revalidate ×1011 on one
+file — a volume bomb. Same disease as auth #7083: content-addressed answer
+re-asked because a different path reached the receipt.
+
+Shell: per-path revalidate work (re-hash demand + snapshot membership).
+Replacement: demand_cid + process _REVALIDATED_DEMANDS; mint prevalidates
+when the snapshot is filled from the same rows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_py_tests.canonicalizer import blake3_512_of
+from sugar_lift_py_tests.import_binding import (
+    _REVALIDATED_DEMANDS,
+    authenticated_import_use_receipts,
+    clear_lexical_revalidation_snapshots,
+)
+
+
+def _mint_many(tmp_path: Path, n_sites: int = 20):
+    lines = ["import json"] + [f'json.loads("{i}")' for i in range(n_sites)]
+    source = "\n".join(lines) + "\n"
+    path = tmp_path / "consumer.py"
+    path.write_text(source, encoding="utf-8")
+    source_cid = blake3_512_of(source.encode("utf-8"))
+    receipts, _ = authenticated_import_use_receipts(
+        tmp_path, path, source, source_cid, module_identities={}
+    )
+    return receipts
+
+
+def test_mint_prevalidates_so_revalidate_is_free(tmp_path: Path, monkeypatch) -> None:
+    clear_lexical_revalidation_snapshots()
+    receipts = _mint_many(tmp_path, n_sites=12)
+    assert len(receipts) == 12
+    # Mint filled _REVALIDATED_DEMANDS for every demand content.
+    assert len(_REVALIDATED_DEMANDS) == 12
+
+    import sugar_lift_py_tests.import_binding as ib
+
+    calls = {"snapshot": 0, "hash": 0}
+    original_snap = ib._lexical_revalidation_snapshot
+    original_hash = ib._hash
+
+    def counting_snap(*args, **kwargs):
+        calls["snapshot"] += 1
+        return original_snap(*args, **kwargs)
+
+    def counting_hash(value):
+        calls["hash"] += 1
+        return original_hash(value)
+
+    monkeypatch.setattr(ib, "_lexical_revalidation_snapshot", counting_snap)
+    monkeypatch.setattr(ib, "_hash", counting_hash)
+
+    # Multi-path revalidate (manager seat + resolve_import_binding + floor).
+    for _ in range(5):
+        for receipt in receipts:
+            receipt.revalidate()
+
+    assert calls["snapshot"] == 0, (
+        f"prevalidated revalidate still opened snapshot {calls['snapshot']} times"
+    )
+    assert calls["hash"] == 0, (
+        f"prevalidated revalidate still re-hashed demand {calls['hash']} times"
+    )
+
+
+def test_second_path_same_content_does_not_re_ask(tmp_path: Path, monkeypatch) -> None:
+    """Reminted receipts with same demand content hit process memo."""
+    clear_lexical_revalidation_snapshots()
+    first = _mint_many(tmp_path, n_sites=8)
+    for receipt in first:
+        receipt.revalidate()
+
+    # Drop instance flags only — process content memo must still serve.
+    for receipt in first:
+        object.__setattr__(receipt, "_revalidated_ok", False)
+
+    import sugar_lift_py_tests.import_binding as ib
+
+    snaps = {"n": 0}
+    original = ib._lexical_revalidation_snapshot
+
+    def counting(*args, **kwargs):
+        snaps["n"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(ib, "_lexical_revalidation_snapshot", counting)
+    for receipt in first:
+        receipt.revalidate()
+    assert snaps["n"] == 0
+
+
+def test_forged_demand_still_fails_after_memo(tmp_path: Path) -> None:
+    clear_lexical_revalidation_snapshots()
+    receipts = _mint_many(tmp_path, n_sites=1)
+    receipt = receipts[0]
+    # Forge a demand that is not in the snapshot; clear prevalidation.
+    forged = dict(receipt.demand)
+    forged["targetSymbol"] = "python:forged.symbol"
+    object.__setattr__(receipt, "demand", forged)
+    object.__setattr__(receipt, "demand_cid", "")  # force recompute
+    object.__setattr__(receipt, "_revalidated_ok", False)
+    # demand_cid empty triggers re-hash in a manual revalidate path — rebuild cid
+    from sugar_lift_py_tests import import_binding as ib
+
+    object.__setattr__(receipt, "demand_cid", ib._hash(forged))
+    _REVALIDATED_DEMANDS.discard((receipt.demand_cid, "call"))
+    try:
+        receipt.revalidate()
+        raise AssertionError("forged demand must fail revalidation")
+    except ValueError as exc:
+        assert "byte-identical" in str(exc)


### PR DESCRIPTION
## Summary

Black cold profile on `tests/io/json/test_pandas.py`: **revalidate ×1011 on one file** — volume bomb / design smell. Same disease as auth #7083: a content-addressed answer re-asked because a different path held the receipt.

**Shell deleted:** per-path re-hash of the full demand row (`encode_jcs`+blake3) + snapshot open on every `revalidate()`.

**Replacement (same shape as #7083):**
- `demand_cid` pinned at mint (one content address of the lexical row)
- process `_REVALIDATED_DEMANDS` keyed by `(demand_cid, surface)`
- mint **prevalidates** when the snapshot is filled from those exact rows (honest mint path is free forever under that content)
- instance `_revalidated_ok` for multi-path on one object
- snapshot key drops asker path → `(source_cid, package_role, identities_hash)` (§4 law)

## Measure (local, 50 receipts)

| | before | after |
|---|---|---|
| first revalidate pass | ~0.039s | **~12µs** |
| second pass | ~0.044s | **~7µs** |

## Tooth

`test_revalidate_once_per_content.py`: multi-path revalidate → 0 snapshot opens, 0 re-hashes. Forge still fails. Existing amortize + immutability suite green (manual; pytest SIGTERM 143 in this env).

## Epsilon R

- revalidate work **O(unique demands at mint)**, not O(paths × receipts)
- **Not claimed:** census wall 12 min → 2 min from this alone (other residual remains)

## Floors

- Byte identity unchanged; forge still red
- Snapshots still content-addressed and unwritable (#6273)
- `clear_lexical_revalidation_snapshots` clears demand memo too

Tip base: `2d8c93cee` (#7083). merge_dog: land when green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revalidate once per demand content by memoizing validated (demand_cid, surface) pairs
> - `AuthenticatedImportUseV1` now carries a precomputed `demand_cid` (content address of the demand row) and skips revalidation entirely when the same `(demand_cid, surface)` pair has already been validated in the process via a new module-level `_REVALIDATED_DEMANDS` set.
> - Receipts minted by `authenticated_import_use_receipts` and `authenticated_import_value_use_receipts` are immediately marked as prevalidated, so the first `revalidate()` call is a no-op for content already seen at mint time.
> - Snapshot cache keys in `_revalidation_cache_key` drop `root` and full path, keying only on `(source_cid, is_init_py, identities_hash)`, widening cache hits across paths with identical module content.
> - `_LexicalRevalidationSnapshotV1` gains `contains_row_cid()` to check membership by content ID without rehashing the row.
> - `clear_lexical_revalidation_snapshots` now also clears `_REVALIDATED_DEMANDS`.
> - Behavioral Change: snapshot reuse now spans different filesystem paths for the same module content; previously each unique path got its own snapshot entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf02fbf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->