### PR TITLE
Fix G/F hierarchy lies: non-binding unpack + GuardedBinding projection

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -61,6 +61,29 @@ class LiveForRuntimeV1:
     else_statements: tuple[object, ...]
 
 
+def _initial_value_sugar_for_loop_prestate(state):
+    """Project one pre-loop binding state into an initial-value sugar.
+
+    Hierarchy law: ``GuardedBinding`` / ``UnboundBinding`` / ``LoopProjectedBinding``
+    are binding *states*, not Nodes. Calling ``state.sugar()`` on them is the same
+    class of lie as AttributeError-on-wrong-kind — it aborts the file. Dispatch
+    through the binding-projection door that already owns every state species.
+    """
+    from .nodes import Node, _construct_binding_projection
+
+    if isinstance(state, LoopProjectedBinding):
+        product = state.constructed_term_product
+        if product is None:
+            raise BindingStateWireGap(
+                "loop projected binding lacks constructed_term_product before "
+                "LiveForRuntimeV1 enrollment"
+            )
+        return product
+    if isinstance(state, Node):
+        return state.sugar()
+    return _construct_binding_projection(state)
+
+
 def _formula_cid(formula) -> str:
     # Encode the Value tree once and hash those bytes. Do not decode the
     # canonical JCS string back through JSON merely to re-encode for the CID.
@@ -690,9 +713,7 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
                 pattern,
                 carried_names,
                 tuple(
-                    entry.state.constructed_term_product
-                    if isinstance(entry.state, LoopProjectedBinding)
-                    else entry.state.sugar()
+                    _initial_value_sugar_for_loop_prestate(entry.state)
                     for entry in pre_runtime
                 ),
                 tuple(loop.body),

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5079,8 +5079,19 @@ class Assign(Statement):
         # Destructure only an already-constructed Tuple/List display.  This is
         # structural projection, not an iterator guess: a symbolic/opaque RHS
         # has no authenticated cardinality and therefore stays loud.
+        #
+        # Lexical binding patterns only. Attribute/Subscript (and mixed) unpack
+        # targets are intentionally NOT enrolled as binding patterns (see
+        # ``_is_binding_target_pattern`` and
+        # ``test_attribute_only_unpack_is_not_minted_as_a_binding_pattern``).
+        # Calling ``require_target_pattern`` when none was minted is a hierarchy
+        # lie — it dresses a non-binding unpack as ``foreign-target-occurrence``
+        # and aborts the file. Return None so mixed/store unpack falls through
+        # to ``_flat_store_unpack_pairs`` / store construction.
         target = self.targets[0]
         if not isinstance(target, (Tuple_, List)):
+            return None
+        if not self.unit.target_patterns_for(self):
             return None
         pattern = self.unit.require_target_pattern(self, target)
         return pattern.bindings_for(self.value)

--- a/implementations/python/sugar-source-tree/tests/test_guarded_binding_not_sugar_method.py
+++ b/implementations/python/sugar-source-tree/tests/test_guarded_binding_not_sugar_method.py
@@ -1,0 +1,36 @@
+"""GuardedBinding is a binding state, not a Node — never call .sugar() on it.
+
+F class from black seal (6 files): AttributeError
+  'GuardedBinding' object has no attribute 'sugar'
+
+LiveForRuntimeV1 pre-state projection assumed every state was a Node.
+``_construct_binding_projection`` already owns every binding-state species;
+route through that door instead of ``state.sugar()``.
+"""
+
+from __future__ import annotations
+
+from sugar_source_tree.binding_state import GuardedBinding, UnboundBinding
+from sugar_source_tree.live_loop_construction import (
+    _initial_value_sugar_for_loop_prestate,
+)
+from sugar_lift_py_tests.floor.branch_result_coordinate import BranchResultSlot
+
+
+def test_guarded_binding_projects_without_sugar_method() -> None:
+    slot = BranchResultSlot("test-slot")
+    when_true = UnboundBinding("x", "then")
+    when_false = UnboundBinding("x", "else")
+    state = GuardedBinding(slot=slot, when_true=when_true, when_false=when_false)
+    # Must not AttributeError
+    sugar = _initial_value_sugar_for_loop_prestate(state)
+    assert sugar is not None
+    # Projection product, not a Node.sugar() result from GuardedBinding
+    assert not hasattr(state, "sugar")
+    assert type(sugar).__name__ == "GuardedProjection"
+
+
+def test_unbound_binding_projects_without_sugar_method() -> None:
+    state = UnboundBinding("x", "never-bound")
+    sugar = _initial_value_sugar_for_loop_prestate(state)
+    assert type(sugar).__name__ == "UnboundProjection"

--- a/implementations/python/sugar-source-tree/tests/test_store_unpack_not_foreign_target.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_unpack_not_foreign_target.py
@@ -1,0 +1,82 @@
+"""Attribute/mixed unpack is not a binding pattern — do not raise foreign-target.
+
+G class from black seal (24 files): shapes like
+  self.a, self.b = ...
+  out, codes[-1] = ...
+  columns[name], buf = ...
+
+These are intentionally NOT enrolled as lexical binding patterns. Asking
+``require_target_pattern`` for them was a hierarchy lie: non-binding unpack
+dressed as foreign-target-occurrence, aborting the whole file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_source_tree.nodes import Assign
+from sugar_source_tree.reporter import NULL_REPORTER
+from sugar_source_tree.tree import SourceFile
+
+
+def _open(tmp_path: Path, name: str, source: str) -> SourceFile:
+    path = tmp_path / name
+    path.write_text(source)
+    # Use path-based open so unit binds module + target patterns.
+    from sugar_lift_python_source.source_oracle import workspace_path_source
+
+    identity = workspace_path_source(str(path), root=str(tmp_path))
+    return SourceFile(identity, reporter=NULL_REPORTER)
+
+
+def test_attribute_only_unpack_substitution_binding_does_not_raise(
+    tmp_path: Path,
+) -> None:
+    """``self.a, self.b = f()`` — no binding pattern, no foreign-target raise."""
+    sf = _open(
+        tmp_path,
+        "attr_unpack.py",
+        "class H:\n"
+        "    def install(self, left, right):\n"
+        "        self.left, self.right = left, right\n",
+    )
+    assignment = next(n for n in sf.nodes() if isinstance(n, Assign))
+    assert assignment.target_patterns == ()
+    # The hierarchy door: substitution_binding must not raise.
+    binding = assignment.substitution_binding({})
+    assert binding is None or binding == {}
+
+
+def test_mixed_name_subscript_unpack_does_not_raise_foreign_target(
+    tmp_path: Path,
+) -> None:
+    """``out, codes[-1] = a, b`` — mixed Name+Subscript, not a pure Name pattern."""
+    sf = _open(
+        tmp_path,
+        "mixed_unpack.py",
+        "def f(out, codes, a, b):\n"
+        "    out, codes[-1] = a, b\n"
+        "    return out\n",
+    )
+    assignment = next(n for n in sf.nodes() if isinstance(n, Assign))
+    # May or may not enroll depending on _is_binding_target_pattern (mixed = no).
+    assert assignment.target_patterns == ()
+    binding = assignment.substitution_binding({})
+    # Must not raise TargetPatternConstructionGapV1
+    assert binding is None or isinstance(binding, dict)
+
+
+def test_pure_name_unpack_still_has_pattern_and_binds(tmp_path: Path) -> None:
+    """``root, leaf = split(key)`` remains a real lexical binding pattern."""
+    sf = _open(
+        tmp_path,
+        "name_unpack.py",
+        "def f(key):\n"
+        "    root, leaf = split(key)\n"
+        "    return root\n",
+    )
+    assignment = next(n for n in sf.nodes() if isinstance(n, Assign))
+    assert len(assignment.target_patterns) == 1
+    # require still works for enrolled patterns
+    pattern = sf.unit.require_target_pattern(assignment, assignment.targets[0])
+    assert pattern is assignment.target_patterns[0]


### PR DESCRIPTION
## Classification (after the 122 ConstructedTerm class)

| n | class | verdict | fix |
|---:|---|---|---|
| **24** | G `foreign-target-occurrence` | **hierarchy lie** | don't require binding pattern for non-binding unpack |
| **6** | F `GuardedBinding` has no `.sugar` | **hierarchy lie** | project via `_construct_binding_projection` |
| 7 | D `If.substitute` foreign branch-result slot | open (slot identity under rewrite) | not this PR |
| 5 | E CM resolution gap | **honest residual** | provisional gap, not a type lie |
| 3 | H max recursion | honest/separate | not this PR |
| 2 | L/Λ LoopProjected / Lambda body | honest/separate | not this PR |

### G — same disease as "wrong door"
Enrollment only mints patterns for **lexical Name** unpacks. Attribute/mixed unpacks (`self.a, self.b = …`, `out, codes[-1] = …`) are correctly **not** enrolled.

`_destructured_binding` still called `require_target_pattern` → empty set dressed as `foreign-target-occurrence` → whole file dies.

**Fix:** if `target_patterns_for(self)` is empty, return `None` so store-unpack paths run. Pure Name unpack still has a pattern and still requires.

### F — same shape as AttributeError-on-wrong-kind
`LiveForRuntimeV1` did `entry.state.sugar()` assuming every pre-state is a **Node**. `GuardedBinding` is a binding **state**.

**Fix:** `_initial_value_sugar_for_loop_prestate` dispatches:
- `LoopProjectedBinding` → `constructed_term_product`
- `Node` → `.sugar()`
- else → `_construct_binding_projection` (GuardedProjection / UnboundProjection)

## Teeth
- attribute-only unpack: `substitution_binding` → None, no raise
- mixed Name+Subscript: no raise; Name leaf can still bind
- pure Name unpack: pattern enrolled, require ok
- GuardedBinding → GuardedProjection without `.sugar`

## Validation
```
attr_unpack binding None
mixed binding {'out': …}
name_unpack ok True
GuardedProjection / UnboundProjection
F_OK
```

Hand to merge_dog. D/E/H/L/Λ remain classified above.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix non-binding unpack targets and GuardedBinding projection in live loop construction
> - `nodes.Assign._destructured_binding` now returns `None` when the assignment has no enrolled target pattern (e.g. `self.a`, `xs[0]`), preventing foreign-target errors for attribute/subscript unpack targets.
> - Adds `_initial_value_sugar_for_loop_prestate` in [live_loop_construction.py](https://github.com/TSavo/sugar/pull/7101/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094) to dispatch pre-loop binding state to initial-value sugar without assuming the state is a `Node`; handles `LoopProjectedBinding`, `Node`, and other states separately.
> - `construct_live_loop_recurrence` now uses this helper instead of conditionally calling `.sugar()` on non-`Node` binding states in For-loop initial values.
> - Raises `BindingStateWireGap` when a `LoopProjectedBinding` has no `constructed_term_product`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef8a3cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->