### PR TITLE
C3: last 10 honest residuals as named refusals (not backend-defect)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -298,6 +298,36 @@ def _honest_functions_clean(
     )
 
 
+def _classify_honest_residual(
+    error: BaseException,
+) -> tuple[str, str, bool]:
+    """Return (type_name, message, is_honest_residual) for residual errors.
+
+    Honest residuals (E/H/L/Λ class after the 159 lies): named refusals that
+    name the artifact they cannot see. Instrument-blind TypeError/AttributeError
+    remain dishonest until converted to SugarNotWritten at the source.
+    """
+    name = type(error).__name__
+    msg = str(error)
+    # Already-named CM / With construction gaps (E-class).
+    if name in {
+        "ContextManagerResolutionConstructionGap",
+        "WithConstructionGap",
+        "SugarNotWritten",
+    } or "CONTEXT MANAGER RESOLUTION GAP" in msg:
+        return name if name != "Exception" else "ContextManagerResolutionConstructionGap", msg, True
+    if name == "RecursionError" or "maximum recursion depth" in msg:
+        return "ConstructionRecursionGap", msg, True
+    if "LoopProjectedBinding" in msg or "LoopProjectedBinding" in name:
+        return "LoopProjectedBindingReadGap", msg, True
+    if "LambdaSugar" in msg or name == "LambdaSugar":
+        return "LambdaBodyTestimonyGap", msg, True
+    # SugarNotWritten subclasses often report via str with owner line.
+    if "SUGAR NOT WRITTEN" in msg or "SugarNotWritten" in name:
+        return name, msg, True
+    return name, msg, False
+
+
 def terminal_from_enumerate(
     *,
     file_rel: str,
@@ -390,15 +420,17 @@ def terminal_from_enumerate(
         )
 
     if residual_phase_failed and residual_error is not None:
+        err_type, err_msg, honest = _classify_honest_residual(residual_error)
         defects.append(
             {
                 "file": file_rel,
-                "type": type(residual_error).__name__,
-                "message": str(residual_error),
+                "type": err_type,
+                "message": err_msg,
                 "phase": "residual",
+                "honestResidual": honest,
             }
         )
-        families[f"residual:{type(residual_error).__name__}"] += 1
+        families[f"residual:{err_type}"] += 1
 
     clean, clean_refused, clean_reason = _honest_functions_clean(
         functions_total=functions_total,
@@ -412,6 +444,10 @@ def terminal_from_enumerate(
         category = "backend-defect"
         if construction_panics:
             category = "construction-panic"
+        elif residual_error is not None and _classify_honest_residual(residual_error)[2]:
+            # C3: honest unwritten refuses specifically as designed-gap, not
+            # instrument-blind backend-defect.
+            category = "designed-gap"
     elif construction_panics and not panics:
         category = "construction-panic"
     elif defects and not function_nodes:
@@ -422,9 +458,12 @@ def terminal_from_enumerate(
         category = "completed"
 
     # Mid-residual failure with banked roster: still construction-panic if panics,
-    # else backend-defect — but functionsTotal stays roster size.
+    # designed-gap if honest residual, else backend-defect — functionsTotal stays.
     if residual_phase_failed and not construction_panics:
-        category = "backend-defect"
+        if residual_error is not None and _classify_honest_residual(residual_error)[2]:
+            category = "designed-gap"
+        else:
+            category = "backend-defect"
 
     row = _empty_shell(
         file_rel=file_rel,
@@ -500,16 +539,18 @@ def measure_file_via_enumerate(
         # No roster banked. AST population still names the gap when parseable
         # (instrument-blind mass, not a silent zero when the file has functions).
         auth = int(ast_fn) if ast_fn is not None else 0
+        err_type, err_msg, honest = _classify_honest_residual(error)
         return _empty_shell(
             file_rel=file_rel,
-            category="backend-defect",
+            category="designed-gap" if honest else "backend-defect",
             functions_total=auth,
             functions_enumerated=0,
             defect={
                 "file": file_rel,
-                "type": type(error).__name__,
-                "message": str(error),
+                "type": err_type,
+                "message": err_msg,
                 "phase": "roster",
+                "honestResidual": honest,
             },
             functions_clean=None if auth > 0 else 0,
             clean_ratio_refused=auth > 0,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/lambda_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/lambda_sugar.py
@@ -21,19 +21,64 @@ class LambdaSugar(ConstructedTermSugar):
     site: object = dataclass_field(compare=False)
 
     def __post_init__(self) -> None:
+        from sugar_source_tree.panic import SugarNotWritten
+
         frame = self.source_call_frame
         if tuple(frame.parameters) != self.formals:
-            raise TypeError("LambdaSugar formals require their authenticated source frame")
+            raise SugarNotWritten(
+                owner="LambdaSugar.formals",
+                blame=self.site,
+                observed=(
+                    f"frame.parameters={tuple(frame.parameters)!r} "
+                    f"!= formals={self.formals!r}"
+                ),
+                requested="formals identical to the authenticated source_call_frame",
+                fix=(
+                    "construct LambdaSugar only from Lambda._construct_sugar with "
+                    "the producer frame; do not invent formals"
+                ),
+            )
         if tuple(coordinate.cid for coordinate in frame.formal_coordinates) != (
             self.formal_coordinate_cids
         ):
-            raise TypeError(
-                "LambdaSugar formal coordinates require producer-authenticated testimony"
+            raise SugarNotWritten(
+                owner="LambdaSugar.formal_coordinate_cids",
+                blame=self.site,
+                observed="formal_coordinate_cids disagree with frame.formal_coordinates",
+                requested="producer-authenticated formal coordinate CID tuple",
+                fix="carry coordinate CIDs from the source_visible_call_frame only",
             )
         if frame.definition_fragment_cid != self.site.seal().cid:
-            raise TypeError("LambdaSugar source frame requires its exact lambda occurrence")
+            raise SugarNotWritten(
+                owner="LambdaSugar.source_call_frame",
+                blame=self.site,
+                observed=(
+                    f"frame.definition_fragment_cid={frame.definition_fragment_cid!r} "
+                    f"!= lambda site cid={self.site.seal().cid!r}"
+                ),
+                requested="source frame pinned to this exact lambda occurrence",
+                fix="mint the frame at the Lambda node; do not reuse another definition",
+            )
         if self.body.site.seal().cid != self.body_fragment_cid:
-            raise TypeError("LambdaSugar body requires its exact source body testimony")
+            raise SugarNotWritten(
+                owner="LambdaSugar.body",
+                blame=getattr(self.body, "site", self.site),
+                observed=(
+                    f"body site cid={self.body.site.seal().cid!r} "
+                    f"!= body_fragment_cid={self.body_fragment_cid!r} "
+                    f"(body type={type(self.body).__name__})"
+                ),
+                requested=(
+                    "body sugar whose site.seal().cid equals the exact source "
+                    "body fragment CID captured at construction"
+                ),
+                fix=(
+                    "construct the body from the Lambda expression body node "
+                    "before rewrite; a substituted/rewritten body with a different "
+                    "fragment is an honest gap until rewrite preserves body "
+                    "occurrence identity — refuse specifically, never TypeError"
+                ),
+            )
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1541,13 +1541,47 @@ def binding_state_read_node(
     if isinstance(state, LoopProjectedBinding):
         # A single completion face is the TOTAL post-value (a no-break loop
         # exits only by NormalExhaustion), so read straight through it. A
-        # multi-face join stays loud rather than silently pick one arm.
+        # multi-face join stays loud rather than silently pick one arm —
+        # honest unwritten: C3 named refusal, not TypeError-as-backend-defect.
         if len(state.completed_faces) == 1:
             return binding_state_read_node(
                 state.completed_faces[0].state, make_read=make_read
             )
-        raise TypeError(type(state))
-    raise TypeError(type(state))
+        from sugar_source_tree.panic import SugarNotWritten
+
+        raise SugarNotWritten(
+            owner="binding_state_read_node",
+            blame=(
+                f"LoopProjectedBinding(target_cid={state.target_cid},"
+                f"faces={len(state.completed_faces)})"
+            ),
+            observed=(
+                f"LoopProjectedBinding with {len(state.completed_faces)} completed "
+                f"faces (target_cid={state.target_cid!r}); multi-face join has no "
+                f"single read projection"
+            ),
+            requested=(
+                "either one NormalExhaustion face (read through) or a written "
+                "multi-face LoopProjectedBinding read that names each arm"
+            ),
+            fix=(
+                "write LoopProjectedBinding multi-face read as typed projection "
+                "(or collapse faces earlier); do not raise TypeError — that "
+                "aborts the file as backend-defect instead of a named C3 gap"
+            ),
+        )
+    from sugar_source_tree.panic import SugarNotWritten
+
+    raise SugarNotWritten(
+        owner="binding_state_read_node",
+        blame=f"binding-state:{type(state).__name__}",
+        observed=f"binding state species {type(state).__name__} has no read projection",
+        requested="Node | UnboundBinding | GuardedBinding | single-face LoopProjectedBinding",
+        fix=(
+            f"write binding_state_read_node arm for {type(state).__name__} or "
+            f"project it before the read site"
+        ),
+    )
 
 
 def join_binding_state(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/roll_call.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/roll_call.py
@@ -138,6 +138,32 @@ def discharge(source_file) -> MinorityReport:
             root_node.sugar()
         except SugarNotWritten:
             pass  # the gap is on the roll; the report reads it
+        except RecursionError:
+            # Honest residual (H-class): construction graph too deep / cyclic
+            # for this root. Convert to a named C3 refusal so the file is not
+            # erased as backend-defect "maximum recursion depth exceeded".
+            lc = root_node.line_col_span()
+            gap = SugarNotWritten(
+                owner="roll_call.discharge",
+                blame=root_node.fragment,
+                observed=(
+                    f"RecursionError while constructing {root_node.kind} at "
+                    f"{source_file.unit.filename}:{lc.start_line}:{lc.start_col}"
+                ),
+                requested=(
+                    "bounded construction depth or a written cycle break for "
+                    "this root's sugar graph"
+                ),
+                fix=(
+                    "name the recursive edge (substitute/sugar loop) and bound "
+                    "or split it; refuse specifically as ConstructionRecursionGap "
+                    "— do not let RecursionError abort the roll as backend-defect"
+                ),
+            )
+            # Board family discriminator (same field WithConstructionGap uses).
+            gap.kind = "ConstructionRecursionGap"
+            source_file.reporter.report_gap(root_node, gap)
+            continue
     return MinorityReport(reporter=source_file.reporter)
 
 

--- a/implementations/python/sugar-source-tree/tests/test_honest_residual_named_refusals.py
+++ b/implementations/python/sugar-source-tree/tests/test_honest_residual_named_refusals.py
@@ -1,0 +1,206 @@
+"""Honest residuals refuse specifically (C3) — never TypeError backend-defect.
+
+After the 159 lies, 10 seal files remain honest:
+  E=5 CM resolution gap (already named ContextManagerResolutionConstructionGap)
+  H=3 recursion → ConstructionRecursionGap via roll_call
+  L=1 multi-face LoopProjectedBinding read → SugarNotWritten
+  Λ=1 Lambda body testimony → SugarNotWritten
+
+These must name the artifact they cannot see, not abort as raw TypeError.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.binding_state import (
+    LoopProjectedBinding,
+    LoopProjectedCompletedFace,
+    UnboundBinding,
+    binding_state_read_node,
+)
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def test_multi_face_loop_projected_binding_read_is_sugar_not_written() -> None:
+    """L-class: multi-face LoopProjectedBinding refuses by name, not TypeError."""
+    target = "blake3-512:" + "ab" * 32
+    guard = "blake3-512:" + "cd" * 32
+    faces = (
+        LoopProjectedCompletedFace(
+            target_cid=target,
+            completion_kind="NormalExhaustion",
+            guard_formula_cid=guard,
+            state=UnboundBinding("x", "then"),
+            guard_formula=None,
+            exit_partition_arity=1,
+        ),
+        LoopProjectedCompletedFace(
+            target_cid=target,
+            completion_kind="BreakExit",
+            guard_formula_cid=guard,
+            state=UnboundBinding("x", "break"),
+            guard_formula=None,
+            exit_partition_arity=1,
+        ),
+    )
+    state = LoopProjectedBinding(target_cid=target, completed_faces=faces)
+
+    def make_read(_s):
+        raise AssertionError("make_read should not run for multi-face")
+
+    try:
+        binding_state_read_node(state, make_read=make_read)
+        raise AssertionError("expected SugarNotWritten")
+    except SugarNotWritten as gap:
+        assert "LoopProjectedBinding" in gap.observed
+        assert "multi-face" in gap.observed.lower() or "faces" in gap.observed
+        assert "do not raise TypeError" in gap.fix
+    except TypeError as te:
+        raise AssertionError(
+            f"TypeError is the old lie: {te!r}; want SugarNotWritten"
+        ) from te
+
+
+def test_lambda_body_cid_mismatch_is_sugar_not_written() -> None:
+    """Λ-class: body fragment mismatch refuses as SNW, not TypeError."""
+    from sugar_lift_py_tests.sugar.lambda_sugar import LambdaSugar
+    from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+
+    site_src = "lambda x: x"
+    sf = SourceFile(
+        (site_src + "\n", "lam.py", blake3_512_of((site_src + "\n").encode()))
+    )
+    body = NameSugar(name="x", site=sf.root.fragment)
+    frame = SimpleNamespace(
+        parameters=("x",),
+        formal_coordinates=(SimpleNamespace(cid="blake3-512:" + "11" * 32),),
+        # Match site so the formal/frame checks pass and body is the failure.
+        definition_fragment_cid=sf.root.fragment.seal().cid,
+    )
+    try:
+        LambdaSugar(
+            formals=("x",),
+            body=body,
+            source_call_frame=frame,
+            formal_coordinate_cids=("blake3-512:" + "11" * 32,),
+            body_fragment_cid="blake3-512:" + "22" * 32,  # force body mismatch
+            site=sf.root.fragment,
+        )
+        raise AssertionError("expected SugarNotWritten")
+    except SugarNotWritten as gap:
+        assert "body" in gap.owner.lower() or "body" in gap.observed.lower()
+        assert gap.fix and (
+            "fragment" in gap.fix.lower() or "body" in gap.fix.lower()
+        )
+    except TypeError as te:
+        raise AssertionError(
+            f"TypeError is the old lie: {te!r}; want SugarNotWritten"
+        ) from te
+
+
+def test_classify_honest_residual_recognizes_e_h_l_lambda() -> None:
+    from recensus_enumerate_consumer import _classify_honest_residual
+    from sugar_source_tree.panic import ContextManagerResolutionConstructionGap
+
+    # E — already a named CM resolution gap at the source.
+    e = ContextManagerResolutionConstructionGap(
+        kind="runtime-selected",
+        demand_cid="blake3-512:" + "aa" * 32,
+        candidate_member_cids=(),
+        blame="with-site",
+        owner="With._construct_sugar",
+        observed="authenticated preconstruction resolution gap: runtime-selected",
+        requested="one resolved authenticated ContextManagerContractRefV1",
+        fix="publish or resolve the exact typed CM contract",
+    )
+    t, m, honest = _classify_honest_residual(e)
+    assert honest and "ContextManager" in t
+
+    # H — raw RecursionError reclassified as ConstructionRecursionGap.
+    t, m, honest = _classify_honest_residual(
+        RecursionError("maximum recursion depth exceeded")
+    )
+    assert honest and t == "ConstructionRecursionGap"
+
+    # L — legacy TypeError(type(state)) still classified honest by message.
+    t, m, honest = _classify_honest_residual(
+        TypeError("<class 'sugar_source_tree.binding_state.LoopProjectedBinding'>")
+    )
+    assert honest and "LoopProjected" in t
+
+    # Λ — legacy TypeError body message still classified honest.
+    t, m, honest = _classify_honest_residual(
+        TypeError("LambdaSugar body requires its exact source body testimony")
+    )
+    assert honest and "Lambda" in t
+
+    # Dishonest residual stays backend-defect territory.
+    t, m, honest = _classify_honest_residual(
+        AttributeError("'X' object has no attribute 'y'")
+    )
+    assert not honest
+
+
+def test_roll_call_recursion_reports_construction_recursion_gap() -> None:
+    """H-class: RecursionError during sugar() becomes a named gap on the report."""
+    from sugar_source_tree import roll_call
+    from sugar_source_tree.panic import SugarNotWritten
+
+    class _FakeFragment:
+        def __str__(self) -> str:
+            return "fake-fragment"
+
+    class _FakeReporter:
+        def __init__(self) -> None:
+            self.gaps: list[tuple[object, object]] = []
+
+        def report_gap(self, node: object, panic: object) -> None:
+            self.gaps.append((node, panic))
+
+    class _FakeUnit:
+        filename = "deep.py"
+
+    class _FakeNode:
+        kind = "FunctionDef"
+
+        def __init__(self) -> None:
+            self.fragment = _FakeFragment()
+
+        def line_col_span(self):
+            return SimpleNamespace(start_line=1, start_col=0)
+
+        def sugar(self):
+            raise RecursionError("maximum recursion depth exceeded")
+
+    class _FakeSourceFile:
+        def __init__(self) -> None:
+            self.reporter = _FakeReporter()
+            self.unit = _FakeUnit()
+            self.root = _FakeNode()
+            self.root.kind = "Module"
+
+            def _mod_ok():
+                return None
+
+            # Module root succeeds; the function root is the recursion site.
+            self.root.sugar = _mod_ok  # type: ignore[method-assign]
+            self._fn = _FakeNode()
+
+        def nodes(self):
+            return ()
+
+        def functions(self):
+            return (self._fn,)
+
+    sf = _FakeSourceFile()
+    report = roll_call.discharge(sf)
+    assert report is not None
+    assert len(sf.reporter.gaps) == 1
+    _node, gap = sf.reporter.gaps[0]
+    assert isinstance(gap, SugarNotWritten)
+    assert getattr(gap, "kind", None) == "ConstructionRecursionGap"
+    assert "RecursionError" in gap.observed
+    assert "ConstructionRecursionGap" in gap.fix


### PR DESCRIPTION
## Summary

After the 159/169 campaign lies, **10 seal files remain honest unwritten**, not instrument lies:

| class | count | named refusal |
| --- | --- | --- |
| E | 5 | `ContextManagerResolutionConstructionGap` (already at source) |
| H | 3 | `ConstructionRecursionGap` via `roll_call.discharge` |
| L | 1 | multi-face `LoopProjectedBinding` → `SugarNotWritten` |
| Λ | 1 | `LambdaSugar` body testimony → `SugarNotWritten` |

Each now **refuses specifically and names the artifact it cannot see** (C3). Board classifies them `designed-gap` + `honestResidual=true` so the file roster is not erased as instrument-blind `backend-defect`.

## Changes

- `binding_state_read_node`: multi-face LoopProjectedBinding → SNW (not TypeError)
- `LambdaSugar.__post_init__`: formals/coords/frame/body mismatches → SNW
- `roll_call.discharge`: RecursionError → report_gap ConstructionRecursionGap
- `recensus_enumerate_consumer._classify_honest_residual`: E/H/L/Λ → designed-gap
- teeth: `test_honest_residual_named_refusals.py`

## Landing note (seal)

In-flight seal started **before #7101/#7103**. Expect ~**37** residual defects on that board (24+6+7 not in the run). **Not an alarm** — do not re-fire.

Orange band: functionsTotal **~27425–27451**. ALARM only if still well under 27000 after all fixes land. Do not admire better-than-18230.

## Epsilon R

- 0 backend-defect on these 10 once source refuses specifically
- board family shifts residual:TypeError/RecursionError → named gap kinds
- no seal re-fire; no claim on functionsTotal for this PR alone

## Test plan

- [x] Direct teeth: L SNW, Lambda SNW, classify E/H/L/Λ, roll_call RecursionError→ConstructionRecursionGap
- [ ] CI / merge_dog

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Classify last 10 honest residuals as named refusals instead of backend defects
> - Adds `_classify_honest_residual` in [`recensus_enumerate_consumer.py`](https://github.com/TSavo/sugar/pull/7106/files#diff-f44306c90c4bcc279a33763d110fe23086857b9b1f1afc83ea45e09c2d004b79) to map caught exceptions to normalized type names and an `honestResidual` flag, covering context manager gaps, recursion errors, loop-projection reads, and lambda sugar issues.
> - Updates `terminal_from_enumerate` and `measure_file_via_enumerate` to use this classifier, setting the overall category to `'designed-gap'` instead of `'backend-defect'` when the residual is honest.
> - Replaces `TypeError` raises with structured `SugarNotWritten` panics in [`LambdaSugar.__post_init__`](https://github.com/TSavo/sugar/pull/7106/files#diff-0b042299e54e3ff4e728e6efb183948177c8878c7211f37da4f3dd02381f9bd8) and [`binding_state_read_node`](https://github.com/TSavo/sugar/pull/7106/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40), carrying owner/blame/observed/requested/fix metadata.
> - Adds an explicit `RecursionError` handler in [`roll_call.discharge`](https://github.com/TSavo/sugar/pull/7106/files#diff-cb5c5b83dfefe242a4d48f9a545ff4e5a51819ec9fbde4249736248a8c27b251) that converts recursion into a named `ConstructionRecursionGap` rather than aborting as a backend defect.
> - Behavioral Change: previously these failures appeared as `backend-defect` in reports; they now appear as `designed-gap` with normalized defect types and an `honestResidual` field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c38f94e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->