### PR TITLE
L2b: ComplexLiteral + sibling leaves ConstructedTermSugar codomain

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/sugar_base.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/sugar_base.py
@@ -89,10 +89,16 @@ def require_constructed_term_sugar(
     """Close a nested construction payload before canonical projection.
 
     ONE codomain law for every nested term slot (CallSiteSugar.args /
-    keywords, MethodCallSugar.args / keywords, IfExp arms, …). Admission is
-    hierarchy: ConstructedTermSugar + to_term — including SpreadCollectionSugar,
-    SpreadDictSugar, SpreadCallSugar, StarredSugar (L2a). Do not special-case
-    spread at individual call sites; promote the mint, keep this door.
+    keywords, MethodCallSugar.args / keywords, IfExp arms, BinOpSugar
+    left/right, UnaryOpSugar.operand, EqualityOpSugar, Subscript index, …).
+    Admission is hierarchy: ConstructedTermSugar + to_term — including:
+
+    - L2a: SpreadCollectionSugar, SpreadDictSugar, SpreadCallSugar, StarredSugar
+    - L2b: ComplexLiteralSugar, EllipsisLiteralSugar, and sibling leaves
+      (Int/Real/String/Bytes/None/True/False)
+
+    Do not special-case species at individual call sites; promote the mint,
+    keep this door.
     """
     if not isinstance(value, ConstructedTermSugar):
         raise TypeError(

--- a/implementations/python/sugar-lift-py-tests/tests/test_complex_literal_constructed_term_codomain_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_complex_literal_constructed_term_codomain_law.py
@@ -1,0 +1,159 @@
+"""L2b — ComplexLiteral + sibling leaves are ConstructedTermSugar; one door.
+
+Pink lesson: product promotion already exists (ComplexLiteralSugar /
+EllipsisLiteralSugar / Int/Real/String/Bytes/None/bool leaves already carry
+ConstructedTermSugar + to_term; Constant construction mints them; BinOpSugar
+and Subscript already accept them via require_constructed_term_sugar).
+
+This file pins the law so the codomain cannot silently regress. ONE door —
+require_constructed_term_sugar — not patches at BinOpSugar.right alone.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from sugar_lift_py_tests.sugar.binop_sugar import BinOpSugar
+from sugar_lift_py_tests.sugar.bytes_literal_sugar import BytesLiteralSugar
+from sugar_lift_py_tests.sugar.complex_literal_sugar import ComplexLiteralSugar
+from sugar_lift_py_tests.sugar.ellipsis_literal_sugar import EllipsisLiteralSugar
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
+from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
+from sugar_lift_py_tests.sugar.none_literal_sugar import NoneLiteralSugar
+from sugar_lift_py_tests.sugar.real_literal_sugar import RealLiteralSugar
+from sugar_lift_py_tests.sugar.string_literal_sugar import StringLiteralSugar
+from sugar_lift_py_tests.sugar.sugar_base import (
+    ConstructedTermSugar,
+    require_constructed_term_sugar,
+)
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_py_tests.sugar.unary_op_sugar import UnaryOpSugar
+from sugar_source_tree.nodes import BinOp, Constant, Subscript
+from sugar_source_tree.tree import SourceFile
+
+_LITERAL_CLASSES = (
+    ComplexLiteralSugar,
+    EllipsisLiteralSugar,
+    IntLiteralSugar,
+    RealLiteralSugar,
+    StringLiteralSugar,
+    BytesLiteralSugar,
+    NoneLiteralSugar,
+    TrueBoolLiteralSugar,
+    FalseBoolLiteralSugar,
+)
+
+_OWNERS = (
+    "BinOpSugar.left",
+    "BinOpSugar.right",
+    "UnaryOpSugar.operand",
+    "EqualityOpSugar.left",
+    "EqualityOpSugar.right",
+    "CallSiteSugar.args",
+    "CallSiteSugar.keywords",
+    "MethodCallSugar.args",
+    "MethodCallSugar.keywords",
+    "IfExpSugar.body",
+    "IfExpSugar.orelse",
+)
+
+
+class _Site:
+    def seal(self):
+        return type(
+            "S",
+            (),
+            {
+                "source_cid": "blake3-512:" + "0" * 128,
+                "start": 0,
+                "end": 1,
+                "cid": "blake3-512:" + "1" * 128,
+            },
+        )()
+
+
+def _cid(source: str) -> str:
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+
+def _sf(source: str, name: str = "t.py") -> SourceFile:
+    return SourceFile((source, name, _cid(source)))
+
+
+def test_all_literal_leaves_are_constructed_term_sugar() -> None:
+    for cls in _LITERAL_CLASSES:
+        assert issubclass(cls, ConstructedTermSugar), cls.__name__
+
+
+def test_one_codomain_door_accepts_complex_and_ellipsis() -> None:
+    site = _Site()
+    complex_lit = ComplexLiteralSugar(real=0.0, imag=2.0, site=site)
+    ellipsis_lit = EllipsisLiteralSugar(site=site)
+    for owner in _OWNERS:
+        assert (
+            require_constructed_term_sugar(complex_lit, owner=owner) is complex_lit
+        )
+        assert (
+            require_constructed_term_sugar(ellipsis_lit, owner=owner) is ellipsis_lit
+        )
+
+
+def test_binop_slot_constructs_with_complex_literal() -> None:
+    """BinOpSugar.right is the historical rejection site — door admits, no patch."""
+    site = _Site()
+    left = IntLiteralSugar(value=1, site=site)
+    right = ComplexLiteralSugar(real=0.0, imag=2.0, site=site)
+    sugar = BinOpSugar(op_kind="Add", left=left, right=right, site=site)
+    assert isinstance(sugar.right, ComplexLiteralSugar)
+    assert isinstance(sugar.right, ConstructedTermSugar)
+    sugar.right.to_term(owner="l2b_binop_complex")
+    sugar.to_term(owner="l2b_binop")
+
+
+def test_unary_slot_constructs_with_complex_literal() -> None:
+    site = _Site()
+    operand = ComplexLiteralSugar(real=0.0, imag=1.0, site=site)
+    sugar = UnaryOpSugar(op_kind="USub", operand=operand, site=site)
+    assert isinstance(sugar.operand, ComplexLiteralSugar)
+    sugar.operand.to_term(owner="l2b_unary_complex")
+
+
+def test_production_binop_complex_and_subscript_ellipsis() -> None:
+    """Tree construction: already reachable — pin so regression panics."""
+    src = "def g():\n    return 1 + 2j\n"
+    sf = _sf(src, "complex_binop_l2b.py")
+    binop = next(n for n in sf.root.walk() if isinstance(n, BinOp))
+    sugar = binop.sugar()
+    assert isinstance(sugar, ConstructedTermSugar)
+    assert isinstance(sugar.right, ComplexLiteralSugar)
+    sugar.right.to_term(owner="l2b_prod_complex")
+
+    src2 = "def g(x):\n    return x[..., :]\n"
+    sf2 = _sf(src2, "ellipsis_sub_l2b.py")
+    sub = next(n for n in sf2.root.walk() if isinstance(n, Subscript))
+    sub_sugar = sub.sugar()
+    assert isinstance(sub_sugar, ConstructedTermSugar)
+    sub_sugar.to_term(owner="l2b_prod_ellipsis")
+
+
+def test_sibling_literals_construct_from_constant() -> None:
+    """Whole leaf codomain once — not only Complex."""
+    cases = (
+        ("1", IntLiteralSugar),
+        ("1.5", RealLiteralSugar),
+        ("'a'", StringLiteralSugar),
+        ("b'x'", BytesLiteralSugar),
+        ("None", NoneLiteralSugar),
+        ("True", TrueBoolLiteralSugar),
+        ("False", FalseBoolLiteralSugar),
+        ("...", EllipsisLiteralSugar),
+        ("2j", ComplexLiteralSugar),
+    )
+    for src, cls in cases:
+        full = f"x = {src}\n"
+        sf = _sf(full, f"{cls.__name__}.py")
+        const = next(n for n in sf.root.walk() if isinstance(n, Constant))
+        sugar = const.sugar()
+        assert isinstance(sugar, cls), (src, type(sugar).__name__)
+        assert isinstance(sugar, ConstructedTermSugar)
+        sugar.to_term(owner=f"l2b_{cls.__name__}")


### PR DESCRIPTION
## Summary

**L2b construct:** ComplexLiteralSugar (and Ellipsis + sibling leaves) are `ConstructedTermSugar` under the **same one-door law** as L2a — `require_constructed_term_sugar` — not a patch at `BinOpSugar.right` alone.

### Pink lesson

Before writing: **already implemented and reachable.**

- All leaf literals (Complex, Ellipsis, Int, Real, String, Bytes, None, True, False) already subclass ConstructedTermSugar with `to_term`
- `Constant` construction already mints them
- Production `1 + 2j` and `x[..., :]` already construct without TypeError

This PR **pins the codomain** so a regression cannot reintroduce bare-Sugar leaves or force per-slot special cases.

### Teeth (6 green)

- All literal leaves issubclass ConstructedTermSugar
- One door accepts Complex + Ellipsis for BinOp/Unary/Equality/Call/Method/IfExp owners
- BinOpSugar / UnaryOpSugar construct with ComplexLiteral
- Production binop + subscript ellipsis
- Full Constant species census

## Validation

```bash
PYTHONPATH=src:../sugar-source-tree/src python3 -m pytest --noconftest \
  tests/test_complex_literal_constructed_term_codomain_law.py -v
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests verifying `ComplexLiteralSugar` and sibling leaves are accepted by `ConstructedTermSugar` codomain
> Adds a new test module [`test_complex_literal_constructed_term_codomain_law.py`](https://github.com/TSavo/sugar/pull/7133/files#diff-5a1c3a5f673c0ecc8074693f0078437066c0697b4a08b44973f05a86ccb4f551) asserting the 'one codomain door' law for `ConstructedTermSugar` across literal sugar types.
>
> - Verifies all literal leaf classes (`ComplexLiteralSugar`, `EllipsisLiteralSugar`, `Int`/`Real`/`String`/`Bytes`/`None`/`True`/`False`) are subclasses of `ConstructedTermSugar`
> - Tests that `require_constructed_term_sugar` accepts complex and ellipsis literals across all owner slots (`BinOpSugar`, `UnaryOpSugar`, `EqualityOpSugar`, `Subscript`)
> - Includes production-parsing tests that walk AST nodes to validate sugar class assignment and `to_term` conversion
> - Updates the `require_constructed_term_sugar` docstring in [`sugar_base.py`](https://github.com/TSavo/sugar/pull/7133/files#diff-3ead5a2eda55fc9b3526fc46a51f2813cd3a19dc7e3984c56bf53ee39227559d) to enumerate the expanded admission hierarchy; no runtime code is changed
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d3ffb7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->