### PR TITLE
Name bare TypeError(type(...)) refusals instead of dumping types

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_state_partition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_state_partition_value.py
@@ -33,7 +33,25 @@ class ReceiverStatePartitionValue(FloorValue):
                     payload = face.effect.to_term(owner=owner)
                 kind = "halted"
             else:  # pragma: no cover - ExitSet is closed over these two faces.
-                raise TypeError(type(face).__name__)
+                # Missing arm over ExitSet faces: name the species and the door.
+                from sugar_lift_py_tests.gap.info import GapKind
+                from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+                construction_panic_gap(
+                    owner="ReceiverStatePartitionValue.to_term",
+                    blame="receiver-state-partition",
+                    observed=(
+                        f"ExitSet face species {type(face).__name__} has no "
+                        f"to_term arm (only Completed and Halted are written)"
+                    ),
+                    requested="Completed | Halted face from ExitSet",
+                    fix=(
+                        f"write to_term arm for {type(face).__name__} or stop "
+                        f"emitting it into receiver-state partitions; do not "
+                        f"raise bare TypeError with only the type name"
+                    ),
+                    gap_kind=GapKind.FLOOR,
+                )
             faces.append(
                 ctor(
                     "python:receiver-state-face",

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -114,7 +114,23 @@ class ConstructedManagerProtocolV1:
 
     def exit_outcome_for(self, entered: EnteredManagerStateValue, ctx: object = None):
         if not isinstance(entered, EnteredManagerStateValue):
-            raise TypeError(type(entered).__name__)
+            # Naked TypeError(type(entered).__name__) named neither the door nor
+            # the artifact we need — instrument noise on the board.
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                blame=self.exit_face_id,
+                owner="ManagerProtocol.exit_outcome_for",
+                observed=(
+                    f"exit_outcome_for received {type(entered).__name__}, not "
+                    f"EnteredManagerStateValue"
+                ),
+                requested="EnteredManagerStateValue from the matching enter face",
+                fix=(
+                    "carry enter's EnteredManagerStateValue into exit; do not "
+                    "raise bare TypeError with only the type name"
+                ),
+            )
         return _call_protocol_method(
             entered.receiver_state,
             "__exit__",
@@ -702,9 +718,18 @@ def exit_generator_resource_outcome_for(protocol, entered, *, ctx: object = None
     from sugar_source_tree.panic import SugarNotWritten
 
     if not isinstance(entered, EnteredGeneratorManagerStateV1):
-        raise TypeError(
-            "GeneratorBackedManagerProtocolV1.exit_outcome_for requires "
-            f"EnteredGeneratorManagerStateV1, not {type(entered).__name__}"
+        raise SugarNotWritten(
+            blame=protocol.exit_face_id,
+            owner="GeneratorBackedManagerProtocolV1.exit_outcome_for",
+            observed=(
+                f"exit_outcome_for received {type(entered).__name__}, not "
+                f"EnteredGeneratorManagerStateV1"
+            ),
+            requested="EnteredGeneratorManagerStateV1 from the matching enter face",
+            fix=(
+                "carry enter's EnteredGeneratorManagerStateV1 into exit; do not "
+                "raise bare TypeError with only the type name"
+            ),
         )
     if entered.protocol_construction_cid != protocol.protocol_construction_cid:
         raise SugarNotWritten(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -11938,7 +11938,27 @@ def _construct_binding_projection(state):
             ),
             state.target_cid,
         )
-    raise TypeError(type(state))
+    # Missing arm over BindingState: name the species and the constructor door.
+    # A bare TypeError(type(state)) aborts the file as instrument noise and
+    # names neither the union nor the unwritten arm.
+    from sugar_source_tree.panic import SugarNotWritten
+
+    raise SugarNotWritten(
+        owner="_construct_binding_projection",
+        blame=f"binding-state:{type(state).__name__}",
+        observed=(
+            f"binding state species {type(state).__name__} has no projection "
+            f"constructor arm"
+        ),
+        requested=(
+            "Node | UnboundBinding | GuardedBinding | LoopProjectedBinding "
+            "(with formula-bearing guards)"
+        ),
+        fix=(
+            f"write _construct_binding_projection arm for {type(state).__name__} "
+            f"or project it before this door; do not raise TypeError"
+        ),
+    )
 
 
 class GuardedBindingRead(Expression):

--- a/implementations/python/sugar-source-tree/tests/test_naked_typeerror_named_refusals.py
+++ b/implementations/python/sugar-source-tree/tests/test_naked_typeerror_named_refusals.py
@@ -1,0 +1,92 @@
+"""Naked TypeError(type(...)) must become named refusals.
+
+A plain type dump is not a limit announcing itself — it is a missing arm
+wearing instrument noise. Every site that used to raise TypeError(type(x))
+must name owner, observed species, requested shape, and fix.
+"""
+
+from __future__ import annotations
+
+from sugar_source_tree.panic import SugarNotWritten
+
+
+def test_construct_binding_projection_unknown_species_is_sugar_not_written() -> None:
+    from sugar_source_tree.nodes import _construct_binding_projection
+
+    class ForeignBindingState:
+        pass
+
+    try:
+        _construct_binding_projection(ForeignBindingState())
+        raise AssertionError("expected SugarNotWritten")
+    except SugarNotWritten as gap:
+        assert "ForeignBindingState" in gap.observed
+        assert gap.requested
+        assert gap.fix
+    except TypeError as te:
+        raise AssertionError(
+            f"naked TypeError is the old lie: {te!r}; want SugarNotWritten"
+        ) from te
+
+
+def test_manager_protocol_exit_wrong_entered_is_sugar_not_written() -> None:
+    from sugar_lift_python_source.manager_protocol_construction import (
+        ConstructedManagerProtocolV1,
+    )
+
+    proto = object.__new__(ConstructedManagerProtocolV1)
+    object.__setattr__(proto, "exit_face_id", "exit-face:test")
+    try:
+        proto.exit_outcome_for(object())
+        raise AssertionError("expected SugarNotWritten")
+    except SugarNotWritten as gap:
+        assert "EnteredManagerStateValue" in gap.observed
+        assert "TypeError" in gap.fix or "enter" in gap.fix.lower()
+    except TypeError as te:
+        raise AssertionError(
+            f"naked TypeError is the old lie: {te!r}; want SugarNotWritten"
+        ) from te
+
+
+def test_generator_exit_wrong_entered_is_sugar_not_written() -> None:
+    from sugar_lift_python_source.manager_protocol_construction import (
+        exit_generator_resource_outcome_for,
+    )
+
+    class _Protocol:
+        exit_face_id = "exit-face:gen"
+        protocol_construction_cid = "blake3-512:" + ("11" * 32)
+
+    try:
+        exit_generator_resource_outcome_for(_Protocol(), object())
+        raise AssertionError("expected SugarNotWritten")
+    except SugarNotWritten as gap:
+        assert "EnteredGeneratorManagerStateV1" in gap.observed
+        assert gap.fix
+    except TypeError as te:
+        raise AssertionError(
+            f"naked TypeError is the old lie: {te!r}; want SugarNotWritten"
+        ) from te
+
+
+def test_receiver_partition_unknown_face_is_construction_panic() -> None:
+    from sugar_lift_py_tests.floor.receiver_state_partition_value import (
+        ReceiverStatePartitionValue,
+    )
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_lift_py_tests.outcome import ExitSet
+
+    class ForeignFace:
+        guard = None
+
+    partition = ReceiverStatePartitionValue(exits=ExitSet((ForeignFace(),)))
+    try:
+        partition.to_term(owner="test")
+        raise AssertionError("expected ConstructionPanic")
+    except ConstructionPanic as panic:
+        assert "ForeignFace" in panic.info.observed
+        assert "Completed" in panic.info.requested or "Halted" in panic.info.requested
+    except TypeError as te:
+        raise AssertionError(
+            f"naked TypeError is the old lie: {te!r}; want ConstructionPanic"
+        ) from te


### PR DESCRIPTION
## Summary

Code that falls over with a plain untyped error is either a bug or a limit without words. Three doors dumped only a class name via `TypeError(type(x))` / `TypeError(type(x).__name__)`. Each now announces what it could not do.

| Site | Was | Now |
|------|-----|-----|
| `_construct_binding_projection` | `TypeError(type(state))` | Named refusal: species has no projection arm |
| `ConstructedManagerProtocolV1.exit_outcome_for` | `TypeError(type(entered).__name__)` | Named refusal: need enter’s entered state |
| Generator exit path | TypeError string | Same shape as above |
| `ReceiverStatePartitionValue.to_term` | `TypeError(type(face).__name__)` | Construction panic: ExitSet face arm missing |

## Validation

Smoke + teeth in `test_naked_typeerror_named_refusals.py`.

## Shot

- Deletes the “type dump” shell at these doors
- Does not census remaining TypeErrors repo-wide; PR, not count

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace bare `TypeError(type(...))` refusals with named structured exceptions
> - Replaces bare `TypeError` raises in `ReceiverStatePartitionValue.to_term`, `ConstructedManagerProtocolV1.exit_outcome_for`, `exit_generator_resource_outcome_for`, and `_construct_binding_projection` with structured exceptions that include owner, blame, observed type, requested type, and fix guidance.
> - Unknown face species in `to_term` now raise `ConstructionPanic` via `construction_panic_gap`; type mismatches in the other three paths raise `SugarNotWritten`.
> - Adds a new test module verifying that all four previously bare `TypeError` paths now raise their respective named exceptions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00e006f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->