### PR TITLE
L2a: Spread ConstructedTermSugar codomain law (one door)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/sugar_base.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/sugar_base.py
@@ -86,7 +86,14 @@ class ConstructedTermSugar(Sugar):
 def require_constructed_term_sugar(
     value: object, *, owner: str
 ) -> ConstructedTermSugar:
-    """Close a nested construction payload before canonical projection."""
+    """Close a nested construction payload before canonical projection.
+
+    ONE codomain law for every nested term slot (CallSiteSugar.args /
+    keywords, MethodCallSugar.args / keywords, IfExp arms, …). Admission is
+    hierarchy: ConstructedTermSugar + to_term — including SpreadCollectionSugar,
+    SpreadDictSugar, SpreadCallSugar, StarredSugar (L2a). Do not special-case
+    spread at individual call sites; promote the mint, keep this door.
+    """
     if not isinstance(value, ConstructedTermSugar):
         raise TypeError(
             f"{owner} requires ConstructedTermSugar, got {type(value).__name__}"

--- a/implementations/python/sugar-lift-py-tests/tests/test_spread_constructed_term_codomain_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_spread_constructed_term_codomain_law.py
@@ -1,0 +1,139 @@
+"""L2a — Spread / starred are ConstructedTermSugar; one codomain law.
+
+ONE law at the type: ``require_constructed_term_sugar`` / ``isinstance(...,
+ConstructedTermSugar)``. Not four patches at CallSiteSugar.args,
+MethodCallSugar.args, IfExp arms, or keywords.
+
+SpreadCollectionSugar, SpreadDictSugar, SpreadCallSugar, and StarredSugar
+admit as nested-construction testimony (same judgment as ListSugar without
+stars / #7099 promotions). Parent slots that require ConstructedTermSugar
+are truthful; the mint must carry the base + to_term.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
+from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
+from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+from sugar_lift_py_tests.sugar.spread_sugar import (
+    SpreadCallSugar,
+    SpreadCollectionSugar,
+    SpreadDictSugar,
+)
+from sugar_lift_py_tests.sugar.starred_sugar import StarredSugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
+from sugar_source_tree.nodes import Call, IfExp, List
+from sugar_source_tree.tree import SourceFile
+
+_OWNERS = (
+    "CallSiteSugar.args",
+    "CallSiteSugar.keywords",
+    "MethodCallSugar.args",
+    "MethodCallSugar.keywords",
+    "IfExpSugar.body",
+    "IfExpSugar.orelse",
+)
+
+
+class _Site:
+    def seal(self):
+        return type(
+            "S",
+            (),
+            {
+                "source_cid": "blake3-512:" + "0" * 128,
+                "start": 0,
+                "end": 1,
+                "cid": "blake3-512:" + "1" * 128,
+            },
+        )()
+
+
+def _cid(source: str) -> str:
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+
+def _sf(source: str, name: str = "t.py") -> SourceFile:
+    return SourceFile((source, name, _cid(source)))
+
+
+def test_spread_family_is_constructed_term_sugar() -> None:
+    """Hierarchy law: spread mints are CTS, not bare Sugar."""
+    for cls in (
+        SpreadCollectionSugar,
+        SpreadDictSugar,
+        SpreadCallSugar,
+        StarredSugar,
+    ):
+        assert issubclass(cls, ConstructedTermSugar), cls.__name__
+
+
+def test_one_codomain_door_accepts_spread_and_starred() -> None:
+    """require_constructed_term_sugar is the only admission door — all owners."""
+    site = _Site()
+    inner = IntLiteralSugar(value=1, site=site)
+    starred = StarredSugar(value=inner, site=site)
+    collection = SpreadCollectionSugar(
+        kind="list",
+        elements=((None, inner), ("python:starred", starred)),
+        site=site,
+    )
+    for owner in _OWNERS:
+        assert require_constructed_term_sugar(starred, owner=owner) is starred
+        assert require_constructed_term_sugar(collection, owner=owner) is collection
+
+
+def test_call_site_and_method_slots_construct_with_starred() -> None:
+    """Slots construct without per-site isinstance special cases."""
+    site = _Site()
+    inner = IntLiteralSugar(value=2, site=site)
+    starred = StarredSugar(value=inner, site=site)
+    # CallSiteSugar.args / keywords
+    CallSiteSugar(target_name="f", args=(starred,), site=site)
+    CallSiteSugar(target_name="f", args=(), keywords=(("k", starred),), site=site)
+    # MethodCallSugar.args / keywords
+    MethodCallSugar(receiver=inner, name="m", args=(starred,), site=site)
+    MethodCallSugar(
+        receiver=inner, name="m", args=(), keywords=(("k", starred),), site=site
+    )
+
+
+def test_ifexp_arms_accept_spread_collection_via_construction() -> None:
+    """Production tree: spread arm is CTS; IfExp constructs (one law at type)."""
+    source = "x = [1, *xs] if flag else ys\n"
+    sf = _sf(source, "ifexp_spread_l2a.py")
+    node = next(n for n in sf.root.walk() if isinstance(n, IfExp))
+    sugar = node.sugar()
+    assert isinstance(sugar, IfExpSugar)
+    assert isinstance(sugar.body, SpreadCollectionSugar)
+    assert isinstance(sugar.body, ConstructedTermSugar)
+    sugar.body.to_term(owner="l2a_ifexp_spread")
+
+
+def test_starred_call_and_list_display_construct_as_terms() -> None:
+    """Production: f(*xs) and [1, *xs] construct as CTS spread sugars."""
+    call_src = "def f(*a): pass\ndef g(xs):\n    return f(*xs)\n"
+    sf = _sf(call_src, "star_call_l2a.py")
+    call = [n for n in sf.root.walk() if isinstance(n, Call)][-1]
+    call_sugar = call.sugar()
+    assert isinstance(call_sugar, SpreadCallSugar)
+    assert isinstance(call_sugar, ConstructedTermSugar)
+    call_sugar.to_term(owner="l2a_star_call")
+
+    list_src = "y = [1, *xs]\n"
+    sf2 = _sf(list_src, "list_star_l2a.py")
+    for node in sf2.root.walk():
+        if not isinstance(node, List):
+            continue
+        sugar = node.sugar()
+        if isinstance(sugar, SpreadCollectionSugar):
+            assert isinstance(sugar, ConstructedTermSugar)
+            sugar.to_term(owner="l2a_list_star")
+            return
+    raise AssertionError("expected SpreadCollectionSugar for [1, *xs]")


### PR DESCRIPTION
## Summary

**L2a construct:** Spread / starred nested terms are `ConstructedTermSugar`. Admission is **one law** — `require_constructed_term_sugar` / hierarchy — not four special-cases on CallSiteSugar.args, MethodCallSugar.args, IfExp arms, and keywords.

Product promotion was already on tip; this PR **pins the law** with teeth and documents the door on `require_constructed_term_sugar`.

### Teeth (all green)

- Spread family issubclass ConstructedTermSugar
- One codomain door accepts StarredSugar + SpreadCollectionSugar for every named owner slot
- CallSiteSugar / MethodCallSugar construct with starred args and keywords
- IfExp arm + list/call production spreads construct and to_term

### Shell

None deleted (promotion already landed); **shell pinned**: bare Sugar in term slots is red at the one door + hierarchy tooth.

## Validation

```bash
PYTHONPATH=src:../sugar-source-tree/src python3 -m pytest --noconftest \
  tests/test_spread_constructed_term_codomain_law.py -v
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add codomain law tests for spread/starred sugars as `ConstructedTermSugar`
> - Adds a new test module [`test_spread_constructed_term_codomain_law.py`](https://github.com/TSavo/sugar/pull/7129/files#diff-0af73f3cd359e3aa150fe82b8989f39851db3f07446f4a007b08f5f1f7bf788f) asserting that `SpreadCollectionSugar`, `SpreadDictSugar`, `SpreadCallSugar`, and `StarredSugar` are subclasses of `ConstructedTermSugar`.
> - Tests verify that `require_constructed_term_sugar` admits all spread/starred variants through a single validation path, with no per-site `isinstance` checks.
> - Expands the docstring in [`sugar_base.py`](https://github.com/TSavo/sugar/pull/7129/files#diff-3ead5a2eda55fc9b3526fc46a51f2813cd3a19dc7e3984c56bf53ee39227559d) to document the single-door codomain law for nested term slots.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86efb10.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->