### PR TITLE
walk(): DAG visit-once — kill nanops setup_method combinatorial blowup

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2671,15 +2671,28 @@ class Node(Typed):
         """Yield (field_name, index-or-None, child) in declared grammar order."""
         yield from self._child_edges()
 
-    def walk(self) -> Iterator["Node"]:
+    def walk(self, *, unique: bool = True) -> Iterator["Node"]:
         """Pre-order walk over the constructed graph. Iterative — never recursive.
 
         Expands each node via ``_child_edges()`` so a walk that follows a
         ``children()`` consumer (or a second walk) does not re-getattr fields.
+
+        Default ``unique=True`` visits each node object **once** (DAG walk by
+        identity). The graph is a DAG by design — e.g. successive
+        ``self.attr = …`` stores share prior ``ReceiverFieldStoreState`` —
+        so walking it as a tree is exponential in sharing depth and is the
+        setup_method/nanops combinatorial blowup. Callers that need one
+        yield per *path* (rare) pass ``unique=False``.
         """
         stack: list[Node] = [self]
+        seen: set[int] | None = set() if unique else None
         while stack:
             node = stack.pop()
+            if seen is not None:
+                nid = id(node)
+                if nid in seen:
+                    continue
+                seen.add(nid)
             yield node
             children = [child for _name, _index, child in node._child_edges()]
             stack.extend(reversed(children))

--- a/implementations/python/sugar-source-tree/tests/fixtures/receiver_field_store_fibonacci_blowup.py
+++ b/implementations/python/sugar-source-tree/tests/fixtures/receiver_field_store_fibonacci_blowup.py
@@ -1,0 +1,27 @@
+# Permanent regression seed: combinatorial ReceiverFieldStoreState blowup.
+#
+# Source: pandas/tests/test_nanops.py TestnanopsDataFrame.setup_method
+# (seal stuck 35+ min @ 99.8% CPU after #7099 removed TypeError abort).
+#
+# Mechanism: each `self.aN = …` becomes ReceiverFieldStoreStatement binding
+# `self` to ReceiverFieldStoreState(receiver=<prior self state>, value=RHS).
+# RHS reads of self.* share the prior state (DAG). walk() without a seen-set
+# treated that DAG as a tree → ~3× node visits per sequential store.
+#
+# Twelve fib-shaped self-field stores: no numpy, no complex, no *args.
+# With DAG-correct walk (visit-once), construct is linear in statement count.
+
+class C:
+    def setup_method(self):
+        self.a0 = 1
+        self.a1 = self.a0
+        self.a2 = self.a1 + self.a0
+        self.a3 = self.a2 + self.a1
+        self.a4 = self.a3 + self.a2
+        self.a5 = self.a4 + self.a3
+        self.a6 = self.a5 + self.a4
+        self.a7 = self.a6 + self.a5
+        self.a8 = self.a7 + self.a6
+        self.a9 = self.a8 + self.a7
+        self.a10 = self.a9 + self.a8
+        self.a11 = self.a10 + self.a9

--- a/implementations/python/sugar-source-tree/tests/test_walk_dag_seen_set.py
+++ b/implementations/python/sugar-source-tree/tests/test_walk_dag_seen_set.py
@@ -1,0 +1,136 @@
+"""walk() is a DAG walk by identity — not a tree walk of shared structure.
+
+Regression for the nanops setup_method seal hang: sequential self.field stores
+build a shared ReceiverFieldStoreState DAG; walk() without a seen-set was
+exponential in sharing depth.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Node
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.tree import SourceFile
+
+FIXTURE = (
+    Path(__file__).resolve().parent
+    / "fixtures"
+    / "receiver_field_store_fibonacci_blowup.py"
+)
+
+
+def _open(text: str, name: str = "walk_dag.py") -> SourceFile:
+    if not text.endswith("\n"):
+        text += "\n"
+    return SourceFile(
+        (text, name, blake3_512_of(text.encode())),
+        reporter=CollectingReporter(),
+    )
+
+
+def test_shared_node_visited_once_by_default() -> None:
+    """A diamond DAG yields the shared child once under unique=True."""
+    # Build:  two parents point at the same Name node object via rewrite-like share.
+    # We can't easily mint arbitrary DAGs without substitute; use field-store
+    # path which is the production share shape.
+    text = (
+        "class C:\n"
+        "    def f(self):\n"
+        "        self.x = 1\n"
+        "        self.y = self.x\n"
+        "        self.z = self.y + self.x\n"
+    )
+    sf = _open(text)
+    fn = next(f for f in sf.functions() if f.name == "f")
+    substituted = fn.substitute({})
+    # After substitute, body is ReceiverFieldStoreStatement chain sharing prior state.
+    last = substituted.body[-1]
+    once = list(last.walk())
+    paths = list(last.walk(unique=False))
+    assert len(once) == len({id(n) for n in once})
+    # Path walk (tree expansion) visits shared structure multiple times.
+    assert len(paths) >= len(once)
+    # Every identity from the unique walk appears in the path walk.
+    assert {id(n) for n in once} <= {id(n) for n in paths}
+
+
+def test_fibonacci_self_field_store_walk_grows_linearly() -> None:
+    """Minimal nanops reproducer: walk node count linear in statement count.
+
+    Historical tree-walk counts (unique=False) grew ~3× per statement:
+      4, 9, 29, 89, 269, 809, 2429, … — combinatorial.
+    DAG walk (unique=True, default) must stay linear in #statements.
+    """
+    text = FIXTURE.read_text()
+    sf = _open(text, name=FIXTURE.name)
+    fn = next(f for f in sf.functions() if f.name == "setup_method")
+    # Empty scope: same door FunctionDef._construct_sugar uses for temporal
+    # substitute of method bodies (formals masked separately).
+    from sugar_source_tree.nodes import (
+        RuntimeBindingEntryFactoryV1,
+        SubstitutionTraceBuilderV1,
+        _BINDING_ENTRY_FACTORY,
+        _SCOPE_OWNER_CID,
+        _SUBSTITUTION_TRACE_BUILDER,
+    )
+    from sugar_lift_python_source.canonical import cid_of_json
+
+    scope_owner_cid = cid_of_json(
+        {
+            "kind": "binding-scope-owner",
+            "schemaVersion": "1",
+            "source": fn.fragment.seal().to_dict(),
+        }
+    )
+    substituted = fn.substitute(
+        {
+            _SCOPE_OWNER_CID: scope_owner_cid,
+            _SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(scope_owner_cid),
+            _BINDING_ENTRY_FACTORY: RuntimeBindingEntryFactoryV1(scope_owner_cid),
+        }
+    )
+
+    # Prefix sizes: after k self-field stores, unique walk count is O(k).
+    # Collect walk sizes of each produced body statement (post-substitute).
+    sizes = [len(list(stmt.walk())) for stmt in substituted.body]
+    assert len(sizes) == 12  # a0..a11
+    # Linear ceiling: each new store adds a bounded number of nodes (RFS +
+    # BinOp + two Attribute loads).  Allow generous constant, still far below
+    # the historical 590_489 at statement 12.
+    for i, n in enumerate(sizes):
+        # O(i) with roomy constant — 200 nodes/statement is already generous.
+        assert n <= 200 * (i + 1), (
+            f"stmt#{i} walk nodes={n} exceeds linear bound; "
+            f"series={sizes} — walk is re-expanding a DAG as a tree"
+        )
+    # Explicit: last statement must not be combinatorial (~590k tree-walk).
+    assert sizes[-1] < 5_000
+    # Monotone non-decreasing is fine; growth factor vs prior must stay small.
+    for i in range(1, len(sizes)):
+        if sizes[i - 1] == 0:
+            continue
+        ratio = sizes[i] / sizes[i - 1]
+        assert ratio < 2.5, (
+            f"stmt#{i} grew {ratio:.2f}× (sizes {sizes[i-1]}→{sizes[i]}); "
+            f"combinatorial tree-walk reintroduced"
+        )
+
+
+def test_fibonacci_self_field_store_constructs() -> None:
+    """Full FunctionDef.sugar of the minimal file must complete (not hang)."""
+    text = FIXTURE.read_text()
+    sf = _open(text, name=FIXTURE.name)
+    fn = next(f for f in sf.functions() if f.name == "setup_method")
+    # Bound construct: if walk regresses, this is where the seal hung.
+    result = fn.sugar()
+    assert result is not None
+
+
+def test_walk_default_is_unique() -> None:
+    """Default signature visits once; unique=False remains available."""
+    import inspect
+
+    sig = inspect.signature(Node.walk)
+    assert sig.parameters["unique"].default is True


### PR DESCRIPTION
## Summary

Seal hung 35+ min on `pandas/tests/test_nanops.py` `setup_method` at 99.8% CPU after #7099 removed a TypeError abort. T-technique diagnosis: `Node.walk()` treated a **DAG as a tree**.

Successive `self.attr = …` become nested `ReceiverFieldStoreState` that **share** prior state by design. `_substitute_body_tracked` calls `produced_stmt.walk()` for NamedExpr after every statement. Without a seen-set, walk node counts grew ~3× per store (706k by stmt 18).

## Fix

`walk(*, unique=True)` by default — visit each node object **once** by `id`. `unique=False` keeps path-complete tree expansion for rare callers.

Callers audited: existence scans, name sets, projection enumerate, roster — all identity-correct under visit-once.

## Teeth

- Fixture: 12 fib-shaped `self.aN = self.a{N-1} + self.a{N-2}` (no numpy/complex/spread)
- Walk sizes **linear** in statement count (assert counts, not wall time)
- Shared node visited once
- Full `FunctionDef.sugar` of the fixture completes

## Epsilon R

Unblocks seal on `test_nanops.py` setup_method and every long `self.field =` chain.

## Test plan

- [x] `test_walk_dag_seen_set.py` all green locally
- [ ] merge_dog

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Node.walk()` to visit each node at most once in DAG traversal
> - Adds a `unique` keyword argument (default `True`) to `Node.walk()` that tracks visited nodes by identity, preventing combinatorial blowup when shared subgraph nodes are revisited.
> - Passing `unique=False` restores the previous path-expanding tree walk behavior.
> - Adds a Fibonacci-like `setup_method` fixture and tests to confirm walk size grows linearly rather than exponentially.
> - Behavioral Change: `Node.walk()` now skips already-visited nodes by default; callers relying on per-path revisits must pass `unique=False`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c742c46.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated tree traversal to avoid visiting shared nodes more than once by default.
  - Preserved the option to revisit nodes when path-based traversal is required.
  - Improved performance for shared structures and prevented traversal-related blowups during code processing.

- **Tests**
  - Added regression coverage for unique and repeated traversal behavior.
  - Added validation for large shared structures and complex Fibonacci-shaped field assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->