### PR TITLE
Criterion 3 R-split law + EnrolledDemandUnresolved door

### DIFF
--- a/docs/path-forward.md
+++ b/docs/path-forward.md
@@ -25,7 +25,7 @@
 |---|---|---|---|
 | **1** | Every pandas file/function on sole tree→sugar path | Complete recensus denominator: every enrolled file has a terminal; no silent skip; construction path is the board door | **Unmeasured at tip** until S1 board banks |
 | **2** | R(construction panics)=R(native)=R(timeout)=R(silent/unaccounted)=0 **simultaneously** | Corpus process floors + board on **same pin** | Process floors: sole-construction; panics: recensus board |
-| **3** | Source-visible constructs; undecidable refuses **naming** the missing artifact | Residual shape is SugarNotWritten / typed gap with owner/requested/fix — not fabricate / soft | Partial (campaign); **not** corpus-proven at tip |
+| **3** | Source-visible constructs; source-undecidable refuses **naming** the artifact it cannot see | Split R only (below). Hierarchy-lie refusals are **not** C3 progress | Law rewritten 2026-08-02; instrument re-scope held on #6988 |
 | **4** | No second mechanisms (spelling, swallow, fabricate, …) | Live parent-vector **citations** + climb to constructors where possible | Parent numbers **were unsound**; re-derive after S2 |
 | **5** | Truthful **and** lying twins per semantic family | Every owned residual family has both faces; enrollment = existence | **Barely touched** campaign-wide; not optional |
 
@@ -195,6 +195,52 @@
 
 ---
 
+## Criterion 3 — R split (law; do not collapse)
+
+**Criterion text:** Source-visible behaviour CONSTRUCTS; source-undecidable behaviour is specifically refused, **naming the artifact it cannot see** — not fabricated, not soft-failed.
+
+### The confusion that almost banked defects as progress
+
+#6988's AST naming auditor (`R_refusals_naming_nothing`) only checks that `observed` interpolates a type/path. **Naming a type is not the same as being legitimately undecidable.** Brown's post-campaign board: **~159 of 169** defect rows were **hierarchy lies** (wrong type/identity checks), not honest source-undecidable refusals. That auditor would have greenlit those lies as good C3 refusals. One unpark away from counting our own defects as criterion progress.
+
+#7022 sealed grounds (`RefusalDecidability`) climb past the prose auditor for axis-1 shape — but the default ground **`KitConstructionIncomplete.holds()` is always True**, so an honest kit gap and a type-hierarchy bug still mint identically. The default erases the distinction the criterion exists to measure.
+
+### Two R axes (never one number)
+
+| Axis | What counts | Drains by | C3 finality? |
+|---|---|---|---|
+| **`R_kit_incomplete`** | Mints whose sealed ground is `KitConstructionIncomplete` (OUR missing sugar/floor arm, or a false arm that should not exist) | Write the sugar/floor **or** prove a hierarchy lie and **delete the false arm** | **No** |
+| **`R_source_undecidable_refusals`** | Mints with **runtime** sealed grounds that `holds(world)`, **plus** residual classes enrolled as honestly undecidable (today: CM resolution gaps; others only when enrolled) | Produce the missing artifact when source decides it, or keep the named refusal with a ground that still holds | **Yes** — this is C3 |
+
+`R_refusals_over_decidable_source` (mint where `holds(world)` is false) remains a **measurement floor**, not a progress counter to lower by softening refusals: those mints must not exist.
+
+### Unrepeatable rule
+
+> **A refusal that exists because a type was wrong is a defect wearing a refusal.**
+> It drains by **fixing the type** (hierarchy / identity / membrane), **never** by improving the prose.
+
+Hierarchy-lie drains (brown's 152–159 class) are **type-ladder work**. They must not enroll as C3 progress when the refusal message is renamed.
+
+### Missing door (makes C3 measurable)
+
+CM resolution residuals currently have nowhere honest to land: derivation returns `ContextManagerResolutionGapV1`, but panic/SNW defaults to `KitConstructionIncomplete` — same bucket as bugs.
+
+**New sealed ground (named; enroll in `sealed_ground.py`):**
+
+| Member | Artifact | `holds(world)` | Why not kit-incomplete |
+|---|---|---|---|
+| **`EnrolledDemandUnresolved`** | `EnrolledDemandArtifact`: `demand_family` (e.g. `context-manager`), `demand_cid`, `use_site`, `gap_kind` (structural key from the resolution table), `expected_ref_type` (e.g. `ContextManagerContractRefV1`) | True iff the enrolled demand is still a **gap**, not a contract ref, in the resolution world at mint | Machinery **ran**; the enrolled demand has **no source-derived ref** after derivation. That is exhaustion of source-derived resolution, not a missing `match` arm on AST |
+
+Until CM (and sibling) residuals mint this ground, **C3 is re-scoped on paper only** — residual mass still collapses into `R_kit_incomplete`.
+
+**If.substitute class:** default residual is `R_kit_incomplete` (carry `branch_result_slot` through substitute). Enroll under `R_source_undecidable_refusals` only if, after the carry law exists, something still severs authenticated identity for undecidable reasons — then name that artifact with a runtime ground, do not leave it as kit-incomplete prose.
+
+### Disposition of #6988
+
+Advisor holds. Axis-1 AST shell **superseded** by #7022. Do not merge as the C3 instrument. See PR comment on #6988 for full finding.
+
+---
+
 ## Standing rules (advisor enforces)
 
 1. **No product drain PR** until Phase 0 PASS (unless already landed — those are done; do not open new ones until 0.3).
@@ -204,6 +250,7 @@
 5. **Never pipe then `$?`.**
 6. **Parent vector 208 is dead** as a plan input until 1.1.
 7. **Off-plan work:** advisor says **OFF-PLAN** before any celebration.
+8. **Criterion 3:** never count hierarchy-lie refusals or bare `KitConstructionIncomplete` renames as C3 progress; only `R_source_undecidable_refusals`.
 
 ---
 
@@ -226,6 +273,7 @@
 |---|---|---|---|
 | 2026-08-01 | `8857e4071` | Plan v1 written; runs 30720169468 + 30720199631 in_progress | — |
 | | | Parent R_total=208 retired as planning input | — |
+| 2026-08-02 | tip | C3 R-split law + `EnrolledDemandUnresolved` door named; #6988 finding posted (not closed); hierarchy-lie ≠ C3 progress | advisor disposition of #6988 |
 
 ### Active ranking
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sealed_ground.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sealed_ground.py
@@ -6,13 +6,37 @@ Shared shell for:
     closed ground that ``holds(world)``. Opt-out kinds land here as siblings
     later; do not invent a second vocabulary.
 
-Law (Criterion 3 axis 2):
-  A refusal is final only when its ground ``holds(world)``.
-  ``R_refusals_over_decidable_source`` = count of mints where the ground does
-  not hold — a MEASUREMENT, not a static guess.
+------------------------------------------------------------------------
+Criterion 3 — R split (law; see docs/path-forward.md)
+
+  Source-visible constructs; source-undecidable refuses **naming the artifact
+  it cannot see**.
+
+  R_kit_incomplete
+      Count of mints whose ground is KitConstructionIncomplete.
+      Drains by writing sugar/floor, OR by proving a hierarchy lie and deleting
+      the false arm. NOT C3 finality.
+
+  R_source_undecidable_refusals
+      Count of mints with runtime sealed grounds that holds(world), plus residual
+      classes enrolled as honestly undecidable (CM resolution via
+      EnrolledDemandUnresolved, …). THIS is C3.
+
+  A refusal that exists because a type was wrong is a **defect wearing a
+  refusal**. It drains by fixing the type, never by improving the prose.
+  Naming a type in observed is not the same as being legitimately undecidable
+  (#6988 auditor would have banked ~159 hierarchy lies as good C3).
+
+  KitConstructionIncomplete.holds() is always True on purpose: the incompleteness
+  is the kit. It must not be the only door for honest undecidable residuals —
+  those mint EnrolledDemandUnresolved (or a sibling runtime ground).
+
+  R_refusals_over_decidable_source = mints where holds(world) is false.
+  That is a floor (must stay empty), not progress to lower by softening refusals.
 
   Pure re-attempt-and-see without a sealed ground is ill-defined and forbidden:
   success does not prove the refused path was wrong.
+------------------------------------------------------------------------
 
 Not the board.
 """
@@ -68,6 +92,26 @@ class KitIncompleteArtifact:
 
     owner: str
     observed_shape: str
+
+
+@dataclass(frozen=True)
+class EnrolledDemandArtifact:
+    """Enrolled demand whose derivation returned a structural gap, not a ref.
+
+    The artifact the refusal cannot see is the source-derived contract ref
+    (``expected_ref_type``) for this demand — not a free-text "undecidable".
+    """
+
+    demand_family: str
+    """Closed family key: context-manager | import-value-use | opaque-call | …"""
+
+    demand_cid: str
+    use_site: str
+    gap_kind: str
+    """Structural gap key from the resolution table vocabulary (never a symbol)."""
+
+    expected_ref_type: str
+    """Type name of the ref that would close the demand (e.g. ContextManagerContractRefV1)."""
 
 
 # ---------------------------------------------------------------------------
@@ -136,11 +180,41 @@ class ConflictingObligation:
 
 
 @dataclass(frozen=True)
+class EnrolledDemandUnresolved:
+    """Enrolled demand still a resolution gap — honest source-undecidable residual.
+
+    C3 door for CM resolution (and sibling resolution tables). Distinct from
+    KitConstructionIncomplete: derivation **ran**; the table has a structural
+    gap, not a contract ref. ``holds`` is false when a ref is present — minting
+    a refusal then would be refusing over decidable/resolvable source.
+
+    world key: ``enrolled_demand_unresolved`` bool (True ⇒ still a gap).
+    """
+
+    artifact: EnrolledDemandArtifact
+
+    def holds(self, world: Mapping[str, Any] | None = None) -> bool:
+        if world is None or "enrolled_demand_unresolved" not in world:
+            raise TypeError(
+                "EnrolledDemandUnresolved.holds requires world["
+                "'enrolled_demand_unresolved']=bool at mint "
+                "(True when resolution table still has a gap for this demand, "
+                "not a contract ref)"
+            )
+        return bool(world["enrolled_demand_unresolved"])
+
+
+@dataclass(frozen=True)
 class KitConstructionIncomplete:
     """Legal construction panic: OUR incomplete sugar/floor arm.
 
-    ``holds`` is always True — the incompleteness is the kit, not a false
-    claim that source was undecidable. Distinct from runtime-undecided grounds.
+    Counts under **R_kit_incomplete**, not R_source_undecidable_refusals.
+    ``holds`` is always True — the incompleteness is the kit, not a claim that
+    source was undecidable. Hierarchy-lie bugs that panic here are defects
+    wearing refusals; drain by fixing the type, not by renaming observed.
+
+    Honest undecidable residuals (CM resolution gaps, …) must NOT default here:
+    mint EnrolledDemandUnresolved (or a sibling runtime ground) instead.
     """
 
     artifact: KitIncompleteArtifact
@@ -155,6 +229,7 @@ RefusalDecidability = Union[
     KeyEqualityUndecided,
     FormalDemandUndischarged,
     ConflictingObligation,
+    EnrolledDemandUnresolved,
     KitConstructionIncomplete,
 ]
 
@@ -163,7 +238,14 @@ _REFUSAL_KINDS = (
     KeyEqualityUndecided,
     FormalDemandUndischarged,
     ConflictingObligation,
+    EnrolledDemandUnresolved,
     KitConstructionIncomplete,
+)
+
+_GROUND_NAMES = (
+    "RuntimeTypeUndecided | KeyEqualityUndecided | "
+    "FormalDemandUndischarged | ConflictingObligation | "
+    "EnrolledDemandUnresolved | KitConstructionIncomplete"
 )
 
 
@@ -172,11 +254,39 @@ def is_refusal_decidability(value: object) -> bool:
 
 
 def kit_incomplete(*, owner: str, observed: object) -> KitConstructionIncomplete:
-    """One door for ordinary construction-panic sites (OUR missing arm)."""
+    """One door for ordinary construction-panic sites (OUR missing arm).
+
+    R_kit_incomplete — not C3 finality. Prefer EnrolledDemandUnresolved when
+    the residual is an enrolled demand whose derivation returned a gap.
+    """
     return KitConstructionIncomplete(
         artifact=KitIncompleteArtifact(
             owner=owner,
             observed_shape=observed if isinstance(observed, str) else repr(observed),
+        )
+    )
+
+
+def enrolled_demand_unresolved(
+    *,
+    demand_family: str,
+    demand_cid: str,
+    use_site: str,
+    gap_kind: str,
+    expected_ref_type: str,
+) -> EnrolledDemandUnresolved:
+    """One door for resolution-table gaps (CM, import-value-use, opaque-call, …).
+
+    R_source_undecidable_refusals — C3. Mint only with world where
+    enrolled_demand_unresolved is True.
+    """
+    return EnrolledDemandUnresolved(
+        artifact=EnrolledDemandArtifact(
+            demand_family=demand_family,
+            demand_cid=demand_cid,
+            use_site=use_site,
+            gap_kind=gap_kind,
+            expected_ref_type=expected_ref_type,
         )
     )
 
@@ -187,24 +297,24 @@ def require_refusal_ground_holds(
 ) -> None:
     """Mint door: sealed ground must hold, or the refusal is over-decidable.
 
-    - ``KitConstructionIncomplete``: always holds (no world).
-    - Runtime grounds: require ``world`` and ``holds(world) is True``.
+    - ``KitConstructionIncomplete``: always holds (no world). Counts as kit R.
+    - Runtime grounds (incl. EnrolledDemandUnresolved): require ``world`` and
+      ``holds(world) is True``.
     - Free-text / unknown types: TypeError (unconstructible).
     """
     if not is_refusal_decidability(decidability):
         raise TypeError(
             "RefusalDecidability must be a closed sealed ground: "
             f"observed={type(decidability).__name__} "
-            "replacement=RuntimeTypeUndecided | KeyEqualityUndecided | "
-            "FormalDemandUndischarged | ConflictingObligation | "
-            "KitConstructionIncomplete"
+            f"replacement={_GROUND_NAMES}"
         )
     if isinstance(decidability, KitConstructionIncomplete):
         return
     if world is None:
         raise TypeError(
             f"{type(decidability).__name__} mint requires world= for holds(); "
-            "kit-incomplete sites use KitConstructionIncomplete instead"
+            "kit-incomplete sites use KitConstructionIncomplete instead; "
+            "CM / resolution gaps use EnrolledDemandUnresolved + world"
         )
     if not decidability.holds(world):
         raise TypeError(

--- a/implementations/python/sugar-lift-py-tests/tests/test_sealed_ground_refusal_decidability.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sealed_ground_refusal_decidability.py
@@ -1,4 +1,4 @@
-"""Teeth for RefusalDecidability sealed grounds (Criterion 3 axis-2 unblock)."""
+"""Teeth for RefusalDecidability sealed grounds (Criterion 3 R split)."""
 
 from __future__ import annotations
 
@@ -7,6 +7,8 @@ import pytest
 from sugar_lift_py_tests.gap.info import ConstructionGap, GapKind, GapLocus
 from sugar_lift_py_tests.gap.panic import construction_panic_gap, ConstructionPanic
 from sugar_lift_py_tests.sealed_ground import (
+    EnrolledDemandArtifact,
+    EnrolledDemandUnresolved,
     FloorRuntimeTypeArtifact,
     FormalDemandArtifact,
     FormalDemandUndischarged,
@@ -15,6 +17,7 @@ from sugar_lift_py_tests.sealed_ground import (
     KitIncompleteArtifact,
     MappingKeyEqualityArtifact,
     RuntimeTypeUndecided,
+    enrolled_demand_unresolved,
     is_refusal_decidability,
     kit_incomplete,
     require_refusal_ground_holds,
@@ -110,3 +113,34 @@ def test_formal_demand_ground() -> None:
         require_refusal_ground_holds(
             ground, {"formal_demand_undischarged": False}
         )
+
+
+def test_enrolled_demand_unresolved_is_c3_door_not_kit_incomplete() -> None:
+    """CM resolution residual: gap in table, not our missing AST arm."""
+    ground = enrolled_demand_unresolved(
+        demand_family="context-manager",
+        demand_cid="demand:blake3-512:test",
+        use_site="pandas/io/json/_json.py:100:8",
+        gap_kind="no-derived-contract",
+        expected_ref_type="ContextManagerContractRefV1",
+    )
+    assert isinstance(ground, EnrolledDemandUnresolved)
+    assert isinstance(ground.artifact, EnrolledDemandArtifact)
+    assert ground.artifact.expected_ref_type == "ContextManagerContractRefV1"
+    assert ground.holds({"enrolled_demand_unresolved": True}) is True
+    assert ground.holds({"enrolled_demand_unresolved": False}) is False
+    require_refusal_ground_holds(ground, {"enrolled_demand_unresolved": True})
+    with pytest.raises(TypeError, match="does not hold"):
+        # Contract ref present → refusing over resolvable source is illegal
+        require_refusal_ground_holds(ground, {"enrolled_demand_unresolved": False})
+    with pytest.raises(TypeError, match="requires world"):
+        require_refusal_ground_holds(ground, world=None)
+
+
+def test_kit_incomplete_is_not_c3_finality_door() -> None:
+    """Always-holds ground: R_kit_incomplete only — hierarchy lies mint the same."""
+    ground = kit_incomplete(owner="WithSugar", observed="hierarchy-lie-shape")
+    assert ground.holds() is True
+    require_refusal_ground_holds(ground)
+    # Distinct type from EnrolledDemandUnresolved so residual class can split R
+    assert not isinstance(ground, EnrolledDemandUnresolved)

--- a/tools/rerank_input.py
+++ b/tools/rerank_input.py
@@ -442,9 +442,15 @@ ENROLLED_RERANK_AXIS_IDS: tuple[str, ...] = (
     "criterion5.missing_lying_twins",
     "criterion5.honest_with_hatch_unsealed",
     "criterion5.opt_outs",
-    # Criterion 3 — naming / decidability
+    # Criterion 3 — split R (see docs/path-forward.md Criterion 3 section)
+    # naming_nothing: superseded by #7022 sealed grounds; held on #6988 disposition
     "criterion3.naming_nothing_drained_but_held",
-    "criterion3.decidability_axis",
+    # kit incomplete: NOT C3 finality — write sugar/floor or delete hierarchy-lie arm
+    "criterion3.R_kit_incomplete",
+    # true C3: runtime sealed grounds that holds(world) + enrolled honest residual classes
+    "criterion3.R_source_undecidable_refusals",
+    # floor: mints where holds(world) was false (must stay empty)
+    "criterion3.R_refusals_over_decidable_source",
     # Criterion 1 — authenticated denominator
     "criterion1.authenticated_denominator",
 )


### PR DESCRIPTION
## Summary

Makes Criterion 3 tractable after brown's hierarchy-lie campaign and the near-miss on #6988.

1. **R split as law** (`docs/path-forward.md` + `sealed_ground.py` module law):
   - `R_kit_incomplete` — write sugar/floor or delete hierarchy-lie arm; **not** C3 finality
   - `R_source_undecidable_refusals` — runtime sealed grounds that `holds(world)` + enrolled honest residual classes; **this is C3**
   - Rule: a refusal that exists because a type was wrong is a **defect wearing a refusal** — drain by fixing the type, never by prose

2. **Missing door named and constructible:** `EnrolledDemandUnresolved` + `EnrolledDemandArtifact` for CM (and sibling) resolution gaps that currently default into always-true `KitConstructionIncomplete`.

3. **#6988:** finding comment posted; **not closed**; advisor disposition. Axis-1 AST auditor superseded by #7022; would have banked ~159 hierarchy lies as good C3.

## Shot accounting

- **R axes named:** `criterion3.R_kit_incomplete`, `criterion3.R_source_undecidable_refusals` (rerank slots)
- **Epsilon R:** no residual mass moved yet — door is enrollable; CM mints not rewired in this PR
- **Shell:** collapses hierarchy-lie and honest undecidable into one progress counter
- **Floors:** does not soft-close #6988; does not claim C3 R=0

## Validation

```
PYTHONPATH=implementations/python/sugar-lift-py-tests/src \
  python3 -c 'from sugar_lift_py_tests.sealed_ground import enrolled_demand_unresolved, require_refusal_ground_holds; ...'
```

Teeth in `test_sealed_ground_refusal_decidability.py`.

## Related

- Comment: https://github.com/TSavo/sugar/pull/6988#issuecomment-5158412069
- #7022 sealed grounds

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `EnrolledDemandUnresolved` sealed ground and split Criterion 3 into R_kit_incomplete and R_source_undecidable_refusals axes
> - Introduces `EnrolledDemandUnresolved` as a new refusal ground in [`sealed_ground.py`](https://github.com/TSavo/sugar/pull/7104/files#diff-c487dc78e65c7d85136d425ff790f8d7aaab5c711756a3be4eaff85e67451e17), distinct from `KitConstructionIncomplete`, to represent honest undecidable resolution gaps rather than kit construction failures.
> - Adds `EnrolledDemandArtifact` dataclass capturing structured metadata (`demand_family`, `demand_cid`, `use_site`, `gap_kind`, `expected_ref_type`) and an `enrolled_demand_unresolved` factory function for minting grounds.
> - `require_refusal_ground_holds` now accepts `EnrolledDemandUnresolved` and enforces a world contract requiring `world['enrolled_demand_unresolved']` to be truthy at mint time.
> - Splits the single `criterion3.decidability_axis` in [`rerank_input.py`](https://github.com/TSavo/sugar/pull/7104/files#diff-3a3a37dd28ac602ae934c5efd59f62a5acc1c8796aa358cd6960d87e287633c5) into three explicit axes: `criterion3.R_kit_incomplete`, `criterion3.R_source_undecidable_refusals`, and `criterion3.R_refusals_over_decidable_source`.
> - Risk: any tooling referencing the old `criterion3.decidability_axis` ID will no longer find it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6f5e32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->