### PR TITLE
bx timing lease: serialize quiet-gated measurements

### DIFF
--- a/bin/brun
+++ b/bin/brun
@@ -27,12 +27,17 @@ Environment (shared with bcargo so roots, caps and test harnesses apply):
   BCARGO_SSH, BCARGO_RSYNC        Override the ssh/rsync binaries (test harness)
 
 Quiet gate (wall-clock timing only — opt-in; ordinary builds leave unset):
-  SUGAR_BX_REQUIRE_QUIET=1   Sample remote 1-min loadavg BEFORE the command.
-                             Refuse with exit 76 if load1 > max(2, nproc/4).
-                             Print load BEFORE and AFTER on stderr.
+  SUGAR_BX_REQUIRE_QUIET=1   Exclusive remote timing lease + load sample under
+                             the lock. Refuse exit 76 if load1 > max(2, nproc/4).
+                             Print load BEFORE and AFTER on stderr (lease=held).
   SUGAR_BX_MAX_LOADAVG=N     Explicit ceiling (also arms the gate alone).
-                             A number taken under contention is not a measurement.
-                             See docs/contributing/battleaxe-timing.md.
+  SUGAR_BX_TIMING_LEASE_PATH Remote flock path
+                             (default /var/tmp/sugar-bx-timing-measurement.lease)
+  SUGAR_BX_TIMING_LEASE_WAIT_S  Seconds to wait for the lease (default 7200).
+                             0 = refuse immediately with exit 77 if busy.
+  Exit 76 = host not quiet. Exit 77 = another measurement holds the lease.
+  A measurement that cannot testify to its own conditions is not a measurement.
+  See docs/contributing/battleaxe-timing.md.
 EOF
 }
 

--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -157,10 +157,23 @@ sugar_bx_require_docker_ready() {
 }
 
 # Exit 76: host not quiet enough for a trusted wall-clock measurement.
+# Exit 77: another quiet-gated timing measurement holds the exclusive lease.
 # A number taken under contention is not a slow measurement — it is not a
 # measurement. Timing runs must set SUGAR_BX_REQUIRE_QUIET=1 (or an explicit
 # SUGAR_BX_MAX_LOADAVG). Ordinary builds leave both unset and are not gated.
 # Sample is always the *remote* box load (via sugar_bx_ssh), never the laptop.
+#
+# Concurrency: load-at-start alone is not enough — six agents can all pass a
+# quiet check then co-run and recreate contention on battleaxe. Quiet-gated
+# ambient runs take an exclusive remote flock
+# (/var/tmp/sugar-bx-timing-measurement.lease by default), re-sample load
+# under that lock, then run. Serialize, do not rely on people.
+sugar_bx_quiet_armed() {
+  local require="${SUGAR_BX_REQUIRE_QUIET:-0}"
+  local max_env="${SUGAR_BX_MAX_LOADAVG:-}"
+  [[ -n "$max_env" || "$require" == 1 || "$require" == true || "$require" == yes ]]
+}
+
 sugar_bx_sample_load() {
   # Prints: load1 nproc  (one line). Uses /proc/loadavg on Linux; falls back
   # to python getloadavg on platforms without it (local-mode macOS tests).
@@ -177,54 +190,31 @@ sugar_bx_sample_load() {
 }
 
 sugar_bx_require_quiet() {
-  local require="${SUGAR_BX_REQUIRE_QUIET:-0}"
-  local max_env="${SUGAR_BX_MAX_LOADAVG:-}"
-  # No gate unless the caller asked for a quiet measurement.
-  if [[ -z "$max_env" && "$require" != 1 && "$require" != true && "$require" != yes ]]; then
-    SUGAR_BX_LOAD_BEFORE=""
+  # Arm the quiet gate. Authoritative load sample + exclusive lease happen
+  # inside sugar_bx_run_ambient under flock so concurrent brun callers cannot
+  # both pass a free load check and then co-measure.
+  SUGAR_BX_QUIET_ARMED=0
+  SUGAR_BX_LOAD_BEFORE=""
+  if ! sugar_bx_quiet_armed; then
     return 0
   fi
-  local sample load1 nproc max
-  set +e
-  sample="$(sugar_bx_sample_load 2>&1)"
-  local sample_status=$?
-  set -e
-  if [[ "$sample_status" != 0 ]]; then
-    printf 'sugarbin: crime=load-sample-failed host=%s status=%s detail=%s replacement=fix ssh to %s; cannot certify a quiet box without a load reading\n' \
-      "$SUGAR_BX_HOST" "$sample_status" "${sample:-<no output>}" "$SUGAR_BX_HOST" >&2
-    return 76
-  fi
-  sample="$(printf '%s' "$sample" | tr -d '\r' | tail -n 1)"
-  load1="${sample%% *}"
-  nproc="${sample##* }"
-  if [[ -z "$load1" || -z "$nproc" || "$load1" == "$sample" ]]; then
-    printf 'sugarbin: crime=load-sample-unparseable host=%s sample=%s replacement=expect \"load1 nproc\" from remote sample\n' \
-      "$SUGAR_BX_HOST" "${sample:-<empty>}" >&2
-    return 76
-  fi
-  SUGAR_BX_LOAD_BEFORE="$load1"
-  SUGAR_BX_NPROC="$nproc"
-  if [[ -n "$max_env" ]]; then
-    max="$max_env"
-  else
-    # Default: 25% of cores, floor 2.0 — battleaxe 32c → 8.0. Contended Mac
-    # (load 13 on 8 cores) is always over; quiet bx (load ~2 on 32) always under.
-    max="$(awk -v n="$nproc" 'BEGIN{ m=n/4.0; if (m < 2.0) m=2.0; printf "%.2f", m }')"
-  fi
-  printf 'sugarbin: bx-load-gate phase=before host=%s load1=%s nproc=%s max=%s\n' \
-    "$SUGAR_BX_HOST" "$load1" "$nproc" "$max" >&2
-  # Refuse when load1 > max (strict). Equality is allowed.
-  if awk -v l="$load1" -v m="$max" 'BEGIN{ exit !(l+0 > m+0) }'; then
-    printf 'sugarbin: crime=host-not-quiet host=%s load1=%s nproc=%s max=%s replacement=wait for load1<=%s on %s (or raise SUGAR_BX_MAX_LOADAVG with cause). A wall-clock number taken under contention manufactured tonight'\''s fake 87%% regression — refuse rather than report.\n' \
-      "$SUGAR_BX_HOST" "$load1" "$nproc" "$max" "$max" "$SUGAR_BX_HOST" >&2
-    return 76
-  fi
+  SUGAR_BX_QUIET_ARMED=1
+  SUGAR_BX_LOAD_MAX="${SUGAR_BX_MAX_LOADAVG:-}"
+  SUGAR_BX_TIMING_LEASE="${SUGAR_BX_TIMING_LEASE_PATH:-/var/tmp/sugar-bx-timing-measurement.lease}"
+  # Default wait 2h (queue). Set SUGAR_BX_TIMING_LEASE_WAIT_S=0 to refuse
+  # immediately with exit 77 when another measurement holds the lease.
+  SUGAR_BX_TIMING_LEASE_WAIT="${SUGAR_BX_TIMING_LEASE_WAIT_S:-7200}"
+  printf 'sugarbin: bx-load-gate phase=arm host=%s max=%s lease=%s wait_s=%s\n' \
+    "$SUGAR_BX_HOST" "${SUGAR_BX_LOAD_MAX:-auto(nproc/4,floor=2)}" \
+    "$SUGAR_BX_TIMING_LEASE" "$SUGAR_BX_TIMING_LEASE_WAIT" >&2
   return 0
 }
 
 sugar_bx_report_load_after() {
-  # Best-effort after sample when a quiet gate was armed. Never fails the run:
-  # the before-gate already certified start conditions; after is telemetry.
+  # After-load is printed under the lease by the remote wrapper when quiet is
+  # armed. This local hook is a no-op for quiet runs (remote already testified)
+  # and a no-op when the gate was never armed.
+  [[ "${SUGAR_BX_QUIET_ARMED:-0}" == 1 ]] && return 0
   [[ -n "${SUGAR_BX_LOAD_BEFORE:-}" ]] || return 0
   local sample load1
   set +e
@@ -244,17 +234,82 @@ sugar_bx_run_ambient() {
       [[ -z "$inner" ]] && inner="$prefix" || inner="$inner:$prefix"
     done
   fi
-  local cmd="cd $(sugar_bx_quote "$remote_cwd") && "
-  [[ -n "$inner" ]] && cmd+="PATH=$(sugar_bx_quote "$inner"):\$PATH "
+  local prefix_cmd="cd $(sugar_bx_quote "$remote_cwd") && "
+  [[ -n "$inner" ]] && prefix_cmd+="PATH=$(sugar_bx_quote "$inner"):\$PATH "
   if ((${#SUGAR_BX_ENV_NAMES[@]} != 0)); then
-    for name in "${SUGAR_BX_ENV_NAMES[@]}"; do [[ ${!name+x} == x ]] && cmd+="$name=$(sugar_bx_quote "${!name}") "; done
+    for name in "${SUGAR_BX_ENV_NAMES[@]}"; do [[ ${!name+x} == x ]] && prefix_cmd+="$name=$(sugar_bx_quote "${!name}") "; done
   fi
-  cmd+="exec"
+  local run_cmd=""
   for arg in "$@"; do
     if [[ "$arg" == "$SUGAR_BX_REPO_ROOT" ]]; then arg="$SUGAR_BX_REPO"; elif [[ "$arg" == "$SUGAR_BX_REPO_ROOT"/* ]]; then arg="$SUGAR_BX_REPO/${arg#"$SUGAR_BX_REPO_ROOT"/}"; fi
-    cmd+=" $(sugar_bx_quote "$arg")"
+    run_cmd+=" $(sugar_bx_quote "$arg")"
   done
-  sugar_bx_ssh "bash -lc $(sugar_bx_quote "$cmd")"
+
+  # Ungated path: one-shot exec (unchanged contract).
+  if [[ "${SUGAR_BX_QUIET_ARMED:-0}" != 1 ]]; then
+    sugar_bx_ssh "bash -lc $(sugar_bx_quote "${prefix_cmd}exec${run_cmd}")"
+    return $?
+  fi
+
+  # Quiet path: exclusive remote lease, then load sample under the lock, then
+  # measure. Do not exec-replace the shell that holds the flock fd.
+  local lock wait_s max_lit host_lit measured_cmd wrapper
+  lock="${SUGAR_BX_TIMING_LEASE:-/var/tmp/sugar-bx-timing-measurement.lease}"
+  wait_s="${SUGAR_BX_TIMING_LEASE_WAIT:-7200}"
+  max_lit="${SUGAR_BX_LOAD_MAX:-}"
+  host_lit="$SUGAR_BX_HOST"
+  # prefix_cmd already ends with spaces/env; run_cmd starts with a leading space.
+  measured_cmd="${prefix_cmd}${run_cmd# }"
+  wrapper="set -euo pipefail
+LOCK=$(sugar_bx_quote "$lock")
+WAIT=$(sugar_bx_quote "$wait_s")
+MAX_LIT=$(sugar_bx_quote "$max_lit")
+HOST=$(sugar_bx_quote "$host_lit")
+touch \"\$LOCK\" || { printf 'sugarbin: crime=timing-lease-uncreatable path=%s\\n' \"\$LOCK\" >&2; exit 77; }
+exec 9>>\"\$LOCK\"
+if ! command -v flock >/dev/null 2>&1; then
+  printf 'sugarbin: crime=timing-lease-flock-missing host=%s replacement=install util-linux flock on battleaxe\\n' \"\$HOST\" >&2
+  exit 77
+fi
+printf 'sugarbin: bx-timing-lease phase=waiting host=%s path=%s wait_s=%s\\n' \"\$HOST\" \"\$LOCK\" \"\$WAIT\" >&2
+if ! flock -w \"\$WAIT\" 9; then
+  printf 'sugarbin: crime=timing-lease-busy host=%s path=%s wait_s=%s replacement=another quiet-gated measurement holds the exclusive lease — serialize; do not co-measure on battleaxe. exit 77\\n' \\
+    \"\$HOST\" \"\$LOCK\" \"\$WAIT\" >&2
+  exit 77
+fi
+printf 'sugarbin: bx-timing-lease phase=acquired host=%s path=%s\\n' \"\$HOST\" \"\$LOCK\" >&2
+if [[ -r /proc/loadavg ]]; then
+  read -r l1 _rest </proc/loadavg
+else
+  l1=\$(python3 -c 'import os; print(os.getloadavg()[0])' 2>/dev/null || echo 0)
+fi
+n=\$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
+if [[ -n \"\$MAX_LIT\" ]]; then
+  max=\"\$MAX_LIT\"
+else
+  max=\$(awk -v n=\"\$n\" 'BEGIN{ m=n/4.0; if (m < 2.0) m=2.0; printf \"%.2f\", m }')
+fi
+printf 'sugarbin: bx-load-gate phase=before host=%s load1=%s nproc=%s max=%s lease=held\\n' \\
+  \"\$HOST\" \"\$l1\" \"\$n\" \"\$max\" >&2
+if awk -v l=\"\$l1\" -v m=\"\$max\" 'BEGIN{ exit !(l+0 > m+0) }'; then
+  printf 'sugarbin: crime=host-not-quiet host=%s load1=%s nproc=%s max=%s lease=held replacement=wait for load1<=%s (or raise SUGAR_BX_MAX_LOADAVG with cause). A measurement that cannot testify to its own conditions is not a measurement.\\n' \\
+    \"\$HOST\" \"\$l1\" \"\$n\" \"\$max\" \"\$max\" >&2
+  exit 76
+fi
+set +e
+${measured_cmd}
+st=\$?
+set -e
+if [[ -r /proc/loadavg ]]; then
+  read -r l2 _rest </proc/loadavg
+else
+  l2=\$(python3 -c 'import os; print(os.getloadavg()[0])' 2>/dev/null || echo unknown)
+fi
+printf 'sugarbin: bx-load-gate phase=after host=%s load1_before=%s load1_after=%s nproc=%s lease=held\\n' \\
+  \"\$HOST\" \"\$l1\" \"\$l2\" \"\$n\" >&2
+printf 'sugarbin: bx-timing-lease phase=release host=%s path=%s status=%s\\n' \"\$HOST\" \"\$LOCK\" \"\$st\" >&2
+exit \"\$st\""
+  sugar_bx_ssh "bash -lc $(sugar_bx_quote "$wrapper")"
 }
 
 sugar_bx_docker_bind_source() {

--- a/docs/build-execution.md
+++ b/docs/build-execution.md
@@ -76,7 +76,7 @@ select `--host bx`; they do not own synchronization, provisioning, artifact
 resolution, or execution policy. `bpytest` additionally selects the managed
 `python-unit` task.
 
-### Quiet gate for wall-clock timing
+### Quiet gate + exclusive timing lease for wall-clock numbers
 
 A wall-clock number taken under host contention is not a measurement. For
 timing runs on battleaxe, arm the quiet gate:
@@ -86,11 +86,14 @@ SUGAR_BX_REQUIRE_QUIET=1 bin/brun -- <command>
 # or: SUGAR_BX_MAX_LOADAVG=8 bin/brun -- <command>
 ```
 
-When armed, the bx backend samples remote 1-minute loadavg **before** the
-command, refuses with **exit 76** if `load1` exceeds the ceiling (default
-`max(2.0, nproc/4)`), and prints load before/after on stderr. Ordinary builds
-leave the gate unset. Canonical timing shapes (single file, N-file walk, LPT
-k=8) live in `docs/contributing/battleaxe-timing.md`.
+When armed, the bx backend takes an exclusive remote flock
+(`/var/tmp/sugar-bx-timing-measurement.lease`), samples load **under that
+lock**, refuses with **exit 76** if `load1` exceeds the ceiling (default
+`max(2.0, nproc/4)`), refuses with **exit 77** if the lease cannot be acquired
+within `SUGAR_BX_TIMING_LEASE_WAIT_S` (default 7200; `0` = non-blocking), and
+prints load before/after with `lease=held` on stderr. Ordinary builds leave
+the gate unset. Canonical timing shapes (single file, N-file walk, LPT k=8)
+live in `docs/contributing/battleaxe-timing.md`.
 
 ## Capabilities and named tasks
 

--- a/docs/contributing/battleaxe-timing.md
+++ b/docs/contributing/battleaxe-timing.md
@@ -19,21 +19,36 @@ Wrappers live in the repo (they are **not** on PATH in a bare shell):
 repo-relative cwd, forwards env with `--env`, and can rsync results back with
 `--sync-back`. Do **not** invent a second remote runner.
 
-## Quiet gate (mandatory for every timing number)
+## Quiet gate + exclusive lease (mandatory for every timing number)
 
 ```bash
 export SUGAR_BX_REQUIRE_QUIET=1
 # optional explicit ceiling (also arms the gate alone):
 # export SUGAR_BX_MAX_LOADAVG=8
+# optional: refuse immediately instead of queueing behind another measurement
+# export SUGAR_BX_TIMING_LEASE_WAIT_S=0
 ```
+
+**Rule:** a measurement that cannot testify to its own conditions is not a
+measurement. Load-at-start alone is not enough — six agents can all pass a free
+check then co-run and recreate contention on battleaxe.
 
 When armed, `bin/brun` / `bin/sugarbin run --host bx`:
 
-1. Samples **remote** 1-minute loadavg and `nproc` **before** the command.
-2. **Refuses with exit 76** if `load1 > max` (default `max = max(2.0, nproc/4)` → 8.0 on 32-core battleaxe).
-3. Prints `bx-load-gate phase=before …` and `phase=after …` on stderr.
+1. Takes an **exclusive remote flock** on
+   `/var/tmp/sugar-bx-timing-measurement.lease` (queue up to
+   `SUGAR_BX_TIMING_LEASE_WAIT_S`, default 7200s; `0` → exit **77** immediately
+   if another quiet-gated measurement holds it).
+2. Under that lock, samples **remote** 1-minute loadavg and `nproc`.
+3. **Refuses with exit 76** if `load1 > max` (default `max = max(2.0, nproc/4)`
+   → 8.0 on 32-core battleaxe).
+4. Runs the command while still holding the lease.
+5. Prints `bx-load-gate phase=before|after … lease=held` and
+   `bx-timing-lease phase=acquired|release` on stderr.
 
-Ordinary builds leave the gate **unset**. Timing runs always arm it.
+Ordinary builds leave the gate **unset** (no lease, no load check). Timing
+runs always arm it. **Serialized measurement is enforced by the tool**, not by
+people agreeing not to overlap.
 
 ## One-time remote env (pinned pandas corpus)
 
@@ -148,16 +163,36 @@ Full k=8 board seal remains the compose job in
 `.github/workflows/control-effect-recensus.yml` (sole SCOREBOARD door). Local
 k=8 timing of a single seat is for latency, not for a sealed board.
 
+### Fleet roles (same door, different SLICE / SHARD / FILE_REL)
+
+**Everyone:** from repo root, `SUGAR_BX_REQUIRE_QUIET=1`, invoke **`bin/brun` by
+path** (not on PATH). One-time: `bin/brun -- bash scripts/bootstrap-venv-py312.sh`.
+Shared PYTHONPATH + CORPUS block as above. Exclusive lease serializes you —
+do not invent a parallel runner. Exit 76/77 = no number.
+
+| Agent | Job | Shape |
+| --- | --- | --- |
+| **mr_orange** | full 1421-file walk | §2 with `SLICE="$CORPUS"` (full package root) |
+| **mr_black** | 200-file before/after | §2 with a 200-file enrolled list or a bounded subtree; same tip+pin both legs; arm quiet both legs |
+| **mr_blonde** | LPT k=8 | §3; plan first, then seats `SHARD=0..7` (serialized by lease — queue, don't co-fire) |
+| **mr_white** | correctness re-run | §2 full or pin-matched slice; compare verdicts/CIDs not wall-clock alone |
+| **mr_pink** | RSS over a walk | §2 + wrap remote body with `/usr/bin/time -v` or `ps` RSS sampling **inside** the quiet-gated brun command so RSS and wall share the same lease/load testimony |
+| **mr_brown** | D3 hang repro | §1 single file (or smallest slice that reproduces); `FILE_REL=…`; keep quiet gate so hang timing is not Mac noise |
+
+Do not each invent argv. Copy from this file. Cite stderr `load1_before` /
+`load1_after` / `lease=held` with every number.
+
 ## How to read the result
 
 | Exit | Meaning |
 | --- | --- |
-| 0 | Command finished; stderr has `bx-load-gate phase=before` and `phase=after`. JSON at sync-back path. |
-| 76 | **Refused — host not quiet.** No number. Do not cite. Wait and retry. |
+| 0 | Command finished; stderr has `bx-timing-lease phase=acquired`, `bx-load-gate phase=before|after … lease=held`. JSON at sync-back path. |
+| 76 | **Refused — host not quiet** (under lease). No number. Do not cite. Wait and retry. |
+| 77 | **Refused — another measurement holds the exclusive lease** (or wait timed out). No number. Queue or set wait; do not invent a second runner. |
 | other | Remote command failure; also not a trusted number. |
 
-A JSON body without a 0 exit, or without the before load line, is not a timing
-receipt.
+A JSON body without a 0 exit, or without the before load line with `lease=held`,
+is not a timing receipt.
 
 ## Forbidden
 

--- a/tests/sugarbin_bx_load_gate.sh
+++ b/tests/sugarbin_bx_load_gate.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Quiet gate: SUGAR_BX_REQUIRE_QUIET / SUGAR_BX_MAX_LOADAVG refuse a busy host
-# (exit 76) and do not run the remote command. Opt-in only — unset leaves
-# ordinary brun builds ungated.
+# Quiet gate + exclusive timing lease.
+# - SUGAR_BX_REQUIRE_QUIET / SUGAR_BX_MAX_LOADAVG arm the gate.
+# - Under the gate: remote exclusive flock, load sample under lock, refuse 76 if
+#   load high, refuse 77 if lease busy (wait_s=0).
+# - Ungated ordinary brun builds unchanged.
 set -euo pipefail
 
 repo_root="${1:-$(git rev-parse --show-toplevel)}"
@@ -14,22 +16,57 @@ rsync_log="$tmp/rsync.log"
 remote_exec_log="$tmp/remote-exec.log"
 
 # Fake ssh:
-# - load-sample commands (contain /proc/loadavg or getloadavg) print BX_FAKE_LOAD
-# - ambient run is bash -lc '… exec …' (must NOT match find -exec reaper)
+# - pure load-sample probes (getloadavg / /proc/loadavg WITHOUT flock) print BX_FAKE_LOAD
+# - quiet wrapper contains flock + load + measured command
+# - ungated ambient is bash -lc '… exec …'
 cat >"$fake_bin/ssh" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$BX_FAKE_SSH_LOG"
 joined="$*"
+
+# Quiet-gated measurement wrapper (exclusive lease + load under lock).
+if [[ "$joined" == *'flock'* && "$joined" == *'bx-load-gate'* ]]; then
+  printf '%s\n' "$joined" >>"$BX_FAKE_REMOTE_EXEC_LOG"
+  if [[ "${BX_FAKE_LEASE_BUSY:-0}" == 1 ]]; then
+    echo "sugarbin: crime=timing-lease-busy host=battleaxe path=/var/tmp/sugar-bx-timing-measurement.lease" >&2
+    exit 77
+  fi
+  # Load comes from BX_FAKE_LOAD (simulates remote /proc/loadavg). Ceiling:
+  # BX_FAKE_MAX if set (explicit SUGAR_BX_MAX_LOADAVG tests), else nproc/4 floor 2
+  # — mirrors the remote wrapper. Do not parse MAX_LIT from the double-quoted
+  # ssh argv (nested sugar_bx_quote makes sed match escapes, not values).
+  load="${BX_FAKE_LOAD:-0.50 32}"
+  load1="${load%% *}"
+  nproc="${load##* }"
+  if [[ -n "${BX_FAKE_MAX:-}" ]]; then
+    max="$BX_FAKE_MAX"
+  else
+    max="$(awk -v n="$nproc" 'BEGIN{ m=n/4.0; if (m < 2.0) m=2.0; printf "%.2f", m }')"
+  fi
+  echo "sugarbin: bx-timing-lease phase=acquired host=battleaxe path=/var/tmp/sugar-bx-timing-measurement.lease" >&2
+  echo "sugarbin: bx-load-gate phase=before host=battleaxe load1=$load1 nproc=$nproc max=$max lease=held" >&2
+  if awk -v l="$load1" -v m="$max" 'BEGIN{ exit !(l+0 > m+0) }'; then
+    echo "sugarbin: crime=host-not-quiet host=battleaxe load1=$load1 nproc=$nproc max=$max lease=held" >&2
+    exit 76
+  fi
+  echo "sugarbin: bx-load-gate phase=after host=battleaxe load1_before=$load1 load1_after=$load1 nproc=$nproc lease=held" >&2
+  echo "sugarbin: bx-timing-lease phase=release host=battleaxe status=0" >&2
+  exit "${BX_FAKE_REMOTE_STATUS:-0}"
+fi
+
+# Bare load sample (should not be the authoritative quiet path anymore, but
+# keep for any residual probes).
 case "$joined" in
   *'/proc/loadavg'*|*'getloadavg'*)
-    # "load1 nproc"
-    printf '%s\n' "${BX_FAKE_LOAD:-0.50 32}"
-    exit 0
+    if [[ "$joined" != *'flock'* ]]; then
+      printf '%s\n' "${BX_FAKE_LOAD:-0.50 32}"
+      exit 0
+    fi
     ;;
 esac
-# Ambient command is sugar_bx_run_ambient: bash -lc 'cd … && exec …'
-# The reaper uses find -exec — do not treat that as the measured command.
-if [[ "$joined" == *'bash -lc'* && "$joined" == *' exec '* ]]; then
+
+# Ungated ambient: bash -lc 'cd … && exec …' (not find -exec).
+if [[ "$joined" == *'bash -lc'* && "$joined" == *' exec '* && "$joined" != *'flock'* ]]; then
   printf '%s\n' "$joined" >>"$BX_FAKE_REMOTE_EXEC_LOG"
   exit "${BX_FAKE_REMOTE_STATUS:-0}"
 fi
@@ -49,6 +86,10 @@ run_bx() {
     PATH="$fake_bin:$PATH" BCARGO_SSH="$fake_bin/ssh" BCARGO_RSYNC="$fake_bin/rsync" \
     BX_FAKE_SSH_LOG="$ssh_log" BX_FAKE_RSYNC_LOG="$rsync_log" \
     BX_FAKE_REMOTE_EXEC_LOG="$remote_exec_log" \
+    BX_FAKE_LOAD="${BX_FAKE_LOAD-}" \
+    BX_FAKE_MAX="${BX_FAKE_MAX-}" \
+    BX_FAKE_LEASE_BUSY="${BX_FAKE_LEASE_BUSY-}" \
+    BX_FAKE_REMOTE_STATUS="${BX_FAKE_REMOTE_STATUS-}" \
     BCARGO_REMOTE_ROOT="${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-load-gate-test}" \
     BCARGO_FORCE_REMOTE=1 \
     "$repo_root/bin/sugarbin" run --host bx --env ambient "$@")
@@ -57,23 +98,26 @@ run_bx() {
 # 1) Gate off by default: busy load must NOT refuse, and command must run.
 : >"$ssh_log"; : >"$rsync_log"; : >"$remote_exec_log"
 export BX_FAKE_LOAD="20.0 32"
+export BX_FAKE_LEASE_BUSY=0
 status=0
 run_bx -- true >/dev/null 2>"$tmp/stderr1" || status=$?
 [[ "$status" -eq 0 ]] || fail "ungated run failed status=$status (want 0)"
 [[ -s "$remote_exec_log" ]] || fail "ungated run never reached remote exec"
 grep -q 'bx-load-gate' "$tmp/stderr1" && fail "ungated run printed load gate noise" || true
+grep -q 'flock' "$remote_exec_log" && fail "ungated run took timing lease" || true
 
-# 2) REQUIRE_QUIET=1 + busy load → exit 76, no remote exec.
+# 2) REQUIRE_QUIET=1 + busy load → exit 76, quiet wrapper ran (lease path).
 : >"$ssh_log"; : >"$rsync_log"; : >"$remote_exec_log"
 export BX_FAKE_LOAD="20.0 32"
 status=0
 SUGAR_BX_REQUIRE_QUIET=1 run_bx -- true >/dev/null 2>"$tmp/stderr2" || status=$?
 [[ "$status" -eq 76 ]] || fail "busy host status=$status want 76"
-[[ ! -s "$remote_exec_log" ]] || fail "busy host still ran remote command"
+[[ -s "$remote_exec_log" ]] || fail "busy host never entered quiet wrapper"
 grep -Fq 'crime=host-not-quiet' "$tmp/stderr2" || fail "missing host-not-quiet crime line"
 grep -Fq 'phase=before' "$tmp/stderr2" || fail "missing before load line"
+grep -Fq 'lease=held' "$tmp/stderr2" || fail "load check not under lease"
 
-# 3) REQUIRE_QUIET=1 + quiet load → runs, prints before+after.
+# 3) REQUIRE_QUIET=1 + quiet load → runs, prints before+after under lease.
 : >"$ssh_log"; : >"$rsync_log"; : >"$remote_exec_log"
 export BX_FAKE_LOAD="2.05 32"
 status=0
@@ -82,25 +126,43 @@ SUGAR_BX_REQUIRE_QUIET=1 run_bx -- true >/dev/null 2>"$tmp/stderr3" || status=$?
 [[ -s "$remote_exec_log" ]] || fail "quiet host never reached remote exec"
 grep -Fq 'phase=before' "$tmp/stderr3" || fail "quiet run missing before"
 grep -Fq 'phase=after' "$tmp/stderr3" || fail "quiet run missing after"
+grep -Fq 'bx-timing-lease phase=acquired' "$tmp/stderr3" || fail "quiet run missing lease acquire"
+grep -Fq 'flock' "$remote_exec_log" || fail "quiet run missing flock in remote script"
 
 # 4) Explicit MAX_LOADAVG alone arms the gate; load just under passes.
 : >"$ssh_log"; : >"$rsync_log"; : >"$remote_exec_log"
 export BX_FAKE_LOAD="7.9 32"
+export BX_FAKE_MAX=8
 status=0
 SUGAR_BX_MAX_LOADAVG=8 run_bx -- true >/dev/null 2>"$tmp/stderr4" || status=$?
 [[ "$status" -eq 0 ]] || fail "max-load under ceiling status=$status want 0"
+unset BX_FAKE_MAX
 
 # 5) Explicit MAX_LOADAVG: load just over refuses.
 : >"$ssh_log"; : >"$rsync_log"; : >"$remote_exec_log"
 export BX_FAKE_LOAD="8.01 32"
+export BX_FAKE_MAX=8
 status=0
 SUGAR_BX_MAX_LOADAVG=8 run_bx -- true >/dev/null 2>"$tmp/stderr5" || status=$?
 [[ "$status" -eq 76 ]] || fail "max-load over ceiling status=$status want 76"
-[[ ! -s "$remote_exec_log" ]] || fail "over-ceiling still ran remote command"
+unset BX_FAKE_MAX
 
-# 6) brun adapter surfaces the same env (wrapper only; exercise via sugarbin path above).
+# 6) Concurrent hole closed: lease busy → exit 77 (wait_s=0 refuse path).
+: >"$ssh_log"; : >"$rsync_log"; : >"$remote_exec_log"
+export BX_FAKE_LOAD="2.05 32"
+export BX_FAKE_LEASE_BUSY=1
+status=0
+SUGAR_BX_REQUIRE_QUIET=1 SUGAR_BX_TIMING_LEASE_WAIT_S=0 \
+  run_bx -- true >/dev/null 2>"$tmp/stderr6" || status=$?
+[[ "$status" -eq 77 ]] || fail "lease busy status=$status want 77"
+grep -Fq 'crime=timing-lease-busy' "$tmp/stderr6" || fail "missing timing-lease-busy crime"
+export BX_FAKE_LEASE_BUSY=0
+
+# 7) brun adapter surfaces quiet + lease env.
 grep -Fq 'SUGAR_BX_REQUIRE_QUIET' "$repo_root/bin/brun" || fail "brun --help text missing quiet gate"
-grep -Fq 'SUGAR_BX_REQUIRE_QUIET' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing require_quiet"
+grep -Fq 'sugar-bx-timing-measurement.lease' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing timing lease path"
+grep -Fq 'timing-lease-busy' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing lease-busy crime"
 test -f "$repo_root/docs/contributing/battleaxe-timing.md" || fail "canonical timing doc missing"
+grep -Fq 'timing-measurement.lease' "$repo_root/docs/contributing/battleaxe-timing.md" || fail "doc missing exclusive lease"
 
 echo "PASS: sugarbin_bx_load_gate"


### PR DESCRIPTION
## Why

#7088 closed host-not-quiet (exit 76). Hole remaining: six agents can all pass a free load check then co-measure on battleaxe, recreating the Mac contention one box over.

## What

When SUGAR_BX_REQUIRE_QUIET=1 is armed:
1. Exclusive remote flock on /var/tmp/sugar-bx-timing-measurement.lease
2. Queue up to SUGAR_BX_TIMING_LEASE_WAIT_S (default 7200; 0 → exit 77)
3. Sample load under the lease → exit 76 if over ceiling
4. Run measurement holding the lease
5. Print bx-load-gate lease=held + bx-timing-lease acquire/release

Fleet shapes + role table: docs/contributing/battleaxe-timing.md

## Validation

bash tests/sugarbin_bx_load_gate.sh  # PASS
bash tests/sugarbin_bx_exec.sh       # PASS

merge_dog: squash-merge please.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize quiet-gated timing measurements via an exclusive remote flock lease
> - Quiet-gated runs in [`sugar_bx_run_ambient`](https://github.com/TSavo/sugar/pull/7089/files#diff-bdd6c46eb799e81d8c3cc8b50ab4a809668391cedbc25e468f6efe8ef9d86ebc) now acquire an exclusive `flock` on a remote lease file (default `/var/tmp/sugar-bx-timing-measurement.lease`) before sampling load and running the measured command, ensuring only one timing measurement runs at a time.
> - The load check (exit 76 if load exceeds ceiling) and command execution both happen while the lock is held; `bx-timing-lease` and `bx-load-gate phase=before/after lease=held` lines are emitted to stderr.
> - If the lease cannot be acquired within the wait window (default 7200s, configurable via `SUGAR_BX_TIMING_LEASE_WAIT_S`), the run exits 77 with a `timing-lease-busy` crime line.
> - Ungated runs are unchanged and bypass the lease path entirely.
> - Behavioral Change: `sugar_bx_require_quiet` no longer samples load or enforces the ceiling directly; it only arms the gate (`SUGAR_BX_QUIET_ARMED=1`). Enforcement is deferred to command execution under the lease.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43b4622.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->