### PR TITLE
L3d: With require door — named gap when no CM contract

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -6994,9 +6994,9 @@ class With(Statement):
             return context.contract_refs.require(coordinate)
         except ContractRefProtocolError:
             # Construct or panic: no contract ref means construction is unwritten.
-            from .panic import SugarNotWritten
+            from .panic import ContextManagerResolutionConstructionGap
 
-            panic = SugarNotWritten(
+            panic = ContextManagerResolutionConstructionGap(
                 blame=self.fragment,
                 owner="With._construct_sugar",
                 observed=(
@@ -7004,7 +7004,11 @@ class With(Statement):
                     f"{coordinate}"
                 ),
                 requested="one resolved authenticated ContextManagerContractRefV1",
-                fix="publish or derive the exact typed CM contract before construction",
+                fix=(
+                    "publish or derive the exact typed CM contract before construction; "
+                    "With constructs only through the require door"
+                ),
+                use_site=coordinate,
             )
             self.reporter.report_gap(self, panic)
             raise panic
@@ -7036,22 +7040,32 @@ class With(Statement):
         return None
 
     def _raise_resolution_gap(self, resolution) -> None:
-        from .panic import SugarNotWritten
+        from .panic import ContextManagerResolutionConstructionGap
 
-        # Construct or panic. Name what failed in observed; no kind taxonomy.
+        # Construct or panic. Name the With door and the contract that was needed.
         detail = getattr(resolution, "detail", None)
         what = getattr(resolution, "kind", None)
+        target = getattr(resolution, "target_symbol", None)
         observed = "authenticated preconstruction resolution has no contract ref"
         if what:
             observed = f"{observed}: {what}"
+        if target:
+            observed = f"{observed} for manager {target!r}"
         if detail:
             observed = f"{observed} [{detail}]"
-        panic = SugarNotWritten(
+        panic = ContextManagerResolutionConstructionGap(
             blame=resolution.use_site,
             owner="With._construct_sugar",
             observed=observed,
             requested="one resolved authenticated ContextManagerContractRefV1",
-            fix="publish or resolve the exact typed CM contract before construction",
+            fix=(
+                "publish or resolve the exact typed CM contract before construction; "
+                "With constructs only through the require door"
+            ),
+            use_site=getattr(resolution, "use_site", None),
+            target_symbol=target if isinstance(target, str) else None,
+            resolution_kind=what if isinstance(what, str) else None,
+            demand_cid=getattr(resolution, "demand_cid", None),
         )
         self.reporter.report_gap(self, panic)
         raise panic

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -172,6 +172,39 @@ class ConstructedValueTestimonyNotWritten(SugarNotWritten):
 # Taxonomy deleted. Construct or panic.
 
 
+class ContextManagerResolutionConstructionGap(SugarNotWritten):
+    """With cannot construct: no authenticated CM contract for this use-site.
+
+    One named door for the require path — not a residual-kind vocabulary.
+    When the preconstruction table carries a gap row, ``kind`` / ``target_symbol``
+    are the row's detail strings (opaque evidence), never a closed enum the
+    board invents kinds from. When the table has no row, those fields are None
+    and ``observed`` names the missing coordinate.
+
+    Construct when a ``ContextManagerContractRefV1`` (or source-derived peer)
+    is present; otherwise this panic — never SoftUnresolvedWithSugar.
+    """
+
+    _LABEL = "CONTEXT MANAGER RESOLUTION GAP"
+
+    def __init__(
+        self,
+        *,
+        use_site: object | None = None,
+        target_symbol: str | None = None,
+        resolution_kind: str | None = None,
+        demand_cid: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.use_site = use_site
+        self.target_symbol = target_symbol
+        self.demand_cid = demand_cid
+        # Optional detail from the resolution row (e.g. "runtime-selected").
+        # Not a closed WithConstructionGapKind vocabulary — deleted.
+        self.kind = resolution_kind
+
+
 class UnsupportedContextManagerSemantics(SugarNotWritten):
     """Manager semantics not constructible — write the arm or stay loud."""
 

--- a/implementations/python/sugar-source-tree/tests/test_with_item_construction_l3d.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_item_construction_l3d.py
@@ -1,0 +1,178 @@
+"""L3d: With item construction — contract present constructs; absent panics named.
+
+One door: ``With._prebound_manager_resolution`` / ``_raise_resolution_gap``.
+
+Checked first: SoftUnresolvedWithSugar is already deleted from production With
+(not an uncalled path). After taxonomy purge, gap rows fell to bare
+``SugarNotWritten`` — restore the single named
+``ContextManagerResolutionConstructionGap`` door (no kind vocabulary).
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType, SimpleNamespace
+
+import pytest
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.context_manager_contract import (
+    EnterResultContractV1,
+    ExitContractV1,
+    ImportSignatureV2,
+    ProtocolResourceSemanticsV1,
+    ReturnTruthinessDispositionV1,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerResolutionGapV1,
+    NativeProtocolSlot,
+    ResolvedContractRefsV1,
+    SourceDerivedContextManagerRefV1,
+    SourceFragmentCoordinateV1,
+    TreeConstructionContextV1,
+    _hash_json,
+)
+from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.ir import PrimitiveSort
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.with_source_resource_sugar import WithSourceResourceSugar
+from sugar_source_tree.panic import ContextManagerResolutionConstructionGap
+from sugar_source_tree.tree import SourceFile
+
+
+def _cid(fill: str) -> str:
+    return "blake3-512:" + (fill * 128)[:128]
+
+
+def _coord_of_with_manager(sf: SourceFile) -> SourceFragmentCoordinateV1:
+    with_node = next(n for n in sf.nodes() if n.kind == "With")
+    item = with_node.items[0]
+    start_line, start_col, end_line, end_col = item._manager_use_site_span()
+    return SourceFragmentCoordinateV1(
+        sf.unit.source_cid, start_line, start_col, end_line, end_col
+    )
+
+
+class _Protocol:
+    def enter_resource_outcome(self, ctx=None):
+        del ctx
+        return Complete(SimpleNamespace(enter_value=TermValue(1)))
+
+    def exit_outcome_for(self, entered, ctx=None):
+        del entered, ctx
+        return Complete(TermValue(False))
+
+
+def test_absent_contract_panics_named_with_door():
+    """No table row: ContextManagerResolutionConstructionGap, owner With."""
+    src = (
+        "import contextlib\n"
+        "def A(z):\n"
+        "    with contextlib.nullcontext():\n"
+        "        z = z\n"
+        "    return z\n"
+    )
+    refs = ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType({}))
+    sf = SourceFile(
+        (src, "l3d_absent.py", blake3_512_of(src.encode())),
+        construction_context=TreeConstructionContextV1(refs),
+    )
+    with pytest.raises(ContextManagerResolutionConstructionGap) as caught:
+        next(sf.functions()).sugar()
+    panic = caught.value
+    assert panic.owner == "With._construct_sugar"
+    assert "derivation" in panic.observed or "coordinate" in panic.observed
+    assert "ContextManagerContractRefV1" in panic.requested
+    assert "With constructs only through the require door" in panic.fix
+
+
+def test_gap_row_panics_with_manager_symbol_and_kind_detail():
+    """Gap row in table: named panic carries target_symbol and kind detail."""
+    src = (
+        "import contextlib\n"
+        "def A(z):\n"
+        "    with contextlib.nullcontext():\n"
+        "        z = z\n"
+        "    return z\n"
+    )
+    bare = SourceFile((src, "l3d_gap.py", blake3_512_of(src.encode())))
+    site = _coord_of_with_manager(bare)
+    preimage = {
+        "useSite": {
+            "sourceCid": site.source_cid,
+            "startLine": site.start_line,
+            "startCol": site.start_col,
+            "endLine": site.end_line,
+            "endCol": site.end_col,
+        },
+        "targetSymbol": "contextlib.nullcontext",
+    }
+    gap = ContextManagerResolutionGapV1(
+        _hash_json(preimage),
+        site,
+        "contextlib.nullcontext",
+        "runtime-selected",
+        (),
+    )
+    refs = ResolvedContractRefsV1(
+        _cid("c"), _cid("t"), MappingProxyType({site: gap})
+    )
+    sf = SourceFile(
+        (src, "l3d_gap.py", blake3_512_of(src.encode())),
+        construction_context=TreeConstructionContextV1(refs),
+    )
+    with pytest.raises(ContextManagerResolutionConstructionGap) as caught:
+        next(sf.functions()).sugar()
+    panic = caught.value
+    assert type(panic).__name__ == "ContextManagerResolutionConstructionGap"
+    assert panic.owner == "With._construct_sugar"
+    assert panic.kind == "runtime-selected"
+    assert panic.target_symbol == "contextlib.nullcontext"
+    assert "nullcontext" in panic.observed
+
+
+def test_source_derived_contract_present_constructs():
+    """Contract present at require door: With constructs WithSourceResourceSugar."""
+    src = (
+        "from dependency import option_context\n"
+        "def f(value):\n"
+        "    with option_context('mode.key', value) as entered:\n"
+        "        return entered\n"
+    )
+    first = SourceFile((src, "l3d_present.py", blake3_512_of(src.encode())))
+    use_site = _coord_of_with_manager(first)
+    enter = SourceFragmentCoordinateV1(_cid("e"), 10, 4, 11, 20)
+    exit_ = SourceFragmentCoordinateV1(_cid("x"), 20, 4, 22, 20)
+    derived = SourceDerivedContextManagerRefV1(
+        use_site=use_site,
+        summary_cid=_cid("s"),
+        semantics=ProtocolResourceSemanticsV1(
+            enter=EnterResultContractV1(sort=PrimitiveSort("Value")),
+            exit=ExitContractV1(disposition=ReturnTruthinessDispositionV1()),
+        ),
+        import_signature=ImportSignatureV2(()),
+        protocol=_Protocol(),
+    )
+    # Contract sits on the require table (same door as production preconstruction).
+    refs = ResolvedContractRefsV1(
+        _cid("c"),
+        _cid("t"),
+        MappingProxyType({use_site: derived}),
+        native_definitions=MappingProxyType(
+            {
+                (use_site, NativeProtocolSlot.CONTEXT_ENTER): enter,
+                (use_site, NativeProtocolSlot.CONTEXT_EXIT): exit_,
+            }
+        ),
+    )
+    sf = SourceFile(
+        (src, "l3d_present.py", blake3_512_of(src.encode())),
+        construction_context=TreeConstructionContextV1(refs),
+    )
+    function = next(sf.functions()).sugar()
+    resource = next(
+        statement
+        for statement in function.statements
+        if isinstance(statement, WithSourceResourceSugar)
+    )
+    assert resource.enter.native_definition_coordinate == enter
+    assert resource.exit.native_definition_coordinate == exit_


### PR DESCRIPTION
## L3d — With item construction / CM require door

**Checked first:** SoftUnresolvedWithSugar already deleted (not uncalled). Construction path when contract is present already works (`WithSourceResourceSugar`). Missing piece after taxonomy purge: gap/missing paths raised bare `SugarNotWritten` instead of a single named With door.

### Change
- Restore `ContextManagerResolutionConstructionGap` as one named `SugarNotWritten` (no `WithConstructionGapKind` vocabulary)
- `_raise_resolution_gap` / empty-table require path raise it with `owner=With._construct_sugar`, target symbol, kind detail when the table row has them

### Law
- Contract present → construct
- Contract absent / gap row → panic naming the With door and what contract was needed

### Teeth
`test_with_item_construction_l3d.py` — 3 green (absent, gap row, present constructs).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise named `ContextManagerResolutionConstructionGap` panic for missing CM contracts in `With` require door
> - Introduces `ContextManagerResolutionConstructionGap`, a new `SugarNotWritten` subclass in [panic.py](https://github.com/TSavo/sugar/pull/7137/files#diff-c49325db55e61059b852041e925bbb2e6a4c203e8a6b41d793822760d14148cb), carrying structured fields: `use_site`, `target_symbol`, `kind`, and `demand_cid`.
> - Updates `With._prebound_manager_resolution` and `With._raise_resolution_gap` in [nodes.py](https://github.com/TSavo/sugar/pull/7137/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) to raise `ContextManagerResolutionConstructionGap` instead of the generic `SugarNotWritten`, with richer observed/error details and door-specific fix text.
> - Behavioral Change: callers catching `SugarNotWritten` are unaffected (subclass), but callers inspecting the exact type or fields of the panic will see a different exception class and additional structured attributes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b8012c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->