### PR TITLE
CM contract derivation so With constructs when manager is visible

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -2822,9 +2822,9 @@ def _install_derivation_gap(
     """Publish a CM resolution gap for this enrolled demand.
 
     Derivation ran; the demand has no ``ContextManagerContractRefV1``.
-    Unwritten: the row means no contract ref — the
-    ground is constructible via ``gap.enrolled_demand_unresolved_ground()``
-    and is minted on consume in ``With._raise_resolution_gap``.
+    Install the row and continue — do not call deleted C3 ground mint
+    (``enrolled_demand_unresolved_ground``). With consumption panics on the
+    gap via ``ContextManagerResolutionConstructionGap`` (L3d require door).
     """
     from sugar_lift_py_tests.context_manager_resolution import (
         ContextManagerResolutionGapV1,
@@ -2838,7 +2838,4 @@ def _install_derivation_gap(
         (),
         detail,
     )
-    # Prove the C3 ground is mintable from the live table world (still a gap).
-    # Does not raise; With consumption mints the panic with the same ground.
-    gap.enrolled_demand_unresolved_ground()
     context.source_derived_contract_refs[coordinate] = gap

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1652,6 +1652,173 @@ def populate_source_derived_resource_refs(
             )
         )
 
+    # Same-module ClassDef managers have no import receipt. Derive them through
+    # module_direct_bindings → Call.force_floor → protocol → summary — the same
+    # publication door as import-backed ClassDef CMs. Uncovered uses stay empty
+    # for With.require (L3d) to panic.
+    _populate_same_module_class_manager_uses(source_file, context, uses)
+
+
+def _populate_same_module_class_manager_uses(source_file, context, uses) -> None:
+    """Derive CM contracts for same-module ClassDef call managers.
+
+    Import receipts never fire for local constructors. When Call.func Name
+    binds to exactly one module ClassDef, construct the instance via the
+    ordinary Call floor (force_floor), then protocol + summary + native
+    enter/exit publication — one pipeline with the import-backed door.
+    """
+    from sugar_lift_py_tests.context.reduce_context import ReduceContext
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceDerivedContextManagerRefV1,
+    )
+    from sugar_lift_py_tests.floor import ObjectValue
+    from sugar_lift_py_tests.temporal import builtin_name_temporal
+    from sugar_source_tree.nodes import Call, ClassDef, Name
+    from sugar_source_tree.panic import SugarNotWritten
+
+    from .canonical import cid_of_json
+    from .manager_construction import ConstructedManagerBehaviorV1
+    from .manager_protocol_construction import (
+        ConstructedManagerProtocolV1,
+        construct_manager_protocol,
+    )
+
+    reduce_ctx = ReduceContext(temporal=builtin_name_temporal())
+    for _key, (coordinate, call, exit_face_id) in uses.items():
+        if coordinate in context.source_derived_contract_refs:
+            continue
+        if not isinstance(call, Call) or not isinstance(call.func, Name):
+            continue
+        binds = (call.unit.module_direct_bindings or {}).get(call.func.id, ())
+        if len(binds) != 1 or not isinstance(binds[0], ClassDef):
+            continue
+        class_def = binds[0]
+        target_symbol = f"python:local:{class_def.name}"
+        try:
+            call_outcome = call.sugar().desugar(reduce_ctx)
+            call_value = getattr(call_outcome, "value", None)
+            if call_value is None or not hasattr(call_value, "force_floor"):
+                _install_local_derivation_gap(
+                    context,
+                    coordinate,
+                    target_symbol,
+                    "non-manager-result",
+                    type(call_outcome).__name__,
+                )
+                continue
+            result = call_value.force_floor(
+                reduce_ctx,
+                owner="populate_same_module_class_manager",
+                project_callsite=False,
+            )
+        except (SugarNotWritten, TypeError) as exc:
+            kind, detail = _populate_body_defect_kind_detail(exc)
+            _install_local_derivation_gap(
+                context, coordinate, target_symbol, kind, detail
+            )
+            continue
+        if not isinstance(result, ObjectValue):
+            _install_local_derivation_gap(
+                context,
+                coordinate,
+                target_symbol,
+                "non-manager-result",
+                type(result).__name__,
+            )
+            continue
+        enter_method = next(
+            (m for m in result.methods if m.name == "__enter__"), None
+        )
+        frame = getattr(enter_method, "source_call_frame", None) if enter_method else None
+        frame_cid = getattr(frame, "frame_cid", None) or result.identity
+        preimage = {
+            "kind": "constructed-manager-behavior",
+            "schemaVersion": "1",
+            "resolvedObjectCid": target_symbol,
+            "receiverStateCid": result.identity,
+            "formalActualBindings": [],
+            "sourceCallFrameCid": frame_cid,
+            "factoryPrefixCids": [],
+        }
+        behavior = ConstructedManagerBehaviorV1(
+            resolved_object_cid=target_symbol,
+            manager_construction_cid=cid_of_json(preimage),
+            receiver_state=result,
+            receiver_state_cid=result.identity,
+            formal_actual_bindings=(),
+            source_call_frame_cid=frame_cid,
+            formal_actual_values=(),
+            source_call_frame=frame,
+            factory_prefix=(),
+            factory_prefix_cids=(),
+        )
+        try:
+            protocol = construct_manager_protocol(
+                behavior, exit_face_id=exit_face_id
+            )
+        except (SugarNotWritten, TypeError) as exc:
+            kind, detail = _populate_body_defect_kind_detail(exc)
+            _install_local_derivation_gap(
+                context, coordinate, target_symbol, kind, detail
+            )
+            continue
+        if not isinstance(protocol, ConstructedManagerProtocolV1):
+            kind, detail = _gap_kind_and_detail(protocol)
+            _install_local_derivation_gap(
+                context, coordinate, target_symbol, kind, detail
+            )
+            continue
+        summary = derive_manager_summary(protocol, behavior=behavior)
+        if not isinstance(summary, DerivedManagerSummaryV1):
+            kind, detail = _gap_kind_and_detail(summary)
+            _install_local_derivation_gap(
+                context, coordinate, target_symbol, kind, detail
+            )
+            continue
+        _publish_class_protocol_native_definitions(context, coordinate, behavior)
+        context.source_derived_contract_refs[coordinate] = (
+            SourceDerivedContextManagerRefV1(
+                coordinate,
+                summary.summary_cid,
+                summary.semantics,
+                summary.import_signature,
+                protocol,
+            )
+        )
+
+
+def _install_local_derivation_gap(
+    context, coordinate, target_symbol: str, kind: str, detail: str | None = None
+) -> None:
+    """Gap row for a same-module manager use (no import receipt)."""
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+        _hash_json,
+    )
+
+    demand_cid = _hash_json(
+        {
+            "kind": "local-manager-demand",
+            "useSite": {
+                "sourceCid": coordinate.source_cid,
+                "startLine": coordinate.start_line,
+                "startCol": coordinate.start_col,
+                "endLine": coordinate.end_line,
+                "endCol": coordinate.end_col,
+            },
+            "targetSymbol": target_symbol,
+        }
+    )
+    gap = ContextManagerResolutionGapV1(
+        demand_cid,
+        coordinate,
+        target_symbol,
+        kind,
+        (),
+        detail,
+    )
+    context.source_derived_contract_refs[coordinate] = gap
+
 
 def _publish_native_definition(context, receiver, slot, definition) -> None:
     """Enroll one authenticated definition coordinate into the shared door table.

--- a/implementations/python/sugar-lift-python-source/tests/test_same_module_class_manager_derivation.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_same_module_class_manager_derivation.py
@@ -1,0 +1,119 @@
+"""Same-module ClassDef CM derivation — receipt-less populate door.
+
+Local ``with M():`` has no import receipt. Populate must still derive a
+``SourceDerivedContextManagerRefV1`` when ``M`` is a module ClassDef with
+``__enter__``/``__exit__``, so With constructs through the L3d require door.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    SourceDerivedContextManagerRefV1,
+    TreeConstructionContextV1,
+)
+from sugar_lift_py_tests.sugar.with_source_resource_sugar import WithSourceResourceSugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.manager_summary_derivation import (
+    populate_source_derived_resource_refs,
+)
+from sugar_source_tree.nodes import With
+from sugar_source_tree.panic import ContextManagerResolutionConstructionGap
+from sugar_source_tree.tree import SourceFile
+
+
+def _source_file(tmp_path: Path, source: str) -> tuple[SourceFile, TreeConstructionContextV1, Path]:
+    path = tmp_path / "consumer.py"
+    path.write_text(source, encoding="utf-8")
+    cid = blake3_512_of(source.encode())
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile((source, str(path), cid), construction_context=context)
+    return tree, context, path
+
+
+def test_local_classdef_cm_derives_and_constructs(tmp_path: Path):
+    """Visible same-module ClassDef CM: populate derives; With constructs."""
+    source = textwrap.dedent(
+        """\
+        class M:
+            def __enter__(self):
+                return self
+            def __exit__(self, *a):
+                return False
+        def f():
+            with M():
+                return 1
+        """
+    )
+    tree, context, path = _source_file(tmp_path, source)
+    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+
+    assert len(context.source_derived_contract_refs) == 1
+    ref = next(iter(context.source_derived_contract_refs.values()))
+    assert isinstance(ref, SourceDerivedContextManagerRefV1)
+
+    with_node = next(n for n in tree.nodes() if isinstance(n, With))
+    sugar = with_node.sugar()
+    assert isinstance(sugar, WithSourceResourceSugar)
+
+
+def test_local_classdef_without_protocol_installs_gap(tmp_path: Path):
+    """ClassDef without __enter__/__exit__: gap row; With panics named."""
+    source = textwrap.dedent(
+        """\
+        class NotCM:
+            def run(self):
+                return 1
+        def f():
+            with NotCM():
+                return 1
+        """
+    )
+    tree, context, path = _source_file(tmp_path, source)
+    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+
+    assert len(context.source_derived_contract_refs) == 1
+    gap = next(iter(context.source_derived_contract_refs.values()))
+    assert type(gap).__name__ == "ContextManagerResolutionGapV1"
+    assert gap.target_symbol == "python:local:NotCM"
+
+    with_node = next(n for n in tree.nodes() if isinstance(n, With))
+    with pytest.raises(ContextManagerResolutionConstructionGap) as caught:
+        with_node.sugar()
+    assert caught.value.owner == "With._construct_sugar"
+
+
+def test_install_gap_never_attribute_errors_on_import_auth_fail(tmp_path: Path):
+    """Import CM without dist: gap installs; no AttributeError on deleted ground mint."""
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "__init__.py").write_text(
+        textwrap.dedent(
+            """\
+            class M:
+                def __enter__(self):
+                    return self
+                def __exit__(self, *a):
+                    return False
+            """
+        ),
+        encoding="utf-8",
+    )
+    source = textwrap.dedent(
+        """\
+        from pkg import M
+        def f():
+            with M():
+                return 1
+        """
+    )
+    tree, context, path = _source_file(tmp_path, source)
+    # No distribution_index → authenticate fails → no-derived-contract gap.
+    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    assert len(context.source_derived_contract_refs) == 1
+    gap = next(iter(context.source_derived_contract_refs.values()))
+    assert type(gap).__name__ == "ContextManagerResolutionGapV1"
+    assert gap.kind == "no-derived-contract"


### PR DESCRIPTION
CM contract derivation so With constructs when the manager is visible.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive context manager contracts for same-module ClassDef `with` constructs
> - Adds `_populate_same_module_class_manager_uses` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/7141/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to resolve local ClassDef constructors through the same construction/protocol/summary pipeline used for import-backed managers, producing `SourceDerivedContextManagerRefV1` entries.
> - When derivation fails (missing protocol, desugar error, etc.), a `ContextManagerResolutionGapV1` is installed via the new `_install_local_derivation_gap` helper, tagged with `python:local:<ClassName>`.
> - Fixes `_install_derivation_gap` to stop calling the deleted `enrolled_demand_unresolved_ground()` method; gap rows are now written directly and `With` panics at consumption time via `ContextManagerResolutionConstructionGap`.
> - Behavioral Change: local ClassDef `with` uses that previously produced no contract ref now produce either a resolved ref or an explicit gap row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 672658c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->