### PR TITLE
bx pin gate: resolve relative pin after remote cd to repo root

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -277,9 +277,13 @@ sugar_bx_run_ambient() {
   measured_cmd="${prefix_cmd}${run_cmd# }"
   # Pin gate under lease after load. Identity mode (version+fileCount) default.
   # All remote expansions use \$ so local $? does not fire while building wrapper.
-  # REPO_CWD: pin check MUST run in the synced checkout — relative
-  # .venv-py312/bin/python and docs/ledgers/pins/… are unresolvable from $HOME
-  # (crime=corpus-pin-python-missing under load1=7 was this cwd bug, not a missing venv).
+  #
+  # REPO_ROOT first, then pin existence. Relative pin/python paths are
+  # repo-root-relative (docs/ledgers/pins/…, .venv-py312/bin/python). Checking
+  # them before cd lands in $HOME (ssh default) or a caller subdir and always
+  # 78s — only absolute /tmp pins worked. Pin against SUGAR_BX_REPO, not
+  # remote_cwd (may be a subdir when REL_CWD is set). measured_cmd still cds
+  # to the caller's cwd via prefix_cmd after the pin authenticates.
   wrapper="set -euo pipefail
 LOCK=$(sugar_bx_quote "$lock")
 WAIT=$(sugar_bx_quote "$wait_s")
@@ -288,8 +292,18 @@ HOST=$(sugar_bx_quote "$host_lit")
 SKIP_PIN=$(sugar_bx_quote "$pin_skip")
 PIN_PATH=$(sugar_bx_quote "$pin_path")
 PIN_PY=$(sugar_bx_quote "$pin_py")
-REPO_CWD=$(sugar_bx_quote "$remote_cwd")
-cd \"\$REPO_CWD\" || { printf 'sugarbin: crime=corpus-pin-cwd-missing path=%s\\n' \"\$REPO_CWD\" >&2; exit 78; }
+REPO_ROOT=$(sugar_bx_quote "$SUGAR_BX_REPO")
+cd \"\$REPO_ROOT\" || { printf 'sugarbin: crime=corpus-pin-cwd-missing path=%s replacement=synced checkout at SUGAR_BX_REPO must exist before pin check\\n' \"\$REPO_ROOT\" >&2; exit 78; }
+# Root relative pin/python against the synced checkout. Absolute paths (e.g.
+# /tmp/pin.json or a fleet venv) pass through unchanged.
+case \"\$PIN_PATH\" in
+  /*) ;;
+  *) PIN_PATH=\"\$REPO_ROOT/\$PIN_PATH\" ;;
+esac
+case \"\$PIN_PY\" in
+  /*) ;;
+  *) PIN_PY=\"\$REPO_ROOT/\$PIN_PY\" ;;
+esac
 touch \"\$LOCK\" || { printf 'sugarbin: crime=timing-lease-uncreatable path=%s\\n' \"\$LOCK\" >&2; exit 77; }
 exec 9>>\"\$LOCK\"
 if ! command -v flock >/dev/null 2>&1; then
@@ -324,15 +338,15 @@ fi
 if [[ \"\$SKIP_PIN\" != 1 && \"\$SKIP_PIN\" != true && \"\$SKIP_PIN\" != yes ]]; then
   export PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:\${PYTHONPATH:-}
   if [[ ! -x \"\$PIN_PY\" ]]; then
-    printf 'sugarbin: crime=corpus-pin-python-missing path=%s replacement=bin/brun -- bash scripts/bootstrap-venv-py312.sh (or reuse remote checkout sugar-bcargo-a978990da5ba which already has .venv-py312)\\n' \"\$PIN_PY\" >&2
+    printf 'sugarbin: crime=corpus-pin-python-missing path=%s cwd=%s replacement=bin/brun -- bash scripts/bootstrap-venv-py312.sh (or absolute SUGAR_BX_CORPUS_PYTHON to a fleet venv with 3.0.3/1421). Relative .venv-py312 is resolved under the synced repo root AFTER remote cd — not from \$HOME.\\n' \"\$PIN_PY\" \"\$REPO_ROOT\" >&2
     exit 78
   fi
   if [[ ! -f \"\$PIN_PATH\" ]]; then
-    printf 'sugarbin: crime=corpus-pin-file-missing path=%s replacement=docs/ledgers/pins/pandas-3.0.3.pin.json must be in the synced checkout\\n' \"\$PIN_PATH\" >&2
+    printf 'sugarbin: crime=corpus-pin-file-missing path=%s cwd=%s replacement=docs/ledgers/pins/pandas-3.0.3.pin.json must be in the synced checkout (sync_paths includes docs/ledgers). Relative pin paths are resolved under repo root AFTER remote cd — a check before that cd always 78s.\\n' \"\$PIN_PATH\" \"\$REPO_ROOT\" >&2
     exit 78
   fi
   set +e
-  \"\$PIN_PY\" tools/bx_corpus_pin_gate.py --expected-pin \"\$PIN_PATH\" --python \"\$PIN_PY\"
+  \"\$PIN_PY\" \"\$REPO_ROOT\"/tools/bx_corpus_pin_gate.py --expected-pin \"\$PIN_PATH\" --python \"\$PIN_PY\"
   pin_st=\$?
   set -e
   if [[ \"\$pin_st\" != 0 ]]; then

--- a/docs/contributing/battleaxe-timing.md
+++ b/docs/contributing/battleaxe-timing.md
@@ -47,14 +47,21 @@ export SUGAR_BX_REQUIRE_QUIET=1
 
 When `SUGAR_BX_REQUIRE_QUIET=1`, `bin/brun` / `bin/sugarbin run --host bx`:
 
-1. Exclusive remote flock `/var/tmp/sugar-bx-timing-measurement.lease`
-2. Under lock: sample load1 → **76** if over ceiling
-3. Under lock: run `tools/bx_corpus_pin_gate.py` against
+1. Remote shell **cd into the synced checkout root** (`SUGAR_BX_REPO`) before
+   any pin path is touched. Relative pin/python paths
+   (`docs/ledgers/pins/…`, `.venv-py312/bin/python`) are then resolved under
+   that root (absolute paths pass through). Checking the pin file *before*
+   this cd always exits **78** even when the pin is synced — only absolute
+   `/tmp` pins worked; that was a gate bug, not a missing pin.
+2. Exclusive remote flock `/var/tmp/sugar-bx-timing-measurement.lease`
+3. Under lock: sample load1 → **76** if over ceiling
+4. Under lock: run `tools/bx_corpus_pin_gate.py` against
    `.venv-py312` + banked pin → **78** if version/fileCount mismatch
    (identity mode: version + file count; prints expected aggregate in the
    receipt). `control_effect_recensus` also exits **78** on pin/aggregate refuse.
-4. Run the measurement while still holding the lease
-5. Print load before/after (`lease=held`) and pin `phase=ok` on stderr
+5. Run the measurement while still holding the lease (measure still cds to
+   the caller's repo-relative cwd via `prefix_cmd`)
+6. Print load before/after (`lease=held`) and pin `phase=ok` on stderr
 
 ## One-time remote env (pinned pandas corpus)
 

--- a/tests/sugarbin_bx_load_gate.sh
+++ b/tests/sugarbin_bx_load_gate.sh
@@ -166,6 +166,23 @@ grep -Fq 'sugar-bx-timing-measurement.lease' "$repo_root/bin/lib/sugar-bx.sh" ||
 grep -Fq 'timing-lease-busy' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing lease-busy crime"
 grep -Fq 'bx_corpus_pin_gate' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing corpus pin gate"
 grep -Fq 'exit 78' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing pin exit 78"
+# Pin-before-cd always 78'd relative paths (only absolute /tmp worked). Tooth:
+# quiet wrapper must set REPO_ROOT and root relative PIN_PATH before pin-file check.
+# Match wrapper-local REPO_ROOT= (not SUGAR_BX_REPO_ROOT elsewhere in the file).
+bx_src="$repo_root/bin/lib/sugar-bx.sh"
+cd_repo_line=$(grep -n 'REPO_ROOT=\$(sugar_bx_quote' "$bx_src" | head -1 | cut -d: -f1)
+pin_rel_case=$(grep -n 'PIN_PATH=.*REPO_ROOT.*PIN_PATH' "$bx_src" | head -1 | cut -d: -f1)
+if [[ -z "$pin_rel_case" ]]; then
+  pin_rel_case=$(grep -n 'REPO_ROOT/\$PIN_PATH\|REPO_ROOT/\\$PIN_PATH' "$bx_src" | head -1 | cut -d: -f1)
+fi
+pin_file_line=$(grep -n 'corpus-pin-file-missing' "$bx_src" | head -1 | cut -d: -f1)
+[[ -n "$cd_repo_line" && -n "$pin_file_line" ]] \
+  || fail "sugar-bx missing REPO_ROOT= before pin-file check (relative pin always 78 without remote cd)"
+[[ "$cd_repo_line" -lt "$pin_file_line" ]] \
+  || fail "sugar-bx pin-file check (line $pin_file_line) must come AFTER REPO_ROOT= (line $cd_repo_line)"
+[[ -n "$pin_rel_case" && "$pin_rel_case" -lt "$pin_file_line" ]] \
+  || fail "sugar-bx must root relative PIN_PATH under REPO_ROOT before pin-file check"
+grep -Fq 'docs/ledgers' "$bx_src" || fail "sugar-bx sync_paths must include docs/ledgers (pin JSON)"
 test -f "$repo_root/docs/contributing/battleaxe-timing.md" || fail "canonical timing doc missing"
 grep -Fq 'timing-measurement.lease' "$repo_root/docs/contributing/battleaxe-timing.md" || fail "doc missing exclusive lease"
 grep -Fq 'corpus-pin' "$repo_root/docs/contributing/battleaxe-timing.md" || fail "doc missing corpus pin gate"


### PR DESCRIPTION
## Summary

Quiet-gated brun checked the corpus pin **before** (or outside) the synced checkout. Relative `SUGAR_BX_REQUIRE_CORPUS_PIN=docs/ledgers/pins/…` and `.venv-py312/bin/python` always failed with exit **78** even when rsynced — only absolute `/tmp` pins worked. That bites every agent.

### Fix
- Remote quiet wrapper **`cd`s to `SUGAR_BX_REPO` (repo root)** before any pin path is touched (not the caller subdir `remote_cwd`).
- Relative pin/python paths are **rooted under that checkout**; absolute paths (e.g. fleet venv, `/tmp` pin) pass through.
- Pin gate binary invoked as `$REPO_ROOT/tools/bx_corpus_pin_gate.py`.
- Measure still cds to the caller's cwd via `prefix_cmd` after the pin authenticates.
- Tooth in `tests/sugarbin_bx_load_gate.sh`: `REPO_ROOT=` and relative `PIN_PATH` rooting must appear **before** `corpus-pin-file-missing`.
- Doc: `docs/contributing/battleaxe-timing.md` states the remote-cd-first rule.

**Shell deleted:** none yet (operational membrane; `docs/ledgers` already on sync_paths from #7093).

**R / Epsilon R:** operational — removes false-78 on correct relative pin; does not change product R axes. No measurement on battleaxe (black holds seal slot).

## Validation
```bash
bash tests/sugarbin_bx_load_gate.sh "$(git rev-parse --show-toplevel)"
# PASS: sugarbin_bx_load_gate
```

No battleaxe measure (serialized: black seal first).

## For merge_dog
Hand to merge_dog. Brown D3 receipt waits until after orange/white slots per fleet queue.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `bx pin gate` to resolve relative pin paths after `cd` to repo root
> - In quiet mode, `sugar_bx_run_ambient` now `cd`s into `SUGAR_BX_REPO` (as `REPO_ROOT`) before any pin checks, so relative `PIN_PATH` and `PIN_PY` values are correctly resolved under the repo root rather than the caller's remote cwd.
> - Relative pin paths are rewritten to be rooted under `REPO_ROOT`; absolute paths pass through unchanged.
> - The gate script is now invoked via an absolute repo-rooted path instead of a path relative to the current directory.
> - Error messages for missing pin cwd, python, and file now include `REPO_ROOT` context.
> - Behavioral Change: previously, pin checks ran before the `cd`, causing spurious exit 78 errors for relative paths; the actual measurement still `cd`s to the caller's repo-relative cwd.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2ef10d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->