### PR TITLE
C5 residual-family twin census (code inventory)

### DIFF
--- a/docs/audits/c5-residual-family-twin-census.md
+++ b/docs/audits/c5-residual-family-twin-census.md
@@ -1,0 +1,134 @@
+# C5 residual-family twin census (code inventory)
+
+**Criterion 5:** every residual family must be proven by BOTH a truthful twin and a lying twin.
+**Method:** closed production vocabularies (`WithConstructionGapKind` 42 members, `SugarNotWritten` hierarchy, `GapKind`, `ConstructionPanic`, recensus board categories) + static `rg` of `implementations/python/**/tests/**` for wire/class tokens and truthful/lying markers.
+**Not a recensus measure.** No battleaxe. Black seal untouched.
+
+## Summary
+
+| metric | count |
+| --- | ---: |
+| residual families inventoried | 65 |
+| both twins (heuristic) | 37 |
+| truthful only | 2 |
+| lying only | 3 |
+| mentioned without twin markers | 8 |
+| neither (no test hit) | 15 |
+| **missing lying twin** | **25** |
+| missing truthful twin | 26 |
+
+A family with **no lying twin** is a family we cannot prove we detect.
+
+### Caveats
+
+- Heuristic over-credit: a multi-kind test file with twin markers can mark several kinds `both` when only one kind is twinned in that file.
+- Under-credit: twins that never spell the wire string (type-only assert) can show as `neither`.
+- Separate domain: Sugar/ProofIR family C5 lives in `scripts/semantic_family_twin_inventory_law.py` (factory `witnesses()` / NotVerdictBearing opt-outs). That is not this residual table.
+
+## Table
+
+| family | wire / product | truthful | path | lying | path | status |
+| --- | --- | :---: | --- | :---: | --- | --- |
+| `WithConstructionGapKind.RUNTIME_SELECTED` | `runtime-selected` | yes | `…mentations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py` | yes | `…mentations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py` | both |
+| `WithConstructionGapKind.UNRESOLVED_SYMBOL` | `unresolved-symbol` | no | `…tations/python/sugar-source-tree/tests/with_resolution_fixture.py` | no | `…tations/python/sugar-source-tree/tests/with_resolution_fixture.py` | mentioned_no_twin_markers |
+| `WithConstructionGapKind.AMBIGUOUS_SYMBOL` | `ambiguous-symbol` | no | `…thon/sugar-lift-py-tests/tests/test_context_manager_resolution.py` | no | `…thon/sugar-lift-py-tests/tests/test_context_manager_resolution.py` | mentioned_no_twin_markers |
+| `WithConstructionGapKind.WRONG_CONTRACT_KIND` | `wrong-contract-kind` | no | `—` | no | `—` | neither |
+| `WithConstructionGapKind.SIGNATURE_MISMATCH` | `signature-mismatch` | no | `—` | no | `—` | neither |
+| `WithConstructionGapKind.UNAUTHENTICATED_MEMBER` | `unauthenticated-member` | no | `—` | no | `—` | neither |
+| `WithConstructionGapKind.PAYLOAD_CID_MISMATCH` | `payload-cid-mismatch` | no | `—` | no | `—` | neither |
+| `WithConstructionGapKind.UNSUPPORTED_CM_SCHEMA` | `unsupported-cm-schema` | no | `…n/sugar-source-tree/tests/test_with_authenticated_contract_ref.py` | no | `…n/sugar-source-tree/tests/test_with_authenticated_contract_ref.py` | mentioned_no_twin_markers |
+| `WithConstructionGapKind.NO_DERIVED_CONTRACT` | `no-derived-contract` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | both |
+| `WithConstructionGapKind.STALE_DERIVED_CONTRACT` | `stale-derived-contract` | no | `—` | no | `—` | neither |
+| `WithConstructionGapKind.UNSUPPORTED_CONTEXT_MANAGER_SEMANTICS` | `unsupported-context-manager-semantics` | no | `—` | no | `—` | neither |
+| `WithConstructionGapKind.UNSUPPORTED_WITH_BINDING_TARGET` | `unsupported-with-binding-target` | no | `—` | no | `—` | neither |
+| `WithConstructionGapKind.ASYNC_CONTEXT_MANAGER_UNSUPPORTED` | `async-context-manager-unsupported` | no | `—` | no | `—` | neither |
+| `WithConstructionGapKind.DYNAMIC_EXPORT` | `dynamic-export` | yes | `…-python-source/tests/test_relative_submodule_member_resolution.py` | yes | `…/sugar-lift-python-source/tests/test_dependency_artifact_graph.py` | both |
+| `WithConstructionGapKind.STATIC_EXPORT_ABSENT` | `static-export-absent` | yes | `…gar-lift-python-source/tests/test_reexport_alias_star_warrants.py` | yes | `…gar-lift-python-source/tests/test_reexport_alias_star_warrants.py` | both |
+| `WithConstructionGapKind.UNSUPPORTED_STATEMENT` | `unsupported-statement` | no | `…python/sugar-source-tree/tests/test_with_construction_gap_kind.py` | no | `…python/sugar-source-tree/tests/test_with_construction_gap_kind.py` | mentioned_no_twin_markers |
+| `WithConstructionGapKind.MALFORMED_IMPORT_BINDING` | `malformed-import-binding` | no | `—` | no | `—` | neither |
+| `WithConstructionGapKind.ARTIFACT_MODULE_ABSENT` | `artifact-module-absent` | yes | `…t-python-source/tests/test_returned_resource_with_construction.py` | yes | `…t-python-source/tests/test_returned_resource_with_construction.py` | both |
+| `WithConstructionGapKind.TARGET_OUTSIDE_BINDING` | `target-outside-binding` | yes | `…-python-source/tests/test_relative_submodule_member_resolution.py` | no | `—` | truthful_only |
+| `WithConstructionGapKind.AMBIGUOUS_STATIC_EXPORT` | `ambiguous-static-export` | yes | `…gar-lift-python-source/tests/test_reexport_alias_star_warrants.py` | yes | `…gar-lift-python-source/tests/test_reexport_alias_star_warrants.py` | both |
+| `WithConstructionGapKind.OPAQUE_SOURCE` | `opaque-source` | no | `—` | no | `—` | neither |
+| `WithConstructionGapKind.REEXPORT_CYCLE` | `reexport-cycle` | yes | `…-python-source/tests/test_relative_submodule_member_resolution.py` | yes | `…gar-lift-python-source/tests/test_reexport_alias_star_warrants.py` | both |
+| `WithConstructionGapKind.INCOMPLETE_CALL_ACTUALS` | `incomplete-call-actuals` | no | `—` | no | `—` | neither |
+| `WithConstructionGapKind.ARTIFACT_MISMATCH` | `artifact-mismatch` | no | `…gar-lift-python-source/tests/test_resolution_session_authority.py` | no | `…gar-lift-python-source/tests/test_resolution_session_authority.py` | mentioned_no_twin_markers |
+| `WithConstructionGapKind.DEFINITION_MISSING` | `definition-missing` | no | `—` | no | `—` | neither |
+| `WithConstructionGapKind.NON_MANAGER_RESULT` | `non-manager-result` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | both |
+| `WithConstructionGapKind.CALL_BINDING` | `call-binding` | yes | `…ugar-lift-python-source/tests/test_source_call_preconstruction.py` | yes | `…ugar-lift-python-source/tests/test_source_call_preconstruction.py` | both |
+| `WithConstructionGapKind.FORCE_FLOOR` | `force-floor` | yes | `…sugar-lift-python-source/tests/test_returned_assertion_manager.py` | yes | `…sugar-lift-python-source/tests/test_returned_assertion_manager.py` | both |
+| `WithConstructionGapKind.CALL_GRAPH_CYCLE` | `call-graph-cycle` | yes | `…ift-python-source/tests/test_external_call_target_construction.py` | yes | `…ift-python-source/tests/test_external_call_target_construction.py` | both |
+| `WithConstructionGapKind.VALUE_CALL_TARGET` | `value-call-target` | yes | `…sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py` | yes | `…sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py` | both |
+| `WithConstructionGapKind.CALL_TARGET_SOURCE_ABSENT` | `call-target-source-absent` | yes | `…ift-python-source/tests/test_external_call_target_construction.py` | yes | `…ift-python-source/tests/test_external_call_target_construction.py` | both |
+| `WithConstructionGapKind.CALL_TARGET_EXPORT_UNRESOLVED` | `call-target-export-unresolved` | yes | `…sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py` | yes | `…sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py` | both |
+| `WithConstructionGapKind.CALL_TARGET_OFF_POPULATION` | `call-target-off-population` | no | `…-lift-python-source/tests/test_population_membrane_stdlib_cite.py` | no | `…-lift-python-source/tests/test_population_membrane_stdlib_cite.py` | mentioned_no_twin_markers |
+| `WithConstructionGapKind.ENTER_MISSING` | `enter-missing` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | both |
+| `WithConstructionGapKind.EXIT_MISSING` | `exit-missing` | no | `—` | no | `—` | neither |
+| `WithConstructionGapKind.METHOD_CONSTRUCTION` | `method-construction` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | both |
+| `WithConstructionGapKind.GENERATOR_MISSING` | `generator-missing` | no | `—` | yes | `…python-source/tests/test_generator_backed_resource_publication.py` | lying_only |
+| `WithConstructionGapKind.GENERATOR_PROTOCOL` | `generator-protocol` | no | `—` | yes | `…python-source/tests/test_generator_backed_resource_publication.py` | lying_only |
+| `WithConstructionGapKind.ENTER_MAY_HALT` | `enter-may-halt` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | both |
+| `WithConstructionGapKind.EXIT_MAY_HALT` | `exit-may-halt` | yes | `…sugar-lift-py-tests/tests/test_first_auth_exit_vertical_slices.py` | yes | `…sugar-lift-py-tests/tests/test_first_auth_exit_vertical_slices.py` | both |
+| `WithConstructionGapKind.OPAQUE_EXIT_TRUTHINESS` | `opaque-exit-truthiness` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | both |
+| `panic.SugarNotWritten` | `SugarNotWritten` | yes | `…ugar-lift-python-source/tests/test_source_call_preconstruction.py` | yes | `…ugar-lift-python-source/tests/test_source_call_preconstruction.py` | both |
+| `panic.UnattributableRefusal` | `UnattributableRefusal` | yes | `…python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py` | yes | `…python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py` | both |
+| `panic.OpaqueSourceCallResolutionGap` | `OpaqueSourceCallResolutionGap` | yes | `…sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py` | yes | `…sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py` | both |
+| `panic.RuntimeSelectedContextManager` | `RuntimeSelectedContextManager` | yes | `…ython/sugar-lift-py-tests/tests/test_recensus_panic_collection.py` | yes | `…ython/sugar-lift-py-tests/tests/test_recensus_panic_collection.py` | both |
+| `panic.ConstructedValueTestimonyNotWritten` | `ConstructedValueTestimonyNotWritten` | yes | `…hon/sugar-source-tree/tests/test_cpython_call_handle_testimony.py` | no | `—` | truthful_only |
+| `panic.WithConstructionGap` | `WithConstructionGap` | yes | `…sugar-lift-python-source/tests/test_returned_assertion_manager.py` | yes | `…sugar-lift-python-source/tests/test_returned_assertion_manager.py` | both |
+| `panic.ContextManagerResolutionConstructionGap` | `ContextManagerResolutionConstructionGap` | yes | `…ython/sugar-lift-py-tests/tests/test_recensus_panic_collection.py` | yes | `…ython/sugar-lift-py-tests/tests/test_recensus_panic_collection.py` | both |
+| `panic.UnsupportedContextManagerSemantics` | `UnsupportedContextManagerSemantics` | yes | `…/python/sugar-source-tree/tests/test_no_swallowed_cm_ref_panic.py` | yes | `…/python/sugar-source-tree/tests/test_no_swallowed_cm_ref_panic.py` | both |
+| `panic.UnsupportedWithBindingTarget` | `UnsupportedWithBindingTarget` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | yes | `…r-lift-python-source/tests/test_sole_path_manager_construction.py` | both |
+| `panic.AsyncContextManagerUnsupported` | `AsyncContextManagerUnsupported` | no | `…n/sugar-source-tree/tests/test_with_authenticated_contract_ref.py` | no | `…n/sugar-source-tree/tests/test_with_authenticated_contract_ref.py` | mentioned_no_twin_markers |
+| `panic.VocabularyMissing` | `VocabularyMissing` | yes | `…mentations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py` | yes | `…mentations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py` | both |
+| `panic.BackendDefect` | `BackendDefect` | yes | `…ns/python/sugar-lift-py-tests/tests/test_if_branch_result_slot.py` | yes | `…mentations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py` | both |
+| `panic.SubstituteNotWritten` | `SubstituteNotWritten` | no | `…ons/python/sugar-source-tree/tests/test_substitute_int_literal.py` | no | `…ons/python/sugar-source-tree/tests/test_substitute_int_literal.py` | mentioned_no_twin_markers |
+| `ConstructionPanic` | `ConstructionPanic` | yes | `…on/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py` | yes | `…on/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py` | both |
+| `recensus.category.completed` | `completed` | yes | `…/sugar-source-tree/tests/test_generator_for_step_v1_instrument.py` | yes | `…/sugar-source-tree/tests/test_generator_for_step_v1_instrument.py` | both |
+| `recensus.category.construction-panic` | `construction-panic` | yes | `…ython/sugar-lift-py-tests/tests/test_recensus_panic_collection.py` | yes | `…ython/sugar-lift-py-tests/tests/test_recensus_panic_collection.py` | both |
+| `recensus.category.backend-defect` | `backend-defect` | yes | `…/sugar-source-tree/tests/test_span_belongs_to_its_minting_unit.py` | yes | `…/sugar-source-tree/tests/test_span_belongs_to_its_minting_unit.py` | both |
+| `recensus.category.instrument-defect-unresolvable-dispatch` | `instrument-defect-unresolvable-dispatch` | no | `—` | no | `—` | neither |
+| `GapKind.FLOOR` | `Floor` | yes | `…ions/python/sugar-lift-py-tests/tests/test_binop_method_caller.py` | yes | `…ions/python/sugar-lift-py-tests/tests/test_binop_method_caller.py` | both |
+| `GapKind.SUGAR` | `Sugar` | yes | `…urce-tree/tests/test_imported_exception_attribute_construction.py` | yes | `…urce-tree/tests/test_imported_exception_attribute_construction.py` | both |
+| `GapKind.CONSTRUCTOR` | `Constructor` | no | `—` | yes | `…/python/sugar-lift-py-tests/tests/vendor/cpython-3.11/datetime.py` | lying_only |
+| `GapKind.SUGAR_ORDERING` | `Sugar ordering` | no | `—` | no | `—` | neither |
+| `GapKind.OPERATION` | `Operation` | yes | `…ons/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py` | yes | `…ons/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py` | both |
+| `GapKind.PROOFIR` | `ProofIR` | yes | `…ar-lift-py-tests/tests/test_semantic_family_twin_inventory_law.py` | yes | `…ar-lift-py-tests/tests/test_semantic_family_twin_inventory_law.py` | both |
+
+## Missing lying twin (action list)
+
+- `WithConstructionGapKind.UNRESOLVED_SYMBOL` (`unresolved-symbol`)
+- `WithConstructionGapKind.AMBIGUOUS_SYMBOL` (`ambiguous-symbol`)
+- `WithConstructionGapKind.WRONG_CONTRACT_KIND` (`wrong-contract-kind`)
+- `WithConstructionGapKind.SIGNATURE_MISMATCH` (`signature-mismatch`)
+- `WithConstructionGapKind.UNAUTHENTICATED_MEMBER` (`unauthenticated-member`)
+- `WithConstructionGapKind.PAYLOAD_CID_MISMATCH` (`payload-cid-mismatch`)
+- `WithConstructionGapKind.UNSUPPORTED_CM_SCHEMA` (`unsupported-cm-schema`)
+- `WithConstructionGapKind.STALE_DERIVED_CONTRACT` (`stale-derived-contract`)
+- `WithConstructionGapKind.UNSUPPORTED_CONTEXT_MANAGER_SEMANTICS` (`unsupported-context-manager-semantics`)
+- `WithConstructionGapKind.UNSUPPORTED_WITH_BINDING_TARGET` (`unsupported-with-binding-target`)
+- `WithConstructionGapKind.ASYNC_CONTEXT_MANAGER_UNSUPPORTED` (`async-context-manager-unsupported`)
+- `WithConstructionGapKind.UNSUPPORTED_STATEMENT` (`unsupported-statement`)
+- `WithConstructionGapKind.MALFORMED_IMPORT_BINDING` (`malformed-import-binding`)
+- `WithConstructionGapKind.TARGET_OUTSIDE_BINDING` (`target-outside-binding`)
+- `WithConstructionGapKind.OPAQUE_SOURCE` (`opaque-source`)
+- `WithConstructionGapKind.INCOMPLETE_CALL_ACTUALS` (`incomplete-call-actuals`)
+- `WithConstructionGapKind.ARTIFACT_MISMATCH` (`artifact-mismatch`)
+- `WithConstructionGapKind.DEFINITION_MISSING` (`definition-missing`)
+- `WithConstructionGapKind.CALL_TARGET_OFF_POPULATION` (`call-target-off-population`)
+- `WithConstructionGapKind.EXIT_MISSING` (`exit-missing`)
+- `panic.ConstructedValueTestimonyNotWritten` (`ConstructedValueTestimonyNotWritten`)
+- `panic.AsyncContextManagerUnsupported` (`AsyncContextManagerUnsupported`)
+- `panic.SubstituteNotWritten` (`SubstituteNotWritten`)
+- `recensus.category.instrument-defect-unresolvable-dispatch` (`instrument-defect-unresolvable-dispatch`)
+- `GapKind.SUGAR_ORDERING` (`Sugar ordering`)
+
+## Group inventory sources
+
+- **WithConstructionGapKind** (42): `implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py`
+- **panic.* residual classes**: SNW subclasses + VocabularyMissing/BackendDefect/SubstituteNotWritten in same file
+- **ConstructionPanic**: `sugar_lift_py_tests/gap/panic.py` (single product class; GapKind is orthogonal)
+- **GapKind** (6): `sugar_lift_py_tests/gap/info.py` — construction-gap locus labels, not CM residual kinds
+- **recensus categories** (4): `recensus_enumerate_consumer.py` board categories
+
+*Generated by static inventory (`/tmp/c5_rows.txt` via tools/c5_residual_family_twin_census approach). No measurement.*

--- a/tools/c5_residual_family_twin_census.py
+++ b/tools/c5_residual_family_twin_census.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""C5 residual-family twin census — pure code inventory (no corpus measure).
+
+Enumerates residual product families from production closed vocabularies and
+reports whether test tree evidence exists for a truthful twin and a lying twin.
+
+Exit 0 always (measurement/orientation artifact). Writes markdown under
+docs/audits/c5-residual-family-twin-census.md when --write is set.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PYR = ROOT / "implementations" / "python"
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _enum_string_members(path: Path, class_name: str) -> list[tuple[str, str]]:
+    text = _read(path)
+    match = re.search(rf"class {class_name}\b.*?(?=\nclass |\Z)", text, re.S)
+    if not match:
+        return []
+    return re.findall(
+        r"^\s{4}([A-Z][A-Z0-9_]*)\s*=\s*\"([^\"]+)\"", match.group(0), re.M
+    )
+
+
+def enumerate_families() -> list[tuple[str, str, str]]:
+    families: list[tuple[str, str, str]] = []
+    panic_path = PYR / "sugar-source-tree/src/sugar_source_tree/panic.py"
+    for name, wire in _enum_string_members(panic_path, "WithConstructionGapKind"):
+        families.append((f"WithConstructionGapKind.{name}", wire, "WithConstructionGapKind"))
+
+    panic = _read(panic_path)
+    for match in re.finditer(r"^class (\w+)\(([^)]+)\):", panic, re.M):
+        cls, bases = match.group(1), match.group(2)
+        if cls == "SourceTreePanic":
+            continue
+        residual = (
+            "SugarNotWritten",
+            "WithConstructionGap",
+            "SourceTreePanic",
+            "VocabularyMissing",
+            "BackendDefect",
+            "SubstituteNotWritten",
+        )
+        if cls in residual or any(b in bases for b in residual):
+            families.append((f"panic.{cls}", cls, "panic_class"))
+
+    gap_path = PYR / "sugar-lift-py-tests/src/sugar_lift_py_tests/gap/info.py"
+    for name, wire in _enum_string_members(gap_path, "GapKind"):
+        families.append((f"GapKind.{name}", wire, "GapKind"))
+
+    families.append(("ConstructionPanic", "ConstructionPanic", "construction_panic"))
+    for cat in (
+        "completed",
+        "construction-panic",
+        "backend-defect",
+        "instrument-defect-unresolvable-dispatch",
+    ):
+        families.append((f"recensus.category.{cat}", cat, "recensus_category"))
+
+    seen: set[str] = set()
+    out: list[tuple[str, str, str]] = []
+    for row in families:
+        if row[0] in seen:
+            continue
+        seen.add(row[0])
+        out.append(row)
+    return out
+
+
+def load_test_corpus() -> list[tuple[Path, str]]:
+    """Load a bounded set of twin/residual-related tests (no deep full-tree walk)."""
+    paths: list[Path] = []
+    # Prefer glob on known test roots only — full rglob of implementations/python
+    # is huge and can starve interactive inventory runs.
+    for base in (
+        PYR / "sugar-lift-py-tests/tests",
+        PYR / "sugar-lift-python-source/tests",
+        PYR / "sugar-source-tree/tests",
+    ):
+        if not base.is_dir():
+            continue
+        paths.extend(sorted(base.glob("test_*.py")))
+        paths.extend(sorted(base.glob("*/*twin*.py")))
+    scripts = PYR / "sugar-lift-py-tests/scripts"
+    if scripts.is_dir():
+        paths.extend(sorted(scripts.glob("*twin*.py")))
+        paths.extend(sorted(scripts.glob("*family*.py")))
+
+    loaded: list[tuple[Path, str]] = []
+    seen: set[Path] = set()
+    for path in paths:
+        if path in seen or not path.is_file():
+            continue
+        seen.add(path)
+        text = _read(path)
+        if not text:
+            continue
+        if not re.search(
+            r"truthful|lying|twin|WithConstructionGap|SugarNotWritten|"
+            r"ConstructionPanic|GapKind|instrument-defect|backend-defect|"
+            r"runtime-selected|call-graph-cycle|dynamic-export",
+            text,
+            re.I,
+        ):
+            continue
+        loaded.append((path, text))
+    return loaded
+
+
+_TR = re.compile(r"truthful|SugarWitnessPair|good_twin", re.I)
+_LY = re.compile(r"lying|bad_twin|flipping", re.I)
+
+
+def evidence(
+    wire: str, cls_token: str, loaded: list[tuple[Path, str]]
+) -> tuple[bool, bool, str] | None:
+    needles = [wire, cls_token, wire.replace("-", "_")]
+    best: tuple[int, bool, bool, str] | None = None
+    for path, text in loaded:
+        if not any(
+            n
+            and len(n) >= 3
+            and re.search(
+                rf"(?<![A-Za-z0-9_\-]){re.escape(n)}(?![A-Za-z0-9_\-])", text
+            )
+            for n in needles
+        ):
+            continue
+        has_t = bool(_TR.search(text) or re.search(r"def\s+test_\w*truthful", text, re.I))
+        has_l = bool(_LY.search(text) or re.search(r"def\s+test_\w*lying", text, re.I))
+        rel = str(path.relative_to(ROOT))
+        score = (2 if has_t else 0) + (2 if has_l else 0) + (1 if "twin" in path.name else 0)
+        if best is None or score > best[0]:
+            best = (score, has_t, has_l, rel)
+    if best is None:
+        return None
+    return best[1], best[2], best[3]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="write docs/audits/c5-residual-family-twin-census.md",
+    )
+    args = parser.parse_args(argv)
+
+    families = enumerate_families()
+    loaded = load_test_corpus()
+    rows: list[tuple] = []
+    for fam, wire, group in families:
+        cls = fam.split(".")[-1]
+        ev = evidence(wire, cls, loaded)
+        if ev is None:
+            rows.append((fam, wire, group, False, "—", False, "—", "neither"))
+        else:
+            has_t, has_l, rel = ev
+            if has_t and has_l:
+                status = "both"
+            elif has_t:
+                status = "truthful_only"
+            elif has_l:
+                status = "lying_only"
+            else:
+                status = "mentioned_no_twin_markers"
+            rows.append(
+                (
+                    fam,
+                    wire,
+                    group,
+                    has_t,
+                    rel if has_t else "—",
+                    has_l,
+                    rel if has_l else "—",
+                    status,
+                )
+            )
+
+    both = sum(1 for r in rows if r[7] == "both")
+    t_only = sum(1 for r in rows if r[7] == "truthful_only")
+    l_only = sum(1 for r in rows if r[7] == "lying_only")
+    neither = sum(1 for r in rows if r[7] in {"neither", "mentioned_no_twin_markers"})
+    miss_l = sum(1 for r in rows if not r[5])
+    miss_t = sum(1 for r in rows if not r[3])
+
+    def short(path: str) -> str:
+        if path == "—":
+            return "—"
+        return path if len(path) <= 72 else "…" + path[-69:]
+
+    lines = [
+        "# C5 residual-family twin census (code inventory)",
+        "",
+        "**Criterion 5:** every residual family must be proven by BOTH a truthful twin and a lying twin.",
+        "**Method:** closed production vocabularies + panic hierarchy; twin presence via static scan of focused test trees for family wire/class tokens + truthful/lying markers.",
+        "**Not a recensus measure.** No battleaxe. No corpus open.",
+        "",
+        "## Summary",
+        "",
+        "| metric | count |",
+        "| --- | ---: |",
+        f"| residual families inventoried | {len(rows)} |",
+        f"| both twins (heuristic) | {both} |",
+        f"| truthful only | {t_only} |",
+        f"| lying only | {l_only} |",
+        f"| neither / no twin markers | {neither} |",
+        f"| **missing lying twin** | **{miss_l}** |",
+        f"| missing truthful twin | {miss_t} |",
+        "",
+        "A family with **no lying twin** is a family we cannot prove we detect.",
+        "",
+        "### Related inventory (different domain)",
+        "",
+        "- Sugar/ProofIR **semantic family** C5: `scripts/semantic_family_twin_inventory_law.py` (factory `witnesses()` / ProofIR verdict pairs).",
+        "- Static twin detection can **over-credit** a kind listed only in a multi-kind vocabulary test that also carries twin markers for another kind.",
+        "- `NotVerdictBearing` opt-outs belong to the sugar-family inventory, not this residual table.",
+        "",
+        "## Table",
+        "",
+        "| family | wire / product | truthful | path | lying | path | status |",
+        "| --- | --- | :---: | --- | :---: | --- | --- |",
+    ]
+    for fam, wire, _group, has_t, t_path, has_l, l_path, status in rows:
+        lines.append(
+            f"| `{fam}` | `{wire}` | {'yes' if has_t else 'no'} | `{short(t_path)}` | "
+            f"{'yes' if has_l else 'no'} | `{short(l_path)}` | {status} |"
+        )
+
+    lines += ["", "## Missing lying twin", ""]
+    for fam, wire, _g, _ht, _tp, has_l, _lp, _st in rows:
+        if not has_l:
+            lines.append(f"- `{fam}` (`{wire}`)")
+
+    lines += ["", "## Group counts", ""]
+    for key, count in sorted(Counter(r[2] for r in rows).items()):
+        lines.append(f"- **{key}**: {count}")
+    lines.append("")
+    lines.append(
+        "*Generated from code inventory only (`tools/c5_residual_family_twin_census.py`).*"
+    )
+
+    report = "\n".join(lines) + "\n"
+    if args.write:
+        out = ROOT / "docs/audits/c5-residual-family-twin-census.md"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(report, encoding="utf-8")
+        print(f"WROTE {out}", flush=True)
+
+    print(
+        f"n={len(rows)} both={both} t_only={t_only} l_only={l_only} "
+        f"neither={neither} missing_lying={miss_l} missing_truthful={miss_t} "
+        f"test_files_scanned={len(loaded)}",
+        flush=True,
+    )
+    # Always print full table to stdout for the agent report
+    print(report, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Makes Criterion 5 measurable for residual families without a corpus run.

Inventories closed residual product vocabularies:
- `WithConstructionGapKind` (42)
- `SugarNotWritten` hierarchy / related panic classes
- `GapKind` (6)
- `ConstructionPanic`
- recensus board categories (4)

For each: static twin evidence (truthful / lying) from test tree.

**Result (heuristic):** 65 families, **25 missing lying twin**, 37 both.

Artifact: `docs/audits/c5-residual-family-twin-census.md`  
Tool: `tools/c5_residual_family_twin_census.py`

No battleaxe. No measurement.

## Floors

data_loss=0, docs/inventory only.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add C5 residual-family twin census CLI tool and audit report
> - Adds [c5_residual_family_twin_census.py](https://github.com/TSavo/sugar/pull/7105/files#diff-ef280bc82347d0fbf5f2e6889e9f8eeea20eaed23c93532a3d860741217c8253), a CLI tool that inventories residual families (from enum-like classes and panic subclasses) and scans a bounded test corpus for truthful/lying twin coverage.
> - Produces a markdown report with a summary table and a list of families missing a lying twin; pass `--write` to persist the output to [docs/audits/c5-residual-family-twin-census.md](https://github.com/TSavo/sugar/pull/7105/files#diff-15adbb86b129af957dc36de46e96eb922715e73a2a8bd7b971bde550f922696d).
> - Adds the pre-generated [audit report](https://github.com/TSavo/sugar/pull/7105/files#diff-15adbb86b129af957dc36de46e96eb922715e73a2a8bd7b971bde550f922696d) produced by the tool.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8af9f3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->