### PR TITLE
sole_path: fix unmatched } left by #7123 WithConstructionGapKind delete

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -2474,9 +2474,7 @@ def _installed_pytest_boundary(tmp_path, manager_call: str, body: str):
 def test_installed_pytest_raises_truthful_route_keeps_enter_gap_typed(
     tmp_path,
 ):
-    from sugar_source_tree.panic import (
-        WithConstructionGap,
-            )
+    from sugar_source_tree.panic import WithConstructionGap
 
     tree, context = _installed_pytest_boundary(
         tmp_path,
@@ -2508,9 +2506,7 @@ def test_installed_pytest_raises_truthful_route_keeps_enter_gap_typed(
 def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
     tmp_path,
 ):
-    from sugar_source_tree.panic import (
-        WithConstructionGap,
-            )
+    from sugar_source_tree.panic import WithConstructionGap
 
     tree, context = _installed_pytest_boundary(
         tmp_path,
@@ -2525,8 +2521,6 @@ def test_installed_pytest_raises_lying_legacy_callable_route_stays_typed_loud(
 
     # Legacy multi-actual form still refuses; residual names the same exit-face
     # unary floor rather than inventing EffectBoundary by spelling.
-        "force-floor", "exit-may-halt",
-    }
     assert "unary_operation_exception_floor:CallSiteValue not" in caught.value.observed
     assert "binary_operation_exception_floor:SymbolicValue + CallSiteValue" not in (
         caught.value.observed


### PR DESCRIPTION
## Why

#7123 deleted `WithConstructionGapKind` asserts but left a half-deleted set-literal body in `test_sole_path_manager_construction.py` — `SyntaxError: unmatched '}'` at line 2529. Same class of dangling syntax as the empty `TYPE_CHECKING` that #7122 fixed in `gap/info.py`.

Main kit imports after #7122. This is the sibling compile red on the sole_path twin file.

## What

- Drop the dangling set members under the deleted `gap_kind` assert (mirror the truthful twin, which already dropped the kind assert).
- Keep the observed-string residual checks.

## Sweep

- `py_compile` clean across sugar-lift-py-tests / sugar-source-tree / sugar-lift-python-source `src` + scripts + this test file.
- No other empty `if TYPE_CHECKING` / empty try/def bodies in packages.
- `WithConstructionGap` still referenced in a few tests at runtime (deleted class) — not a parse failure; out of this PR.

## Shell deleted

None. Syntax floor restoration after taxonomy delete.

Predicted Epsilon R: main package import green (already via #7122); sole_path file parse green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix unmatched `}` left by stale string literals in sole_path construction tests
> Removes two orphaned string literals (`"force-floor"`, `"exit-may-halt"`) and a trailing `}` left behind in [test_sole_path_manager_construction.py](https://github.com/TSavo/sugar/pull/7124/files#diff-66a8978c573ce822d1d2e242f2e0761e4bcdf509d2513e27a73b8692656b2477) by a prior deletion of `WithConstructionGapKind`. Also reformats multiline `WithConstructionGap` imports to single-line within the affected test functions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60dcb6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->