### PR TITLE
Promote ObjectPlace to ConstructedTermSugar; extend codomain law dynamic reach

### DIFF
--- a/docs/audits/construction-consumer-codomain-law.json
+++ b/docs/audits/construction-consumer-codomain-law.json
@@ -2,14 +2,15 @@
   "gaps": [],
   "summary": {
     "R_construction_consumer_codomain_gap": 0,
+    "R_expression_construct_not_term": 0,
     "R_kind_dispatch_codomain_gap": 0,
     "R_total": 0,
-    "binding_state_types": 5,
-    "classes": 146,
-    "closed_doors": 3,
-    "construct_minted": 0,
-    "constructed_term_types": 56,
-    "kind_literals": 5,
-    "modules_indexed": 89
+    "binding_state_types": 10,
+    "classes": 270,
+    "closed_doors": 5,
+    "construct_minted": 92,
+    "constructed_term_types": 57,
+    "kind_literals": 51,
+    "modules_indexed": 90
   }
 }

--- a/docs/audits/construction-consumer-codomain-law.md
+++ b/docs/audits/construction-consumer-codomain-law.md
@@ -19,9 +19,32 @@ them; this instrument finds them **forwards**, in seconds, with no corpus.
 
 ## Method (static AST)
 
-1. **Produced:** `ConstructedTermSugar` descendants + binding-state species  
+1. **Produced:** inheritance-proven `ConstructedTermSugar` descendants + binding-state species  
 2. **Closed doors:** `isinstance` / `require_constructed_term_sugar` arms that also raise `TypeError` or `SugarNotWritten`  
-3. **Gap:** produced sibling absent from a door that totalizes that family  
+3. **Gap (sibling):** produced sibling absent from a door that totalizes that family  
+4. **Gap (dynamic-discharge proxy):** `Expression` / `*StateV1` / `*Place*` `_construct_sugar` returns a `*Sugar` that is **not** a `ConstructedTermSugar` descendant → axis `R_expression_construct_not_term`
+
+### Axis 4 — why it exists (fifth lie, sealed board)
+
+Sealed board found:
+`AttributeSugar.receiver requires ConstructedTermSugar, got ConstructedObjectPlaceSugar`
+on `tests/frame/test_arithmetic.py`. Pure isinstance-sibling scan reported
+`R_total=0` because `require_constructed_term_sugar` accepts the **base**
+`ConstructedTermSugar` (all descendants covered) — it cannot see a mint that
+lives **outside** the term hierarchy entirely. That mint is dynamic discharge
+currency: `ObjectPlaceStateV1(Expression)._construct_sugar` → nested slot.
+
+Static proxy enrolled: scan Expression-ish `_construct_sugar` Call returns;
+flag Sugar-not-CTS. **Do not** union every `*Sugar` mint into the term set —
+that lie hid ObjectPlace pre-promote.
+
+### Reach honesty (what static still cannot follow)
+
+- `getattr` / variable factories / runtime type mutations
+- mints outside enrolled roots
+
+Those remain **runtime-only**: `require_constructed_term_sugar` TypeError at
+the slot + sealed-board / discharge twins. Do not force a static answer.
 
 ## Bankable zero language (load-bearing)
 
@@ -30,12 +53,14 @@ them; this instrument finds them **forwards**, in seconds, with no corpus.
 That sentence is the difference between a measured zero and silence-as-a-clean-floor.
 It is the distinction this campaign exists to defend.
 
-### Caveat (must stay prominent)
+### Caveat (must stay prominent — proven load-bearing by ObjectPlace)
 
-Zero is **under this instrument's reach**: static AST on enrolled doors and mint
-packages. **Do not read `R_total=0` as "the class is closed forever".** It means:
-at this tip, every produced sibling is accepted by every closed door we can see
-statically. Remaining gaps may be **dynamic-only**.
+Zero is **under this instrument's reach**: static AST on enrolled doors, mint
+packages, and Expression `_construct_sugar` mint→term proxy. **Do not read
+`R_total=0` as "the class is closed forever".** It means: at this tip, every
+produced sibling is accepted by every closed door we can see statically, and
+every Expression-ish construct mint we can name is a ConstructedTermSugar.
+Remaining gaps may still be dynamic-only (getattr factories, etc.).
 
 ## CI law (enrollment is existence)
 
@@ -58,13 +83,22 @@ python3 implementations/python/sugar-lift-py-tests/scripts/construction_consumer
 | R_total | 0 |
 | R_construction_consumer_codomain_gap | 0 |
 | R_kind_dispatch_codomain_gap | 0 |
+| R_expression_construct_not_term | 0 |
 
-Closed doors (typical tip surface):
+Closed doors / mints (typical tip surface):
 
 - `require_constructed_term_sugar` — base `ConstructedTermSugar`
 - `binding_state_read_node` — `Node | UnboundBinding | GuardedBinding | LoopProjectedBinding`
 - `_projection_term` — ConstructedTermSugar + projection faces
+- `ObjectPlaceStateV1._construct_sugar` → `ConstructedObjectPlaceSugar` (promoted to CTS)
 
-After #7099 / #7101 / #7103 hierarchy fixes, static closed doors accept every
-produced sibling this instrument can see. The four hierarchy lies **may** be the
-whole class at tip — proven zero is still bankable under the caveat above.
+After #7099 / #7101 / #7103 hierarchy fixes + ObjectPlace promote, static closed
+doors and Expression mint→term proxy accept every inhabitant this instrument
+can see. Proven zero remains bankable under the caveat above.
+
+## Fix judgment (ObjectPlace fifth lie)
+
+**Promote** `ConstructedObjectPlaceSugar` → `ConstructedTermSugar` + `to_term`.
+Do **not** widen `AttributeSugar.receiver`. An object place projects
+authenticated construction testimony of an object — same ontology as
+`ConstructedReceiverRefSugar`. The slot was truthful; the mint understated.

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_consumer_codomain_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_consumer_codomain_law.py
@@ -66,13 +66,17 @@ from typing import Iterator, NamedTuple, Sequence
 # Roots to scan (kit construction + consumers only)
 # ---------------------------------------------------------------------------
 
-# Focused roots: sugar mint package + binding-state / loop construction.
+# Focused roots: sugar mint package + binding-state / loop construction +
+# Expression-currency nodes (ObjectPlaceStateV1 lives in nodes.py; without it
+# the dynamic-discharge proxy cannot see Expression._construct_sugar mints).
 # (Full sugar-source-tree/src is huge; fifth-lie doors live in these surfaces.)
 _DEFAULT_PACKAGES = (
     "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar",
     "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
     "implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py",
     "implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py",
+    # Expression._construct_sugar discharge mints (ObjectPlaceStateV1, …)
+    "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
 )
 
 # Families known to mint construction currency that doors must totalize over.
@@ -128,6 +132,8 @@ class ModuleIndex:
         "class_lines",
         "construct_returns",
         "kind_literals",
+        # (owner_class, returned_sugar_name, line) for Expression-ish _construct_sugar
+        "expression_construct_mints",
     )
 
     def __init__(self, path: Path, tree: ast.AST) -> None:
@@ -137,6 +143,7 @@ class ModuleIndex:
         self.class_lines: dict[str, int] = {}
         self.construct_returns: dict[str, set[str]] = defaultdict(set)
         self.kind_literals: set[str] = set()
+        self.expression_construct_mints: list[tuple[str, str, int]] = []
 
 
 def _iter_py_files(roots: Sequence[Path]) -> Iterator[Path]:
@@ -216,6 +223,11 @@ def index_module(path: Path) -> ModuleIndex | None:
                         n = _name_of(sub.value.func)
                         if n:
                             idx.construct_returns[node.name].add(n)
+                            # Record mint line for expression-currency scan later
+                            # once inheritance of owner is known (second pass).
+                            idx.expression_construct_mints.append(
+                                (node.name, n, item.lineno)
+                            )
         # kind="X" / kind='X' string literals on keyword or compare
         if isinstance(node, ast.keyword) and node.arg == "kind":
             if isinstance(node.value, ast.Constant) and isinstance(
@@ -357,8 +369,10 @@ def collect_closed_doors(
                 "project_loop_post_binding",
                 "unwrap_binding_state",
             }
-            _BINDING_MARKERS = {
-                "Node",
+            # Binding-state *currency* species — not bare Node (every walker
+            # accepts Node; _substitute_field is substitution plumbing, not a
+            # construction→consumer codomain door).
+            _BINDING_CURRENCY = {
                 "UnboundBinding",
                 "GuardedBinding",
                 "LoopProjectedBinding",
@@ -366,8 +380,8 @@ def collect_closed_doors(
             is_named = node.name in _FIFTH_LIE_DOORS or (
                 "binding_state_read" in node.name
             )
-            is_binding_currency_door = bool(accepted & _BINDING_MARKERS) and (
-                len(accepted) >= 2 or "TypeError" in raises or "SugarNotWritten" in raises
+            is_binding_currency_door = bool(accepted & _BINDING_CURRENCY) and (
+                "TypeError" in raises or "SugarNotWritten" in raises
             )
             is_require_term = (
                 "require_constructed_term" in node.name
@@ -406,16 +420,19 @@ def collect_produced(
     """Return (constructed_term_types, binding_state_types, construct_minted)."""
     cache: dict[str, set[str]] = {}
     constructed = all_descendants(classes, _CONSTRUCTED_TERM_ROOT)
-    # Also include classes that claim Sugar and are returned as construction
-    sugar_desc = all_descendants(classes, _SUGAR_ROOT)
 
     minted: set[str] = set()
     for idx in indexes:
         for owner, rets in idx.construct_returns.items():
             for r in rets:
                 minted.add(r)
-                if r in sugar_desc or r in constructed:
-                    constructed.add(r)
+                # Only inheritance-proven ConstructedTermSugar descendants count
+                # as term currency. Adding every Sugar mint here hid
+                # ConstructedObjectPlaceSugar (Sugar-not-term) from both axes.
+                if r not in constructed and r in classes:
+                    bases = transitive_bases(classes, r, cache=cache) | {r}
+                    if _CONSTRUCTED_TERM_ROOT in bases:
+                        constructed.add(r)
 
     binding: set[str] = set()
     for name in classes:
@@ -484,16 +501,136 @@ def sibling_gap(
     return True
 
 
+def find_expression_mint_not_term_gaps(
+    indexes: Sequence[ModuleIndex],
+    classes: dict[str, set[str]],
+    constructed_terms: set[str],
+    *,
+    repo: Path | None = None,
+) -> list[Gap]:
+    """Dynamic-path static proxy: Expression._construct_sugar mints non-term Sugar.
+
+    AttributeSugar.receiver and peer slots require ConstructedTermSugar at
+    discharge. If an Expression node mints a Sugar that is NOT a
+    ConstructedTermSugar descendant, the require door TypeErrors at runtime
+    while pure isinstance-sibling scans report R=0 (the mint is outside the
+    term hierarchy entirely). That is the ConstructedObjectPlaceSugar class —
+    sealed board fifth lie on tests/frame/test_arithmetic.py.
+
+    Reach: static AST of Expression-ish ``_construct_sugar`` return Call
+    targets. Does NOT follow dynamic getattr/factory variables — those remain
+    runtime-only (require_constructed_term_sugar TypeError + board discharge).
+    """
+    gaps: list[Gap] = []
+    cache: dict[str, set[str]] = {}
+    expression_roots = {"Expression", "expr"}  # Node expression currency
+    sugar_desc = all_descendants(classes, _SUGAR_ROOT)
+    # HONEST term set only: inheritance-proven ConstructedTermSugar descendants.
+    # Do NOT union with every *Sugar mint name — that hid ObjectPlace pre-promote.
+    term_desc = set(constructed_terms) | all_descendants(
+        classes, _CONSTRUCTED_TERM_ROOT
+    )
+    # Re-filter: only names whose bases include ConstructedTermSugar (or are it).
+    honest_terms: set[str] = set()
+    for name in term_desc:
+        bases = transitive_bases(classes, name, cache=cache) | {name}
+        if _CONSTRUCTED_TERM_ROOT in bases or name == _CONSTRUCTED_TERM_ROOT:
+            honest_terms.add(name)
+    term_desc = honest_terms
+
+    for idx in indexes:
+        if repo is not None and idx.path.is_relative_to(repo):
+            rel = str(idx.path.relative_to(repo))
+        else:
+            rel = str(idx.path)
+        for owner, minted, line in idx.expression_construct_mints:
+            owner_bases = transitive_bases(classes, owner, cache=cache) | {owner}
+            # Only Expression / expression-state construction currency.
+            # Statement sugars (FunctionDef, Assert, …) are not Attribute receivers.
+            if not (owner_bases & expression_roots) and "Expression" not in owner_bases:
+                if not (
+                    owner.endswith("StateV1")
+                    or owner.endswith("State")
+                    or "Place" in owner
+                    or "Expression" in owner
+                ):
+                    continue
+            if minted not in sugar_desc and not minted.endswith("Sugar"):
+                continue
+            if minted in term_desc or minted == _CONSTRUCTED_TERM_ROOT:
+                continue
+            # Minted sugar that is not ConstructedTermSugar
+            minted_bases = transitive_bases(classes, minted, cache=cache) | {minted}
+            if _CONSTRUCTED_TERM_ROOT in minted_bases:
+                continue
+            # Only construction-currency mints: names that claim nested term
+            # testimony (Constructed*, *Place*, *Receiver*). Effect/suspension
+            # sugars (YieldSuspensionSugar, YieldFromSugar, …) intentionally
+            # sit outside CTS — GeneratorConstructionV1 only. Flagging them as
+            # "promote" is a lie; they are refuse-named by design.
+            if not _claims_construction_currency(minted):
+                continue
+            gaps.append(
+                Gap(
+                    axis="R_expression_construct_not_term",
+                    door=f"{owner}._construct_sugar",
+                    door_path=rel,
+                    door_line=line,
+                    produced=minted,
+                    accepted=(_CONSTRUCTED_TERM_ROOT,),
+                    note=(
+                        f"{owner}._construct_sugar mints {minted}, which claims "
+                        f"construction currency (Constructed*/Place/Receiver) but "
+                        f"is not ConstructedTermSugar. Nested slots "
+                        f"(AttributeSugar.receiver, BinOpSugar, …) call "
+                        f"require_constructed_term_sugar and TypeError at discharge "
+                        f"— dynamic path invisible to pure sibling isinstance scans."
+                    ),
+                    fix=(
+                        f"promote {minted} to ConstructedTermSugar + to_term "
+                        f"(slots are truthful; mint missing the base — same as #7099) "
+                        f"OR rename/refuse if it is not nested-construction testimony"
+                    ),
+                )
+            )
+    return gaps
+
+
+def _claims_construction_currency(minted: str) -> bool:
+    """Heuristic: mint name asserts nested-construction / place / receiver currency.
+
+    ObjectPlace fifth lie: ConstructedObjectPlaceSugar. Peer: ConstructedReceiverRefSugar.
+    YieldSuspensionSugar does NOT claim this — suspension boundary only.
+    """
+    if minted.startswith("Constructed"):
+        return True
+    if "Place" in minted or "Receiver" in minted:
+        return True
+    if minted.endswith("PlaceSugar") or minted.endswith("ReceiverSugar"):
+        return True
+    return False
+
+
 def find_gaps(
     doors: Sequence[ClosedDoor],
     constructed: set[str],
     binding: set[str],
     classes: dict[str, set[str]],
     kind_literals: set[str],
+    indexes: Sequence[ModuleIndex] | None = None,
+    *,
+    repo: Path | None = None,
 ) -> list[Gap]:
     gaps: list[Gap] = []
     term_family = {_CONSTRUCTED_TERM_ROOT, _SUGAR_ROOT}
     binding_family = set(_BINDING_STATE_FAMILY)
+
+    if indexes is not None:
+        gaps.extend(
+            find_expression_mint_not_term_gaps(
+                indexes, classes, constructed, repo=repo
+            )
+        )
 
     # Core binding-state currency (what binding_state_read_node must totalize).
     binding_core = frozenset(
@@ -624,13 +761,24 @@ def run(roots: Sequence[Path], repo: Path) -> tuple[list[Gap], dict[str, object]
             indexes.append(idx)
     classes = merge_classes(indexes)
     constructed, binding, minted = collect_produced(indexes, classes)
-    # Minted ConstructedTerm names count as produced even if inheritance parse missed
-    constructed |= {m for m in minted if m.endswith("Sugar")}
+    # Do NOT union every *Sugar mint into constructed. That lie hid
+    # ConstructedObjectPlaceSugar (Sugar, not ConstructedTermSugar) from both
+    # sibling and expression-mint axes. Only inheritance-proven CTS counts.
+    # Unresolved imported bases: keep only names already in `constructed`
+    # via all_descendants (which requires a known base edge in this scan).
     doors = collect_closed_doors(indexes, repo)
     kind_literals: set[str] = set()
     for idx in indexes:
         kind_literals |= idx.kind_literals
-    gaps = find_gaps(doors, constructed, binding, classes, kind_literals)
+    gaps = find_gaps(
+        doors,
+        constructed,
+        binding,
+        classes,
+        kind_literals,
+        indexes=indexes,
+        repo=repo,
+    )
     # Dedup by (door, produced, axis)
     uniq: dict[tuple[str, str, str, int], Gap] = {}
     for g in gaps:
@@ -651,16 +799,21 @@ def run(roots: Sequence[Path], repo: Path) -> tuple[list[Gap], dict[str, object]
         "R_kind_dispatch_codomain_gap": sum(
             1 for g in ordered if g.axis == "R_kind_dispatch_codomain_gap"
         ),
+        "R_expression_construct_not_term": sum(
+            1 for g in ordered if g.axis == "R_expression_construct_not_term"
+        ),
         "R_total": len(ordered),
     }
     return ordered, summary
 
 
 def discrimination_self_test() -> bool:
-    """Plant a lagging door; prove the instrument goes red then clean.
+    """Plant lagging doors; prove the instrument goes red then clean.
 
-    Planted shape (tonight's fifth lie): construction produces LoopProjectedBinding
-    while binding_state_read_node only accepts GuardedBinding and TypeErrors.
+    Two planted shapes:
+    1. binding_state_read_node lagging LoopProjectedBinding (sibling isinstance).
+    2. Expression._construct_sugar minting Sugar-not-CTS (dynamic-discharge
+       proxy — sealed-board ObjectPlace fifth lie).
     """
     import tempfile
 
@@ -711,6 +864,43 @@ def binding_state_read_node(state):
         fix="write arm",
     )
 '''
+    # Dynamic-discharge proxy plant: Expression mints Sugar outside CTS.
+    planted_expr = '''
+class Sugar:
+    pass
+
+class ConstructedTermSugar(Sugar):
+    pass
+
+class Expression:
+    pass
+
+class ConstructedObjectPlaceSugar(Sugar):
+    """Object place claimed as construction currency but not a term."""
+    pass
+
+class ObjectPlaceStateV1(Expression):
+    def _construct_sugar(self):
+        return ConstructedObjectPlaceSugar()
+'''
+    clean_expr = '''
+class Sugar:
+    pass
+
+class ConstructedTermSugar(Sugar):
+    pass
+
+class Expression:
+    pass
+
+class ConstructedObjectPlaceSugar(ConstructedTermSugar):
+    """Promoted: object place IS nested-construction testimony."""
+    pass
+
+class ObjectPlaceStateV1(Expression):
+    def _construct_sugar(self):
+        return ConstructedObjectPlaceSugar()
+'''
     with tempfile.TemporaryDirectory() as raw:
         root = Path(raw)
         fixture = root / "binding_state.py"
@@ -718,12 +908,30 @@ def binding_state_read_node(state):
         red_gaps, red_summary = run((root,), root)
         fixture.write_text(clean, encoding="utf-8")
         green_gaps, green_summary = run((root,), root)
+
+        expr_root = root / "expr_mint"
+        expr_root.mkdir()
+        expr_fixture = expr_root / "nodes.py"
+        expr_fixture.write_text(planted_expr, encoding="utf-8")
+        red_expr_gaps, red_expr_summary = run((expr_root,), root)
+        expr_fixture.write_text(clean_expr, encoding="utf-8")
+        green_expr_gaps, green_expr_summary = run((expr_root,), root)
+
     red_ok = (
         red_summary["R_total"] >= 1
         and any(g.produced == "LoopProjectedBinding" for g in red_gaps)
     )
     green_ok = green_summary["R_total"] == 0
-    return red_ok and green_ok
+    expr_red_ok = (
+        red_expr_summary.get("R_expression_construct_not_term", 0) >= 1
+        and any(
+            g.produced == "ConstructedObjectPlaceSugar"
+            and g.axis == "R_expression_construct_not_term"
+            for g in red_expr_gaps
+        )
+    )
+    expr_green_ok = green_expr_summary["R_total"] == 0
+    return red_ok and green_ok and expr_red_ok and expr_green_ok
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -797,6 +1005,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"  R_kind_dispatch_codomain_gap="
             f"{summary['R_kind_dispatch_codomain_gap']}"
         )
+        print(
+            f"  R_expression_construct_not_term="
+            f"{summary['R_expression_construct_not_term']}"
+        )
         print(f"  R_total={summary['R_total']}")
         if gaps:
             print()
@@ -817,9 +1029,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             print(
                 "  R_total=0 under THIS instrument reach (static AST on enrolled"
-                " doors). Not \"the class is closed forever\" — remaining gaps may"
-                " be dynamic-only. At this tip every produced sibling is accepted"
-                " by every closed door we can see statically."
+                " doors + Expression._construct_sugar mint→term proxy)."
+                " Not \"the class is closed forever\" — remaining gaps may still"
+                " be dynamic-only (getattr factories, runtime type mutations)."
+                " Those are caught by require_constructed_term_sugar TypeError"
+                " at discharge and sealed-board twins, not by this scan."
             )
 
     return 1 if gaps else 0

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_object_place_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_object_place_sugar.py
@@ -3,11 +3,24 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from sugar_lift_py_tests.outcome import Complete, Outcome
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 
 
 @dataclass(frozen=True)
-class ConstructedObjectPlaceSugar(Sugar):
+class ConstructedObjectPlaceSugar(ConstructedTermSugar):
+    """Authenticated object-place currency as nested-construction testimony.
+
+    ObjectPlaceStateV1 projects a constructed object (with field-version
+    identity) into expression slots. AttributeSugar.receiver and peer
+    ConstructedTermSugar slots were truthful — this class was missing the
+    base that admits it as nested-construction testimony (same judgment as
+    ConstructedReceiverRefSugar / #7099 Spread-Complex-Ellipsis promotions).
+
+    Promote, do not widen AttributeSugar.receiver: an object place IS a
+    constructed term (identity + testimony of the object), not a distinct
+    un-termed sugar that slots must special-case.
+    """
+
     value: object = field(compare=False)
     testimony: object
     site: object = field(compare=False)
@@ -20,6 +33,29 @@ class ConstructedObjectPlaceSugar(Sugar):
             sugar_name=cls.__name__,
             floor_name="FloorValue",
             reason="projects one already-constructed value from authenticated testimony",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        # Nested-construction coordinate: occurrence + authenticated semantic
+        # testimony cid + the constructed value's term. Value must already
+        # admit to_term (it is the projected floor / constructed object).
+        value_term = self.value.to_term(owner=owner)
+        testimony_cid = getattr(self.testimony, "semantic_value_cid", None)
+        if not isinstance(testimony_cid, str):
+            raise TypeError(
+                f"{owner}: ConstructedObjectPlaceSugar.testimony requires "
+                f"semantic_value_cid str, got {type(self.testimony).__name__}"
+            )
+        return ctor(
+            "python:constructed-object-place",
+            (
+                self.occurrence_term(owner=owner),
+                str_const(testimony_cid),
+                value_term,
+            ),
+            symbol_kind="coordinate",
         )
 
     def desugar(self, ctx: object = None) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_object_place_is_term.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_object_place_is_term.py
@@ -1,0 +1,107 @@
+"""ConstructedObjectPlaceSugar IS ConstructedTermSugar — AttributeSugar.receiver.
+
+Sealed board (fifth hierarchy lie, dynamic discharge):
+  tests/frame/test_arithmetic.py
+  RuntimeError: AttributeSugar.receiver requires ConstructedTermSugar,
+  got ConstructedObjectPlaceSugar
+
+Same class as the 122: construction produces a type the ConstructedTerm slot
+refuses. Static codomain law reported R=0 because ObjectPlace was Sugar-not-term
+— a DYNAMIC path the isinstance-family scan could not see as a sibling gap
+once require_constructed_term_sugar already accepts the base.
+
+Judgment (parallel #7099): AttributeSugar.receiver requiring ConstructedTermSugar
+is truthful. An object place projects authenticated construction testimony of an
+object — same ontology as ConstructedReceiverRefSugar. Promote the mint class;
+do not widen the slot.
+
+AST-only tooth: full sugar imports hang in some agent shells (exit 143); the
+hierarchy law is source geometry — base class + to_term — and the instrument
+self-test plants the pre-promote shape red then green after promote.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_KIT = Path(__file__).resolve().parents[1]
+_PLACE = (
+    _KIT
+    / "src"
+    / "sugar_lift_py_tests"
+    / "sugar"
+    / "constructed_object_place_sugar.py"
+)
+_ATTR = _KIT / "src" / "sugar_lift_py_tests" / "sugar" / "attribute_sugar.py"
+_NODES = (
+    _KIT.parent  # implementations/python
+    / "sugar-source-tree"
+    / "src"
+    / "sugar_source_tree"
+    / "nodes.py"
+)
+
+
+def _base_names(cls: ast.ClassDef) -> set[str]:
+    names: set[str] = set()
+    for b in cls.bases:
+        if isinstance(b, ast.Name):
+            names.add(b.id)
+        elif isinstance(b, ast.Attribute):
+            names.add(b.attr)
+    return names
+
+
+def test_constructed_object_place_bases_constructed_term_sugar() -> None:
+    """Promote geometry: class extends ConstructedTermSugar (not bare Sugar)."""
+    tree = ast.parse(_PLACE.read_text(encoding="utf-8"))
+    cls = next(
+        n
+        for n in tree.body
+        if isinstance(n, ast.ClassDef) and n.name == "ConstructedObjectPlaceSugar"
+    )
+    bases = _base_names(cls)
+    assert "ConstructedTermSugar" in bases, bases
+    assert "Sugar" not in bases or "ConstructedTermSugar" in bases
+    methods = {
+        n.name
+        for n in cls.body
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    assert "to_term" in methods, methods
+    assert "desugar" in methods, methods
+
+
+def test_attribute_receiver_still_requires_constructed_term() -> None:
+    """Slot stays truthful — do not widen AttributeSugar.receiver."""
+    tree = ast.parse(_ATTR.read_text(encoding="utf-8"))
+    src = ast.dump(tree)
+    assert "require_constructed_term_sugar" in src
+    assert "AttributeSugar.receiver" in _ATTR.read_text(encoding="utf-8")
+
+
+def test_object_place_state_still_mints_promoted_class() -> None:
+    """ObjectPlaceStateV1._construct_sugar still returns ConstructedObjectPlaceSugar."""
+    text = _NODES.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    cls = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.ClassDef) and n.name == "ObjectPlaceStateV1"
+    )
+    construct = next(
+        n
+        for n in cls.body
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name == "_construct_sugar"
+    )
+    returns: set[str] = set()
+    for sub in ast.walk(construct):
+        if isinstance(sub, ast.Return) and isinstance(sub.value, ast.Call):
+            func = sub.value.func
+            if isinstance(func, ast.Name):
+                returns.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                returns.add(func.attr)
+    assert "ConstructedObjectPlaceSugar" in returns, returns


### PR DESCRIPTION
## Summary

Sealed board found the fifth hierarchy lie on the **dynamic discharge path**:

`AttributeSugar.receiver requires ConstructedTermSugar, got ConstructedObjectPlaceSugar`
(`tests/frame/test_arithmetic.py`)

Static codomain law reported `R_total=0` — exactly the load-bearing caveat: zero under instrument reach, not closed forever.

### 1. Fix (brown: promote, not widen)

- **Promote** `ConstructedObjectPlaceSugar` → `ConstructedTermSugar` + `to_term`
- Slot `AttributeSugar.receiver` stays truthful (same as #7099)
- Object place IS nested-construction testimony (peer of `ConstructedReceiverRefSugar`)

### 2. Instrument reach (more valuable)

New axis **`R_expression_construct_not_term`**: Expression-ish `_construct_sugar` minting construction-currency `*Sugar` that is **not** `ConstructedTermSugar`.

- Scans `nodes.py` Expression currency (`ObjectPlaceStateV1`, …)
- Stops unioning every `*Sugar` mint into the term set (that hid ObjectPlace pre-promote)
- Discrimination twin plants ObjectPlace red→green
- **Not forced static for everything:** getattr factories / runtime type mutations remain runtime-only (`require_constructed_term_sugar` TypeError + sealed-board twins)

Live tip: `R_total=0` under extended reach (sibling + expression-mint proxy).

## Validation

```bash
python3 implementations/python/sugar-lift-py-tests/scripts/construction_consumer_codomain_law.py --self-test
python3 implementations/python/sugar-lift-py-tests/scripts/construction_consumer_codomain_law.py
# R_total=0; R_expression_construct_not_term=0
```

AST hierarchy teeth for ObjectPlace promote (no heavy import hang).

## Shot accounting

| | |
| --- | --- |
| **R axis** | fifth-lie ObjectPlace dynamic residual; instrument reach gap |
| **Epsilon R** | ObjectPlace residual → 0; static Expression mint→term proxy enrolled |
| **Shell deleted** | none — promote is the rung; #7113 instrument extended not deleted |
| **Floors** | mass/denominator honesty unchanged; battleaxe seal untouched |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Promote `ConstructedObjectPlaceSugar` to `ConstructedTermSugar` and extend codomain law analysis
> - Changes `ConstructedObjectPlaceSugar` base class from `Sugar` to `ConstructedTermSugar` and implements `to_term()`, allowing it to satisfy consumers that require a constructed term (e.g. `require_constructed_term_sugar`).
> - Adds a new gap axis `R_expression_construct_not_term` to [construction_consumer_codomain_law.py](https://github.com/TSavo/sugar/pull/7114/files#diff-45a30f6247d40314fad331d5ec5205d68a219cd2f887b70e57e61fdcd19afc09) that detects `Expression._construct_sugar` methods returning construction-currency-named sugars that do not inherit `ConstructedTermSugar`.
> - Tightens `collect_produced` to count only inheritance-proven `ConstructedTermSugar` descendants, and narrows `collect_closed_doors` to binding-currency types that raise `TypeError` or `SugarNotWritten`.
> - Adds [test_constructed_object_place_is_term.py](https://github.com/TSavo/sugar/pull/7114/files#diff-0a5f85d41ff1e09e022a56abb30ffc34b288ff8e84b3ad8ca40227c9278fec1c) to statically assert the new base, `to_term`, and that `ObjectPlaceStateV1._construct_sugar` returns the promoted class.
> - Behavioral Change: `constructed_term_types` metric now excludes generic `*Sugar` mints that do not inherit `ConstructedTermSugar`, lowering historic counts until those classes are promoted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd6060a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->