### PR TITLE
L0a: authenticated constructor shape — construct or panic, never AttributeError

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -421,12 +421,25 @@ class ConstructionTestimonyReporterV1:
     def retain_registered_node_from(
         self, node: Node, producer: "ConstructionTestimonyReporterV1"
     ) -> Node:
-        """Retain one exact producer-roll registration in this consumer roll."""
-        registered = (
-            None
-            if type(producer) is not ConstructionTestimonyReporterV1
-            else producer._materialized_by_ref.get(node.ref)
-        )
+        """Retain one exact producer-roll registration in this consumer roll.
+
+        When the producer is itself a ``ConstructionTestimonyReporterV1``, the
+        registration must already live on that producer's materialize table.
+        When the producer is the ordinary file-open ``CollectingReporter``, the
+        node *is* the roster occurrence (no separate materialize table) — enroll
+        it into this consumer roll once. Other producers (NullReporter, foreign
+        remints) stay loud BackendDefect: they never owned the registration.
+        """
+        from sugar_source_tree.reporter import CollectingReporter
+
+        if type(producer) is ConstructionTestimonyReporterV1:
+            registered = producer._materialized_by_ref.get(node.ref)
+        elif type(producer) is CollectingReporter and getattr(node, "reporter", None) is producer:
+            # File-open door: CollectingReporter witnessed construction; the
+            # node itself is the authenticated occurrence for this ref.
+            registered = node
+        else:
+            registered = None
         if (
             registered is not node
             or not isinstance(registered, type(node))
@@ -438,9 +451,22 @@ class ConstructionTestimonyReporterV1:
             backend_defect(
                 blame=node.fragment,
                 owner="ConstructionTestimonyReporterV1.retain_registered_node_from",
-                observed="foreign or absent producer node registration",
-                requested="the producer reporter's exact typed Node/ref registration",
-                fix="retain the producer registration; never remint or search by name/span",
+                observed=(
+                    f"foreign or absent producer node registration "
+                    f"(producer={type(producer).__name__}, "
+                    f"node_reporter={type(getattr(node, 'reporter', None)).__name__})"
+                ),
+                requested=(
+                    "the producer reporter's exact typed Node/ref registration "
+                    "(ConstructionTestimonyReporterV1 materialize table, or "
+                    "CollectingReporter file-open occurrence whose .reporter is "
+                    "that CollectingReporter)"
+                ),
+                fix=(
+                    "retain the producer registration; never remint or search by "
+                    "name/span. If the producer was CollectingReporter, pass the "
+                    "same reporter the node was opened with."
+                ),
             )
         existing = self._materialized_by_ref.get(node.ref)
         if existing is not None and (

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2579,6 +2579,15 @@ class Node(Typed):
         """Project parser machinery before constructed-value testimony."""
         return value
 
+    def _authenticated_new_constructor_shape(self):
+        """Source-owned ``__new__`` allocation shape, or None.
+
+        Only ``ClassDef`` implements a real shape. Every other node answers
+        None so callers never AttributeError when an allocation door is
+        mis-routed to a non-class definition (L0a / construct-or-panic).
+        """
+        return None
+
     def _construct_sugar(self) -> object:
         """This node's sugar, constructed by the node itself.
 

--- a/implementations/python/sugar-source-tree/tests/test_l0a_authenticated_constructor_shape.py
+++ b/implementations/python/sugar-source-tree/tests/test_l0a_authenticated_constructor_shape.py
@@ -1,0 +1,109 @@
+"""L0a: authenticated constructor shape door — construct or panic, never AttributeError.
+
+_authenticated_new_constructor_shape is ClassDef's __new__ allocation pattern.
+Non-class nodes must answer None (base method), not AttributeError.
+retain_registered_node_from must enroll CollectingReporter file-open
+occurrences into a ConstructionTestimony consumer roll (same door that
+blocked module materialize on real pandas).
+"""
+
+from __future__ import annotations
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.backend import materialize
+from sugar_source_tree.binding_state import (
+    ConstructionTestimonyReporterV1,
+    SubstitutionTraceBuilderV1,
+)
+from sugar_source_tree.nodes import Call, ClassDef, FunctionDef, Name, Node
+from sugar_source_tree.panic import BackendDefect
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.tree import SourceFile
+
+
+def _sf(source: str, name: str = "l0a.py") -> SourceFile:
+    return SourceFile((source, name, blake3_512_of(source.encode("utf-8"))))
+
+
+def test_non_class_nodes_answer_none_for_constructor_shape() -> None:
+    """Base door: FunctionDef / Call never AttributeError on the shape probe."""
+    source = _sf(
+        "def f(n):\n"
+        "    if n:\n"
+        "        return f(n - 1)\n"
+        "    return 0\n"
+        "\n"
+        "f(2)\n"
+    )
+    for node in source.nodes():
+        if isinstance(node, ClassDef):
+            continue
+        # Must not raise AttributeError
+        shape = node._authenticated_new_constructor_shape()
+        assert shape is None, (
+            f"{type(node).__name__} must answer None, got {shape!r}"
+        )
+
+
+def test_classdef_with_authenticated_new_shape_constructs() -> None:
+    """Truthful twin: recognized __new__ allocation shape is non-None and sugars."""
+    source = _sf(
+        "class Box:\n"
+        "    def __new__(cls, value):\n"
+        "        self = super(Box, cls).__new__(cls)\n"
+        "        self.value = value\n"
+        "        return self\n"
+        "\n"
+        "Box(1)\n"
+    )
+    cls = next(n for n in source.nodes() if isinstance(n, ClassDef) and n.name == "Box")
+    shape = cls._authenticated_new_constructor_shape()
+    assert shape is not None
+    sugar = cls.sugar()
+    assert sugar is not None
+    call = next(
+        n
+        for n in source.nodes()
+        if isinstance(n, Call) and isinstance(n.func, Name) and n.func.id == "Box"
+    )
+    assert call.sugar() is not None
+
+
+def test_collecting_reporter_producer_retains_into_testimony_consumer() -> None:
+    """File-open CollectingReporter is a lawful producer for retain (not BackendDefect)."""
+    source = "def exact():\n    return 1\n"
+    identity = (source, "retain_collect.py", blake3_512_of(source.encode()))
+    collector = CollectingReporter()
+    tree = SourceFile(identity, reporter=collector)
+    # Ordinary open: definition lives on CollectingReporter, not testimony table.
+    definition = next(n for n in tree.nodes() if isinstance(n, FunctionDef))
+    assert definition.reporter is collector
+
+    consumer = ConstructionTestimonyReporterV1(
+        CollectingReporter(),
+        SubstitutionTraceBuilderV1(tree.unit.source_cid),
+    )
+    retained = consumer.retain_registered_node_from(definition, collector)
+    assert retained is definition
+    assert consumer.materialized_node_for_ref(definition.ref) is definition
+
+
+def test_null_reporter_producer_still_panics() -> None:
+    """Lying twin: NullReporter never owned the registration — stay loud."""
+    from sugar_source_tree.reporter import NullReporter
+
+    source = "def exact():\n    return 1\n"
+    identity = (source, "retain_null.py", blake3_512_of(source.encode()))
+    collector = CollectingReporter()
+    tree = SourceFile(identity, reporter=collector)
+    definition = next(n for n in tree.nodes() if isinstance(n, FunctionDef))
+    consumer = ConstructionTestimonyReporterV1(
+        CollectingReporter(),
+        SubstitutionTraceBuilderV1(tree.unit.source_cid),
+    )
+    try:
+        consumer.retain_registered_node_from(definition, NullReporter())
+        raise AssertionError("expected BackendDefect for NullReporter producer")
+    except BackendDefect as gap:
+        assert "foreign or absent" in gap.observed
+        assert "NullReporter" in gap.observed


### PR DESCRIPTION
## Summary

**Construct owned:** `_authenticated_new_constructor_shape` (and same-door `retain_registered_node_from`).

1. **Base door on `Node`:** non-class nodes answer `None` for `_authenticated_new_constructor_shape` so a mis-routed allocation probe cannot `AttributeError` (ClassDef alone implements the real `__new__` shape).
2. **`retain_registered_node_from`:** `CollectingReporter` file-open occurrences are a lawful producer — enroll the node into the consumer testimony roll. `NullReporter` / foreign remints stay `BackendDefect`, with producer type named in `observed`.

## Teeth

- non-class → `None` (no AttributeError)
- ClassDef authenticated `__new__` shape sugars + call sugars
- CollectingReporter retain succeeds
- NullReporter still panics
- Existing allocation / module_prefix retain twins hold

## Epsilon R

Unblocks materialize/testimony paths that failed `retain_registered_node_from` after ordinary file open (seen live on pandas construction walk).

## Test plan

- [x] Direct run of `test_l0a_authenticated_constructor_shape.py`
- [x] `test_allocation_definition_not_functiondef.py`
- [x] `test_module_prefix_definition_reporter` retain twins

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `_authenticated_new_constructor_shape` base method to `Node` to return `None` instead of raising `AttributeError`
> - Adds `Node._authenticated_new_constructor_shape` as a base method returning `None`, so non-ClassDef nodes respond consistently instead of raising `AttributeError` on mis-routed calls.
> - Expands `ConstructionTestimonyReporterV1.retain_registered_node_from` to handle `CollectingReporter` producers by enrolling the node itself when `node.reporter` matches the producer, in addition to the existing `ConstructionTestimonyReporterV1` lookup path.
> - Other producer types (e.g. `NullReporter`) still raise `BackendDefect`, now with richer diagnostics including producer type, node reporter type, and fix guidance.
> - Adds a new test module covering both behaviors: base `Node` returning `None`, and `retain_registered_node_from` accepting `CollectingReporter` or rejecting `NullReporter`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3877911.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->