### PR TITLE
CI: corpus pin gate on control-effect recensus plan and shards

### DIFF
--- a/.github/workflows/control-effect-recensus.yml
+++ b/.github/workflows/control-effect-recensus.yml
@@ -19,6 +19,13 @@ name: Control-effect recensus (authoritative scoreboard)
 # - Missing or failed seat → UNMEASURED envelope naming the missing shards;
 #   NEVER seal over the shards that finished.
 # - fail-fast: false so compose always sees the receipt set.
+# - CORPUS PIN GATE (exit 78): every plan and every shard job refuses unless the
+#   runner's pandas matches docs/ledgers/pins/pandas-3.0.3.pin.json
+#   (3.0.3 / 1421 files). A sealed board against the wrong pin is worse than
+#   no board — it carries a receipt. tools/bx_corpus_pin_gate.py.
+#   Load (76) / lease (77) apply to human brun timing; CI pin is mandatory.
+#   Lease is not wired here until runner topology is proven shared-vs-private
+#   (matrix may be multi-box).
 #
 # WHY NIGHTLY AND NOT push:[main]
 #
@@ -78,6 +85,23 @@ jobs:
           }
           echo "recensus population: authenticated pandas corpus at $PANDAS_CORPUS"
           echo "root=$PANDAS_CORPUS" >> "$GITHUB_OUTPUT"
+
+      # Gate before any plan artifact: wrong pandas (e.g. system 2.3.3/1415)
+      # must not produce planCid / LPT keys / sealed boards. Exit 78.
+      - name: "Phase: corpus pin gate (3.0.3 / 1421; exit 78 if wrong)"
+        shell: bash
+        env:
+          PANDAS_CORPUS: ${{ steps.population.outputs.root }}
+        run: |
+          set -euo pipefail
+          export PYTHONPATH="implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src${PYTHONPATH:+:$PYTHONPATH}"
+          PIN="docs/ledgers/pins/pandas-3.0.3.pin.json"
+          test -f "$PIN" || { echo "::error::banked corpus pin missing at $PIN"; exit 78; }
+          test -d "$PANDAS_CORPUS" || { echo "::error::corpus root missing: $PANDAS_CORPUS"; exit 78; }
+          python tools/bx_corpus_pin_gate.py \
+            --expected-pin "$PIN" \
+            --corpus-root "$PANDAS_CORPUS"
+          echo "JOB_LOG phase=corpus-pin-gate status=ok job=plan root=$PANDAS_CORPUS"
 
       # Pin first so the LPT cache key includes aggregateHash — empty CI runners
       # otherwise plan with an empty shelf and degrade to equal-count (1.87× pole).
@@ -261,6 +285,23 @@ jobs:
             lpt-recensus-file-costs-${{ needs.plan.outputs.aggregate_hash }}-
             lpt-recensus-file-costs-
 
+      # Each seat re-gates: matrix runners may not share the plan job's env.
+      # Wrong pin on one seat would mint a partial that looks like product signal.
+      - name: "Phase: corpus pin gate (3.0.3 / 1421; exit 78 if wrong)"
+        shell: bash
+        env:
+          PANDAS_CORPUS: ${{ needs.plan.outputs.root }}
+        run: |
+          set -euo pipefail
+          export PYTHONPATH="implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src${PYTHONPATH:+:$PYTHONPATH}"
+          PIN="docs/ledgers/pins/pandas-3.0.3.pin.json"
+          test -f "$PIN" || { echo "::error::banked corpus pin missing at $PIN"; exit 78; }
+          test -d "$PANDAS_CORPUS" || { echo "::error::corpus root missing: $PANDAS_CORPUS"; exit 78; }
+          python tools/bx_corpus_pin_gate.py \
+            --expected-pin "$PIN" \
+            --corpus-root "$PANDAS_CORPUS"
+          echo "JOB_LOG phase=corpus-pin-gate status=ok job=shard seat=s$(printf '%02d' '${{ matrix.shard }}') root=$PANDAS_CORPUS"
+
       - name: "Phase: measure shard partial only"
         shell: bash
         env:
@@ -279,11 +320,13 @@ jobs:
           echo "recensus phase=measure-shard status=start shard=$SHARD/$K corpus_root=$PANDAS_CORPUS commit=$GITHUB_SHA"
           # Worker: --plan-json + --shard-index → PARTIAL only (never seals).
           # control_effect_recensus write-throughs each file_s → LPT shelf.
+          # --require-corpus-pin: second belt (exit 78) if pin drifts mid-run.
           python -u implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py \
             "$PANDAS_CORPUS" \
             --corpus-root "$PANDAS_CORPUS" \
             --repo "$GITHUB_WORKSPACE" \
             --commit "$GITHUB_SHA" \
+            --require-corpus-pin docs/ledgers/pins/pandas-3.0.3.pin.json \
             --out-dir "$OUT" \
             --plan-json "$PLAN" \
             --shard-index "$SHARD" \

--- a/docs/contributing/battleaxe-timing.md
+++ b/docs/contributing/battleaxe-timing.md
@@ -220,6 +220,19 @@ Do not each invent argv. Copy from this file. Cite stderr `load1_before` /
 A JSON body without exit 0, or without load `lease=held` **and** pin `phase=ok`,
 is not a timing receipt.
 
+## CI recensus (control-effect k=8)
+
+Human brun timing uses all three gates (76/77/78). The GitHub
+`control-effect-recensus` workflow (LPT k=8 + compose seal) **must** run the
+**corpus pin gate** on every plan and every shard job before it mints plan or
+partial artifacts — **exit 78** if the runner is not pandas **3.0.3 / 1421**
+(`docs/ledgers/pins/pandas-3.0.3.pin.json` via `tools/bx_corpus_pin_gate.py`).
+A sealed board against the wrong pin is worse than no board.
+
+Load (76) and lease (77) stay brun-path defaults until CI runner topology is
+proven shared-vs-private (matrix may already be multi-box). Pin is mandatory
+either way.
+
 ## Forbidden
 
 - Any pandas open / walk / census / profile / cProfile / k=8 / demand-table
@@ -227,9 +240,12 @@ is not a timing receipt.
 - Broad local pytest.
 - Reporting a wall-clock taken while `bx-load-gate` was not armed or exited 76.
 - Inventing a parallel harness next to `bin/brun`.
+- CI plan/shard without the corpus pin gate (exit 78).
 
 ## Related
 
 - `docs/build-execution.md` — sugarbin / brun / bpytest routes
+- `docs/contributing/measurement-conditions.md` — law + incidents (when present on tip)
 - `docs/contributing/heavy-measurement-lease.md` — exclusive heavy jobs on the box
 - `bin/brun --help` — options and quiet-gate env vars
+- `.github/workflows/control-effect-recensus.yml` — pin gate on plan + each seat

--- a/docs/contributing/measurement-conditions.md
+++ b/docs/contributing/measurement-conditions.md
@@ -89,25 +89,40 @@ Optional but preferred: expected **aggregate hash** from the banked pin (printed
 on pin-ok), host name, and `nproc`. JSON result bodies should not be cited
 without the matching stderr gate lines from the same run.
 
-## How to obey
+## CI recensus
 
-- Invoke **`bin/brun` by path** from the repo root (not on PATH in a bare shell).
+Human `bin/brun` timing uses all three gates. The control-effect recensus
+workflow (`.github/workflows/control-effect-recensus.yml`, LPT k=8 + compose)
+**must** run the **corpus pin gate** on **plan and every shard job** before
+minting plan or partial bodies — **exit 78** if the runner is not pandas
+**3.0.3 / 1421** (`tools/bx_corpus_pin_gate.py` + banked pin). Shard measure
+also passes `--require-corpus-pin` into `control_effect_recensus` (second belt).
+
+A sealed board against the wrong pin is worse than no board — it carries a
+receipt.
+
+**Load (76) and lease (77) are not wired in CI** until runner topology is
+proven: the matrix may already be multi-box (lease would only serialize
+same-host seats). Pin is mandatory either way. If topology later proves a
+shared box, add lease under the same quiet discipline as brun.
+
+## How to obey (human timing)
+
+- Invoke **`bin/brun` by path** from the repo root.
 - Always arm quiet: `SUGAR_BX_REQUIRE_QUIET=1`.
-- Always measure with **`.venv-py312/bin/python`** after
-  `bin/brun -- bash scripts/bootstrap-venv-py312.sh` (or a remote checkout
-  already proven by exit-0 pin gate).
-- Canonical shapes (single file, N-walk, k=8): **`docs/contributing/battleaxe-timing.md`**.
-- Implementation: load + lease in `bin/lib/sugar-bx.sh`; pin in
-  `tools/bx_corpus_pin_gate.py`; recensus pin refuse exit 78 in
-  `control_effect_recensus.py`.
+- Always measure with **`.venv-py312/bin/python`** after bootstrap (or a remote
+  checkout already proven by exit-0 pin gate).
+- Canonical shapes: **`docs/contributing/battleaxe-timing.md`**.
 
 ## Forbidden
 
 - Wall-clock or residual numbers from the Mac under agent load.
 - Concurrent quiet-gated runs that skip the lease.
 - System python / unpinned site-packages as the corpus.
-- Citing a JSON artifact without load, lease, pin, file count, and tip SHA.
+- Citing a JSON artifact without load, lease, pin, file count, and tip SHA
+  (for brun timing); citing a CI board without pin gate green.
 - Inventing a second remote harness next to `bin/brun`.
+- CI plan/shard that mints artifacts before the corpus pin gate.
 
 ---
 


### PR DESCRIPTION
## Why

The three gates protect **human brun** measurements. CI recensus (LPT k=8 from #7079) could still mint plan/partials/sealed boards against the wrong pandas on a self-hosted runner — the same hole that nearly shipped 2.3.3/1415 numbers on battleaxe. A sealed wrong-pin board is worse than no board.

## What

`.github/workflows/control-effect-recensus.yml`:

- **Plan job:** after authenticated population, run `tools/bx_corpus_pin_gate.py` vs `docs/ledgers/pins/pandas-3.0.3.pin.json` (**exit 78** if not 3.0.3/1421)
- **Each shard:** same pin gate before measure
- **Measure:** `--require-corpus-pin` second belt on `control_effect_recensus`

Load (76) / lease (77) **not** wired in CI yet — matrix may be multi-box; pin is mandatory either way.

Also banks/updates `docs/contributing/measurement-conditions.md` (CI section) + `battleaxe-timing.md` cookbook note.

## Validation

```bash
python3 -m pytest -q tests/test_bx_corpus_pin_gate.py  # existing 5
rg 'bx_corpus_pin_gate|require-corpus-pin' .github/workflows/control-effect-recensus.yml
```

No full recensus run (heavy).

merge_dog: squash-merge please.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add corpus pin gate to control-effect recensus CI plan and shard jobs
> - Adds a corpus pin verification step to both the plan job and each shard job in [control-effect-recensus.yml](.github/workflows/control-effect-recensus.yml), exiting with code 78 if the runner's corpus does not match `docs/ledgers/pins/pandas-3.0.3.pin.json`.
> - Passes `--require-corpus-pin docs/ledgers/pins/pandas-3.0.3.pin.json` to `control_effect_recensus.py` in each shard measurement step, enforcing a second check during execution.
> - Updates contributing docs to document the pin gate requirement and clarify that load (76) and lease (77) exits remain human-focused.
> - Behavioral Change: plan and shard jobs now refuse to mint artifacts and abort with exit 78 if the corpus pin is missing or mismatched at any point during the run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7ec70f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->