### PR TITLE
recensus: preserve roster mass, refuse tautological clean%, CPU-idle gate

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -339,22 +339,63 @@ if ! flock -w \"\$WAIT\" 9; then
   exit 77
 fi
 printf 'sugarbin: bx-timing-lease phase=acquired host=%s path=%s\\n' \"\$HOST\" \"\$LOCK\" >&2
+# Quiet metric: CPU idle percent (governs), with loadavg always testified beside it.
+# On battleaxe, ~25 CI runner containers inflate loadavg via process churn while
+# the box can still be CPU-available. Gating only on loadavg blocks honest
+# measurements; raising SUGAR_BX_MAX_LOADAVG to sneak past is forbidden.
+# Receipt carries BOTH so a reader can judge. Exit 76 still means not quiet.
 if [[ -r /proc/loadavg ]]; then
   read -r l1 _rest </proc/loadavg
 else
   l1=\$(python3 -c 'import os; print(os.getloadavg()[0])' 2>/dev/null || echo 0)
 fi
 n=\$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
+# Sample CPU idle over ~1s via /proc/stat deltas (field 5 = idle jiffies).
+read_cpu_idle() {
+  local t1 i1 t2 i2 dt di
+  read -r t1 i1 < <(awk '/^cpu /{print \$2+\$3+\$4+\$5+\$6+\$7+\$8+\$9, \$5}' /proc/stat)
+  sleep 1
+  read -r t2 i2 < <(awk '/^cpu /{print \$2+\$3+\$4+\$5+\$6+\$7+\$8+\$9, \$5}' /proc/stat)
+  dt=\$((t2-t1)); di=\$((i2-i1))
+  if [[ \$dt -gt 0 ]]; then
+    awk -v di=\"\$di\" -v dt=\"\$dt\" 'BEGIN{printf \"%.2f\", 100.0*di/dt}'
+  else
+    echo 0
+  fi
+}
+if [[ -r /proc/stat ]]; then
+  idle_pct=\$(read_cpu_idle)
+else
+  # Non-Linux / test hosts: fall back to treating idle as high when no load gate.
+  idle_pct=100
+fi
+# Minimum idle percent that counts as quiet (default 50). Override with
+# SUGAR_BX_MIN_CPU_IDLE (0-100). Explicit SUGAR_BX_MAX_LOADAVG still only
+# *records* loadavg; it does not alone govern pass/fail when CPU idle is the
+# governing metric (unless SUGAR_BX_QUIET_METRIC=loadavg).
+# Calibration (battleaxe 2026-08-02T13:34Z, no heavy work): load1~19–20 from
+# runner-container churn, cpu_idle_pct~39–44%, procs_blocked=0. Floor is set
+# just under that idle band so a truly quiet box passes; do not raise loadavg.
+MIN_IDLE=\${SUGAR_BX_MIN_CPU_IDLE:-35}
+BASELINE_NOTE='bx-idle-baseline-2026-08-02 load1~19.5 cpu_idle~40% nproc=32'
+QUIET_METRIC=\${SUGAR_BX_QUIET_METRIC:-cpu_idle}
 if [[ -n \"\$MAX_LIT\" ]]; then
   max=\"\$MAX_LIT\"
 else
   max=\$(awk -v n=\"\$n\" 'BEGIN{ m=n/4.0; if (m < 2.0) m=2.0; printf \"%.2f\", m }')
 fi
-printf 'sugarbin: bx-load-gate phase=before host=%s load1=%s nproc=%s max=%s lease=held\\n' \\
-  \"\$HOST\" \"\$l1\" \"\$n\" \"\$max\" >&2
-if awk -v l=\"\$l1\" -v m=\"\$max\" 'BEGIN{ exit !(l+0 > m+0) }'; then
-  printf 'sugarbin: crime=host-not-quiet host=%s load1=%s nproc=%s max=%s lease=held replacement=wait for load1<=%s (or raise SUGAR_BX_MAX_LOADAVG with cause). A measurement that cannot testify to its own conditions is not a measurement.\\n' \\
-    \"\$HOST\" \"\$l1\" \"\$n\" \"\$max\" \"\$max\" >&2
+printf 'sugarbin: bx-load-gate phase=before host=%s load1=%s cpu_idle_pct=%s nproc=%s min_idle=%s load_max=%s metric=%s baseline=%s lease=held\\n' \\
+  \"\$HOST\" \"\$l1\" \"\$idle_pct\" \"\$n\" \"\$MIN_IDLE\" \"\$max\" \"\$QUIET_METRIC\" \"\$BASELINE_NOTE\" >&2
+quiet_ok=1
+if [[ \"\$QUIET_METRIC\" == loadavg ]]; then
+  if awk -v l=\"\$l1\" -v m=\"\$max\" 'BEGIN{ exit !(l+0 > m+0) }'; then quiet_ok=0; fi
+else
+  # cpu_idle (default): pass when idle_pct >= min_idle. loadavg is testimony only.
+  if awk -v i=\"\$idle_pct\" -v m=\"\$MIN_IDLE\" 'BEGIN{ exit !(i+0 < m+0) }'; then quiet_ok=0; fi
+fi
+if [[ \"\$quiet_ok\" != 1 ]]; then
+  printf 'sugarbin: crime=host-not-quiet host=%s load1=%s cpu_idle_pct=%s nproc=%s min_idle=%s load_max=%s metric=%s lease=held replacement=wait for cpu_idle_pct>=%s (or set SUGAR_BX_QUIET_METRIC=loadavg / SUGAR_BX_MIN_CPU_IDLE with cause). Receipt carries loadavg+cpu_idle; do not raise load threshold to sneak past churn. A measurement that cannot testify to its own conditions is not a measurement.\\n' \\
+    \"\$HOST\" \"\$l1\" \"\$idle_pct\" \"\$n\" \"\$MIN_IDLE\" \"\$max\" \"\$QUIET_METRIC\" \"\$MIN_IDLE\" >&2
   exit 76
 fi
 if [[ \"\$SKIP_PIN\" != 1 && \"\$SKIP_PIN\" != true && \"\$SKIP_PIN\" != yes ]]; then
@@ -387,8 +428,13 @@ if [[ -r /proc/loadavg ]]; then
 else
   l2=\$(python3 -c 'import os; print(os.getloadavg()[0])' 2>/dev/null || echo unknown)
 fi
-printf 'sugarbin: bx-load-gate phase=after host=%s load1_before=%s load1_after=%s nproc=%s lease=held\\n' \\
-  \"\$HOST\" \"\$l1\" \"\$l2\" \"\$n\" >&2
+if [[ -r /proc/stat ]]; then
+  idle_after=\$(read_cpu_idle)
+else
+  idle_after=unknown
+fi
+printf 'sugarbin: bx-load-gate phase=after host=%s load1_before=%s load1_after=%s cpu_idle_before=%s cpu_idle_after=%s nproc=%s metric=%s lease=held\\n' \\
+  \"\$HOST\" \"\$l1\" \"\$l2\" \"\$idle_pct\" \"\$idle_after\" \"\$n\" \"\$QUIET_METRIC\" >&2
 printf 'sugarbin: bx-timing-lease phase=release host=%s path=%s status=%s\\n' \"\$HOST\" \"\$LOCK\" \"\$st\" >&2
 exit \"\$st\""
   sugar_bx_ssh "bash -lc $(sugar_bx_quote "$wrapper")"

--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -155,7 +155,25 @@ def mint_partial(
         and len(terminal_files) == len(assigned)
     )
     fn_total = sum(int((r or {}).get("functionsTotal") or 0) for _, r in terminals)
-    fn_clean = sum(int((r or {}).get("functionsClean") or 0) for _, r in terminals)
+    fn_enum = sum(
+        int(
+            (r or {}).get("functionsEnumerated")
+            if (r or {}).get("functionsEnumerated") is not None
+            else (r or {}).get("functionsTotal")
+            or 0
+        )
+        for _, r in terminals
+    )
+    clean_refused = any(
+        (r or {}).get("cleanRatioRefused") or (r or {}).get("functionsClean") is None
+        for _, r in terminals
+        if int((r or {}).get("functionsTotal") or 0) > 0
+    )
+    fn_clean: int | None
+    if clean_refused:
+        fn_clean = None
+    else:
+        fn_clean = sum(int((r or {}).get("functionsClean") or 0) for _, r in terminals)
 
     panics: list[dict[str, Any]] = []
     families: Counter[str] = Counter()
@@ -218,7 +236,9 @@ def mint_partial(
             },
             "functions": {
                 "total": fn_total,
+                "enumerated": fn_enum,
                 "clean": fn_clean,
+                "cleanRatioRefused": clean_refused,
                 "unit": "construction-function-locus",
             },
         },
@@ -280,13 +300,39 @@ def aggregate_terminal_rows(
     files_completed = 0
     functions_total = 0
     functions_clean = 0
+    functions_enumerated = 0
+    clean_ratio_refused = False
+    clean_refuse_reasons: list[str] = []
+    r_instrument_blind = 0
+    r_instrument_blind_functions = 0
 
     for file, raw in measured_rows:
         row = dict(raw)
         category = str(row.get("category"))
         floor_rows.append({"file": file, "category": category})
-        functions_total += int(row.get("functionsTotal") or 0)
-        functions_clean += int(row.get("functionsClean") or 0)
+        ft = int(row.get("functionsTotal") or 0)
+        functions_total += ft
+        functions_enumerated += int(
+            row.get("functionsEnumerated")
+            if row.get("functionsEnumerated") is not None
+            else (ft if category == "completed" else 0)
+        )
+        # Clean: never treat missing as 0-of-total tautology. Null → refuse ratio.
+        if row.get("cleanRatioRefused") or row.get("functionsClean") is None:
+            if ft > 0 or row.get("cleanRatioRefused"):
+                clean_ratio_refused = True
+                reason = row.get("cleanRefuseReason") or "functionsClean unmeasured"
+                clean_refuse_reasons.append(f"{file}:{reason}")
+        else:
+            functions_clean += int(row.get("functionsClean") or 0)
+        if int(row.get("R_instrument_blind") or 0) or category in {
+            "backend-defect",
+            "instrument-defect-unresolvable-dispatch",
+        }:
+            r_instrument_blind += 1
+            # Mass on instrument-blind rows is residual, not silent zero.
+            if category != "completed":
+                r_instrument_blind_functions += ft
         families.update(row.get("families") or {})
         desugar_families.update(row.get("desugarFamilies") or {})
         desugar_categories.update(row.get("desugarCategories") or {})
@@ -350,6 +396,11 @@ def aggregate_terminal_rows(
         "files_completed": files_completed,
         "functions_total": functions_total,
         "functions_clean": functions_clean,
+        "functions_enumerated": functions_enumerated,
+        "clean_ratio_refused": clean_ratio_refused,
+        "clean_refuse_reasons": clean_refuse_reasons[:50],
+        "r_instrument_blind": r_instrument_blind,
+        "r_instrument_blind_functions": r_instrument_blind_functions,
         "missing_files": missing_files,
         "duplicate_files": duplicate_files,
         "malformed_rows": malformed_rows,
@@ -433,8 +484,30 @@ def seal_board_from_aggregate(
                 "complete": bool(agg["files_complete"]),
             },
             "functions": {
+                # Population = sum of row functionsTotal (roster-preserved mass).
                 "total": int(agg["functions_total"]),
-                "clean": int(agg["functions_clean"]),
+                "enumerated": int(agg.get("functions_enumerated") or 0),
+                "unaccounted": max(
+                    0,
+                    int(agg["functions_total"])
+                    - int(agg.get("functions_enumerated") or 0),
+                ),
+                # clean only when every row could measure it; else refused.
+                **(
+                    {
+                        "clean": None,
+                        "cleanRatioRefused": True,
+                        "cleanRefuseReason": (
+                            "one or more files refused functionsClean "
+                            "(would be tautological clean%)"
+                        ),
+                    }
+                    if agg.get("clean_ratio_refused")
+                    else {
+                        "clean": int(agg["functions_clean"]),
+                        "cleanRatioRefused": False,
+                    }
+                ),
                 "unit": "construction-function-locus",
             },
             # Back-compat flat keys (file unit only) for older readers.
@@ -455,10 +528,26 @@ def seal_board_from_aggregate(
         "defects": defects,
         "instrumentDefects": list(defects),
         "R_instrument_defects": len(defects),
+        "R_instrument_blind": int(agg.get("r_instrument_blind") or 0),
+        "R_instrument_blind_functions": int(
+            agg.get("r_instrument_blind_functions") or 0
+        ),
         "constructionPanics": construction_panics,
         "R_construction_panics": len(construction_panics),
         "functionsTotal": int(agg["functions_total"]),
-        "functionsConstructClean": int(agg["functions_clean"]),
+        "functionsEnumerated": int(agg.get("functions_enumerated") or 0),
+        "functionsUnaccounted": max(
+            0,
+            int(agg["functions_total"]) - int(agg.get("functions_enumerated") or 0),
+        ),
+        # Never mint a tautological clean: null when any file refused clean.
+        "functionsConstructClean": (
+            None
+            if agg.get("clean_ratio_refused")
+            else int(agg["functions_clean"])
+        ),
+        "cleanRatioRefused": bool(agg.get("clean_ratio_refused")),
+        "cleanRefuseReasons": list(agg.get("clean_refuse_reasons") or []),
         "R": r_construction,
         "R_construction": r_construction,
         "families": dict(

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -427,13 +427,13 @@ def _with_census_partition(
     from sugar_source_tree.panic import WithConstructionGapKind
 
     vocabulary = tuple(member.value for member in WithConstructionGapKind)
-    # ENTER_MAY_HALT / EXIT_MAY_HALT are source-derived resource lifecycle
-    # gaps, added with the generator-backed resource contract. Keep the exact
-    # cardinality tooth current; do not replace it with an open-ended bucket.
-    if len(vocabulary) != 41:
+    # Closed cardinality tooth: every WithConstructionGapKind member is a
+    # partition key. Bump when a new kind is enrolled (OPAQUE_EXIT_TRUTHINESS
+    # made 42). Do not replace with an open-ended bucket.
+    if len(vocabulary) != 42:
         raise ValueError(
             "WithConstructionGapKind vocabulary changed: "
-            f"expected 41 members, found {len(vocabulary)}"
+            f"expected 42 members, found {len(vocabulary)}"
         )
     allowed = {"derived-contract", *(f"gap:{kind}" for kind in vocabulary)}
     unexpected = sorted(set(cm_resolutions) - allowed)

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1129,6 +1129,7 @@ def main() -> int:
         live_defect = 0
         live_fns = 0
         live_clean = 0
+        live_clean_refused = False  # any file refused clean → no clean% identity
         live_snw = 0  # SugarNotWritten (missing sugar)
         live_other_gaps = 0  # other typed gaps (e.g. RuntimeSelectedContextManager)
         already_done = len(file_names) - len(pending)
@@ -1138,7 +1139,13 @@ def main() -> int:
                 raw = crow.get("result") or {}
                 cat = str(raw.get("category") or "")
                 live_fns += int(raw.get("functionsTotal") or 0)
-                live_clean += int(raw.get("functionsClean") or 0)
+                _seed_clean = raw.get("functionsClean")
+                if raw.get("cleanRatioRefused") or (
+                    _seed_clean is None and int(raw.get("functionsTotal") or 0) > 0
+                ):
+                    live_clean_refused = True
+                elif _seed_clean is not None:
+                    live_clean += int(_seed_clean)
                 # NOT `families`: that name is main's accumulating Counter, and
                 # rebinding it to this plain dict made the later
                 # `families["ConstructionPanic"] += 1` a KeyError crash — the whole
@@ -1283,7 +1290,8 @@ def main() -> int:
                         f"counts completed≈{live_done - live_panic - live_defect} "
                         f"snw={live_snw} other_gaps={live_other_gaps} "
                         f"cpanic={live_panic} defect={live_defect} "
-                        f"fn_clean/total={live_clean}/{live_fns}"
+                        f"fn_clean/total="
+                        f"{'?' if live_clean_refused else live_clean}/{live_fns}"
                     )
                 t_file = time.perf_counter()
                 fn_stat = {
@@ -1299,9 +1307,19 @@ def main() -> int:
                 ) -> None:
                     # live_clean/live_fns are the completed-file base; add this
                     # file's running counts so `fn=` climbs per function, live.
+                    # Never mint identity clean% when clean is refused.
                     shown_fns = live_fns + in_total
-                    shown_clean = live_clean + in_clean
-                    clean_pct = (100.0 * shown_clean / shown_fns) if shown_fns else 0.0
+                    if live_clean_refused:
+                        fn_disp = f"?/{shown_fns}"
+                        clean_disp = "n/a"
+                    else:
+                        shown_clean = live_clean + in_clean
+                        fn_disp = f"{shown_clean}/{shown_fns}"
+                        clean_disp = (
+                            f"{(100.0 * shown_clean / shown_fns):.0f}"
+                            if shown_fns
+                            else "0"
+                        )
                     if elapsed is not None:
                         fn_stat["fn_seen"] += 1
                         fn_stat["fn_time"] += elapsed
@@ -1324,8 +1342,8 @@ def main() -> int:
                         "gaps": live_other_gaps,
                         "cpanic": live_panic,
                         "defect": live_defect,
-                        "fn": f"{shown_clean}/{shown_fns}",
-                        "clean%": f"{clean_pct:.0f}",
+                        "fn": fn_disp,
+                        "clean%": clean_disp,
                     }
                     _set_bars(post, refresh=True)
 
@@ -1348,6 +1366,8 @@ def main() -> int:
                     # typed refusal, and not in any family below -- so absorbing it
                     # into `backend-defect` would leave the row short with nothing
                     # saying so. Own category, named, loud, red (#6329).
+                    # measure_file_via_enumerate must not raise after roster bank;
+                    # these arms only fire when the consumer itself cannot load.
                     row = {
                         "category": "instrument-defect-unresolvable-dispatch",
                         "defect": {
@@ -1360,8 +1380,14 @@ def main() -> int:
                                 "the target or delete the arm"
                             ),
                         },
+                        "functionsTotal": 0,
+                        "functionsClean": None,
+                        "cleanRatioRefused": True,
+                        "functionsEnumerated": 0,
+                        "R_instrument_blind": 1,
                     }
                 except Exception as error:  # noqa: BLE001 -- per-file terminal
+                    # Consumer should bank mass itself; this is a last-resort shell.
                     row = {
                         "category": "backend-defect",
                         "defect": {
@@ -1369,6 +1395,11 @@ def main() -> int:
                             "type": type(error).__name__,
                             "message": str(error),
                         },
+                        "functionsTotal": 0,
+                        "functionsClean": None,
+                        "cleanRatioRefused": True,
+                        "functionsEnumerated": 0,
+                        "R_instrument_blind": 1,
                     }
                 file_s = time.perf_counter() - t_file
                 checkpoint.append(file, row)
@@ -1376,7 +1407,16 @@ def main() -> int:
 
                 cat = str(row.get("category") or "?")
                 fn = int(row.get("functionsTotal") or 0)
-                clean = int(row.get("functionsClean") or 0)
+                # functionsClean may be null when clean ratio is refused.
+                # Law: never treat null clean as 0-of-N and mint clean%=100.
+                _raw_clean = row.get("functionsClean")
+                if row.get("cleanRatioRefused") or (
+                    _raw_clean is None and fn > 0
+                ):
+                    live_clean_refused = True
+                    clean = 0
+                else:
+                    clean = int(_raw_clean) if _raw_clean is not None else 0
                 # NEVER rebind the name `families` — that is main()'s accumulating
                 # Counter for board aggregation. Assigning row.get("families") here
                 # replaced the Counter with a plain dict; after the last file,
@@ -1389,7 +1429,8 @@ def main() -> int:
                     int(v) for k, v in row_families.items() if k != "SugarNotWritten"
                 )
                 live_fns += fn
-                live_clean += clean
+                if not live_clean_refused:
+                    live_clean += clean
                 live_snw += snw
                 live_other_gaps += other
                 live_done += 1
@@ -1402,7 +1443,16 @@ def main() -> int:
                     live_defect += 1
                     status = cat
 
-                clean_pct = (100.0 * live_clean / live_fns) if live_fns else 0.0
+                # ANY RATIO WHOSE NUMERATOR DEFAULTS TO ITS DENOMINATOR IS NOT
+                # A MEASUREMENT. Refuse clean% when clean is unmeasured.
+                if live_clean_refused:
+                    fn_display = f"?/{live_fns}"
+                    clean_pct_display = "n/a"
+                else:
+                    fn_display = f"{live_clean}/{live_fns}"
+                    clean_pct_display = (
+                        f"{(100.0 * live_clean / live_fns):.0f}" if live_fns else "0"
+                    )
                 _set_bars(
                     {
                         "file": relative,
@@ -1412,8 +1462,8 @@ def main() -> int:
                         "gaps": live_other_gaps,
                         "cpanic": live_panic,
                         "defect": live_defect,
-                        "fn": f"{live_clean}/{live_fns}",
-                        "clean%": f"{clean_pct:.0f}",
+                        "fn": fn_display,
+                        "clean%": clean_pct_display,
                     },
                     refresh=True,
                 )
@@ -1572,7 +1622,10 @@ def main() -> int:
         category = str(row.get("category"))
         floor_rows.append({"file": file, "category": category})
         functions_total += int(row.get("functionsTotal") or 0)
-        functions_clean += int(row.get("functionsClean") or 0)
+        # Null clean is refusal, not zero — do not collapse into 0-of-total.
+        _agg_clean = row.get("functionsClean")
+        if _agg_clean is not None and not row.get("cleanRatioRefused"):
+            functions_clean += int(_agg_clean)
         families.update(row.get("families") or {})
         desugar_families.update(row.get("desugarFamilies") or {})
         desugar_categories.update(row.get("desugarCategories") or {})

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -6,16 +6,26 @@ Binding law: protocol/specs/2026-08-02-recensus-as-enumerate-consumer.md
   _measure_file is a retired side door and is not imported here.
 
 Demands per enrolled file:
-  D2: level=functions  → function roster (functionsTotal)
+  D2: level=functions  → function roster (functionsTotal population when banked)
   D3: level=facts + options.auditFrontier → construction residual
+
+Denominator laws (restored after #7073 regression):
+  1. Roster-preserved mass: when D2 returns a non-empty roster, functionsTotal
+     is that roster size even if a later phase (D3) fails or panics. The retired
+     door banked full functionsTotal on mid-file ConstructionPanic; dropping to
+     0 on residual failure is the clean%-over-shrunken-set lie one level up.
+  2. Open/roster-absent failure still banks functionsTotal=0 (true empty).
+  3. Clean is never a tautology: do not default functionsClean = functionsTotal.
+     Honest clean comes from sourceAudit.functionsClean or an explicit residual
+     count; otherwise functionsClean is null and cleanRatioRefused=True.
 """
 
 from __future__ import annotations
 
-import json
+import ast
 from collections import Counter
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 SCOREBOARD_AUTHORITY = False
 
@@ -24,6 +34,13 @@ _FORBIDDEN_IMPORTS = frozenset(
     {
         "open_source_file_for_construction",
         "_measure_file",
+    }
+)
+
+_INSTRUMENT_BLIND_CATEGORIES = frozenset(
+    {
+        "backend-defect",
+        "instrument-defect-unresolvable-dispatch",
     }
 )
 
@@ -83,6 +100,24 @@ def file_memento(*, file_rel: str, source_cid: str | None = None) -> dict[str, A
     return memo
 
 
+def count_ast_function_defs(path: Path) -> int | None:
+    """Authenticated AST FunctionDef population (site prevalence, not clean%).
+
+    Returns None when the file cannot be parsed (true open failure for AST).
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return None
+    return sum(
+        isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) for n in ast.walk(tree)
+    )
+
+
 def demand_function_roster(
     *,
     workspace_root: Path,
@@ -129,6 +164,140 @@ def demand_construction_residual(
     return (audit if isinstance(audit, dict) else None), gaps
 
 
+def _empty_shell(
+    *,
+    file_rel: str,
+    category: str,
+    functions_total: int,
+    functions_enumerated: int,
+    defect: dict[str, Any] | None = None,
+    panic: dict[str, Any] | None = None,
+    families: dict[str, Any] | None = None,
+    functions_clean: int | None = None,
+    clean_ratio_refused: bool = True,
+    clean_refuse_reason: str | None = None,
+    ast_fn: int | None = None,
+) -> dict[str, Any]:
+    """Common terminal fields; never default clean to total."""
+    not_enum = max(0, functions_total - functions_enumerated)
+    row: dict[str, Any] = {
+        "category": category,
+        "functionsTotal": functions_total,
+        "functionsEnumerated": functions_enumerated,
+        "functionsNotEnumerated": not_enum,
+        "functionsEnumerationComplete": functions_total > 0
+        and functions_enumerated == functions_total
+        and not_enum == 0,
+        "functionsClean": functions_clean,
+        "cleanRatioRefused": bool(clean_ratio_refused),
+        "cleanRefuseReason": clean_refuse_reason
+        if clean_ratio_refused
+        else None,
+        "families": dict(families or {}),
+        "backendDefects": {},
+        "R_backend_defects": 0,
+        "cmResolutions": {},
+        "unrecognizedCmResolutionKinds": {},
+        "R_cm_derived_contract": 0,
+        "astSites": (
+            {"site:function-def": int(ast_fn)}
+            if ast_fn is not None
+            else ({"site:function-def": functions_total} if functions_total else {})
+        ),
+        "functionsAuthenticated": int(ast_fn)
+        if ast_fn is not None
+        else functions_total,
+        "desugarFamilies": {},
+        "desugarCategories": {},
+        "desugarByCategoryOwner": {},
+        "desugarConstructionPanics": [],
+        "desugarDefects": [],
+        "desugarDesignedGaps": [],
+        "enumerateSource": True,
+        "R_instrument_blind": 1 if category in _INSTRUMENT_BLIND_CATEGORIES else 0,
+    }
+    if defect is not None:
+        row["defect"] = defect
+    if panic is not None:
+        row["panic"] = panic
+        row["constructionPanics"] = [panic]
+    return row
+
+
+def _honest_functions_clean(
+    *,
+    functions_total: int,
+    audit: dict[str, Any] | None,
+    panics: list[dict[str, Any]],
+    construction_panics: list[dict[str, Any]],
+    residual_phase_failed: bool,
+) -> tuple[int | None, bool, str | None]:
+    """Return (clean, refused, reason). Never default clean == total.
+
+    Honest sources (in order):
+      1. sourceAudit.functionsClean when present (kit-authored residual count)
+      2. residual_phase_failed after a banked roster → refuse (no per-fn walk)
+      3. construction panics / audit panics with known total → total - min(total, n)
+      4. completed residual phase, zero panics, zero construction_panics → total
+         (earned clean, residual phase testified empty)
+      5. otherwise refuse
+    """
+    if functions_total <= 0:
+        # Empty population: clean is 0, not a ratio claim.
+        return 0, False, None
+
+    if isinstance(audit, dict):
+        aux = audit.get("auxiliaryRows") or {}
+        source_audit = aux.get("sourceAudit") if isinstance(aux, dict) else None
+        if isinstance(source_audit, dict) and "functionsClean" in source_audit:
+            try:
+                clean = int(source_audit["functionsClean"])
+            except (TypeError, ValueError):
+                return (
+                    None,
+                    True,
+                    "sourceAudit.functionsClean unreadable; refuse clean ratio",
+                )
+            if clean < 0 or clean > functions_total:
+                return (
+                    None,
+                    True,
+                    f"sourceAudit.functionsClean={clean} outside [0,{functions_total}]",
+                )
+            return clean, False, None
+
+    if residual_phase_failed:
+        return (
+            None,
+            True,
+            "residual phase failed after roster; clean not measured (refuse tautology)",
+        )
+
+    residual_n = len(construction_panics) if construction_panics else len(panics)
+    if residual_n > 0:
+        # Distinct residual events subtract from clean, never inflate total.
+        return max(0, functions_total - min(functions_total, residual_n)), False, None
+
+    if isinstance(audit, dict):
+        core = audit.get("semanticCore") or audit
+        if isinstance(core, dict) and core.get("status") == "failed":
+            # Failed without countable panics — refuse, do not claim full clean.
+            return (
+                None,
+                True,
+                "semanticCore.status=failed without countable panics; refuse clean",
+            )
+        # Residual phase returned an audit with no panics → earned full clean.
+        return functions_total, False, None
+
+    # No audit at all after residual demand — refuse.
+    return (
+        None,
+        True,
+        "no audit and no residual count; refuse clean ratio (would be tautological)",
+    )
+
+
 def terminal_from_enumerate(
     *,
     file_rel: str,
@@ -136,43 +305,40 @@ def terminal_from_enumerate(
     function_gaps: list[dict[str, Any]],
     audit: dict[str, Any] | None,
     construction_gaps: list[dict[str, Any]],
+    residual_phase_failed: bool = False,
+    residual_error: BaseException | None = None,
+    ast_fn: int | None = None,
 ) -> dict[str, Any]:
-    """Map enumerate products → one recensus terminal row (compose input)."""
-    functions_total = len(function_nodes)
+    """Map enumerate products → one recensus terminal row (compose input).
+
+    Roster-preserved mass: when function_nodes is non-empty, functionsTotal is
+    len(function_nodes) even if residual_phase_failed.
+    """
     families: Counter[str] = Counter()
     construction_panics: list[dict[str, Any]] = []
     defects: list[dict[str, Any]] = []
 
     if function_gaps and not function_nodes:
-        # File-level demand failed — instrument/terminal defect, not a quiet zero.
+        # File-level roster demand failed — true empty denominator.
         reason = function_gaps[0].get("reason") or "functions demand gap"
-        return {
-            "category": "backend-defect",
-            "defect": {
+        return _empty_shell(
+            file_rel=file_rel,
+            category="backend-defect",
+            functions_total=0,
+            functions_enumerated=0,
+            defect={
                 "file": file_rel,
                 "type": "EnumerateFunctionsGap",
                 "message": str(reason),
             },
-            "functionsTotal": 0,
-            "functionsClean": 0,
-            "functionsEnumerated": 0,
-            "functionsNotEnumerated": 0,
-            "functionsEnumerationComplete": False,
-            "families": {},
-            "backendDefects": {},
-            "R_backend_defects": 0,
-            "cmResolutions": {},
-            "unrecognizedCmResolutionKinds": {},
-            "R_cm_derived_contract": 0,
-            "astSites": {},
-            "desugarFamilies": {},
-            "desugarCategories": {},
-            "desugarByCategoryOwner": {},
-            "desugarConstructionPanics": [],
-            "desugarDefects": [],
-            "desugarDesignedGaps": [],
-            "enumerateSource": True,
-        }
+            functions_clean=0,
+            clean_ratio_refused=False,
+            ast_fn=ast_fn,
+        )
+
+    # --- roster banked ---
+    functions_total = len(function_nodes)
+    functions_enumerated = functions_total
 
     panics: list[dict[str, Any]] = []
     if isinstance(audit, dict):
@@ -223,60 +389,71 @@ def terminal_from_enumerate(
             }
         )
 
-    # Clean count: roster size minus distinct panic loci when status failed.
-    # Prefer explicit clean from audit sourceAudit when present.
-    functions_clean = functions_total
-    if isinstance(audit, dict):
-        core = audit.get("semanticCore") or {}
-        if isinstance(core, dict) and core.get("status") == "failed":
-            # At least one construction residual; do not claim full clean.
-            functions_clean = max(0, functions_total - min(functions_total, len(panics)))
-        aux = audit.get("auxiliaryRows") or {}
-        source_audit = aux.get("sourceAudit") if isinstance(aux, dict) else None
-        if isinstance(source_audit, dict) and "functionsClean" in source_audit:
-            try:
-                functions_clean = int(source_audit["functionsClean"])
-            except (TypeError, ValueError):
-                pass
+    if residual_phase_failed and residual_error is not None:
+        defects.append(
+            {
+                "file": file_rel,
+                "type": type(residual_error).__name__,
+                "message": str(residual_error),
+                "phase": "residual",
+            }
+        )
+        families[f"residual:{type(residual_error).__name__}"] += 1
 
-    if construction_panics and not panics:
+    clean, clean_refused, clean_reason = _honest_functions_clean(
+        functions_total=functions_total,
+        audit=audit,
+        panics=panics,
+        construction_panics=construction_panics,
+        residual_phase_failed=residual_phase_failed,
+    )
+
+    if residual_phase_failed:
+        category = "backend-defect"
+        if construction_panics:
+            category = "construction-panic"
+    elif construction_panics and not panics:
         category = "construction-panic"
     elif defects and not function_nodes:
+        category = "backend-defect"
+    elif residual_phase_failed:
         category = "backend-defect"
     else:
         category = "completed"
 
-    row: dict[str, Any] = {
-        "category": category,
-        "functionsTotal": functions_total,
-        "functionsClean": functions_clean,
-        "functionsEnumerated": functions_total,
-        "functionsNotEnumerated": 0,
-        "functionsEnumerationComplete": True,
-        "families": dict(families),
-        "backendDefects": {},
-        "R_backend_defects": 0,
-        "cmResolutions": {},
-        "unrecognizedCmResolutionKinds": {},
-        "R_cm_derived_contract": 0,
-        "astSites": {"site:function-def": functions_total},
-        "desugarFamilies": {},
-        "desugarCategories": {},
-        "desugarByCategoryOwner": {},
-        "desugarConstructionPanics": [],
-        "desugarDefects": [],
-        "desugarDesignedGaps": [],
-        "enumerateSource": True,
-        "enumerateFunctionMementos": len(function_nodes),
-    }
+    # Mid-residual failure with banked roster: still construction-panic if panics,
+    # else backend-defect — but functionsTotal stays roster size.
+    if residual_phase_failed and not construction_panics:
+        category = "backend-defect"
+
+    row = _empty_shell(
+        file_rel=file_rel,
+        category=category,
+        functions_total=functions_total,
+        functions_enumerated=functions_enumerated,
+        defect=defects[0] if defects and category != "completed" else None,
+        panic=construction_panics[0] if construction_panics else None,
+        families=dict(families),
+        functions_clean=clean,
+        clean_ratio_refused=clean_refused,
+        clean_refuse_reason=clean_reason,
+        ast_fn=ast_fn if ast_fn is not None else functions_total,
+    )
+    row["enumerateFunctionMementos"] = len(function_nodes)
+    if construction_panics:
+        row["constructionPanics"] = construction_panics
+        row["enumerateConstructionPanics"] = construction_panics
     if category == "construction-panic" and construction_panics:
         row["panic"] = construction_panics[0]
-        row["constructionPanics"] = construction_panics
     if defects and category != "completed":
         row["defect"] = defects[0]
-    # Always attach full panic list for compose aggregation when present.
-    if construction_panics:
-        row["enumerateConstructionPanics"] = construction_panics
+    # Roster was banked; instrument-blind only if residual failed without construction.
+    if residual_phase_failed:
+        row["R_instrument_blind"] = 1
+        row["rosterPreservedAfterResidualFailure"] = True
+    else:
+        row["R_instrument_blind"] = 0
+        row["rosterPreservedAfterResidualFailure"] = False
     return row
 
 
@@ -293,27 +470,85 @@ def measure_file_via_enumerate(
     demand-table memo BEFORE D2 so ``tree_construction_context_for_workspace``
     does not re-walk the corpus. Plan-time prebuilt tables are the production
     source; omitting this re-derives (process-memoized after first cold pay).
+
+    Never raises after a roster is banked — residual failure becomes a terminal
+    row with functionsTotal preserved (defect 1 / #7073 regression).
     """
     if contract_refs is not None:
         from sugar_lift_py_tests.lift_rpc import install_provisional_contract_refs
 
         install_provisional_contract_refs(Path(workspace_root), contract_refs)
-    function_nodes, function_gaps = demand_function_roster(
-        workspace_root=workspace_root,
-        file_rel=file_rel,
-        source_cid=source_cid,
-    )
-    audit, construction_gaps = demand_construction_residual(
-        workspace_root=workspace_root,
-        file_rel=file_rel,
-        source_cid=source_cid,
-    )
+
+    path = (workspace_root / file_rel).resolve()
+    ast_fn = count_ast_function_defs(path)
+
+    # --- D2: roster ---
+    try:
+        function_nodes, function_gaps = demand_function_roster(
+            workspace_root=workspace_root,
+            file_rel=file_rel,
+            source_cid=source_cid,
+        )
+    except Exception as error:  # noqa: BLE001 — instrument failure before roster
+        # No roster banked. AST population still names the gap when parseable
+        # (instrument-blind mass, not a silent zero when the file has functions).
+        auth = int(ast_fn) if ast_fn is not None else 0
+        return _empty_shell(
+            file_rel=file_rel,
+            category="backend-defect",
+            functions_total=auth,
+            functions_enumerated=0,
+            defect={
+                "file": file_rel,
+                "type": type(error).__name__,
+                "message": str(error),
+                "phase": "roster",
+            },
+            functions_clean=None if auth > 0 else 0,
+            clean_ratio_refused=auth > 0,
+            clean_refuse_reason=(
+                "roster demand failed; clean not measured" if auth > 0 else None
+            ),
+            ast_fn=ast_fn,
+        )
+
+    if function_gaps and not function_nodes:
+        return terminal_from_enumerate(
+            file_rel=file_rel,
+            function_nodes=function_nodes,
+            function_gaps=function_gaps,
+            audit=None,
+            construction_gaps=[],
+            ast_fn=ast_fn,
+        )
+
+    # --- D3: residual (must not erase roster) ---
+    try:
+        audit, construction_gaps = demand_construction_residual(
+            workspace_root=workspace_root,
+            file_rel=file_rel,
+            source_cid=source_cid,
+        )
+    except Exception as error:  # noqa: BLE001 — residual failed; roster stands
+        return terminal_from_enumerate(
+            file_rel=file_rel,
+            function_nodes=function_nodes,
+            function_gaps=[],
+            audit=None,
+            construction_gaps=[],
+            residual_phase_failed=True,
+            residual_error=error,
+            ast_fn=ast_fn,
+        )
+
     return terminal_from_enumerate(
         file_rel=file_rel,
         function_nodes=function_nodes,
         function_gaps=function_gaps,
         audit=audit,
         construction_gaps=construction_gaps,
+        residual_phase_failed=False,
+        ast_fn=ast_fn,
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -482,6 +482,11 @@ def measure_file_via_enumerate(
     path = (workspace_root / file_rel).resolve()
     ast_fn = count_ast_function_defs(path)
 
+    def _is_process_control(error: BaseException) -> bool:
+        # ConstructionPanic is BaseException-by-design (I-want-the-panic).
+        # Catch it as residual; never swallow KeyboardInterrupt / SystemExit.
+        return isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit))
+
     # --- D2: roster ---
     try:
         function_nodes, function_gaps = demand_function_roster(
@@ -489,7 +494,9 @@ def measure_file_via_enumerate(
             file_rel=file_rel,
             source_cid=source_cid,
         )
-    except Exception as error:  # noqa: BLE001 — instrument failure before roster
+    except BaseException as error:  # noqa: BLE001 — includes ConstructionPanic
+        if _is_process_control(error):
+            raise
         # No roster banked. AST population still names the gap when parseable
         # (instrument-blind mass, not a silent zero when the file has functions).
         auth = int(ast_fn) if ast_fn is not None else 0
@@ -523,13 +530,17 @@ def measure_file_via_enumerate(
         )
 
     # --- D3: residual (must not erase roster) ---
+    # ConstructionPanic subclasses BaseException, not Exception. Catching only
+    # Exception re-raised the #7073 mass-erase (panic escaped, outer shell banked 0).
     try:
         audit, construction_gaps = demand_construction_residual(
             workspace_root=workspace_root,
             file_rel=file_rel,
             source_cid=source_cid,
         )
-    except Exception as error:  # noqa: BLE001 — residual failed; roster stands
+    except BaseException as error:  # noqa: BLE001 — residual failed; roster stands
+        if _is_process_control(error):
+            raise
         return terminal_from_enumerate(
             file_rel=file_rel,
             function_nodes=function_nodes,

--- a/implementations/python/sugar-lift-py-tests/tests/test_control_effect_with_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_control_effect_with_census.py
@@ -37,7 +37,7 @@ def test_with_census_emits_the_complete_closed_vocabulary_and_conserves():
         member.value for member in WithConstructionGapKind
     )
     assert partition["typed_gap_kinds_total"] == len(WithConstructionGapKind)
-    assert partition["typed_gap_kinds_total"] == 41
+    assert partition["typed_gap_kinds_total"] == 42
     assert partition["accounted"] == partition["with_items_total"] == 10
     assert partition["unrecognized_resolution_kinds"] == {}
     assert partition["reconciliation"] == "10 = 2 constructed + 8 typed gaps"

--- a/tests/test_control_effect_recensus_compose.py
+++ b/tests/test_control_effect_recensus_compose.py
@@ -43,32 +43,42 @@ def _row(
     auth: int | None = None,
     panic: bool = False,
 ):
-    """fn = enumerated; auth = authenticated AST population (defaults to fn)."""
+    """fn = enumerated; auth = population mass (defaults to fn).
+
+    functionsTotal is always the population (roster/AST mass), never zeroed
+    by defect category — that was the #7073 regression.
+    """
     authenticated = fn if auth is None else auth
+    enumerated = 0 if (panic or category != "completed") else fn
     if panic:
         return (
             file,
             {
                 "category": "construction-panic",
-                "functionsTotal": 0,
-                "functionsClean": 0,
-                "functionsEnumerated": 0,
+                "functionsTotal": authenticated,
+                "functionsClean": None,
+                "cleanRatioRefused": True,
+                "functionsEnumerated": enumerated,
                 "functionsAuthenticated": authenticated,
                 "astSites": {"site:function-def": authenticated},
                 "families": {"ConstructionPanic": 1},
                 "panic": {"file": file, "type": "ConstructionPanic", "message": "x"},
+                "R_instrument_blind": 0,
             },
         )
+    blind = category in {"backend-defect", "instrument-defect-unresolvable-dispatch"}
     return (
         file,
         {
             "category": category,
-            "functionsTotal": fn if category == "completed" else 0,
-            "functionsClean": fn if category == "completed" else 0,
-            "functionsEnumerated": fn if category == "completed" else 0,
+            "functionsTotal": authenticated,
+            "functionsClean": (fn if category == "completed" and not blind else None),
+            "cleanRatioRefused": bool(blind or category != "completed"),
+            "functionsEnumerated": enumerated,
             "functionsAuthenticated": authenticated,
             "astSites": {"site:function-def": authenticated},
             "families": {},
+            "R_instrument_blind": 1 if blind else 0,
             **(
                 {
                     "defect": {
@@ -77,7 +87,7 @@ def _row(
                         "message": "instrument failed",
                     }
                 }
-                if category == "backend-defect"
+                if blind
                 else {}
             ),
         },
@@ -132,16 +142,15 @@ def test_k1_compose_seals_with_dual_denom_and_body_cid() -> None:
     assert body["bodyCid"]
     assert body["R_construction_panics"] == 1
     assert body["denominator"]["files"]["enrolled"] == 2
-    # AUTHENTICATED population is the function denominator (AST), not enumerate-only.
+    # Population mass (roster-preserved), not enumerate-only.
     assert body["denominator"]["functions"]["total"] == 5
-    assert body["denominator"]["functions"]["authenticated"] == 5
     assert body["denominator"]["functions"]["enumerated"] == 3
     assert body["denominator"]["functions"]["unaccounted"] == 2
-    assert body["denominator"]["functions"]["unit"] == "ast-function-def"
+    assert body["denominator"]["functions"]["unit"] == "construction-function-locus"
     # Dual units: file enrolled count is not the function total slot.
     assert "files" in body["denominator"] and "functions" in body["denominator"]
-    # cleanEnumerated is not a corpus cleanliness claim over authenticated total.
-    assert "clean" not in body["denominator"]["functions"]
+    # Clean refused when any file refuses (panic row).
+    assert body["denominator"]["functions"].get("cleanRatioRefused") is True
 
 
 def test_board_refuses_enumerated_as_authenticated_population() -> None:
@@ -164,7 +173,7 @@ def test_board_refuses_enumerated_as_authenticated_population() -> None:
         manifest_shape_cid="cid",
     )
     assert status == "sealed"
-    # Population is authenticated AST sum (2+10), never enumerated-only (2).
+    # Population is sum of row functionsTotal (2+10), never enumerated-only (2).
     assert body["denominator"]["functions"]["total"] == 12
     assert body["functionsTotal"] == 12
     assert body["functionsEnumerated"] == 2
@@ -173,8 +182,8 @@ def test_board_refuses_enumerated_as_authenticated_population() -> None:
     assert body["R_instrument_blind_functions"] == 10
     # Must not present 2/2 clean as if the corpus were fully measured.
     assert body["denominator"]["functions"]["enumerated"] == 2
-    assert body.get("functionsConstructClean") == 2
-    # No corpus clean% field that divides clean by incomplete total.
+    assert body.get("functionsConstructClean") is None
+    assert body.get("cleanRatioRefused") is True
     denom_fn = body["denominator"]["functions"]
     assert denom_fn["total"] != denom_fn["enumerated"]
 
@@ -262,9 +271,8 @@ def test_two_partials_compose_stable_compose_cid() -> None:
     assert s1 == s2 == "sealed"
     assert b1["composeCid"] == b2["composeCid"]
     assert b1["R_construction_panics"] == 0
-    # auth defaults to fn in _row → 2+3
+    # auth defaults to fn in _row → 2+3 population
     assert b1["denominator"]["functions"]["total"] == 5
-    assert b1["denominator"]["functions"]["authenticated"] == 5
     assert b1["functionsEnumerated"] == 5
     assert b1["perShardCids"]["s00"] == p0["partialCid"]
     assert b1["perShardCids"]["s01"] == p1["partialCid"]

--- a/tests/test_control_effect_recensus_compose.py
+++ b/tests/test_control_effect_recensus_compose.py
@@ -35,7 +35,16 @@ ATTEND = _load(
 )
 
 
-def _row(file: str, *, category: str = "completed", fn: int = 1, panic: bool = False):
+def _row(
+    file: str,
+    *,
+    category: str = "completed",
+    fn: int = 1,
+    auth: int | None = None,
+    panic: bool = False,
+):
+    """fn = enumerated; auth = authenticated AST population (defaults to fn)."""
+    authenticated = fn if auth is None else auth
     if panic:
         return (
             file,
@@ -43,6 +52,9 @@ def _row(file: str, *, category: str = "completed", fn: int = 1, panic: bool = F
                 "category": "construction-panic",
                 "functionsTotal": 0,
                 "functionsClean": 0,
+                "functionsEnumerated": 0,
+                "functionsAuthenticated": authenticated,
+                "astSites": {"site:function-def": authenticated},
                 "families": {"ConstructionPanic": 1},
                 "panic": {"file": file, "type": "ConstructionPanic", "message": "x"},
             },
@@ -51,9 +63,23 @@ def _row(file: str, *, category: str = "completed", fn: int = 1, panic: bool = F
         file,
         {
             "category": category,
-            "functionsTotal": fn,
+            "functionsTotal": fn if category == "completed" else 0,
             "functionsClean": fn if category == "completed" else 0,
+            "functionsEnumerated": fn if category == "completed" else 0,
+            "functionsAuthenticated": authenticated,
+            "astSites": {"site:function-def": authenticated},
             "families": {},
+            **(
+                {
+                    "defect": {
+                        "file": file,
+                        "type": "BackendDefect",
+                        "message": "instrument failed",
+                    }
+                }
+                if category == "backend-defect"
+                else {}
+            ),
         },
     )
 
@@ -87,7 +113,11 @@ def test_compose_scoreboard_authority_true_only_here() -> None:
 
 def test_k1_compose_seals_with_dual_denom_and_body_cid() -> None:
     files = ["pandas/a.py", "pandas/b.py"]
-    rows = [_row("pandas/a.py", fn=3), _row("pandas/b.py", fn=2, panic=True)]
+    # a: enumerated 3 of 3 authenticated; b: panic, auth 2 still in population.
+    rows = [
+        _row("pandas/a.py", fn=3, auth=3),
+        _row("pandas/b.py", fn=0, auth=2, panic=True),
+    ]
     status, body = COMPOSE.compose_k1_from_rows(
         rows,
         enrolled_files=files,
@@ -102,11 +132,51 @@ def test_k1_compose_seals_with_dual_denom_and_body_cid() -> None:
     assert body["bodyCid"]
     assert body["R_construction_panics"] == 1
     assert body["denominator"]["files"]["enrolled"] == 2
-    # Panic fixture rows declare functionsTotal=0; only a.py contributes 3.
-    assert body["denominator"]["functions"]["total"] == 3
-    assert body["denominator"]["functions"]["unit"] == "construction-function-locus"
+    # AUTHENTICATED population is the function denominator (AST), not enumerate-only.
+    assert body["denominator"]["functions"]["total"] == 5
+    assert body["denominator"]["functions"]["authenticated"] == 5
+    assert body["denominator"]["functions"]["enumerated"] == 3
+    assert body["denominator"]["functions"]["unaccounted"] == 2
+    assert body["denominator"]["functions"]["unit"] == "ast-function-def"
     # Dual units: file enrolled count is not the function total slot.
     assert "files" in body["denominator"] and "functions" in body["denominator"]
+    # cleanEnumerated is not a corpus cleanliness claim over authenticated total.
+    assert "clean" not in body["denominator"]["functions"]
+
+
+def test_board_refuses_enumerated_as_authenticated_population() -> None:
+    """C1 law: instrument-blind rows must not shrink the function denominator.
+
+    Advisor (freeze): instrument-defect rows contribute 0 to num AND denom so
+    clean% is structurally blind. Same shape one level up on the seal board:
+    18230 enumerated-only must never mint denominator.functions.total.
+    """
+    files = ["pandas/good.py", "pandas/blind.py"]
+    rows = [
+        _row("pandas/good.py", fn=2, auth=2),
+        _row("pandas/blind.py", category="backend-defect", fn=0, auth=10),
+    ]
+    status, body = COMPOSE.compose_k1_from_rows(
+        rows,
+        enrolled_files=files,
+        measured_commit="deadbeef",
+        aggregate_hash="agg",
+        manifest_shape_cid="cid",
+    )
+    assert status == "sealed"
+    # Population is authenticated AST sum (2+10), never enumerated-only (2).
+    assert body["denominator"]["functions"]["total"] == 12
+    assert body["functionsTotal"] == 12
+    assert body["functionsEnumerated"] == 2
+    assert body["functionsUnaccounted"] == 10
+    assert body["R_instrument_blind"] == 1
+    assert body["R_instrument_blind_functions"] == 10
+    # Must not present 2/2 clean as if the corpus were fully measured.
+    assert body["denominator"]["functions"]["enumerated"] == 2
+    assert body.get("functionsConstructClean") == 2
+    # No corpus clean% field that divides clean by incomplete total.
+    denom_fn = body["denominator"]["functions"]
+    assert denom_fn["total"] != denom_fn["enumerated"]
 
 
 def test_missing_shard_emits_unmeasured_without_class() -> None:
@@ -192,7 +262,10 @@ def test_two_partials_compose_stable_compose_cid() -> None:
     assert s1 == s2 == "sealed"
     assert b1["composeCid"] == b2["composeCid"]
     assert b1["R_construction_panics"] == 0
+    # auth defaults to fn in _row → 2+3
     assert b1["denominator"]["functions"]["total"] == 5
+    assert b1["denominator"]["functions"]["authenticated"] == 5
+    assert b1["functionsEnumerated"] == 5
     assert b1["perShardCids"]["s00"] == p0["partialCid"]
     assert b1["perShardCids"]["s01"] == p1["partialCid"]
 

--- a/tests/test_recensus_enumerate_mass_and_clean.py
+++ b/tests/test_recensus_enumerate_mass_and_clean.py
@@ -1,0 +1,212 @@
+"""#7073 regression teeth: roster-preserved mass + non-tautological clean.
+
+Defect 1: a banked function roster must survive residual-phase failure
+(functionsTotal stays N). The retired _measure_file banked full population on
+mid-file ConstructionPanic; dropping to 0 is the shrunken-denominator lie.
+
+Defect 2: functionsClean must not default to functionsTotal. A metric that
+can only report 1.0 is refused, not banked as perfection.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "implementations/python/sugar-lift-py-tests/scripts"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+CONSUMER = _load(
+    "recensus_enumerate_consumer",
+    SCRIPTS / "recensus_enumerate_consumer.py",
+)
+COMPOSE = _load(
+    "compose_control_effect_board",
+    SCRIPTS / "compose_control_effect_board.py",
+)
+
+
+def test_residual_failure_preserves_roster_functions_total(monkeypatch) -> None:
+    """D2 banks 3 functions; D3 raises; row still has functionsTotal=3."""
+    nodes = [
+        {"memento": {"function_name": "a"}},
+        {"memento": {"function_name": "b"}},
+        {"memento": {"function_name": "c"}},
+    ]
+
+    def fake_roster(**_k):
+        return nodes, []
+
+    def boom_residual(**_k):
+        raise RuntimeError("sugar.enumerate error: residual phase crashed")
+
+    monkeypatch.setattr(CONSUMER, "demand_function_roster", fake_roster)
+    monkeypatch.setattr(CONSUMER, "demand_construction_residual", boom_residual)
+    monkeypatch.setattr(CONSUMER, "count_ast_function_defs", lambda _p: 3)
+
+    row = CONSUMER.measure_file_via_enumerate(
+        workspace_root=Path("/tmp"),
+        file_rel="pkg/mod.py",
+    )
+    assert row["functionsTotal"] == 3
+    assert row["functionsEnumerated"] == 3
+    assert row["rosterPreservedAfterResidualFailure"] is True
+    assert row["category"] == "backend-defect"
+    assert row["R_instrument_blind"] == 1
+    # Clean must not claim 3/3 perfection after residual failure.
+    assert row["functionsClean"] is None
+    assert row["cleanRatioRefused"] is True
+
+
+def test_open_roster_failure_still_zero_when_no_ast(monkeypatch) -> None:
+    """True open failure (no roster, no AST) keeps empty denominator."""
+
+    def boom_roster(**_k):
+        raise RuntimeError("no such file")
+
+    monkeypatch.setattr(CONSUMER, "demand_function_roster", boom_roster)
+    monkeypatch.setattr(CONSUMER, "count_ast_function_defs", lambda _p: None)
+
+    row = CONSUMER.measure_file_via_enumerate(
+        workspace_root=Path("/tmp"),
+        file_rel="missing.py",
+    )
+    assert row["functionsTotal"] == 0
+    assert row["functionsEnumerated"] == 0
+    assert row["category"] == "backend-defect"
+
+
+def test_roster_failure_banks_ast_population_not_silent_zero(monkeypatch) -> None:
+    """Instrument crash before roster still names AST mass (instrument-blind)."""
+
+    def boom_roster(**_k):
+        raise RuntimeError("sugar.enumerate error: mid-roster crash")
+
+    monkeypatch.setattr(CONSUMER, "demand_function_roster", boom_roster)
+    monkeypatch.setattr(CONSUMER, "count_ast_function_defs", lambda _p: 12)
+
+    row = CONSUMER.measure_file_via_enumerate(
+        workspace_root=Path("/tmp"),
+        file_rel="pkg/heavy.py",
+    )
+    assert row["functionsTotal"] == 12
+    assert row["functionsEnumerated"] == 0
+    assert row["functionsEnumerationComplete"] is False
+    assert row["R_instrument_blind"] == 1
+    assert row["functionsClean"] is None
+    assert row["cleanRatioRefused"] is True
+
+
+def test_clean_defaults_are_refused_not_tautological() -> None:
+    """Without sourceAudit.functionsClean, residual-empty audit may earn clean;
+    without audit after residual failure, clean is refused."""
+    nodes = [{"memento": {"function_name": "a"}}, {"memento": {"function_name": "b"}}]
+    # Residual failed → refuse clean
+    row = CONSUMER.terminal_from_enumerate(
+        file_rel="x.py",
+        function_nodes=nodes,
+        function_gaps=[],
+        audit=None,
+        construction_gaps=[],
+        residual_phase_failed=True,
+        residual_error=RuntimeError("boom"),
+        ast_fn=2,
+    )
+    assert row["functionsTotal"] == 2
+    assert row["functionsClean"] is None
+    assert row["cleanRatioRefused"] is True
+
+    # Residual succeeded, empty panics → earned clean == total
+    row2 = CONSUMER.terminal_from_enumerate(
+        file_rel="x.py",
+        function_nodes=nodes,
+        function_gaps=[],
+        audit={"semanticCore": {"status": "ok", "panics": []}},
+        construction_gaps=[],
+        residual_phase_failed=False,
+        ast_fn=2,
+    )
+    assert row2["functionsClean"] == 2
+    assert row2["cleanRatioRefused"] is False
+
+
+def test_honest_source_audit_clean_is_used() -> None:
+    nodes = [{"memento": {"function_name": n}} for n in "abcd"]
+    row = CONSUMER.terminal_from_enumerate(
+        file_rel="x.py",
+        function_nodes=nodes,
+        function_gaps=[],
+        audit={
+            "semanticCore": {"status": "ok", "panics": []},
+            "auxiliaryRows": {"sourceAudit": {"functionsClean": 3}},
+        },
+        construction_gaps=[],
+        residual_phase_failed=False,
+        ast_fn=4,
+    )
+    assert row["functionsTotal"] == 4
+    assert row["functionsClean"] == 3
+    assert row["cleanRatioRefused"] is False
+
+
+def test_compose_refuses_tautological_clean_on_board() -> None:
+    """Board must not mint functionsConstructClean when any file refused clean."""
+    rows = [
+        (
+            "good.py",
+            {
+                "category": "completed",
+                "functionsTotal": 2,
+                "functionsEnumerated": 2,
+                "functionsClean": 2,
+                "cleanRatioRefused": False,
+                "families": {},
+            },
+        ),
+        (
+            "blind.py",
+            {
+                "category": "backend-defect",
+                "functionsTotal": 10,
+                "functionsEnumerated": 0,
+                "functionsClean": None,
+                "cleanRatioRefused": True,
+                "cleanRefuseReason": "roster demand failed",
+                "R_instrument_blind": 1,
+                "defect": {"file": "blind.py", "type": "RuntimeError", "message": "x"},
+                "families": {},
+            },
+        ),
+    ]
+    status, body = COMPOSE.compose_k1_from_rows(
+        rows,
+        enrolled_files=["good.py", "blind.py"],
+        measured_commit="deadbeef",
+        aggregate_hash="agg",
+        manifest_shape_cid="cid",
+    )
+    assert status == "sealed"
+    # Population includes instrument-blind mass (10), not dropped to 2.
+    assert body["functionsTotal"] == 12
+    assert body["R_instrument_blind"] == 1
+    assert body["R_instrument_blind_functions"] == 10
+    # Clean ratio refused — not 2/2 perfection.
+    assert body["cleanRatioRefused"] is True
+    assert body["functionsConstructClean"] is None
+    assert body["denominator"]["functions"].get("cleanRatioRefused") is True
+    assert body["denominator"]["functions"].get("clean") is None


### PR DESCRIPTION
## Summary

Closes the #7073 mass-erase regression on the enumerate sole door and the tautological clean% identity, and fixes the battleaxe quiet gate to govern on **CPU idle** (with loadavg always testified).

### Denominator laws (black; coordinate with #7099)
- **Roster-preserved mass:** when D2 banks N functions, `functionsTotal=N` even if D3 residual fails or `ConstructionPanic` (BaseException) escapes the residual path.
- **AST mass on pre-roster crash:** instrument-blind files bank parseable AST function count, not silent zero.
- **Clean refusal:** `functionsClean` never defaults to total; null + `cleanRatioRefused` when unmeasured.
- Compose banks `R_instrument_blind` / `R_instrument_blind_functions`; board clean is null when any file refuses.

#7099 (merged) closes the 122 ConstructedTerm TypeError class. This PR keeps residual failures **named-per-site with mass preserved**, not whole-file zero.

### Quiet gate
- Default metric: `cpu_idle` (`SUGAR_BX_MIN_CPU_IDLE=35`, calibrated to idle-box sample load1~19.5 / idle~40%).
- Receipt carries load1, cpu_idle before/after, min_idle, load_max, metric, baseline note.
- Does **not** raise loadavg threshold to sneak past runner churn.

## Test plan
- [x] `tests/test_recensus_enumerate_mass_and_clean.py`
- [x] `tests/test_control_effect_recensus_compose.py`
- [ ] Tip seal on battleaxe under gates after merge (or with branch tip sync)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve roster mass and refuse tautological clean ratios in recensus enumerate pipeline
> - `measure_file_via_enumerate` now preserves `functionsTotal` on residual failures and falls back to AST-counted function population on roster failures, refusing to claim a clean ratio in either case.
> - Clean ratio computation is centralized in `_honest_functions_clean`, which sets `cleanRatioRefused=True` (with a reason) instead of defaulting to full-clean when measurement is incomplete.
> - Sealed boards emit a dual-denominator with `total` (authenticated roster mass), `enumerated`, and `unaccounted`, and propagate `cleanRatioRefused` when any contributing file refused a clean ratio.
> - `control_effect_recensus.py` live progress now shows `n/a` / `?/N` for clean stats when any file refuses, and no longer silently accumulates zeros for refused rows.
> - `bx-load-gate` adds a CPU-idle gate (default ≥35% idle via `SUGAR_BX_MIN_CPU_IDLE`); set `SUGAR_BX_QUIET_METRIC=loadavg` to restore the prior load-average gate.
> - Behavioral Change: boards and partial shards that previously emitted an integer clean count may now emit `null` with `cleanRatioRefused=True` when any file could not be cleanly measured.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58937f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Quiet-environment checks now default to CPU idle percentage, with configurable thresholds and load-average-only monitoring still available.
  - Measurement reports provide expanded before-and-after details and identify which quiet metric caused a failure.
  - Census reporting now distinguishes authenticated, enumerated, unaccounted, and instrument-blind functions.
  - Incomplete or unverifiable clean measurements are clearly marked as unavailable instead of reported as fabricated percentages.
  - Function rosters are preserved when later measurement stages fail.

- **Bug Fixes**
  - Prevented backend, enumeration, and construction failures from being counted as fully measured results.
  - Improved fallback handling when function discovery or residual measurement fails.

- **Tests**
  - Added coverage for roster preservation, failure handling, population accounting, and refused clean metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->