### PR TITLE
docs: measurement must testify to its own conditions

### DIFF
--- a/docs/contributing/battleaxe-timing.md
+++ b/docs/contributing/battleaxe-timing.md
@@ -1,5 +1,10 @@
 # Battleaxe timing measurements (canonical door)
 
+**Law:** [measurement-conditions.md](./measurement-conditions.md) —
+*a measurement must testify to its own conditions* (quiet box, exclusive
+lease, correct corpus). This file is the **invocation cookbook**; that file is
+the **law and the incidents**.
+
 **Wall-clock numbers for pandas recensus / open / walk / k=8 are taken on
 battleaxe only.** Not on the Mac. The Mac is an 8-core laptop that hosts the
 agent fleet; a number taken there under load is not a slow measurement — it is

--- a/docs/contributing/measurement-conditions.md
+++ b/docs/contributing/measurement-conditions.md
@@ -1,0 +1,116 @@
+# Measurement conditions (the law)
+
+> **A measurement must testify to its own conditions.**
+> Quiet box, exclusive lease, correct corpus.
+> Any one missing and the number is a guess wearing a receipt.
+
+This is not style guidance. It is the only reason a wall-clock, residual, or
+board number may be cited. The incidents below are the argument; the three
+gates are the instrument. Nobody will remember the night in a month — this
+file is how the law outlives it.
+
+## The law
+
+A number taken from a correctness instrument is **not evidence** unless the
+run can show, in its own stderr and artifacts:
+
+1. **The box was quiet** when the work started (and load after is recorded).
+2. **No other quiet-gated measurement held the box** while it ran.
+3. **The corpus is the authenticated pin**, not whatever was on system python.
+
+If any of those three cannot be shown, do not cite the number. Do not put it
+in a PR, a bisect, a merge hold, or a fleet comparison. Re-run under the
+gates, or treat the work as unmeasured.
+
+## What each gate cost us (2026-08-02)
+
+### No load gate → fake speed
+
+The Mac is 8 cores and was carrying the agent fleet (load average ~13.84, ~30
+python processes). The same commit read **2.82s** and **6.46s** an hour apart
+because wall-clock was taken on a contended laptop. That noise manufactured a
+**fake ~87% serial regression** and a **fake single-file 3×**, which drove a
+**merge hold** and a **four-way bisect** — pure contention, not code.
+
+**Gate:** `SUGAR_BX_REQUIRE_QUIET=1` on `bin/brun`. Sample remote load1 under
+the lease; refuse **exit 76** if over ceiling. Print load **before and after**.
+
+### No exclusive lease → measuring each other
+
+Six agents fired battleaxe measurements at once. Each load check could pass
+while another run was mid-flight; each timed the others. Contention moved from
+the Mac to the 32-core box without anyone noticing.
+
+**Gate:** exclusive remote flock
+`/var/tmp/sugar-bx-timing-measurement.lease` while quiet is armed. Queue or
+refuse **exit 77**. Load is sampled **under** the lease, not before grab.
+
+### No corpus pin → wrong pandas
+
+Battleaxe **system python** has carried **pandas 2.3.3 (1415 files)**. The
+authenticated pin is **pandas 3.0.3 (1421 files)**
+(`docs/ledgers/pins/pandas-3.0.3.pin.json`). Five agents were about to report
+numbers against the wrong corpus. A “correctness” comparison across two pandas
+versions would have shown **phantom regressions and phantom fixes** with
+confident receipts. Blonde caught it from ENOENT on files that exist only on
+3.0.3.
+
+**Gate:** under the lease, after load, run `tools/bx_corpus_pin_gate.py`
+against `.venv-py312` + the banked pin; refuse **exit 78** on version/fileCount
+mismatch. Recensus pin/aggregate refuse is also **exit 78**. Never measure with
+system python.
+
+## The three exits
+
+| Exit | Name | Meaning |
+| --- | --- | --- |
+| **76** | host-not-quiet | load1 over ceiling under lease — not a slow measurement |
+| **77** | timing-lease-busy | another quiet-gated measurement holds the exclusive lease |
+| **78** | corpus-pin-mismatch | wrong distribution/version/fileCount (e.g. 2.3.3/1415 ≠ 3.0.3/1421) |
+
+Exit **0** is necessary but not sufficient. A green exit without the receipt
+fields below is still a guess.
+
+## What a measurement receipt must carry
+
+Every citable wall-clock or board body for a fleet timing run must include, at
+minimum:
+
+| Field | Where | Proves |
+| --- | --- | --- |
+| **load1 before** | stderr: `bx-load-gate phase=before … lease=held` | box quiet at start |
+| **load1 after** | stderr: `bx-load-gate phase=after …` | load context after work |
+| **lease held** | stderr: `bx-timing-lease phase=acquired` / `lease=held` | exclusive run |
+| **corpus pin** | stderr: `bx-corpus-pin phase=ok` (version, distribution) | right package identity |
+| **file count** | pin line / pin JSON summary (e.g. 1421) | right population size |
+| **tip SHA** | recensus `--commit` / receipt `commit` / measured tip | which code was measured |
+
+Optional but preferred: expected **aggregate hash** from the banked pin (printed
+on pin-ok), host name, and `nproc`. JSON result bodies should not be cited
+without the matching stderr gate lines from the same run.
+
+## How to obey
+
+- Invoke **`bin/brun` by path** from the repo root (not on PATH in a bare shell).
+- Always arm quiet: `SUGAR_BX_REQUIRE_QUIET=1`.
+- Always measure with **`.venv-py312/bin/python`** after
+  `bin/brun -- bash scripts/bootstrap-venv-py312.sh` (or a remote checkout
+  already proven by exit-0 pin gate).
+- Canonical shapes (single file, N-walk, k=8): **`docs/contributing/battleaxe-timing.md`**.
+- Implementation: load + lease in `bin/lib/sugar-bx.sh`; pin in
+  `tools/bx_corpus_pin_gate.py`; recensus pin refuse exit 78 in
+  `control_effect_recensus.py`.
+
+## Forbidden
+
+- Wall-clock or residual numbers from the Mac under agent load.
+- Concurrent quiet-gated runs that skip the lease.
+- System python / unpinned site-packages as the corpus.
+- Citing a JSON artifact without load, lease, pin, file count, and tip SHA.
+- Inventing a second remote harness next to `bin/brun`.
+
+---
+
+*Banked after the 2026-08-02 measurement night. The gates exist because each
+failure produced a confident wrong number. Do not delete a gate without a
+stronger substrate that still makes the illegal measurement unrepresentable.*


### PR DESCRIPTION
## Why

Nobody will remember tonight's incidents in a month. The three gates (76/77/78) only stay law if the **incidents are the argument** in a short, durable doc.

## What

`docs/contributing/measurement-conditions.md`:

- The rule: **a measurement must testify to its own conditions**
- Quiet box, exclusive lease, correct corpus — any one missing → not a measurement
- What each missing gate cost (fake 87%/3x + bisect; six concurrent agents; wrong pandas 2.3.3 vs 3.0.3)
- What a receipt must carry: load before/after, lease held, pin + file count, tip SHA
- Link from `battleaxe-timing.md` (cookbook → law)

## Validation

Docs only. No code/runtime change.

merge_dog: squash-merge please.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document required conditions for citing benchmark measurements
> - Adds [measurement-conditions.md](https://github.com/TSavo/sugar/pull/7091/files#diff-50d73db50d766dcc546a7e0223b39952230bbb3c2bbbd8522e135f2bf72ff84d) defining three mandatory gates (quiet box, exclusive lease, correct corpus) that a run must satisfy before its results can be cited.
> - Specifies three exit codes, mandatory receipt fields, required invocation paths via `bin/brun`, and pinned Python environment as compliance steps.
> - Lists forbidden practices and failure modes motivating each gate.
> - Updates [battleaxe-timing.md](https://github.com/TSavo/sugar/pull/7091/files#diff-60cbb7b810d3d7761cde354c4b67596fedb4e890c3dc15d1480eb648638df96c) with a preface linking to the new file, framing it as the invocation cookbook and the new doc as the governing law.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 798fa7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added measurement-conditions policy guidance covering required environment checks, timing exclusivity, and authenticated data sources.
  * Documented relevant failure codes, measurement receipt requirements, approved invocation practices, and prohibited procedures.
  * Clarified the distinction between governing measurement rules and the invocation cookbook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->