### PR TITLE
_binding_site_and_path: structural paths (orange #7110 follow-up)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2325,30 +2325,37 @@ class Node(Typed):
         return wrapped
 
     def _binding_site_and_path(self, name: str, ordinal: int):
-        candidates = []
+        """Locate a bound name's site and a **structural** local projection path.
+
+        Paths are derived from grammar structure (``targets/i/tuple/j``,
+        ``target/list/0``, …) — never from ``enumerate(walk())`` position.
+        Walk order is a traversal policy (and default ``walk`` is unique-by-id);
+        a coordinate must not depend on that policy. Orange audit of the
+        DAG seen-set: path-position indices would under-count if a target
+        DAG ever shared a Name across two edges.
+        """
+        candidates: list[tuple[object, tuple]] = []
+
+        def collect(node: Node, path: tuple) -> None:
+            if isinstance(node, Name):
+                if node.id == name:
+                    candidates.append((node.fragment, path))
+                return
+            if isinstance(node, Starred):
+                collect(node.value, (*path, "starred"))
+                return
+            if isinstance(node, (Tuple_, List)):
+                kind = "tuple" if isinstance(node, Tuple_) else "list"
+                for index, child in enumerate(node.elts):
+                    collect(child, (*path, kind, index))
+
         targets = getattr(self, "targets", None)
         if isinstance(targets, tuple):
             for target_index, target in enumerate(targets):
-                for projection_index, node in enumerate(target.walk()):
-                    if isinstance(node, Name) and node.id == name:
-                        candidates.append(
-                            (
-                                node.fragment,
-                                (
-                                    "targets",
-                                    target_index,
-                                    "projection",
-                                    projection_index,
-                                ),
-                            )
-                        )
+                collect(target, ("targets", target_index))
         target = getattr(self, "target", None)
         if isinstance(target, Node):
-            for projection_index, node in enumerate(target.walk()):
-                if isinstance(node, Name) and node.id == name:
-                    candidates.append(
-                        (node.fragment, ("target", "projection", projection_index))
-                    )
+            collect(target, ("target",))
         if ordinal < len(candidates):
             return candidates[ordinal]
         return self.fragment, ("constructed-projection", ordinal)
@@ -2683,6 +2690,11 @@ class Node(Typed):
         so walking it as a tree is exponential in sharing depth and is the
         setup_method/nanops combinatorial blowup. Callers that need one
         yield per *path* (rare) pass ``unique=False``.
+
+        Do **not** mint coordinates from ``enumerate(walk())`` — a walk index
+        is a traversal policy, not a structural locus. Binding projection
+        paths use grammar structure (``_binding_site_and_path``), which is
+        independent of whether ``walk`` is unique-by-id or path-complete.
         """
         stack: list[Node] = [self]
         seen: set[int] | None = set() if unique else None

--- a/implementations/python/sugar-source-tree/tests/test_binding_site_structural_path.py
+++ b/implementations/python/sugar-source-tree/tests/test_binding_site_structural_path.py
@@ -1,0 +1,99 @@
+"""Binding projection paths are structural — independent of walk() policy.
+
+Orange audit of the walk() DAG seen-set (#7110): ``_binding_site_and_path``
+must not use ``enumerate(walk())`` indices. A walk index is a traversal
+policy; coordinates must come from grammar structure so unique-by-id walk
+cannot under-count shared Name nodes under two target edges.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Assign, For, Name, Tuple_
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.tree import SourceFile
+
+
+def _open(text: str, name: str = "struct_path.py") -> SourceFile:
+    if not text.endswith("\n"):
+        text += "\n"
+    return SourceFile(
+        (text, name, blake3_512_of(text.encode())),
+        reporter=CollectingReporter(),
+    )
+
+
+def test_unpack_binding_path_uses_tuple_structure_not_walk_index() -> None:
+    """``a, b = 1, 2`` projects as targets/0/tuple/i — not projection/<walk i>."""
+    sf = _open("def f():\n    a, b = 1, 2\n")
+    fn = next(sf.functions())
+    assign = next(n for n in fn.body if isinstance(n, Assign))
+    site_a, path_a = assign._binding_site_and_path("a", 0)
+    site_b, path_b = assign._binding_site_and_path("b", 0)
+    assert path_a == ("targets", 0, "tuple", 0)
+    assert path_b == ("targets", 0, "tuple", 1)
+    assert "projection" not in path_a
+    assert "projection" not in path_b
+    assert site_a is not None and site_b is not None
+
+
+def test_for_target_binding_path_is_structural() -> None:
+    """``for x, y in items:`` uses target/tuple/i structure."""
+    sf = _open("def f(items):\n    for x, y in items:\n        pass\n")
+    fn = next(sf.functions())
+    loop = next(n for n in fn.body if isinstance(n, For))
+    _, path_x = loop._binding_site_and_path("x", 0)
+    _, path_y = loop._binding_site_and_path("y", 0)
+    assert path_x == ("target", "tuple", 0)
+    assert path_y == ("target", "tuple", 1)
+    assert "projection" not in path_x
+
+
+def test_two_name_leaves_two_structural_coordinates() -> None:
+    """Two Name leaves under one target yield two distinct structural paths.
+
+    Even when both bind the same spelling (``x, x = …``), structure still
+    distinguishes the edges. Walk-index paths would also distinguish them
+    today, but only while walk is path-complete; structural paths stay correct
+    if the graph later shares a Name object across edges.
+    """
+    sf = _open("def f():\n    x, x = 1, 2\n")
+    fn = next(sf.functions())
+    assign = next(n for n in fn.body if isinstance(n, Assign))
+    # Collect both matches via the structural collector (Assign returns last).
+    matches = []
+
+    def collect(target, path):
+        if isinstance(target, Name):
+            if target.id == "x":
+                matches.append(path)
+            return
+        if isinstance(target, Tuple_):
+            for i, child in enumerate(target.elts):
+                collect(child, (*path, "tuple", i))
+
+    for ti, t in enumerate(assign.targets):
+        collect(t, ("targets", ti))
+    assert matches == [
+        ("targets", 0, "tuple", 0),
+        ("targets", 0, "tuple", 1),
+    ]
+    # Live binding door: last match wins (documented Assign law).
+    _, path = assign._binding_site_and_path("x", 0)
+    assert path == ("targets", 0, "tuple", 1)
+
+
+def test_base_path_never_uses_projection_walk_token() -> None:
+    """No remaining 'projection' token from the old enumerate(walk()) scheme."""
+    sf = _open(
+        "def f(xs):\n"
+        "    a = 1\n"
+        "    b, c = xs\n"
+        "    for i, j in xs:\n"
+        "        pass\n"
+    )
+    fn = next(sf.functions())
+    for stmt in fn.body:
+        for name in ("a", "b", "c", "i", "j"):
+            _site, path = stmt._binding_site_and_path(name, 0)
+            assert "projection" not in path, (type(stmt).__name__, name, path)


### PR DESCRIPTION
## Summary

Orange audited #7110 (walk DAG seen-set) and cleared the default unique-by-id walk — every hot caller is set/existence/CID keyed; L2430 NamedExpr scan is **node identity** and requires visit-once.

**One risk:** `_binding_site_and_path` used `enumerate(target.walk())` as a projection index. That couples a **coordinate** to a **traversal policy**. If a target DAG ever shared a Name across two edges, unique walk would under-count projection candidates.

## Fix (Option 1)

Mint paths from grammar structure — same shape Assign already used:

- `targets/i/tuple/j`, `targets/i/list/k`, `starred`
- `target/tuple/j` for For/etc.

Walk policy (unique or path-complete) cannot change those coordinates. Document on `walk()`: do not mint coords from `enumerate(walk())`.

Default seen-set stays. Per-path remains opt-in (`unique=False`) — not the default.

## Teeth

- unpack / for structural paths
- two Name leaves (`x, x = …`) → two structural paths
- no legacy `"projection"` walk-index token

## Relation

- #7110 MERGED — bomb defused
- this PR — coordinates decoupled from traversal so the seen-set cannot silently wrong-mint BindingEntry paths

## Test plan

- [x] `test_binding_site_structural_path.py` + prior walk teeth green locally
- [ ] merge_dog

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace walk-index binding paths with structural paths in `Node._binding_site_and_path`
> - Rewrites `_binding_site_and_path` in [nodes.py](https://github.com/TSavo/sugar/pull/7112/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to traverse assignment targets by grammar structure rather than using `enumerate(walk())` indices.
> - Paths now use structural tokens like `('targets', i, 'tuple', j)` or `('target', 'list', j)` with `'starred'` for starred targets, replacing the legacy `'projection'` token and walk-order indices.
> - Adds new tests in [test_binding_site_structural_path.py](https://github.com/TSavo/sugar/pull/7112/files#diff-ce6732331bc999157f381c3e99532fd39a0a1da15feaa81da6ad8f6a7c1cf997) covering tuple unpacking, for-loop targets, duplicate name bindings, and absence of the `'projection'` token.
> - Behavioral Change: returned paths are now independent of `walk()` traversal policy; any code consuming paths containing `'projection'` or numeric walk indices will receive different path shapes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03430c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->