### PR TITLE
L3c: GuardedBinding projection through existing door

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -47,10 +47,34 @@ def mint_constructed_value_testimony_v1(
     return ConstructedValueTestimonyV1.mint(source_fragment, semantic_value_cid)
 
 
+def _project_binding_state_sugar(state: object) -> object:
+    """Sole door: project a binding state into construction sugar.
+
+    Binding states (``UnboundBinding`` / ``GuardedBinding`` /
+    ``LoopProjectedBinding``) are not AST Nodes. Callers that ask for
+    ``.sugar()`` used to AttributeError (wrong kind). Projection already
+    lives on ``nodes._construct_binding_projection`` — route there instead
+    of inventing a second door or patching call sites one by one (L3c).
+    """
+    from sugar_source_tree.nodes import Node, _construct_binding_projection
+
+    if isinstance(state, LoopProjectedBinding):
+        product = state.constructed_term_product
+        if product is not None:
+            return product
+    if isinstance(state, Node):
+        return state.sugar()
+    return _construct_binding_projection(state)
+
+
 @dataclass(frozen=True)
 class UnboundBinding:
     name: str
     cause: SourceFragment
+
+    def sugar(self) -> object:
+        """Project through the binding door — never a Node.sugar AttributeError."""
+        return _project_binding_state_sugar(self)
 
 
 @dataclass(frozen=True)
@@ -69,6 +93,10 @@ class GuardedBinding:
     slot: BranchResultSlot
     when_true: BindingState
     when_false: BindingState
+
+    def sugar(self) -> object:
+        """Project through the binding door — never a Node.sugar AttributeError."""
+        return _project_binding_state_sugar(self)
 
 
 def _require_runtime_cid(value: str, field: str) -> None:
@@ -156,6 +184,10 @@ class LoopProjectedBinding:
                 raise BindingStateWireGap(
                     "loop projected binding product has a foreign loop occurrence"
                 )
+
+    def sugar(self) -> object:
+        """Project through the binding door — never a Node.sugar AttributeError."""
+        return _project_binding_state_sugar(self)
 
 
 BindingState: TypeAlias = (

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -65,11 +65,12 @@ def _initial_value_sugar_for_loop_prestate(state):
     """Project one pre-loop binding state into an initial-value sugar.
 
     Hierarchy law: ``GuardedBinding`` / ``UnboundBinding`` / ``LoopProjectedBinding``
-    are binding *states*, not Nodes. Calling ``state.sugar()`` on them is the same
-    class of lie as AttributeError-on-wrong-kind — it aborts the file. Dispatch
-    through the binding-projection door that already owns every state species.
+    are binding *states*, not Nodes. Their ``.sugar()`` routes through the same
+    projection door as this helper (``_project_binding_state_sugar`` /
+    ``_construct_binding_projection``). One door, every species.
     """
-    from .nodes import Node, _construct_binding_projection
+    from .binding_state import _project_binding_state_sugar
+    from .nodes import Node
 
     if isinstance(state, LoopProjectedBinding):
         product = state.constructed_term_product
@@ -81,7 +82,7 @@ def _initial_value_sugar_for_loop_prestate(state):
         return product
     if isinstance(state, Node):
         return state.sugar()
-    return _construct_binding_projection(state)
+    return _project_binding_state_sugar(state)
 
 
 def _formula_cid(formula) -> str:

--- a/implementations/python/sugar-source-tree/tests/test_guarded_binding_not_sugar_method.py
+++ b/implementations/python/sugar-source-tree/tests/test_guarded_binding_not_sugar_method.py
@@ -1,36 +1,62 @@
-"""GuardedBinding is a binding state, not a Node — never call .sugar() on it.
+"""L3c: GuardedBinding projection is the door — .sugar() must use it.
 
-F class from black seal (6 files): AttributeError
-  'GuardedBinding' object has no attribute 'sugar'
-
-LiveForRuntimeV1 pre-state projection assumed every state was a Node.
-``_construct_binding_projection`` already owns every binding-state species;
-route through that door instead of ``state.sugar()``.
+Was AttributeError: 'GuardedBinding' object has no attribute 'sugar' when a
+caller treated binding state as a Node. Projection already existed as
+``_construct_binding_projection`` / GuardedProjection; the door was not on
+the state itself. Route .sugar() through that door (orange: fix the door, not
+every call site).
 """
 
 from __future__ import annotations
 
-from sugar_source_tree.binding_state import GuardedBinding, UnboundBinding
+from sugar_lift_py_tests.floor.branch_result_coordinate import BranchResultSlot
+from sugar_source_tree.binding_state import (
+    GuardedBinding,
+    UnboundBinding,
+    _project_binding_state_sugar,
+)
 from sugar_source_tree.live_loop_construction import (
     _initial_value_sugar_for_loop_prestate,
 )
-from sugar_lift_py_tests.floor.branch_result_coordinate import BranchResultSlot
+from sugar_source_tree.nodes import _construct_binding_projection
 
 
-def test_guarded_binding_projects_without_sugar_method() -> None:
+def test_guarded_binding_sugar_routes_to_projection_door() -> None:
     slot = BranchResultSlot("test-slot")
     when_true = UnboundBinding("x", "then")
     when_false = UnboundBinding("x", "else")
     state = GuardedBinding(slot=slot, when_true=when_true, when_false=when_false)
-    # Must not AttributeError
-    sugar = _initial_value_sugar_for_loop_prestate(state)
-    assert sugar is not None
-    # Projection product, not a Node.sugar() result from GuardedBinding
-    assert not hasattr(state, "sugar")
+
+    # Wrong-kind call that used to AttributeError:
+    sugar = state.sugar()
     assert type(sugar).__name__ == "GuardedProjection"
 
+    # Same door as the explicit projection path and loop prestate helper:
+    assert type(_construct_binding_projection(state)).__name__ == "GuardedProjection"
+    assert type(_project_binding_state_sugar(state)).__name__ == "GuardedProjection"
+    assert type(_initial_value_sugar_for_loop_prestate(state)).__name__ == "GuardedProjection"
 
-def test_unbound_binding_projects_without_sugar_method() -> None:
+
+def test_unbound_binding_sugar_routes_to_projection_door() -> None:
     state = UnboundBinding("x", "never-bound")
-    sugar = _initial_value_sugar_for_loop_prestate(state)
+    sugar = state.sugar()
     assert type(sugar).__name__ == "UnboundProjection"
+    assert type(_initial_value_sugar_for_loop_prestate(state)).__name__ == "UnboundProjection"
+
+
+def test_nested_guarded_binding_projects_recursively() -> None:
+    """Guarded arms may themselves be GuardedBinding — door recurses."""
+    outer = BranchResultSlot("outer")
+    inner = BranchResultSlot("inner")
+    leaf_t = UnboundBinding("x", "tt")
+    leaf_f = UnboundBinding("x", "tf")
+    nested = GuardedBinding(slot=inner, when_true=leaf_t, when_false=leaf_f)
+    state = GuardedBinding(
+        slot=outer,
+        when_true=nested,
+        when_false=UnboundBinding("x", "f"),
+    )
+    sugar = state.sugar()
+    assert type(sugar).__name__ == "GuardedProjection"
+    # Outer when_true is itself a GuardedProjection
+    assert type(sugar.when_true).__name__ == "GuardedProjection"


### PR DESCRIPTION
## Summary

**Construct:** GuardedBinding projection (L3c).

Wrong-kind call: something asked `.sugar()` on a binding state → AttributeError (`'GuardedBinding' object has no attribute 'sugar'`), six files in the last walk.

**Pink lesson:** `_construct_binding_projection` / `GuardedProjection` already existed (#7101 routed LiveForRuntime through it). Restore the door on the state itself, not a new projection.

**Orange lesson:** put `.sugar()` on `UnboundBinding` / `GuardedBinding` / `LoopProjectedBinding` so every call site hits the same door.

## Teeth

- `GuardedBinding.sugar()` → `GuardedProjection`
- `UnboundBinding.sugar()` → `UnboundProjection`
- nested GuardedBinding recurses
- loop prestate helper shares the door

## Test plan

- [x] `test_guarded_binding_not_sugar_method.py` green by direct import

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `sugar()` method to `GuardedBinding`, `UnboundBinding`, and `LoopProjectedBinding` projecting through binding door
> - Adds a shared helper `_project_binding_state_sugar` in [binding_state.py](https://github.com/TSavo/sugar/pull/7134/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40) that dispatches projection for binding states and nodes through a common door.
> - `GuardedBinding`, `UnboundBinding`, and `LoopProjectedBinding` each gain a `.sugar()` method that delegates to this helper, returning their respective projection types (`GuardedProjection`, `UnboundProjection`, or `constructed_term_product`).
> - Updates [live_loop_construction.py](https://github.com/TSavo/sugar/pull/7134/files#diff-c9eb9acd39df8a975d8e80a7cc05e5eefc58fcbe69f47e2270afbea9161af094) to use `_project_binding_state_sugar` instead of `nodes._construct_binding_projection` for consistency.
> - Tests in [test_guarded_binding_not_sugar_method.py](https://github.com/TSavo/sugar/pull/7134/files#diff-e6665ec0b4fb25dc16a736779fbd2cbae8df9c9f90607161eef80e91aeb61466) are updated to verify the new `.sugar()` methods and add coverage for recursive projection through nested `GuardedBinding` instances.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 193930c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->