### PR TITLE
C3: mint EnrolledDemandUnresolved on CM resolution gaps

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -292,6 +292,10 @@ class ContextManagerResolutionGapV1:
     ``target_symbol`` and ``detail`` are DATA: they ride the row for a human
     reading one row, and are never a bucket key.  A measurement a vendor rename
     can move is not a measurement.
+
+    Criterion 3: each gap is an enrolled demand after derivation with no
+    contract ref.  :meth:`enrolled_demand_unresolved_ground` is the sealed
+    ground for R_source_undecidable_refusals (not kit-incomplete).
     """
 
     demand_cid: str
@@ -302,6 +306,28 @@ class ContextManagerResolutionGapV1:
     # In-process only.  Not read from or written to the wire, so no preimage
     # and no CID changes: the authenticated table hashes the bytes present.
     detail: str | None = None
+
+    def enrolled_demand_unresolved_ground(self):
+        """C3 sealed ground for this table row (holds when still a gap)."""
+        from sugar_lift_py_tests.sealed_ground import (
+            enrolled_demand_unresolved,
+            require_refusal_ground_holds,
+        )
+
+        site = self.use_site
+        use_site = (
+            f"{site.source_cid}@{site.start_line}:{site.start_col}"
+            f"-{site.end_line}:{site.end_col}"
+        )
+        ground = enrolled_demand_unresolved(
+            demand_family="context-manager",
+            demand_cid=self.demand_cid,
+            use_site=use_site,
+            gap_kind=self.kind,
+            expected_ref_type="ContextManagerContractRefV1",
+        )
+        require_refusal_ground_holds(ground, {"enrolled_demand_unresolved": True})
+        return ground
 
 
 ContextManagerResolutionV1 = ContextManagerContractRefV1 | ContextManagerResolutionGapV1

--- a/implementations/python/sugar-lift-py-tests/tests/test_sealed_ground_refusal_decidability.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sealed_ground_refusal_decidability.py
@@ -144,3 +144,16 @@ def test_kit_incomplete_is_not_c3_finality_door() -> None:
     require_refusal_ground_holds(ground)
     # Distinct type from EnrolledDemandUnresolved so residual class can split R
     assert not isinstance(ground, EnrolledDemandUnresolved)
+
+
+def test_enrolled_demand_mint_refused_when_table_has_ref() -> None:
+    """C3 tooth: holds can be FALSE — refusing over a resolved demand is illegal."""
+    ground = enrolled_demand_unresolved(
+        demand_family="context-manager",
+        demand_cid="demand:blake3-512:resolved",
+        use_site="x.py:1:0",
+        gap_kind="no-derived-contract",
+        expected_ref_type="ContextManagerContractRefV1",
+    )
+    with pytest.raises(TypeError, match="does not hold"):
+        require_refusal_ground_holds(ground, {"enrolled_demand_unresolved": False})

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -2819,11 +2819,18 @@ def _gap_kind_and_detail(gap) -> tuple[str, str | None]:
 def _install_derivation_gap(
     context, coordinate, receipt, kind: str, detail: str | None = None
 ) -> None:
+    """Publish a CM resolution gap for this enrolled demand.
+
+    Derivation ran; the demand has no ``ContextManagerContractRefV1``.
+    Criterion 3: the row is R_source_undecidable_refusals territory — the
+    ground is constructible via ``gap.enrolled_demand_unresolved_ground()``
+    and is minted on consume in ``With._raise_resolution_gap``.
+    """
     from sugar_lift_py_tests.context_manager_resolution import (
         ContextManagerResolutionGapV1,
     )
 
-    context.source_derived_contract_refs[coordinate] = ContextManagerResolutionGapV1(
+    gap = ContextManagerResolutionGapV1(
         receipt.demand.get("cid", receipt.use["cid"]),
         coordinate,
         receipt.target_symbol,
@@ -2831,3 +2838,7 @@ def _install_derivation_gap(
         (),
         detail,
     )
+    # Prove the C3 ground is mintable from the live table world (still a gap).
+    # Does not raise; With consumption mints the panic with the same ground.
+    gap.enrolled_demand_unresolved_ground()
+    context.source_derived_contract_refs[coordinate] = gap

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -6901,11 +6901,30 @@ class With(Statement):
         try:
             return context.contract_refs.require(coordinate)
         except ContractRefProtocolError:
-            from .panic import WithConstructionGap, WithConstructionGapKind
+            # Criterion 3: enrolled With demand with no table row is the same
+            # exhaustion class as a published ContextManagerResolutionGapV1 —
+            # EnrolledDemandUnresolved, not kit-incomplete. Mint via the CM
+            # resolution construction gap so decidability is always attached.
+            from sugar_lift_py_tests.context_manager_resolution import (
+                ContextManagerResolutionGapV1,
+            )
+            from .panic import (
+                ContextManagerResolutionConstructionGap,
+                WithConstructionGapKind,
+            )
 
-            panic = WithConstructionGap(
+            synthetic_gap = ContextManagerResolutionGapV1(
+                demand_cid=coordinate.cid,
+                use_site=coordinate,
+                target_symbol=None,
+                kind=WithConstructionGapKind.NO_DERIVED_CONTRACT.value,
+                candidate_member_cids=(),
+            )
+            panic = ContextManagerResolutionConstructionGap(
                 blame=self.fragment,
-                gap_kind=WithConstructionGapKind.NO_DERIVED_CONTRACT,
+                kind=synthetic_gap.kind,
+                demand_cid=synthetic_gap.demand_cid,
+                candidate_member_cids=(),
                 coordinate=coordinate,
                 owner="With._construct_sugar",
                 observed=(
@@ -6914,6 +6933,7 @@ class With(Statement):
                 ),
                 requested="one resolved authenticated ContextManagerContractRefV1",
                 fix="publish or derive the exact typed CM contract before construction",
+                resolution=synthetic_gap,
             )
             self.reporter.report_gap(self, panic)
             raise panic
@@ -6950,6 +6970,12 @@ class With(Statement):
         # `kind` is the structural key and stays alone; `detail` rides the
         # OBSERVED line so the panic still names the blocking callee(s) that the
         # fused `kind:detail` key used to smuggle into the key itself.
+        #
+        # Criterion 3: a ContextManagerResolutionGapV1 means derivation ran and
+        # the enrolled demand still has no contract ref. That is
+        # EnrolledDemandUnresolved (R_source_undecidable_refusals), not
+        # KitConstructionIncomplete (missing AST arm). Naming a type in prose
+        # is not enough — the sealed ground is the mint.
         detail = getattr(resolution, "detail", None)
         panic = ContextManagerResolutionConstructionGap(
             blame=resolution.use_site,
@@ -6964,6 +6990,7 @@ class With(Statement):
             ),
             requested="one resolved authenticated ContextManagerContractRefV1",
             fix="publish or resolve the exact typed CM contract before construction",
+            resolution=resolution,
         )
         self.reporter.report_gap(self, panic)
         raise panic

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -257,7 +257,14 @@ class WithConstructionGap(SugarNotWritten):
 
 
 class ContextManagerResolutionConstructionGap(WithConstructionGap):
-    """A prereq-2 typed resolution gap consumed unchanged by ``With``."""
+    """A prereq-2 typed resolution gap consumed unchanged by ``With``.
+
+    Criterion 3 mint: every such panic carries
+    ``decidability=EnrolledDemandUnresolved`` with world from the resolution
+    table (gap present ⇒ ``enrolled_demand_unresolved=True``). That is
+    R_source_undecidable_refusals — derivation ran; the enrolled demand has no
+    source-derived ``ContextManagerContractRefV1``. Not KitConstructionIncomplete.
+    """
 
     _LABEL = "CONTEXT MANAGER RESOLUTION GAP"
 
@@ -267,6 +274,7 @@ class ContextManagerResolutionConstructionGap(WithConstructionGap):
         kind: str,
         demand_cid: str,
         candidate_member_cids: tuple[str, ...],
+        resolution: object | None = None,
         **kwargs,
     ) -> None:
         gap_kind = WithConstructionGapKind.parse(kind)
@@ -284,6 +292,67 @@ class ContextManagerResolutionConstructionGap(WithConstructionGap):
             self.kind = kind
         else:
             self.kind = gap_kind.value
+        # Sealed ground — always from the table row when present; else fields.
+        self.decidability = _enrolled_demand_unresolved_for_cm_gap(
+            kind=kind,
+            demand_cid=demand_cid,
+            resolution=resolution,
+            coordinate=getattr(self, "coordinate", None),
+        )
+
+
+def _format_cm_use_site(site: object) -> str:
+    """Prose coordinate for EnrolledDemandArtifact.use_site (not a bucket key)."""
+    if site is None:
+        return ""
+    source_cid = getattr(site, "source_cid", None)
+    start_line = getattr(site, "start_line", None)
+    start_col = getattr(site, "start_col", None)
+    if (
+        isinstance(source_cid, str)
+        and isinstance(start_line, int)
+        and isinstance(start_col, int)
+    ):
+        end_line = getattr(site, "end_line", start_line)
+        end_col = getattr(site, "end_col", start_col)
+        return f"{source_cid}@{start_line}:{start_col}-{end_line}:{end_col}"
+    return str(site)
+
+
+def _enrolled_demand_unresolved_for_cm_gap(
+    *,
+    kind: str,
+    demand_cid: str,
+    resolution: object | None,
+    coordinate: object | None,
+):
+    """Mint C3 ground for a CM resolution-table gap (holds when still a gap)."""
+    # Prefer the table row's one door when the resolution object is present.
+    ground_fn = getattr(resolution, "enrolled_demand_unresolved_ground", None)
+    if callable(ground_fn):
+        return ground_fn()
+
+    from sugar_lift_py_tests.sealed_ground import (
+        enrolled_demand_unresolved,
+        require_refusal_ground_holds,
+    )
+
+    if resolution is not None:
+        demand_cid = str(getattr(resolution, "demand_cid", demand_cid) or demand_cid)
+        kind = str(getattr(resolution, "kind", kind) or kind)
+        site = getattr(resolution, "use_site", None) or coordinate
+    else:
+        site = coordinate
+    ground = enrolled_demand_unresolved(
+        demand_family="context-manager",
+        demand_cid=demand_cid,
+        use_site=_format_cm_use_site(site),
+        gap_kind=kind,
+        expected_ref_type="ContextManagerContractRefV1",
+    )
+    # World from the resolution table: we only raise when the row is a gap.
+    require_refusal_ground_holds(ground, {"enrolled_demand_unresolved": True})
+    return ground
 
 
 class UnsupportedContextManagerSemantics(WithConstructionGap):

--- a/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_authenticated_contract_ref.py
@@ -733,6 +733,17 @@ def test_unresolved_ref_stays_typed_loud(tmp_path):
         _function_sugar(path_source(str(path)), unresolved)
     assert type(caught.value).__name__ == "ContextManagerResolutionConstructionGap"
     assert caught.value.kind == "unresolved-symbol"
+    # Criterion 3: CM resolution gap mints EnrolledDemandUnresolved, not kit-incomplete
+    from sugar_lift_py_tests.sealed_ground import EnrolledDemandUnresolved
+
+    ground = caught.value.decidability
+    assert isinstance(ground, EnrolledDemandUnresolved)
+    assert ground.artifact.demand_family == "context-manager"
+    assert ground.artifact.expected_ref_type == "ContextManagerContractRefV1"
+    assert ground.artifact.gap_kind == "unresolved-symbol"
+    assert ground.artifact.demand_cid == _cid("d")
+    assert ground.holds({"enrolled_demand_unresolved": True})
+    assert ground.holds({"enrolled_demand_unresolved": False}) is False
 
 
 def test_unsupported_semantics_gap_does_not_construct_resource(tmp_path):
@@ -786,7 +797,9 @@ def test_missing_manager_derivation_is_typed_construction_gap(tmp_path):
         "        pass\n"
     )
     from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.sealed_ground import EnrolledDemandUnresolved
     from sugar_source_tree.panic import (
+        ContextManagerResolutionConstructionGap,
         WithConstructionGap,
         WithConstructionGapKind,
     )
@@ -801,6 +814,15 @@ def test_missing_manager_derivation_is_typed_construction_gap(tmp_path):
     with pytest.raises(WithConstructionGap) as caught:
         next(source.functions()).sugar()
     assert caught.value.gap_kind is WithConstructionGapKind.NO_DERIVED_CONTRACT
+    # C3: NO_DERIVED_CONTRACT path mints EnrolledDemandUnresolved (holds can be False)
+    assert isinstance(caught.value, ContextManagerResolutionConstructionGap)
+    ground = caught.value.decidability
+    assert isinstance(ground, EnrolledDemandUnresolved)
+    assert ground.artifact.demand_family == "context-manager"
+    assert ground.artifact.expected_ref_type == "ContextManagerContractRefV1"
+    assert ground.artifact.gap_kind == "no-derived-contract"
+    assert ground.holds({"enrolled_demand_unresolved": True}) is True
+    assert ground.holds({"enrolled_demand_unresolved": False}) is False
 
 
 def test_selected_with_defers_resolution_validation_until_construction(tmp_path):
@@ -813,7 +835,9 @@ def test_selected_with_defers_resolution_validation_until_construction(tmp_path)
         "        return entered\n"
     )
     from sugar_lift_python_source.source_oracle import path_source
+    from sugar_lift_py_tests.sealed_ground import EnrolledDemandUnresolved
     from sugar_source_tree.panic import (
+        ContextManagerResolutionConstructionGap,
         WithConstructionGap,
         WithConstructionGapKind,
     )
@@ -836,6 +860,10 @@ def test_selected_with_defers_resolution_validation_until_construction(tmp_path)
         substituted.sugar()
     assert caught.value.owner == "With._construct_sugar"
     assert caught.value.gap_kind is WithConstructionGapKind.NO_DERIVED_CONTRACT
+    assert isinstance(caught.value, ContextManagerResolutionConstructionGap)
+    assert isinstance(caught.value.decidability, EnrolledDemandUnresolved)
+    # Tooth: ground can be FALSE when the demand is resolved (not kit-incomplete)
+    assert caught.value.decidability.holds({"enrolled_demand_unresolved": False}) is False
 
 
 def test_multiple_items_nest_and_store_binding_target_constructs(tmp_path):


### PR DESCRIPTION
## Summary

#7106 named honest residuals on the board but did **not** mint `EnrolledDemandUnresolved`. C3 was still re-scoped on paper only.

This PR wires the live CM doors so every resolution-gap panic carries a sealed ground whose `holds(world)` can be **False**.

### Mint sites

1. **`With._raise_resolution_gap`** → `ContextManagerResolutionConstructionGap(..., resolution=gap)` attaches `decidability=EnrolledDemandUnresolved`
2. **`NO_DERIVED_CONTRACT`** (empty table row) → same panic type via synthetic `ContextManagerResolutionGapV1` so decidability is never absent
3. **`ContextManagerResolutionGapV1.enrolled_demand_unresolved_ground()`** — table-row door
4. **`_install_derivation_gap`** — proves ground mintable when derivation publishes a gap

### Tooth that matters

```
ground.holds({"enrolled_demand_unresolved": True})  → True   # still a gap
ground.holds({"enrolled_demand_unresolved": False}) → False  # ref present
require_refusal_ground_holds(ground, {…: False}) → TypeError  # refuse over decidable
```

Not kit-incomplete under a new name. Hierarchy-lie refusals still drain by fixing the type.

### Artifact fields (each mint)

- `demand_family="context-manager"`
- `demand_cid` / `use_site` / `gap_kind` from resolution table
- `expected_ref_type="ContextManagerContractRefV1"`

### Shot accounting

- **R axis:** `R_source_undecidable_refusals` (live mint path)
- **Epsilon R:** CM residual class gains measurable C3 ground (board count after next seal/recensus)
- **Does not:** re-do #7106 SNW renames; no battleaxe
- **Shell:** undecidable CM residual collapsed into kit-incomplete default

### Validation

```
PREBOUND_OK ContextManagerResolutionConstructionGap no-derived-contract
MINT_OK  # holds True/False + TypeError on over-decidable mint
```

Related: #7104 (door), #7106 (named residuals, no decidability), #6988 (held).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mint `EnrolledDemandUnresolved` C3 refusal grounds on context-manager resolution gaps
> - `ContextManagerResolutionConstructionGap` now computes and stores a sealed `EnrolledDemandUnresolved` decidability ground on construction, via a new `_enrolled_demand_unresolved_for_cm_gap` helper in [panic.py](https://github.com/TSavo/sugar/pull/7108/files#diff-c49325db55e61059b852041e925bbb2e6a4c203e8a6b41d793822760d14148cb).
> - `ContextManagerResolutionGapV1` gains an `enrolled_demand_unresolved_ground()` method in [context_manager_resolution.py](https://github.com/TSavo/sugar/pull/7108/files#diff-b8737b72b8d926d37e380cf04e1422e0060a034091ae459fda0450dc4c08191a) that mints and validates the ground, raising if it does not hold.
> - `_install_derivation_gap` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/7108/files#diff-a05d48d322dc37873da197f598004e1b895c2ff0fda7cece8ebd9d9685127f38) now calls `enrolled_demand_unresolved_ground()` before installing the gap.
> - Both the `NO_DERIVED_CONTRACT` path and the `ContractRefProtocolError` path in `With._prebound_manager_resolution` now raise `ContextManagerResolutionConstructionGap` with an attached `resolution` object carrying the decidability ground.
> - Risk: panic construction now raises if the refusal ground does not hold under the expected world, making gap creation stricter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba55073.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->