### PR TITLE
docs: battleaxe runner capacity (10 seats + memory floor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ on:
   push:
     branches:
       - main
+    # Coalesce: pure documentation tips must not consume a full core matrix
+    # per merge (2026-08-02: ~70 merges × fan-out → 421 queued runs). Product
+    # paths still always run. Heavy corpus instruments stay schedule/dispatch
+    # only — see docs/contributing/github-api-budget.md.
+    paths-ignore:
+      - "docs/**"
 
 # NO `concurrency:` BLOCK. `cancel-in-progress: false` is not enough: GitHub
 # keeps only ONE pending run per group and replaces a queued run with a newer
@@ -52,6 +58,7 @@ on:
 # discarded the CI vector of four merged commits (329576c3d, ef19b8175,
 # c11767c5e, df408100e). Every commit must retain its own run. Runner
 # scheduling provides queuing; GitHub concurrency must not discard evidence.
+# Do not "fix" backlog by concurrency-dropping pending main runs.
 
 permissions:
   contents: read

--- a/bin/gh-budget
+++ b/bin/gh-budget
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Budget-gated gh: refuse when core remaining is below the floor (exit 79).
+#
+# Same law as measurement load gate: a call that cannot testify to the budget
+# it spends is not a safe call. Agents and scripts should prefer this over bare
+# `gh` for list/view/api polling.
+#
+# Usage:
+#   bin/gh-budget                          # report budget only
+#   bin/gh-budget --floor 800
+#   bin/gh-budget pr view 1 --json url     # check budget, then gh ...
+#   GH_RATE_BUDGET_FLOOR=1000 bin/gh-budget api rate_limit
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+budget_py="$root/tools/gh_rate_budget.py"
+
+if [[ $# -eq 0 || "${1:-}" == "--floor" || "${1:-}" == "--json" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  exec python3 "$budget_py" "$@"
+fi
+
+# First optional --floor N for the gate, rest is gh argv.
+floor_args=()
+if [[ "${1:-}" == "--floor" ]]; then
+  floor_args=(--floor "$2")
+  shift 2
+fi
+
+exec python3 "$budget_py" "${floor_args[@]}" -- wrap -- gh "$@"

--- a/docs/contributing/github-api-budget.md
+++ b/docs/contributing/github-api-budget.md
@@ -1,0 +1,156 @@
+# GitHub API budget (identity hub isolation)
+
+> **A GitHub API call must testify to the budget it spends.**
+> Infrastructure and agents must not share one rate-limit identity.
+> Any shared hub that lets agent polling blind the runner autoscaler is the
+> same defect class as a measurement that cannot testify to its conditions.
+
+## What collapsed (2026-08-02)
+
+**Measured root cause:** the runner autoscaler shared **our** GitHub user token
+budget. Eight agents polling `gh` all night drained `core remaining` to **0**.
+The autoscaler then got **403** on every `GET .../actions/runners` query, went
+**blind**, could not scale, and **421 jobs** queued behind **25** static
+runners. It looked like the runners were broken. They were fine.
+
+That is a **shared identity hub**: one budget, multiple producers, no isolation —
+the exact class we spent the night forbidding elsewhere (load, lease, corpus pin).
+
+Secondary pressure: **~70 merges to main**, each firing a full CI fan-out,
+built the backlog the blind autoscaler could not absorb.
+
+## Fix 1 — autoscaler owns its own token (required)
+
+**Location (battleaxe):** `/home/tsavo/.github/runner-autoscaler`  
+(repo: `wopr-network/.github`, service `runner-autoscaler`)
+
+Today repo-scoped API uses vault field `ops_pat` on `secret/shared/github`
+(`GITHUB_REPO_PAT_FIELD`, default was `ops_pat`). That PAT lives in the same
+user-rate-limit pool as agent `gh` auth as `TSavo`.
+
+### What T must put in Vault (credentials this agent cannot mint)
+
+**Preferred:** GitHub App installation for infrastructure only.
+
+1. Create a GitHub App (e.g. `wopr-runner-autoscaler`) on the org / user that
+   owns the runners:
+   - Permissions (minimum): **Actions** (read), **Administration** /
+     self-hosted runners (write/admin as needed for registration), **Metadata**
+   - Install on `wopr-network` and on `TSavo/sugar` (and any other
+     `GITHUB_REPOS` entries)
+2. Prefer **installation access tokens** (App JWT → installation token) so the
+   quota is **installation-scoped**, not the human user 5000/hr pool.
+
+**Acceptable interim:** a **machine-user** classic/fine-grained PAT (separate
+GitHub user, e.g. `wopr-runner-bot`), never the human `TSavo` oauth/PAT that
+agents use.
+
+3. Store the secret in Vault:
+   - Path: `secret/shared/github`
+   - **New field:** `autoscaler_pat` (or App installation token material under
+     a dedicated path if you extend the client)
+   - Do **not** reuse `ops_pat` / agent tokens
+
+4. Point the autoscaler at it:
+
+```bash
+# /home/tsavo/.github/runner-autoscaler/.env
+GITHUB_REPO_PAT_FIELD=autoscaler_pat
+```
+
+(Default in config should already be `autoscaler_pat` after the isolation
+patch; set explicitly until rolled out.)
+
+5. Restart:
+
+```bash
+cd /home/tsavo/.github/runner-autoscaler && bin/start.sh
+# or: docker compose up -d --build autoscaler
+```
+
+6. **Verify isolation:** agent `gh api rate_limit` remaining should not drop
+   when only the autoscaler lists runners; autoscaler logs must not 403 while
+   agents are quiet.
+
+Org-scoped registration may still use `runner_registration_pat` — keep that
+field **infra-only** as well; never the agent oauth token.
+
+## Fix 2a — meter agent/tooling use (load-gate shape)
+
+```bash
+# report only
+python3 tools/gh_rate_budget.py
+# or
+bin/gh-budget
+
+# refuse if remaining < floor (default 500) — exit 79
+bin/gh-budget --floor 800
+
+# spend only if budget ok
+bin/gh-budget pr view 1 --json url
+# equivalent:
+python3 tools/gh_rate_budget.py --floor 500 -- wrap -- gh pr view 1 --json url
+```
+
+| Exit | Meaning |
+| --- | --- |
+| 0 | remaining ≥ floor (optional wrapped command ran) |
+| **79** | **budget low** — do not spend; wait for reset |
+| 2 | cannot measure budget |
+
+**Floor default 500** leaves headroom for the autoscaler and a cancellation
+sweep. Raise `GH_RATE_BUDGET_FLOOR` during incidents.
+
+**Agents must not** bare-poll `gh pr view` / `gh api` / `gh run list` in loops.
+Prefer `bin/gh-budget`. No polling until reset after a 79.
+
+## Fix 2b — coalesce merge fan-out (policy + soft controls)
+
+Every merge to `main` that triggers a full matrix is a budget and runner
+multiplier. Prefer:
+
+1. **Path filters** on per-commit workflows so pure `docs/**` (and other
+   non-product paths) do not fan out heavy jobs.
+2. **Keep heavy corpus instruments** on `schedule` + `workflow_dispatch` (as
+   control-effect-recensus already is) — not on every push.
+3. **Batch merges** during a train: fewer tips, fewer identical suite starts.
+4. **Do not** reintroduce GitHub `concurrency:` that **drops pending runs** on
+   `main` (evidence loss — see `ci.yml` comment). Coalesce by **not starting**
+   redundant work, not by discarding queued evidence.
+
+`ci.yml` may use `paths-ignore: ['docs/**']` so documentation-only tips do not
+consume a full core matrix; product paths still always run.
+
+## Unstoppable workflow runs (delete, do not cancel)
+
+These runs accept cancel but never change state — no runner will claim them to
+process the cancel. **Cancel loops forever; they need admin delete**, not more
+cancel API.
+
+| Run ID | Commit | Note |
+| --- | --- | --- |
+| `25907072649` | `6030866eb` | unstoppable — delete |
+| `25907072689` | `6030866eb` | unstoppable — delete |
+| `25907063329` | `6030866eb` | unstoppable — delete |
+
+**Delete path (when API budget allows, by infra owner):**
+
+```bash
+# Requires admin actions permission; may need UI:
+# Repo → Actions → run → ⋯ → Delete workflow run
+#
+# API (sparingly — this is the budget we just saved):
+gh api -X DELETE "/repos/TSavo/sugar/actions/runs/25907072649"
+gh api -X DELETE "/repos/TSavo/sugar/actions/runs/25907072689"
+gh api -X DELETE "/repos/TSavo/sugar/actions/runs/25907063329"
+```
+
+If DELETE is 403/404, use the Actions UI as admin. Document any replacement IDs
+here when a future bankruptcy leaves zombies — do not cancel-loop them.
+
+## Related
+
+- Runner autoscaler: battleaxe `/home/tsavo/.github/runner-autoscaler`
+- Measurement law (same isolation class): `docs/contributing/measurement-conditions.md`
+- Host lease path (shared container bind-mount):  
+  `/home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease`

--- a/docs/ops/battleaxe-runner-capacity.md
+++ b/docs/ops/battleaxe-runner-capacity.md
@@ -1,0 +1,45 @@
+# Battleaxe runner capacity (MAX_RUNNERS=10 + memory floor)
+
+## Why 10 (not 25)
+
+| Seats | RAM demand (~3.4GB each) | On 62GB host |
+| --- | ---: | --- |
+| 25 | ~85GB | **137%** → thrash (2026-08-02: AnonPages 57GB, MemFree 1GB, load 138) |
+| **10** | **~34GB** | **~28GB headroom** for recensus / floors / walls / sshd |
+
+Heavy work is single-process or k=8 — never needed 25 seats. There is **no
+MIN_RUNNERS**; the pool is demand-driven (spawn on queue, reaper on idle).
+
+## Memory law (not a guess)
+
+Autoscaler refuses to spawn when:
+
+`MemAvailable - RUNNER_ESTIMATED_MB < RUNNER_MEMORY_FLOOR_MB`
+
+Defaults: floor **28672 MiB** (28 GiB), estimate **3482 MiB** (~3.4GB).
+
+Same shape as the measurement load gate: a resource with no meter overfills.
+
+## Apply on battleaxe (when WSL is confirmed back — once)
+
+Do **not** SSH while WSL is restarting. When joe says battleaxe is up:
+
+```bash
+cd /home/tsavo/.github/runner-autoscaler
+# Pull wopr-network/.github branch with host_memory + config, or rsync from Mac:
+#   /Users/tsavo/.github/runner-autoscaler  (has the patch)
+
+# Count + memory env (effect on next compose start — one bounce only):
+grep -q '^MAX_RUNNERS=' .env && sed -i 's/^MAX_RUNNERS=.*/MAX_RUNNERS=10/' .env \
+  || echo 'MAX_RUNNERS=10' >> .env
+grep -q '^RUNNER_MEMORY_FLOOR_MB=' .env || echo 'RUNNER_MEMORY_FLOOR_MB=28672' >> .env
+grep -q '^RUNNER_ESTIMATED_MB=' .env || echo 'RUNNER_ESTIMATED_MB=3482' >> .env
+
+docker compose up -d --build autoscaler
+```
+
+If `bin/start.sh` regenerates `.env` from vault only, ensure it preserves or
+re-emits `MAX_RUNNERS=10` and the memory floor vars.
+
+Do not raise `MAX_RUNNERS` without re-running the RAM arithmetic and keeping
+the memory floor.

--- a/tests/test_gh_rate_budget.py
+++ b/tests/test_gh_rate_budget.py
@@ -1,0 +1,45 @@
+"""Focused tests for tools/gh_rate_budget.py — no live GitHub when mocked."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "tools" / "gh_rate_budget.py"
+
+
+def _run(env_extra: dict[str, str] | None = None, args: list[str] | None = None) -> subprocess.CompletedProcess[str]:
+    env = {**dict(**{k: v for k, v in __import__("os").environ.items()})}
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(TOOL), *(args or ["--json"])],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_help_or_import_main_exists() -> None:
+    assert TOOL.is_file()
+    text = TOOL.read_text(encoding="utf-8")
+    assert "EXIT_BUDGET = 79" in text
+    assert "github-api-budget-low" in text
+
+
+def test_wrap_argv_parsing_documented() -> None:
+    text = TOOL.read_text(encoding="utf-8")
+    assert "-- wrap" in text
+    assert "autoscaler_pat" in text
+
+
+def test_bin_wrapper_exists() -> None:
+    wrapper = ROOT / "bin" / "gh-budget"
+    assert wrapper.is_file()
+    body = wrapper.read_text(encoding="utf-8")
+    assert "gh_rate_budget.py" in body

--- a/tools/gh_rate_budget.py
+++ b/tools/gh_rate_budget.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""GitHub API rate-budget gate — same shape as the load gate for measurements.
+
+A gh call that cannot testify to the budget it is spending is the same defect
+class as a measurement that cannot testify to its conditions. The 2026-08-02
+infrastructure collapse: eight agents + the runner autoscaler shared one user
+token; agents drained core remaining to 0; the autoscaler got 403 on every
+runners query, went blind, and 421 jobs queued behind 25 static runners.
+
+Exit codes:
+  0   — budget above floor; prints remaining/reset (and runs -- wrap if given)
+  79  — remaining below floor; refuse to spend (crime=github-api-budget-low)
+  2   — cannot measure budget (gh missing / unauthenticated / network)
+
+Usage:
+  python3 tools/gh_rate_budget.py                  # report + exit 0/79
+  python3 tools/gh_rate_budget.py --floor 500
+  python3 tools/gh_rate_budget.py --json
+  python3 tools/gh_rate_budget.py -- wrap -- gh pr view 1 --json url
+
+Env:
+  GH_RATE_BUDGET_FLOOR   default floor (default 500 remaining core units)
+  GH_TOKEN / gh auth     whatever gh uses; do not point agent gh at the
+                         autoscaler vault field — separate identity hub
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any
+
+EXIT_BUDGET = 79
+EXIT_MEASURE = 2
+DEFAULT_FLOOR = 500
+
+
+def _eprint(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def fetch_rate_limit() -> dict[str, Any]:
+    if shutil.which("gh") is None:
+        raise RuntimeError("gh not on PATH")
+    # Single lightweight call — this is the budget probe itself.
+    proc = subprocess.run(
+        ["gh", "api", "rate_limit"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip()
+        raise RuntimeError(f"gh api rate_limit failed: {err[:500]}")
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("gh api rate_limit returned non-JSON") from exc
+
+
+def core_resources(payload: dict[str, Any]) -> dict[str, Any]:
+    resources = payload.get("resources") or {}
+    core = resources.get("core") or payload.get("rate") or {}
+    if not isinstance(core, dict):
+        raise RuntimeError("rate_limit payload missing resources.core")
+    return core
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--floor",
+        type=int,
+        default=int(os.environ.get("GH_RATE_BUDGET_FLOOR", str(DEFAULT_FLOOR))),
+        help=f"refuse when core remaining < floor (default {DEFAULT_FLOOR})",
+    )
+    parser.add_argument("--json", action="store_true", help="machine-readable stdout")
+    parser.add_argument(
+        "--wrap",
+        nargs=argparse.REMAINDER,
+        help="if budget ok, exec remaining args (use: -- wrap -- gh ...)",
+    )
+    args = parser.parse_args(argv)
+
+    wrap = list(args.wrap or [])
+    if wrap and wrap[0] == "--":
+        wrap = wrap[1:]
+
+    try:
+        payload = fetch_rate_limit()
+        core = core_resources(payload)
+    except Exception as exc:
+        _eprint(
+            f"sugarbin: crime=github-api-budget-unmeasured detail={exc} "
+            f"replacement=install/auth gh; cannot spend API without a budget reading"
+        )
+        return EXIT_MEASURE
+
+    remaining = int(core.get("remaining", -1))
+    limit = int(core.get("limit", -1))
+    reset = int(core.get("reset", 0))
+    reset_in = max(0, reset - int(time.time())) if reset else 0
+
+    report = {
+        "kind": "github-api-rate-budget",
+        "resource": "core",
+        "remaining": remaining,
+        "limit": limit,
+        "resetUnix": reset,
+        "resetInSeconds": reset_in,
+        "floor": args.floor,
+        "status": "ok" if remaining >= args.floor else "low",
+    }
+
+    _eprint(
+        f"sugarbin: gh-rate-budget phase=check resource=core "
+        f"remaining={remaining} limit={limit} floor={args.floor} "
+        f"reset_in_s={reset_in}"
+    )
+
+    if args.json:
+        print(json.dumps(report, sort_keys=True))
+    else:
+        print(
+            f"github-api-budget core remaining={remaining}/{limit} "
+            f"floor={args.floor} reset_in_s={reset_in} status={report['status']}"
+        )
+
+    if remaining < args.floor:
+        _eprint(
+            f"sugarbin: crime=github-api-budget-low remaining={remaining} "
+            f"floor={args.floor} reset_in_s={reset_in} "
+            f"replacement=stop agent gh polling; autoscaler shares a user-scoped "
+            f"budget until it has its own token (vault field autoscaler_pat / "
+            f"GitHub App). Exit {EXIT_BUDGET}."
+        )
+        return EXIT_BUDGET
+
+    if wrap:
+        _eprint(f"sugarbin: gh-rate-budget phase=spend remaining={remaining} cmd={wrap[0]!r}")
+        os.execvp(wrap[0], wrap)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Documents why MAX_RUNNERS=10 and memory floor. Implementation: wopr-network/.github#25. No battleaxe touch (WSL restart).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub API rate-limit budget gate and battleaxe runner capacity docs
> - Introduces [`tools/gh_rate_budget.py`](https://github.com/TSavo/sugar/pull/7119/files#diff-73cdd5eec304c26e8b007d790ee6471cc19b6194cf69cea98ccc769ac61ae7bf), a CLI that checks GitHub API core remaining against a floor (default 500 or `GH_RATE_BUDGET_FLOOR`), exits 79 when below floor, and optionally wraps a command via `execvp` so it only runs when budget is sufficient.
> - Adds [`bin/gh-budget`](https://github.com/TSavo/sugar/pull/7119/files#diff-44646bd69b9cca8330bc0165f6562cc1d25a03016c2b89d4e83d53bb51d75be2), a bash wrapper that gates `gh` CLI calls through the budget tool, parsing an optional `--floor N` before forwarding arguments.
> - Updates [`ci.yml`](https://github.com/TSavo/sugar/pull/7119/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) to skip CI on pushes that only touch `docs/**`, with a comment warning against using concurrency to drop pending main-branch runs.
> - Adds ops and contributing docs covering runner capacity limits, memory floor calculations, and GitHub API rate-limit isolation.
> - Risk: `gh` commands wrapped via `bin/gh-budget` will exit 79 (instead of running) when core remaining is below the floor, which is a new hard failure mode in any workflow using the wrapper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a231c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->