### PR TITLE
Board numbers: one name per meaning; drop desugar residual kinds

### DIFF
--- a/docs/audits/board-number-meanings.md
+++ b/docs/audits/board-number-meanings.md
@@ -8,46 +8,43 @@ A number that secretly means several things is the same defect as
 
 | Name | Meaning | One door |
 | --- | --- | --- |
-| **functionsPopulation** (`functionsTotal` back-compat) | How many functions **exist** on the pin (AST / population) | `seal_functions_population_v1` |
-| **functionsEnumerated** | How many the construction door **processed** (roster) | `seal_functions_enumerated_v1` |
+| **functionsPopulation** (`functionsTotal` back-compat) | How many functions **exist** on the pin | `seal_functions_population_v1` |
+| **functionsEnumerated** | How many the construction door **processed** | `seal_functions_enumerated_v1` |
 | **functionsConstructClean** | How many were **clean** (or refused — never defaulted) | `seal_functions_clean_v1` |
 | **functionsUnaccounted** | population − enumerated (derived at compose) | `board_fields_from_sealed_facts` |
 
-Those nearly sealed as one figure. They are three sealed facts.
-
-## Files unit (same shape, was three names for one slot)
+## Files unit (distinct quantities)
 
 | Name | Meaning |
 | --- | --- |
-| **filesEnrolled** | How many files **exist** on the pin |
-| **filesTerminal** | How many we **processed** (got a terminal row) |
-| **filesCompleted** | How many **constructed** |
-| **filesPanicked** | How many terminals **panicked** (not constructed) |
-| **filesMissing** | Enrolled with **no** terminal row |
+| **filesEnrolled** | exist on the pin |
+| **filesTerminal** | we processed (got a row) |
+| **filesCompleted** | constructed |
+| **filesPanicked** | terminal but did not construct |
+| **filesMissing** | enrolled, no terminal row |
 
-Aliases (same meaning as enrolled — not a fourth fact): `filesTotal`,
-`enrolledFiles`, `populationSize`.
+Aliases of enrolled only: `filesTotal`, `enrolledFiles`, `populationSize`.
 
-## Residual counts (not kind taxonomies)
+## Residual counts (quantities, not failure kinds)
 
 | Name | Meaning |
 | --- | --- |
-| **R_construction_panics** | `len(constructionPanics)` — construction failed loud |
+| **R_construction_panics** | `len(constructionPanics)` |
 | **R_desugar_construction_panics** | desugar-phase panics only |
-| **R_desugar_defects** | desugar defects only |
-| **R_desugar_owed_work** / **R_desugar_accounted_semantics** | desugar partition parts when present |
 | **R_cm_constructed** / **R_cm_unconstructed** | with-items that constructed vs not |
-| **R_defects** | `len(defects)` |
 
-**Deleted as sole residual:** bag totals that summed heterogeneous family tables
-into one `R` / `R_construction` / bare `R_desugar` and looked like a single
-remaining-work number. Family tables may still appear for owner detail; they
-are **not** the residual counter.
+### Dropped — kinds wearing counts (do not re-seal)
 
-## Rule for the next agent
+| Was | Why dropped |
+| --- | --- |
+| **R_desugar_defects** | “Defect” = Exception path vs ConstructionPanic — a **kind of failure**, not a second quantity. Under the law, failed construction is panic. |
+| **R_desugar_owed_work** (typed-refusal) | Outcome label for SugarNotWritten rows in a mixed R_desugar bag — **kind of row**, not a separate physical count of enrolled work. |
+| **R_desugar_accounted_semantics** (constructed-effect) | Successful desugar products (Incomplete/effect) counted as residual — **not unwritten work at all**. The 7.6× lie. |
+| **R** / **R_construction** family bag | Sum of heterogeneous owner tags as one residual. |
+| Bare **R_desugar** bag | Sum of refusal + effect rows as one remaining-work number. |
 
-Before sealing a new board field:
+## Rule
 
-1. Name **one** meaning in the field name.  
-2. Point at **one** place that computes it.  
-3. If two meanings share a spelling, **split** — do not document the overload.
+Before sealing a field: is this a **quantity that exists regardless of failure labels**
+(enrolled vs terminal, constructed vs panicked), or a **kind of failure**?
+Ship only the first.

--- a/docs/audits/board-number-meanings.md
+++ b/docs/audits/board-number-meanings.md
@@ -1,0 +1,53 @@
+# Board numbers: one name, one meaning
+
+**Law:** construct, or panic. Counts on the sealed board name **one thing each**.  
+A number that secretly means several things is the same defect as
+`functionsTotal` wearing population + enumerated + clean.
+
+## Already split (the original lie)
+
+| Name | Meaning | One door |
+| --- | --- | --- |
+| **functionsPopulation** (`functionsTotal` back-compat) | How many functions **exist** on the pin (AST / population) | `seal_functions_population_v1` |
+| **functionsEnumerated** | How many the construction door **processed** (roster) | `seal_functions_enumerated_v1` |
+| **functionsConstructClean** | How many were **clean** (or refused — never defaulted) | `seal_functions_clean_v1` |
+| **functionsUnaccounted** | population − enumerated (derived at compose) | `board_fields_from_sealed_facts` |
+
+Those nearly sealed as one figure. They are three sealed facts.
+
+## Files unit (same shape, was three names for one slot)
+
+| Name | Meaning |
+| --- | --- |
+| **filesEnrolled** | How many files **exist** on the pin |
+| **filesTerminal** | How many we **processed** (got a terminal row) |
+| **filesCompleted** | How many **constructed** |
+| **filesPanicked** | How many terminals **panicked** (not constructed) |
+| **filesMissing** | Enrolled with **no** terminal row |
+
+Aliases (same meaning as enrolled — not a fourth fact): `filesTotal`,
+`enrolledFiles`, `populationSize`.
+
+## Residual counts (not kind taxonomies)
+
+| Name | Meaning |
+| --- | --- |
+| **R_construction_panics** | `len(constructionPanics)` — construction failed loud |
+| **R_desugar_construction_panics** | desugar-phase panics only |
+| **R_desugar_defects** | desugar defects only |
+| **R_desugar_owed_work** / **R_desugar_accounted_semantics** | desugar partition parts when present |
+| **R_cm_constructed** / **R_cm_unconstructed** | with-items that constructed vs not |
+| **R_defects** | `len(defects)` |
+
+**Deleted as sole residual:** bag totals that summed heterogeneous family tables
+into one `R` / `R_construction` / bare `R_desugar` and looked like a single
+remaining-work number. Family tables may still appear for owner detail; they
+are **not** the residual counter.
+
+## Rule for the next agent
+
+Before sealing a new board field:
+
+1. Name **one** meaning in the field name.  
+2. Point at **one** place that computes it.  
+3. If two meanings share a spelling, **split** — do not document the overload.

--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -311,6 +311,7 @@ def aggregate_terminal_rows(
     defects: list[dict[str, Any]] = []
     floor_rows: list[dict[str, Any]] = []
     files_completed = 0
+    files_panicked = 0
     functions_total = 0
     functions_clean = 0
     functions_enumerated = 0
@@ -354,6 +355,7 @@ def aggregate_terminal_rows(
         if category == "completed":
             files_completed += 1
         else:
+            files_panicked += 1
             # construct-or-panic: anything not completed is a panic (no kind labels)
             panic = row.get("panic")
             if isinstance(panic, dict):
@@ -391,6 +393,7 @@ def aggregate_terminal_rows(
         "defects": defects,
         "floor_rows": floor_rows,
         "files_completed": files_completed,
+        "files_panicked": files_panicked,
         "functions_total": functions_total,
         "functions_clean": functions_clean,
         "functions_enumerated": functions_enumerated,
@@ -433,9 +436,25 @@ def seal_board_from_aggregate(
     backend_defects = Counter(agg["backend_defects"])
     construction_panics = list(agg["construction_panics"])
     defects = list(agg["defects"])
-    r_construction = sum(families.values())
-    r_desugar = sum(desugar_families.values())
+    # One meaning each — never bag-sum-as-the-residual.
+    r_construction_panics = len(construction_panics)
+    r_desugar_panics = len(agg["desugar_construction_panics"])
+    r_desugar_defects = len(agg["desugar_defects"])
+    r_desugar_owed = int(desugar_categories.get("typed-refusal", 0))
+    r_desugar_accounted = int(desugar_categories.get("constructed-effect", 0))
     r_backend = sum(backend_defects.values())
+    cm = Counter(agg["cm_resolutions"])
+    r_cm_constructed = int(cm.get("constructed", 0) + cm.get("derived-contract", 0))
+    r_cm_unconstructed = int(cm.get("unconstructed", 0)) + sum(
+        int(v) for k, v in cm.items() if str(k).startswith("gap:")
+    )
+    files_enrolled = len(file_names)
+    files_terminal = int(agg["terminal_count"])
+    files_completed = int(agg["files_completed"])
+    files_panicked = int(
+        agg.get("files_panicked") or max(0, files_terminal - files_completed)
+    )
+    files_missing = len(agg["missing_files"])
 
     # C4 Step 1: three sealed meanings, not one overloaded int.
     # LocalReadings are free; only the seal doors + board_fields_from_sealed_facts
@@ -506,13 +525,15 @@ def seal_board_from_aggregate(
         "door": "enum:path_source→SourceFile→functions→sugar→desugar",
         "isolation": "in-process",
         "paths": dict(paths or {}),
-        # Dual unit denominator — files and functions NEVER share a slot.
-        # functions.* comes only from sealed meaning types (C4 consumer close).
+        # Dual unit denominator — one name per meaning (see board-number-meanings.md).
         "denominator": {
             "files": {
-                "enrolled": len(file_names),
-                "terminalRows": int(agg["terminal_count"]),
-                "completed": int(agg["files_completed"]),
+                "enrolled": files_enrolled,
+                "terminal": files_terminal,
+                "completed": files_completed,
+                "panicked": files_panicked,
+                "missing": files_missing,
+                "terminalRows": files_terminal,
                 "corpusManifestCid": agg.get("manifest_cid"),
                 "enrolledFiles": list(file_names),
                 "missingFiles": list(agg["missing_files"]),
@@ -521,46 +542,35 @@ def seal_board_from_aggregate(
                 "complete": bool(agg["files_complete"]),
             },
             "functions": dict(fn_fields["denominator_functions"]),
-            # Back-compat flat keys (file unit only) for older readers.
-            "enrolled": len(file_names),
-            "terminalRows": int(agg["terminal_count"]),
-            "completed": int(agg["files_completed"]),
-            "corpusManifestCid": agg.get("manifest_cid"),
-            "enrolledFiles": list(file_names),
-            "missingFiles": list(agg["missing_files"]),
-            "duplicateFiles": list(agg["duplicate_files"]),
-            "malformedRows": list(agg["malformed_rows"]),
-            "complete": bool(agg["files_complete"]),
         },
-        "filesTotal": len(file_names),
-        "filesCompleted": int(agg["files_completed"]),
-        "enrolledFiles": len(file_names),
-        "populationSize": len(file_names),
-        "defects": defects,
-        "instrumentDefects": list(defects),
-        "R_instrument_defects": len(defects),
-        "constructionPanics": construction_panics,
-        "R_construction_panics": len(construction_panics),
-        # Function fields only via sealed types — bare ints cannot land here.
-        "functionsTotal": fn_fields["functionsTotal"],
+        "filesEnrolled": files_enrolled,
+        "filesTerminal": files_terminal,
+        "filesCompleted": files_completed,
+        "filesPanicked": files_panicked,
+        "filesMissing": files_missing,
+        "filesTotal": files_enrolled,
+        "enrolledFiles": files_enrolled,
+        "populationSize": files_enrolled,
+        "functionsPopulation": fn_fields["functionsTotal"],
         "functionsEnumerated": fn_fields["functionsEnumerated"],
         "functionsUnaccounted": fn_fields["functionsUnaccounted"],
         "functionsConstructClean": fn_fields["functionsConstructClean"],
         "cleanRatioRefused": fn_fields["cleanRatioRefused"],
         "sealedFunctionFactCids": dict(fn_fields["sealedFactCids"]),
         "cleanRefuseReasons": list(agg.get("clean_refuse_reasons") or []),
-        "R": r_construction,
-        "R_construction": r_construction,
-        "families": dict(
-            sorted(families.items(), key=lambda item: (-item[1], item[0]))
-        ),
-        "R_desugar": r_desugar,
+        "functionsTotal": fn_fields["functionsTotal"],
+        "constructionPanics": construction_panics,
+        "R_construction_panics": r_construction_panics,
+        "defects": defects,
+        "R_defects": len(defects),
+        "desugarConstructionPanics": list(agg["desugar_construction_panics"]),
+        "R_desugar_construction_panics": r_desugar_panics,
+        "desugarDefects": list(agg["desugar_defects"]),
+        "R_desugar_defects": r_desugar_defects,
+        "R_desugar_owed_work": r_desugar_owed,
+        "R_desugar_accounted_semantics": r_desugar_accounted,
         "desugarCategories": dict(
             sorted(desugar_categories.items(), key=lambda item: (-item[1], item[0]))
-        ),
-        "R_desugar_owed_work": int(desugar_categories.get("typed-refusal", 0)),
-        "R_desugar_accounted_semantics": int(
-            desugar_categories.get("constructed-effect", 0)
         ),
         "desugarByCategoryOwner": dict(
             sorted(
@@ -571,19 +581,10 @@ def seal_board_from_aggregate(
         "desugarFamilies": dict(
             sorted(desugar_families.items(), key=lambda item: (-item[1], item[0]))
         ),
-        "R_backend_defects": r_backend,
-        "backendDefects": dict(
-            sorted(backend_defects.items(), key=lambda item: (-item[1], item[0]))
-        ),
-        "cmResolutions": dict(
-            sorted(
-                Counter(agg["cm_resolutions"]).items(),
-                key=lambda item: (-item[1], item[0]),
-            )
-        ),
-        "R_cm_derived_contract": int(
-            Counter(agg["cm_resolutions"]).get("derived-contract", 0)
-        ),
+        "cmResolutions": dict(sorted(cm.items(), key=lambda item: (-item[1], item[0]))),
+        "R_cm_constructed": r_cm_constructed,
+        "R_cm_unconstructed": r_cm_unconstructed,
+        "R_cm_derived_contract": r_cm_constructed,
         "withCensus": with_census,
         "astSitePrevalence": dict(
             sorted(
@@ -591,12 +592,25 @@ def seal_board_from_aggregate(
                 key=lambda item: (-item[1], item[0]),
             )
         ),
-        "desugarConstructionPanics": list(agg["desugar_construction_panics"]),
-        "R_desugar_construction_panics": len(agg["desugar_construction_panics"]),
-        "desugarDefects": list(agg["desugar_defects"]),
-        "R_desugar_defects": len(agg["desugar_defects"]),
         "unresolvableDispatchTargets": list(agg["unresolvable_dispatch"]),
         "R_unresolvable_dispatch_targets": len(agg["unresolvable_dispatch"]),
+        "R_backend_defects": r_backend,
+        "backendDefects": dict(
+            sorted(backend_defects.items(), key=lambda item: (-item[1], item[0]))
+        ),
+        "families": dict(
+            sorted(families.items(), key=lambda item: (-item[1], item[0]))
+        ),
+        "boardNumberMeanings": {
+            "files": "enrolled | terminal | completed | panicked | missing",
+            "functions": "population | enumerated | clean (or clean refused)",
+            "construction": "R_construction_panics = len(constructionPanics)",
+            "desugar": (
+                "R_desugar_construction_panics | R_desugar_defects | "
+                "R_desugar_owed_work | R_desugar_accounted_semantics"
+            ),
+            "cm": "R_cm_constructed | R_cm_unconstructed",
+        },
         "elapsedSeconds": elapsed_seconds,
         "planCid": (plan or {}).get("planCid"),
         "perShardCids": dict(sorted((per_shard_cids or {}).items())),

--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -431,17 +431,15 @@ def seal_board_from_aggregate(
     """Mint the sealed authoritative board body. Sole mint of the class."""
     file_names = list(agg["enrolled_files"])
     families = Counter(agg["families"])
-    desugar_families = Counter(agg["desugar_families"])
-    desugar_categories = Counter(agg["desugar_categories"])
     backend_defects = Counter(agg["backend_defects"])
     construction_panics = list(agg["construction_panics"])
     defects = list(agg["defects"])
     # One meaning each — never bag-sum-as-the-residual.
+    # Desugar: only panic count is residual. defects / typed-refusal / constructed-effect
+    # were outcome KINDS (Exception vs SugarNotWritten vs Incomplete), not quantities
+    # of unwritten work. Dropped as residual axes (T correction: two outcomes only).
     r_construction_panics = len(construction_panics)
     r_desugar_panics = len(agg["desugar_construction_panics"])
-    r_desugar_defects = len(agg["desugar_defects"])
-    r_desugar_owed = int(desugar_categories.get("typed-refusal", 0))
-    r_desugar_accounted = int(desugar_categories.get("constructed-effect", 0))
     r_backend = sum(backend_defects.values())
     cm = Counter(agg["cm_resolutions"])
     r_cm_constructed = int(cm.get("constructed", 0) + cm.get("derived-contract", 0))
@@ -565,22 +563,8 @@ def seal_board_from_aggregate(
         "R_defects": len(defects),
         "desugarConstructionPanics": list(agg["desugar_construction_panics"]),
         "R_desugar_construction_panics": r_desugar_panics,
-        "desugarDefects": list(agg["desugar_defects"]),
-        "R_desugar_defects": r_desugar_defects,
-        "R_desugar_owed_work": r_desugar_owed,
-        "R_desugar_accounted_semantics": r_desugar_accounted,
-        "desugarCategories": dict(
-            sorted(desugar_categories.items(), key=lambda item: (-item[1], item[0]))
-        ),
-        "desugarByCategoryOwner": dict(
-            sorted(
-                Counter(agg["desugar_by_category_owner"]).items(),
-                key=lambda item: (-item[1], item[0]),
-            )
-        ),
-        "desugarFamilies": dict(
-            sorted(desugar_families.items(), key=lambda item: (-item[1], item[0]))
-        ),
+        # desugarDefects / typed-refusal / constructed-effect NOT sealed as R_* —
+        # those were kinds of outcome, not independent quantities of unwritten work.
         "cmResolutions": dict(sorted(cm.items(), key=lambda item: (-item[1], item[0]))),
         "R_cm_constructed": r_cm_constructed,
         "R_cm_unconstructed": r_cm_unconstructed,
@@ -605,10 +589,7 @@ def seal_board_from_aggregate(
             "files": "enrolled | terminal | completed | panicked | missing",
             "functions": "population | enumerated | clean (or clean refused)",
             "construction": "R_construction_panics = len(constructionPanics)",
-            "desugar": (
-                "R_desugar_construction_panics | R_desugar_defects | "
-                "R_desugar_owed_work | R_desugar_accounted_semantics"
-            ),
+            "desugar": "R_desugar_construction_panics only (constructed or panicked)",
             "cm": "R_cm_constructed | R_cm_unconstructed",
         },
         "elapsedSeconds": elapsed_seconds,

--- a/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
@@ -112,12 +112,15 @@ def test_seal_board_splits_file_and_residual_meanings() -> None:
     assert body["functionsEnumerated"] == 9
     assert body["functionsUnaccounted"] == 1
     assert body["functionsConstructClean"] == 7
-    # Residual = panic counts, not bag totals
+    # Residual = panic counts, not kind bags
     assert body["R_construction_panics"] == 1
     assert body["R_desugar_construction_panics"] == 1
-    assert body["R_desugar_defects"] == 0
     assert body["R_cm_constructed"] == 3
     assert body["R_cm_unconstructed"] == 1
-    assert "R_construction" not in body  # bag total deleted
-    assert "R" not in body or body.get("R") is None
+    # Dropped: defect / owed / accounted were failure KINDS, not quantities
+    assert "R_desugar_defects" not in body
+    assert "R_desugar_owed_work" not in body
+    assert "R_desugar_accounted_semantics" not in body
+    assert "R_construction" not in body
+    assert "R" not in body
     assert "boardNumberMeanings" in body

--- a/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
@@ -1,0 +1,123 @@
+"""Board numbers: one name, one meaning (files + functions + panic counts)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "compose_control_effect_board.py"
+)
+
+
+def _load_compose():
+    spec = importlib.util.spec_from_file_location(
+        "compose_control_effect_board_meanings", _SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_functions_three_meanings_not_one_figure() -> None:
+    """Population / enumerated / clean are three sealed facts, not one int."""
+    from sugar_lift_py_tests.c4.board_function_facts import (
+        LocalReading,
+        board_fields_from_sealed_facts,
+        seal_functions_clean_v1,
+        seal_functions_enumerated_v1,
+        seal_functions_population_v1,
+    )
+
+    tip = "deadbeef"
+    pin = "pin-test"
+    pop = seal_functions_population_v1(
+        LocalReading(100, "pop"), tip=tip, pin=pin
+    )
+    enum = seal_functions_enumerated_v1(
+        LocalReading(90, "enum"), tip=tip, pin=pin
+    )
+    clean = seal_functions_clean_v1(
+        LocalReading(80, "clean"), tip=tip, pin=pin, refused=False
+    )
+    fields = board_fields_from_sealed_facts(pop, enum, clean)
+    assert fields["functionsTotal"] == 100
+    assert fields["functionsEnumerated"] == 90
+    assert fields["functionsUnaccounted"] == 10
+    assert fields["functionsConstructClean"] == 80
+    assert fields["cleanRatioRefused"] is False
+    # Three distinct fact CIDs — not one body wearing three labels.
+    cids = fields["sealedFactCids"]
+    assert len(set(cids.values())) == 3
+
+
+def test_seal_board_splits_file_and_residual_meanings() -> None:
+    """Compose seals enrolled/terminal/completed/panicked separately."""
+    mod = _load_compose()
+    agg = {
+        "families": {},
+        "desugar_families": {},
+        "desugar_categories": {},
+        "desugar_by_category_owner": {},
+        "backend_defects": {},
+        "cm_resolutions": {"constructed": 3, "unconstructed": 1},
+        "unrecognized_cm_kinds": {},
+        "ast_sites": {},
+        "desugar_construction_panics": [{"file": "a.py", "type": "Panic"}],
+        "desugar_defects": [],
+        "desugar_designed_gaps": [],
+        "unresolvable_dispatch": [],
+        "construction_panics": [
+            {"file": "p.py", "type": "SugarNotWritten", "message": "unwritten"}
+        ],
+        "defects": [{"file": "p.py", "type": "panic", "message": "unwritten"}],
+        "floor_rows": [],
+        "files_completed": 2,
+        "files_panicked": 1,
+        "functions_total": 10,
+        "functions_clean": 7,
+        "functions_enumerated": 9,
+        "clean_ratio_refused": False,
+        "clean_refuse_reasons": [],
+        "r_instrument_blind": 0,
+        "r_instrument_blind_functions": 0,
+        "missing_files": ["missing.py"],
+        "duplicate_files": [],
+        "malformed_rows": [],
+        "files_complete": False,
+        "enrolled_files": ["a.py", "b.py", "p.py", "missing.py"],
+        "terminal_count": 3,
+        "manifest_cid": None,
+    }
+    body = mod.seal_board_from_aggregate(
+        agg,
+        plan=None,
+        per_shard_cids=None,
+        compose_cid=None,
+        measured_commit="abc123",
+        aggregate_hash="pin-hash",
+    )
+    # Files unit
+    assert body["filesEnrolled"] == 4
+    assert body["filesTerminal"] == 3
+    assert body["filesCompleted"] == 2
+    assert body["filesPanicked"] == 1
+    assert body["filesMissing"] == 1
+    assert body["filesTotal"] == body["filesEnrolled"]  # alias only
+    # Functions unit
+    assert body["functionsPopulation"] == 10
+    assert body["functionsEnumerated"] == 9
+    assert body["functionsUnaccounted"] == 1
+    assert body["functionsConstructClean"] == 7
+    # Residual = panic counts, not bag totals
+    assert body["R_construction_panics"] == 1
+    assert body["R_desugar_construction_panics"] == 1
+    assert body["R_desugar_defects"] == 0
+    assert body["R_cm_constructed"] == 3
+    assert body["R_cm_unconstructed"] == 1
+    assert "R_construction" not in body  # bag total deleted
+    assert "R" not in body or body.get("R") is None
+    assert "boardNumberMeanings" in body


### PR DESCRIPTION
## Summary

Board counts that secretly meant several things get one name each. Same defect as `functionsTotal` wearing population + enumerated + clean.

### Keep (distinct quantities)

| Axis | Meanings |
| --- | --- |
| **Files** | enrolled \| terminal \| completed \| panicked \| missing |
| **Functions** | population \| enumerated \| clean (already sealed types) |
| **Construction residual** | `R_construction_panics` only (family bag gone) |
| **CM with-items** | constructed \| unconstructed |
| **Desugar residual** | `R_desugar_construction_panics` only |

### Drop (failure *kinds* wearing counts)

- **R_desugar_defects** — Exception vs ConstructionPanic is a failure kind, not a second quantity. Failed construction is a panic; that is the end of it.
- **R_desugar_owed_work** (typed-refusal) — row label inside a mixed desugar census, not a distinct physical count.
- **R_desugar_accounted_semantics** (constructed-effect) — **see below**.

### The third drop is not tidying — it is a real finding

**`R_desugar_accounted_semantics` counted successful effect construction as residual.**

Finished work reported as unfinished. In the historical desugar census this overstated remaining work by about **7.6×** (most “R_desugar” rows were accounted semantics — correct outputs of reductions that succeeded — not unwritten work).

Everything else today **understated**: rosters erased, functions uncounted, cleanliness faked. This one **overstated** remaining work by counting completed construction as owed. Both directions are the same defect: **a number that could not tell what it was measuring.**

In a month, if the board reports less work left, this is why: we stopped counting finished desugar effects as residual.

### Validation

```bash
PYTHONPATH=src:../sugar-source-tree/src python3 -m pytest --noconftest \
  implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py -v
```

Audit: `docs/audits/board-number-meanings.md`

## Shot accounting

| | |
| --- | --- |
| **What** | One name per board quantity; kill residual axes that were kinds |
| **Shell deleted** | R_desugar_defects / owed / accounted as sealed residual; R / R_construction bag; bare R_desugar bag |
| **Epsilon R** | Desugar residual meaning corrected (overstatement removed); no product drain claimed |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce one-name-per-meaning semantics for board numbers and drop desugar residual fields
> - Reworks `seal_board_from_aggregate` in [compose_control_effect_board.py](https://github.com/TSavo/sugar/pull/7127/files#diff-74e790a1f60d3814877eedd08ed5ab4d88fa6c54e5d483d8fec41180cd0f0915) to expose distinct file-unit counts (`filesEnrolled`, `filesTerminal`, `filesCompleted`, `filesPanicked`, `filesMissing`) and panic-only residuals (`R_construction_panics`, `R_desugar_construction_panics`).
> - Adds CM resolution residuals (`R_cm_constructed`, `R_cm_unconstructed`, `R_cm_derived_contract`) and removes the old mixed residual/categorization keys (`R`, `R_desugar`, `desugarCategories`, `desugarFamilies`, `desugarDefects`, etc.).
> - Adds `files_panicked` to `aggregate_terminal_rows`, counting all non-completed terminal rows.
> - Adds tests in [test_board_number_meanings.py](https://github.com/TSavo/sugar/pull/7127/files#diff-f24f2599005508cbf2bd7dd97be5267af975083b81653f2ac6873b149f090793) validating the new one-meaning-per-name semantics.
> - Documents canonical meanings for all board numbers in [board-number-meanings.md](https://github.com/TSavo/sugar/pull/7127/files#diff-dc919fa43ce160e118651adc475441045378d8b85e9aa9950f549f0c4298a12d).
> - Behavioral Change: consumers relying on the removed fields (`R`, `R_desugar`, `desugarCategories`, `desugarByCategoryOwner`, `desugarFamilies`, `desugarDefects`, `R_desugar_defects`, etc.) will no longer find them in the sealed board output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a293ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced control boards with separate enrolled, completed, panicked, and missing file metrics.
  * Added distinct counts for construction panics, desugaring panics, backend defects, and constructed versus unconstructed resolutions.
  * Clarified board-number definitions and how quantities are represented.

* **Tests**
  * Added coverage ensuring file-level, function-level, residual, cleanliness, and panic metrics remain distinct.
  * Verified obsolete aggregate failure fields are no longer reported.

* **Documentation**
  * Documented board-number meanings and rules for representing quantities and construction failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->