### PR TITLE
ImportAliasValue/MutableGlobalValue: undecided attribution, not write-more-Floor

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_alias_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_alias_value.py
@@ -66,26 +66,35 @@ class ImportAliasValue(FloorValue):
         )
         raise AssertionError("construction_panic_gap returned")
 
+    def runtime_type_is_decided(self) -> bool:
+        """Import alias has no lift-time runtime type — only a binding coordinate."""
+        return False
+
+    # Undecided-attribution door (same law as ImportMemberValue): FloorValue
+    # defaults panic ``write more Floor: implement X.attribute``, miscounting
+    # undecidable import-alias type as OUR missing floor method. Enter
+    # undecided_* instead — vocabulary already on FloorValue.
+
     def subscript(self, index, site):
         return self.undecided_subscript(
             index, site, owner="ImportAliasValue.subscript"
         )
 
-    def getattr_static(self, name: str, site):
-        from sugar_lift_py_tests.gap.info import GapKind, GapLocus
-        from sugar_lift_py_tests.gap.panic import construction_panic_gap
-
-        target = self.import_target or self.name
-        construction_panic_gap(
-            owner="ImportAliasValue",
-            blame=site,
-            observed=f"{target}.{name}",
-            requested="authenticated import attribute coordinate",
-            fix="consume an authenticated contract bridge; no source-hunt fallback exists",
-            gap_kind=GapKind.FLOOR,
-            gap_locus=GapLocus.CONSTRUCTION,
+    def attribute(self, name, site):
+        return self.undecided_attribute(
+            name, site, owner="ImportAliasValue.attribute"
         )
-        raise AssertionError("construction_panic_gap returned")
+
+    def contains(self, item, site):
+        return self.undecided_contains(
+            item, site, owner="ImportAliasValue.contains"
+        )
+
+    def getattr_static(self, name: str, site):
+        """Static getattr on an inert import alias — undecided, not missing floor."""
+        return self.undecided_attribute(
+            name, site, owner="ImportAliasValue.getattr_static"
+        )
 
     def guarded(self, formula):
         del formula

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mutable_global_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mutable_global_value.py
@@ -44,6 +44,16 @@ class MutableGlobalValue(FloorValue):
     def denotes_value(self) -> bool:
         return True
 
+    def runtime_type_is_decided(self) -> bool:
+        """Only dict pins decide membership/lookup structure; other kinds stay undecided."""
+        return self.kind == "dict"
+
+    def attribute(self, name, site):
+        """Mutable pin has no field layout at lift — undecided, not missing Floor.attribute."""
+        return self.undecided_attribute(
+            name, site, owner="MutableGlobalValue.attribute"
+        )
+
     def subscript(self, index, site):
         if self.kind != "dict":
             return self.undecided_subscript(
@@ -96,7 +106,9 @@ class MutableGlobalValue(FloorValue):
 
     def contains(self, item, site):
         if self.kind != "dict":
-            return super().contains(item, site)
+            return self.undecided_contains(
+                item, site, owner="MutableGlobalValue.contains"
+            )
         if getattr(site, "source_cid", None) != self.pin_source_cid:
             from sugar_source_tree.panic import SugarNotWritten
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_undecided_attribution_sweep.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_undecided_attribution_sweep.py
@@ -1,0 +1,142 @@
+"""Undecided attribution sweep — do not count source-undecided as missing Floor.
+
+ImportMemberValue already wires subscript/attribute/contains into
+FloorValue.undecided_* (#import-member ops). This file pins the *same* law for
+other value types that still fell through to:
+
+  write more Floor: implement {Type}.attribute
+
+when the honest answer is "runtime type not lift-time decided".
+
+Triage: vocabulary already exists on FloorValue; offenders were wrong entrance
+(base construction-panic arm), not empty building.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_lift_py_tests.floor.import_alias_value import ImportAliasValue
+from sugar_lift_py_tests.floor.mutable_global_value import MutableGlobalValue
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_source_tree.fragment import SourceMemento
+from sugar_source_tree.panic import SugarNotWritten
+
+_CID = "blake3-512:" + ("ab" * 64)
+_CID2 = "blake3-512:" + ("cd" * 64)
+
+
+class _Site:
+    def __str__(self) -> str:
+        return "site:undecided_sweep.py:1:1"
+
+    source_cid = _CID
+
+    def is_within_annotation(self) -> bool:
+        return False
+
+
+def _alias() -> ImportAliasValue:
+    return ImportAliasValue(name="os", bound_name="os", import_target="os")
+
+
+def _mutable(*, kind: str = "list") -> MutableGlobalValue:
+    memento = SourceMemento(
+        file="mod.py",
+        source_cid=_CID,
+        cid=_CID2,
+        start=0,
+        end=1,
+    )
+    return MutableGlobalValue(
+        name="g",
+        kind=kind,
+        pin_source_cid=_CID,
+        binding_memento=memento,
+    )
+
+
+def test_import_alias_runtime_type_undecided() -> None:
+    assert _alias().runtime_type_is_decided() is False
+
+
+def test_import_alias_attribute_is_undecided_not_write_more_floor() -> None:
+    """Was: ConstructionPanic write more Floor: implement ImportAliasValue.attribute."""
+    v = _alias()
+    site = _Site()
+    with pytest.raises(SugarNotWritten, match="ImportAliasValue.attribute") as caught:
+        v.attribute("path", site)
+    msg = str(caught.value)
+    assert "write more Floor" not in msg
+    assert "undecided" in caught.value.observed.lower()
+
+
+def test_import_alias_contains_is_undecided_not_write_more_floor() -> None:
+    v = _alias()
+    site = _Site()
+    with pytest.raises(SugarNotWritten, match="ImportAliasValue.contains") as caught:
+        v.contains(v, site)
+    assert "write more Floor" not in str(caught.value)
+
+
+def test_import_alias_subscript_still_undecided() -> None:
+    v = _alias()
+    site = _Site()
+    with pytest.raises(SugarNotWritten, match="ImportAliasValue.subscript"):
+        v.subscript(0, site)
+
+
+def test_import_alias_getattr_static_is_undecided_not_construction_gap() -> None:
+    """getattr_static used to construction_panic_gap; same undecided law."""
+    v = _alias()
+    site = _Site()
+    with pytest.raises(SugarNotWritten, match="ImportAliasValue.getattr_static"):
+        v.getattr_static("path", site)
+
+
+def test_mutable_global_non_dict_contains_is_undecided_not_write_more_floor() -> None:
+    """kind!=dict used super().contains → write more Floor: implement MutableGlobalValue.contains."""
+    v = _mutable(kind="list")
+    site = _Site()
+    assert v.runtime_type_is_decided() is False
+    with pytest.raises(SugarNotWritten, match="MutableGlobalValue.contains") as caught:
+        v.contains(0, site)
+    assert "write more Floor" not in str(caught.value)
+
+
+def test_mutable_global_attribute_is_undecided_not_write_more_floor() -> None:
+    v = _mutable(kind="dict")
+    site = _Site()
+    with pytest.raises(SugarNotWritten, match="MutableGlobalValue.attribute") as caught:
+        v.attribute("keys", site)
+    assert "write more Floor" not in str(caught.value)
+
+
+def test_mutable_global_dict_contains_still_constructs() -> None:
+    """Do not break decided dict membership on the pin."""
+    from sugar_lift_py_tests.floor.term_value import TermValue
+    from sugar_lift_py_tests.outcome import Complete
+
+    v = _mutable(kind="dict")
+    site_ok = SimpleNamespace(
+        __str__=lambda self: "site:mod.py:1:1",
+        source_cid=_CID,
+    )
+    outcome = v.contains(TermValue(1), site_ok)
+    assert isinstance(outcome, Complete)
+
+
+def test_no_construction_panic_on_alias_attribute() -> None:
+    """Regression class: ConstructionPanic is the forbidden miscount costume."""
+    v = _alias()
+    site = _Site()
+    with pytest.raises(SugarNotWritten):
+        v.attribute("x", site)
+    try:
+        v.attribute("x", site)
+    except ConstructionPanic:
+        pytest.fail("ImportAliasValue.attribute must not ConstructionPanic")
+    except SugarNotWritten:
+        pass


### PR DESCRIPTION
ImportAliasValue and MutableGlobalValue were falling through to write-more-Floor when the honest answer is the source is undecided. 9 teeth.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route attribute and membership access on `ImportAliasValue` and `MutableGlobalValue` to undecided handling
> - `ImportAliasValue` now returns `False` from `runtime_type_is_decided()` and delegates attribute access, `contains`, and `getattr_static` to `FloorValue.undecided_attribute`/`undecided_contains` instead of triggering construction panics or missing-floor paths.
> - `MutableGlobalValue` adds `runtime_type_is_decided()` (returns `True` only for dict pins), routes attribute access to `undecided_attribute`, and fixes non-dict `contains` to use `undecided_contains` instead of the base class missing-floor path. Dict membership behavior is unchanged.
> - A new test module [`test_undecided_attribution_sweep.py`](https://github.com/TSavo/sugar/pull/7143/files#diff-17f6d46f655e3709bd89ff770a2b9e311cc63e15451d25e80474ab0e2175451f) verifies undecided routing for both types and preserves dict membership construction.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d2819b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->