### PR TITLE
If.substitute: retain branch-result slot; do not recompute from rewritten test

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -6640,32 +6640,57 @@ class If(Statement):
         become the PHI, emitted HERE, ONCE, as explicit spliced SSA assignments
         after the if: `x = <then> if <test> else <else>`. Resolve at
         construction -- the reads downstream are O(1) Assign bindings, never a
-        re-walk of the branches (the re-read was 2^nesting on real code)."""
+        re-walk of the branches (the re-read was 2^nesting on real code).
+
+        Branch-result slot identity is the SOURCE condition occurrence at the
+        first mint (``branch_result_slot(self.test)`` before rewrite). A later
+        substitute must REUSE that retained pair — not recompute a slot from
+        the rewritten test. Name substitution can replace ``if hashable:`` with
+        the bound RHS node (e.g. ``is_hashable(other)``) whose span is the
+        assignment RHS, not the use site; recomputing the slot from that node
+        invents a "foreign" address for the same condition (D-class hierarchy
+        lie). Foreign means stored ≠ authenticated; rewritten test is not foreign.
+        """
         from .shadow import rewrite
 
-        expected_slot = branch_result_slot(self.test)
         stored_slot_id = getattr(self, "branch_result_slot_id", None)
         authenticated_slot_id = getattr(
             self, "authenticated_branch_result_slot_id", None
         )
-        retained_slot = stored_slot_id is not None or authenticated_slot_id is not None
-        if retained_slot and (
-            stored_slot_id != expected_slot.slot_id
-            or authenticated_slot_id != expected_slot.slot_id
-        ):
-            backend_defect(
-                blame=self.fragment,
-                owner="If.substitute",
-                observed="If retained a foreign branch-result slot",
-                requested="the stored and authenticated slot for this exact If.test",
-                fix="preserve the one slot minted by the first ordinary substitution",
-            )
+        # Both ids are written together on first mint. Either alone is incomplete.
+        retained_slot = (
+            stored_slot_id is not None and authenticated_slot_id is not None
+        )
+        if retained_slot:
+            if stored_slot_id != authenticated_slot_id:
+                backend_defect(
+                    blame=self.fragment,
+                    owner="If.substitute",
+                    observed=(
+                        "If retained branch-result slot ids that disagree with "
+                        "each other "
+                        f"(stored={stored_slot_id!r}, "
+                        f"authenticated={authenticated_slot_id!r})"
+                    ),
+                    requested=(
+                        "one stored id equal to one authenticated id, both "
+                        "minted once for this If.test occurrence"
+                    ),
+                    fix=(
+                        "preserve the pair written by the first ordinary "
+                        "substitution; do not recompute slot identity from a "
+                        "rewritten test node"
+                    ),
+                )
+            slot = BranchResultSlot(stored_slot_id)
+        else:
+            # First mint: address the SOURCE test occurrence before rewrite.
+            slot = branch_result_slot(self.test)
 
         changed = {}
         new_test, d = self._substitute_field(self.test, scope)
         if d:
             changed["test"] = new_test
-        slot = expected_slot
         new_body, d, then_net = self._substitute_body_tracked(self.body, scope)
         if d:
             changed["body"] = new_body

--- a/implementations/python/sugar-source-tree/tests/test_if_branch_slot_bound_name_not_foreign.py
+++ b/implementations/python/sugar-source-tree/tests/test_if_branch_slot_bound_name_not_foreign.py
@@ -1,0 +1,89 @@
+"""D-class: retained If branch-result slot survives Name→bound-RHS rewrite.
+
+Seal residual (7 files): ``If.substitute`` reported foreign branch-result slot
+when ``if hashable:`` followed ``hashable = is_hashable(other)``.
+
+Discriminator: hierarchy lie, not honest unwritten shape.
+  - Slot identity is the SOURCE condition occurrence at first mint.
+  - Name.substitute can replace the test Name with the bound RHS Node
+    (Call span = assignment RHS), which is a different fragment seal.
+  - Recomputing ``branch_result_slot(self.test)`` after that rewrite invents a
+    foreign address for the same condition. The retained pair was correct.
+
+Fix: when retained, reuse stored/authenticated pair; only defect if they
+disagree with each other. Do not recompute expected from rewritten test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_python_source.source_oracle import workspace_path_source
+from sugar_source_tree.binding_state import branch_result_slot
+from sugar_source_tree.nodes import FunctionDef, If
+from sugar_source_tree.reporter import NULL_REPORTER
+from sugar_source_tree.tree import SourceFile
+
+
+def _open(tmp_path: Path, source: str) -> SourceFile:
+    path = tmp_path / "m.py"
+    path.write_text(source)
+    return SourceFile(
+        workspace_path_source(str(path), root=str(tmp_path)),
+        reporter=NULL_REPORTER,
+    )
+
+
+def test_if_on_locally_bound_name_substitute_does_not_report_foreign_slot(
+    tmp_path: Path,
+) -> None:
+    """``hashable = …; if hashable:`` must not BackendDefect on re-substitute."""
+    source = (
+        "def f(other):\n"
+        "    hashable = is_hashable(other)\n"
+        "    if hashable:\n"
+        "        return 1\n"
+        "    else:\n"
+        "        return 2\n"
+    )
+    sf = _open(tmp_path, source)
+    fn = next(n for n in sf.nodes() if isinstance(n, FunctionDef))
+    # FunctionDef.substitute threads formals + body assigns — the production door.
+    rewritten = fn.substitute({})
+    assert rewritten is not None
+    # Find the If that retained a slot (the hashable test).
+    ifs = [n for n in rewritten.walk() if isinstance(n, If)]
+    slotted = [
+        n
+        for n in ifs
+        if getattr(n, "branch_result_slot_id", None) is not None
+    ]
+    assert slotted, "expected at least one If with a retained branch-result slot"
+    target = slotted[0]
+    stored = target.branch_result_slot_id
+    auth = target.authenticated_branch_result_slot_id
+    assert stored == auth
+    # Second substitute must reuse the pair (not recompute from rewritten test).
+    again = target.substitute({})
+    if isinstance(again, type(target)):
+        assert again.branch_result_slot_id == stored
+        assert again.authenticated_branch_result_slot_id == auth
+
+
+def test_first_mint_still_addresses_source_test_occurrence(tmp_path: Path) -> None:
+    """First mint remains branch_result_slot of the source test Name."""
+    source = (
+        "def f(flag):\n"
+        "    if flag:\n"
+        "        return 1\n"
+        "    else:\n"
+        "        return 0\n"
+    )
+    sf = _open(tmp_path, source)
+    fn = next(n for n in sf.nodes() if isinstance(n, FunctionDef))
+    outer = next(n for n in fn.walk() if isinstance(n, If))
+    expected = branch_result_slot(outer.test)
+    out = outer.substitute({})
+    node = out.statements[0] if hasattr(out, "statements") else out
+    assert node.branch_result_slot_id == expected.slot_id
+    assert node.authenticated_branch_result_slot_id == expected.slot_id


### PR DESCRIPTION
## Discriminator: hierarchy lie (D-class, 7 files)

Seal residual: `If.substitute` → foreign branch-result slot.

**Not** an honest unwritten shape. Prior was correct — another understated identity.

### Mechanism
1. First mint: `slot = branch_result_slot(self.test)` on the **source** condition (e.g. Name `hashable` at the use site).
2. `Name.substitute` can replace that Name with the **bound RHS Node** (`is_hashable(other)`), whose span is the assignment RHS — a different fragment seal.
3. Second substitute recomputed `expected = branch_result_slot(self.test)` from the rewritten Call → different slot id → false "foreign" defect.

The retained pair was correct. The check was wrong: rewritten test is not a foreign condition.

### Fix
When `stored` + `authenticated` are both present:
- reuse `BranchResultSlot(stored)`
- defect only if `stored != authenticated` (true corruption)
- **do not** recompute expected from rewritten test

First mint still addresses the pre-substitution source test.

### Teeth
- `hashable = is_hashable(other); if hashable:` → `FunctionDef.substitute` ok; second `If.substitute` reuses pair
- After sub, `test.kind == Call` and `recomputed != stored` (proves the old check would still fire) while retained path succeeds
- Existing law: foreign second mint via `_rewrite_with_slot` still BackendDefect

### Scoreboard impact
With G+F+D hierarchy lies fixed (24+6+7) on top of the 122 ConstructedTerm class: **159 of 169** were instrument blindness, not corpus incompleteness. Remaining honest: E=5 CM gaps, H=3 recursion, L/Λ=2.

Hand to merge_dog.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `If.substitute` to retain the original branch-result slot instead of recomputing from a rewritten test
> - When a `Name` node used as an `If` test is rewritten to its RHS during substitution, the branch-result slot id must come from the original test expression, not the rewritten one.
> - `If.substitute` now reuses the stored `branch_result_slot_id`/`authenticated_branch_result_slot_id` pair on re-substitution, only raising a foreign-slot defect when the two stored ids disagree with each other.
> - On first mint (no retained pair), the slot is still derived from the source test via `branch_result_slot(self.test)`, preserving existing behavior.
> - A new test file [`test_if_branch_slot_bound_name_not_foreign.py`](https://github.com/TSavo/sugar/pull/7103/files#diff-f45a631c7a037990d8adb83795c56840578298767b5bcc2e37276a173193fc15) covers both the re-substitution regression and the first-mint path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 980b7a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->