### PR TITLE
L1a: FunctionDef/AsyncFunctionDef body construction one door

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3166,7 +3166,10 @@ class FunctionDef(Statement):
             (
                 ()
                 if generator_steps is not None
-                else tuple(statement.sugar() for statement in substituted_body)
+                else tuple(
+                    self._sugar_body_statement(statement)
+                    for statement in substituted_body
+                )
             ),
             self.fragment,
         )
@@ -3224,7 +3227,10 @@ class FunctionDef(Statement):
         if self._source_visible_generator_steps_from(substituted_body) is not None:
             return SourceVisibleFunctionBodySugar((), self.fragment)
         return SourceVisibleFunctionBodySugar(
-            tuple(statement.sugar() for statement in substituted_body), self.fragment
+            tuple(
+                self._sugar_body_statement(statement) for statement in substituted_body
+            ),
+            self.fragment,
         )
 
     def _source_visible_generator_steps(self, scope):
@@ -4029,6 +4035,13 @@ class FunctionDef(Statement):
 
 
 class AsyncFunctionDef(Statement):
+    """`async def` — same FunctionUniverse body door as FunctionDef (L1a).
+
+    Fields match FunctionDef. Construction does not invent a second path:
+    substitute, formals, and body statements all share FunctionDef's door so
+    every async function walks child-before-parent via ``_sugar_body_statement``.
+    """
+
     name: str
     params: Tuple[Param, ...]
     body: Tuple[Statement, ...]
@@ -4042,9 +4055,28 @@ class AsyncFunctionDef(Statement):
         return _arguments_projection(self.params)
 
     def substitute(self, scope):
-        """Same scope shape as FunctionDef (identical fields): masks its
-        parameters for the threaded body."""
+        """Same scope shape as FunctionDef (identical fields)."""
         return FunctionDef.substitute(self, scope)
+
+    def _make_parameter_entry(self, parameter: Param, ordinal: int, scope):
+        return FunctionDef._make_parameter_entry(self, parameter, ordinal, scope)
+
+    def _formal_coordinate(self, parameter: Param, ordinal: int):
+        return FunctionDef._formal_coordinate(self, parameter, ordinal)
+
+    def formal_coordinates(self) -> tuple:
+        return FunctionDef.formal_coordinates(self)
+
+    def _make_parameter_ref(self, parameter: Param, ordinal: int) -> "Node":
+        return FunctionDef._make_parameter_ref(self, parameter, ordinal)
+
+    def _sugar_body_statement(self, stmt: "Node") -> object:
+        """One body door: statement constructs through its children."""
+        return FunctionDef._sugar_body_statement(self, stmt)
+
+    def _construct_sugar(self):
+        """L1a: FunctionUniverse body construction — same door as FunctionDef."""
+        return FunctionDef._construct_sugar(self)
 
 
 class ClassDef(Statement):

--- a/implementations/python/sugar-source-tree/tests/test_l1a_functiondef_body_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_l1a_functiondef_body_construction.py
@@ -1,0 +1,105 @@
+"""L1a — FunctionDef / FunctionUniverse body construction, one door.
+
+Every method and function walks ``FunctionDef._construct_sugar`` (shared by
+``AsyncFunctionDef``). Body statements construct through their children via
+``_sugar_body_statement`` → ``stmt.sugar()`` — never a kind ladder on the def.
+
+ClassDef methods (blonde) depend on ``method.sugar()``; this package owns that
+path alone.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.sugar.function_universe_sugar import FunctionUniverseSugar
+from sugar_source_tree.nodes import (
+    AsyncFunctionDef,
+    FunctionDef,
+    ClassDef,
+)
+from sugar_source_tree.tree import SourceFile
+
+
+def _tree(source: str, name: str = "l1a.py") -> SourceFile:
+    return SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _fn(source: str, name: str = "f"):
+    tree = _tree(source)
+    return next(fn for fn in tree.functions() if fn.name == name)
+
+
+def test_functiondef_sugar_is_function_universe_with_child_body_statements() -> None:
+    """``def f(x): return x`` constructs FunctionUniverseSugar via body children."""
+    fn = _fn("def f(x):\n    return x\n")
+    assert isinstance(fn, FunctionDef)
+    sugar = fn.sugar()
+    assert isinstance(sugar, FunctionUniverseSugar)
+    assert sugar.name == "f"
+    assert sugar.formals == ("x",)
+    assert len(sugar.statements) == 1
+    assert type(sugar.statements[0]).__name__ == "ReturnSugar"
+
+
+def test_functiondef_multi_statement_body_constructs_each_child() -> None:
+    """Each body statement is its own sugar — child-before-parent, not a bag."""
+    fn = _fn("def g(a, b):\n    x = a\n    return x\n", name="g")
+    sugar = fn.sugar()
+    assert isinstance(sugar, FunctionUniverseSugar)
+    kinds = tuple(type(s).__name__ for s in sugar.statements)
+    # substitute may inline; body still produced statement sugars.
+    assert kinds
+    assert all(hasattr(s, "desugar") for s in sugar.statements)
+
+
+def test_method_sugar_is_function_universe_door() -> None:
+    """Class methods walk the same FunctionDef.sugar door blonde will call."""
+    tree = _tree("class C:\n    def m(self, x):\n        return x\n")
+    cls = next(n for n in tree.nodes() if isinstance(n, ClassDef))
+    method = next(b for b in cls.body if isinstance(b, FunctionDef))
+    sugar = method.sugar()
+    assert isinstance(sugar, FunctionUniverseSugar)
+    assert sugar.name == "m"
+    assert type(sugar.statements[0]).__name__ == "ReturnSugar"
+
+
+def test_async_functiondef_shares_function_universe_body_door() -> None:
+    """Async def constructs FunctionUniverseSugar — same door, not SugarNotWritten."""
+    fn = _fn("async def h(x):\n    return x\n", name="h")
+    assert isinstance(fn, AsyncFunctionDef)
+    sugar = fn.sugar()
+    assert isinstance(sugar, FunctionUniverseSugar)
+    assert sugar.name == "h"
+    assert sugar.formals == ("x",)
+    assert type(sugar.statements[0]).__name__ == "ReturnSugar"
+
+
+def test_async_functiondef_construct_sugar_delegates_to_functiondef_door() -> None:
+    """AsyncFunctionDef does not mint a second FunctionUniverse producer."""
+    src = inspect.getsource(AsyncFunctionDef._construct_sugar)
+    assert "FunctionDef._construct_sugar" in src
+    assert "FunctionUniverseSugar(" not in src
+    body_door = inspect.getsource(AsyncFunctionDef._sugar_body_statement)
+    assert "FunctionDef._sugar_body_statement" in body_door
+
+
+def test_body_statement_door_is_stmt_sugar_only() -> None:
+    """``_sugar_body_statement`` constructs only via the statement's sugar()."""
+    src = inspect.getsource(FunctionDef._sugar_body_statement)
+    assert "stmt.sugar()" in src
+    # No kind ladder / isinstance bag on the body statement at this door.
+    assert "isinstance" not in src
+    assert "match " not in src
+
+
+def test_construct_sugar_routes_body_through_sugar_body_statement() -> None:
+    """FunctionUniverse statements are built only through the one body door."""
+    src = inspect.getsource(FunctionDef._construct_sugar)
+    assert "_sugar_body_statement" in src
+    assert "FunctionUniverseSugar(" in src


### PR DESCRIPTION
## Summary

L1a — **FunctionDef / FunctionUniverse body construction**, one door.

- Every `def` and `async def` walks `FunctionDef._construct_sugar` into `FunctionUniverseSugar`.
- Body statements construct through their children via `_sugar_body_statement` → `stmt.sugar()` (including source-visible call-frame bodies).
- `AsyncFunctionDef` previously had no `_construct_sugar` (`SugarNotWritten`); it now shares FunctionDef's door (formals, body, universe mint).
- ClassDef methods (blonde) depend on `method.sugar()` — this path lands first.

## Teeth

`implementations/python/sugar-source-tree/tests/test_l1a_functiondef_body_construction.py` — 7 green:
- FunctionDef → FunctionUniverseSugar with child body statements
- multi-statement body constructs statement sugars
- method.sugar() is the same door
- AsyncFunctionDef constructs (not SNW)
- Async delegates to FunctionDef (no second mint)
- `_sugar_body_statement` is stmt.sugar only
- `_construct_sugar` routes body through that door

## Shot accounting

- **R axis:** FunctionDef body construction completeness (async hole + one-door body)
- **Epsilon R:** AsyncFunctionDef SugarNotWritten → constructed FunctionUniverse; dual body sugar call sites closed on FunctionDef
- **Floors:** no ClassDef edits (blonde); no pandas file thrash

## Validation

Direct import of the 7 teeth (green). Manual construct of def / async def / method.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route FunctionDef and AsyncFunctionDef body construction through a single `_sugar_body_statement` door
> - In `FunctionDef`, replaces direct `statement.sugar()` calls in `source_visible_call_frame` and `_source_visible_body` with routing through `self._sugar_body_statement(statement)`, so all non-generator body sugar goes through one path.
> - `AsyncFunctionDef` now delegates `_construct_sugar`, `_sugar_body_statement`, and all parameter/coordinate methods to the corresponding `FunctionDef` implementations instead of duplicating logic.
> - Adds [test_l1a_functiondef_body_construction.py](https://github.com/TSavo/sugar/pull/7135/files#diff-7fcc14f02a5b6edae5260cd347f22789a9685d82936cf4f696ee6b83ea6717ed) to assert both node types use the single body-construction door and that `AsyncFunctionDef` properly delegates to `FunctionDef`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9cc442.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->