### PR TITLE
CI: host load + shared lease on control-effect measure

### DIFF
--- a/.github/workflows/control-effect-recensus.yml
+++ b/.github/workflows/control-effect-recensus.yml
@@ -23,9 +23,14 @@ name: Control-effect recensus (authoritative scoreboard)
 #   runner's pandas matches docs/ledgers/pins/pandas-3.0.3.pin.json
 #   (3.0.3 / 1421 files). A sealed board against the wrong pin is worse than
 #   no board — it carries a receipt. tools/bx_corpus_pin_gate.py.
-#   Load (76) / lease (77) apply to human brun timing; CI pin is mandatory.
-#   Lease is not wired here until runner topology is proven shared-vs-private
-#   (matrix may be multi-box).
+# - LOAD (76) + HOST LEASE (77): topology proven SHARED — ~25 runners are
+#   containers on one box (battleaxe), same bootId. Measure steps wrap with
+#   tools/bx_host_measure_gates.sh --shared (shared flock so k=8 seats may
+#   co-run; exclusive brun quiet waits). Lease path MUST be the host
+#   bind-mount /home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease
+#   — NOT /var/tmp (per-container lock theatre). Load sample under the lease.
+#   Without this, CI seats fight human brun on the same kernel and seal a
+#   contaminated board with a receipt.
 #
 # WHY NIGHTLY AND NOT push:[main]
 #
@@ -49,6 +54,11 @@ env:
   PYTHONUNBUFFERED: "1"
   # Banked LPT k — keep fixed; change the split KEY (prior), not k (#7055).
   RECENSUS_SHARD_COUNT: "8"
+  # Host bind-mount lease (serializes with human brun exclusive quiet gate).
+  # Never /var/tmp — per-container on battleaxe runners.
+  SUGAR_BX_TIMING_LEASE_PATH: /home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease
+  # Queue for exclusive brun / peer shared holders (2h).
+  SUGAR_BX_TIMING_LEASE_WAIT_S: "7200"
 
 jobs:
   # ------------------------------------------------------------------ plan
@@ -302,7 +312,7 @@ jobs:
             --corpus-root "$PANDAS_CORPUS"
           echo "JOB_LOG phase=corpus-pin-gate status=ok job=shard seat=s$(printf '%02d' '${{ matrix.shard }}') root=$PANDAS_CORPUS"
 
-      - name: "Phase: measure shard partial only"
+      - name: "Phase: measure shard partial only (shared host lease + load)"
         shell: bash
         env:
           PANDAS_CORPUS: ${{ needs.plan.outputs.root }}
@@ -318,19 +328,21 @@ jobs:
             exit 1
           fi
           echo "recensus phase=measure-shard status=start shard=$SHARD/$K corpus_root=$PANDAS_CORPUS commit=$GITHUB_SHA"
+          # Shared host lease: k=8 seats may co-run; exclusive brun quiet waits.
+          # Load under lease (exit 76). Wrong path /var/tmp → lock theatre (77).
           # Worker: --plan-json + --shard-index → PARTIAL only (never seals).
-          # control_effect_recensus write-throughs each file_s → LPT shelf.
-          # --require-corpus-pin: second belt (exit 78) if pin drifts mid-run.
-          python -u implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py \
-            "$PANDAS_CORPUS" \
-            --corpus-root "$PANDAS_CORPUS" \
-            --repo "$GITHUB_WORKSPACE" \
-            --commit "$GITHUB_SHA" \
-            --require-corpus-pin docs/ledgers/pins/pandas-3.0.3.pin.json \
-            --out-dir "$OUT" \
-            --plan-json "$PLAN" \
-            --shard-index "$SHARD" \
-            --partial-out "$OUT/partial-s$(printf '%02d' "$SHARD").json"
+          chmod +x tools/bx_host_measure_gates.sh
+          tools/bx_host_measure_gates.sh --shared -- \
+            python -u implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py \
+              "$PANDAS_CORPUS" \
+              --corpus-root "$PANDAS_CORPUS" \
+              --repo "$GITHUB_WORKSPACE" \
+              --commit "$GITHUB_SHA" \
+              --require-corpus-pin docs/ledgers/pins/pandas-3.0.3.pin.json \
+              --out-dir "$OUT" \
+              --plan-json "$PLAN" \
+              --shard-index "$SHARD" \
+              --partial-out "$OUT/partial-s$(printf '%02d' "$SHARD").json"
           echo "recensus phase=measure-shard status=done shard=$SHARD"
           ls -la "$OUT"/partial-s*.json || true
           PRIOR_N="$(find "${SUGAR_LPT_PRIOR_DIR}" -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"

--- a/bin/brun
+++ b/bin/brun
@@ -30,8 +30,10 @@ Quiet gate (wall-clock timing only — opt-in; ordinary builds leave unset):
   SUGAR_BX_REQUIRE_QUIET=1   Arms all three gates: exclusive lease + load under
                              lock + corpus pin (unless SKIP). 
   SUGAR_BX_MAX_LOADAVG=N     Explicit load ceiling (also arms the gate alone).
-  SUGAR_BX_TIMING_LEASE_PATH Remote flock path
-                             (default /var/tmp/sugar-bx-timing-measurement.lease)
+  SUGAR_BX_TIMING_LEASE_PATH Remote flock path (prefer host bind-mount:
+                             /home/runner|tsavo/.cache/sugar/binaries/
+                             .sugar-heavy-measurement.lease — NOT /var/tmp on
+                             battleaxe containers; that is lock theatre)
   SUGAR_BX_TIMING_LEASE_WAIT_S  Seconds to wait for the lease (default 7200).
                              0 = refuse immediately with exit 77 if busy.
   SUGAR_BX_REQUIRE_CORPUS_PIN  Pin JSON path (default

--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -167,9 +167,11 @@ sugar_bx_require_docker_ready() {
 #
 # Concurrency: load-at-start alone is not enough — six agents can all pass a
 # quiet check then co-run and recreate contention on battleaxe. Quiet-gated
-# ambient runs take an exclusive remote flock
-# (/var/tmp/sugar-bx-timing-measurement.lease by default), re-sample load
-# under that lock, then run. Serialize, do not rely on people.
+# ambient runs take an exclusive remote flock on the host bind-mount lease
+# (/home/runner|tsavo/.cache/sugar/binaries/.sugar-heavy-measurement.lease;
+# never /var/tmp on containers — lock theatre), re-sample load under that
+# lock, then run. CI seats use shared flock on the same path
+# (tools/bx_host_measure_gates.sh --shared). Serialize, do not rely on people.
 sugar_bx_quiet_armed() {
   local require="${SUGAR_BX_REQUIRE_QUIET:-0}"
   local max_env="${SUGAR_BX_MAX_LOADAVG:-}"
@@ -202,7 +204,18 @@ sugar_bx_require_quiet() {
   fi
   SUGAR_BX_QUIET_ARMED=1
   SUGAR_BX_LOAD_MAX="${SUGAR_BX_MAX_LOADAVG:-}"
-  SUGAR_BX_TIMING_LEASE="${SUGAR_BX_TIMING_LEASE_PATH:-/var/tmp/sugar-bx-timing-measurement.lease}"
+  # Prefer host bind-mount lease (serializes CI containers + host brun).
+  # /var/tmp is per-container lock theatre on battleaxe (same bootId, different
+  # inode). See docs/contributing/heavy-measurement-lease.md.
+  if [[ -n "${SUGAR_BX_TIMING_LEASE_PATH:-}" ]]; then
+    SUGAR_BX_TIMING_LEASE="$SUGAR_BX_TIMING_LEASE_PATH"
+  elif [[ -d /home/runner/.cache/sugar/binaries ]]; then
+    SUGAR_BX_TIMING_LEASE=/home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease
+  elif [[ -d /home/tsavo/.cache/sugar/binaries ]]; then
+    SUGAR_BX_TIMING_LEASE=/home/tsavo/.cache/sugar/binaries/.sugar-heavy-measurement.lease
+  else
+    SUGAR_BX_TIMING_LEASE=/var/tmp/sugar-bx-timing-measurement.lease
+  fi
   # Default wait 2h (queue). Set SUGAR_BX_TIMING_LEASE_WAIT_S=0 to refuse
   # immediately with exit 77 when another measurement holds the lease.
   SUGAR_BX_TIMING_LEASE_WAIT="${SUGAR_BX_TIMING_LEASE_WAIT_S:-7200}"
@@ -266,7 +279,16 @@ sugar_bx_run_ambient() {
   # Three gates, one law: quiet box, exclusive lease, correct corpus.
   local lock wait_s max_lit host_lit measured_cmd wrapper
   local pin_path pin_py pin_skip
-  lock="${SUGAR_BX_TIMING_LEASE:-/var/tmp/sugar-bx-timing-measurement.lease}"
+  lock="${SUGAR_BX_TIMING_LEASE:-}"
+  if [[ -z "$lock" ]]; then
+    if [[ -d /home/runner/.cache/sugar/binaries ]]; then
+      lock=/home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease
+    elif [[ -d /home/tsavo/.cache/sugar/binaries ]]; then
+      lock=/home/tsavo/.cache/sugar/binaries/.sugar-heavy-measurement.lease
+    else
+      lock=/var/tmp/sugar-bx-timing-measurement.lease
+    fi
+  fi
   wait_s="${SUGAR_BX_TIMING_LEASE_WAIT:-7200}"
   max_lit="${SUGAR_BX_LOAD_MAX:-}"
   host_lit="$SUGAR_BX_HOST"

--- a/docs/contributing/battleaxe-timing.md
+++ b/docs/contributing/battleaxe-timing.md
@@ -229,16 +229,17 @@ is not a timing receipt.
 
 ## CI recensus (control-effect k=8)
 
-Human brun timing uses all three gates (76/77/78). The GitHub
-`control-effect-recensus` workflow (LPT k=8 + compose seal) **must** run the
-**corpus pin gate** on every plan and every shard job before it mints plan or
-partial artifacts — **exit 78** if the runner is not pandas **3.0.3 / 1421**
-(`docs/ledgers/pins/pandas-3.0.3.pin.json` via `tools/bx_corpus_pin_gate.py`).
-A sealed board against the wrong pin is worse than no board.
+Topology: runners are **containers on battleaxe** (shared host). All three
+gates apply.
 
-Load (76) and lease (77) stay brun-path defaults until CI runner topology is
-proven shared-vs-private (matrix may already be multi-box). Pin is mandatory
-either way.
+| Gate | CI |
+| --- | --- |
+| Pin 78 | plan + each shard; `--require-corpus-pin` on measure |
+| Load 76 | under lease on measure (`tools/bx_host_measure_gates.sh`) |
+| Lease 77 | **shared** flock on measure so k=8 co-runs; brun quiet is **exclusive** on the same host path |
+
+Lease path: `/home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease`  
+(not `/var/tmp` — per-container lock theatre).
 
 ## Forbidden
 

--- a/docs/contributing/measurement-conditions.md
+++ b/docs/contributing/measurement-conditions.md
@@ -91,20 +91,31 @@ without the matching stderr gate lines from the same run.
 
 ## CI recensus
 
-Human `bin/brun` timing uses all three gates. The control-effect recensus
-workflow (`.github/workflows/control-effect-recensus.yml`, LPT k=8 + compose)
-**must** run the **corpus pin gate** on **plan and every shard job** before
-minting plan or partial bodies — **exit 78** if the runner is not pandas
-**3.0.3 / 1421** (`tools/bx_corpus_pin_gate.py` + banked pin). Shard measure
-also passes `--require-corpus-pin` into `control_effect_recensus` (second belt).
+Topology is **proven shared** (2026-08-02, white): ~25 GitHub runners are
+**containers on one box** (battleaxe) — same `bootId`, different container
+hostnames. So all three gates apply in CI, not only pin.
 
-A sealed board against the wrong pin is worse than no board — it carries a
-receipt.
+The control-effect recensus workflow
+(`.github/workflows/control-effect-recensus.yml`, LPT k=8 + compose):
 
-**Load (76) and lease (77) are not wired in CI** until runner topology is
-proven: the matrix may already be multi-box (lease would only serialize
-same-host seats). Pin is mandatory either way. If topology later proves a
-shared box, add lease under the same quiet discipline as brun.
+| Gate | CI wiring |
+| --- | --- |
+| **Pin (78)** | Plan + every shard before mint; measure `--require-corpus-pin` |
+| **Load (76)** | Under host lease on each **measure** step |
+| **Lease (77)** | `tools/bx_host_measure_gates.sh --shared` on measure |
+
+**Lease path (mandatory):**  
+`/home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease`  
+— host bind-mount, verified across live containers. **Never `/var/tmp`**:
+per-container rootfs, same bootId, different inode → lock theatre (suite and
+floors once waited 0.0007s each and still overlapped).
+
+**Shared vs exclusive:** CI seats take a **shared** flock so k=8 may co-run.
+Human brun quiet takes **exclusive** on the same path and waits for shared
+holders (and blocks new shared while measuring). Without that, a sealed CI
+board and a human timing number can contaminate each other on one kernel.
+
+A sealed board without pin / load / lease testimony is worse than no board.
 
 ## How to obey (human timing)
 

--- a/tests/bx_host_measure_gates.sh
+++ b/tests/bx_host_measure_gates.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Focused tests for tools/bx_host_measure_gates.sh — no corpus, no network.
+# macOS often lacks util-linux flock; provide a stub that always acquires.
+set -euo pipefail
+
+repo_root="${1:-$(git rev-parse --show-toplevel)}"
+gate="$repo_root/tools/bx_host_measure_gates.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+chmod +x "$gate"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+fake_bin="$tmp/bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/flock" <<'SH'
+#!/usr/bin/env bash
+# Stub: consume flock flags + optional FD; always succeed (no real lock).
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s|-x|-n|-u) shift ;;
+    -w) shift; [[ $# -gt 0 ]] && shift ;;
+    -w*) shift ;;
+    [0-9]*) shift; break ;;
+    *) break ;;
+  esac
+done
+if [[ $# -gt 0 ]]; then exec "$@"; fi
+exit 0
+SH
+chmod +x "$fake_bin/flock"
+export PATH="$fake_bin:$PATH"
+
+# 1) Exclusive success on a private lease path under tmp.
+lease="$tmp/host-shared/.sugar-heavy-measurement.lease"
+mkdir -p "$(dirname "$lease")"
+export SUGAR_BX_TIMING_LEASE_PATH="$lease"
+export SUGAR_BX_TIMING_LEASE_WAIT_S=5
+export SUGAR_BX_MAX_LOADAVG=999
+status=0
+"$gate" --exclusive -- true >/dev/null 2>"$tmp/err1" || status=$?
+[[ "$status" -eq 0 ]] || fail "exclusive true status=$status want 0 stderr=$(cat "$tmp/err1")"
+grep -Fq 'phase=acquired' "$tmp/err1" || fail "missing acquired"
+grep -Fq 'phase=before' "$tmp/err1" || fail "missing load before"
+grep -Fq 'phase=after' "$tmp/err1" || fail "missing load after"
+grep -Fq 'mode=exclusive' "$tmp/err1" || fail "missing exclusive mode"
+
+# 2) Shared success
+status=0
+"$gate" --shared -- true >/dev/null 2>"$tmp/err2" || status=$?
+[[ "$status" -eq 0 ]] || fail "shared true status=$status"
+grep -Fq 'mode=shared' "$tmp/err2" || fail "missing shared mode"
+
+# 3) Load refuse (exit 76)
+status=0
+SUGAR_BX_MAX_LOADAVG=0 "$gate" --exclusive -- true >/dev/null 2>"$tmp/err3" || status=$?
+[[ "$status" -eq 76 ]] || fail "load refuse status=$status want 76"
+grep -Fq 'host-not-quiet' "$tmp/err3" || fail "missing host-not-quiet"
+
+# 4) Command failure propagates
+status=0
+"$gate" --exclusive -- bash -c 'exit 42' >/dev/null 2>"$tmp/err4" || status=$?
+[[ "$status" -eq 42 ]] || fail "status prop status=$status want 42"
+
+# 5) Shared then exclusive sequential on same path
+status=0
+"$gate" --shared -- true >/dev/null 2>/dev/null || status=$?
+[[ "$status" -eq 0 ]] || fail "shared pre-exclusive failed"
+status=0
+"$gate" --exclusive -- true >/dev/null 2>"$tmp/err5" || status=$?
+[[ "$status" -eq 0 ]] || fail "exclusive after shared status=$status"
+
+# 6) Default path preference documents host bind-mount (script source).
+grep -Fq '/home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease' "$gate" \
+  || fail "gate missing runner bind-mount path"
+grep -Fq '/var/tmp' "$gate" || fail "gate should mention /var/tmp only as last resort"
+
+# 7) Workflow wires shared wrap
+wf="$repo_root/.github/workflows/control-effect-recensus.yml"
+grep -Fq 'bx_host_measure_gates.sh --shared' "$wf" \
+  || fail "workflow missing shared measure wrap"
+grep -Fq 'SUGAR_BX_TIMING_LEASE_PATH: /home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease' "$wf" \
+  || fail "workflow missing host lease path env"
+
+echo "PASS: bx_host_measure_gates"

--- a/tools/bx_host_measure_gates.sh
+++ b/tools/bx_host_measure_gates.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Host-level measurement gates for battleaxe: exclusive/shared lease + load.
+#
+# Exit 76: host not quiet (load1 over ceiling under the lease).
+# Exit 77: lease busy / lock theatre (per-container /var/tmp, or wait timeout).
+#
+# Topology (proven 2026-08-02): ~25 GitHub runners are containers on ONE box
+# (battleaxe). /var/tmp is per-container — flock there is lock theatre.
+# The path that serializes across containers is a host bind-mount:
+#   /home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease
+# (host ambient: /home/tsavo/.cache/sugar/binaries/.sugar-heavy-measurement.lease)
+#
+# Lock modes (reader-writer):
+#   --shared     CI recensus seats may co-run (shared flock).
+#   --exclusive  Human brun / sole measurement (exclusive flock); waits for
+#                all shared holders; blocks new shared while held.
+#
+# Usage:
+#   tools/bx_host_measure_gates.sh [--shared|--exclusive] -- command [args...]
+set -euo pipefail
+
+mode=exclusive
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --shared) mode=shared; shift ;;
+    --exclusive) mode=exclusive; shift ;;
+    --) shift; break ;;
+    -h|--help)
+      sed -n '2,30p' "$0"
+      exit 0
+      ;;
+    *)
+      # bare command without --
+      break
+      ;;
+  esac
+done
+if [[ "${1:-}" == "--" ]]; then shift; fi
+if [[ $# -lt 1 ]]; then
+  echo "usage: tools/bx_host_measure_gates.sh [--shared|--exclusive] -- command [args...]" >&2
+  exit 2
+fi
+
+# Prefer host-shared bind-mount paths. Never default to /var/tmp on a box
+# that has the shared cache — that was the twelve-container false green.
+default_lease() {
+  if [[ -n "${SUGAR_BX_TIMING_LEASE_PATH:-}" ]]; then
+    printf '%s\n' "$SUGAR_BX_TIMING_LEASE_PATH"
+    return
+  fi
+  if [[ -d /home/runner/.cache/sugar/binaries ]]; then
+    printf '%s\n' /home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease
+    return
+  fi
+  if [[ -d /home/tsavo/.cache/sugar/binaries ]]; then
+    printf '%s\n' /home/tsavo/.cache/sugar/binaries/.sugar-heavy-measurement.lease
+    return
+  fi
+  printf '%s\n' /var/tmp/sugar-bx-timing-measurement.lease
+}
+
+LEASE="$(default_lease)"
+WAIT="${SUGAR_BX_TIMING_LEASE_WAIT_S:-7200}"
+MAX_LIT="${SUGAR_BX_MAX_LOADAVG:-}"
+
+mkdir -p "$(dirname "$LEASE")"
+touch "$LEASE" || {
+  echo "sugarbin: crime=timing-lease-uncreatable path=$LEASE" >&2
+  exit 77
+}
+
+# Scope check (banked in docs/contributing/heavy-measurement-lease.md):
+# inside a container, refuse a lease on the same device as / — that is the
+# container rootfs, invisible to peers (lock theatre).
+in_container=0
+if [[ -f /.dockerenv || -f /run/.containerenv ]]; then
+  in_container=1
+elif [[ -r /proc/1/cgroup ]] && grep -Eq 'docker|containerd|kubepods|libpod' /proc/1/cgroup 2>/dev/null; then
+  in_container=1
+fi
+if [[ "$in_container" == 1 ]]; then
+  if command -v stat >/dev/null 2>&1; then
+    root_dev="$(stat -c '%d' / 2>/dev/null || stat -f '%d' / 2>/dev/null || echo "")"
+    lease_dev="$(stat -c '%d' "$LEASE" 2>/dev/null || stat -f '%d' "$LEASE" 2>/dev/null || echo "")"
+    if [[ -n "$root_dev" && -n "$lease_dev" && "$root_dev" == "$lease_dev" ]]; then
+      echo "sugarbin: crime=timing-lease-on-container-rootfs path=$LEASE root_dev=$root_dev replacement=use host bind-mount /home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease (not /var/tmp). Exit 77." >&2
+      exit 77
+    fi
+  fi
+fi
+
+if ! command -v flock >/dev/null 2>&1; then
+  echo "sugarbin: crime=timing-lease-flock-missing replacement=install util-linux flock" >&2
+  exit 77
+fi
+
+exec 9>>"$LEASE"
+flock_mode_flag="-x"
+[[ "$mode" == shared ]] && flock_mode_flag="-s"
+
+echo "sugarbin: bx-timing-lease phase=waiting mode=$mode path=$LEASE wait_s=$WAIT" >&2
+if ! flock $flock_mode_flag -w "$WAIT" 9; then
+  echo "sugarbin: crime=timing-lease-busy mode=$mode path=$LEASE wait_s=$WAIT replacement=another measurement holds the host lease — serialize. Exit 77." >&2
+  exit 77
+fi
+echo "sugarbin: bx-timing-lease phase=acquired mode=$mode path=$LEASE lease=held" >&2
+
+if [[ -r /proc/loadavg ]]; then
+  read -r l1 _rest </proc/loadavg
+else
+  l1="$(python3 -c 'import os; print(os.getloadavg()[0])' 2>/dev/null || echo 0)"
+fi
+n="$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)"
+if [[ -n "$MAX_LIT" ]]; then
+  max="$MAX_LIT"
+else
+  max="$(awk -v n="$n" 'BEGIN{ m=n/4.0; if (m < 2.0) m=2.0; printf "%.2f", m }')"
+fi
+echo "sugarbin: bx-load-gate phase=before load1=$l1 nproc=$n max=$max lease=held mode=$mode" >&2
+if awk -v l="$l1" -v m="$max" 'BEGIN{ exit !(l+0 > m+0) }'; then
+  echo "sugarbin: crime=host-not-quiet load1=$l1 nproc=$n max=$max lease=held replacement=wait for load1<=$max. Exit 76. A measurement that cannot testify to its own conditions is not a measurement." >&2
+  exit 76
+fi
+
+set +e
+"$@"
+st=$?
+set -e
+
+if [[ -r /proc/loadavg ]]; then
+  read -r l2 _rest </proc/loadavg
+else
+  l2=unknown
+fi
+echo "sugarbin: bx-load-gate phase=after load1_before=$l1 load1_after=$l2 nproc=$n lease=held mode=$mode" >&2
+echo "sugarbin: bx-timing-lease phase=release mode=$mode path=$LEASE status=$st" >&2
+exit "$st"


### PR DESCRIPTION
## Why

Topology is **proven shared** (white): ~25 runners are containers on **one** box (battleaxe), same `bootId`. Leaving load/lease brun-only left a hole: k=8 CI seats and human brun can fight the same kernel and seal a contaminated board with a receipt.

`/var/tmp` is **lock theatre** (per-container). Banked path:
`/home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease` (host bind-mount).

## What

- `tools/bx_host_measure_gates.sh` — load under lease; `--shared` / `--exclusive`; refuses container-rootfs lease (exit 77)
- CI measure: wrap with `--shared` + env `SUGAR_BX_TIMING_LEASE_PATH` to the bind-mount
- brun quiet default lease prefers host cache paths (runner or tsavo) over `/var/tmp`
- Shared seats + exclusive brun = reader/writer so k=8 still co-runs
- Docs: measurement-conditions + battleaxe-timing

## Validation

```bash
bash tests/bx_host_measure_gates.sh   # PASS
bash tests/sugarbin_bx_load_gate.sh   # PASS
```

merge_dog: squash-merge — last gate hole.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared host lease and load gate to control-effect measure CI jobs
> - Introduces [tools/bx_host_measure_gates.sh](https://github.com/TSavo/sugar/pull/7097/files#diff-4e58c67fcfd1f8bb2207bed7451ac69b4e150ba0bd44f77c647200c8e53c7cf9), a new wrapper script that acquires a shared or exclusive `flock` on a host bind-mount lease path, samples load average under the lease, and propagates the wrapped command's exit status.
> - CI shard measure steps in [control-effect-recensus.yml](https://github.com/TSavo/sugar/pull/7097/files#diff-7e202e700aa9f13d566241432324fdcbab9681d436e4227693482c2c51b3acd0) now invoke the wrapper with `--shared`, coordinating with other seats and `brun` on the same host.
> - Default lease path resolution in [bin/lib/sugar-bx.sh](https://github.com/TSavo/sugar/pull/7097/files#diff-bdd6c46eb799e81d8c3cc8b50ab4a809668391cedbc25e468f6efe8ef9d86ebc) now prefers `/home/runner` or `/home/tsavo` bind-mount paths over `/var/tmp`, avoiding per-container lock paths.
> - Risk: measure jobs may now exit 76 (host load too high) or 77 (lease busy/unavailable), which are new failure modes not previously surfaced in CI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ccdddd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->