### PR TITLE
Construction doors: name what could not be built, not bare errors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/claim_envelope.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/claim_envelope.py
@@ -154,7 +154,14 @@ def _authoring_to_value(a: Authoring) -> Value:
         if a.rationale is not None and a.rationale != "":
             pairs.append(("rationale", vstr(a.rationale)))
         return vobj(pairs)
-    raise TypeError(f"unknown Authoring variant: {type(a)!r}")
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+    construction_panic_gap(
+        owner="claim_envelope.authoring",
+        blame="claim_envelope",
+        observed=f"Authoring species {type(a).__name__} has no arm",
+        requested="a written Authoring variant",
+        fix=f"write Authoring arm for {type(a).__name__}",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/effect.py
@@ -127,4 +127,12 @@ def effect_status(effect: Effect) -> EffectStatus:
 
 
 def _unhandled_effect(effect: Never) -> NoReturn:
-    raise TypeError(f"unhandled Effect arm: {type(effect).__name__}")
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner="effect._unhandled_effect",
+        blame=f"effect:{type(effect).__name__}",
+        observed=f"Effect species {type(effect).__name__} has no dispatch arm",
+        requested="a written Effect class with effect_status/effect_reason arms",
+        fix=f"write the Effect arm for {type(effect).__name__}; do not raise bare TypeError",
+    )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect_router.py
@@ -461,7 +461,15 @@ def route(
             "must keep a runtime-selected exit loud before routing, never "
             "let it arrive here for the router to guess a policy"
         )
-    raise TypeError(f"unknown context-manager contract: {type(contract).__name__}")
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner="effect_router.route",
+        blame=site if site is not None else "effect_router.route",
+        observed=f"context-manager contract species {type(contract).__name__} has no route arm",
+        requested="Expects | Suppresses | NeverSuppresses (RuntimeSelected must not reach the router)",
+        fix=f"write route arm for {type(contract).__name__} or keep it loud before routing",
+    )
 
 
 def route_except(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_dispatch_surface.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_dispatch_surface.py
@@ -406,7 +406,13 @@ def require_floor_dispatch_surface(
     )
     if missing:
         joined = ", ".join(missing)
-        raise TypeError(
-            f"{cls.__name__} is missing floor operation method(s): {joined}"
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="require_floor_dispatch_surface",
+            blame=cls.__name__,
+            observed=f"{cls.__name__} is missing floor operation method(s): {joined}",
+            requested="every FLOOR_OPERATION_METHOD_NAMES method present on the floor class",
+            fix=f"implement missing methods on {cls.__name__}: {joined}",
         )
     return cls

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/ir.py
@@ -967,7 +967,15 @@ def formula_term(formula: Formula) -> Term:
             [str_const(formula.name), str_const(sort_name), formula_term(formula.body)],
             symbol_kind="coordinate",
         )
-    raise TypeError(f"unknown Formula construction: {type(formula).__name__}")
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner="ir.formula_term",
+        blame="ir.formula_term",
+        observed=f"Formula species {type(formula).__name__} has no formula_term arm",
+        requested="Atomic | Connective | Quantifier (written Formula constructors)",
+        fix=f"write formula_term arm for {type(formula).__name__}",
+    )
 
 
 # EvidenceTerm --------------------------------------------------------------

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/complete_value.py
@@ -16,8 +16,14 @@ def complete_value(outcome: Outcome, *, owner: str) -> FloorValue:
     gap so kit-domain multi-arm outcomes stay on the typed-gap axis, never bare.
     """
     if isinstance(outcome, Incomplete):
-        raise RuntimeError(
-            f"{owner} cannot read completed value from incomplete effect: {outcome.reason}"
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner=owner,
+            blame=owner,
+            observed=f"Incomplete effect (reason={outcome.reason!r}); no completed floor value",
+            requested="Complete floor value",
+            fix="do not project complete_value from Incomplete; reduce or leave the gap loud",
         )
     if isinstance(outcome, Complete):
         return outcome.value
@@ -41,6 +47,12 @@ def complete_value(outcome: Outcome, *, owner: str) -> FloorValue:
                 gap_locus=GapLocus.PROJECTION,
             )
         )
-    raise RuntimeError(
-        f"{owner} cannot read completed value from {type(outcome).__name__}"
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner=owner,
+        blame=owner,
+        observed=f"outcome species {type(outcome).__name__} has no complete_value arm",
+        requested="Complete | ExitSet (ExitSet already handled) | Incomplete (refused)",
+        fix=f"write complete_value arm for {type(outcome).__name__} or refuse earlier",
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
@@ -135,9 +135,14 @@ def _boundary_halted_edge(disposition, incoming):
             held=_consumed(disposition, incoming),
             failed=incoming.effect,
         )
-    raise TypeError(
-        "message verdict must be MatchDecided or MatchRetained; "
-        f"got {type(verdict).__name__}"
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner="exit_disposition.message_verdict",
+        blame="exit_disposition",
+        observed=f"message verdict species {type(verdict).__name__} has no arm",
+        requested="MatchDecided | MatchRetained",
+        fix=f"write message-verdict arm for {type(verdict).__name__}",
     )
 
 
@@ -188,10 +193,17 @@ def _resource_verdict(disposition: object, effect: object) -> str:
     if isinstance(disposition, Suppresses):
         return _suppresses_verdict(disposition, effect)
 
-    raise TypeError(
-        "exit disposition must be NeverSuppresses, ExitSuppressionContract, "
-        "RuntimeSelected, Suppresses, or EffectBoundaryDisposition; "
-        f"got {type(disposition).__name__}"
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner="exit_disposition._resource_verdict",
+        blame="exit_disposition",
+        observed=f"exit disposition species {type(disposition).__name__} has no verdict arm",
+        requested=(
+            "NeverSuppresses | ExitSuppressionContract | RuntimeSelected | "
+            "Suppresses | EffectBoundaryDisposition"
+        ),
+        fix=f"write _resource_verdict arm for {type(disposition).__name__}",
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -284,7 +284,15 @@ class ComparisonOpSugar(ConstructedTermSugar):
 
     def __post_init__(self) -> None:
         if self.op_kind not in COMPARISON_KINDS:
-            raise ValueError(f"unknown comparison operator {self.op_kind!r}")
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="ComparisonOpSugar",
+                blame=self.site,
+                observed=f"comparison operator {self.op_kind!r} has no ComparisonOpSugar arm",
+                requested="a written comparison kind in COMPARISON_KINDS",
+                fix=f"enroll {self.op_kind!r} in ComparisonOpSugar or refuse earlier",
+            )
         require_constructed_term_sugar(self.left, owner="ComparisonOpSugar.left")
         require_constructed_term_sugar(self.right, owner="ComparisonOpSugar.right")
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_object_place_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/constructed_object_place_sugar.py
@@ -44,9 +44,17 @@ class ConstructedObjectPlaceSugar(ConstructedTermSugar):
         value_term = self.value.to_term(owner=owner)
         testimony_cid = getattr(self.testimony, "semantic_value_cid", None)
         if not isinstance(testimony_cid, str):
-            raise TypeError(
-                f"{owner}: ConstructedObjectPlaceSugar.testimony requires "
-                f"semantic_value_cid str, got {type(self.testimony).__name__}"
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner=owner,
+                blame=getattr(self, "site", owner),
+                observed=(
+                    "ConstructedObjectPlaceSugar.testimony has no semantic_value_cid str; "
+                    f"got {type(self.testimony).__name__}"
+                ),
+                requested="testimony with semantic_value_cid: str",
+                fix="mint constructed-value testimony before ConstructedObjectPlaceSugar.to_term",
             )
         return ctor(
             "python:constructed-object-place",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
@@ -151,18 +151,36 @@ def _projection_term(state, *, owner: str):
             not isinstance(state.target_cid, str)
             or not state.target_cid.startswith("blake3-512:")
         ):
-            raise TypeError(
-                "loop guarded binding projection requires authenticated target CID"
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="_projection_term",
+                blame=owner,
+                observed="LoopGuardedProjection has no authenticated target CID (blake3-512:…)",
+                requested="LoopGuardedProjection.target_cid as blake3-512 CID string",
+                fix="carry authenticated loop target CID through projection construction",
             )
         faces = []
         for face in state.completed_faces:
             if face.guard_formula is None:
-                raise TypeError(
-                    "loop guarded binding projection requires exact guard testimony"
+                from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+                construction_panic_gap(
+                    owner="_projection_term",
+                    blame=owner,
+                    observed="LoopGuardedProjection face has no exact guard formula",
+                    requested="guard_formula testimony on each completed face",
+                    fix="do not project CID-only guards; carry exact formula through the loop face",
                 )
             if not isinstance(face.exit_partition_arity, int):
-                raise TypeError(
-                    "loop guarded binding projection requires exit-family arity"
+                from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+                construction_panic_gap(
+                    owner="_projection_term",
+                    blame=owner,
+                    observed="LoopGuardedProjection face has no integer exit_partition_arity",
+                    requested="exit_partition_arity: int on each completed face",
+                    fix="carry exit-family arity through loop projection construction",
                 )
             guard_cid = blake3_512_of(
                 encode_jcs(formula_to_value(face.guard_formula)).encode("utf-8")
@@ -184,9 +202,17 @@ def _projection_term(state, *, owner: str):
             (str_const(state.target_cid), *faces),
             symbol_kind="coordinate",
         )
-    raise TypeError(
-        "guarded binding read requires constructed projection testimony, got "
-        f"{type(state).__name__}"
+    from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+    construction_panic_gap(
+        owner="_projection_term",
+        blame=owner,
+        observed=(
+            f"binding projection species {type(state).__name__} has no "
+            f"_projection_term arm"
+        ),
+        requested="Sugar | UnboundProjection | GuardedProjection | LoopGuardedProjection",
+        fix=f"write _projection_term arm for {type(state).__name__}",
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/unary_op_sugar.py
@@ -107,7 +107,15 @@ class UnaryOpSugar(ConstructedTermSugar):
 
     def __post_init__(self) -> None:
         if self.op_kind not in {*UNARYOP_METHODS, "Not"}:
-            raise ValueError(f"unknown unary operator {self.op_kind!r}")
+            from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+            construction_panic_gap(
+                owner="UnaryOpSugar",
+                blame=self.site,
+                observed=f"unary operator {self.op_kind!r} has no UnaryOpSugar arm",
+                requested="a written unary op kind (Not or UNARYOP_METHODS entry)",
+                fix=f"enroll {self.op_kind!r} in UnaryOpSugar or refuse earlier",
+            )
         require_constructed_term_sugar(self.operand, owner="UnaryOpSugar.operand")
 
     @classmethod

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -524,7 +524,15 @@ def _route_warning_boundary(*, body, ctx, manager_exit, expected, pattern, mode,
                 )
             )
             continue
-        raise TypeError(f"unknown warning message verdict {type(verdict).__name__}")
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="WithEffectBoundarySugar.warning_message",
+            blame=getattr(self, "site", "with-effect-boundary"),
+            observed=f"warning message verdict species {type(verdict).__name__} has no arm",
+            requested="a written warning-message verdict class",
+            fix=f"write warning-message arm for {type(verdict).__name__}",
+        )
     return ExitSet(tuple(exits)).normalize()
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_bare_error_named_panics.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bare_error_named_panics.py
@@ -1,0 +1,68 @@
+"""Bare TypeError/RuntimeError/ValueError on construction doors must name the gap.
+
+Construct or panic. A type dump is not a panic that says what could not be built.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_source_tree.panic import SugarNotWritten
+
+
+def test_unhandled_effect_panics_with_species() -> None:
+    from sugar_lift_py_tests.effect.effect import _unhandled_effect
+
+    class ForeignEffect:
+        pass
+
+    try:
+        _unhandled_effect(ForeignEffect())  # type: ignore[arg-type]
+        raise AssertionError("expected ConstructionPanic")
+    except ConstructionPanic as p:
+        assert "ForeignEffect" in p.info.observed
+        assert p.info.requested
+        assert p.info.fix
+
+
+def test_complete_value_unknown_outcome_panics() -> None:
+    from sugar_lift_py_tests.outcome.complete_value import complete_value
+
+    class ForeignOutcome:
+        pass
+
+    try:
+        complete_value(ForeignOutcome(), owner="test.owner")  # type: ignore[arg-type]
+        raise AssertionError("expected ConstructionPanic")
+    except ConstructionPanic as p:
+        assert "ForeignOutcome" in p.info.observed
+        assert p.info.owner == "test.owner"
+
+
+def test_ordered_binding_keys_non_str_panics() -> None:
+    from sugar_source_tree.nodes import _ordered_binding_keys
+
+    try:
+        _ordered_binding_keys(["ok", 12])  # type: ignore[list-item]
+        raise AssertionError("expected SugarNotWritten")
+    except SugarNotWritten as gap:
+        assert "int" in gap.observed or "12" in gap.observed or "not a str" in gap.observed
+        assert gap.fix
+
+
+def test_unknown_unary_op_panics() -> None:
+    from sugar_lift_py_tests.sugar.unary_op_sugar import UnaryOpSugar
+    from sugar_lift_py_tests.sugar.name_sugar import NameSugar
+    from sugar_source_tree.tree import SourceFile
+    from sugar_lift_python_source.canonical import blake3_512_of
+
+    src = "x\n"
+    sf = SourceFile((src, "u.py", blake3_512_of(src.encode())))
+    try:
+        UnaryOpSugar(
+            op_kind="NotARealOp",
+            operand=NameSugar(name="x", site=sf.root.fragment),
+            site=sf.root.fragment,
+        )
+        raise AssertionError("expected ConstructionPanic")
+    except ConstructionPanic as p:
+        assert "NotARealOp" in p.info.observed

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -949,7 +949,15 @@ def _node_shape_v2_preimage(ref: object, child_cid: "dict[int, str]") -> dict[st
         else:
             # NEVER a fallback to subtree embedding: an unknown slot kind is a
             # gap in the schema, reported loudly, not inlined behind our backs.
-            raise TypeError(f"unknown backend slot {type(slot).__name__}")
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                blame=desc.kind if hasattr(desc, "kind") else "node-shape-v2",
+                owner="backend_node_shape_v2",
+                observed=f"backend slot species {type(slot).__name__} has no NodeShapeV2 arm",
+                requested="Child | MaybeChild | Children | Leaf | OpLeaf | OpsLeaf",
+                fix=f"write NodeShapeV2 arm for {type(slot).__name__}; never inline a fallback",
+            )
         slots.append({"name": name, "value": value})
     return {
         "domain": NODE_SHAPE_V2_DOMAIN,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -422,7 +422,15 @@ def _ordered_binding_keys(names):
     ordered.extend(name for name in internal_names if name in names)
     if len(ordered) != len(names):
         unknown = next(name for name in names if name not in ordered)
-        raise TypeError(f"unsupported binding-map key: {type(unknown).__name__}")
+        from sugar_source_tree.panic import SugarNotWritten
+
+        raise SugarNotWritten(
+            blame="binding-map",
+            owner="_ordered_binding_keys",
+            observed=f"binding-map key species {type(unknown).__name__} is not a str name",
+            requested="str binding names only (plus known internal marker keys)",
+            fix="do not put non-str keys in the binding map; project to str names first",
+        )
     return ordered
 
 


### PR DESCRIPTION
## Summary

More construction doors that used to raise plain TypeError / ValueError / RuntimeError now **panic with owner, observed species, requested shape, and fix**.

Construct or panic. No taxonomy, no new category labels. Compose/recensus scripts **not** touched (grey lock).

### Doors converted (examples)
- Effect dispatch (`_unhandled_effect`)
- effect_router unknown contract
- complete_value Incomplete / unknown outcome
- binding projection terms + loop projection testimony gaps
- backend NodeShapeV2 unknown slot
- binding-map non-str key
- exit disposition verdicts
- unary / comparison unknown op kinds
- ConstructedObjectPlaceSugar missing testimony cid
- warning message verdict
- formula_term unknown Formula
- floor dispatch surface missing methods
- claim Authoring unknown variant

### Teeth
`test_bare_error_named_panics.py` — panics name the species, not a type dump.

### Left for later
Wire protocol / AST adapter / canonical codecs still have many ValueErrors — next sweeps.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace bare `TypeError`/`RuntimeError` raises with structured `ConstructionPanic` in construction doors
> - Across ~12 files in `sugar-lift-py-tests` and `sugar-source-tree`, bare `TypeError`, `ValueError`, and `RuntimeError` fallbacks in exhausted match arms and validation checks are replaced with `construction_panic_gap` or `SugarNotWritten`, which carry structured fields: `owner`, `blame`, `observed`, `requested`, and `fix`.
> - The structured panics name the concrete species or type that was encountered, making diagnostic output actionable rather than generic.
> - A new test module [test_bare_error_named_panics.py](https://github.com/TSavo/sugar/pull/7125/files#diff-7f7f363bab36d6127b45671ef28259625dd473a2745b96324aeecf2c5dd43c6a) asserts that each previously bare-error site now raises `ConstructionPanic` or `SugarNotWritten` with populated species names and structured fields.
> - Behavioral Change: callers catching `TypeError`, `ValueError`, or `RuntimeError` at these sites will no longer catch the errors; they must handle `ConstructionPanic` or `SugarNotWritten` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6fc60b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->