### PR TITLE
Memo provisional demand table by workspace root (D2 process amortize)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -74,6 +74,14 @@ _BOUND_CALL_CONTRACT_REFS = None
 # object (materialize-once) instead of reconstructing the function.
 _RETAINED_LINK_UNITS = {}
 _RETAINED_BY_MEMENTO = {}
+# Provisional With/call demand table by resolved workspace root. Deriving it
+# walks every enrolled ``*.py`` (authenticated import uses + With sites) —
+# measured multi-minute on pandas (1421 files). Recensus builds it "once" in
+# control_effect_recensus, but ``measure_file_via_enumerate`` never received
+# that table: each D2 ``sugar.enumerate level=functions`` re-derived via
+# ``tree_construction_context_for_workspace`` → hang-looking multi-minute
+# per file. Process memo makes the paid scan real amortization.
+_PROVISIONAL_CONTRACT_REFS_BY_ROOT: Dict[str, Any] = {}
 
 
 def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
@@ -165,8 +173,24 @@ def provisional_contract_refs_from_demands(root: Path):
     ``gapKind`` (default ``runtime-selected``). Source-derived managers may still
     win via ``populate_source_derived_resource_refs`` after the context is
     installed — derived takes precedence over this provisional gap table.
+
+    Process-memoized by resolved root: the walk is O(corpus), not O(file). A
+    second open of the same workspace root must not re-scan every module.
     """
-    return provisional_contract_refs_from_demand_rows(_preconstruction_demand_rows(root))
+    key = str(Path(root).resolve())
+    cached = _PROVISIONAL_CONTRACT_REFS_BY_ROOT.get(key)
+    if cached is not None:
+        return cached
+    refs = provisional_contract_refs_from_demand_rows(
+        _preconstruction_demand_rows(root)
+    )
+    _PROVISIONAL_CONTRACT_REFS_BY_ROOT[key] = refs
+    return refs
+
+
+def clear_provisional_contract_refs_memo() -> None:
+    """Drop process demand-table memo (tests / hermetic process reuse)."""
+    _PROVISIONAL_CONTRACT_REFS_BY_ROOT.clear()
 
 
 def tree_construction_context_for_workspace(

--- a/implementations/python/sugar-lift-py-tests/tests/test_provisional_demand_table_process_memo.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_provisional_demand_table_process_memo.py
@@ -1,0 +1,41 @@
+"""Provisional demand table is process-memoized by workspace root.
+
+``_preconstruction_demand_rows`` walks every enrolled ``*.py`` (call uses +
+With sites). Recensus paid that once, but ``measure_file_via_enumerate`` never
+received the table — each D2 ``level=functions`` re-derived via
+``tree_construction_context_for_workspace`` and looked like a multi-minute hang
+on a single file (pandas _json). Process memo makes the scan O(corpus) once.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_py_tests import lift_rpc as lr
+
+
+def test_provisional_contract_refs_second_call_is_same_object(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text(
+        "from contextlib import contextmanager\n"
+        "@contextmanager\n"
+        "def cm():\n"
+        "    yield\n"
+        "def f():\n"
+        "    with cm():\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    lr.clear_provisional_contract_refs_memo()
+    first = lr.provisional_contract_refs_from_demands(tmp_path)
+    second = lr.provisional_contract_refs_from_demands(tmp_path)
+    assert second is first
+    # Different root is a different memo seat.
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "c.py").write_text("y = 2\n", encoding="utf-8")
+    third = lr.provisional_contract_refs_from_demands(other)
+    assert third is not first
+    lr.clear_provisional_contract_refs_memo()
+    fourth = lr.provisional_contract_refs_from_demands(tmp_path)
+    assert fourth is not first


### PR DESCRIPTION
## Summary

**Code diagnosis (stands without a stopwatch):**  
`provisional_contract_refs_from_demands` walks every enrolled `*.py` once — O(corpus). Recensus paid that once in theory, but `measure_file_via_enumerate` never received a bound table. Each D2 `sugar.enumerate level=functions` re-entered `tree_construction_context_for_workspace` → re-derived the full provisional demand table → looked like a multi-minute hang on a single file (e.g. `_json.py`).

**Fix:** process memo keyed by resolved workspace root. Second open of the same root returns the same object. `clear_provisional_contract_refs_memo()` for hermetic tests.

## Timing

**Pending** a quiet battleaxe measurement via `bin/brun` once grey’s canonical invocation lands. Not measured on this PR (measurement stop / Mac load rules). Do not hold the code law for a stopwatch.

## Validation

Focused unit twin only (tmp tree, no pandas corpus):
- second call `is` first object for same root
- different root is different seat
- clear drops memo

## Not claiming

- Wall-time / hang seconds on pandas
- That this alone hits the 2-minute recensus target
- Multi-host CI topology change

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Memoize `provisional_contract_refs_from_demands` by workspace root to amortize D2 process cost
> - Adds a module-level dict `_PROVISIONAL_CONTRACT_REFS_BY_ROOT` in [`lift_rpc.py`](https://github.com/TSavo/sugar/pull/7087/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) to cache provisional contract refs keyed by resolved workspace root path.
> - Repeated calls with the same root now return the cached object instead of re-scanning all enrolled modules; different roots are cached independently.
> - Adds `clear_provisional_contract_refs_memo()` to explicitly reset the cache for hermetic test reuse.
> - New test in [`test_provisional_demand_table_process_memo.py`](https://github.com/TSavo/sugar/pull/7087/files#diff-b49aa82570d2630e0d8df5d8ba78ef0ca17f30252f02fdb466c6f9bda7bf030b) verifies same-root identity, different-root independence, and post-clear recomputation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39aac76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->