### PR TITLE
Audit: static vs board halves of codomain-law zero

### DIFF
--- a/docs/audits/construction-consumer-codomain-law.md
+++ b/docs/audits/construction-consumer-codomain-law.md
@@ -38,13 +38,26 @@ Static proxy enrolled: scan Expression-ish `_construct_sugar` Call returns;
 flag Sugar-not-CTS. **Do not** union every `*Sugar` mint into the term set —
 that lie hid ObjectPlace pre-promote.
 
-### Reach honesty (what static still cannot follow)
+### Reach honesty (stated boundary — makes the zero meaningful)
 
-- `getattr` / variable factories / runtime type mutations
-- mints outside enrolled roots
+**This is not a failure of the instrument. It is its stated boundary.**
+Stating it is what makes `R_total=0` meaningful — same discipline as the first
+caveat, which turned out to be exactly where the fifth lie lived.
 
-Those remain **runtime-only**: `require_constructed_term_sugar` TypeError at
-the slot + sealed-board / discharge twins. Do not force a static answer.
+| Half | What is measured | What catches residual |
+| --- | --- | --- |
+| **Static (this floor)** | closed-door isinstance siblings + Expression mint→term proxy (`R_expression_construct_not_term`) | this instrument, red while R > 0 |
+| **Dynamic (not this floor)** | `getattr` / variable factories / runtime type mutations / mints outside enrolled roots | `require_constructed_term_sugar` TypeError at the slot **plus** sealed-board / discharge twins |
+
+Do not force a static answer for the dynamic half.
+
+### Honest position at close (anyone reading the zero)
+
+**`R_total=0` under extended static reach**, with **dynamic getattr paths caught
+by the board rather than the floor**. Anyone reading the zero should know
+which half is which. The sixth lie of the Expression-mint class is caught
+forwards by this instrument; a sixth of the pure-getattr class is still a
+board finding until a stronger substrate can name it statically.
 
 ## Bankable zero language (load-bearing)
 
@@ -60,7 +73,8 @@ packages, and Expression `_construct_sugar` mint→term proxy. **Do not read
 `R_total=0` as "the class is closed forever".** It means: at this tip, every
 produced sibling is accepted by every closed door we can see statically, and
 every Expression-ish construct mint we can name is a ConstructedTermSugar.
-Remaining gaps may still be dynamic-only (getattr factories, etc.).
+Remaining gaps may still be dynamic-only (getattr factories, etc.) — board
+half, not floor half.
 
 ## CI law (enrollment is existence)
 


### PR DESCRIPTION
## Summary

Doc-only. Pins the **honest position at close** for `construction-consumer-codomain-law`:

- **`R_total=0` under extended static reach** (sibling doors + Expression mint→term proxy)
- **Dynamic getattr paths** caught by `require_constructed_term_sugar` TypeError **plus board**, not this floor

Stating the boundary is what makes the zero meaningful — same discipline as the first caveat (where the fifth lie lived).

Follows #7114 (already on main). No code change.

## Shot accounting

| | |
| --- | --- |
| **R axis** | none (orientation only) |
| **Epsilon R** | 0 |
| **Shell deleted** | none |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document static vs dynamic halves of codomain-law zero in construction-consumer audit
> Updates [construction-consumer-codomain-law.md](https://github.com/TSavo/sugar/pull/7115/files#diff-55eba93091381580701b75a33900ba4f25d36c14faffe58ae1bdeb0a2e8768b9) to clarify the boundary between static and dynamic reach in the codomain-law zero analysis.
>
> - Rewrites the "Reach honesty" subsection with an explicit boundary statement and a two-column table distinguishing what is measured statically vs what the board catches dynamically.
> - Adds a note that `R_total=0` falls under extended static reach and that dynamic `getattr` paths are handled by the board, including coverage of the sixth lie classes.
> - Updates the "Bankable zero language" section to state that remaining gaps are dynamic-only and belong to the board half, not the floor half.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c825fbb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->