### PR TITLE
L0c: dependency seat materialize at most once per open

### DIFF
--- a/implementations/python/sugar-lift-python-source/tests/test_config_prefix_session_memo.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_config_prefix_session_memo.py
@@ -1,19 +1,13 @@
-"""In-population prefix memo: one session → config SourceFile not ×N.
+"""In-population prefix memo + L0c seat materialize once.
 
-After membrane (#7057) killed stdlib rebuilds, residual open cost on
+After membrane killed stdlib rebuilds, residual open cost on
 ``pandas/io/json/_json.py`` was ``pandas/_config/config.py`` MaterializeModule
-dozens of times via ``prefix_has_completed_fallthrough`` →
-``_module_prefix_outcome`` (export fallthrough once per locus).
-
-Frame-door module memo is #7064. This tooth owns the **prefix door** on the
-same ``SourceResolutionSession`` (file-open already threads one session).
-
-Values stay session-owned (context-bound). No process-global projection memo.
+dozens of times. L0c: process_resident + session memos → ≤1 construction.
+Count constructions; do not time them.
 """
 
 from __future__ import annotations
 
-from collections import Counter
 from importlib import metadata
 from pathlib import Path
 
@@ -24,13 +18,16 @@ from sugar_source_tree.file_open_profile import (
     end_file_open_profile,
     summarize_module_materialize,
 )
-from sugar_source_tree.tree import SourceFile as RealSourceFile
+from sugar_source_tree.process_resident_file import (
+    clear_process_resident_files,
+    prepare_count_for,
+)
 
 
-def test_json_open_config_sourcefile_not_dozens(monkeypatch) -> None:
+def test_json_open_config_sourcefile_at_most_once() -> None:
     from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
     from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
-    from sugar_source_tree import tree as tree_mod
+    from sugar_source_tree.process_resident_file import _RESIDENT  # type: ignore
 
     pandas_distribution = metadata.distribution("pandas")
     install_root = Path(pandas_distribution.locate_file("")).resolve()
@@ -38,16 +35,7 @@ def test_json_open_config_sourcefile_not_dozens(monkeypatch) -> None:
     if not path.is_file():
         pytest.skip(f"pandas _json.py not installed at {path}")
 
-    builds: Counter = Counter()
-    orig = tree_mod.SourceFile.__init__
-
-    def counting(self, identity, *args, **kwargs):
-        seat = identity[1] if isinstance(identity, tuple) else str(identity)
-        builds[Path(str(seat)).name] += 1
-        return orig(self, identity, *args, **kwargs)
-
-    monkeypatch.setattr(tree_mod.SourceFile, "__init__", counting)
-
+    clear_process_resident_files()
     bag = begin_file_open_profile()
     try:
         sf = open_source_file_for_construction(
@@ -59,23 +47,38 @@ def test_json_open_config_sourcefile_not_dozens(monkeypatch) -> None:
         fns = len(tuple(sf.functions()))
     finally:
         end_file_open_profile()
+
     summary = summarize_module_materialize(bag)
-    config_sf = builds.get("config.py", 0)
-    config_mat = sum(
-        int(row["count"])
-        for row in (summary.get("top") or [])
-        if str(row["module"]).endswith("config.py")
+    config_prepares = 0
+    enum_prepares = 0
+    for cid, ctx in list(_RESIDENT.items()):
+        name = Path(str(ctx.filename)).name
+        n = prepare_count_for(cid)
+        if name == "config.py":
+            config_prepares = max(config_prepares, n)
+        if name == "enum.py":
+            enum_prepares = max(enum_prepares, n)
+
+    mat_config = 0
+    mat_enum = 0
+    for row in summary.get("top") or []:
+        seats = [Path(str(s)).name for s in (row.get("seats") or [])]
+        count = int(row.get("count") or 0)
+        if "config.py" in seats or str(row.get("module", "")).endswith("config.py"):
+            mat_config += count
+        if "enum.py" in seats or str(row.get("module", "")).endswith("enum.py"):
+            mat_enum += count
+
+    assert config_prepares <= 1, (
+        f"config.py prepare_count={config_prepares} (want ≤1); top={summary.get('top')}"
     )
-    # Pre-fix residual: SourceFile config.py dozens (33 measured). After
-    # prefix door (#7066) + one shared lexical pass over the prefix SourceFile:
-    # prefix door 1 + frame door 1. Lexical use/value no longer re-Materialize.
-    assert config_sf <= 2, (
-        f"config.py SourceFile constructions={config_sf} (want ≤2); "
-        f"all={dict(builds)}; mat_top={summary.get('top')}"
+    assert enum_prepares <= 1, (
+        f"enum.py prepare_count={enum_prepares} (want ≤1); top={summary.get('top')}"
     )
-    assert config_mat <= 2, (
-        f"config.py MaterializeModule count={config_mat} (want ≤2); "
-        f"top={summary.get('top')}"
+    assert mat_config <= 1, (
+        f"config.py MaterializeModule count={mat_config} (want ≤1); top={summary.get('top')}"
     )
-    # False-zero floor: open must keep the real function roster.
+    assert mat_enum <= 1, (
+        f"enum.py MaterializeModule count={mat_enum} (want ≤1); top={summary.get('top')}"
+    )
     assert fns >= 40, f"_json open banked {fns} functions"

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -670,15 +670,14 @@ class Backend:
         from .file_open_profile import _TimedModuleMaterialize, current_file_open_profile
 
         # Profile only when a file-open instrument is active (recensus etc.).
+        # L0c: key by content CID, not seat path — same module at two seats is
+        # one construction; seat-keyed profiles falsely counted N (enum ×35).
         profile = current_file_open_profile()
         if profile is not None:
-            # Prefer human path; fall back to content address.
-            module_key = str(
-                getattr(unit, "filename", None)
-                or getattr(unit, "path", None)
-                or getattr(unit, "source_cid", "unknown")
-            )
-            with _TimedModuleMaterialize(module_key):
+            source_cid = getattr(unit, "source_cid", None) or ""
+            filename = str(getattr(unit, "filename", None) or "")
+            module_key = str(source_cid) if source_cid else (filename or "unknown")
+            with _TimedModuleMaterialize(module_key, seat=filename):
                 return self._materialize_module_body(unit, reporter)
         return self._materialize_module_body(unit, reporter)
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/file_open_profile.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/file_open_profile.py
@@ -3,6 +3,9 @@
 Enabled only while a recensus (or other instrument) holds the contextvar.
 Default is off — zero cost when unset. materialize_module records count+time
 per module identity so a slow open names which dependency rebuilds dominate.
+
+L0c: module keys are content CIDs (not seat paths). Construction count is the
+tooth; elapsed time is diagnostic only.
 """
 
 from __future__ import annotations
@@ -20,7 +23,7 @@ _PROFILE: ContextVar[dict[str, Any] | None] = ContextVar(
 def begin_file_open_profile() -> dict[str, Any]:
     """Start a profile bag for one file open; return it for the caller to fill."""
     bag: dict[str, Any] = {
-        "module_materialize": {},  # module_key -> {count, s}
+        "module_materialize": {},  # module_key -> {count, s, seats}
     }
     _PROFILE.set(bag)
     return bag
@@ -37,18 +40,35 @@ def end_file_open_profile() -> dict[str, Any] | None:
     return bag
 
 
-def record_module_materialize(module_key: str, elapsed_s: float) -> None:
-    """Accumulate one materialize_module completion into the active profile."""
+def record_module_materialize(
+    module_key: str,
+    elapsed_s: float,
+    *,
+    seat: str | None = None,
+) -> None:
+    """Accumulate one materialize_module completion into the active profile.
+
+    ``module_key`` is the content address (L0c). Construction count is what
+    teeth read — elapsed time is diagnostic only.
+    """
     bag = _PROFILE.get()
     if bag is None:
         return
     table = bag.setdefault("module_materialize", {})
     row = table.get(module_key)
     if row is None:
-        table[module_key] = {"count": 1, "s": round(elapsed_s, 6)}
+        table[module_key] = {
+            "count": 1,
+            "s": round(elapsed_s, 6),
+            "seats": [seat] if seat else [],
+        }
     else:
         row["count"] = int(row["count"]) + 1
         row["s"] = round(float(row["s"]) + elapsed_s, 6)
+        if seat:
+            seats = row.setdefault("seats", [])
+            if seat not in seats:
+                seats.append(seat)
 
 
 def summarize_module_materialize(bag: dict[str, Any] | None) -> dict[str, Any]:
@@ -63,16 +83,18 @@ def summarize_module_materialize(bag: dict[str, Any] | None) -> dict[str, Any]:
     table = bag.get("module_materialize") or {}
     total_calls = 0
     total_s = 0.0
-    ranked: list[tuple[str, int, float]] = []
+    ranked: list[tuple[str, int, float, list]] = []
     for key, row in table.items():
         c = int(row.get("count") or 0)
         s = float(row.get("s") or 0.0)
+        seats = list(row.get("seats") or [])
         total_calls += c
         total_s += s
-        ranked.append((str(key), c, s))
+        ranked.append((str(key), c, s, seats))
     ranked.sort(key=lambda item: (-item[2], -item[1], item[0]))
     top = [
-        {"module": key, "count": c, "s": round(s, 4)} for key, c, s in ranked[:8]
+        {"module": key, "count": c, "s": round(s, 4), "seats": seats}
+        for key, c, s, seats in ranked[:8]
     ]
     return {
         "modulesDistinct": len(table),
@@ -85,8 +107,9 @@ def summarize_module_materialize(bag: dict[str, Any] | None) -> dict[str, Any]:
 class _TimedModuleMaterialize:
     """Context manager: time one materialize_module and record it."""
 
-    def __init__(self, module_key: str) -> None:
+    def __init__(self, module_key: str, *, seat: str | None = None) -> None:
         self.module_key = module_key
+        self.seat = seat
         self._t0 = 0.0
 
     def __enter__(self) -> "_TimedModuleMaterialize":
@@ -94,4 +117,8 @@ class _TimedModuleMaterialize:
         return self
 
     def __exit__(self, *_exc: object) -> None:
-        record_module_materialize(self.module_key, time.perf_counter() - self._t0)
+        record_module_materialize(
+            self.module_key,
+            time.perf_counter() - self._t0,
+            seat=self.seat,
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
@@ -66,6 +66,26 @@ class SourceFile:
     something structurally invalid). Never silence, never a bare None.
     """
 
+    def __new__(
+        cls,
+        identity: Tuple[str, str, str],
+        backend: Optional[Backend] = None,
+        reporter: AuditReporter = NULL_REPORTER,
+        construction_context: object | None = None,
+    ):
+        # L0c / enumeration protocol §4: one prepared shell per content CID.
+        # Return the process-resident instance so the same module content is not
+        # reconstructed once per dependency seat. MaterializeModule runs only
+        # on the residency miss path inside source_file_from_identity.
+        from .process_resident_file import source_file_from_identity
+
+        return source_file_from_identity(
+            identity,
+            backend=backend,
+            reporter=reporter,
+            construction_context=construction_context,
+        )
+
     def __init__(
         self,
         identity: Tuple[str, str, str],
@@ -73,27 +93,19 @@ class SourceFile:
         reporter: AuditReporter = NULL_REPORTER,
         construction_context: object | None = None,
     ) -> None:
-        # Enumeration protocol §4: process-resident under whole-file content CID.
-        # Construction goes through residency so the same CID never pays
-        # MaterializeModule twice in one process.
-        from .process_resident_file import source_file_from_identity
-
-        # Always adopt the resident (or first-prepare) shell. Callers hold a
-        # view; the process holds the preparation under content CID.
-        resident = source_file_from_identity(
-            identity,
-            backend=backend,
-            reporter=reporter,
-            construction_context=construction_context,
-        )
-        self.unit = resident.unit
-        self.backend = resident.backend
-        self.reporter = resident.reporter
-        self.constructed_module = resident.constructed_module
-        self.root = resident.root
-        self.closed_roll_call = resident.closed_roll_call
-        self.provider_member_rows = resident.provider_member_rows
-        self.construction_event_receipt_cid = resident.construction_event_receipt_cid
+        # When ``__new__`` returns the resident shell, Python still calls
+        # ``__init__``. The shell is already prepared; only rebind consumer
+        # seating (construction_context / reporter).
+        del identity, backend
+        if not hasattr(self, "unit"):
+            raise RuntimeError(
+                "SourceFile must be prepared by process_resident "
+                "source_file_from_identity before __init__ rebind"
+            )
+        if construction_context is not None:
+            object.__setattr__(self.unit, "construction_context", construction_context)
+        if reporter is not None and reporter is not NULL_REPORTER:
+            self.reporter = reporter
 
     @classmethod
     def _prepare_uncached(

--- a/implementations/python/sugar-source-tree/tests/test_l0c_dependency_seat_materialize_once.py
+++ b/implementations/python/sugar-source-tree/tests/test_l0c_dependency_seat_materialize_once.py
@@ -1,0 +1,121 @@
+"""L0c: dependency seat materialize at most once per open.
+
+Doors (black owns these keys alone):
+  - process_resident under whole-file content CID
+  - session module_materialize under authenticated module key
+
+Tooth: one open of pandas/io/json/_json.py → enum ≤1 and config ≤1
+constructions. Count constructions; do not time them.
+"""
+
+from __future__ import annotations
+
+from importlib import metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_source_tree.file_open_profile import (
+    begin_file_open_profile,
+    end_file_open_profile,
+    summarize_module_materialize,
+)
+from sugar_source_tree.process_resident_file import (
+    clear_process_resident_files,
+    prepare_count_for,
+    resident_size,
+)
+
+
+def _install_root() -> Path:
+    return Path(metadata.distribution("pandas").locate_file("")).resolve()
+
+
+def test_same_content_many_seats_one_prepare() -> None:
+    from sugar_lift_python_source.canonical import blake3_512_of
+    from sugar_source_tree.tree import SourceFile
+
+    clear_process_resident_files()
+    body = "def f():\n    return 1\n"
+    cid = blake3_512_of(body.encode("utf-8"))
+    for i in range(35):
+        SourceFile((body, f"seat_{i}/enum.py", cid))
+    assert prepare_count_for(cid) == 1, prepare_count_for(cid)
+    assert resident_size() == 1
+
+
+def test_sourcefile_constructor_returns_resident_identity() -> None:
+    from sugar_lift_python_source.canonical import blake3_512_of
+    from sugar_source_tree.tree import SourceFile
+
+    clear_process_resident_files()
+    body = "x = 1\n"
+    cid = blake3_512_of(body.encode("utf-8"))
+    a = SourceFile((body, "pkg/a.py", cid))
+    b = SourceFile((body, "other/a.py", cid))
+    assert a is b
+    assert prepare_count_for(cid) == 1
+
+
+def test_json_open_enum_and_config_at_most_once() -> None:
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+    from sugar_source_tree.process_resident_file import _RESIDENT  # type: ignore
+
+    install_root = _install_root()
+    path = install_root / "pandas" / "io" / "json" / "_json.py"
+    if not path.is_file():
+        pytest.skip(f"pandas _json.py not installed at {path}")
+
+    clear_process_resident_files()
+    bag = begin_file_open_profile()
+    try:
+        sf = open_source_file_for_construction(
+            path,
+            root=install_root,
+            construction_context=TreeConstructionContextV1.for_source_call_construction(),
+            populate_derived=True,
+        )
+        fns = len(tuple(sf.functions()))
+    finally:
+        end_file_open_profile()
+
+    summary = summarize_module_materialize(bag)
+
+    enum_prepares = 0
+    config_prepares = 0
+    for cid, ctx in list(_RESIDENT.items()):
+        name = Path(str(ctx.filename)).name
+        n = prepare_count_for(cid)
+        if name == "enum.py":
+            enum_prepares = max(enum_prepares, n)
+        if name == "config.py":
+            config_prepares = max(config_prepares, n)
+
+    mat_enum = 0
+    mat_config = 0
+    for row in summary.get("top") or []:
+        seats = [Path(str(s)).name for s in (row.get("seats") or [])]
+        count = int(row.get("count") or 0)
+        if "enum.py" in seats or str(row.get("module", "")).endswith("enum.py"):
+            mat_enum += count
+        if "config.py" in seats or str(row.get("module", "")).endswith("config.py"):
+            mat_config += count
+
+    assert enum_prepares <= 1, (
+        f"L0c FAIL: enum.py prepare_count={enum_prepares} (want ≤1); "
+        f"mat_top={summary.get('top')}"
+    )
+    assert config_prepares <= 1, (
+        f"L0c FAIL: config.py prepare_count={config_prepares} (want ≤1); "
+        f"mat_top={summary.get('top')}"
+    )
+    assert mat_enum <= 1, (
+        f"L0c FAIL: enum.py MaterializeModule count={mat_enum} (want ≤1); "
+        f"top={summary.get('top')}"
+    )
+    assert mat_config <= 1, (
+        f"L0c FAIL: config.py MaterializeModule count={mat_config} (want ≤1); "
+        f"top={summary.get('top')}"
+    )
+    assert fns >= 40, f"_json open banked {fns} functions (roster floor)"


### PR DESCRIPTION
## Summary

**L0c only** (not L0b). Dependency seat materialize at most once per open.

One open of `_json.py` was rebuilding the same dependency module once per seat that referenced it (enum ×35, config ×17) — same content, different seats.

### Door (black owns these keys alone)
- `process_resident` under whole-file content CID
- session `module_materialize` (unchanged table; residency now returns one shell)

### Fix
- `SourceFile.__new__` returns the process-resident instance (no per-seat wrapper that copied unit/root)
- `SourceFile.__init__` only rebinds consumer seating (construction_context / reporter)
- Profile materialize keys by **content CID**, not seat path (seat-keyed counts were a false N)

### Tooth (count constructions, do not time them)
- 35 seats, one content → `prepare_count == 1`
- `SourceFile(identity)` returns resident identity (`a is b`)
- `_json` open: enum ≤1 and config ≤1 prepare/MaterializeModule (integration; prepare path proven by unit teeth)

Blue L0b (`authenticate_stdlib` / `resolve_source_visible_frame` membrane) untouched.

## Test plan
- [x] `test_same_content_many_seats_one_prepare`
- [x] `test_sourcefile_constructor_returns_resident_identity`
- [x] existing `test_process_resident_file_cid` suite (runpy)
- [ ] CI / merge_dog

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ensure dependency seat `SourceFile` materializes at most once per open via content CID residency
> - `SourceFile.__new__` now returns a process-resident instance keyed by content CID, so multiple dependency seats referencing the same file content share a single prepared instance instead of each triggering a `MaterializeModule`.
> - `SourceFile.__init__` is reduced to rebinding `construction_context` and `reporter` on the resident shell; it raises `RuntimeError` if called without a resident unit.
> - `file_open_profile` tracks distinct seat filenames per content-CID key, and `Backend.materialize_module` now keys profiling by `source_cid` rather than path.
> - New tests in [`test_l0c_dependency_seat_materialize_once.py`](https://github.com/TSavo/sugar/pull/7136/files#diff-28e40aea28ff17b3638654b0c1a2b4ef97d67cb4b6eb4efc7979c20a8cf75c7f) verify that 35 distinct seats with the same CID produce exactly one prepare and one resident entry.
> - Behavioral Change: `SourceFile` constructor no longer returns a fresh object per call — it returns the shared resident, so identity checks (`is`) across seats with the same content will now be `True`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb1dcaf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->