### PR TITLE
bx load gate: refuse wall-clock when battleaxe is not quiet

### DIFF
--- a/bin/brun
+++ b/bin/brun
@@ -25,6 +25,14 @@ Environment (shared with bcargo so roots, caps and test harnesses apply):
   BCARGO_CLEAN_REMOTE_ROOT_UNSAFE Set to 1 to allow cleanup outside
                                   /home/tsavo/remote/sugar-bcargo-*
   BCARGO_SSH, BCARGO_RSYNC        Override the ssh/rsync binaries (test harness)
+
+Quiet gate (wall-clock timing only — opt-in; ordinary builds leave unset):
+  SUGAR_BX_REQUIRE_QUIET=1   Sample remote 1-min loadavg BEFORE the command.
+                             Refuse with exit 76 if load1 > max(2, nproc/4).
+                             Print load BEFORE and AFTER on stderr.
+  SUGAR_BX_MAX_LOADAVG=N     Explicit ceiling (also arms the gate alone).
+                             A number taken under contention is not a measurement.
+                             See docs/contributing/battleaxe-timing.md.
 EOF
 }
 

--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -156,6 +156,86 @@ sugar_bx_require_docker_ready() {
   fi
 }
 
+# Exit 76: host not quiet enough for a trusted wall-clock measurement.
+# A number taken under contention is not a slow measurement — it is not a
+# measurement. Timing runs must set SUGAR_BX_REQUIRE_QUIET=1 (or an explicit
+# SUGAR_BX_MAX_LOADAVG). Ordinary builds leave both unset and are not gated.
+# Sample is always the *remote* box load (via sugar_bx_ssh), never the laptop.
+sugar_bx_sample_load() {
+  # Prints: load1 nproc  (one line). Uses /proc/loadavg on Linux; falls back
+  # to python getloadavg on platforms without it (local-mode macOS tests).
+  sugar_bx_ssh 'bash -lc "
+    set -e
+    if [[ -r /proc/loadavg ]]; then
+      read -r l1 _rest </proc/loadavg
+    else
+      l1=\$(python3 -c \"import os; print(os.getloadavg()[0])\" 2>/dev/null || echo 0)
+    fi
+    n=\$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
+    printf \"%s %s\\n\" \"\$l1\" \"\$n\"
+  "'
+}
+
+sugar_bx_require_quiet() {
+  local require="${SUGAR_BX_REQUIRE_QUIET:-0}"
+  local max_env="${SUGAR_BX_MAX_LOADAVG:-}"
+  # No gate unless the caller asked for a quiet measurement.
+  if [[ -z "$max_env" && "$require" != 1 && "$require" != true && "$require" != yes ]]; then
+    SUGAR_BX_LOAD_BEFORE=""
+    return 0
+  fi
+  local sample load1 nproc max
+  set +e
+  sample="$(sugar_bx_sample_load 2>&1)"
+  local sample_status=$?
+  set -e
+  if [[ "$sample_status" != 0 ]]; then
+    printf 'sugarbin: crime=load-sample-failed host=%s status=%s detail=%s replacement=fix ssh to %s; cannot certify a quiet box without a load reading\n' \
+      "$SUGAR_BX_HOST" "$sample_status" "${sample:-<no output>}" "$SUGAR_BX_HOST" >&2
+    return 76
+  fi
+  sample="$(printf '%s' "$sample" | tr -d '\r' | tail -n 1)"
+  load1="${sample%% *}"
+  nproc="${sample##* }"
+  if [[ -z "$load1" || -z "$nproc" || "$load1" == "$sample" ]]; then
+    printf 'sugarbin: crime=load-sample-unparseable host=%s sample=%s replacement=expect \"load1 nproc\" from remote sample\n' \
+      "$SUGAR_BX_HOST" "${sample:-<empty>}" >&2
+    return 76
+  fi
+  SUGAR_BX_LOAD_BEFORE="$load1"
+  SUGAR_BX_NPROC="$nproc"
+  if [[ -n "$max_env" ]]; then
+    max="$max_env"
+  else
+    # Default: 25% of cores, floor 2.0 — battleaxe 32c → 8.0. Contended Mac
+    # (load 13 on 8 cores) is always over; quiet bx (load ~2 on 32) always under.
+    max="$(awk -v n="$nproc" 'BEGIN{ m=n/4.0; if (m < 2.0) m=2.0; printf "%.2f", m }')"
+  fi
+  printf 'sugarbin: bx-load-gate phase=before host=%s load1=%s nproc=%s max=%s\n' \
+    "$SUGAR_BX_HOST" "$load1" "$nproc" "$max" >&2
+  # Refuse when load1 > max (strict). Equality is allowed.
+  if awk -v l="$load1" -v m="$max" 'BEGIN{ exit !(l+0 > m+0) }'; then
+    printf 'sugarbin: crime=host-not-quiet host=%s load1=%s nproc=%s max=%s replacement=wait for load1<=%s on %s (or raise SUGAR_BX_MAX_LOADAVG with cause). A wall-clock number taken under contention manufactured tonight'\''s fake 87%% regression — refuse rather than report.\n' \
+      "$SUGAR_BX_HOST" "$load1" "$nproc" "$max" "$max" "$SUGAR_BX_HOST" >&2
+    return 76
+  fi
+  return 0
+}
+
+sugar_bx_report_load_after() {
+  # Best-effort after sample when a quiet gate was armed. Never fails the run:
+  # the before-gate already certified start conditions; after is telemetry.
+  [[ -n "${SUGAR_BX_LOAD_BEFORE:-}" ]] || return 0
+  local sample load1
+  set +e
+  sample="$(sugar_bx_sample_load 2>/dev/null)"
+  set -e
+  sample="$(printf '%s' "$sample" | tr -d '\r' | tail -n 1)"
+  load1="${sample%% *}"
+  printf 'sugarbin: bx-load-gate phase=after host=%s load1_before=%s load1_after=%s nproc=%s\n' \
+    "$SUGAR_BX_HOST" "$SUGAR_BX_LOAD_BEFORE" "${load1:-unknown}" "${SUGAR_BX_NPROC:-unknown}" >&2
+}
+
 sugar_bx_run_ambient() {
   local remote_cwd="$SUGAR_BX_REPO" arg inner="" prefix="" name
   [[ -n "$SUGAR_BX_REL_CWD" ]] && remote_cwd="$SUGAR_BX_REPO/$SUGAR_BX_REL_CWD"

--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -264,6 +264,9 @@ dispatch_execution_subcommand() {
   sugar_bx_init "$repo_root" "$local_cwd" || return $?
   [[ "$route_env" != docker ]] || sugar_bx_require_docker_ready || return $?
   sugar_bx_sync_workspace || return $?
+  # Quiet gate is opt-in (SUGAR_BX_REQUIRE_QUIET / SUGAR_BX_MAX_LOADAVG).
+  # Armed for wall-clock timing only; ordinary builds leave it unset.
+  sugar_bx_require_quiet || return $?
   if [[ "$route_env" == docker ]]; then
     sugar_bx_write_mount_proof || return $?
     local remote_needs="$needs" has_artifacts=0
@@ -274,6 +277,7 @@ dispatch_execution_subcommand() {
       has_artifacts=1
     fi
     if [[ "$subcommand" == build ]]; then
+      sugar_bx_report_load_after
       sugar_bx_finish 0
       return $?
     fi
@@ -281,6 +285,7 @@ dispatch_execution_subcommand() {
     sugar_bx_run_docker "$docker_image" "$task_network" "$has_artifacts" "${command[@]}"
     status=$?
     set -e
+    sugar_bx_report_load_after
     sugar_bx_finish "$status"
     return $?
   fi
@@ -291,6 +296,7 @@ dispatch_execution_subcommand() {
       sugar_bx_ssh "cd $(sugar_bx_quote "$SUGAR_BX_REPO") && bin/sugarbin build --profile $(sugar_bx_quote "$profile") --platform $(sugar_bx_quote "$remote_platform") --needs $(sugar_bx_quote "$remote_needs")"
       status=$?
       set -e
+      sugar_bx_report_load_after
       sugar_bx_finish "$status"
       return $?
     fi
@@ -298,13 +304,20 @@ dispatch_execution_subcommand() {
     command=(bash -lc "$remote_setup \"\$@\"; status=\$?; rm -rf \"\$dir\"; exit \$status" bash "${command[@]}")
   fi
   if [[ "$subcommand" == cargo ]]; then
+    # Quiet gate already armed above; cargo path reports after inside finish sites.
+    local cargo_status=0
+    set +e
     sugarbin_bx_cargo "$repo_root"
-    return $?
+    cargo_status=$?
+    set -e
+    sugar_bx_report_load_after
+    return "$cargo_status"
   fi
   set +e
   sugar_bx_run_ambient "${command[@]}"
   status=$?
   set -e
+  sugar_bx_report_load_after
   if [[ "$status" == 0 ]]; then
     if ((${#SUGAR_BX_SYNC_BACKS[@]} != 0)); then
       for pair in "${SUGAR_BX_SYNC_BACKS[@]}"; do

--- a/docs/build-execution.md
+++ b/docs/build-execution.md
@@ -76,6 +76,22 @@ select `--host bx`; they do not own synchronization, provisioning, artifact
 resolution, or execution policy. `bpytest` additionally selects the managed
 `python-unit` task.
 
+### Quiet gate for wall-clock timing
+
+A wall-clock number taken under host contention is not a measurement. For
+timing runs on battleaxe, arm the quiet gate:
+
+```bash
+SUGAR_BX_REQUIRE_QUIET=1 bin/brun -- <command>
+# or: SUGAR_BX_MAX_LOADAVG=8 bin/brun -- <command>
+```
+
+When armed, the bx backend samples remote 1-minute loadavg **before** the
+command, refuses with **exit 76** if `load1` exceeds the ceiling (default
+`max(2.0, nproc/4)`), and prints load before/after on stderr. Ordinary builds
+leave the gate unset. Canonical timing shapes (single file, N-file walk, LPT
+k=8) live in `docs/contributing/battleaxe-timing.md`.
+
 ## Capabilities and named tasks
 
 `sugar-build.toml` owns exact tool versions, capability dependencies, immutable

--- a/docs/contributing/battleaxe-timing.md
+++ b/docs/contributing/battleaxe-timing.md
@@ -1,0 +1,174 @@
+# Battleaxe timing measurements (canonical door)
+
+**Wall-clock numbers for pandas recensus / open / walk / k=8 are taken on
+battleaxe only.** Not on the Mac. The Mac is an 8-core laptop that hosts the
+agent fleet; a number taken there under load is not a slow measurement — it is
+not a measurement. Tonight's fake 87% regression and fake single-file 3× came
+from that defect.
+
+Wrappers live in the repo (they are **not** on PATH in a bare shell):
+
+| Wrapper | Path | Role |
+| --- | --- | --- |
+| `brun` | `bin/brun` | Sync workspace to battleaxe, run an arbitrary command there |
+| `bpytest` | `bin/bpytest` | Managed pytest on battleaxe (`python-unit` task) |
+| `bcargo` | `bin/bcargo` | Cargo on battleaxe |
+
+`bin/brun` is already the harness: it syncs the tip of the current checkout to
+`BCARGO_REMOTE_HOST` (default SSH alias `battleaxe`), runs from the same
+repo-relative cwd, forwards env with `--env`, and can rsync results back with
+`--sync-back`. Do **not** invent a second remote runner.
+
+## Quiet gate (mandatory for every timing number)
+
+```bash
+export SUGAR_BX_REQUIRE_QUIET=1
+# optional explicit ceiling (also arms the gate alone):
+# export SUGAR_BX_MAX_LOADAVG=8
+```
+
+When armed, `bin/brun` / `bin/sugarbin run --host bx`:
+
+1. Samples **remote** 1-minute loadavg and `nproc` **before** the command.
+2. **Refuses with exit 76** if `load1 > max` (default `max = max(2.0, nproc/4)` → 8.0 on 32-core battleaxe).
+3. Prints `bx-load-gate phase=before …` and `phase=after …` on stderr.
+
+Ordinary builds leave the gate **unset**. Timing runs always arm it.
+
+## One-time remote env (pinned pandas corpus)
+
+From any checkout root (on the Mac; work runs on battleaxe):
+
+```bash
+bin/brun -- bash scripts/bootstrap-venv-py312.sh
+```
+
+That builds `.venv-py312` on the remote with **CPython 3.12.13 + pandas==3.0.3**
+(and the other declared pins). Re-run only when the pin changes.
+
+## Canonical command shapes
+
+Always from the **repo root**. Always with `SUGAR_BX_REQUIRE_QUIET=1`.
+Always invoke `bin/brun` by path.
+
+Shared remote body (PYTHONPATH + corpus root from the pin):
+
+```bash
+export SUGAR_BX_REQUIRE_QUIET=1
+# Optional: pin an explicit SHA the remote checkout already has after sync.
+# The sync is the current tip of this worktree; commit id is recorded by the
+# recensus via --commit when you pass it.
+
+REMOTE_JSON=/tmp/sugar-bx-measure.json   # path ON battleaxe
+LOCAL_JSON=/tmp/sugar-bx-measure.json    # path ON the Mac after sync-back
+```
+
+### 1. Single file
+
+```bash
+SUGAR_BX_REQUIRE_QUIET=1 bin/brun \
+  --sync-back "${REMOTE_JSON}:${LOCAL_JSON}" \
+  -- bash -lc '
+    set -euo pipefail
+    PY=.venv-py312/bin/python
+    test -x "$PY" || { echo "missing .venv-py312; run: bin/brun -- bash scripts/bootstrap-venv-py312.sh" >&2; exit 2; }
+    CORPUS=$("$PY" -c "import pandas, pathlib; print(pathlib.Path(pandas.__file__).resolve().parent)")
+    export PYTHONPATH=implementations/python/sugar-lift-py-tests/scripts:implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src
+    FILE_REL="${FILE_REL:-io/json/_json.py}"
+    "$PY" -u implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py \
+      "$CORPUS/$FILE_REL" \
+      --corpus-root "$CORPUS" \
+      --repo . \
+      --commit "$(git rev-parse HEAD)" \
+      --json /tmp/sugar-bx-measure.json
+  '
+# JSON at $LOCAL_JSON. Trust only if the command exited 0 (not 76).
+```
+
+Override the file:
+
+```bash
+FILE_REL=core/arrays/categorical.py SUGAR_BX_REQUIRE_QUIET=1 bin/brun ...
+```
+
+### 2. N-file walk (subtree or full package root)
+
+Pass a directory under the corpus root as the first positional (still with
+`--corpus-root` set to the package root so demand-table identity matches the
+full run):
+
+```bash
+SUGAR_BX_REQUIRE_QUIET=1 bin/brun \
+  --sync-back "${REMOTE_JSON}:${LOCAL_JSON}" \
+  -- bash -lc '
+    set -euo pipefail
+    PY=.venv-py312/bin/python
+    CORPUS=$("$PY" -c "import pandas, pathlib; print(pathlib.Path(pandas.__file__).resolve().parent)")
+    export PYTHONPATH=implementations/python/sugar-lift-py-tests/scripts:implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src
+    SLICE="${SLICE:-$CORPUS/io/json}"   # or $CORPUS for full package
+    "$PY" -u implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py \
+      "$SLICE" \
+      --corpus-root "$CORPUS" \
+      --repo . \
+      --commit "$(git rev-parse HEAD)" \
+      --json /tmp/sugar-bx-measure.json
+  '
+```
+
+### 3. LPT k=8 (one seat, or plan+all seats via CI)
+
+Plan is not a measurement. Measure a seat with the production worker shape:
+
+```bash
+# After plan.json exists under .sugar/pandas-control-effect/ (from the CI plan
+# job or tools/plan_control_effect_recensus_shards.py on battleaxe):
+SUGAR_BX_REQUIRE_QUIET=1 bin/brun \
+  --sync-back "${REMOTE_JSON}:${LOCAL_JSON}" \
+  -- bash -lc '
+    set -euo pipefail
+    PY=.venv-py312/bin/python
+    CORPUS=$("$PY" -c "import pandas, pathlib; print(pathlib.Path(pandas.__file__).resolve().parent)")
+    export PYTHONPATH=implementations/python/sugar-lift-py-tests/scripts:implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src
+    OUT=.sugar/pandas-control-effect
+    SHARD="${SHARD:-0}"
+    "$PY" -u implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py \
+      "$CORPUS" \
+      --corpus-root "$CORPUS" \
+      --repo . \
+      --commit "$(git rev-parse HEAD)" \
+      --out-dir "$OUT" \
+      --plan-json "$OUT/plan.json" \
+      --shard-index "$SHARD" \
+      --partial-out "$OUT/partial-s$(printf %02d "$SHARD").json"
+    cp "$OUT/partial-s$(printf %02d "$SHARD").json" /tmp/sugar-bx-measure.json
+  '
+```
+
+Full k=8 board seal remains the compose job in
+`.github/workflows/control-effect-recensus.yml` (sole SCOREBOARD door). Local
+k=8 timing of a single seat is for latency, not for a sealed board.
+
+## How to read the result
+
+| Exit | Meaning |
+| --- | --- |
+| 0 | Command finished; stderr has `bx-load-gate phase=before` and `phase=after`. JSON at sync-back path. |
+| 76 | **Refused — host not quiet.** No number. Do not cite. Wait and retry. |
+| other | Remote command failure; also not a trusted number. |
+
+A JSON body without a 0 exit, or without the before load line, is not a timing
+receipt.
+
+## Forbidden
+
+- Any pandas open / walk / census / profile / cProfile / k=8 / demand-table
+  scan on the Mac.
+- Broad local pytest.
+- Reporting a wall-clock taken while `bx-load-gate` was not armed or exited 76.
+- Inventing a parallel harness next to `bin/brun`.
+
+## Related
+
+- `docs/build-execution.md` — sugarbin / brun / bpytest routes
+- `docs/contributing/heavy-measurement-lease.md` — exclusive heavy jobs on the box
+- `bin/brun --help` — options and quiet-gate env vars

--- a/tests/sugarbin_bx_load_gate.sh
+++ b/tests/sugarbin_bx_load_gate.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Quiet gate: SUGAR_BX_REQUIRE_QUIET / SUGAR_BX_MAX_LOADAVG refuse a busy host
+# (exit 76) and do not run the remote command. Opt-in only — unset leaves
+# ordinary brun builds ungated.
+set -euo pipefail
+
+repo_root="${1:-$(git rev-parse --show-toplevel)}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+fake_bin="$tmp/bin"
+mkdir -p "$fake_bin"
+ssh_log="$tmp/ssh.log"
+rsync_log="$tmp/rsync.log"
+remote_exec_log="$tmp/remote-exec.log"
+
+# Fake ssh:
+# - load-sample commands (contain /proc/loadavg or getloadavg) print BX_FAKE_LOAD
+# - ambient run is bash -lc '… exec …' (must NOT match find -exec reaper)
+cat >"$fake_bin/ssh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$BX_FAKE_SSH_LOG"
+joined="$*"
+case "$joined" in
+  *'/proc/loadavg'*|*'getloadavg'*)
+    # "load1 nproc"
+    printf '%s\n' "${BX_FAKE_LOAD:-0.50 32}"
+    exit 0
+    ;;
+esac
+# Ambient command is sugar_bx_run_ambient: bash -lc 'cd … && exec …'
+# The reaper uses find -exec — do not treat that as the measured command.
+if [[ "$joined" == *'bash -lc'* && "$joined" == *' exec '* ]]; then
+  printf '%s\n' "$joined" >>"$BX_FAKE_REMOTE_EXEC_LOG"
+  exit "${BX_FAKE_REMOTE_STATUS:-0}"
+fi
+exit 0
+SH
+cat >"$fake_bin/rsync" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$BX_FAKE_RSYNC_LOG"
+exit 0
+SH
+chmod +x "$fake_bin/ssh" "$fake_bin/rsync"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+run_bx() {
+  (cd "$repo_root" &&
+    PATH="$fake_bin:$PATH" BCARGO_SSH="$fake_bin/ssh" BCARGO_RSYNC="$fake_bin/rsync" \
+    BX_FAKE_SSH_LOG="$ssh_log" BX_FAKE_RSYNC_LOG="$rsync_log" \
+    BX_FAKE_REMOTE_EXEC_LOG="$remote_exec_log" \
+    BCARGO_REMOTE_ROOT="${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-load-gate-test}" \
+    BCARGO_FORCE_REMOTE=1 \
+    "$repo_root/bin/sugarbin" run --host bx --env ambient "$@")
+}
+
+# 1) Gate off by default: busy load must NOT refuse, and command must run.
+: >"$ssh_log"; : >"$rsync_log"; : >"$remote_exec_log"
+export BX_FAKE_LOAD="20.0 32"
+status=0
+run_bx -- true >/dev/null 2>"$tmp/stderr1" || status=$?
+[[ "$status" -eq 0 ]] || fail "ungated run failed status=$status (want 0)"
+[[ -s "$remote_exec_log" ]] || fail "ungated run never reached remote exec"
+grep -q 'bx-load-gate' "$tmp/stderr1" && fail "ungated run printed load gate noise" || true
+
+# 2) REQUIRE_QUIET=1 + busy load → exit 76, no remote exec.
+: >"$ssh_log"; : >"$rsync_log"; : >"$remote_exec_log"
+export BX_FAKE_LOAD="20.0 32"
+status=0
+SUGAR_BX_REQUIRE_QUIET=1 run_bx -- true >/dev/null 2>"$tmp/stderr2" || status=$?
+[[ "$status" -eq 76 ]] || fail "busy host status=$status want 76"
+[[ ! -s "$remote_exec_log" ]] || fail "busy host still ran remote command"
+grep -Fq 'crime=host-not-quiet' "$tmp/stderr2" || fail "missing host-not-quiet crime line"
+grep -Fq 'phase=before' "$tmp/stderr2" || fail "missing before load line"
+
+# 3) REQUIRE_QUIET=1 + quiet load → runs, prints before+after.
+: >"$ssh_log"; : >"$rsync_log"; : >"$remote_exec_log"
+export BX_FAKE_LOAD="2.05 32"
+status=0
+SUGAR_BX_REQUIRE_QUIET=1 run_bx -- true >/dev/null 2>"$tmp/stderr3" || status=$?
+[[ "$status" -eq 0 ]] || fail "quiet host status=$status want 0"
+[[ -s "$remote_exec_log" ]] || fail "quiet host never reached remote exec"
+grep -Fq 'phase=before' "$tmp/stderr3" || fail "quiet run missing before"
+grep -Fq 'phase=after' "$tmp/stderr3" || fail "quiet run missing after"
+
+# 4) Explicit MAX_LOADAVG alone arms the gate; load just under passes.
+: >"$ssh_log"; : >"$rsync_log"; : >"$remote_exec_log"
+export BX_FAKE_LOAD="7.9 32"
+status=0
+SUGAR_BX_MAX_LOADAVG=8 run_bx -- true >/dev/null 2>"$tmp/stderr4" || status=$?
+[[ "$status" -eq 0 ]] || fail "max-load under ceiling status=$status want 0"
+
+# 5) Explicit MAX_LOADAVG: load just over refuses.
+: >"$ssh_log"; : >"$rsync_log"; : >"$remote_exec_log"
+export BX_FAKE_LOAD="8.01 32"
+status=0
+SUGAR_BX_MAX_LOADAVG=8 run_bx -- true >/dev/null 2>"$tmp/stderr5" || status=$?
+[[ "$status" -eq 76 ]] || fail "max-load over ceiling status=$status want 76"
+[[ ! -s "$remote_exec_log" ]] || fail "over-ceiling still ran remote command"
+
+# 6) brun adapter surfaces the same env (wrapper only; exercise via sugarbin path above).
+grep -Fq 'SUGAR_BX_REQUIRE_QUIET' "$repo_root/bin/brun" || fail "brun --help text missing quiet gate"
+grep -Fq 'SUGAR_BX_REQUIRE_QUIET' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing require_quiet"
+test -f "$repo_root/docs/contributing/battleaxe-timing.md" || fail "canonical timing doc missing"
+
+echo "PASS: sugarbin_bx_load_gate"


### PR DESCRIPTION
## Why

A wall-clock number taken under host contention is **not a measurement**. Tonight's fake 87% regression and fake single-file 3× came from measuring on the Mac (8 cores, load ~14, 30 python processes) instead of battleaxe (32 cores, load ~2).

`bin/brun` already *is* the remote harness. This PR does not invent a parallel tool. It adds the only missing piece: a **quiet gate** on the bx path, and the fleet-facing canonical timing commands.

## What

- **`SUGAR_BX_REQUIRE_QUIET=1`** or **`SUGAR_BX_MAX_LOADAVG=N`** (opt-in) on `bin/brun` / `bin/sugarbin run --host bx`:
  - sample **remote** 1-min loadavg + nproc **before** the command
  - **exit 76** if `load1 > max` (default `max(2.0, nproc/4)` → 8.0 on 32c)
  - print `bx-load-gate phase=before|after` on stderr
- Ordinary builds leave the gate **unset** (no change for cargo/tests).
- Canonical single-file / N-file walk / LPT k=8 shapes: `docs/contributing/battleaxe-timing.md`
- Focused unit test: `tests/sugarbin_bx_load_gate.sh` (fake ssh load; no corpus, no wall-clock product measurement)

## Canonical command (single file)

```bash
# from repo root — invoke by path; not on PATH
SUGAR_BX_REQUIRE_QUIET=1 bin/brun \
  --sync-back /tmp/sugar-bx-measure.json:/tmp/sugar-bx-measure.json \
  -- bash -lc '
    set -euo pipefail
    PY=.venv-py312/bin/python
    CORPUS=$("$PY" -c "import pandas, pathlib; print(pathlib.Path(pandas.__file__).resolve().parent)")
    export PYTHONPATH=implementations/python/sugar-lift-py-tests/scripts:implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src
    "$PY" -u implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py \
      "$CORPUS/io/json/_json.py" \
      --corpus-root "$CORPUS" --repo . --commit "$(git rev-parse HEAD)" \
      --json /tmp/sugar-bx-measure.json
  '
```

Exit 76 = refused (do not cite a number). Exit 0 + before/after load lines = trustworthy receipt.

One-time remote pin env: `bin/brun -- bash scripts/bootstrap-venv-py312.sh`

## Validation

```bash
bash tests/sugarbin_bx_load_gate.sh   # PASS
bash tests/sugarbin_bx_exec.sh        # PASS (existing contract)
```

No pandas corpus / no Mac wall-clock runs (hard rule).

## R / shell

- New instrument: quiet gate on bx path (exit 76 = host-not-quiet).
- Shell deleted: none yet (this is the first rung — load refuse).
- Epsilon R: 0 product axes; measurement *trust* defect closed for fleet numbers that arm the gate.

merge_dog: please squash-merge when green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add load gate to `bx` that refuses wall-clock timing runs when remote host is not quiet
> - Adds `sugar_bx_require_quiet` in [sugar-bx.sh](https://github.com/TSavo/sugar/pull/7088/files#diff-bdd6c46eb799e81d8c3cc8b50ab4a809668391cedbc25e468f6efe8ef9d86ebc) that samples the remote host's 1-minute load average via `sugar_bx_sample_load` and exits 76 if load exceeds the ceiling; the gate is a no-op unless `SUGAR_BX_REQUIRE_QUIET` or `SUGAR_BX_MAX_LOADAVG` is set.
> - Default ceiling is `max(2.0, nproc/4.0)`; `SUGAR_BX_MAX_LOADAVG` overrides it.
> - Inserts the gate into `dispatch_execution_subcommand` in [bin/sugarbin](https://github.com/TSavo/sugar/pull/7088/files#diff-2b8f7e68bdef16827d284767f61c9a26ffa589c12f114f50129677d05e35383b) after sync and before execution; adds `sugar_bx_report_load_after` calls at all exit paths (docker build/run, remote build, cargo, ambient).
> - Adds documentation in [docs/build-execution.md](https://github.com/TSavo/sugar/pull/7088/files#diff-56397a55a6e75e496ba77537290cc6228957b751b66d5570a348ed9f8ebb3037) and a new [battleaxe-timing.md](https://github.com/TSavo/sugar/pull/7088/files#diff-60cbb7b810d3d7761cde354c4b67596fedb4e890c3dc15d1480eb648638df96c) describing canonical timing procedures.
> - Behavioral Change: when either env var is set, runs on an over-loaded host now exit 76 without executing the remote command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a4b0e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->