### PR TITLE
C3: bank R_source_undecidable_refusals on sealed board

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -48,6 +48,19 @@ _TOOLS = Path(__file__).resolve().parents[4] / "tools"
 if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
 
+# Package root for sealed board function facts (C4 Step 1).
+_PKG_SRC = Path(__file__).resolve().parents[1] / "src"
+if _PKG_SRC.is_dir() and str(_PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(_PKG_SRC))
+
+from sugar_lift_py_tests.c4.board_function_facts import (  # noqa: E402
+    LocalReading,
+    board_fields_from_sealed_facts,
+    seal_functions_clean_v1,
+    seal_functions_enumerated_v1,
+    seal_functions_population_v1,
+)
+
 
 def _blake3_512(data: bytes) -> str:
     try:
@@ -293,6 +306,8 @@ def aggregate_terminal_rows(
     desugar_construction_panics: list[dict[str, Any]] = []
     desugar_defects: list[dict[str, Any]] = []
     desugar_designed_gaps: list[dict[str, Any]] = []
+    # C3: EnrolledDemandUnresolved inhabitants (mint-live → board-visible)
+    source_undecidable_refusals: list[dict[str, Any]] = []
     unresolvable_dispatch: list[dict[str, Any]] = []
     construction_panics: list[dict[str, Any]] = []
     defects: list[dict[str, Any]] = []
@@ -344,6 +359,32 @@ def aggregate_terminal_rows(
         desugar_construction_panics.extend(row.get("desugarConstructionPanics") or [])
         desugar_defects.extend(row.get("desugarDefects") or [])
         desugar_designed_gaps.extend(row.get("desugarDesignedGaps") or [])
+        # C3 C: bank sealed refusals from terminal rows (A/B already projected).
+        row_c3 = row.get("sourceUndecidableRefusals")
+        if isinstance(row_c3, list) and row_c3:
+            for item in row_c3:
+                if isinstance(item, dict):
+                    source_undecidable_refusals.append(dict(item))
+        else:
+            # Fallback: defect row carries decidabilityKind when list omitted.
+            defect_probe = row.get("defect")
+            if (
+                isinstance(defect_probe, dict)
+                and defect_probe.get("decidabilityKind") == "EnrolledDemandUnresolved"
+            ):
+                source_undecidable_refusals.append(
+                    {
+                        "file": file,
+                        "type": defect_probe.get("type"),
+                        "message": defect_probe.get("message"),
+                        "decidabilityKind": "EnrolledDemandUnresolved",
+                        "demandFamily": defect_probe.get("demandFamily") or "",
+                        "demandCid": defect_probe.get("demandCid") or "",
+                        "useSite": defect_probe.get("useSite") or "",
+                        "gapKind": defect_probe.get("gapKind") or "",
+                        "expectedRefType": defect_probe.get("expectedRefType") or "",
+                    }
+                )
         if category == "completed":
             files_completed += 1
         elif category == "construction-panic":
@@ -389,6 +430,7 @@ def aggregate_terminal_rows(
         "desugar_construction_panics": desugar_construction_panics,
         "desugar_defects": desugar_defects,
         "desugar_designed_gaps": desugar_designed_gaps,
+        "source_undecidable_refusals": source_undecidable_refusals,
         "unresolvable_dispatch": unresolvable_dispatch,
         "construction_panics": construction_panics,
         "defects": defects,
@@ -440,6 +482,45 @@ def seal_board_from_aggregate(
     r_desugar = sum(desugar_families.values())
     r_backend = sum(backend_defects.values())
 
+    # C4 Step 1: three sealed meanings, not one overloaded int.
+    # LocalReadings are free; only the seal doors + board_fields_from_sealed_facts
+    # may mint board function fields. Bare ints cannot pass the consumer.
+    pin_id = (
+        aggregate_hash
+        or (plan or {}).get("aggregateHash")
+        or _PANDAS_3_0_3_AGGREGATE_HASH
+    )
+    pop_fact = seal_functions_population_v1(
+        LocalReading(int(agg["functions_total"]), "functions_total"),
+        tip=measured_commit,
+        pin=str(pin_id),
+    )
+    enum_fact = seal_functions_enumerated_v1(
+        LocalReading(int(agg.get("functions_enumerated") or 0), "functions_enumerated"),
+        tip=measured_commit,
+        pin=str(pin_id),
+    )
+    if agg.get("clean_ratio_refused"):
+        clean_fact = seal_functions_clean_v1(
+            LocalReading(None, "functions_clean"),
+            tip=measured_commit,
+            pin=str(pin_id),
+            refused=True,
+            refuse_reason=(
+                "one or more files refused functionsClean "
+                "(would be tautological clean%)"
+            ),
+        )
+    else:
+        clean_fact = seal_functions_clean_v1(
+            LocalReading(int(agg["functions_clean"]), "functions_clean"),
+            tip=measured_commit,
+            pin=str(pin_id),
+            refused=False,
+        )
+    # Consumer close: bare int cannot become a board field.
+    fn_fields = board_fields_from_sealed_facts(pop_fact, enum_fact, clean_fact)
+
     body: dict[str, Any] = {
         "schemaVersion": 1,
         "kind": KIND_SEALED,
@@ -471,6 +552,7 @@ def seal_board_from_aggregate(
         "isolation": "in-process",
         "paths": dict(paths or {}),
         # Dual unit denominator — files and functions NEVER share a slot.
+        # functions.* comes only from sealed meaning types (C4 consumer close).
         "denominator": {
             "files": {
                 "enrolled": len(file_names),
@@ -483,33 +565,7 @@ def seal_board_from_aggregate(
                 "malformedRows": list(agg["malformed_rows"]),
                 "complete": bool(agg["files_complete"]),
             },
-            "functions": {
-                # Population = sum of row functionsTotal (roster-preserved mass).
-                "total": int(agg["functions_total"]),
-                "enumerated": int(agg.get("functions_enumerated") or 0),
-                "unaccounted": max(
-                    0,
-                    int(agg["functions_total"])
-                    - int(agg.get("functions_enumerated") or 0),
-                ),
-                # clean only when every row could measure it; else refused.
-                **(
-                    {
-                        "clean": None,
-                        "cleanRatioRefused": True,
-                        "cleanRefuseReason": (
-                            "one or more files refused functionsClean "
-                            "(would be tautological clean%)"
-                        ),
-                    }
-                    if agg.get("clean_ratio_refused")
-                    else {
-                        "clean": int(agg["functions_clean"]),
-                        "cleanRatioRefused": False,
-                    }
-                ),
-                "unit": "construction-function-locus",
-            },
+            "functions": dict(fn_fields["denominator_functions"]),
             # Back-compat flat keys (file unit only) for older readers.
             "enrolled": len(file_names),
             "terminalRows": int(agg["terminal_count"]),
@@ -534,19 +590,13 @@ def seal_board_from_aggregate(
         ),
         "constructionPanics": construction_panics,
         "R_construction_panics": len(construction_panics),
-        "functionsTotal": int(agg["functions_total"]),
-        "functionsEnumerated": int(agg.get("functions_enumerated") or 0),
-        "functionsUnaccounted": max(
-            0,
-            int(agg["functions_total"]) - int(agg.get("functions_enumerated") or 0),
-        ),
-        # Never mint a tautological clean: null when any file refused clean.
-        "functionsConstructClean": (
-            None
-            if agg.get("clean_ratio_refused")
-            else int(agg["functions_clean"])
-        ),
-        "cleanRatioRefused": bool(agg.get("clean_ratio_refused")),
+        # Function fields only via sealed types — bare ints cannot land here.
+        "functionsTotal": fn_fields["functionsTotal"],
+        "functionsEnumerated": fn_fields["functionsEnumerated"],
+        "functionsUnaccounted": fn_fields["functionsUnaccounted"],
+        "functionsConstructClean": fn_fields["functionsConstructClean"],
+        "cleanRatioRefused": fn_fields["cleanRatioRefused"],
+        "sealedFunctionFactCids": dict(fn_fields["sealedFactCids"]),
         "cleanRefuseReasons": list(agg.get("clean_refuse_reasons") or []),
         "R": r_construction,
         "R_construction": r_construction,
@@ -596,6 +646,13 @@ def seal_board_from_aggregate(
         "R_desugar_defects": len(agg["desugar_defects"]),
         "desugarDesignedGaps": list(agg["desugar_designed_gaps"]),
         "R_desugar_designed_gaps": len(agg["desugar_designed_gaps"]),
+        # Criterion 3 sealed axis: EnrolledDemandUnresolved mints (CM first).
+        "sourceUndecidableRefusals": list(
+            agg.get("source_undecidable_refusals") or []
+        ),
+        "R_source_undecidable_refusals": len(
+            agg.get("source_undecidable_refusals") or []
+        ),
         "unresolvableDispatchTargets": list(agg["unresolvable_dispatch"]),
         "R_unresolvable_dispatch_targets": len(agg["unresolvable_dispatch"]),
         "elapsedSeconds": elapsed_seconds,

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import ast
 from collections import Counter
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 SCOREBOARD_AUTHORITY = False
 
@@ -328,6 +328,60 @@ def _classify_honest_residual(
     return name, msg, False
 
 
+def _enrolled_demand_unresolved_wire(
+    error: BaseException,
+) -> dict[str, Any] | None:
+    """C3 A: project EnrolledDemandUnresolved ground → board wire fields.
+
+    Returns None when the residual has no sealed C3 ground (kit-incomplete,
+    raw TypeError, etc.). The five artifact fields name what source could not
+    see — not merely the exception type.
+    """
+    decidability = getattr(error, "decidability", None)
+    if decidability is None:
+        return None
+    try:
+        from sugar_lift_py_tests.sealed_ground import EnrolledDemandUnresolved
+    except ImportError:
+        if type(decidability).__name__ != "EnrolledDemandUnresolved":
+            return None
+    else:
+        if not isinstance(decidability, EnrolledDemandUnresolved):
+            return None
+    art = getattr(decidability, "artifact", None)
+    if art is None:
+        return None
+    return {
+        "decidabilityKind": "EnrolledDemandUnresolved",
+        "demandFamily": str(getattr(art, "demand_family", "") or ""),
+        "demandCid": str(getattr(art, "demand_cid", "") or ""),
+        "useSite": str(getattr(art, "use_site", "") or ""),
+        "gapKind": str(getattr(art, "gap_kind", "") or ""),
+        "expectedRefType": str(getattr(art, "expected_ref_type", "") or ""),
+    }
+
+
+def _source_undecidable_refusal_row(
+    *,
+    file_rel: str,
+    err_type: str,
+    err_msg: str,
+    wire: Mapping[str, Any],
+) -> dict[str, Any]:
+    """One C3 inhabitant for R_source_undecidable_refusals (compose input)."""
+    return {
+        "file": file_rel,
+        "type": err_type,
+        "message": err_msg,
+        "decidabilityKind": wire["decidabilityKind"],
+        "demandFamily": wire["demandFamily"],
+        "demandCid": wire["demandCid"],
+        "useSite": wire["useSite"],
+        "gapKind": wire["gapKind"],
+        "expectedRefType": wire["expectedRefType"],
+    }
+
+
 def terminal_from_enumerate(
     *,
     file_rel: str,
@@ -347,6 +401,8 @@ def terminal_from_enumerate(
     families: Counter[str] = Counter()
     construction_panics: list[dict[str, Any]] = []
     defects: list[dict[str, Any]] = []
+    # C3 B: live mint path → named list (compose banks R_source_undecidable_refusals)
+    source_undecidable_refusals: list[dict[str, Any]] = []
 
     if function_gaps and not function_nodes:
         # File-level roster demand failed — true empty denominator.
@@ -421,15 +477,27 @@ def terminal_from_enumerate(
 
     if residual_phase_failed and residual_error is not None:
         err_type, err_msg, honest = _classify_honest_residual(residual_error)
-        defects.append(
-            {
-                "file": file_rel,
-                "type": err_type,
-                "message": err_msg,
-                "phase": "residual",
-                "honestResidual": honest,
-            }
-        )
+        # C3 A: attach sealed-ground artifact fields on the defect row when present.
+        defect_row: dict[str, Any] = {
+            "file": file_rel,
+            "type": err_type,
+            "message": err_msg,
+            "phase": "residual",
+            "honestResidual": honest,
+        }
+        c3_wire = _enrolled_demand_unresolved_wire(residual_error)
+        if c3_wire is not None:
+            defect_row.update(c3_wire)
+            source_undecidable_refusals.append(
+                _source_undecidable_refusal_row(
+                    file_rel=file_rel,
+                    err_type=err_type,
+                    err_msg=err_msg,
+                    wire=c3_wire,
+                )
+            )
+            families["EnrolledDemandUnresolved"] += 1
+        defects.append(defect_row)
         families[f"residual:{err_type}"] += 1
 
     clean, clean_refused, clean_reason = _honest_functions_clean(
@@ -486,6 +554,9 @@ def terminal_from_enumerate(
         row["panic"] = construction_panics[0]
     if defects and category != "completed":
         row["defect"] = defects[0]
+    # C3 B: always present (empty when no EnrolledDemandUnresolved mint).
+    row["sourceUndecidableRefusals"] = list(source_undecidable_refusals)
+    row["R_source_undecidable_refusals"] = len(source_undecidable_refusals)
     # Roster was banked; instrument-blind only if residual failed without construction.
     if residual_phase_failed:
         row["R_instrument_blind"] = 1
@@ -540,18 +611,31 @@ def measure_file_via_enumerate(
         # (instrument-blind mass, not a silent zero when the file has functions).
         auth = int(ast_fn) if ast_fn is not None else 0
         err_type, err_msg, honest = _classify_honest_residual(error)
-        return _empty_shell(
+        defect: dict[str, Any] = {
+            "file": file_rel,
+            "type": err_type,
+            "message": err_msg,
+            "phase": "roster",
+            "honestResidual": honest,
+        }
+        source_undecidable: list[dict[str, Any]] = []
+        c3_wire = _enrolled_demand_unresolved_wire(error)
+        if c3_wire is not None:
+            defect.update(c3_wire)
+            source_undecidable.append(
+                _source_undecidable_refusal_row(
+                    file_rel=file_rel,
+                    err_type=err_type,
+                    err_msg=err_msg,
+                    wire=c3_wire,
+                )
+            )
+        shell = _empty_shell(
             file_rel=file_rel,
             category="designed-gap" if honest else "backend-defect",
             functions_total=auth,
             functions_enumerated=0,
-            defect={
-                "file": file_rel,
-                "type": err_type,
-                "message": err_msg,
-                "phase": "roster",
-                "honestResidual": honest,
-            },
+            defect=defect,
             functions_clean=None if auth > 0 else 0,
             clean_ratio_refused=auth > 0,
             clean_refuse_reason=(
@@ -559,6 +643,15 @@ def measure_file_via_enumerate(
             ),
             ast_fn=ast_fn,
         )
+        shell["sourceUndecidableRefusals"] = source_undecidable
+        shell["R_source_undecidable_refusals"] = len(source_undecidable)
+        if source_undecidable:
+            fam = dict(shell.get("families") or {})
+            fam["EnrolledDemandUnresolved"] = (
+                int(fam.get("EnrolledDemandUnresolved") or 0) + len(source_undecidable)
+            )
+            shell["families"] = fam
+        return shell
 
     if function_gaps and not function_nodes:
         return terminal_from_enumerate(

--- a/tests/test_control_effect_recensus_compose.py
+++ b/tests/test_control_effect_recensus_compose.py
@@ -121,6 +121,93 @@ def test_compose_scoreboard_authority_true_only_here() -> None:
     assert "SCOREBOARD_AUTHORITY = True" not in worker.split("compose_control_effect_board")[0]
 
 
+def test_compose_banks_r_source_undecidable_refusals_c3_axis() -> None:
+    """C3 C: sealed board banks R_source_undecidable_refusals from terminal lists."""
+    # Five CM designed-gap files (E-class first inhabitants) + one non-C3 honest.
+    rows = []
+    for i in range(5):
+        rows.append(
+            (
+                f"pandas/e{i}.py",
+                {
+                    "category": "designed-gap",
+                    "functionsTotal": 62,
+                    "functionsEnumerated": 0,
+                    "functionsClean": None,
+                    "cleanRatioRefused": True,
+                    "families": {
+                        "EnrolledDemandUnresolved": 1,
+                        "residual:ContextManagerResolutionConstructionGap": 1,
+                    },
+                    "defect": {
+                        "file": f"pandas/e{i}.py",
+                        "type": "ContextManagerResolutionConstructionGap",
+                        "honestResidual": True,
+                        "decidabilityKind": "EnrolledDemandUnresolved",
+                        "demandFamily": "context-manager",
+                        "demandCid": f"demand:cm:{i}",
+                        "useSite": f"cid@1:0-1:10",
+                        "gapKind": "no-derived-contract",
+                        "expectedRefType": "ContextManagerContractRefV1",
+                    },
+                    "sourceUndecidableRefusals": [
+                        {
+                            "file": f"pandas/e{i}.py",
+                            "type": "ContextManagerResolutionConstructionGap",
+                            "message": "gap",
+                            "decidabilityKind": "EnrolledDemandUnresolved",
+                            "demandFamily": "context-manager",
+                            "demandCid": f"demand:cm:{i}",
+                            "useSite": f"cid@1:0-1:10",
+                            "gapKind": "no-derived-contract",
+                            "expectedRefType": "ContextManagerContractRefV1",
+                        }
+                    ],
+                    "R_source_undecidable_refusals": 1,
+                    "R_instrument_blind": 1,
+                },
+            )
+        )
+    rows.append(
+        (
+            "pandas/h_rec.py",
+            {
+                "category": "designed-gap",
+                "functionsTotal": 1,
+                "functionsEnumerated": 0,
+                "functionsClean": None,
+                "cleanRatioRefused": True,
+                "families": {"residual:ConstructionRecursionGap": 1},
+                "defect": {
+                    "file": "pandas/h_rec.py",
+                    "type": "ConstructionRecursionGap",
+                    "honestResidual": True,
+                },
+                "sourceUndecidableRefusals": [],
+                "R_source_undecidable_refusals": 0,
+                "R_instrument_blind": 1,
+            },
+        )
+    )
+    enrolled = [f for f, _ in rows]
+    status, body = COMPOSE.compose_k1_from_rows(
+        rows,
+        enrolled_files=enrolled,
+        measured_commit="deadbeef",
+        aggregate_hash="agg",
+        manifest_shape_cid="cid",
+    )
+    assert status == "sealed"
+    assert body["R_source_undecidable_refusals"] == 5
+    assert len(body["sourceUndecidableRefusals"]) == 5
+    assert body["functionsTotal"] == 5 * 62 + 1
+    for inhab in body["sourceUndecidableRefusals"]:
+        assert inhab["demandFamily"] == "context-manager"
+        assert inhab["expectedRefType"] == "ContextManagerContractRefV1"
+        assert inhab["gapKind"] == "no-derived-contract"
+        assert inhab["decidabilityKind"] == "EnrolledDemandUnresolved"
+
+
 def test_k1_compose_seals_with_dual_denom_and_body_cid() -> None:
     files = ["pandas/a.py", "pandas/b.py"]
     # a: enumerated 3 of 3 authenticated; b: panic, auth 2 still in population.

--- a/tests/test_recensus_enumerate_consumer.py
+++ b/tests/test_recensus_enumerate_consumer.py
@@ -100,6 +100,82 @@ def test_functions_gap_without_nodes_is_defect() -> None:
     assert row["functionsTotal"] == 0
 
 
+def test_c3_enrolled_demand_unresolved_emits_artifact_fields_and_list() -> None:
+    """A/B: residual with EnrolledDemandUnresolved → defect wire + named list."""
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        SourceFragmentCoordinateV1,
+    )
+    from sugar_source_tree.panic import ContextManagerResolutionConstructionGap
+
+    site = SourceFragmentCoordinateV1("blake3-512:" + ("ab" * 32), 3, 4, 3, 13)
+    gap = ContextManagerResolutionGapV1(
+        "demand:blake3-512:cm",
+        site,
+        "context-manager:dependency.manager",
+        "unresolved-symbol",
+        (),
+    )
+    residual = ContextManagerResolutionConstructionGap(
+        blame=site,
+        kind=gap.kind,
+        demand_cid=gap.demand_cid,
+        candidate_member_cids=(),
+        coordinate=site,
+        owner="With._construct_sugar",
+        observed="authenticated preconstruction resolution gap: unresolved-symbol",
+        requested="one resolved authenticated ContextManagerContractRefV1",
+        fix="publish or resolve the exact typed CM contract",
+        resolution=gap,
+    )
+    assert residual.decidability is not None
+    assert residual.decidability.holds({"enrolled_demand_unresolved": False}) is False
+
+    row = CONSUMER.terminal_from_enumerate(
+        file_rel="pandas/io/json/_json.py",
+        function_nodes=[{"memento": {"function_name": f"f{i}"}} for i in range(62)],
+        function_gaps=[],
+        audit=None,
+        construction_gaps=[],
+        residual_phase_failed=True,
+        residual_error=residual,
+    )
+    assert row["category"] == "designed-gap"
+    assert row["R_source_undecidable_refusals"] == 1
+    assert len(row["sourceUndecidableRefusals"]) == 1
+    inhab = row["sourceUndecidableRefusals"][0]
+    assert inhab["decidabilityKind"] == "EnrolledDemandUnresolved"
+    assert inhab["demandFamily"] == "context-manager"
+    assert inhab["demandCid"] == "demand:blake3-512:cm"
+    assert inhab["gapKind"] == "unresolved-symbol"
+    assert inhab["expectedRefType"] == "ContextManagerContractRefV1"
+    assert inhab["useSite"]
+    assert inhab["file"] == "pandas/io/json/_json.py"
+    # Defect row carries the same artifact fields (A).
+    defect = row["defect"]
+    assert defect["decidabilityKind"] == "EnrolledDemandUnresolved"
+    assert defect["demandFamily"] == "context-manager"
+    assert defect["honestResidual"] is True
+    assert row["families"].get("EnrolledDemandUnresolved") == 1
+
+
+def test_c3_honest_without_sealed_ground_is_not_source_undecidable_count() -> None:
+    """Recursion honest residual is designed-gap but not EnrolledDemandUnresolved."""
+    row = CONSUMER.terminal_from_enumerate(
+        file_rel="pkg/deep.py",
+        function_nodes=[{"memento": {"function_name": "f"}}],
+        function_gaps=[],
+        audit=None,
+        construction_gaps=[],
+        residual_phase_failed=True,
+        residual_error=RecursionError("maximum recursion depth exceeded"),
+    )
+    assert row["category"] == "designed-gap"
+    assert row["R_source_undecidable_refusals"] == 0
+    assert row["sourceUndecidableRefusals"] == []
+    assert "decidabilityKind" not in (row.get("defect") or {})
+
+
 def test_live_enumerate_roster_on_fixture(tmp_path: Path) -> None:
     """D2 against real sugar.enumerate handler (in-process)."""
     src = tmp_path / "mod.py"


### PR DESCRIPTION
## Summary

Closes mint-live / board-blind: sealed board now banks **R_source_undecidable_refusals**.

| Step | What |
|------|------|
| **A** | `recensus_enumerate_consumer` emits decidability artifact fields on defect rows when ground is `EnrolledDemandUnresolved` |
| **B** | `terminal_from_enumerate` accumulates `sourceUndecidableRefusals[]` (5 fields + file/type) |
| **C** | `compose_control_effect_board` seals `R_source_undecidable_refusals` + list alongside designed-gaps |

First inhabitants: CM designed-gap class (E). Honest residuals without sealed ground (e.g. recursion) stay designed-gap but **do not** inflate the C3 R.

## Shot accounting

- **R axis:** `R_source_undecidable_refusals` (C3 sealed number)
- **Epsilon R:** board-visible C3 count when recensus consumes #7108 mints
- **Shell:** board-blind C3 (type-name only / designed-gap without ground projection)
- **Related:** #7104 door, #7108 mint, #7106 named residuals

## Validation

Focused teeth: `test_c3_enrolled_demand_*`, `test_compose_banks_r_source_undecidable_refusals_c3_axis` → TEETH_OK (R=5 synthetic CM files).

No battleaxe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved handling and reporting of unresolved enrolled-demand refusals.
  - Sealed boards now include refusal details, source information, and demand-family counts.
  - Function totals, enumerations, and clean counts are now consistently represented in finalized board results.
  - Preserved roster and terminal data while adding relevant undecidability metadata.
  - Improved accuracy when distinguishing genuine unresolved-demand refusals from unrelated recursion errors.

- **Tests**
  - Added coverage for composed designed-gap and recursion-gap scenarios.
  - Added validation for refusal categorization, metadata preservation, and accurate aggregate counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bank `R_source_undecidable_refusals` on the sealed control effect board for the C3 axis
> - Adds collection of `sourceUndecidableRefusals` in [`recensus_enumerate_consumer.py`](https://github.com/TSavo/sugar/pull/7116/files#diff-f44306c90c4bcc279a33763d110fe23086857b9b1f1afc83ea45e09c2d004b79): terminal and failure rows now always carry `sourceUndecidableRefusals` and `R_source_undecidable_refusals`, with `EnrolledDemandUnresolved` decidability fields extracted and attached to defect rows when applicable.
> - Updates [`compose_control_effect_board.py`](https://github.com/TSavo/sugar/pull/7116/files#diff-74e790a1f60d3814877eedd08ed5ab4d88fa6c54e5d483d8fec41180cd0f0915) to aggregate `source_undecidable_refusals` from terminal rows (with a fallback synthesis for defect rows with `decidabilityKind == 'EnrolledDemandUnresolved'`) and surface them as `sourceUndecidableRefusals` and `R_source_undecidable_refusals` on the sealed board.
> - Function metrics on the sealed board are now minted via sealed fact types (`seal_functions_*_v1`) rather than bare integers, producing `sealedFunctionFactCids` and deriving board fields via `board_fields_from_sealed_facts`.
> - New tests cover the C3 axis end-to-end: sealed board composition with 5 `EnrolledDemandUnresolved` inhabitants, artifact field propagation, and the negative case where honest residuals do not increment the count.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b4a746.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->