### PR TITLE
ImportMemberValue operations: undecided path, not write-more-Floor panic

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
@@ -4,11 +4,18 @@ The lexical import pass authenticates the head; the static Attribute chain
 names the export path.  This floor carries that joined coordinate without
 re-asking an opaque module receiver for a member and without inventing
 AttributeError.
+
+Operations on this floor share one door: the export is source-authenticated
+but its runtime type is not lift-time decided (``runtime_type_is_decided`` is
+False). Lookups use the existing undecided_* named-refusal helpers. Call,
+iteration, and method dispatch stay at the import-member runtime boundary —
+never invent CallSite / MethodCall construction here.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 from .floor_value import FloorValue
 
@@ -78,6 +85,123 @@ class ImportMemberValue(FloorValue):
             "python:exception_type_identity",
             [str_const("import"), str_const(self.qualified_name)],
         )
+
+    # ------------------------------------------------------------------
+    # Import-member operations door (one surface; type undecided)
+    # ------------------------------------------------------------------
+    # Wiring: FloorValue already owns undecided_subscript / undecided_attribute /
+    # undecided_contains. ImportMemberValue's only job is to enter those doors
+    # instead of the default construction-panic "write more Floor" arm — which
+    # would miscount an undecided runtime type as OUR missing floor method.
+
+    def subscript(self, index, site):
+        return self.undecided_subscript(
+            index, site, owner="ImportMemberValue.subscript"
+        )
+
+    def attribute(self, name, site):
+        return self.undecided_attribute(
+            name, site, owner="ImportMemberValue.attribute"
+        )
+
+    def contains(self, item, site):
+        return self.undecided_contains(
+            item, site, owner="ImportMemberValue.contains"
+        )
+
+    def attribute_with(self, operation: Any, ctx: object):
+        del ctx
+        return self.attribute(operation.name, operation.site)
+
+    def subscript_with(self, operation: Any, ctx: object):
+        del ctx
+        return self.subscript(operation.index, operation.site)
+
+    def contains_with(self, operation: Any, ctx: object):
+        del ctx
+        return self.contains(operation.item, operation.site)
+
+    def callable_application_with(self, operation: Any, ctx: object):
+        """Call-through-import: boundary effect, not CallSite construction.
+
+        Runtime type is undecided at lift; do not invent a CallSite sugar path
+        here (that door is not this floor's). Name the import-member call
+        boundary with the shared ImportedModuleRuntimeEffect incomplete.
+        """
+        del ctx
+        return _import_member_runtime_effect(
+            self,
+            site=operation.site,
+            shape=f"{self.qualified_name}(...)",
+            replacement="ImportMemberCallEffect",
+        )
+
+    def call_method_with(self, operation: Any, ctx: object):
+        del ctx
+        return _import_member_runtime_effect(
+            self,
+            site=operation.site,
+            shape=f"{self.qualified_name}.{operation.name}(...)",
+            replacement="ImportMemberMethodCallEffect",
+        )
+
+    def iter_with(self, operation: Any, ctx: object):
+        del ctx
+        return _import_member_runtime_effect(
+            self,
+            site=operation.site,
+            shape=f"iter({self.qualified_name})",
+            replacement="ImportMemberIterEffect",
+        )
+
+    def binary_operator_with(self, operation: Any, ctx: object):
+        del ctx
+        return _import_member_runtime_effect(
+            self,
+            site=operation.site,
+            shape=f"{self.qualified_name} {operation.operator} ...",
+            replacement="ImportMemberBinaryEffect",
+        )
+
+    def equals(self, other, site):
+        """Comparison constructs on the authenticated term, not runtime type.
+
+        Equality uses content-addressed import-member terms already carried by
+        ``to_term`` — no runtime-type decision required.
+        """
+        return super().equals(other, site)
+
+
+def _import_member_runtime_effect(
+    value: ImportMemberValue, *, site, shape: str, replacement: str
+):
+    """Shared incomplete for ops that would require evaluating the export."""
+    from sugar_lift_py_tests.effect import (
+        ImportedModuleRuntimeEffect,
+        runtime_effect_evidence_from_terms,
+    )
+    from sugar_lift_py_tests.ir import ctor, str_const
+    from sugar_lift_py_tests.outcome import Incomplete
+
+    member = value.to_term(owner="ImportMemberRuntimeEffect")
+    operand = ctor("call:import_member", [member])
+    return Incomplete(
+        ImportedModuleRuntimeEffect(
+            "import-member runtime boundary: "
+            f"`{shape}` requires evaluating authenticated export "
+            f"`{value.qualified_name}` (path={value.exported_member_path!r}). "
+            "Runtime type is not lift-time decided; source hunting is cut. "
+            f"replacement={replacement}; blame={site}",
+            **runtime_effect_evidence_from_terms(
+                ctor(
+                    "python:import_member_floor_operation",
+                    [operand, str_const(replacement), str_const(shape)],
+                ),
+                operand,
+                site,
+            ),
+        )
+    )
 
 
 def _mint_import_member_value(receipt):

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_member_operations.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_member_operations.py
@@ -1,0 +1,129 @@
+"""Import-member operations door — one floor, many uses.
+
+ImportMemberValue is a source-authenticated export whose runtime type is not
+lift-time decided. Ops must not fall through to FloorValue's construction-
+panic ``write more Floor`` arm (that miscounts undecided type as OUR defect).
+
+Triage:
+  - subscript / attribute / contains → existing FloorValue.undecided_* (wire)
+  - call / method / iter / binary → ImportedModuleRuntimeEffect incomplete
+  - equals → FloorValue.equals via to_term (already constructs)
+
+Not this door: CallSiteSugar / MethodCallSugar / sugar_base (blue).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_lift_py_tests.floor.import_member_value import ImportMemberValue
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_source_tree.panic import SugarNotWritten
+
+
+def _import_member_and_site() -> tuple[ImportMemberValue, object]:
+    """Real seated ImportMemberValue + its source fragment (for effect locus)."""
+    from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+    from sugar_lift_python_source.dependency_artifact import DependencyArtifactGraph
+    from sugar_lift_python_source.manager_construction import (
+        _seat_import_value_use_receipts,
+    )
+    from sugar_lift_python_source.resolution_session import SourceResolutionSession
+    from sugar_source_tree.nodes import Attribute, ClassDef
+    from sugar_source_tree.tree import SourceFile
+
+    graph = DependencyArtifactGraph.authenticate_stdlib_module("re")
+    module = graph.modules["re"]
+    context = TreeConstructionContextV1.for_source_call_construction()
+    source_file = SourceFile(
+        (module.source, module.source_seat, module.source_cid),
+        construction_context=context,
+    )
+    regex_flag = next(
+        node
+        for node in source_file.root.body
+        if isinstance(node, ClassDef) and node.name == "RegexFlag"
+    )
+    _seat_import_value_use_receipts(
+        source_file=source_file,
+        module=module,
+        target=regex_flag,
+        session=SourceResolutionSession(enabled=False),
+        context=context,
+        dependency_graphs={"re": graph},
+    )
+    member = next(
+        node
+        for node in source_file.nodes()
+        if isinstance(node, Attribute) and node.attr == "SRE_FLAG_ASCII"
+    )
+    outcome = member.sugar().desugar()
+    assert isinstance(outcome, Complete)
+    assert type(outcome.value) is ImportMemberValue
+    return outcome.value, member.fragment
+
+
+def _import_member() -> ImportMemberValue:
+    return _import_member_and_site()[0]
+
+
+def test_import_member_runtime_type_undecided() -> None:
+    v = _import_member()
+    assert v.denotes_value() is True
+    assert v.runtime_type_is_decided() is False
+
+
+def test_subscript_is_undecided_refusal_not_write_more_floor() -> None:
+    """Wiring: enter FloorValue.undecided_subscript, not construction panic."""
+    v, site = _import_member_and_site()
+    with pytest.raises(SugarNotWritten, match="ImportMemberValue.subscript") as caught:
+        v.subscript(v, site)
+    assert "write more Floor" not in str(caught.value)
+    assert "undecided" in str(caught.value.observed).lower()
+
+
+def test_attribute_is_undecided_refusal_not_write_more_floor() -> None:
+    v, site = _import_member_and_site()
+    with pytest.raises(SugarNotWritten, match="ImportMemberValue.attribute") as caught:
+        v.attribute("bit_count", site)
+    assert "write more Floor" not in str(caught.value)
+    assert "undecided" in str(caught.value.observed).lower()
+
+
+def test_contains_is_undecided_refusal_not_write_more_floor() -> None:
+    v, site = _import_member_and_site()
+    with pytest.raises(SugarNotWritten, match="ImportMemberValue.contains") as caught:
+        v.contains(v, site)
+    assert "write more Floor" not in str(caught.value)
+
+
+def test_call_through_import_is_runtime_boundary_incomplete() -> None:
+    """Call-through-import: Incomplete effect — not CallSite, not write-more-Floor."""
+    v, site = _import_member_and_site()
+    op = SimpleNamespace(site=site, name="__call__")
+    outcome = v.callable_application_with(op, None)
+    assert isinstance(outcome, Incomplete)
+    from sugar_lift_py_tests.effect import ImportedModuleRuntimeEffect
+
+    assert type(outcome.effect) is ImportedModuleRuntimeEffect
+    msg = str(outcome.effect).lower()
+    assert "import" in msg and "member" in msg
+
+
+def test_iteration_is_runtime_boundary_incomplete() -> None:
+    v, site = _import_member_and_site()
+    op = SimpleNamespace(site=site)
+    outcome = v.iter_with(op, None)
+    assert isinstance(outcome, Incomplete)
+    from sugar_lift_py_tests.effect import ImportedModuleRuntimeEffect
+
+    assert type(outcome.effect) is ImportedModuleRuntimeEffect
+
+
+def test_comparison_constructs_on_authenticated_term() -> None:
+    """Equals uses to_term — constructs without inventing runtime type."""
+    v, site = _import_member_and_site()
+    outcome = v.equals(v, site)
+    assert isinstance(outcome, Complete)


### PR DESCRIPTION
Wires ImportMemberValue ops to the existing undecided path. Was falling through to panic write more Floor when the honest answer is source undecided.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route `ImportMemberValue` operations to undecided helpers instead of panicking
> - `ImportMemberValue` previously panicked on operations like subscript, attribute, contains, and call. It now routes these to `undecided_*` helpers (with owner annotations) or returns an `Incomplete` carrying `ImportedModuleRuntimeEffect`.
> - A new `_import_member_runtime_effect` helper constructs the `Incomplete` result for call/method/iter/binary operations, embedding operation shape, qualified name, and blame site in the evidence.
> - A new test module [`test_import_member_operations.py`](https://github.com/TSavo/sugar/pull/7139/files#diff-7c870fa863f84508430ebdbf8c5c0b30fbc690a45e565194c60ba334b86256d4) verifies that subscript/attribute/contains raise undecided refusals and that call/iter return `Incomplete` with the correct effect type.
> - Behavioral Change: operations on `ImportMemberValue` that previously triggered a construction panic now produce structured undecided refusals or runtime-boundary `Incomplete` results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a49b2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->