### PR TITLE
C4 Step 1: three sealed board function facts + compose consumer close

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -48,6 +48,19 @@ _TOOLS = Path(__file__).resolve().parents[4] / "tools"
 if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
 
+# Package root for sealed board function facts (C4 Step 1).
+_PKG_SRC = Path(__file__).resolve().parents[1] / "src"
+if _PKG_SRC.is_dir() and str(_PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(_PKG_SRC))
+
+from sugar_lift_py_tests.c4.board_function_facts import (  # noqa: E402
+    LocalReading,
+    board_fields_from_sealed_facts,
+    seal_functions_clean_v1,
+    seal_functions_enumerated_v1,
+    seal_functions_population_v1,
+)
+
 
 def _blake3_512(data: bytes) -> str:
     try:
@@ -440,6 +453,45 @@ def seal_board_from_aggregate(
     r_desugar = sum(desugar_families.values())
     r_backend = sum(backend_defects.values())
 
+    # C4 Step 1: three sealed meanings, not one overloaded int.
+    # LocalReadings are free; only the seal doors + board_fields_from_sealed_facts
+    # may mint board function fields. Bare ints cannot pass the consumer.
+    pin_id = (
+        aggregate_hash
+        or (plan or {}).get("aggregateHash")
+        or _PANDAS_3_0_3_AGGREGATE_HASH
+    )
+    pop_fact = seal_functions_population_v1(
+        LocalReading(int(agg["functions_total"]), "functions_total"),
+        tip=measured_commit,
+        pin=str(pin_id),
+    )
+    enum_fact = seal_functions_enumerated_v1(
+        LocalReading(int(agg.get("functions_enumerated") or 0), "functions_enumerated"),
+        tip=measured_commit,
+        pin=str(pin_id),
+    )
+    if agg.get("clean_ratio_refused"):
+        clean_fact = seal_functions_clean_v1(
+            LocalReading(None, "functions_clean"),
+            tip=measured_commit,
+            pin=str(pin_id),
+            refused=True,
+            refuse_reason=(
+                "one or more files refused functionsClean "
+                "(would be tautological clean%)"
+            ),
+        )
+    else:
+        clean_fact = seal_functions_clean_v1(
+            LocalReading(int(agg["functions_clean"]), "functions_clean"),
+            tip=measured_commit,
+            pin=str(pin_id),
+            refused=False,
+        )
+    # Consumer close: bare int cannot become a board field.
+    fn_fields = board_fields_from_sealed_facts(pop_fact, enum_fact, clean_fact)
+
     body: dict[str, Any] = {
         "schemaVersion": 1,
         "kind": KIND_SEALED,
@@ -471,6 +523,7 @@ def seal_board_from_aggregate(
         "isolation": "in-process",
         "paths": dict(paths or {}),
         # Dual unit denominator — files and functions NEVER share a slot.
+        # functions.* comes only from sealed meaning types (C4 consumer close).
         "denominator": {
             "files": {
                 "enrolled": len(file_names),
@@ -483,33 +536,7 @@ def seal_board_from_aggregate(
                 "malformedRows": list(agg["malformed_rows"]),
                 "complete": bool(agg["files_complete"]),
             },
-            "functions": {
-                # Population = sum of row functionsTotal (roster-preserved mass).
-                "total": int(agg["functions_total"]),
-                "enumerated": int(agg.get("functions_enumerated") or 0),
-                "unaccounted": max(
-                    0,
-                    int(agg["functions_total"])
-                    - int(agg.get("functions_enumerated") or 0),
-                ),
-                # clean only when every row could measure it; else refused.
-                **(
-                    {
-                        "clean": None,
-                        "cleanRatioRefused": True,
-                        "cleanRefuseReason": (
-                            "one or more files refused functionsClean "
-                            "(would be tautological clean%)"
-                        ),
-                    }
-                    if agg.get("clean_ratio_refused")
-                    else {
-                        "clean": int(agg["functions_clean"]),
-                        "cleanRatioRefused": False,
-                    }
-                ),
-                "unit": "construction-function-locus",
-            },
+            "functions": dict(fn_fields["denominator_functions"]),
             # Back-compat flat keys (file unit only) for older readers.
             "enrolled": len(file_names),
             "terminalRows": int(agg["terminal_count"]),
@@ -534,19 +561,13 @@ def seal_board_from_aggregate(
         ),
         "constructionPanics": construction_panics,
         "R_construction_panics": len(construction_panics),
-        "functionsTotal": int(agg["functions_total"]),
-        "functionsEnumerated": int(agg.get("functions_enumerated") or 0),
-        "functionsUnaccounted": max(
-            0,
-            int(agg["functions_total"]) - int(agg.get("functions_enumerated") or 0),
-        ),
-        # Never mint a tautological clean: null when any file refused clean.
-        "functionsConstructClean": (
-            None
-            if agg.get("clean_ratio_refused")
-            else int(agg["functions_clean"])
-        ),
-        "cleanRatioRefused": bool(agg.get("clean_ratio_refused")),
+        # Function fields only via sealed types — bare ints cannot land here.
+        "functionsTotal": fn_fields["functionsTotal"],
+        "functionsEnumerated": fn_fields["functionsEnumerated"],
+        "functionsUnaccounted": fn_fields["functionsUnaccounted"],
+        "functionsConstructClean": fn_fields["functionsConstructClean"],
+        "cleanRatioRefused": fn_fields["cleanRatioRefused"],
+        "sealedFunctionFactCids": dict(fn_fields["sealedFactCids"]),
         "cleanRefuseReasons": list(agg.get("clean_refuse_reasons") or []),
         "R": r_construction,
         "R_construction": r_construction,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/__init__.py
@@ -1,0 +1,36 @@
+"""C4 — production topology of seal authority (not denominator truth).
+
+Correct-by-construction of PRODUCTION TOPOLOGY is not correct-by-construction
+of DENOMINATORS. C4 green means no second seal path for this fact class. It
+never means the board is true. C1 and C2 remain the truth instruments.
+
+Enrollment makes dual production of THIS SEALED MEANING unsealable. Meaning is
+fixed by type fields plus witness or twin. SOLE CONSTRUCTOR IS NOT EVIDENCE THE
+MEANING IS RIGHT.
+"""
+
+from __future__ import annotations
+
+from .board_function_facts import (
+    BoardFunctionFactError,
+    FunctionsCleanV1,
+    FunctionsEnumeratedV1,
+    FunctionsPopulationV1,
+    LocalReading,
+    board_fields_from_sealed_facts,
+    seal_functions_clean_v1,
+    seal_functions_enumerated_v1,
+    seal_functions_population_v1,
+)
+
+__all__ = [
+    "BoardFunctionFactError",
+    "FunctionsCleanV1",
+    "FunctionsEnumeratedV1",
+    "FunctionsPopulationV1",
+    "LocalReading",
+    "board_fields_from_sealed_facts",
+    "seal_functions_clean_v1",
+    "seal_functions_enumerated_v1",
+    "seal_functions_population_v1",
+]

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py
@@ -1,0 +1,537 @@
+"""Three sealed board function meanings — C4 Step 1 (topology only).
+
+The board already proved the split is real: population 28264, enumerated 27954,
+clean refused. Those are THREE facts that lived under one informal name and
+nearly sealed as one number.
+
+Sealed meanings (types, not registry ids):
+
+  FunctionsPopulationV1  — authenticated AST count over the pin
+  FunctionsEnumeratedV1  — what the sole construction door actually rostered
+  FunctionsCleanV1       — measured or absent, never defaulted
+
+Each carries its own body and content address. Consumers take the type, not an
+int. Enforcement lives at the compose consumer (``board_fields_from_sealed_facts``),
+not producer privacy — Python cannot give unrepresentable construction.
+
+Law (verbatim, Orange / T):
+
+  Enrollment makes dual production of THIS SEALED MEANING unsealable. Meaning is
+  fixed by type fields plus witness or twin. SOLE CONSTRUCTOR IS NOT EVIDENCE THE
+  MEANING IS RIGHT.
+
+Correct-by-construction of PRODUCTION TOPOLOGY is not correct-by-construction of
+DENOMINATORS. C1 and C2 remain the truth instruments.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+# Per-meaning seal tokens. A second producer cannot mint the sealed type without
+# the private token of the sole door module. That is Python-honest sole-ness, not
+# rustc unrepresentability (Attack 3).
+_POPULATION_SEAL = object()
+_ENUMERATED_SEAL = object()
+_CLEAN_SEAL = object()
+
+AXIS_POPULATION = "FunctionsPopulationV1"
+AXIS_ENUMERATED = "FunctionsEnumeratedV1"
+AXIS_CLEAN = "FunctionsCleanV1"
+UNIT = "construction-function-locus"
+
+
+class BoardFunctionFactError(TypeError, ValueError):
+    """Bare int / LocalReading / wrong type refused at a sealed meaning door."""
+
+
+def _blake3_512(data: bytes) -> str:
+    try:
+        import blake3  # type: ignore
+
+        return "blake3-512:" + blake3.blake3(data, max_threads=1).digest(64).hex()
+    except Exception:  # noqa: BLE001
+        return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _fact_cid(
+    *,
+    tip: str,
+    pin: str,
+    axis: str,
+    body: Mapping[str, Any],
+    witness: str,
+) -> str:
+    """Content address of a sealed fact: h(tip, pin, axis, body, witness)."""
+    payload = {
+        "tip": tip,
+        "pin": pin,
+        "axis": axis,
+        "body": dict(body),
+        "witness": witness,
+    }
+    rendered = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return _blake3_512(rendered.encode("utf-8"))
+
+
+def _require_nonempty_str(name: str, value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise BoardFunctionFactError(
+            f"{name} must be a non-empty str (got {type(value).__name__!r}={value!r}); "
+            f"a sealed meaning without tip/pin has no identity"
+        )
+    return value.strip()
+
+
+def _require_int_ge0(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise BoardFunctionFactError(
+            f"{name} must be a non-negative int (got {type(value).__name__})"
+        )
+    if value < 0:
+        raise BoardFunctionFactError(f"{name} must be >= 0 (got {value})")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# LocalReading — any compute site; not a seal; cannot enter compose
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class LocalReading:
+    """A local measurement any module may hold. Not authoritative. Cannot seal.
+
+    Workers, shards, and scratch counters mint these freely. Only a sole seal
+    door upgrades a LocalReading into a sealed meaning type. Compose never
+    accepts a LocalReading as a board field.
+    """
+
+    value: int | None
+    label: str
+    source: str = "local"
+
+    def is_sealed(self) -> bool:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Three sealed meanings — distinct types, distinct content addresses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionsPopulationV1:
+    """Authenticated AST count over the pin — the population denominator.
+
+    Not enumerated roster mass. Not clean residual. C1 owns whether the count
+    is true; C4 owns that only one seal path can mint this meaning.
+    """
+
+    tip: str
+    pin: str
+    count: int
+    unit: str
+    witness: str
+    fact_cid: str
+    _seal: object
+
+    def __post_init__(self) -> None:
+        if self._seal is not _POPULATION_SEAL:
+            raise BoardFunctionFactError(
+                "FunctionsPopulationV1 is sealed: use seal_functions_population_v1(...); "
+                "a bare int, LocalReading, or second-producer forge has no constructor "
+                "for this sealed meaning. Enrollment makes dual production of THIS "
+                "SEALED MEANING unsealable. SOLE CONSTRUCTOR IS NOT EVIDENCE THE "
+                "MEANING IS RIGHT."
+            )
+        object.__setattr__(self, "tip", _require_nonempty_str("tip", self.tip))
+        object.__setattr__(self, "pin", _require_nonempty_str("pin", self.pin))
+        object.__setattr__(
+            self, "count", _require_int_ge0("count", self.count)
+        )
+        object.__setattr__(
+            self, "unit", _require_nonempty_str("unit", self.unit)
+        )
+        object.__setattr__(
+            self, "witness", _require_nonempty_str("witness", self.witness)
+        )
+        object.__setattr__(
+            self, "fact_cid", _require_nonempty_str("fact_cid", self.fact_cid)
+        )
+
+    def is_sealed(self) -> bool:
+        return True
+
+    def body(self) -> dict[str, Any]:
+        return {"count": self.count, "unit": self.unit}
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionsEnumeratedV1:
+    """What the sole construction door actually rostered (enumerate mementos).
+
+    Distinct from population. unaccounted = population - enumerated is derived
+    at compose from the two sealed facts; it is not a third informal int.
+    """
+
+    tip: str
+    pin: str
+    count: int
+    unit: str
+    witness: str
+    fact_cid: str
+    _seal: object
+
+    def __post_init__(self) -> None:
+        if self._seal is not _ENUMERATED_SEAL:
+            raise BoardFunctionFactError(
+                "FunctionsEnumeratedV1 is sealed: use seal_functions_enumerated_v1(...); "
+                "a bare int, LocalReading, or second-producer forge has no constructor "
+                "for this sealed meaning. Enrollment makes dual production of THIS "
+                "SEALED MEANING unsealable. SOLE CONSTRUCTOR IS NOT EVIDENCE THE "
+                "MEANING IS RIGHT."
+            )
+        object.__setattr__(self, "tip", _require_nonempty_str("tip", self.tip))
+        object.__setattr__(self, "pin", _require_nonempty_str("pin", self.pin))
+        object.__setattr__(
+            self, "count", _require_int_ge0("count", self.count)
+        )
+        object.__setattr__(
+            self, "unit", _require_nonempty_str("unit", self.unit)
+        )
+        object.__setattr__(
+            self, "witness", _require_nonempty_str("witness", self.witness)
+        )
+        object.__setattr__(
+            self, "fact_cid", _require_nonempty_str("fact_cid", self.fact_cid)
+        )
+
+    def is_sealed(self) -> bool:
+        return True
+
+    def body(self) -> dict[str, Any]:
+        return {"count": self.count, "unit": self.unit}
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionsCleanV1:
+    """Measured clean count or absent — never defaulted to zero.
+
+    When any file refuses clean measurement, ``refused`` is True and ``count``
+    is None. A bare 0 is not a lawful stand-in for refusal (tautological clean%
+    lie). Meaning is fixed by the refused/measured body shape.
+    """
+
+    tip: str
+    pin: str
+    count: int | None
+    refused: bool
+    refuse_reason: str | None
+    unit: str
+    witness: str
+    fact_cid: str
+    _seal: object
+
+    def __post_init__(self) -> None:
+        if self._seal is not _CLEAN_SEAL:
+            raise BoardFunctionFactError(
+                "FunctionsCleanV1 is sealed: use seal_functions_clean_v1(...); "
+                "a bare int, LocalReading, or second-producer forge has no constructor "
+                "for this sealed meaning. Enrollment makes dual production of THIS "
+                "SEALED MEANING unsealable. SOLE CONSTRUCTOR IS NOT EVIDENCE THE "
+                "MEANING IS RIGHT."
+            )
+        object.__setattr__(self, "tip", _require_nonempty_str("tip", self.tip))
+        object.__setattr__(self, "pin", _require_nonempty_str("pin", self.pin))
+        object.__setattr__(
+            self, "unit", _require_nonempty_str("unit", self.unit)
+        )
+        object.__setattr__(
+            self, "witness", _require_nonempty_str("witness", self.witness)
+        )
+        object.__setattr__(
+            self, "fact_cid", _require_nonempty_str("fact_cid", self.fact_cid)
+        )
+        if self.refused:
+            if self.count is not None:
+                raise BoardFunctionFactError(
+                    "FunctionsCleanV1 refused body forbids a count "
+                    f"(got count={self.count!r}); measured-or-absent, never both"
+                )
+            if not self.refuse_reason or not str(self.refuse_reason).strip():
+                raise BoardFunctionFactError(
+                    "FunctionsCleanV1 refused body requires a non-empty refuse_reason"
+                )
+        else:
+            if self.count is None:
+                raise BoardFunctionFactError(
+                    "FunctionsCleanV1 measured body requires a non-negative count; "
+                    "absent clean must set refused=True (never default count to 0)"
+                )
+            object.__setattr__(
+                self, "count", _require_int_ge0("count", self.count)
+            )
+            if self.refuse_reason is not None:
+                raise BoardFunctionFactError(
+                    "FunctionsCleanV1 measured body forbids refuse_reason"
+                )
+
+    def is_sealed(self) -> bool:
+        return True
+
+    def body(self) -> dict[str, Any]:
+        if self.refused:
+            return {
+                "count": None,
+                "refused": True,
+                "refuseReason": self.refuse_reason,
+                "unit": self.unit,
+            }
+        return {
+            "count": self.count,
+            "refused": False,
+            "unit": self.unit,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Sole seal doors — one module, one function per sealed meaning
+# ---------------------------------------------------------------------------
+
+
+def seal_functions_population_v1(
+    reading: LocalReading,
+    *,
+    tip: str,
+    pin: str,
+    witness: str = "compose-aggregate/functions_total",
+) -> FunctionsPopulationV1:
+    """Sole mint door for FunctionsPopulationV1. Accepts LocalReading only."""
+    if not isinstance(reading, LocalReading):
+        raise BoardFunctionFactError(
+            "seal_functions_population_v1 accepts LocalReading only "
+            f"(got {type(reading).__name__}); bare int is not a reading and "
+            "cannot upgrade to a sealed meaning"
+        )
+    if reading.value is None:
+        raise BoardFunctionFactError(
+            "FunctionsPopulationV1 refuses LocalReading with value=None; "
+            "population is an authenticated count, never absent"
+        )
+    count = _require_int_ge0("population", reading.value)
+    tip_s = _require_nonempty_str("tip", tip)
+    pin_s = _require_nonempty_str("pin", pin)
+    wit = _require_nonempty_str("witness", witness)
+    body = {"count": count, "unit": UNIT}
+    cid = _fact_cid(
+        tip=tip_s, pin=pin_s, axis=AXIS_POPULATION, body=body, witness=wit
+    )
+    return FunctionsPopulationV1(
+        tip=tip_s,
+        pin=pin_s,
+        count=count,
+        unit=UNIT,
+        witness=wit,
+        fact_cid=cid,
+        _seal=_POPULATION_SEAL,
+    )
+
+
+def seal_functions_enumerated_v1(
+    reading: LocalReading,
+    *,
+    tip: str,
+    pin: str,
+    witness: str = "compose-aggregate/functions_enumerated",
+) -> FunctionsEnumeratedV1:
+    """Sole mint door for FunctionsEnumeratedV1. Accepts LocalReading only."""
+    if not isinstance(reading, LocalReading):
+        raise BoardFunctionFactError(
+            "seal_functions_enumerated_v1 accepts LocalReading only "
+            f"(got {type(reading).__name__}); bare int is not a reading and "
+            "cannot upgrade to a sealed meaning"
+        )
+    if reading.value is None:
+        raise BoardFunctionFactError(
+            "FunctionsEnumeratedV1 refuses LocalReading with value=None; "
+            "enumerated is a rostered count (may be 0), never absent"
+        )
+    count = _require_int_ge0("enumerated", reading.value)
+    tip_s = _require_nonempty_str("tip", tip)
+    pin_s = _require_nonempty_str("pin", pin)
+    wit = _require_nonempty_str("witness", witness)
+    body = {"count": count, "unit": UNIT}
+    cid = _fact_cid(
+        tip=tip_s, pin=pin_s, axis=AXIS_ENUMERATED, body=body, witness=wit
+    )
+    return FunctionsEnumeratedV1(
+        tip=tip_s,
+        pin=pin_s,
+        count=count,
+        unit=UNIT,
+        witness=wit,
+        fact_cid=cid,
+        _seal=_ENUMERATED_SEAL,
+    )
+
+
+def seal_functions_clean_v1(
+    reading: LocalReading,
+    *,
+    tip: str,
+    pin: str,
+    refused: bool = False,
+    refuse_reason: str | None = None,
+    witness: str = "compose-aggregate/functions_clean",
+) -> FunctionsCleanV1:
+    """Sole mint door for FunctionsCleanV1. Measured or refused — never defaulted."""
+    if not isinstance(reading, LocalReading):
+        raise BoardFunctionFactError(
+            "seal_functions_clean_v1 accepts LocalReading only "
+            f"(got {type(reading).__name__}); bare int is not a reading and "
+            "cannot upgrade to a sealed meaning"
+        )
+    tip_s = _require_nonempty_str("tip", tip)
+    pin_s = _require_nonempty_str("pin", pin)
+    wit = _require_nonempty_str("witness", witness)
+    if refused:
+        count: int | None = None
+        reason = refuse_reason or (
+            "one or more files refused functionsClean "
+            "(would be tautological clean%)"
+        )
+        body = {
+            "count": None,
+            "refused": True,
+            "refuseReason": reason,
+            "unit": UNIT,
+        }
+    else:
+        if reading.value is None:
+            raise BoardFunctionFactError(
+                "FunctionsCleanV1 measured path requires a non-None LocalReading.value; "
+                "absent clean must set refused=True (never default count to 0)"
+            )
+        count = _require_int_ge0("clean", reading.value)
+        reason = None
+        body = {"count": count, "refused": False, "unit": UNIT}
+    cid = _fact_cid(
+        tip=tip_s, pin=pin_s, axis=AXIS_CLEAN, body=body, witness=wit
+    )
+    return FunctionsCleanV1(
+        tip=tip_s,
+        pin=pin_s,
+        count=count,
+        refused=refused,
+        refuse_reason=reason,
+        unit=UNIT,
+        witness=wit,
+        fact_cid=cid,
+        _seal=_CLEAN_SEAL,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Consumer close — compose enforcement point (not producer privacy)
+# ---------------------------------------------------------------------------
+
+
+def board_fields_from_sealed_facts(
+    population: FunctionsPopulationV1,
+    enumerated: FunctionsEnumeratedV1,
+    clean: FunctionsCleanV1,
+) -> dict[str, Any]:
+    """Sole path from sealed meanings to board function fields.
+
+    Refuse bare int, LocalReading, wrong type, or a second-producer forge.
+    Returns flat + denominator.functions fragments for the sealed board body.
+
+    This is the enforcement point: a bare int cannot become a board field.
+    """
+    if isinstance(population, int) or not isinstance(
+        population, FunctionsPopulationV1
+    ):
+        raise BoardFunctionFactError(
+            "board_fields_from_sealed_facts refuses non-FunctionsPopulationV1 for "
+            f"population (got {type(population).__name__}); a bare int or "
+            "LocalReading cannot become a board field. Close the consumer: "
+            "compose accepts only the sealed meaning type."
+        )
+    if isinstance(enumerated, int) or not isinstance(
+        enumerated, FunctionsEnumeratedV1
+    ):
+        raise BoardFunctionFactError(
+            "board_fields_from_sealed_facts refuses non-FunctionsEnumeratedV1 for "
+            f"enumerated (got {type(enumerated).__name__}); a bare int or "
+            "LocalReading cannot become a board field. Close the consumer: "
+            "compose accepts only the sealed meaning type."
+        )
+    if isinstance(clean, int) or not isinstance(clean, FunctionsCleanV1):
+        raise BoardFunctionFactError(
+            "board_fields_from_sealed_facts refuses non-FunctionsCleanV1 for "
+            f"clean (got {type(clean).__name__}); a bare int or LocalReading "
+            "cannot become a board field. Close the consumer: compose accepts "
+            "only the sealed meaning type."
+        )
+    if not population.is_sealed() or not enumerated.is_sealed() or not clean.is_sealed():
+        raise BoardFunctionFactError(
+            "board_fields_from_sealed_facts requires sealed facts "
+            f"(population.sealed={population.is_sealed()}, "
+            f"enumerated.sealed={enumerated.is_sealed()}, "
+            f"clean.sealed={clean.is_sealed()})"
+        )
+    # Tip/pin must agree — three facts about one board observation.
+    if not (population.tip == enumerated.tip == clean.tip):
+        raise BoardFunctionFactError(
+            "board_fields_from_sealed_facts refuses tip mismatch across the three "
+            f"sealed meanings: pop={population.tip!r} enum={enumerated.tip!r} "
+            f"clean={clean.tip!r}"
+        )
+    if not (population.pin == enumerated.pin == clean.pin):
+        raise BoardFunctionFactError(
+            "board_fields_from_sealed_facts refuses pin mismatch across the three "
+            f"sealed meanings: pop={population.pin!r} enum={enumerated.pin!r} "
+            f"clean={clean.pin!r}"
+        )
+
+    unaccounted = max(0, population.count - enumerated.count)
+    denom_functions: dict[str, Any] = {
+        "total": population.count,
+        "enumerated": enumerated.count,
+        "unaccounted": unaccounted,
+        "unit": UNIT,
+        "factCids": {
+            "population": population.fact_cid,
+            "enumerated": enumerated.fact_cid,
+            "clean": clean.fact_cid,
+        },
+    }
+    if clean.refused:
+        denom_functions["clean"] = None
+        denom_functions["cleanRatioRefused"] = True
+        denom_functions["cleanRefuseReason"] = clean.refuse_reason
+        construct_clean: int | None = None
+        clean_ratio_refused = True
+    else:
+        denom_functions["clean"] = clean.count
+        denom_functions["cleanRatioRefused"] = False
+        construct_clean = clean.count
+        clean_ratio_refused = False
+
+    return {
+        "functionsTotal": population.count,
+        "functionsEnumerated": enumerated.count,
+        "functionsUnaccounted": unaccounted,
+        "functionsConstructClean": construct_clean,
+        "cleanRatioRefused": clean_ratio_refused,
+        "denominator_functions": denom_functions,
+        "sealedFactCids": {
+            "FunctionsPopulationV1": population.fact_cid,
+            "FunctionsEnumeratedV1": enumerated.fact_cid,
+            "FunctionsCleanV1": clean.fact_cid,
+        },
+    }

--- a/tests/test_board_function_facts_c4.py
+++ b/tests/test_board_function_facts_c4.py
@@ -1,0 +1,288 @@
+"""Teeth for C4 Step 1: three sealed board function meanings.
+
+Split overloaded functionsTotal into:
+  FunctionsPopulationV1 / FunctionsEnumeratedV1 / FunctionsCleanV1
+
+Consumer close (not producer privacy):
+  board_fields_from_sealed_facts refuses bare int for any of the three.
+  LocalReading may exist and cannot seal.
+  Second producer minting the same sealed meaning cannot seal.
+
+Enrollment makes dual production of THIS SEALED MEANING unsealable. Meaning is
+fixed by type fields plus witness or twin. SOLE CONSTRUCTOR IS NOT EVIDENCE THE
+MEANING IS RIGHT.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG_SRC = (
+    ROOT
+    / "implementations/python/sugar-lift-py-tests/src"
+)
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+from sugar_lift_py_tests.c4 import board_function_facts as BFF  # noqa: E402
+
+SCRIPTS = ROOT / "implementations/python/sugar-lift-py-tests/scripts"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+TIP = "deadbeef"
+PIN = "pin-agg-hash-test"
+
+
+def _mint_triple(
+    *,
+    population: int = 5,
+    enumerated: int = 3,
+    clean: int | None = None,
+    refused: bool = True,
+):
+    pop = BFF.seal_functions_population_v1(
+        BFF.LocalReading(population, "functions_total"),
+        tip=TIP,
+        pin=PIN,
+    )
+    enum = BFF.seal_functions_enumerated_v1(
+        BFF.LocalReading(enumerated, "functions_enumerated"),
+        tip=TIP,
+        pin=PIN,
+    )
+    if refused:
+        clean_f = BFF.seal_functions_clean_v1(
+            BFF.LocalReading(None, "functions_clean"),
+            tip=TIP,
+            pin=PIN,
+            refused=True,
+            refuse_reason="test refuse",
+        )
+    else:
+        assert clean is not None
+        clean_f = BFF.seal_functions_clean_v1(
+            BFF.LocalReading(clean, "functions_clean"),
+            tip=TIP,
+            pin=PIN,
+            refused=False,
+        )
+    return pop, enum, clean_f
+
+
+def test_three_meanings_are_distinct_types_and_cids() -> None:
+    """Population / enumerated / clean are three facts, three addresses."""
+    pop, enum, clean = _mint_triple(population=28264, enumerated=27954, refused=True)
+    assert type(pop) is BFF.FunctionsPopulationV1
+    assert type(enum) is BFF.FunctionsEnumeratedV1
+    assert type(clean) is BFF.FunctionsCleanV1
+    assert pop.count == 28264
+    assert enum.count == 27954
+    assert clean.refused is True
+    assert clean.count is None
+    # Distinct content addresses — same informal name would have collided as one int.
+    assert pop.fact_cid != enum.fact_cid
+    assert pop.fact_cid != clean.fact_cid
+    assert enum.fact_cid != clean.fact_cid
+    assert pop.fact_cid.startswith(("blake3-512:", "sha256:"))
+
+
+def test_board_fields_from_sealed_facts_wires_three_numbers() -> None:
+    pop, enum, clean = _mint_triple(population=12, enumerated=2, refused=True)
+    fields = BFF.board_fields_from_sealed_facts(pop, enum, clean)
+    assert fields["functionsTotal"] == 12
+    assert fields["functionsEnumerated"] == 2
+    assert fields["functionsUnaccounted"] == 10
+    assert fields["functionsConstructClean"] is None
+    assert fields["cleanRatioRefused"] is True
+    assert fields["denominator_functions"]["total"] == 12
+    assert fields["denominator_functions"]["enumerated"] == 2
+    assert fields["sealedFactCids"]["FunctionsPopulationV1"] == pop.fact_cid
+
+
+def test_consumer_refuses_bare_int_for_population() -> None:
+    """TOOTH: compose refuses a bare int for any of the three."""
+    _, enum, clean = _mint_triple()
+    with pytest.raises(BFF.BoardFunctionFactError, match="bare int|FunctionsPopulationV1"):
+        BFF.board_fields_from_sealed_facts(28264, enum, clean)  # type: ignore[arg-type]
+
+
+def test_consumer_refuses_bare_int_for_enumerated() -> None:
+    pop, _, clean = _mint_triple()
+    with pytest.raises(BFF.BoardFunctionFactError, match="bare int|FunctionsEnumeratedV1"):
+        BFF.board_fields_from_sealed_facts(pop, 27954, clean)  # type: ignore[arg-type]
+
+
+def test_consumer_refuses_bare_int_for_clean() -> None:
+    pop, enum, _ = _mint_triple()
+    with pytest.raises(BFF.BoardFunctionFactError, match="bare int|FunctionsCleanV1"):
+        BFF.board_fields_from_sealed_facts(pop, enum, 0)  # type: ignore[arg-type]
+
+
+def test_local_reading_exists_and_cannot_seal_via_consumer() -> None:
+    """A LocalReading may exist and cannot seal as a board field."""
+    local = BFF.LocalReading(28264, "functions_total", source="worker-shard")
+    assert local.is_sealed() is False
+    assert local.value == 28264
+    _, enum, clean = _mint_triple()
+    with pytest.raises(BFF.BoardFunctionFactError, match="LocalReading|FunctionsPopulationV1"):
+        BFF.board_fields_from_sealed_facts(local, enum, clean)  # type: ignore[arg-type]
+
+
+def test_direct_construct_without_seal_token_refuses() -> None:
+    """Discrimination: forged constructor without sole-door seal cannot mint."""
+    with pytest.raises(BFF.BoardFunctionFactError, match="sealed|SOLE CONSTRUCTOR"):
+        BFF.FunctionsPopulationV1(
+            tip=TIP,
+            pin=PIN,
+            count=28264,
+            unit=BFF.UNIT,
+            witness="forged-second-producer",
+            fact_cid="blake3-512:" + "0" * 128,
+            _seal=object(),  # wrong token — second producer forge
+        )
+
+
+def test_second_producer_cannot_seal_same_meaning() -> None:
+    """Plant a second producer minting the same sealed meaning; prove it cannot seal.
+
+    Python cannot make construction unrepresentable. The load-bearing move is
+    consumer close: a second site's forge is not FunctionsPopulationV1 and is
+    refused at board_fields_from_sealed_facts.
+    """
+
+    class SecondProducerPopulation:
+        """Hostile second door claiming the same sealed meaning."""
+
+        def __init__(self, count: int) -> None:
+            self.tip = TIP
+            self.pin = PIN
+            self.count = count
+            self.unit = BFF.UNIT
+            self.witness = "second-producer/forge"
+            self.fact_cid = "blake3-512:" + "f" * 128
+
+        def is_sealed(self) -> bool:
+            return True  # lie
+
+    forge = SecondProducerPopulation(28264)
+    _, enum, clean = _mint_triple(population=28264, enumerated=27954)
+    with pytest.raises(BFF.BoardFunctionFactError, match="FunctionsPopulationV1|bare int"):
+        BFF.board_fields_from_sealed_facts(forge, enum, clean)  # type: ignore[arg-type]
+
+
+def test_clean_never_defaults_absent_to_zero() -> None:
+    """FunctionsCleanV1: measured or absent, never defaulted."""
+    with pytest.raises(BFF.BoardFunctionFactError, match="refused=True|never default"):
+        BFF.seal_functions_clean_v1(
+            BFF.LocalReading(None, "functions_clean"),
+            tip=TIP,
+            pin=PIN,
+            refused=False,  # measured path with None is illegal
+        )
+    refused = BFF.seal_functions_clean_v1(
+        BFF.LocalReading(None, "functions_clean"),
+        tip=TIP,
+        pin=PIN,
+        refused=True,
+        refuse_reason="would be tautological clean%",
+    )
+    assert refused.count is None
+    assert refused.refused is True
+    measured = BFF.seal_functions_clean_v1(
+        BFF.LocalReading(100, "functions_clean"),
+        tip=TIP,
+        pin=PIN,
+        refused=False,
+    )
+    assert measured.count == 100
+    assert measured.refused is False
+
+
+def test_seal_doors_refuse_bare_int_input() -> None:
+    with pytest.raises(BFF.BoardFunctionFactError, match="LocalReading"):
+        BFF.seal_functions_population_v1(28264, tip=TIP, pin=PIN)  # type: ignore[arg-type]
+    with pytest.raises(BFF.BoardFunctionFactError, match="LocalReading"):
+        BFF.seal_functions_enumerated_v1(27954, tip=TIP, pin=PIN)  # type: ignore[arg-type]
+    with pytest.raises(BFF.BoardFunctionFactError, match="LocalReading"):
+        BFF.seal_functions_clean_v1(0, tip=TIP, pin=PIN)  # type: ignore[arg-type]
+
+
+def test_compose_seal_uses_three_sealed_meanings() -> None:
+    """Integration: seal_board_from_aggregate mints via sealed types (local only)."""
+    compose = _load(
+        "compose_control_effect_board_c4",
+        SCRIPTS / "compose_control_effect_board.py",
+    )
+
+    def _row(file: str, *, fn: int = 1, auth: int | None = None, panic: bool = False):
+        authenticated = fn if auth is None else auth
+        enumerated = 0 if panic else fn
+        return (
+            file,
+            {
+                "category": "construction-panic" if panic else "completed",
+                "functionsTotal": authenticated,
+                "functionsClean": None if panic else fn,
+                "cleanRatioRefused": bool(panic),
+                "functionsEnumerated": enumerated,
+                "functionsAuthenticated": authenticated,
+                "astSites": {"site:function-def": authenticated},
+                "families": {"ConstructionPanic": 1} if panic else {},
+                **(
+                    {
+                        "panic": {
+                            "file": file,
+                            "type": "ConstructionPanic",
+                            "message": "x",
+                        }
+                    }
+                    if panic
+                    else {}
+                ),
+                "R_instrument_blind": 0,
+            },
+        )
+
+    files = ["pandas/a.py", "pandas/b.py"]
+    status, body = compose.compose_k1_from_rows(
+        [
+            _row("pandas/a.py", fn=3, auth=3),
+            _row("pandas/b.py", fn=0, auth=2, panic=True),
+        ],
+        enrolled_files=files,
+        measured_commit="deadbeef",
+        aggregate_hash="agg",
+        manifest_shape_cid="cid",
+    )
+    assert status == "sealed"
+    assert body["functionsTotal"] == 5
+    assert body["functionsEnumerated"] == 3
+    assert body["functionsUnaccounted"] == 2
+    assert body["functionsConstructClean"] is None
+    assert body["cleanRatioRefused"] is True
+    # Content addresses of the three sealed meanings land on the board.
+    cids = body["sealedFunctionFactCids"]
+    assert set(cids) == {
+        "FunctionsPopulationV1",
+        "FunctionsEnumeratedV1",
+        "FunctionsCleanV1",
+    }
+    assert cids["FunctionsPopulationV1"] != cids["FunctionsEnumeratedV1"]
+    denom_fn = body["denominator"]["functions"]
+    assert denom_fn["total"] == 5
+    assert denom_fn["enumerated"] == 3
+    assert denom_fn["factCids"]["population"] == cids["FunctionsPopulationV1"]


### PR DESCRIPTION
## Summary

C4 Step 1 (topology only): split the overloaded board function count into three sealed meaning types, then close compose so a bare int cannot become a board field.

- **FunctionsPopulationV1** — authenticated AST count over the pin
- **FunctionsEnumeratedV1** — what the sole construction door actually rostered
- **FunctionsCleanV1** — measured or absent, never defaulted

Each carries its own body and content address (`fact_cid`). Consumers take the type, not an int.

Compose (`seal_board_from_aggregate`) mints via sole seal doors from `LocalReading`, then `board_fields_from_sealed_facts` is the enforcement point. Board gains `sealedFunctionFactCids`.

### Teeth
- bare int refused for any of the three
- `LocalReading` may exist and cannot seal
- second producer forge cannot seal (wrong seal token + duck-typed impostor)

## Denominator disclaimer (verbatim)

**Correct-by-construction of production topology is not correct-by-construction of denominators.**  
**C4 green never means the board is true.** C1 and C2 remain the truth instruments.

Enrollment makes dual production of THIS SEALED MEANING unsealable. Meaning is fixed by type fields plus witness or twin. **SOLE CONSTRUCTOR IS NOT EVIDENCE THE MEANING IS RIGHT.**

## Test plan
- [x] `PYTHONPATH=implementations/python/sugar-lift-py-tests/src python3 -m pytest -q tests/test_board_function_facts_c4.py tests/test_control_effect_recensus_compose.py` → **20 passed** local
- [ ] merge_dog lands when ready (no CI gate wait)

## Shell / R
- Promotes informal overloaded `functionsTotal` blob into three typed sealed meanings
- Closes compose consumer (not producer privacy — Python cannot give unrepresentable construction)
- Does **not** claim denominator truth; C4 topology only

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sealed board function facts and consumer close for C4 Step 1
> - Introduces three sealed meaning types (`FunctionsPopulationV1`, `FunctionsEnumeratedV1`, `FunctionsCleanV1`) in [`board_function_facts.py`](https://github.com/TSavo/sugar/pull/7117/files#diff-6fc7f1c62fe83accfe8c8f7cabfcd90f1e3a38714bc41443fe0460d26b1bf579), each with validated, content-addressed construction via corresponding `seal_functions_*_v1` mint doors that reject bare ints and `None` values.
> - Adds `board_fields_from_sealed_facts` consumer close that enforces sealed types, validates tip/pin alignment across all three facts, computes derived fields (`functionsUnaccounted`, `cleanRatioRefused`), and returns numeric fields plus `sealedFactCids` and per-denominator `factCids`.
> - Updates `seal_board_from_aggregate` in [`compose_control_effect_board.py`](https://github.com/TSavo/sugar/pull/7117/files#diff-74e790a1f60d3814877eedd08ed5ab4d88fa6c54e5d483d8fec41180cd0f0915) to derive all function metrics via the sealed fact flow instead of direct integer calculations; the response now includes `sealedFunctionFactCids` and `denominator.functions.factCids`.
> - Exports the full API from the new [`sugar_lift_py_tests/c4/__init__.py`](https://github.com/TSavo/sugar/pull/7117/files#diff-750834d0ee36056ce4635c4510b1342dd9e9005d92a92efb16a895c5db8833f2) package.
> - Behavioral Change: `seal_board_from_aggregate` no longer returns raw integer function fields directly; values are now mediated by non-negative int validation and explicit refusal semantics for clean ratio.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59101c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->