### PR TITLE
bx corpus pin gate: refuse wrong pandas (exit 78)

### DIFF
--- a/bin/brun
+++ b/bin/brun
@@ -27,16 +27,21 @@ Environment (shared with bcargo so roots, caps and test harnesses apply):
   BCARGO_SSH, BCARGO_RSYNC        Override the ssh/rsync binaries (test harness)
 
 Quiet gate (wall-clock timing only — opt-in; ordinary builds leave unset):
-  SUGAR_BX_REQUIRE_QUIET=1   Exclusive remote timing lease + load sample under
-                             the lock. Refuse exit 76 if load1 > max(2, nproc/4).
-                             Print load BEFORE and AFTER on stderr (lease=held).
-  SUGAR_BX_MAX_LOADAVG=N     Explicit ceiling (also arms the gate alone).
+  SUGAR_BX_REQUIRE_QUIET=1   Arms all three gates: exclusive lease + load under
+                             lock + corpus pin (unless SKIP). 
+  SUGAR_BX_MAX_LOADAVG=N     Explicit load ceiling (also arms the gate alone).
   SUGAR_BX_TIMING_LEASE_PATH Remote flock path
                              (default /var/tmp/sugar-bx-timing-measurement.lease)
   SUGAR_BX_TIMING_LEASE_WAIT_S  Seconds to wait for the lease (default 7200).
                              0 = refuse immediately with exit 77 if busy.
-  Exit 76 = host not quiet. Exit 77 = another measurement holds the lease.
-  A measurement that cannot testify to its own conditions is not a measurement.
+  SUGAR_BX_REQUIRE_CORPUS_PIN  Pin JSON path (default
+                             docs/ledgers/pins/pandas-3.0.3.pin.json)
+  SUGAR_BX_CORPUS_PYTHON     Interpreter that must see the pin
+                             (default .venv-py312/bin/python)
+  SUGAR_BX_SKIP_CORPUS_PIN=1 Skip pin (load/lease unit tests only — never for
+                             pandas wall-clock)
+  Exit 76 = host not quiet. Exit 77 = lease busy. Exit 78 = wrong corpus pin.
+  Three gates, one law: quiet box, exclusive lease, correct corpus.
   See docs/contributing/battleaxe-timing.md.
 EOF
 }

--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -204,9 +204,17 @@ sugar_bx_require_quiet() {
   # Default wait 2h (queue). Set SUGAR_BX_TIMING_LEASE_WAIT_S=0 to refuse
   # immediately with exit 77 when another measurement holds the lease.
   SUGAR_BX_TIMING_LEASE_WAIT="${SUGAR_BX_TIMING_LEASE_WAIT_S:-7200}"
-  printf 'sugarbin: bx-load-gate phase=arm host=%s max=%s lease=%s wait_s=%s\n' \
+  # Corpus pin (third gate). Quiet timing without a pin is a guess: battleaxe
+  # system python has been pandas 2.3.3/1415 while the authenticated pin is
+  # 3.0.3/1421. Default banked pin; SUGAR_BX_SKIP_CORPUS_PIN=1 only for
+  # non-corpus quiet probes (load/lease unit tests).
+  SUGAR_BX_CORPUS_PIN_PATH="${SUGAR_BX_REQUIRE_CORPUS_PIN:-docs/ledgers/pins/pandas-3.0.3.pin.json}"
+  SUGAR_BX_CORPUS_PYTHON="${SUGAR_BX_CORPUS_PYTHON:-.venv-py312/bin/python}"
+  SUGAR_BX_SKIP_CORPUS_PIN="${SUGAR_BX_SKIP_CORPUS_PIN:-0}"
+  printf 'sugarbin: bx-load-gate phase=arm host=%s max=%s lease=%s wait_s=%s corpus_pin=%s skip_pin=%s\n' \
     "$SUGAR_BX_HOST" "${SUGAR_BX_LOAD_MAX:-auto(nproc/4,floor=2)}" \
-    "$SUGAR_BX_TIMING_LEASE" "$SUGAR_BX_TIMING_LEASE_WAIT" >&2
+    "$SUGAR_BX_TIMING_LEASE" "$SUGAR_BX_TIMING_LEASE_WAIT" \
+    "$SUGAR_BX_CORPUS_PIN_PATH" "$SUGAR_BX_SKIP_CORPUS_PIN" >&2
   return 0
 }
 
@@ -251,20 +259,30 @@ sugar_bx_run_ambient() {
     return $?
   fi
 
-  # Quiet path: exclusive remote lease, then load sample under the lock, then
+  # Quiet path: exclusive remote lease → load under lock → corpus pin →
   # measure. Do not exec-replace the shell that holds the flock fd.
+  # Three gates, one law: quiet box, exclusive lease, correct corpus.
   local lock wait_s max_lit host_lit measured_cmd wrapper
+  local pin_path pin_py pin_skip
   lock="${SUGAR_BX_TIMING_LEASE:-/var/tmp/sugar-bx-timing-measurement.lease}"
   wait_s="${SUGAR_BX_TIMING_LEASE_WAIT:-7200}"
   max_lit="${SUGAR_BX_LOAD_MAX:-}"
   host_lit="$SUGAR_BX_HOST"
+  pin_path="${SUGAR_BX_CORPUS_PIN_PATH:-docs/ledgers/pins/pandas-3.0.3.pin.json}"
+  pin_py="${SUGAR_BX_CORPUS_PYTHON:-.venv-py312/bin/python}"
+  pin_skip="${SUGAR_BX_SKIP_CORPUS_PIN:-0}"
   # prefix_cmd already ends with spaces/env; run_cmd starts with a leading space.
   measured_cmd="${prefix_cmd}${run_cmd# }"
+  # Pin gate under lease after load. Identity mode (version+fileCount) default.
+  # All remote expansions use \$ so local $? does not fire while building wrapper.
   wrapper="set -euo pipefail
 LOCK=$(sugar_bx_quote "$lock")
 WAIT=$(sugar_bx_quote "$wait_s")
 MAX_LIT=$(sugar_bx_quote "$max_lit")
 HOST=$(sugar_bx_quote "$host_lit")
+SKIP_PIN=$(sugar_bx_quote "$pin_skip")
+PIN_PATH=$(sugar_bx_quote "$pin_path")
+PIN_PY=$(sugar_bx_quote "$pin_py")
 touch \"\$LOCK\" || { printf 'sugarbin: crime=timing-lease-uncreatable path=%s\\n' \"\$LOCK\" >&2; exit 77; }
 exec 9>>\"\$LOCK\"
 if ! command -v flock >/dev/null 2>&1; then
@@ -295,6 +313,27 @@ if awk -v l=\"\$l1\" -v m=\"\$max\" 'BEGIN{ exit !(l+0 > m+0) }'; then
   printf 'sugarbin: crime=host-not-quiet host=%s load1=%s nproc=%s max=%s lease=held replacement=wait for load1<=%s (or raise SUGAR_BX_MAX_LOADAVG with cause). A measurement that cannot testify to its own conditions is not a measurement.\\n' \\
     \"\$HOST\" \"\$l1\" \"\$n\" \"\$max\" \"\$max\" >&2
   exit 76
+fi
+if [[ \"\$SKIP_PIN\" != 1 && \"\$SKIP_PIN\" != true && \"\$SKIP_PIN\" != yes ]]; then
+  export PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:\${PYTHONPATH:-}
+  if [[ ! -x \"\$PIN_PY\" ]]; then
+    printf 'sugarbin: crime=corpus-pin-python-missing path=%s replacement=bin/brun -- bash scripts/bootstrap-venv-py312.sh (or reuse remote checkout sugar-bcargo-a978990da5ba which already has .venv-py312)\\n' \"\$PIN_PY\" >&2
+    exit 78
+  fi
+  if [[ ! -f \"\$PIN_PATH\" ]]; then
+    printf 'sugarbin: crime=corpus-pin-file-missing path=%s replacement=docs/ledgers/pins/pandas-3.0.3.pin.json must be in the synced checkout\\n' \"\$PIN_PATH\" >&2
+    exit 78
+  fi
+  set +e
+  \"\$PIN_PY\" tools/bx_corpus_pin_gate.py --expected-pin \"\$PIN_PATH\" --python \"\$PIN_PY\"
+  pin_st=\$?
+  set -e
+  if [[ \"\$pin_st\" != 0 ]]; then
+    printf 'sugarbin: crime=corpus-pin-mismatch exit=%s (78=wrong corpus; a number against the wrong pandas is not a measurement)\\n' \"\$pin_st\" >&2
+    exit 78
+  fi
+else
+  printf 'sugarbin: bx-corpus-pin phase=skipped reason=SUGAR_BX_SKIP_CORPUS_PIN\\n' >&2
 fi
 set +e
 ${measured_cmd}

--- a/docs/build-execution.md
+++ b/docs/build-execution.md
@@ -76,24 +76,23 @@ select `--host bx`; they do not own synchronization, provisioning, artifact
 resolution, or execution policy. `bpytest` additionally selects the managed
 `python-unit` task.
 
-### Quiet gate + exclusive timing lease for wall-clock numbers
+### Quiet gate + exclusive lease + corpus pin for wall-clock numbers
 
-A wall-clock number taken under host contention is not a measurement. For
-timing runs on battleaxe, arm the quiet gate:
+A wall-clock number that cannot testify to its conditions is not a measurement.
+For timing runs on battleaxe, arm the quiet gate:
 
 ```bash
 SUGAR_BX_REQUIRE_QUIET=1 bin/brun -- <command>
-# or: SUGAR_BX_MAX_LOADAVG=8 bin/brun -- <command>
+# pin defaults to docs/ledgers/pins/pandas-3.0.3.pin.json via .venv-py312
 ```
 
-When armed, the bx backend takes an exclusive remote flock
-(`/var/tmp/sugar-bx-timing-measurement.lease`), samples load **under that
-lock**, refuses with **exit 76** if `load1` exceeds the ceiling (default
-`max(2.0, nproc/4)`), refuses with **exit 77** if the lease cannot be acquired
-within `SUGAR_BX_TIMING_LEASE_WAIT_S` (default 7200; `0` = non-blocking), and
-prints load before/after with `lease=held` on stderr. Ordinary builds leave
-the gate unset. Canonical timing shapes (single file, N-file walk, LPT k=8)
-live in `docs/contributing/battleaxe-timing.md`.
+When armed, the bx backend: exclusive remote flock
+(`/var/tmp/sugar-bx-timing-measurement.lease`); load sample under that lock
+(**exit 76** if over ceiling); corpus pin gate via
+`tools/bx_corpus_pin_gate.py` (**exit 78** if version/fileCount ≠ 3.0.3/1421);
+**exit 77** if the lease cannot be acquired. Prints load + pin on stderr.
+Ordinary builds leave the gate unset. Canonical shapes:
+`docs/contributing/battleaxe-timing.md`.
 
 ## Capabilities and named tasks
 

--- a/docs/contributing/battleaxe-timing.md
+++ b/docs/contributing/battleaxe-timing.md
@@ -19,43 +19,53 @@ Wrappers live in the repo (they are **not** on PATH in a bare shell):
 repo-relative cwd, forwards env with `--env`, and can rsync results back with
 `--sync-back`. Do **not** invent a second remote runner.
 
-## Quiet gate + exclusive lease (mandatory for every timing number)
+## Three gates (mandatory for every timing number)
+
+**Rule:** a measurement that cannot testify to its own conditions is not a
+measurement. Three independent holes closed so far tonight:
+
+| Gate | Proves | Refuse |
+| --- | --- | --- |
+| **Load** | box was quiet under the lease | exit **76** |
+| **Lease** | no concurrent quiet measurement | exit **77** |
+| **Corpus pin** | measuring pandas **3.0.3 / 1421 files**, not system 2.3.3 / 1415 | exit **78** |
 
 ```bash
 export SUGAR_BX_REQUIRE_QUIET=1
-# optional explicit ceiling (also arms the gate alone):
-# export SUGAR_BX_MAX_LOADAVG=8
-# optional: refuse immediately instead of queueing behind another measurement
-# export SUGAR_BX_TIMING_LEASE_WAIT_S=0
+# optional: SUGAR_BX_MAX_LOADAVG=8
+# optional: SUGAR_BX_TIMING_LEASE_WAIT_S=0   # refuse if lease busy
+# pin defaults (override only with cause):
+#   SUGAR_BX_REQUIRE_CORPUS_PIN=docs/ledgers/pins/pandas-3.0.3.pin.json
+#   SUGAR_BX_CORPUS_PYTHON=.venv-py312/bin/python
+# never for fleet wall-clock: SUGAR_BX_SKIP_CORPUS_PIN=1
 ```
 
-**Rule:** a measurement that cannot testify to its own conditions is not a
-measurement. Load-at-start alone is not enough — six agents can all pass a free
-check then co-run and recreate contention on battleaxe.
+When `SUGAR_BX_REQUIRE_QUIET=1`, `bin/brun` / `bin/sugarbin run --host bx`:
 
-When armed, `bin/brun` / `bin/sugarbin run --host bx`:
-
-1. Takes an **exclusive remote flock** on
-   `/var/tmp/sugar-bx-timing-measurement.lease` (queue up to
-   `SUGAR_BX_TIMING_LEASE_WAIT_S`, default 7200s; `0` → exit **77** immediately
-   if another quiet-gated measurement holds it).
-2. Under that lock, samples **remote** 1-minute loadavg and `nproc`.
-3. **Refuses with exit 76** if `load1 > max` (default `max = max(2.0, nproc/4)`
-   → 8.0 on 32-core battleaxe).
-4. Runs the command while still holding the lease.
-5. Prints `bx-load-gate phase=before|after … lease=held` and
-   `bx-timing-lease phase=acquired|release` on stderr.
-
-Ordinary builds leave the gate **unset** (no lease, no load check). Timing
-runs always arm it. **Serialized measurement is enforced by the tool**, not by
-people agreeing not to overlap.
+1. Exclusive remote flock `/var/tmp/sugar-bx-timing-measurement.lease`
+2. Under lock: sample load1 → **76** if over ceiling
+3. Under lock: run `tools/bx_corpus_pin_gate.py` against
+   `.venv-py312` + banked pin → **78** if version/fileCount mismatch
+   (identity mode: version + file count; prints expected aggregate in the
+   receipt). `control_effect_recensus` also exits **78** on pin/aggregate refuse.
+4. Run the measurement while still holding the lease
+5. Print load before/after (`lease=held`) and pin `phase=ok` on stderr
 
 ## One-time remote env (pinned pandas corpus)
 
-From any checkout root (on the Mac; work runs on battleaxe):
+**Never use system python on battleaxe for measurement.** It has carried
+pandas **2.3.3 (1415 files)**. The authenticated pin is **3.0.3 (1421 files)**
+at `docs/ledgers/pins/pandas-3.0.3.pin.json`.
 
 ```bash
+# Preferred: bootstrap in *this* checkout's remote root
 bin/brun -- bash scripts/bootstrap-venv-py312.sh
+
+# Blonde is bootstrapping .venv-py312 with pandas==3.0.3 on the box.
+# Brown found an existing remote checkout that already has the right venv:
+#   sugar-bcargo-a978990da5ba  (tag a978990da5ba)
+# Reuse only if ` .venv-py312/bin/python -c 'import pandas; print(pandas.__version__)' `
+# prints 3.0.3 and the pin gate exits 0.
 ```
 
 That builds `.venv-py312` on the remote with **CPython 3.12.13 + pandas==3.0.3**
@@ -63,16 +73,14 @@ That builds `.venv-py312` on the remote with **CPython 3.12.13 + pandas==3.0.3**
 
 ## Canonical command shapes
 
-Always from the **repo root**. Always with `SUGAR_BX_REQUIRE_QUIET=1`.
-Always invoke `bin/brun` by path.
-
-Shared remote body (PYTHONPATH + corpus root from the pin):
+Always from the **repo root**. Always `SUGAR_BX_REQUIRE_QUIET=1`.
+Always invoke `bin/brun` by path. Always `.venv-py312` as `PY`.
+The quiet wrapper authenticates the pin before your command runs.
 
 ```bash
 export SUGAR_BX_REQUIRE_QUIET=1
-# Optional: pin an explicit SHA the remote checkout already has after sync.
-# The sync is the current tip of this worktree; commit id is recorded by the
-# recensus via --commit when you pass it.
+export SUGAR_BX_REQUIRE_CORPUS_PIN=docs/ledgers/pins/pandas-3.0.3.pin.json
+export SUGAR_BX_CORPUS_PYTHON=.venv-py312/bin/python
 
 REMOTE_JSON=/tmp/sugar-bx-measure.json   # path ON battleaxe
 LOCAL_JSON=/tmp/sugar-bx-measure.json    # path ON the Mac after sync-back
@@ -81,12 +89,15 @@ LOCAL_JSON=/tmp/sugar-bx-measure.json    # path ON the Mac after sync-back
 ### 1. Single file
 
 ```bash
-SUGAR_BX_REQUIRE_QUIET=1 bin/brun \
+SUGAR_BX_REQUIRE_QUIET=1 \
+SUGAR_BX_REQUIRE_CORPUS_PIN=docs/ledgers/pins/pandas-3.0.3.pin.json \
+SUGAR_BX_CORPUS_PYTHON=.venv-py312/bin/python \
+bin/brun \
   --sync-back "${REMOTE_JSON}:${LOCAL_JSON}" \
   -- bash -lc '
     set -euo pipefail
     PY=.venv-py312/bin/python
-    test -x "$PY" || { echo "missing .venv-py312; run: bin/brun -- bash scripts/bootstrap-venv-py312.sh" >&2; exit 2; }
+    test -x "$PY" || { echo "missing .venv-py312; bin/brun -- bash scripts/bootstrap-venv-py312.sh" >&2; exit 78; }
     CORPUS=$("$PY" -c "import pandas, pathlib; print(pathlib.Path(pandas.__file__).resolve().parent)")
     export PYTHONPATH=implementations/python/sugar-lift-py-tests/scripts:implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src
     FILE_REL="${FILE_REL:-io/json/_json.py}"
@@ -95,9 +106,10 @@ SUGAR_BX_REQUIRE_QUIET=1 bin/brun \
       --corpus-root "$CORPUS" \
       --repo . \
       --commit "$(git rev-parse HEAD)" \
+      --require-corpus-pin docs/ledgers/pins/pandas-3.0.3.pin.json \
       --json /tmp/sugar-bx-measure.json
   '
-# JSON at $LOCAL_JSON. Trust only if the command exited 0 (not 76).
+# Trust only exit 0. Cite stderr: lease=held, load1_before/after, bx-corpus-pin phase=ok.
 ```
 
 Override the file:
@@ -113,7 +125,10 @@ Pass a directory under the corpus root as the first positional (still with
 full run):
 
 ```bash
-SUGAR_BX_REQUIRE_QUIET=1 bin/brun \
+SUGAR_BX_REQUIRE_QUIET=1 \
+SUGAR_BX_REQUIRE_CORPUS_PIN=docs/ledgers/pins/pandas-3.0.3.pin.json \
+SUGAR_BX_CORPUS_PYTHON=.venv-py312/bin/python \
+bin/brun \
   --sync-back "${REMOTE_JSON}:${LOCAL_JSON}" \
   -- bash -lc '
     set -euo pipefail
@@ -126,6 +141,7 @@ SUGAR_BX_REQUIRE_QUIET=1 bin/brun \
       --corpus-root "$CORPUS" \
       --repo . \
       --commit "$(git rev-parse HEAD)" \
+      --require-corpus-pin docs/ledgers/pins/pandas-3.0.3.pin.json \
       --json /tmp/sugar-bx-measure.json
   '
 ```
@@ -137,7 +153,10 @@ Plan is not a measurement. Measure a seat with the production worker shape:
 ```bash
 # After plan.json exists under .sugar/pandas-control-effect/ (from the CI plan
 # job or tools/plan_control_effect_recensus_shards.py on battleaxe):
-SUGAR_BX_REQUIRE_QUIET=1 bin/brun \
+SUGAR_BX_REQUIRE_QUIET=1 \
+SUGAR_BX_REQUIRE_CORPUS_PIN=docs/ledgers/pins/pandas-3.0.3.pin.json \
+SUGAR_BX_CORPUS_PYTHON=.venv-py312/bin/python \
+bin/brun \
   --sync-back "${REMOTE_JSON}:${LOCAL_JSON}" \
   -- bash -lc '
     set -euo pipefail
@@ -151,6 +170,7 @@ SUGAR_BX_REQUIRE_QUIET=1 bin/brun \
       --corpus-root "$CORPUS" \
       --repo . \
       --commit "$(git rev-parse HEAD)" \
+      --require-corpus-pin docs/ledgers/pins/pandas-3.0.3.pin.json \
       --out-dir "$OUT" \
       --plan-json "$OUT/plan.json" \
       --shard-index "$SHARD" \
@@ -186,12 +206,13 @@ Do not each invent argv. Copy from this file. Cite stderr `load1_before` /
 
 | Exit | Meaning |
 | --- | --- |
-| 0 | Command finished; stderr has `bx-timing-lease phase=acquired`, `bx-load-gate phase=before|after … lease=held`. JSON at sync-back path. |
-| 76 | **Refused — host not quiet** (under lease). No number. Do not cite. Wait and retry. |
-| 77 | **Refused — another measurement holds the exclusive lease** (or wait timed out). No number. Queue or set wait; do not invent a second runner. |
+| 0 | Finished; stderr has lease acquired, load before/after `lease=held`, and `bx-corpus-pin phase=ok`. JSON at sync-back path. |
+| 76 | **Host not quiet** (under lease). No number. |
+| 77 | **Lease busy** (or wait timed out). No number. Queue — do not invent a second runner. |
+| 78 | **Wrong corpus pin** (e.g. system 2.3.3/1415 vs pin 3.0.3/1421). No number. Bootstrap `.venv-py312`. |
 | other | Remote command failure; also not a trusted number. |
 
-A JSON body without a 0 exit, or without the before load line with `lease=held`,
+A JSON body without exit 0, or without load `lease=held` **and** pin `phase=ok`,
 is not a timing receipt.
 
 ## Forbidden

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -824,11 +824,25 @@ def main() -> int:
         manifest_shape_cid = corpus_manifest_shape_cid(list(observed_pin.paths))
         _authenticate_declared_pandas_corpus(observed_pin, manifest_shape_cid)
     except CorpusPinDefect as defect:
+        # Exit 78: corpus pin gate — distinct from generic instrument failure (2).
+        # A number against the wrong pandas is not a measurement.
         print(str(defect), file=sys.stderr, flush=True)
-        return 2
+        print(
+            "control_effect_recensus: crime=corpus-pin-mismatch exit=78 "
+            "(use .venv-py312 pandas==3.0.3 fileCount=1421; never system 2.3.3/1415)",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 78
     except ValueError as defect:
+        # Declared pandas 3.0.3 aggregate / shape CID refusal — same class as pin.
         print(str(defect), file=sys.stderr, flush=True)
-        return 2
+        print(
+            "control_effect_recensus: crime=corpus-pin-mismatch exit=78",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 78
     _phase_end("manifest_cid_and_pin", t_pin)
     _narrate(
         "RECENSUS PIN "

--- a/tests/sugarbin_bx_load_gate.sh
+++ b/tests/sugarbin_bx_load_gate.sh
@@ -82,6 +82,7 @@ chmod +x "$fake_bin/ssh" "$fake_bin/rsync"
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
 run_bx() {
+  # Load/lease unit tests skip the corpus pin (no pandas on the fake remote).
   (cd "$repo_root" &&
     PATH="$fake_bin:$PATH" BCARGO_SSH="$fake_bin/ssh" BCARGO_RSYNC="$fake_bin/rsync" \
     BX_FAKE_SSH_LOG="$ssh_log" BX_FAKE_RSYNC_LOG="$rsync_log" \
@@ -92,6 +93,7 @@ run_bx() {
     BX_FAKE_REMOTE_STATUS="${BX_FAKE_REMOTE_STATUS-}" \
     BCARGO_REMOTE_ROOT="${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-load-gate-test}" \
     BCARGO_FORCE_REMOTE=1 \
+    SUGAR_BX_SKIP_CORPUS_PIN="${SUGAR_BX_SKIP_CORPUS_PIN:-1}" \
     "$repo_root/bin/sugarbin" run --host bx --env ambient "$@")
 }
 
@@ -158,11 +160,29 @@ SUGAR_BX_REQUIRE_QUIET=1 SUGAR_BX_TIMING_LEASE_WAIT_S=0 \
 grep -Fq 'crime=timing-lease-busy' "$tmp/stderr6" || fail "missing timing-lease-busy crime"
 export BX_FAKE_LEASE_BUSY=0
 
-# 7) brun adapter surfaces quiet + lease env.
+# 7) brun adapter surfaces quiet + lease + pin env.
 grep -Fq 'SUGAR_BX_REQUIRE_QUIET' "$repo_root/bin/brun" || fail "brun --help text missing quiet gate"
 grep -Fq 'sugar-bx-timing-measurement.lease' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing timing lease path"
 grep -Fq 'timing-lease-busy' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing lease-busy crime"
+grep -Fq 'bx_corpus_pin_gate' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing corpus pin gate"
+grep -Fq 'exit 78' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing pin exit 78"
 test -f "$repo_root/docs/contributing/battleaxe-timing.md" || fail "canonical timing doc missing"
 grep -Fq 'timing-measurement.lease' "$repo_root/docs/contributing/battleaxe-timing.md" || fail "doc missing exclusive lease"
+grep -Fq 'corpus-pin' "$repo_root/docs/contributing/battleaxe-timing.md" || fail "doc missing corpus pin gate"
+test -f "$repo_root/tools/bx_corpus_pin_gate.py" || fail "bx_corpus_pin_gate.py missing"
+
+# 8) Quiet path without SKIP must mention pin gate in remote wrapper.
+: >"$ssh_log"; : >"$rsync_log"; : >"$remote_exec_log"
+export BX_FAKE_LOAD="2.05 32"
+status=0
+SUGAR_BX_REQUIRE_QUIET=1 SUGAR_BX_SKIP_CORPUS_PIN=0 \
+  run_bx -- true >/dev/null 2>"$tmp/stderr8" || status=$?
+# Fake remote does not run real pin; wrapper must still carry pin gate text.
+grep -Fq 'bx_corpus_pin_gate' "$remote_exec_log" \
+  || grep -Fq 'bx_corpus_pin_gate' "$ssh_log" \
+  || fail "quiet+pin wrapper missing bx_corpus_pin_gate"
+grep -Fq 'PIN_PATH=' "$remote_exec_log" "$ssh_log" 2>/dev/null \
+  || grep -Fq 'pandas-3.0.3.pin.json' "$remote_exec_log" "$ssh_log" \
+  || fail "quiet+pin wrapper missing pin path"
 
 echo "PASS: sugarbin_bx_load_gate"

--- a/tests/test_bx_corpus_pin_gate.py
+++ b/tests/test_bx_corpus_pin_gate.py
@@ -1,0 +1,128 @@
+"""Focused unit tests for tools/bx_corpus_pin_gate.py — no live pandas corpus.
+
+Identity mode with --observed-* test doubles: pure comparison, no Mac open of
+pandas, no battleaxe. Exit 78 on mismatch; exit 0 on match.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GATE = ROOT / "tools" / "bx_corpus_pin_gate.py"
+EXIT_PIN = 78
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(GATE), *args],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_identity_match_exit_0() -> None:
+    r = _run(
+        [
+            "--expected-version",
+            "3.0.3",
+            "--expected-file-count",
+            "1421",
+            "--observed-version",
+            "3.0.3",
+            "--observed-file-count",
+            "1421",
+        ]
+    )
+    assert r.returncode == 0, r.stderr
+    assert "phase=ok" in r.stderr
+    assert "bx-corpus-pin-ok" in r.stdout
+
+
+def test_wrong_version_exit_78() -> None:
+    r = _run(
+        [
+            "--expected-version",
+            "3.0.3",
+            "--expected-file-count",
+            "1421",
+            "--observed-version",
+            "2.3.3",
+            "--observed-file-count",
+            "1421",
+        ]
+    )
+    assert r.returncode == EXIT_PIN, (r.returncode, r.stderr)
+    assert "corpus-pin-mismatch" in r.stderr
+    assert "2.3.3" in r.stderr
+
+
+def test_wrong_file_count_exit_78() -> None:
+    """Tonight's hole: system 1415 vs pin 1421."""
+    r = _run(
+        [
+            "--expected-version",
+            "3.0.3",
+            "--expected-file-count",
+            "1421",
+            "--observed-version",
+            "3.0.3",
+            "--observed-file-count",
+            "1415",
+        ]
+    )
+    assert r.returncode == EXIT_PIN, (r.returncode, r.stderr)
+    assert "file_count" in r.stderr
+    assert "1415" in r.stderr
+
+
+def test_system_python_combo_exit_78() -> None:
+    """pandas 2.3.3 with 1415 files — the wrong corpus that almost shipped."""
+    r = _run(
+        [
+            "--expected-version",
+            "3.0.3",
+            "--expected-file-count",
+            "1421",
+            "--observed-version",
+            "2.3.3",
+            "--observed-file-count",
+            "1415",
+        ]
+    )
+    assert r.returncode == EXIT_PIN
+    assert "crime=corpus-pin-mismatch" in r.stderr
+
+
+def test_banked_pin_file_loads_expected_identity() -> None:
+    pin = ROOT / "docs" / "ledgers" / "pins" / "pandas-3.0.3.pin.json"
+    assert pin.is_file(), "banked pin missing from checkout"
+    # Need corpus_pin import path for load_pin.
+    env_pythonpath = (
+        f"{ROOT / 'implementations/python/sugar-lift-py-tests/src'}:"
+        f"{ROOT / 'implementations/python/sugar-source-tree/src'}"
+    )
+    r = subprocess.run(
+        [
+            sys.executable,
+            str(GATE),
+            "--expected-pin",
+            str(pin),
+            "--observed-version",
+            "3.0.3",
+            "--observed-file-count",
+            "1421",
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**dict(**{k: v for k, v in __import__("os").environ.items()}), "PYTHONPATH": env_pythonpath},
+    )
+    assert r.returncode == 0, r.stderr
+    assert "3.0.3" in r.stderr
+    assert "1421" in r.stderr

--- a/tools/bx_corpus_pin_gate.py
+++ b/tools/bx_corpus_pin_gate.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Corpus pin gate for battleaxe timing measurements.
+
+Exit codes:
+  0  — observed corpus matches the declared pin (identity at minimum)
+  78 — corpus pin mismatch or pin could not be established (not a measurement)
+
+A wall-clock number against the wrong pandas is not a slow measurement — it is
+not a measurement. System python on battleaxe has carried pandas 2.3.3
+(1415 files) while the authenticated pin is 3.0.3 (1421). Five agents almost
+reported numbers against the wrong corpus; this gate refuses before the walk.
+
+Identity mode (default, cheap): distribution + version + file count.
+Full mode (``--full``): also require aggregate hash via pin_corpus/require_pin.
+
+Prints ``bx-corpus-pin phase=…`` lines on stderr so the receipt can carry the
+pin next to the load/lease lines from the quiet brun wrapper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+EXIT_PIN = 78
+
+# Banked authenticated pin (docs/ledgers/pins/pandas-3.0.3.pin.json).
+DEFAULT_PIN_REL = "docs/ledgers/pins/pandas-3.0.3.pin.json"
+DEFAULT_DISTRIBUTION = "pandas"
+DEFAULT_VERSION = "3.0.3"
+DEFAULT_FILE_COUNT = 1421
+
+
+def _eprint(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def _resolve_corpus_via_python(python: Path, distribution: str) -> Path:
+    """Import distribution with *python* and return its package root."""
+    code = (
+        "import importlib, pathlib, sys\n"
+        f"m = importlib.import_module({distribution!r})\n"
+        "print(pathlib.Path(m.__file__).resolve().parent)\n"
+    )
+    try:
+        out = subprocess.check_output(
+            [str(python), "-c", code],
+            text=True,
+            stderr=subprocess.STDOUT,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        _eprint(
+            f"sugarbin: crime=corpus-pin-import-failed python={python} "
+            f"distribution={distribution} detail={exc} "
+            f"replacement=use .venv-py312/bin/python after "
+            f"`bin/brun -- bash scripts/bootstrap-venv-py312.sh` "
+            f"(system python often has the wrong pandas)"
+        )
+        raise SystemExit(EXIT_PIN) from exc
+    root = Path(out.strip())
+    if not root.is_dir():
+        _eprint(
+            f"sugarbin: crime=corpus-pin-root-missing path={root} "
+            f"replacement=install {distribution} into the measurement venv"
+        )
+        raise SystemExit(EXIT_PIN)
+    return root
+
+
+def _observe_identity(root: Path, distribution: str) -> tuple[str, int]:
+    """Version from dist-info + file count from SourceTree (no content hash)."""
+    # Prefer in-process if packages importable; else shell out is caller's job.
+    try:
+        from sugar_lift_py_tests.corpus_pin import (  # type: ignore
+            CorpusPinDefect,
+            distribution_version,
+        )
+        from sugar_source_tree.tree import SourceTree  # type: ignore
+    except ImportError as exc:
+        _eprint(
+            f"sugarbin: crime=corpus-pin-imports-missing detail={exc} "
+            f"replacement=set PYTHONPATH to sugar-lift-py-tests/src + "
+            f"sugar-source-tree/src before the gate"
+        )
+        raise SystemExit(EXIT_PIN) from exc
+    try:
+        version = distribution_version(root, distribution)
+        count = sum(1 for _ in SourceTree(root).paths())
+    except CorpusPinDefect as defect:
+        _eprint(str(defect))
+        raise SystemExit(EXIT_PIN) from defect
+    return version, count
+
+
+def _observe_full(root: Path, distribution: str):
+    from sugar_lift_py_tests.corpus_pin import CorpusPinDefect, pin_corpus  # type: ignore
+
+    try:
+        return pin_corpus(root, distribution=distribution)
+    except CorpusPinDefect as defect:
+        _eprint(str(defect))
+        raise SystemExit(EXIT_PIN) from defect
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--expected-pin",
+        type=Path,
+        default=None,
+        help=f"banked sugar-corpus-pin/v1 JSON (default: {DEFAULT_PIN_REL})",
+    )
+    parser.add_argument(
+        "--corpus-root",
+        type=Path,
+        default=None,
+        help="package root; default: import via --python",
+    )
+    parser.add_argument(
+        "--python",
+        type=Path,
+        default=None,
+        help="interpreter that must see the pinned corpus (prefer .venv-py312/bin/python)",
+    )
+    parser.add_argument(
+        "--distribution",
+        default=None,
+        help="override distribution name (default: from pin or pandas)",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="require aggregate hash match (slow: hashes every enrolled file)",
+    )
+    parser.add_argument(
+        "--expected-version",
+        default=None,
+        help="override expected version when no pin file (tests)",
+    )
+    parser.add_argument(
+        "--expected-file-count",
+        type=int,
+        default=None,
+        help="override expected file count when no pin file (tests)",
+    )
+    parser.add_argument(
+        "--observed-version",
+        default=None,
+        help="test double: skip live observe, use this version",
+    )
+    parser.add_argument(
+        "--observed-file-count",
+        type=int,
+        default=None,
+        help="test double: skip live observe, use this file count",
+    )
+    args = parser.parse_args(argv)
+
+    expected_version = args.expected_version
+    expected_count = args.expected_file_count
+    expected_aggregate = ""
+    distribution = args.distribution or DEFAULT_DISTRIBUTION
+    pin_path = args.expected_pin
+
+    if pin_path is None and expected_version is None:
+        # Default banked pin relative to cwd (repo root on battleaxe).
+        candidate = Path(DEFAULT_PIN_REL)
+        if candidate.is_file():
+            pin_path = candidate
+
+    if pin_path is not None:
+        if not pin_path.is_file():
+            _eprint(
+                f"sugarbin: crime=corpus-pin-file-missing path={pin_path} "
+                f"replacement=use docs/ledgers/pins/pandas-3.0.3.pin.json from the repo"
+            )
+            return EXIT_PIN
+        try:
+            from sugar_lift_py_tests.corpus_pin import (  # type: ignore
+                CorpusPinDefect,
+                load_pin,
+            )
+        except ImportError as exc:
+            _eprint(
+                f"sugarbin: crime=corpus-pin-imports-missing detail={exc} "
+                f"replacement=set PYTHONPATH before the gate"
+            )
+            return EXIT_PIN
+        try:
+            expected = load_pin(pin_path)
+        except (OSError, ValueError, CorpusPinDefect, KeyError, TypeError) as exc:
+            _eprint(
+                f"sugarbin: crime=corpus-pin-unreadable path={pin_path} detail={exc}"
+            )
+            return EXIT_PIN
+        distribution = args.distribution or expected.distribution
+        expected_version = expected.version
+        expected_count = expected.file_count
+        expected_aggregate = expected.aggregate_hash
+    else:
+        expected_version = expected_version or DEFAULT_VERSION
+        expected_count = (
+            expected_count if expected_count is not None else DEFAULT_FILE_COUNT
+        )
+
+    if expected_version is None or expected_count is None:
+        _eprint(
+            "sugarbin: crime=corpus-pin-undeclared "
+            "replacement=pass --expected-pin or --expected-version/--expected-file-count"
+        )
+        return EXIT_PIN
+
+    # Test doubles: pure comparison without opening a corpus on the Mac.
+    if args.observed_version is not None or args.observed_file_count is not None:
+        if args.observed_version is None or args.observed_file_count is None:
+            _eprint(
+                "sugarbin: crime=corpus-pin-test-double-incomplete "
+                "replacement=pass both --observed-version and --observed-file-count"
+            )
+            return EXIT_PIN
+        root = args.corpus_root or Path("<test-double>")
+        observed_version = args.observed_version
+        observed_count = args.observed_file_count
+        _eprint(
+            f"sugarbin: bx-corpus-pin phase=check mode=identity-test-double "
+            f"distribution={distribution} expected_version={expected_version} "
+            f"expected_file_count={expected_count} "
+            f"observed_version={observed_version} "
+            f"observed_file_count={observed_count}"
+        )
+        failures: list[str] = []
+        if observed_version != expected_version:
+            failures.append(
+                f"version: observed {observed_version!r} expected {expected_version!r}"
+            )
+        if observed_count != expected_count:
+            failures.append(
+                f"file_count: observed {observed_count} expected {expected_count}"
+            )
+        if failures:
+            _eprint(
+                "sugarbin: crime=corpus-pin-mismatch mode=identity "
+                + "; ".join(failures)
+                + f" replacement=use .venv-py312 with {distribution}=={expected_version} "
+                f"(fileCount {expected_count}); system python on battleaxe has been "
+                f"2.3.3/1415 — that is a different corpus, not a different speed"
+            )
+            return EXIT_PIN
+        _eprint(
+            f"sugarbin: bx-corpus-pin phase=ok mode=identity-test-double "
+            f"distribution={distribution} version={observed_version} "
+            f"file_count={observed_count}"
+        )
+        print(
+            json.dumps(
+                {
+                    "kind": "bx-corpus-pin-ok",
+                    "mode": "identity-test-double",
+                    "distribution": distribution,
+                    "version": observed_version,
+                    "fileCount": observed_count,
+                    "expectedAggregateHash": expected_aggregate or None,
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    root = args.corpus_root
+    if root is None:
+        if args.python is None:
+            _eprint(
+                "sugarbin: crime=corpus-pin-no-root "
+                "replacement=pass --corpus-root or --python (.venv-py312/bin/python)"
+            )
+            return EXIT_PIN
+        root = _resolve_corpus_via_python(args.python.resolve(), distribution)
+    root = root.resolve()
+
+    _eprint(
+        f"sugarbin: bx-corpus-pin phase=check "
+        f"distribution={distribution} expected_version={expected_version} "
+        f"expected_file_count={expected_count} "
+        f"expected_aggregate={expected_aggregate or 'unset'} "
+        f"root={root} full={int(bool(args.full))}"
+    )
+
+    if args.full and pin_path is not None:
+        from sugar_lift_py_tests.corpus_pin import (  # type: ignore
+            CorpusPinDefect,
+            load_pin,
+            require_pin,
+        )
+
+        observed = _observe_full(root, distribution)
+        try:
+            require_pin(load_pin(pin_path), observed)
+        except CorpusPinDefect as defect:
+            _eprint(str(defect))
+            _eprint(
+                f"sugarbin: crime=corpus-pin-mismatch mode=full "
+                f"observed_version={observed.version} "
+                f"observed_file_count={observed.file_count} "
+                f"observed_aggregate={observed.aggregate_hash} "
+                f"expected_version={expected_version} "
+                f"expected_file_count={expected_count} "
+                f"expected_aggregate={expected_aggregate} "
+                f"replacement=use .venv-py312 with pandas=={expected_version} "
+                f"(fileCount {expected_count}); never system python 2.3.3/1415"
+            )
+            return EXIT_PIN
+        _eprint(
+            f"sugarbin: bx-corpus-pin phase=ok mode=full "
+            f"distribution={observed.distribution} version={observed.version} "
+            f"file_count={observed.file_count} aggregate={observed.aggregate_hash} "
+            f"root={observed.root}"
+        )
+        # Machine-readable one-liner for receipts.
+        print(
+            json.dumps(
+                {
+                    "kind": "bx-corpus-pin-ok",
+                    "mode": "full",
+                    "distribution": observed.distribution,
+                    "version": observed.version,
+                    "fileCount": observed.file_count,
+                    "aggregateHash": observed.aggregate_hash,
+                    "root": observed.root,
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    # Identity mode: version + file count (catches 2.3.3/1415 vs 3.0.3/1421).
+    observed_version, observed_count = _observe_identity(root, distribution)
+    failures: list[str] = []
+    if observed_version != expected_version:
+        failures.append(
+            f"version: observed {observed_version!r} expected {expected_version!r}"
+        )
+    if observed_count != expected_count:
+        failures.append(
+            f"file_count: observed {observed_count} expected {expected_count}"
+        )
+    if failures:
+        _eprint(
+            "sugarbin: crime=corpus-pin-mismatch mode=identity "
+            + "; ".join(failures)
+            + f" root={root} "
+            f"replacement=use .venv-py312 with {distribution}=={expected_version} "
+            f"(fileCount {expected_count}); system python on battleaxe has been "
+            f"2.3.3/1415 — that is a different corpus, not a different speed"
+        )
+        return EXIT_PIN
+
+    _eprint(
+        f"sugarbin: bx-corpus-pin phase=ok mode=identity "
+        f"distribution={distribution} version={observed_version} "
+        f"file_count={observed_count} "
+        f"expected_aggregate={expected_aggregate or 'unset'} "
+        f"root={root}"
+    )
+    print(
+        json.dumps(
+            {
+                "kind": "bx-corpus-pin-ok",
+                "mode": "identity",
+                "distribution": distribution,
+                "version": observed_version,
+                "fileCount": observed_count,
+                "expectedAggregateHash": expected_aggregate or None,
+                "root": str(root),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    # Allow focused unit tests to exercise without full package tree via env.
+    if os.environ.get("BX_CORPUS_PIN_GATE_SELFTEST") == "1":
+        raise SystemExit(0)
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

#7088 load + #7089 lease still left a third hole: **battleaxe system python is pandas 2.3.3 (1415 files)** while the authenticated pin is **3.0.3 (1421)**. Five agents nearly reported numbers against the wrong corpus; blonde caught it via ENOENT on 3.0.3-only files.

A measurement must testify to its conditions: quiet box, exclusive lease, **correct corpus**. Any one missing and the number is a guess wearing a receipt.

## What

| Exit | Gate |
| --- | --- |
| 76 | host not quiet (under lease) |
| 77 | timing lease busy |
| **78** | **corpus pin mismatch** (version/fileCount; default pin 3.0.3/1421) |

- `tools/bx_corpus_pin_gate.py` — identity mode default (catches 2.3.3/1415); optional `--full` aggregate
- Quiet brun runs pin gate under lease after load against `.venv-py312` + `docs/ledgers/pins/pandas-3.0.3.pin.json`
- `control_effect_recensus` pin/aggregate refuse → exit **78**
- Canonical commands require `.venv-py312` and `--require-corpus-pin`

## Validation

```bash
python3 -m pytest -q tests/test_bx_corpus_pin_gate.py   # 5 passed
bash tests/sugarbin_bx_load_gate.sh                     # PASS
bash tests/sugarbin_bx_exec.sh                          # PASS
```

No local pandas corpus open.

merge_dog: squash-merge. Fleet must pull this before any more battleaxe numbers.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add corpus pin gate to `bx` quiet timing that exits 78 on wrong pandas
> - Adds [tools/bx_corpus_pin_gate.py](https://github.com/TSavo/sugar/pull/7090/files#diff-f53748799ee1abe0d36f5a7e9ac152e100274dac07f3f90724a0b2b02eae7435), a CLI that verifies the measured pandas corpus matches an expected pin (version, file count, and optionally aggregate hash), exiting 78 on any mismatch.
> - Extends the quiet timing path in [bin/lib/sugar-bx.sh](https://github.com/TSavo/sugar/pull/7090/files#diff-bdd6c46eb799e81d8c3cc8b50ab4a809668391cedbc25e468f6efe8ef9d86ebc) to run the corpus pin gate under the exclusive lease after the load check, forming a three-gate model (lease → load → corpus pin).
> - Gate behavior is controlled by `SUGAR_BX_CORPUS_PIN_PATH` (default `docs/ledgers/pins/pandas-3.0.3.pin.json`), `SUGAR_BX_CORPUS_PYTHON` (default `.venv-py312/bin/python`), and `SUGAR_BX_SKIP_CORPUS_PIN` (default `0`).
> - Updates `control_effect_recensus.py` to exit 78 (instead of 2) with explicit `crime=corpus-pin-mismatch` messages on pin or aggregate failures.
> - Behavioral Change: timing runs that previously completed against the wrong pandas version now abort with exit 78 and a stderr crime message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6eb813d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->