### PR TITLE
recensus: outer-shell mass preserve + static clean-identity tooth

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -619,6 +619,108 @@ def _measure_file(
     )
 
 
+
+
+def _is_process_control(error: BaseException) -> bool:
+    """Never swallow process death as a per-file terminal."""
+    return isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit))
+
+
+def terminal_after_measure_escape(
+    *,
+    path: Path,
+    relative: str,
+    workspace_root: Path,
+    error: BaseException,
+    category: str = "backend-defect",
+) -> dict[str, Any]:
+    """Outer-shell law: never bank 0 when roster/AST mass is recoverable.
+
+    measure_file_via_enumerate must not raise after a roster bank — but when
+    anything escapes (new BaseException subclass, consumer refactor, outer
+    path), this shell must bank the recoverable population and name the
+    escape as residual. Banking functionsTotal=0 over known mass is the
+    #7073 mass-erase class with a timer on it.
+    """
+    try:
+        from recensus_enumerate_consumer import (
+            count_ast_function_defs,
+            demand_function_roster,
+            terminal_from_enumerate,
+        )
+    except ImportError:
+        # Consumer itself cannot load — true empty instrument path.
+        return {
+            "category": category,
+            "defect": {
+                "file": relative,
+                "type": type(error).__name__,
+                "message": str(error),
+                "phase": "outer-shell-escape",
+            },
+            "functionsTotal": 0,
+            "functionsEnumerated": 0,
+            "functionsClean": None,
+            "cleanRatioRefused": True,
+            "cleanRefuseReason": "consumer import failed; clean not measured",
+            "R_instrument_blind": 1,
+            "families": {f"outer-escape:{type(error).__name__}": 1},
+            "enumerateSource": True,
+        }
+
+    function_nodes: list[dict[str, Any]] = []
+    try:
+        function_nodes, _gaps = demand_function_roster(
+            workspace_root=workspace_root,
+            file_rel=relative,
+        )
+    except BaseException as roster_err:
+        if _is_process_control(roster_err):
+            raise
+        function_nodes = []
+
+    ast_fn = count_ast_function_defs(path)
+    if function_nodes:
+        # Recovered D2 roster — bank full mass, residual is the outer escape.
+        return terminal_from_enumerate(
+            file_rel=relative,
+            function_nodes=function_nodes,
+            function_gaps=[],
+            audit=None,
+            construction_gaps=[],
+            residual_phase_failed=True,
+            residual_error=error,
+            ast_fn=ast_fn,
+        )
+
+    # No D2 nodes — AST mass still forbids silent zero when the file has defs.
+    bank = int(ast_fn) if ast_fn is not None else 0
+    return {
+        "category": category,
+        "defect": {
+            "file": relative,
+            "type": type(error).__name__,
+            "message": str(error),
+            "phase": "outer-shell-escape",
+        },
+        "functionsTotal": bank,
+        "functionsEnumerated": 0,
+        "functionsNotEnumerated": bank,
+        "functionsEnumerationComplete": False,
+        "functionsClean": None if bank > 0 else 0,
+        "cleanRatioRefused": bank > 0,
+        "cleanRefuseReason": (
+            "outer shell escape; clean not measured" if bank > 0 else None
+        ),
+        "functionsAuthenticated": bank,
+        "astSites": {"site:function-def": bank} if bank else {},
+        "R_instrument_blind": 1,
+        "rosterPreservedAfterResidualFailure": bank > 0,
+        "families": {f"outer-escape:{type(error).__name__}": 1},
+        "enumerateSource": True,
+    }
+
+
 def main() -> int:
     # Line-buffer stdout even when not a TTY (CI pipes / artifact capture).
     try:
@@ -1362,15 +1464,20 @@ def main() -> int:
                     )
                 except (ImportError, AttributeError) as error:
                     # An arm that cannot resolve its dispatch target is UNWRITTEN,
-                    # wearing a working arm's clothes. It is not a panic, not a
-                    # typed refusal, and not in any family below -- so absorbing it
-                    # into `backend-defect` would leave the row short with nothing
-                    # saying so. Own category, named, loud, red (#6329).
-                    # measure_file_via_enumerate must not raise after roster bank;
-                    # these arms only fire when the consumer itself cannot load.
-                    row = {
-                        "category": "instrument-defect-unresolvable-dispatch",
-                        "defect": {
+                    # wearing a working arm's clothes. Own category, named, loud
+                    # (#6329). Still recover roster/AST mass when possible — never
+                    # bank silent 0 over a file that has functions.
+                    row = terminal_after_measure_escape(
+                        path=path,
+                        relative=relative,
+                        workspace_root=corpus_root,
+                        error=error,
+                        category="instrument-defect-unresolvable-dispatch",
+                    )
+                    # Preserve #6329 owner metadata on the defect object.
+                    defect = dict(row.get("defect") or {})
+                    defect.update(
+                        {
                             "file": relative,
                             "type": type(error).__name__,
                             "message": str(error),
@@ -1379,28 +1486,23 @@ def main() -> int:
                                 "the arm imports a name that does not exist; write "
                                 "the target or delete the arm"
                             ),
-                        },
-                        "functionsTotal": 0,
-                        "functionsClean": None,
-                        "cleanRatioRefused": True,
-                        "functionsEnumerated": 0,
-                        "R_instrument_blind": 1,
-                    }
-                except Exception as error:  # noqa: BLE001 -- per-file terminal
-                    # Consumer should bank mass itself; this is a last-resort shell.
-                    row = {
-                        "category": "backend-defect",
-                        "defect": {
-                            "file": relative,
-                            "type": type(error).__name__,
-                            "message": str(error),
-                        },
-                        "functionsTotal": 0,
-                        "functionsClean": None,
-                        "cleanRatioRefused": True,
-                        "functionsEnumerated": 0,
-                        "R_instrument_blind": 1,
-                    }
+                        }
+                    )
+                    row["defect"] = defect
+                    row["category"] = "instrument-defect-unresolvable-dispatch"
+                except BaseException as error:  # noqa: BLE001 -- per-file terminal
+                    # Last-resort shell. Must NOT bank functionsTotal=0 over known
+                    # mass: recover D2 roster (or AST) and name the escape residual.
+                    # ConstructionPanic is BaseException; other escapes will be too.
+                    if _is_process_control(error):
+                        raise
+                    row = terminal_after_measure_escape(
+                        path=path,
+                        relative=relative,
+                        workspace_root=corpus_root,
+                        error=error,
+                        category="backend-defect",
+                    )
                 file_s = time.perf_counter() - t_file
                 checkpoint.append(file, row)
                 measured_now.append((file, row))

--- a/tests/test_recensus_enumerate_mass_and_clean.py
+++ b/tests/test_recensus_enumerate_mass_and_clean.py
@@ -210,3 +210,126 @@ def test_compose_refuses_tautological_clean_on_board() -> None:
     assert body["functionsConstructClean"] is None
     assert body["denominator"]["functions"].get("cleanRatioRefused") is True
     assert body["denominator"]["functions"].get("clean") is None
+
+
+
+def test_consumer_source_forbids_clean_equal_total_assignment() -> None:
+    """Static tooth: no bare functions_clean = functions_total default.
+
+    ANY RATIO WHOSE NUMERATOR DEFAULTS TO ITS DENOMINATOR IS NOT A MEASUREMENT.
+    Makes the class unrepresentable rather than fixing today's instance.
+    """
+    import ast
+
+    path = SCRIPTS / "recensus_enumerate_consumer.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    crimes: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            continue
+        if node.targets[0].id not in {"functions_clean", "functionsClean"}:
+            continue
+        if isinstance(node.value, ast.Name) and node.value.id in {
+            "functions_total",
+            "functionsTotal",
+        }:
+            crimes.append(
+                f"L{node.lineno}: {node.targets[0].id} = {node.value.id} "
+                "(identity default - not a measurement)"
+            )
+    assert not crimes, (
+        "ANY RATIO WHOSE NUMERATOR DEFAULTS TO ITS DENOMINATOR IS NOT A "
+        "MEASUREMENT.\n" + "\n".join(crimes)
+    )
+
+
+def test_outer_shell_escape_banks_recovered_roster_not_zero(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Outer last-resort must not bank functionsTotal=0 over a recoverable roster.
+
+    Latent hole: except Exception banked 0 whenever measure_file escaped. Make
+    that shape unrepresentable - recover D2 (or AST) mass and name residual.
+    """
+    recensus = _load(
+        "control_effect_recensus",
+        SCRIPTS / "control_effect_recensus.py",
+    )
+    src = tmp_path / "multi.py"
+    src.write_text(
+        "def a():\n    return 1\n\ndef b():\n    return 2\n\ndef c():\n    return 3\n",
+        encoding="utf-8",
+    )
+
+    # Escape shape: a BaseException that is not process control.
+    class NewBaseExceptionGap(BaseException):
+        pass
+
+    nodes = [
+        {"memento": {"function_name": "a"}},
+        {"memento": {"function_name": "b"}},
+        {"memento": {"function_name": "c"}},
+    ]
+
+    def fake_roster(**_k):
+        return nodes, []
+
+    monkeypatch.setattr(CONSUMER, "demand_function_roster", fake_roster)
+    # Also patch the name as imported by the helper after its import.
+    import recensus_enumerate_consumer as consumer_mod
+
+    monkeypatch.setattr(consumer_mod, "demand_function_roster", fake_roster)
+
+    row = recensus.terminal_after_measure_escape(
+        path=src,
+        relative="multi.py",
+        workspace_root=tmp_path,
+        error=NewBaseExceptionGap("escaped past consumer"),
+        category="backend-defect",
+    )
+    assert row["functionsTotal"] == 3, (
+        f"outer shell must bank recovered roster, got {row.get('functionsTotal')}"
+    )
+    assert row.get("rosterPreservedAfterResidualFailure") is True
+    assert row.get("cleanRatioRefused") is True
+    assert row.get("functionsClean") is None
+    defect = row.get("defect") or {}
+    assert defect.get("type") == "NewBaseExceptionGap" or "NewBaseExceptionGap" in str(
+        row.get("families") or {}
+    )
+
+
+def test_outer_shell_escape_banks_ast_when_roster_demand_also_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """If D2 recovery also fails, AST mass still forbids silent zero."""
+    recensus = _load(
+        "control_effect_recensus",
+        SCRIPTS / "control_effect_recensus.py",
+    )
+    src = tmp_path / "multi.py"
+    src.write_text(
+        "def a():\n    return 1\n\ndef b():\n    return 2\n",
+        encoding="utf-8",
+    )
+
+    def boom_roster(**_k):
+        raise RuntimeError("roster recovery failed too")
+
+    import recensus_enumerate_consumer as consumer_mod
+
+    monkeypatch.setattr(consumer_mod, "demand_function_roster", boom_roster)
+
+    row = recensus.terminal_after_measure_escape(
+        path=src,
+        relative="multi.py",
+        workspace_root=tmp_path,
+        error=RuntimeError("outer escape"),
+        category="backend-defect",
+    )
+    assert row["functionsTotal"] == 2  # AST FunctionDef count
+    assert row["functionsEnumerated"] == 0
+    assert row.get("R_instrument_blind") == 1
+    assert row.get("cleanRatioRefused") is True


### PR DESCRIPTION
## Summary

Delta-only on top of #7100 (`f91f875e6`). Does **not** re-apply roster/clean/BaseException consumer work already on main.

1. **Outer-shell mass-erase hole closed.** `control_effect_recensus` last-resort catch banked `functionsTotal=0` on any escape from `measure_file_via_enumerate`. Unreachable for ConstructionPanic today (consumer catches `BaseException`), but reachable the moment a new BaseException subclass or consumer refactor raises past it — same #7073 mass-erase with a timer.

   `terminal_after_measure_escape` recovers D2 roster (else AST mass), banks that population, names the escape residual. Catch is `BaseException` with process-control re-raise. Silent zero over known functions is unrepresentable.

2. **Static AST tooth** forbidding `functions_clean = functions_total` assignment in the consumer module.

   Law: **ANY RATIO WHOSE NUMERATOR DEFAULTS TO ITS DENOMINATOR IS NOT A MEASUREMENT.**

`clean% n/a` progress display already landed in #7100 — not duplicated here.

## Shell deleted

- Outer last-resort zero-bank over recoverable mass
- Identity clean=total assignment (static unrepresentable)

## Test plan

- [x] `terminal_after_measure_escape` recovers roster of 3 on BaseException escape
- [x] AST fallback banks 2 when D2 recovery also fails
- [x] Static AST tooth clean (no identity assign)
- [ ] CI: `tests/test_recensus_enumerate_mass_and_clean.py`

## Not in this PR

- #7100 consumer BaseException / roster / clean refuse (already main)
- Full 1421 re-seal

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve recovered roster and AST mass on outer-shell escapes in `control_effect_recensus`
> - Adds `terminal_after_measure_escape` helper that, on consumer failure during file measurement, attempts to recover function mass from `demand_function_roster` or falls back to an AST count rather than returning `functionsTotal=0`.
> - Adds `_is_process_control` utility to distinguish `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit` from other exceptions; process-control exceptions are re-raised instead of converted to defect rows.
> - Widens the per-file error handler in `main` from `except Exception` to `except BaseException` so `ConstructionPanic` and similar escapes are caught and routed through `terminal_after_measure_escape` with category `backend-defect`.
> - Adds a static analysis test that prevents direct assignment of `functions_clean` from `functions_total` in `recensus_enumerate_consumer.py`.
> - Behavioral Change: per-file failures no longer zero out `functionsTotal`; recovered counts are banked and the escape is recorded as a residual error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d77ee97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->