### PR TITLE
L3b: nested Name-only unpack targets construct

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/nested_dynamic_unpack_assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/nested_dynamic_unpack_assign_sugar.py
@@ -1,0 +1,174 @@
+"""Nested Name-only unpack against a non-display RHS.
+
+``(a, b), (c, d) = mask_info`` — target is a tree of Names; RHS is not a display
+``Assign._destructured_binding`` can zip. Flat ``DynamicUnpackAssignSugar`` only
+admits flat Name leaves. This sugar owns the nested Name-only tree.
+
+Same law as flat dynamic unpack: evaluate RHS once, then ask the reduced value
+what it unpacks to. Nested structure is real (outer arity then inner), never
+flattened into a four-name demand that would lie about FormalRef unpack.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from typing import Any
+
+from sugar_lift_py_tests.outcome import Complete, Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import typed_red_effect_witness
+
+# Pattern tree: leaf name, or tuple of sub-patterns.
+NameUnpackPattern = str | tuple["NameUnpackPattern", ...]
+
+
+def flatten_pattern_names(pattern: NameUnpackPattern) -> tuple[str, ...]:
+    if isinstance(pattern, str):
+        return (pattern,)
+    names: list[str] = []
+    for part in pattern:
+        names.extend(flatten_pattern_names(part))
+    return tuple(names)
+
+
+def pattern_desc(pattern: NameUnpackPattern) -> str:
+    if isinstance(pattern, str):
+        return pattern
+    return "(" + ", ".join(pattern_desc(p) for p in pattern) + ")"
+
+
+@dataclass(frozen=True)
+class NestedDynamicUnpackAssignSugar(Sugar):
+    """``(a, b), (c, d) = <rhs>`` Name-only nested targets, non-display RHS."""
+
+    pattern: tuple[NameUnpackPattern, ...]
+    value: Sugar
+    site: object = dataclass_field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return typed_red_effect_witness(
+            name="nested_sequence_unpack_runtime_effect",
+            owner_sugar="NestedDynamicUnpackAssignSugar",
+            source=(
+                "def A(mask_info, v):\n"
+                "    (a, b), (c, d) = mask_info\n"
+                "    return v\n"
+            ),
+            effect_class="SequenceUnpackRuntimeEffect",
+            reason_needle="nested sequence unpack",
+            blame_needle="arity=2",
+            wrong_reason_needle="exactly 4 members",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        return self.value.desugar(ctx).and_then(
+            lambda value: self._project(value, self.pattern, ctx)
+        )
+
+    def _project(
+        self, value: Any, pattern: tuple[NameUnpackPattern, ...], ctx: object
+    ) -> Outcome:
+        from sugar_lift_py_tests.operations.sequence_projection_operation import (
+            SequenceProjectionOperation,
+        )
+
+        if all(isinstance(part, str) for part in pattern):
+            return SequenceProjectionOperation(
+                target_names=tuple(pattern),  # type: ignore[arg-type]
+                owner=type(self).__name__,
+                blame=self.site,
+            ).submit(value, ctx)
+
+        members = _authenticated_finite_members(value)
+        if members is None:
+            return self._runtime_nested(value, pattern)
+
+        if len(members) != len(pattern):
+            return SequenceProjectionOperation(
+                target_names=tuple(
+                    p if isinstance(p, str) else f"@{i}" for i, p in enumerate(pattern)
+                ),
+                owner=type(self).__name__,
+                blame=self.site,
+            )._arity_mismatch_exit(value, len(members), "nested-unpack")
+
+        return self._bind_nested_authenticated(members, pattern, ctx)
+
+    def _bind_nested_authenticated(
+        self,
+        members: tuple[Any, ...],
+        pattern: tuple[NameUnpackPattern, ...],
+        ctx: object,
+    ) -> Outcome:
+        from sugar_lift_py_tests.floor.scope_rebind import ScopeRebinds
+
+        collected: list[tuple[str, Any]] = []
+
+        def step(index: int) -> Outcome:
+            if index == len(pattern):
+                return Complete(ScopeRebinds(tuple(collected)))
+            part = pattern[index]
+            member = members[index]
+            if isinstance(part, str):
+                collected.append((part, member))
+                return step(index + 1)
+            sub = self._project(member, part, ctx)
+            if not isinstance(sub, Complete):
+                return sub
+            if isinstance(sub.value, ScopeRebinds):
+                collected.extend(sub.value.bindings)
+            else:
+                from sugar_source_tree.panic import SugarNotWritten
+
+                raise SugarNotWritten(
+                    blame=self.site,
+                    owner="NestedDynamicUnpackAssignSugar",
+                    observed=f"nested unpack sub-project produced {type(sub.value).__name__}",
+                    requested="ScopeRebinds of leaf names",
+                    fix="nested Name-only unpack must rebind leaves through ScopeRebinds",
+                )
+            return step(index + 1)
+
+        return step(0)
+
+    def _runtime_nested(
+        self, value: Any, pattern: tuple[NameUnpackPattern, ...]
+    ) -> Outcome:
+        from sugar_lift_py_tests.effect import (
+            SequenceUnpackRuntimeEffect,
+            runtime_effect_evidence_from_terms,
+        )
+        from sugar_lift_py_tests.ir import ctor, num
+        from sugar_lift_py_tests.outcome import Incomplete
+
+        term = value.to_term(owner=f"{type(self).__name__}.value")
+        arity = len(pattern)
+        operation = ctor(
+            "python:unpack.destructure",
+            [term, num(arity)],
+            symbol_kind="coordinate",
+        )
+        desc = pattern_desc(pattern)
+        leaves = ", ".join(flatten_pattern_names(pattern))
+        return Incomplete(
+            SequenceUnpackRuntimeEffect(
+                "nested sequence unpack runtime boundary: unpack demands "
+                f"nested pattern {desc} (outer arity={arity}, leaves=({leaves})) "
+                "but the right-hand side carries no authenticated cardinality -- "
+                "iteration count belongs to Python's runtime __iter__; "
+                f"arity={arity} nested=True site={self.site}",
+                **runtime_effect_evidence_from_terms(operation, operation, self.site),
+            )
+        )
+
+
+def _authenticated_finite_members(value: Any) -> tuple[Any, ...] | None:
+    items = getattr(value, "items", None)
+    if isinstance(items, tuple):
+        return items
+    finite = getattr(value, "finite_elements", None)
+    if isinstance(finite, tuple):
+        return finite
+    return None

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5194,6 +5194,41 @@ class Assign(Statement):
                 suffix.append(element.id)
         return (tuple(prefix), star.value.id, tuple(suffix))
 
+    def _name_only_nested_unpack_pattern(self, target):
+        """Name-only nested Tuple/List tree for non-display dynamic unpack.
+
+        Flat all-Name targets stay with ``DynamicUnpackAssignSugar``. This
+        admits only trees that nest at least one Tuple/List of Names (no
+        Attribute/Subscript/Starred). Returns a pattern tuple for
+        ``NestedDynamicUnpackAssignSugar``, or ``None``.
+        """
+        if not isinstance(target, (Tuple_, List)):
+            return None
+
+        def build(node):
+            if isinstance(node, Name):
+                return node.id
+            if isinstance(node, (Tuple_, List)):
+                if not node.elts:
+                    return None
+                parts = []
+                for element in node.elts:
+                    part = build(element)
+                    if part is None:
+                        return None
+                    parts.append(part)
+                return tuple(parts)
+            return None
+
+        pattern = build(target)
+        if not isinstance(pattern, tuple):
+            return None
+        # Flat all-str is owned by DynamicUnpackAssignSugar — not nested.
+        if all(isinstance(part, str) for part in pattern):
+            return None
+        # Every leaf must be a name (build already refused other shapes).
+        return pattern
+
     def _flat_mixed_unpack_targets(self, target):
         """Parse flat Name|Attribute|Subscript|*Name into typed unpack targets.
 
@@ -5676,12 +5711,27 @@ class Assign(Statement):
                     DynamicUnpackAssignSugar,
                 )
 
-                # Exact-arity: every leaf is a plain Name.
+                # Exact-arity: every leaf is a plain Name (flat).
                 if all(isinstance(item, Name) for item in target.elts):
                     return DynamicUnpackAssignSugar(
                         tuple(item.id for item in target.elts),
                         self.value.sugar(),
                         self.fragment,
+                    )
+                # Nested Name-only tree: ``(a, b), (c, d) = formal``.
+                # Construction already exists for flat dynamic unpack; this
+                # only admits the nested case that used to fall through to
+                # Assign.sugar SNW (not a missing call — missing arm).
+                nested = self._name_only_nested_unpack_pattern(target)
+                if nested is not None:
+                    from sugar_lift_py_tests.sugar.nested_dynamic_unpack_assign_sugar import (
+                        NestedDynamicUnpackAssignSugar,
+                    )
+
+                    return NestedDynamicUnpackAssignSugar(
+                        pattern=nested,
+                        value=self.value.sugar(),
+                        site=self.fragment,
                     )
                 # Starred: at most one *Name among flat Name leaves. Opaque /
                 # runtime-selected RHS keeps the typed unpack obligation via

--- a/implementations/python/sugar-source-tree/tests/test_assign_nested_unpack_l3b.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_nested_unpack_l3b.py
@@ -1,0 +1,99 @@
+"""L3b: nested Name-only unpack targets construct (non-display RHS).
+
+``(a, b), (c, d) = formal`` used to hit Assign.sugar SNW. Flat dynamic unpack
+and nested display unpack already constructed — wire the missing nested
+non-display arm only.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
+from sugar_lift_py_tests.sugar.dynamic_unpack_assign_sugar import DynamicUnpackAssignSugar
+from sugar_lift_py_tests.sugar.nested_dynamic_unpack_assign_sugar import (
+    NestedDynamicUnpackAssignSugar,
+)
+from sugar_source_tree.nodes import (
+    Assign,
+    RuntimeBindingEntryFactoryV1,
+    SubstitutionTraceBuilderV1,
+    _BINDING_ENTRY_FACTORY,
+    _SCOPE_OWNER_CID,
+    _SUBSTITUTION_TRACE_BUILDER,
+)
+from sugar_source_tree.reporter import CollectingReporter
+from sugar_source_tree.tree import SourceFile
+
+
+def _fn_sugar(src: str):
+    sf = SourceFile(
+        (src, "l3b_assign.py", blake3_512_of(src.encode())),
+        reporter=CollectingReporter(),
+    )
+    fn = next(sf.functions())
+    cid = cid_of_json(
+        {
+            "kind": "binding-scope-owner",
+            "schemaVersion": "1",
+            "source": fn.fragment.seal().to_dict(),
+        }
+    )
+    scope = {
+        _SCOPE_OWNER_CID: cid,
+        _SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(cid),
+        _BINDING_ENTRY_FACTORY: RuntimeBindingEntryFactoryV1(cid),
+    }
+    return fn.substitute(scope).sugar()
+
+
+def _first_assign_sugar(src: str):
+    sf = SourceFile(
+        (src, "l3b_assign.py", blake3_512_of(src.encode())),
+        reporter=CollectingReporter(),
+    )
+    fn = next(sf.functions())
+    cid = cid_of_json(
+        {
+            "kind": "binding-scope-owner",
+            "schemaVersion": "1",
+            "source": fn.fragment.seal().to_dict(),
+        }
+    )
+    scope = {
+        _SCOPE_OWNER_CID: cid,
+        _SUBSTITUTION_TRACE_BUILDER: SubstitutionTraceBuilderV1(cid),
+        _BINDING_ENTRY_FACTORY: RuntimeBindingEntryFactoryV1(cid),
+    }
+    body = fn.substitute(scope)
+    assign = next(n for n in body.walk() if isinstance(n, Assign))
+    return assign.sugar()
+
+
+def test_nested_name_only_formal_unpack_constructs_nested_dynamic_sugar():
+    sugar = _first_assign_sugar(
+        "def A(p):\n    (a, b), (c, d) = p\n    return a\n"
+    )
+    assert isinstance(sugar, NestedDynamicUnpackAssignSugar)
+    assert sugar.pattern == (("a", "b"), ("c", "d"))
+
+
+def test_nested_name_only_formal_function_sugar_constructs():
+    sugar = _fn_sugar("def A(p):\n    (a, b), (c, d) = p\n    return a\n")
+    assert sugar is not None
+
+
+def test_flat_dynamic_unpack_still_uses_flat_sugar():
+    sugar = _first_assign_sugar("def A(p):\n    a, b = p\n    return a\n")
+    assert isinstance(sugar, DynamicUnpackAssignSugar)
+
+
+def test_nested_display_unpack_still_constructs():
+    sugar = _fn_sugar(
+        "def A():\n    (a, b), (c, d) = (1, 2), (3, 4)\n    return a\n"
+    )
+    assert sugar is not None
+
+
+def test_attr_and_subscript_store_targets_still_construct():
+    assert _fn_sugar("def A(o, z):\n    o.x = z\n    return o\n") is not None
+    assert _fn_sugar("def A(o, z):\n    o[0] = z\n    return o\n") is not None
+    assert _fn_sugar("def A(o, p):\n    a, o.x = p\n    return a\n") is not None


### PR DESCRIPTION
## L3b — Assign / unpack targets

**Door:** Assign construction + nested unpack sugar only.

### What was already written
- Flat `a, b = formal` → `DynamicUnpackAssignSugar`
- Nested display `(a,b),(c,d) = (1,2),(3,4)` → destructure path
- Attr/subscript/mixed store unpack already construct

### What was missing (not a dead call)
- Nested Name-only non-display: `(a, b), (c, d) = formal` fell through to `Assign.sugar` SNW

### Change
- `NestedDynamicUnpackAssignSugar` — nested pattern tree, same desugar law as flat (runtime cardinality effect, no four-name flatten lie)
- `Assign._name_only_nested_unpack_pattern` + arm in `_construct_sugar`

### Teeth
`test_assign_nested_unpack_l3b.py` — 5 green (nested formal, flat still flat, display, attr/sub stores).

Still loud (not this PR): nested star `(a, *b), c = p`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add nested Name-only unpack target desugaring via `NestedDynamicUnpackAssignSugar`
> - Introduces `NestedDynamicUnpackAssignSugar` in [`nested_dynamic_unpack_assign_sugar.py`](https://github.com/TSavo/sugar/pull/7131/files#diff-ada6935977ecc123f49ade851478a58a82cf83c5214557b2c17ebd315932b41c) to handle assignments like `(a, b), (c, d) = rhs` where RHS is not a display.
> - `Assign._construct_sugar` in [`nodes.py`](https://github.com/TSavo/sugar/pull/7131/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now detects nested Name-only patterns via `_name_only_nested_unpack_pattern` and routes them to the new sugar class instead of the generic fallback.
> - When RHS provides authenticated finite members, all leaf names are bound; on arity mismatch, a projection arity error is returned; when cardinality is unauthenticated, an `Incomplete` with a `SequenceUnpackRuntimeEffect` is emitted.
> - Tests in [`test_assign_nested_unpack_l3b.py`](https://github.com/TSavo/sugar/pull/7131/files#diff-8551e0236b4a518388b74a1000138943009a90f8bcc85659bf43c6cb4cc71a3c) verify that flat dynamic unpacks still use `DynamicUnpackAssignSugar` and nested display unpacks still construct correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e2acdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->