### PR TITLE
prebuilt demand table: derive once, load in shards, zero cold walks

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -80,6 +80,8 @@ def build_plan(
     prior_hits: int,
     prior_misses: int,
     estimated_loads: Sequence[float],
+    demand_table_cid: str | None = None,
+    demand_table_path: str | None = None,
 ) -> dict[str, Any]:
     enrolled = sorted(enrolled_files)
     bin_lists = [list(b) for b in bins]
@@ -110,6 +112,12 @@ def build_plan(
         "bins": bin_lists,
         "estimatedLoadS": [float(x) for x in estimated_loads],
     }
+    # Prebuilt provisional demand table: content-addressed once at plan time;
+    # every shard LOADS it so cold processes never re-walk the corpus (k=8).
+    if demand_table_cid is not None:
+        plan["demandTableCid"] = demand_table_cid
+    if demand_table_path is not None:
+        plan["demandTablePath"] = demand_table_path
     plan["planCid"] = canonical_cid({k: v for k, v in plan.items() if k != "planCid"})
     return plan
 

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -36,11 +36,10 @@ So this instrument states its denominator before it states any number:
 One process. Two named axes (never merged into one R):
 
     SourceTree(corpus).paths()
-      → provisional_contract_refs_from_demands(corpus)  (once)
-      → open_source_file_for_construction (context + source-derived CM refs)
-      → functions()
-      → fn.sugar()                    # axis 1: construction families
-      → sugar.desugar(None)           # axis 2: desugar refusals + typed red
+      → mint prebuilt demand table ONCE (or LOAD plan-time artifact)
+      → install into process memo (shards: zero walk)
+      → measure_file_via_enumerate(contract_refs=…)  # D2/D3 sugar.enumerate
+      → (legacy path) open_source_file_for_construction + sugar/desugar
 
 Construction R answers "is the tree total?". Desugar R answers "is meaning
 reducible?". Yield/YieldFrom construct then refuse at desugar — correct; they
@@ -755,6 +754,25 @@ def main() -> int:
         default=None,
         help="where to write the shard partial JSON (default: <out-dir>/partial-sXX.json)",
     )
+    parser.add_argument(
+        "--demand-table-path",
+        type=Path,
+        default=None,
+        help=(
+            "load a plan-time prebuilt provisional demand table (content-addressed). "
+            "Shards MUST use this so cold processes do not re-walk 1421 files. "
+            "Corpus pin on the table must match the observed pin or refuse."
+        ),
+    )
+    parser.add_argument(
+        "--write-demand-table",
+        type=Path,
+        default=None,
+        help=(
+            "after deriving the provisional demand table once, write the "
+            "content-addressed artifact for shards to load"
+        ),
+    )
     args = parser.parse_args()
     if args.shard_index is not None and args.plan_json is None:
         parser.error("--shard-index requires --plan-json")
@@ -942,21 +960,97 @@ def main() -> int:
     # files; each file still gets a fresh TreeConstructionContextV1 so
     # source-derived manager refs do not leak between files. Deriving this from
     # anything but the root is the corpus-context drift defect.
-    from sugar_lift_py_tests.lift_rpc import provisional_contract_refs_from_demands
+    #
+    # k=8 law: the walk is O(corpus) per cold process. Plan time derives once
+    # and writes a content-addressed artifact; every shard LOADS it so D2 never
+    # re-walks. Process memo alone is not enough — each shard is a new process.
+    from sugar_lift_py_tests.lift_rpc import install_provisional_contract_refs
+    from sugar_lift_py_tests.prebuilt_demand_table import (
+        DemandTableArtifactRefusal,
+        DemandTablePinMismatch,
+        install_prebuilt_demand_table,
+        load_prebuilt_demand_table,
+        mint_prebuilt_demand_table,
+        write_prebuilt_demand_table,
+    )
 
-    # Demand-table walk can take minutes with only a BEGIN/END pair — that is
-    # blind by construction. Alive heartbeats every ≤30s hit the job log.
-    _narrate(
-        f"RECENSUS DEMAND_TABLE deriving provisional refs from workspace_root={workspace_root}"
-    )
-    contract_refs = _phase_call(
-        "demand_table_derivation",
-        lambda: provisional_contract_refs_from_demands(workspace_root),
-    )
-    _narrate(
-        "RECENSUS DEMAND_TABLE ready "
-        f"(type={type(contract_refs).__name__})"
-    )
+    pin_identity = {
+        "distribution": observed_pin.distribution,
+        "version": observed_pin.version,
+        "fileCount": observed_pin.file_count,
+        "aggregateHash": observed_pin.aggregate_hash,
+    }
+    demand_table_cid: str | None = None
+    # Plan may carry demandTableCid / demandTablePath for shard workers.
+    plan_demand_path = args.demand_table_path
+    plan_demand_cid = None
+    if shard_plan is not None:
+        plan_demand_cid = shard_plan.get("demandTableCid")
+        if plan_demand_path is None and shard_plan.get("demandTablePath"):
+            plan_demand_path = Path(str(shard_plan["demandTablePath"]))
+
+    if plan_demand_path is not None:
+        _narrate(
+            f"RECENSUS DEMAND_TABLE loading prebuilt path={plan_demand_path} "
+            f"planCid={plan_demand_cid or 'none'}"
+        )
+        try:
+            prebuilt = load_prebuilt_demand_table(
+                plan_demand_path,
+                expected_corpus_pin=pin_identity,
+                expected_content_cid=plan_demand_cid,
+            )
+        except (DemandTablePinMismatch, DemandTableArtifactRefusal) as refuse:
+            print(str(refuse), file=sys.stderr, flush=True)
+            return 78
+        contract_refs = _phase_call(
+            "demand_table_load",
+            lambda: install_prebuilt_demand_table(
+                prebuilt, root=workspace_root
+            ),
+        )
+        demand_table_cid = prebuilt.content_cid
+        _narrate(
+            "RECENSUS DEMAND_TABLE loaded "
+            f"contentCid={demand_table_cid} rows={len(prebuilt.rows)} "
+            f"(zero corpus walk)"
+        )
+    else:
+        # Demand-table walk can take minutes with only a BEGIN/END pair — that
+        # is blind by construction. Alive heartbeats every ≤30s hit the job log.
+        _narrate(
+            f"RECENSUS DEMAND_TABLE deriving provisional refs from "
+            f"workspace_root={workspace_root}"
+        )
+
+        def _derive_and_maybe_write():
+            table = mint_prebuilt_demand_table(
+                workspace_root, corpus_pin=pin_identity
+            )
+            write_path = args.write_demand_table
+            if write_path is None and args.out_dir is not None:
+                # Default artifact next to board outputs so shards can find it.
+                write_path = Path(args.out_dir) / "provisional-demand-table.json"
+            if write_path is not None:
+                write_prebuilt_demand_table(table, write_path)
+                _narrate(
+                    f"RECENSUS DEMAND_TABLE wrote path={write_path} "
+                    f"contentCid={table.content_cid}"
+                )
+            refs = install_prebuilt_demand_table(table, root=workspace_root)
+            return refs, table.content_cid
+
+        contract_refs, demand_table_cid = _phase_call(
+            "demand_table_derivation",
+            _derive_and_maybe_write,
+        )
+        # Also keep the process memo path warm for any code that still calls
+        # provisional_contract_refs_from_demands directly.
+        install_provisional_contract_refs(workspace_root, contract_refs)
+        _narrate(
+            "RECENSUS DEMAND_TABLE ready "
+            f"(type={type(contract_refs).__name__} contentCid={demand_table_cid})"
+        )
 
     from pandas_census_checkpoint import Checkpoint
 
@@ -1246,6 +1340,7 @@ def main() -> int:
                     row = measure_file_via_enumerate(
                         workspace_root=corpus_root,
                         file_rel=relative,
+                        contract_refs=contract_refs,
                     )
                 except (ImportError, AttributeError) as error:
                     # An arm that cannot resolve its dispatch target is UNWRITTEN,

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -285,8 +285,19 @@ def measure_file_via_enumerate(
     workspace_root: Path,
     file_rel: str,
     source_cid: str | None = None,
+    contract_refs=None,
 ) -> dict[str, Any]:
-    """Produce one terminal solely from sugar.enumerate demands."""
+    """Produce one terminal solely from sugar.enumerate demands.
+
+    ``contract_refs`` — when provided, installed into the process provisional
+    demand-table memo BEFORE D2 so ``tree_construction_context_for_workspace``
+    does not re-walk the corpus. Plan-time prebuilt tables are the production
+    source; omitting this re-derives (process-memoized after first cold pay).
+    """
+    if contract_refs is not None:
+        from sugar_lift_py_tests.lift_rpc import install_provisional_contract_refs
+
+        install_provisional_contract_refs(Path(workspace_root), contract_refs)
     function_nodes, function_gaps = demand_function_roster(
         workspace_root=workspace_root,
         file_rel=file_rel,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -80,8 +80,14 @@ _RETAINED_BY_MEMENTO = {}
 # control_effect_recensus, but ``measure_file_via_enumerate`` never received
 # that table: each D2 ``sugar.enumerate level=functions`` re-derived via
 # ``tree_construction_context_for_workspace`` → hang-looking multi-minute
-# per file. Process memo makes the paid scan real amortization.
+# per file. Process memo makes the paid scan real amortization within one
+# process; k=8 still pays ×k cold startups unless shards LOAD a prebuilt
+# table (see ``prebuilt_demand_table`` + ``install_provisional_contract_refs``).
 _PROVISIONAL_CONTRACT_REFS_BY_ROOT: Dict[str, Any] = {}
+# How many times ``_preconstruction_demand_rows`` actually walked a corpus.
+# Unit tests count this (do not time it): a cold process given a prebuilt
+# table must leave this at zero after install + measure.
+_PRECONSTRUCTION_WALK_COUNT = 0
 
 
 def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
@@ -128,8 +134,17 @@ def _context_manager_demand_rows(root: Path) -> List[Dict[str, Any]]:
     return rows
 
 
-def provisional_contract_refs_from_demand_rows(rows):
-    """Project one already-authenticated demand table into construction refs."""
+def provisional_contract_refs_from_demand_rows(
+    rows,
+    *,
+    table_cid: str | None = None,
+    catalog_cid: str | None = None,
+):
+    """Project one already-authenticated demand table into construction refs.
+
+    No corpus walk. When ``table_cid`` is omitted, the table is content-addressed
+    from the CM demand rows so two identical row sets share one CID.
+    """
     from types import MappingProxyType
 
     from sugar_lift_py_tests.context_manager_resolution import (
@@ -138,11 +153,14 @@ def provisional_contract_refs_from_demand_rows(rows):
         SourceFragmentCoordinateV1,
         _hash_json,
     )
+    from sugar_lift_python_source.canonical import cid_of_json
 
     resolutions = {}
+    cm_rows = []
     for row in rows:
         if row.get("kind") != "context-manager-demand":
             continue
+        cm_rows.append(row)
         site = SourceFragmentCoordinateV1.decode(row["useSite"])
         preimage = {
             key: row[key]
@@ -155,8 +173,12 @@ def provisional_contract_refs_from_demand_rows(rows):
             row.get("gapKind") or "runtime-selected",
             (),
         )
-    catalog_cid = "blake3-512:" + ("c" * 128)
-    table_cid = "blake3-512:" + ("t" * 128)
+    if table_cid is None:
+        table_cid = cid_of_json(
+            {"kind": "provisional-demand-table-rows", "rows": cm_rows}
+        )
+    if catalog_cid is None:
+        catalog_cid = table_cid
     return ResolvedContractRefsV1(catalog_cid, table_cid, MappingProxyType(resolutions))
 
 
@@ -176,6 +198,8 @@ def provisional_contract_refs_from_demands(root: Path):
 
     Process-memoized by resolved root: the walk is O(corpus), not O(file). A
     second open of the same workspace root must not re-scan every module.
+    Prefer ``install_provisional_contract_refs`` / prebuilt load for cold
+    shard processes so the walk is not paid again.
     """
     key = str(Path(root).resolve())
     cached = _PROVISIONAL_CONTRACT_REFS_BY_ROOT.get(key)
@@ -188,9 +212,30 @@ def provisional_contract_refs_from_demands(root: Path):
     return refs
 
 
+def install_provisional_contract_refs(root: Path, refs) -> None:
+    """Seed the process demand-table memo without walking the corpus.
+
+    Shards load a plan-time prebuilt table and call this once. Subsequent
+    ``provisional_contract_refs_from_demands`` / D2 enumerate hits the memo.
+    """
+    key = str(Path(root).resolve())
+    _PROVISIONAL_CONTRACT_REFS_BY_ROOT[key] = refs
+
+
 def clear_provisional_contract_refs_memo() -> None:
     """Drop process demand-table memo (tests / hermetic process reuse)."""
     _PROVISIONAL_CONTRACT_REFS_BY_ROOT.clear()
+
+
+def preconstruction_walk_count() -> int:
+    """How many times the corpus was walked for provisional demand rows."""
+    return _PRECONSTRUCTION_WALK_COUNT
+
+
+def reset_preconstruction_walk_count() -> None:
+    """Zero the walk counter (tests only)."""
+    global _PRECONSTRUCTION_WALK_COUNT
+    _PRECONSTRUCTION_WALK_COUNT = 0
 
 
 def tree_construction_context_for_workspace(
@@ -563,7 +608,12 @@ def _preconstruction_demand_rows(root: Path) -> List[Dict[str, Any]]:
     contract.  Its call coordinate supplies the authenticated import binding,
     but must not also enroll an independent function-contract demand for the
     same use site.
+
+    Each call is one corpus walk (counted by ``preconstruction_walk_count``).
+    Cold shards must load a prebuilt table instead of re-entering this door.
     """
+    global _PRECONSTRUCTION_WALK_COUNT
+    _PRECONSTRUCTION_WALK_COUNT += 1
     call_rows = _call_contract_demand_rows(root)
     calls_by_site = {
         json.dumps(row["useSite"], sort_keys=True): row

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
@@ -1,0 +1,258 @@
+"""Prebuilt provisional demand table: derive once per content, load in shards.
+
+Law: ``provisional_contract_refs_from_demands`` walks every enrolled ``*.py``
+(O(corpus)). Process memo (#7087) amortizes within one process; k=8 still
+pays the walk eight times because each shard is a cold process and the cost
+is invisible to LPT (per-process startup, not per-file).
+
+Shape:
+  - plan / first process DERIVES the table once and content-addresses it
+  - every shard LOADS the artifact and installs it into the process memo
+  - D2 ``sugar.enumerate level=functions`` then never re-derives
+
+Corpus pin binding (blonde law): the artifact carries the corpus pin identity
+it was built against. Load refuses a pin mismatch — a table for the wrong
+pandas is not a table.
+
+Walk counting is the unit-test instrument: a cold process given a prebuilt
+table must perform ZERO corpus walks (count them; do not time them).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from sugar_lift_python_source.canonical import cid_of_json
+
+SCHEMA = "python-provisional-demand-table/v1"
+
+
+class DemandTablePinMismatch(ValueError):
+    """Table was built for a different corpus pin than the one required."""
+
+
+class DemandTableArtifactRefusal(ValueError):
+    """Artifact is missing, malformed, or its contentCid does not recompute."""
+
+
+@dataclass(frozen=True)
+class CorpusPinIdentityV1:
+    """Minimal corpus pin fields the demand table authenticates against."""
+
+    distribution: str
+    version: str
+    file_count: int
+    aggregate_hash: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "distribution": self.distribution,
+            "version": self.version,
+            "fileCount": self.file_count,
+        }
+        if self.aggregate_hash is not None:
+            body["aggregateHash"] = self.aggregate_hash
+        return body
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> "CorpusPinIdentityV1":
+        # Accept fileCount or file_count; aggregateHash optional.
+        file_count = raw.get("fileCount", raw.get("file_count"))
+        distribution = raw.get("distribution")
+        version = raw.get("version")
+        if distribution is None or version is None or file_count is None:
+            raise DemandTableArtifactRefusal(
+                f"corpus pin identity missing required fields "
+                f"(need distribution, version, fileCount); got keys={sorted(raw)}"
+            )
+        agg = raw.get("aggregateHash", raw.get("aggregate_hash"))
+        return cls(
+            distribution=str(distribution),
+            version=str(version),
+            file_count=int(file_count),
+            aggregate_hash=str(agg) if agg is not None else None,
+        )
+
+    def matches(self, other: "CorpusPinIdentityV1") -> bool:
+        if (
+            self.distribution != other.distribution
+            or self.version != other.version
+            or self.file_count != other.file_count
+        ):
+            return False
+        # If either side carries aggregateHash, both must agree when both present.
+        if (
+            self.aggregate_hash is not None
+            and other.aggregate_hash is not None
+            and self.aggregate_hash != other.aggregate_hash
+        ):
+            return False
+        return True
+
+
+@dataclass(frozen=True)
+class PrebuiltDemandTableV1:
+    """Content-addressed provisional demand table for shard load."""
+
+    content_cid: str
+    corpus_pin: CorpusPinIdentityV1
+    rows: tuple[dict[str, Any], ...]
+    schema: str = SCHEMA
+
+    def preimage(self) -> dict[str, Any]:
+        """Bytes that content_cid addresses (no contentCid field)."""
+        return {
+            "schema": self.schema,
+            "corpusPin": self.corpus_pin.as_dict(),
+            "rows": list(self.rows),
+        }
+
+    def to_json_dict(self) -> dict[str, Any]:
+        body = self.preimage()
+        body["contentCid"] = self.content_cid
+        return body
+
+
+def content_cid_for_preimage(preimage: Mapping[str, Any]) -> str:
+    return cid_of_json(dict(preimage))
+
+
+def mint_prebuilt_demand_table(
+    root: Path,
+    *,
+    corpus_pin: Mapping[str, Any] | CorpusPinIdentityV1,
+) -> PrebuiltDemandTableV1:
+    """Derive the provisional demand table once and content-address it.
+
+    This is the only door that is allowed to walk the corpus for the table.
+    """
+    from sugar_lift_py_tests.lift_rpc import _preconstruction_demand_rows
+
+    pin = (
+        corpus_pin
+        if isinstance(corpus_pin, CorpusPinIdentityV1)
+        else CorpusPinIdentityV1.from_mapping(corpus_pin)
+    )
+    rows = tuple(_preconstruction_demand_rows(Path(root)))
+    preimage = {
+        "schema": SCHEMA,
+        "corpusPin": pin.as_dict(),
+        "rows": list(rows),
+    }
+    return PrebuiltDemandTableV1(
+        content_cid=content_cid_for_preimage(preimage),
+        corpus_pin=pin,
+        rows=rows,
+    )
+
+
+def write_prebuilt_demand_table(table: PrebuiltDemandTableV1, path: Path) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(table.to_json_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def load_prebuilt_demand_table(
+    path: Path,
+    *,
+    expected_corpus_pin: Mapping[str, Any] | CorpusPinIdentityV1,
+    expected_content_cid: str | None = None,
+) -> PrebuiltDemandTableV1:
+    """Load and authenticate a prebuilt table.
+
+    Refuses:
+      - missing / malformed artifact
+      - contentCid that does not recompute from preimage
+      - corpus pin mismatch (wrong pandas / fileCount / aggregate)
+      - expected_content_cid mismatch when the plan pin requires a specific CID
+    """
+    path = Path(path)
+    if not path.is_file():
+        raise DemandTableArtifactRefusal(
+            f"prebuilt demand table missing path={path} "
+            f"replacement=mint at plan time and pass the path to every shard"
+        )
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DemandTableArtifactRefusal(
+            f"prebuilt demand table unreadable path={path} detail={exc}"
+        ) from exc
+    if not isinstance(raw, dict):
+        raise DemandTableArtifactRefusal("prebuilt demand table root must be an object")
+    if raw.get("schema") != SCHEMA:
+        raise DemandTableArtifactRefusal(
+            f"prebuilt demand table schema mismatch got={raw.get('schema')!r} "
+            f"want={SCHEMA!r}"
+        )
+    if not isinstance(raw.get("rows"), list):
+        raise DemandTableArtifactRefusal("prebuilt demand table carries no rows list")
+    pin = CorpusPinIdentityV1.from_mapping(raw.get("corpusPin") or {})
+    expected = (
+        expected_corpus_pin
+        if isinstance(expected_corpus_pin, CorpusPinIdentityV1)
+        else CorpusPinIdentityV1.from_mapping(expected_corpus_pin)
+    )
+    if not pin.matches(expected):
+        raise DemandTablePinMismatch(
+            f"prebuilt demand table corpus pin mismatch: "
+            f"table={pin.as_dict()!r} expected={expected.as_dict()!r} "
+            f"replacement=rebuild the table against the authenticated pin "
+            f"(blonde law: wrong corpus is not a measurement)"
+        )
+    preimage = {
+        "schema": SCHEMA,
+        "corpusPin": pin.as_dict(),
+        "rows": list(raw["rows"]),
+    }
+    recomputed = content_cid_for_preimage(preimage)
+    presented = raw.get("contentCid")
+    if presented != recomputed:
+        raise DemandTableArtifactRefusal(
+            f"prebuilt demand table contentCid mismatch: "
+            f"presented={presented!r} recomputed={recomputed!r}"
+        )
+    if expected_content_cid is not None and presented != expected_content_cid:
+        raise DemandTableArtifactRefusal(
+            f"prebuilt demand table contentCid != plan demandTableCid: "
+            f"artifact={presented!r} plan={expected_content_cid!r}"
+        )
+    return PrebuiltDemandTableV1(
+        content_cid=str(presented),
+        corpus_pin=pin,
+        rows=tuple(raw["rows"]),
+    )
+
+
+def refs_from_prebuilt_table(table: PrebuiltDemandTableV1):
+    """Project authenticated rows into construction refs (no corpus walk)."""
+    from sugar_lift_py_tests.lift_rpc import provisional_contract_refs_from_demand_rows
+
+    return provisional_contract_refs_from_demand_rows(
+        list(table.rows),
+        table_cid=table.content_cid,
+        catalog_cid=table.content_cid,
+    )
+
+
+def install_prebuilt_demand_table(
+    table: PrebuiltDemandTableV1,
+    *,
+    root: Path,
+):
+    """Install table into the process memo so D2 never re-derives.
+
+    Zero corpus walks. Returns the installed ResolvedContractRefsV1.
+    """
+    from sugar_lift_py_tests.lift_rpc import install_provisional_contract_refs
+
+    refs = refs_from_prebuilt_table(table)
+    install_provisional_contract_refs(Path(root), refs)
+    return refs

--- a/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
@@ -1,0 +1,166 @@
+"""Prebuilt provisional demand table: zero walks + corpus pin refuse.
+
+Counting walks is a unit test, not a measurement. No stopwatch.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests import lift_rpc as lr
+from sugar_lift_py_tests.prebuilt_demand_table import (
+    DemandTableArtifactRefusal,
+    DemandTablePinMismatch,
+    install_prebuilt_demand_table,
+    load_prebuilt_demand_table,
+    mint_prebuilt_demand_table,
+    write_prebuilt_demand_table,
+)
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+_PIN = {
+    "distribution": "tiny-corpus",
+    "version": "0.0.1",
+    "fileCount": 2,
+    "aggregateHash": "sha256:" + ("ab" * 32),
+}
+
+
+def _tiny_corpus(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "a.py").write_text("x = 1\n", encoding="utf-8")
+    (root / "b.py").write_text(
+        "from contextlib import contextmanager\n"
+        "@contextmanager\n"
+        "def cm():\n"
+        "    yield\n"
+        "def f():\n"
+        "    with cm():\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_mint_content_cid_stable_for_same_rows(tmp_path: Path) -> None:
+    corpus = _tiny_corpus(tmp_path / "c1")
+    lr.clear_provisional_contract_refs_memo()
+    lr.reset_preconstruction_walk_count()
+    first = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    lr.clear_provisional_contract_refs_memo()
+    second = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    assert first.content_cid == second.content_cid
+    assert first.content_cid.startswith("blake3-512:")
+    assert lr.preconstruction_walk_count() == 2  # two mints = two walks
+
+
+def test_cold_process_with_prebuilt_table_performs_zero_corpus_walks(
+    tmp_path: Path,
+) -> None:
+    """THE tooth: load + install + measure must not re-walk the corpus."""
+    corpus = _tiny_corpus(tmp_path / "c")
+    artifact = tmp_path / "table.json"
+    lr.clear_provisional_contract_refs_memo()
+    lr.reset_preconstruction_walk_count()
+    table = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    write_prebuilt_demand_table(table, artifact)
+    walks_at_mint = lr.preconstruction_walk_count()
+    assert walks_at_mint == 1
+
+    # Cold process simulation: clear memo + walk counter (new process).
+    lr.clear_provisional_contract_refs_memo()
+    lr.reset_preconstruction_walk_count()
+    assert lr.preconstruction_walk_count() == 0
+
+    loaded = load_prebuilt_demand_table(artifact, expected_corpus_pin=_PIN)
+    assert loaded.content_cid == table.content_cid
+    refs = install_prebuilt_demand_table(loaded, root=corpus)
+    assert lr.preconstruction_walk_count() == 0
+
+    # D2 path: provisional_contract_refs_from_demands must hit memo, no walk.
+    got = lr.provisional_contract_refs_from_demands(corpus)
+    assert got is refs
+    assert lr.preconstruction_walk_count() == 0
+
+    # measure_file_via_enumerate with contract_refs also zero walks.
+    from recensus_enumerate_consumer import measure_file_via_enumerate
+
+    row = measure_file_via_enumerate(
+        workspace_root=corpus,
+        file_rel="b.py",
+        contract_refs=refs,
+    )
+    assert isinstance(row, dict)
+    assert "category" in row
+    assert lr.preconstruction_walk_count() == 0, (
+        f"cold process with prebuilt table walked the corpus "
+        f"{lr.preconstruction_walk_count()} times; want 0"
+    )
+
+
+def test_load_refuses_corpus_pin_mismatch(tmp_path: Path) -> None:
+    """Blonde law: table for the wrong pandas is not a table."""
+    corpus = _tiny_corpus(tmp_path / "c")
+    artifact = tmp_path / "table.json"
+    lr.clear_provisional_contract_refs_memo()
+    table = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    write_prebuilt_demand_table(table, artifact)
+
+    wrong = {
+        "distribution": "pandas",
+        "version": "2.3.3",
+        "fileCount": 1415,
+        "aggregateHash": "sha256:" + ("cd" * 32),
+    }
+    with pytest.raises(DemandTablePinMismatch, match="corpus pin mismatch"):
+        load_prebuilt_demand_table(artifact, expected_corpus_pin=wrong)
+
+
+def test_load_refuses_tampered_content_cid(tmp_path: Path) -> None:
+    corpus = _tiny_corpus(tmp_path / "c")
+    artifact = tmp_path / "table.json"
+    lr.clear_provisional_contract_refs_memo()
+    table = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    write_prebuilt_demand_table(table, artifact)
+    raw = artifact.read_text(encoding="utf-8")
+    # Flip one hex nibble in the presented contentCid.
+    bad = raw.replace(table.content_cid[-4:], "ffff", 1)
+    artifact.write_text(bad, encoding="utf-8")
+    with pytest.raises(DemandTableArtifactRefusal, match="contentCid mismatch"):
+        load_prebuilt_demand_table(artifact, expected_corpus_pin=_PIN)
+
+
+def test_load_refuses_plan_cid_mismatch(tmp_path: Path) -> None:
+    corpus = _tiny_corpus(tmp_path / "c")
+    artifact = tmp_path / "table.json"
+    lr.clear_provisional_contract_refs_memo()
+    table = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    write_prebuilt_demand_table(table, artifact)
+    with pytest.raises(DemandTableArtifactRefusal, match="plan demandTableCid"):
+        load_prebuilt_demand_table(
+            artifact,
+            expected_corpus_pin=_PIN,
+            expected_content_cid="blake3-512:" + ("0" * 128),
+        )
+
+
+def test_install_without_walk_seeds_memo(tmp_path: Path) -> None:
+    corpus = _tiny_corpus(tmp_path / "c")
+    lr.clear_provisional_contract_refs_memo()
+    lr.reset_preconstruction_walk_count()
+    table = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    walks = lr.preconstruction_walk_count()
+    lr.clear_provisional_contract_refs_memo()
+    lr.reset_preconstruction_walk_count()
+    install_prebuilt_demand_table(table, root=corpus)
+    assert lr.preconstruction_walk_count() == 0
+    # Second call to from_demands uses memo — still zero walks.
+    lr.provisional_contract_refs_from_demands(corpus)
+    assert lr.preconstruction_walk_count() == 0
+    assert walks == 1


### PR DESCRIPTION
## Summary

`provisional_contract_refs_from_demands` walks every enrolled `*.py` (O(corpus)) on every **cold process**. #7087 memoizes file 2 onward **within one process**, so a serial walk pays once — but **k=8 pays it eight times**, and LPT cannot see it (per-process startup, not per-file cost).

### Shape (derive once per content, not once per process)
1. **Plan / first process** mints a content-addressed provisional demand table bound to the **corpus pin** (`python-provisional-demand-table/v1`).
2. **Every shard LOADS** the artifact, authenticates pin + contentCid, **installs** into the process memo.
3. **`measure_file_via_enumerate(..., contract_refs=…)`** installs before D2 so enumerate never re-derives.

### Teeth (unit tests — count walks, do not time them)
- Cold process + prebuilt table → `preconstruction_walk_count() == 0` through install + measure.
- Load **refuses** corpus pin mismatch (blonde law: wrong pandas is not a table).
- contentCid recomputes; plan `demandTableCid` mismatch refuses.

### Files
- `prebuilt_demand_table.py` — mint / write / load / install
- `lift_rpc` — walk counter, `install_provisional_contract_refs`, content-addressed row CIDs
- `recensus_enumerate_consumer.measure_file_via_enumerate` — accepts `contract_refs`
- `control_effect_recensus` — `--demand-table-path` / `--write-demand-table`, default write under out-dir, load path for shards
- `compose_control_effect_board.build_plan` — optional `demandTableCid` / `demandTablePath`

**Shell deleted:** none yet. Process memo remains; prebuilt load is the shard door that makes the cold walk avoidable. Full unrepresentability of cold re-walk would require requiring the path on every shard.

**R / Epsilon R:** operational k=8 startup cost (not a scoreboard R axis). No battleaxe measurement.

## Validation
```text
TEETH_PASS walks=0 pin_refuse=ok  (inline script over test_prebuilt_demand_table law)
PROCESS_MEMO_OK
```
No battleaxe (serialized: black seal / queue).

## For merge_dog
Hand to merge_dog. Brown D3 receipt still waits for measurement slot after black→orange→white.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add prebuilt demand table support to derive once, load in shards, and skip cold corpus walks
> - Introduces [prebuilt_demand_table.py](https://github.com/TSavo/sugar/pull/7098/files#diff-c9a8d3af76f6724a4431dab259902f9ac9cf470781760a699c29a90e6418715c) with `mint_prebuilt_demand_table`, `write_prebuilt_demand_table`, `load_prebuilt_demand_table`, and `install_prebuilt_demand_table` to create, persist, and authenticate content-addressed demand table artifacts.
> - Updates [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/7098/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) to load a prebuilt table (from plan or `--demand-table-path`) or mint one fresh, with `--write-demand-table` to persist it; refuses with exit code 78 on pin or content CID mismatch.
> - Passes `contract_refs` into `measure_file_via_enumerate` so shard processes seed the memo from the prebuilt table instead of re-walking the corpus.
> - Adds `preconstruction_walk_count` / `reset_preconstruction_walk_count` to `lift_rpc.py` and a test suite in [test_prebuilt_demand_table.py](https://github.com/TSavo/sugar/pull/7098/files#diff-d0bfca5fa44601c91de7ce0dbb42184e1b0666656cddfb459faefc7145e54460) verifying zero corpus walks when a prebuilt table is loaded.
> - Behavioral Change: `provisional_contract_refs_from_demand_rows` now computes stable content-derived CIDs instead of returning placeholders.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff7b909.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->