### PR TITLE
Revalidate once per use content CID, not per path

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -215,7 +215,17 @@ class AuthenticatedImportUseV1:
         Call-target and value-use demands revalidate against their own
         row/outcome surfaces so Call receipts stay unchanged and neither
         surface can authorize the other.
+
+        Ask once per content, not once per path: the same authenticated use
+        face (``use["cid"]``) is revalidated at every seating / resolve /
+        roster retain door.  Measured cold open of
+        ``pandas/tests/io/json/test_pandas.py``: 1011 revalidate calls over
+        only 75 unique use CIDs (max 67× one face).  The answer cannot change
+        for a given content address; memo success so later doors free.
         """
+        use_cid = self.use.get("cid")
+        if use_cid is not None and use_cid in _REVALIDATED_USE_CIDS:
+            return
         site = self.use["useSite"]
         key = (
             site["startLine"],
@@ -247,6 +257,8 @@ class AuthenticatedImportUseV1:
             raise ValueError(
                 "authenticated import use is not byte-identical to lexical revalidation"
             )
+        if use_cid is not None:
+            _REVALIDATED_USE_CIDS.add(use_cid)
 
 
 def _authenticated_binding_target_symbol(binding: ImportBindingV1) -> str:
@@ -1069,12 +1081,17 @@ _REVALIDATION_SNAPSHOTS: dict[
 _VALUE_REVALIDATION_SNAPSHOTS: dict[
     tuple[str, str, str, str], _LexicalRevalidationSnapshotV1
 ] = {}
+# Content-addressed "this use face already passed revalidate".  Process-global
+# is legitimate: the key is the use CID (complete preimage of the face), and
+# the value is pure success — never a live context.  Cleared with snapshots.
+_REVALIDATED_USE_CIDS: set[str] = set()
 
 
 def clear_lexical_revalidation_snapshots() -> None:
     """Drop amortized revalidation snapshots (tests / hermetic process reuse)."""
     _REVALIDATION_SNAPSHOTS.clear()
     _VALUE_REVALIDATION_SNAPSHOTS.clear()
+    _REVALIDATED_USE_CIDS.clear()
 
 
 def _revalidation_cache_key(

--- a/implementations/python/sugar-lift-py-tests/tests/test_revalidate_once_per_content.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_revalidate_once_per_content.py
@@ -1,0 +1,121 @@
+"""Revalidate asks once per use content, not once per path.
+
+Cold open of pandas/tests/io/json/test_pandas.py measured 1011
+``AuthenticatedImportUseV1.revalidate`` calls over only 75 unique use CIDs
+(max 67× one face).  Snapshot amortization already shared the module pass;
+the residual was re-hashing the same demand face at every seating / resolve /
+roster-retain door.  Success is pure content: memo it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.canonicalizer import blake3_512_of
+from sugar_lift_py_tests.import_binding import (
+    _REVALIDATED_USE_CIDS,
+    authenticated_import_use_receipts,
+    authenticated_import_value_use_receipts,
+    clear_lexical_revalidation_snapshots,
+)
+
+_SOURCE = "import example_pkg\nexample_pkg.build(1)\nexample_pkg.build(2)\n"
+
+
+@pytest.fixture(autouse=True)
+def _hermetic():
+    clear_lexical_revalidation_snapshots()
+    yield
+    clear_lexical_revalidation_snapshots()
+
+
+def _module(tmp_path: Path, source: str = _SOURCE):
+    path = tmp_path / "consumer.py"
+    path.write_text(source, encoding="utf-8")
+    return tmp_path, path, source, blake3_512_of(source.encode("utf-8"))
+
+
+def test_revalidate_second_call_is_free_for_same_use_cid(tmp_path: Path) -> None:
+    root, path, text, cid = _module(tmp_path)
+    receipts, _ = authenticated_import_use_receipts(
+        root, path, text, cid, module_identities={}
+    )
+    assert receipts, "fixture must mint at least one call-use receipt"
+    receipt = receipts[0]
+    use_cid = receipt.use["cid"]
+
+    receipt.revalidate()
+    assert use_cid in _REVALIDATED_USE_CIDS
+
+    # Force a second path: same content, fresh object face from a second mint
+    # would still share use cid; re-call on the same object must not re-work.
+    # Patch contains_row to explode if the body re-enters.
+    from sugar_lift_py_tests import import_binding as ib
+
+    orig = ib._LexicalRevalidationSnapshotV1.contains_row
+
+    def boom(self, row):  # type: ignore[no-untyped-def]
+        raise AssertionError(
+            "revalidate re-entered snapshot body for an already-passed use cid"
+        )
+
+    ib._LexicalRevalidationSnapshotV1.contains_row = boom  # type: ignore[method-assign]
+    try:
+        receipt.revalidate()  # must return on content memo
+        receipt.revalidate()
+    finally:
+        ib._LexicalRevalidationSnapshotV1.contains_row = orig  # type: ignore[method-assign]
+
+
+def test_revalidate_clear_drops_content_memo(tmp_path: Path) -> None:
+    root, path, text, cid = _module(tmp_path)
+    receipts, _ = authenticated_import_use_receipts(
+        root, path, text, cid, module_identities={}
+    )
+    receipt = receipts[0]
+    receipt.revalidate()
+    assert _REVALIDATED_USE_CIDS
+    clear_lexical_revalidation_snapshots()
+    assert not _REVALIDATED_USE_CIDS
+
+
+def test_failed_revalidate_is_not_memoized(tmp_path: Path) -> None:
+    """Only successful revalidate enters the content set — failures re-check."""
+    root, path, text, cid = _module(tmp_path)
+    receipts, _ = authenticated_import_use_receipts(
+        root, path, text, cid, module_identities={}
+    )
+    target = receipts[0]
+    # Poison demand so snapshot membership fails; must not land in the set.
+    use_cid = target.use["cid"]
+    target.demand["forgedMarker"] = True
+    with pytest.raises(ValueError, match="byte-identical"):
+        target.revalidate()
+    assert use_cid not in _REVALIDATED_USE_CIDS
+
+
+def test_value_use_revalidate_also_memos(tmp_path: Path) -> None:
+    source = "import example_pkg\nx = example_pkg.build\n"
+    root, path, text, cid = _module(tmp_path, source)
+    receipts, _ = authenticated_import_value_use_receipts(
+        root, path, text, cid, module_identities={}
+    )
+    if not receipts:
+        pytest.skip("no value-use receipts for fixture")
+    r = receipts[0]
+    r.revalidate()
+    assert r.use["cid"] in _REVALIDATED_USE_CIDS
+    from sugar_lift_py_tests import import_binding as ib
+
+    orig = ib._LexicalRevalidationSnapshotV1.contains_row
+
+    def boom(self, row):  # type: ignore[no-untyped-def]
+        raise AssertionError("value-use revalidate re-entered after content memo")
+
+    ib._LexicalRevalidationSnapshotV1.contains_row = boom  # type: ignore[method-assign]
+    try:
+        r.revalidate()
+    finally:
+        ib._LexicalRevalidationSnapshotV1.contains_row = orig  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary

Owns the **revalidate volume bomb** (coord: brown took auth → #7083).

Cold open of `pandas/tests/io/json/test_pandas.py` measured **1011** `AuthenticatedImportUseV1.revalidate` calls over only **75 unique use CIDs** (max 67× one face). Module snapshot amortization already existed; residual was re-hashing the same demand at every seating / resolve / roster-retain door.

**Fix:** content-addressed success memo keyed by `use["cid"]`. First success does the work; later doors free. Cleared with `clear_lexical_revalidation_snapshots`. Failures are not memoized.

## Measured (tip + this change, v312)

| | before | after |
|---|---|---|
| revalidate call sites | 1011 | ~1029 (callers still call) |
| body entries (real work) | 1011 | **75** |
| unique use CIDs | 75 | 75 |

## Not claiming

- Auth spam (brown / #7083 MERGED).
- Removing redundant call sites (optional follow-up; memo makes them free).
- Wall-time floor for full recensus (single-box contention dominates).

## Validation

Inline twin: second revalidate does not re-enter `contains_row`; clear drops memo; failed revalidate not memoized.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Memoize `AuthenticatedImportUseV1.revalidate` per use content CID instead of per path
> - Introduces a process-global `_REVALIDATED_USE_CIDS` set in [import_binding.py](https://github.com/TSavo/sugar/pull/7086/files#diff-7ed90ea16c2ad4ca10c3dc0d09d9e32172d598701588b5f8b3e08040e56bab4a) that tracks use CIDs that have already passed revalidation.
> - On a successful revalidation, the use CID is added to the set; subsequent calls for the same CID short-circuit before any snapshot work.
> - Failed revalidations are not memoized, so they are retried on the next call.
> - `clear_lexical_revalidation_snapshots` now also clears `_REVALIDATED_USE_CIDS` to keep the memo in sync with snapshot state.
> - New tests in [test_revalidate_once_per_content.py](https://github.com/TSavo/sugar/pull/7086/files#diff-8545f84f3193ce46ead8afb15bf51684af8101a333a35e2f24f0e7741e9b166d) cover memoization, clearing, failure, and value-use receipt cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a15fbf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->