### PR TITLE
Bound session frame_holds to frame_results LRU lifetime

### DIFF
--- a/docs/contributing/rss-walk-residency-prediction.md
+++ b/docs/contributing/rss-walk-residency-prediction.md
@@ -1,0 +1,131 @@
+# Prediction: process-resident RSS over a 1421-file pandas walk
+
+**Author:** mr_pink  
+**Status:** prediction only — committed **before** any quiet-gated RSS measure  
+**Code basis:** `sugar_source_tree/process_resident_file.py` (#7071 SourceFile,
+#7078 lexical), `sugar_lift_python_source/resolution_session.py` (#7081 walk
+session). Default `SUGAR_PROCESS_RESIDENT_FILE_LIMIT=512`.
+
+This note is how we catch a wrong number instead of believing it. When the
+measurement slot opens, compare observed RSS / prepare counts / late-walk
+wall against the claims below.
+
+## What residency holds
+
+Two process-global LRU maps (OrderedDict, access-order):
+
+| Map | Key | Value | Cap |
+| --- | --- | --- | ---: |
+| `_RESIDENT` | whole-file content CID | `ProcessResidentFileContext` (SourceFile shell + prepared MaterializeModule tree) | 512 |
+| `_LEXICAL` | `(source_cid, is_package, identities)` | pure lexical import `_Pass` product | 512 |
+
+Eviction: on insert, `move_to_end`; while `len > limit`, `popitem(last=False)`
+drops the **oldest**. Dropped objects become GC-eligible; **prepare counters
+are not cleared** (`_PREPARE_COUNTS` / `_LEXICAL_PREPARE_COUNTS` grow forever
+and record re-pays after eviction).
+
+Hit path: `get_resident` / lexical hit rebinds consumer `construction_context`
+and returns the shell without re-MaterializeModule.
+
+## What is *not* LRU-capped
+
+Walk-scoped `SourceResolutionSession` (production open default via
+`walk_session_for(root)`):
+
+- `frame_results` / **`frame_holds`** (keeps projected SourceFiles alive)
+- `module_materializations` / `prefix_files`
+- export / lexical session tables, `dependency_graphs`
+
+These dicts have **no size bound**. They grow for the life of the process
+session under one workspace root.
+
+## Predicted RSS shape (1421 enrolled files, one process, sequential open)
+
+Assume default limit 512, pin pandas 3.0.3, populate_derived=True, walk session
+shared across the walk.
+
+### Phase A — fill (roughly until ~512 unique content CIDs demanded)
+
+- `resident_size` climbs toward 512.
+- `lexical_size` climbs toward 512 (not necessarily in lockstep with
+  SourceFile: package role + identity map can diversify keys).
+- **RSS rises roughly with fill** — each miss pays MaterializeModule + holds
+  a full prepared tree. This is the intended wall-time ↔ memory trade of §4.
+
+### Phase B — at/after the cap
+
+- **`resident_size` and `lexical_size` MUST plateau at ≤512.**  
+  If either exceeds the limit, the LRU is broken (instrument failure).
+- **RSS need not plateau.** Two independent reasons:
+
+  1. **Walk session maps (primary unbounded risk).** `frame_holds` pins live
+     projection SourceFiles for every distinct frame key ever served. Orange
+     measured almost no cross-file frame *hits* on a 20-file sample
+     (`frame_results` after 20 files ≈ 1), but the **holds still accumulate**
+     for every definition projected during populate of *this* file's use-sites.
+     Over 1421 consumers that is a large, session-lifetime set — not content-CID
+     LRU.
+
+  2. **Allocator high-water.** Even when LRU drops a SourceFile, CPython often
+     does not return pages to the OS. RSS can stay near the peak of phase A
+     (or keep creeping) while `resident_size` is flat.
+
+### Re-preparation after eviction
+
+- Unique consumer bodies in a once-through walk: each enrolled file's own CID
+  is prepared **once** unless the walk revisits the same content later.
+- Shared dependency modules (imported from many consumers) are the thrash
+  surface: after cap, an old dep CID can be evicted, then re-demanded →
+  `_PREPARE_COUNTS[cid] > 1`.
+- **Prediction:** `prep_cids_gt1 > 0` and `prep_sum > prep_unique` once the
+  walk has demanded more than 512 distinct prepared CIDs (consumers + deps).
+  If unique prepared CIDs stay ≤512 for the whole walk, prep_gt1 may stay 0
+  and LRU never fires — also a legal observation (narrow dep set).
+
+### Late-walk wall (Q4 vs Q1 mean file time)
+
+| Observation | Read as |
+| --- | --- |
+| Q4/Q1 ≈ 1.0–1.5 and prep_gt1 moderate | expected: mild thrash + session bloat |
+| Q4/Q1 ≫ 2 and prep_gt1 high | eviction thrash is load-bearing — limit too small or working set too large |
+| Q4/Q1 high and prep_gt1 ≈ 0 | **not** SourceFile LRU — blame walk-session growth / GC / other |
+
+#7081's own caveat (memory pressure late in a walk) points at session
+`frame_holds`, not at the 512 SourceFile cap.
+
+## Falsifiers (measurement must name these)
+
+1. `resident_size_end > 512` or `lexical_size_end > 512` → LRU bug.
+2. RSS **flat** after file ~100 while `resident_size` is still rising → RSS
+   sampling broken (wrong process, wrong metric).
+3. `prep_cids_gt1 == 0` with `prep_unique ≫ 512` → miss path not counting or
+   eviction not re-entering prepare (protocol bug).
+4. RSS grows unbounded while both LRU sizes stay at 512 and walk-session map
+   sizes stay flat → unknown retainer; investigate before blaming residency.
+
+## What a successful measure must report (slot = after black seal)
+
+Under `SUGAR_BX_REQUIRE_QUIET=1` + corpus pin 3.0.3/1421 + lease held:
+
+- `load1_before` / `load1_after`, `lease=held`, `bx-corpus-pin phase=ok`
+- RSS start / end / max (`/usr/bin/time -v` Maximum resident set size)
+- `resident_size` / `lexical_size` time series or end values vs limit 512
+- `prep_unique`, `prep_sum`, `prep_cids_gt1` (and lexical analogues)
+- walk-session `len(frame_holds)`, `len(frame_results)`,
+  `len(module_materializations)` at end
+- quartile mean file wall if available
+
+**Non-claims until measured:** absolute RSS in MiB, whether eviction thrash is
+the dominant late cost, whether #7081 must be bounded or reverted.
+
+## Relation to #7081
+
+Process residency (#7071/#7078) is **capped** and is the honest §4 door.
+Walk session is the **uncapped** live-Node store. If RSS is the problem at
+corpus scale, the first place to bound is session maps (or session lifetime),
+not deleting content-CID residency.
+
+---
+
+*No wall-clock numbers in this document. Measurement waits for the fleet
+queue after mr_black's seal.*

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -73,6 +73,11 @@ Legitimacy (why this is not process-global free-for-all):
   never parked under a process-global content map. §4 residency covers pure
   content-derived prep (SourceFile body, lexical import pass); visible-frame
   projection stays on the session object the walk owns.
+* ``frame_results`` / ``frame_holds`` are LRU-capped (default 512, same order
+  of magnitude as process-resident file limit). A hold exists only while its
+  memo row is served — walk-scoped sessions must not retain every projected
+  SourceFile for the whole corpus (that was the unbounded-accumulation
+  disease: shared session degraded across opens while fresh stayed flat).
 * Measured (orange, tip #7078): cross-file shared session is ~15% on a mixed
   20-file lib sample (frame_results after 20 files ≈ 1 — almost no shared
   definitions). Same-content re-open under the same walk session is the
@@ -86,12 +91,32 @@ Callers that need isolation pass an explicit ``SourceResolutionSession()`` or
 
 from __future__ import annotations
 
+import collections
+import os
 from pathlib import Path
 from typing import Any
 
 # Resolved workspace root path -> walk-owned session. Not content-keyed; not a
 # substitute for §4 residency. Cleared only by tests (clear_walk_sessions).
 _WALK_SESSIONS: dict[str, "SourceResolutionSession"] = {}
+
+# Default matches process-resident file LRU (#7071). A walk-scoped session that
+# retained frame_holds for every projected SourceFile forever recreated the
+# "shared context degrades across opens" disease at corpus scale.
+_DEFAULT_FRAME_MEMO_LIMIT = 512
+
+
+def _frame_memo_limit() -> int:
+    """Cap for session frame_results (+ co-evicted frame_holds).
+
+    Env ``SUGAR_SESSION_FRAME_MEMO_LIMIT`` (default 512). Hold lifetime must
+    track the memo row it guards — never longer (see remember_frame).
+    """
+    raw = os.environ.get("SUGAR_SESSION_FRAME_MEMO_LIMIT", str(_DEFAULT_FRAME_MEMO_LIMIT))
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_FRAME_MEMO_LIMIT
 
 
 class SourceResolutionSession:
@@ -134,11 +159,18 @@ class SourceResolutionSession:
         # Same key -> definition/gap only (no warrants). Shared by reexport hops
         # that carry path warrants and cannot use export_resolutions.
         self.export_terminals: dict[tuple[str, str, str], Any] = {}
-        # definition coordinate -> (frame, target) | ManagerConstructionGapV1
-        self.frame_results: dict[tuple, Any] = {}
-        # Keep the SourceFile that owns cached (frame, target) node identity
-        # alive for exactly as long as this session serves that memo.
-        self.frame_holds: dict[tuple, Any] = {}
+        # definition coordinate -> (frame, target) | ManagerConstructionGapV1.
+        # OrderedDict LRU: walk-scoped sessions must not retain every projected
+        # definition forever. Access order tracks hits/remembers; oldest keys
+        # evict with their frame_holds (hold outlives memo by zero extra time).
+        self.frame_results: collections.OrderedDict[tuple, Any] = (
+            collections.OrderedDict()
+        )
+        # SourceFile that owns cached (frame, target) node identity — alive for
+        # exactly as long as frame_results serves that key, not one moment longer.
+        self.frame_holds: collections.OrderedDict[tuple, Any] = (
+            collections.OrderedDict()
+        )
         # In-progress definition coordinates.  A cross-module call graph that
         # re-enters a definition already being projected is a cycle: it stays
         # typed-loud exactly like the local recursive case, and never loops.
@@ -192,14 +224,46 @@ class SourceResolutionSession:
     # -- source-visible frame memo ---------------------------------------
 
     def frame_hit(self, key: tuple) -> Any | None:
-        return self.frame_results.get(key) if self.enabled else None
+        if not self.enabled:
+            return None
+        hit = self.frame_results.get(key)
+        if hit is not None:
+            # LRU access: keep hold + memo co-ordered.
+            self.frame_results.move_to_end(key)
+            if key in self.frame_holds:
+                self.frame_holds.move_to_end(key)
+        return hit
 
     def remember_frame(self, key: tuple, result: Any, hold: Any = None) -> None:
+        """Memo one frame result; pin hold for exactly the memo's lifetime.
+
+        Hold invariant: a ``frame_holds`` entry outlives its ``frame_results``
+        row by zero extra time. Walk-scoped sessions used to retain every
+        projected SourceFile for the whole 1421-file walk; that unbounded hold
+        is the accumulation disease (shared context degrades across opens).
+        LRU co-evicts hold when the memo row is dropped.
+        """
         if not self.enabled:
             return
         if hold is not None:
             self.frame_holds[key] = hold
+            self.frame_holds.move_to_end(key)
         self.frame_results[key] = result
+        self.frame_results.move_to_end(key)
+        self._evict_frame_memo_lru()
+
+    def _evict_frame_memo_lru(self) -> None:
+        """Drop oldest frame memos until at limit; release holds in lockstep."""
+        limit = _frame_memo_limit()
+        while len(self.frame_results) > limit:
+            old_key, _ = self.frame_results.popitem(last=False)
+            self.frame_holds.pop(old_key, None)
+        # Holds without a memo row are dead weight (should not happen if
+        # remember_frame is the only writer; scrub anyway).
+        if len(self.frame_holds) > len(self.frame_results):
+            for dead in list(self.frame_holds.keys()):
+                if dead not in self.frame_results:
+                    del self.frame_holds[dead]
 
     # -- module materialize memo (shared across definitions in one module) --
 

--- a/implementations/python/sugar-lift-python-source/tests/test_frame_memo_lru.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_frame_memo_lru.py
@@ -1,0 +1,83 @@
+"""frame_holds lifetime tracks frame_results — LRU co-eviction.
+
+Walk-scoped sessions that retained every hold for the whole corpus recreated
+shared-context accumulation. Tooth: hold is released when its memo row is
+evicted; hit refreshes order; limit is respected.
+"""
+
+from __future__ import annotations
+
+import os
+
+from sugar_lift_python_source.resolution_session import (
+    SourceResolutionSession,
+    _frame_memo_limit,
+)
+
+
+def test_frame_memo_limit_default() -> None:
+    prev = os.environ.pop("SUGAR_SESSION_FRAME_MEMO_LIMIT", None)
+    try:
+        assert _frame_memo_limit() == 512
+        os.environ["SUGAR_SESSION_FRAME_MEMO_LIMIT"] = "3"
+        assert _frame_memo_limit() == 3
+        os.environ["SUGAR_SESSION_FRAME_MEMO_LIMIT"] = "0"
+        assert _frame_memo_limit() == 1  # floor
+    finally:
+        if prev is None:
+            os.environ.pop("SUGAR_SESSION_FRAME_MEMO_LIMIT", None)
+        else:
+            os.environ["SUGAR_SESSION_FRAME_MEMO_LIMIT"] = prev
+
+
+def test_frame_holds_evict_with_memo_row(monkeypatch) -> None:
+    """Hold must not outlive the memo it guards."""
+    monkeypatch.setenv("SUGAR_SESSION_FRAME_MEMO_LIMIT", "2")
+    session = SourceResolutionSession()
+
+    holds = [object() for _ in range(4)]
+    for i, hold in enumerate(holds):
+        session.remember_frame(("def", i), result=f"frame-{i}", hold=hold)
+
+    assert len(session.frame_results) == 2
+    assert len(session.frame_holds) == 2
+    # Oldest two keys (0, 1) dropped; 2 and 3 remain.
+    assert ("def", 0) not in session.frame_results
+    assert ("def", 0) not in session.frame_holds
+    assert ("def", 1) not in session.frame_results
+    assert ("def", 1) not in session.frame_holds
+    assert session.frame_results[("def", 2)] == "frame-2"
+    assert session.frame_holds[("def", 2)] is holds[2]
+    assert session.frame_results[("def", 3)] == "frame-3"
+    assert session.frame_holds[("def", 3)] is holds[3]
+
+
+def test_frame_hit_refreshes_lru_order(monkeypatch) -> None:
+    """A hit keeps its hold; next eviction drops a colder key."""
+    monkeypatch.setenv("SUGAR_SESSION_FRAME_MEMO_LIMIT", "2")
+    session = SourceResolutionSession()
+    h0, h1, h2 = object(), object(), object()
+    session.remember_frame(("k", 0), "r0", hold=h0)
+    session.remember_frame(("k", 1), "r1", hold=h1)
+    # Touch key 0 so key 1 is oldest.
+    assert session.frame_hit(("k", 0)) == "r0"
+    session.remember_frame(("k", 2), "r2", hold=h2)
+
+    assert ("k", 1) not in session.frame_results
+    assert ("k", 1) not in session.frame_holds
+    assert session.frame_holds[("k", 0)] is h0
+    assert session.frame_holds[("k", 2)] is h2
+    assert set(session.frame_results) == {("k", 0), ("k", 2)}
+
+
+def test_remember_frame_without_hold_still_bounded(monkeypatch) -> None:
+    """Gap memos (no hold) also count toward the limit."""
+    monkeypatch.setenv("SUGAR_SESSION_FRAME_MEMO_LIMIT", "2")
+    session = SourceResolutionSession()
+    session.remember_frame(("g", 0), "gap0")
+    session.remember_frame(("g", 1), "gap1", hold=object())
+    session.remember_frame(("g", 2), "gap2")
+    assert len(session.frame_results) == 2
+    assert ("g", 0) not in session.frame_results
+    assert ("g", 1) in session.frame_results
+    assert ("g", 2) in session.frame_results

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -404,9 +404,12 @@ def test_disablement_preserves_parked_obligation_verdicts(tmp_path: Path) -> Non
 @pytest.fixture
 def leaky_process_memo(monkeypatch):
     """Restore the defect: every session shares ONE set of process-wide tables."""
+    from collections import OrderedDict
+
     exports: dict = {}
-    frames: dict = {}
-    holds: dict = {}
+    # OrderedDict: production remember_frame/frame_hit use move_to_end + LRU.
+    frames: OrderedDict = OrderedDict()
+    holds: OrderedDict = OrderedDict()
     active: set = set()
     modules: dict = {}
 


### PR DESCRIPTION
## Summary

Walk-scoped `SourceResolutionSession` retained every projected SourceFile in `frame_holds` for the life of the walk — hold outlived the memo it exists to protect. That is the accumulation disease (shared session degrades across opens; fresh stays flat).

**Fix:** `frame_results` is an OrderedDict LRU (default limit 512, `SUGAR_SESSION_FRAME_MEMO_LIMIT`). On eviction of a memo row, co-evict its `frame_holds` entry. Hits refresh order. Invariant: a hold outlives its memo by zero extra time.

## Shell deleted

Unbounded walk-session SourceFile retention via `frame_holds` without an eviction path. The hold table no longer grows without bound across a 1421-file walk.

## Teeth

`test_frame_memo_lru.py` — limit floor, co-eviction, hit refreshes order, gap memos count toward limit.

## Validation

Inline unit checks green (limit=2 eviction + hit refresh). No wall-clock measure (fleet queue; code-only fix).

## Floors

data_loss=0, no secret, no test deleted for green, silent=0.

@merge_dog

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound `SourceResolutionSession` frame holds to an LRU-limited frame results cache
> - Converts `frame_results` and `frame_holds` in `SourceResolutionSession` from plain dicts to `OrderedDict` to support LRU eviction.
> - Adds a `_frame_memo_limit` helper that reads `SUGAR_SESSION_FRAME_MEMO_LIMIT` from the environment (default 512, minimum 1) to cap cache size.
> - On cache hits, `frame_hit` moves the entry to the end of both dicts to refresh LRU order; `remember_frame` enforces the limit via the new `_evict_frame_memo_lru` helper.
> - Eviction removes the oldest entry from `frame_results` and its corresponding hold from `frame_holds`, ensuring no holds outlive their memo rows.
> - Adds tests in [test_frame_memo_lru.py](https://github.com/TSavo/sugar/pull/7095/files#diff-044f0df1b5b9da56640701a3f487a59c1542984623f5022c172dbcffecb2830d) covering default/configured limits, hold co-eviction, LRU refresh, and hold-free memos.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 878df49.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->