### PR TITLE
L1b: ClassDef body members (fields, nested, conditionals)

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4070,7 +4070,7 @@ class ClassDef(Statement):
                 fix="carry the parser-owned ClassDef name occurrence as binding_target",
             )
 
-    def _method_descriptor_kind(self, method: "FunctionDef") -> Optional[str]:
+    def _method_descriptor_kind(self, method: "FunctionDef | AsyncFunctionDef") -> Optional[str]:
         """Authenticate one language descriptor decorator by lexical binding.
 
         The decorator spelling is only a lookup key.  A same-named module
@@ -4189,11 +4189,59 @@ class ClassDef(Statement):
             changed["body"] = new_body
         return self if not changed else rewrite(self, **changed)
 
-    def _construct_sugar(self):
-        """Construct source-visible class structure through child method Sugars.
 
-        Instantiation/receiver fields remain a typed coordinate gap in the
-        resulting floor value.  No class body is interpreted beside this door.
+    def _construct_class_method_member(self, method):
+        """Enroll one method through the FunctionDef construction door only.
+
+        ClassDef owns member *membership* and field construction (L1b). Method
+        bodies are FunctionDef / AsyncFunctionDef construction — not reimplemented
+        here. AsyncFunctionDef shares the FunctionDef door (same formals/body shape).
+        """
+        from sugar_lift_py_tests.floor import ConstructedClassMethodV1
+
+        if isinstance(method, FunctionDef):
+            # White FunctionDef door — ClassDef does not reimplement method bodies.
+            body = method.sugar()
+            frame = method.source_visible_call_frame()
+        elif isinstance(method, AsyncFunctionDef):
+            from sugar_source_tree.panic import SugarNotWritten
+
+            # Membership is recognized (not "unsupported class member"). Body
+            # construction is the FunctionDef door (async arm not written yet).
+            raise SugarNotWritten(
+                blame=method.fragment,
+                owner="ClassDef._construct_class_method_member",
+                observed="AsyncFunctionDef method body construction",
+                requested="AsyncFunctionDef construction through the FunctionDef door",
+                fix=(
+                    "write AsyncFunctionDef body construction on the FunctionDef "
+                    "door; ClassDef L1b owns fields/nested/conditionals only"
+                ),
+            )
+        else:
+            from sugar_source_tree.panic import SugarNotWritten
+
+            raise SugarNotWritten(
+                blame=method.fragment,
+                owner="ClassDef._construct_class_method_member",
+                observed=f"class method species {type(method).__name__}",
+                requested="FunctionDef or AsyncFunctionDef",
+                fix="route method bodies through the FunctionDef construction door",
+            )
+        return ConstructedClassMethodV1(
+            method.name,
+            method.fragment.seal().cid,
+            body,
+            frame,
+            self._method_descriptor_kind(method),
+        )
+
+    def _construct_sugar(self):
+        """Construct source-visible class structure through body members.
+
+        L1b (this door): fields, nested ClassDef, conditional fields.
+        Methods (FunctionDef / AsyncFunctionDef) enroll through the FunctionDef
+        construction door — ClassDef does not reimplement method bodies.
         """
         if (
             not isinstance(self.binding_target, Name)
@@ -4208,7 +4256,11 @@ class ClassDef(Statement):
                 requested="the exact identifier child bound by this ClassDef",
                 fix="carry the parser-owned ClassDef name occurrence as binding_target",
             )
-        methods = tuple(item for item in self.body if isinstance(item, FunctionDef))
+        methods = tuple(
+            item
+            for item in self.body
+            if isinstance(item, (FunctionDef, AsyncFunctionDef))
+        )
         docstring_cid = None
         if self.body:
             first = self.body[0]
@@ -4230,7 +4282,7 @@ class ClassDef(Statement):
         unsupported = tuple(
             item
             for index, item in enumerate(self.body)
-            if not isinstance(item, (FunctionDef, ClassDef, If, Pass))
+            if not isinstance(item, (FunctionDef, AsyncFunctionDef, ClassDef, If, Pass))
             and not (
                 index == 0
                 and isinstance(item, Expr)
@@ -4341,20 +4393,13 @@ class ClassDef(Statement):
             return tuple(fields)
 
         constructed = tuple(
-            ConstructedClassMethodV1(
-                method.name,
-                method.fragment.seal().cid,
-                method.sugar(),
-                method.source_visible_call_frame(),
-                self._method_descriptor_kind(method),
-            )
-            for method in methods
+            self._construct_class_method_member(method) for method in methods
         )
         fields = conditional_fields(
             tuple(
                 item
                 for index, item in enumerate(self.body)
-                if not isinstance(item, (FunctionDef, Pass))
+                if not isinstance(item, (FunctionDef, AsyncFunctionDef, Pass))
                 and not (
                     index == 0
                     and isinstance(item, Expr)

--- a/implementations/python/sugar-source-tree/tests/test_classdef_body_members_l1b.py
+++ b/implementations/python/sugar-source-tree/tests/test_classdef_body_members_l1b.py
@@ -1,0 +1,130 @@
+"""L1b: ClassDef body members — fields, nested ClassDef, conditional fields.
+
+Methods enroll through the FunctionDef door (not reimplemented here).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_py_tests.floor import ConstructedClassFieldV1
+from sugar_lift_py_tests.sugar.class_definition_sugar import (
+    ClassDefinitionSugar,
+    ConstructedClassConditionalFieldsV1,
+)
+from sugar_source_tree.nodes import ClassDef
+from sugar_source_tree.tree import SourceFile
+
+
+def _class(src: str, name: str = "C") -> ClassDef:
+    seat = f"{name}.py"
+    cid = cid_of_json({"source": src, "seat": seat})
+    source = SourceFile((src, seat, cid))
+    return next(
+        node
+        for node in source.nodes()
+        if isinstance(node, ClassDef) and node.name == name
+    )
+
+
+def test_l1b_simple_fields_construct() -> None:
+    sugar = _class(
+        "class C:\n"
+        "    a = 1\n"
+        "    b: int = 2\n"
+    ).sugar()
+    assert isinstance(sugar, ClassDefinitionSugar)
+    assert sugar.methods == ()
+    assert tuple(field.name for field in sugar.fields) == ("a", "b")
+    assert all(isinstance(field, ConstructedClassFieldV1) for field in sugar.fields)
+
+
+def test_l1b_nested_classdef_is_a_field() -> None:
+    sugar = _class(
+        "class Outer:\n"
+        "    x = 1\n"
+        "    class Inner:\n"
+        "        y = 2\n",
+        name="Outer",
+    ).sugar()
+    assert isinstance(sugar, ClassDefinitionSugar)
+    names = tuple(
+        field.name if isinstance(field, ConstructedClassFieldV1) else type(field).__name__
+        for field in sugar.fields
+    )
+    assert names == ("x", "Inner")
+    inner = next(
+        field for field in sugar.fields if getattr(field, "name", None) == "Inner"
+    )
+    assert isinstance(inner, ConstructedClassFieldV1)
+    assert isinstance(inner.value_sugar, ClassDefinitionSugar)
+    assert inner.value_sugar.class_name == "Inner"
+    assert tuple(f.name for f in inner.value_sugar.fields) == ("y",)
+
+
+def test_l1b_conditional_fields_construct() -> None:
+    sugar = _class(
+        "class C:\n"
+        "    if True:\n"
+        "        a = 1\n"
+        "    else:\n"
+        "        a = 2\n"
+    ).sugar()
+    assert len(sugar.fields) == 1
+    cond = sugar.fields[0]
+    assert isinstance(cond, ConstructedClassConditionalFieldsV1)
+    assert len(cond.when_true) == 1 and len(cond.when_false) == 1
+    assert isinstance(cond.when_true[0], ConstructedClassFieldV1)
+    assert cond.when_true[0].name == "a"
+    assert cond.when_false[0].name == "a"
+
+
+def test_l1b_elif_chain_is_nested_conditional() -> None:
+    sugar = _class(
+        "class C:\n"
+        "    if False:\n"
+        "        a = 1\n"
+        "    elif True:\n"
+        "        a = 2\n"
+        "    else:\n"
+        "        a = 3\n"
+    ).sugar()
+    assert len(sugar.fields) == 1
+    outer = sugar.fields[0]
+    assert isinstance(outer, ConstructedClassConditionalFieldsV1)
+    # orelse of outer is elif → another conditional
+    assert len(outer.when_false) == 1
+    assert isinstance(outer.when_false[0], ConstructedClassConditionalFieldsV1)
+
+
+def test_l1b_fields_alongside_sync_method() -> None:
+    """Fields construct; method body uses FunctionDef door (not ClassDef)."""
+    sugar = _class(
+        "class C:\n"
+        "    a = 1\n"
+        "    def m(self):\n"
+        "        return self.a\n"
+    ).sugar()
+    assert tuple(f.name for f in sugar.fields) == ("a",)
+    assert len(sugar.methods) == 1
+    assert sugar.methods[0].name == "m"
+    assert sugar.methods[0].source_call_frame is not None
+
+
+def test_l1b_async_method_is_method_member_not_unsupported() -> None:
+    """AsyncFunctionDef is a method member — FunctionDef door, not unsupported."""
+    from sugar_source_tree.panic import SugarNotWritten
+
+    with pytest.raises(SugarNotWritten) as ei:
+        _class(
+            "class C:\n"
+            "    a = 1\n"
+            "    async def m(self):\n"
+            "        return 1\n"
+        ).sugar()
+    err = ei.value
+    assert err.owner == "ClassDef._construct_class_method_member"
+    assert "AsyncFunctionDef" in err.observed
+    assert "unsupported class member" not in err.observed
+    assert "FunctionDef door" in err.fix


### PR DESCRIPTION
## Summary

**Construct:** ClassDef body members (L1b) — fields, nested `ClassDef`, conditional fields.

**Not this door:** method bodies → FunctionDef door (white). ClassDef only enrolls methods and calls that door for sync `FunctionDef`.

### Changes
- Route `AsyncFunctionDef` as a method member (no longer `unsupported class member AsyncFunctionDef`)
- Sync methods: `FunctionDef.sugar` + `source_visible_call_frame` only
- Async methods: loud panic naming FunctionDef door until white writes that arm
- Teeth in `test_classdef_body_members_l1b.py` — all green

## Test plan
- [x] All six L1b teeth green locally

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add L1b ClassDef body member construction for fields, nested classes, conditionals, and async methods
> - Extends `ClassDef._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/7132/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to handle simple fields, nested `ClassDef` fields, and conditional fields (including `elif` nesting) as L1b class body members.
> - Adds `_construct_class_method_member` helper to build `ConstructedClassMethodV1` entries; delegates `FunctionDef` construction through the existing FunctionDef door and raises `SugarNotWritten` for `AsyncFunctionDef`.
> - `AsyncFunctionDef` is no longer classified as an unsupported member — it is recognized as a method and raises `SugarNotWritten` with owner `ClassDef._construct_class_method_member`.
> - Broadens `_method_descriptor_kind` parameter type to accept `FunctionDef | AsyncFunctionDef`.
> - Adds tests in [test_classdef_body_members_l1b.py](https://github.com/TSavo/sugar/pull/7132/files#diff-877ae5d249c81f57c57b15e5e5fa10734291ec13db3b4e5471b8613c96ae1fa3) covering all new member kinds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b3971d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->