### PR TITLE
Update RaiseEffect.for_builtin callers to narrowed API

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
@@ -257,7 +257,6 @@ def test_pandas_common_143_composes_compare_exit_with_assertion_contract():
         
         blame="pandas/tests/arithmetic/common.py:144:8",
         occurrence="pandas/tests/arithmetic/common.py:144:8",
-        exception_type_coordinate=producer_coordinate,
         exception_type_mro=(producer_coordinate,),
         raised_value=CallSiteValue(
             "TypeError",
@@ -268,6 +267,7 @@ def test_pandas_common_143_composes_compare_exit_with_assertion_contract():
         ),
         producer_node_owner="ComparisonOpSugar.desugar",
     )
+    assert producer_effect.exception_type_coordinate == expected.identity
     matching = Halted(true_guard(), producer_effect, _state("compare"))
     other = _raise("ValueError", "other-type")
     nameless_effect = UndeterminedRaiseEffect(
@@ -319,8 +319,7 @@ def test_pandas_common_143_composes_compare_exit_with_assertion_contract():
     assert binding is not None
     assert binding.slot_id == "excinfo"
     assert binding.effect is producer_effect
-    assert binding.effect.exception_type_coordinate is producer_coordinate
-    assert binding.effect.exception_type_coordinate is not expected.identity
+    assert binding.effect.exception_type_coordinate == expected.identity
     assert binding.effect.producer_node_owner == "ComparisonOpSugar.desugar"
     assert binding.effect.occurrence_id == "pandas/tests/arithmetic/common.py:144:8"
     assert failed_message.effect is producer_effect
@@ -631,7 +630,6 @@ def test_factored_none_face_consumes_matching_raise_and_binds_exact_occurrence()
         
         blame=occurrence,
         occurrence=occurrence,
-        exception_type_coordinate=_identity("ValueError"),
         exception_type_mro=(_identity("ValueError"),),
         raised_value=CallSiteValue(
             "ValueError",
@@ -658,10 +656,8 @@ def test_factored_none_face_consumes_matching_raise_and_binds_exact_occurrence()
     binding = _observed_binding(none_consumed[0])
     assert binding.slot_id == "excinfo"
     assert binding.effect is producer
-    assert binding.effect.occurrence == occurrence
-    assert (
-        binding.effect.exception_type_coordinate is producer.exception_type_coordinate
-    )
+    assert binding.effect.occurrence_id == occurrence
+    assert binding.effect.exception_type_coordinate == _identity("ValueError")
     assert binding.effect.producer_node_owner == "Compare.desugar"
 
 
@@ -674,7 +670,6 @@ def test_factored_pattern_face_binds_only_on_held_arm_not_complement():
         
         blame=occurrence,
         occurrence=occurrence,
-        exception_type_coordinate=_identity("ValueError"),
         exception_type_mro=(_identity("ValueError"),),
         raised_value=CallSiteValue(
             "ValueError",
@@ -707,7 +702,7 @@ def test_factored_pattern_face_binds_only_on_held_arm_not_complement():
     assert held_binding is not None
     assert held_binding.slot_id == "excinfo"
     assert held_binding.effect is producer
-    assert held_binding.effect.occurrence == occurrence
+    assert held_binding.effect.occurrence_id == occurrence
 
     # Complement preserves the original halt and authenticates no slot.
     assert failed.effect is producer
@@ -726,7 +721,6 @@ def test_factored_as_binding_faces_keep_distinct_guards_and_identities():
         
         blame="producer.py:1:0",
         occurrence="producer.py:1:0",
-        exception_type_coordinate=_identity("ValueError"),
         exception_type_mro=(_identity("ValueError"),),
         raised_value=CallSiteValue(
             "ValueError",
@@ -771,7 +765,6 @@ def test_factored_none_face_without_as_slot_consumes_without_binding():
         
         blame="producer.py:2:0",
         occurrence="producer.py:2:0",
-        exception_type_coordinate=_identity("ValueError"),
         exception_type_mro=(_identity("ValueError"),),
         raised_value=CallSiteValue(
             "ValueError",

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
@@ -179,10 +179,9 @@ def test_and_exit_never_suppresses_restores_body_halt():
 def test_and_exit_proven_contract_consumes_named_halt():
     from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
 
-    coordinate, mro = _builtin_exception_identity("ValueError")
+    _, mro = _builtin_exception_identity("ValueError")
     body = RaiseEffect.for_builtin("ValueError",
         
-        exception_type_coordinate=coordinate,
         exception_type_mro=mro,
         occurrence="exit_set.py:2:0",
     )
@@ -218,10 +217,9 @@ def test_and_exit_proven_contract_suppresses_only_matching_face():
     from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
 
     condition = _guard("condition")
-    coordinate, mro = _builtin_exception_identity("ValueError")
+    _, mro = _builtin_exception_identity("ValueError")
     effect = RaiseEffect.for_builtin("ValueError",
         
-        exception_type_coordinate=coordinate,
         exception_type_mro=mro,
         occurrence="exit_set.py:3:0",
     )
@@ -236,10 +234,9 @@ def test_and_exit_proven_contract_suppresses_only_matching_face():
 def test_and_exit_membrane_suppresses_matcher_authority():
     from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
 
-    coordinate, mro = _builtin_exception_identity("KeyError")
+    _, mro = _builtin_exception_identity("KeyError")
     body = RaiseEffect.for_builtin("KeyError",
         
-        exception_type_coordinate=coordinate,
         exception_type_mro=mro,
         occurrence="exit_set.py:1:0",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_stop_iteration_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_stop_iteration_coordinate.py
@@ -8,6 +8,7 @@ exhaustion. Missing coordinate is SugarNotWritten — never a name fallback.
 from __future__ import annotations
 
 from dataclasses import replace
+from types import SimpleNamespace
 
 import pytest
 
@@ -29,11 +30,11 @@ def test_truthful_stop_iteration_coordinate_is_exhaustion() -> None:
     identity, mro = _stop_identity()
     effect = RaiseEffect.for_builtin("StopIteration",
         
-        exception_type_coordinate=identity,
         exception_type_mro=mro,
         occurrence="loop.py:1:0",
         producer_node_owner="project_next",
     )
+    assert effect.exception_type_coordinate == identity
     assert _is_authenticated_stop_iteration(effect) is True
 
 
@@ -41,7 +42,6 @@ def test_lying_twin_same_spelling_foreign_coordinate_is_not_exhaustion() -> None
     identity, mro = _stop_identity()
     truthful = RaiseEffect.for_builtin("StopIteration",
         
-        exception_type_coordinate=identity,
         exception_type_mro=mro,
         occurrence="loop.py:1:0",
     )
@@ -60,10 +60,9 @@ def test_lying_twin_same_spelling_foreign_coordinate_is_not_exhaustion() -> None
 
 
 def test_missing_coordinate_throws_named_not_name_fallback() -> None:
-    effect = RaiseEffect.for_builtin("StopIteration",
-        
+    effect = SimpleNamespace(
+        exception_name="StopIteration",
         exception_type_coordinate=None,
-        occurrence="loop.py:2:0",
     )
     with pytest.raises(SugarNotWritten) as caught:
         _is_authenticated_stop_iteration(effect)

--- a/implementations/python/sugar-lift-py-tests/tests/test_method_raise_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_method_raise_transport.py
@@ -393,7 +393,6 @@ def test_wrong_exception_observation_is_not_the_method_effect() -> None:
         
         blame="foreign.py:1:0",
         occurrence="foreign.py:1:0",
-        exception_type_coordinate=_identity("ValueError"),
         exception_type_mro=(_identity("ValueError"),),
     )
     with pytest.raises(AssertionError):

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
@@ -178,15 +178,13 @@ def test_a_real_value_term_still_retains_the_question() -> None:
 
 def test_matching_halt_without_message_operand_retains_message_obligation() -> None:
     """Truthful twin: the raised VALUE exists, but its rendered message is open."""
-    identity = TermValue(1).to_term(owner="exception identity")
     raised_value = TermValue(7)
     effect = RaiseEffect.for_builtin("ValueError",
         
-        exception_type_coordinate=identity,
         occurrence=OCCURRENCE,
         raised_value=raised_value,
     )
-    expected = _AuthenticatedHandler(identity)
+    expected = _AuthenticatedHandler(effect.exception_type_coordinate)
 
     verdict = raise_effect_message_verdict(
         effect, expected, StringValue("boom")
@@ -202,24 +200,24 @@ def test_matching_halt_without_message_operand_retains_message_obligation() -> N
 
 def test_valueless_halt_cannot_use_occurrence_as_message_evidence() -> None:
     """Lying twin: a source coordinate is not a rendered-message operand."""
-    identity = TermValue(1).to_term(owner="exception identity")
     effect = RaiseEffect.for_builtin("ValueError",
         
-        exception_type_coordinate=identity,
         occurrence=OCCURRENCE,
         raised_value=None,
     )
-    expected = _AuthenticatedHandler(identity)
+    expected = _AuthenticatedHandler(effect.exception_type_coordinate)
 
     with pytest.raises(SugarNotWritten) as raised:
         raise_effect_message_verdict(effect, expected, StringValue("boom"))
 
     assert raised.value.owner == "authenticated_exception_matching._message_term"
-    assert OCCURRENCE not in str(raised.value)
+    assert str(raised.value.blame) == OCCURRENCE
+    assert OCCURRENCE not in raised.value.observed
+    assert OCCURRENCE not in raised.value.requested
+    assert OCCURRENCE not in raised.value.fix
 
 
 def _effect_with_message(message: str) -> tuple[RaiseEffect, _AuthenticatedHandler]:
-    identity = TermValue(1).to_term(owner="exception identity")
     raised_value = CallSiteValue(
         "ValueError",
         (StringValue(message),),
@@ -227,15 +225,12 @@ def _effect_with_message(message: str) -> tuple[RaiseEffect, _AuthenticatedHandl
         ctor("call:ValueError", []),
         None,
     )
-    return (
-        RaiseEffect.for_builtin("ValueError",
-            
-            exception_type_coordinate=identity,
-            occurrence=OCCURRENCE,
-            raised_value=raised_value,
-        ),
-        _AuthenticatedHandler(identity),
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence=OCCURRENCE,
+        raised_value=raised_value,
     )
+    return effect, _AuthenticatedHandler(effect.exception_type_coordinate)
 
 
 def test_written_empty_message_regex_is_not_an_absent_predicate() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
@@ -250,7 +250,6 @@ def _no_warning_from_exitset(body_es):
 
 def _raise_with_entries(*entries):
     """Exception edge: body statements then a real RaiseEffect halt."""
-    type_identity = _identity("TypeError")
     raised_value = CallSiteValue(
         target_name="raised",
         arg_values=(StringValue("operand failed"),),
@@ -269,7 +268,6 @@ def _raise_with_entries(*entries):
                 true_guard(),
                 RaiseEffect.for_builtin("TypeError",
                     
-                    exception_type_coordinate=type_identity,
                     occurrence="body.py:3:4",
                     raised_value=raised_value,
                 ),
@@ -424,7 +422,6 @@ def _pattern_boundary(*, semantics, expected, pattern, body):
 
 
 def _raise_after_warning(*, warning_message="deprecated operand"):
-    type_identity = _identity("TypeError")
     raised_value = CallSiteValue(
         target_name="renamed_error",
         arg_values=(StringValue("unsupported operand type for &:"),),
@@ -451,7 +448,6 @@ def _raise_after_warning(*, warning_message="deprecated operand"):
                 true_guard(),
                 RaiseEffect.for_builtin("TypeError",
                     
-                    exception_type_coordinate=type_identity,
                     occurrence="renamed.py:6:8",
                     raised_value=raised_value,
                 ),

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -659,12 +659,11 @@ def test_lying_the_equivalence_is_specific_to_never_suppresses():
     from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
 
     exit_es = ExitSet((Completed(true_guard(), _FloorValue("exited")),))
-    coordinate, mro = _builtin_exception_identity("ValueError")
+    _, mro = _builtin_exception_identity("ValueError")
     halted = Halted(
         true_guard(),
         RaiseEffect.for_builtin("ValueError",
             
-            exception_type_coordinate=coordinate,
             exception_type_mro=mro,
             occurrence="equiv.py:1:0",
         ),

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
@@ -136,7 +136,7 @@ def test_summary_suppresses_disposition_consumes_matching_body_halt():
         semantics=SimpleNamespace(exit=SimpleNamespace(disposition=disposition))
     )
     protocol = _CompletedProtocol()
-    coordinate, mro = _builtin_exception_identity("ValueError")
+    _, mro = _builtin_exception_identity("ValueError")
     sugar = _source_resource(
         manager=_FixedSugar(Complete(TermValue(1))),
         protocol=protocol,
@@ -147,7 +147,6 @@ def test_summary_suppresses_disposition_consumes_matching_body_halt():
                     RaiseEffect.for_builtin("ValueError",
                         
                         occurrence="resource.py:4:8",
-                        exception_type_coordinate=coordinate,
                         exception_type_mro=mro,
                     )
                 )

--- a/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
@@ -723,10 +723,8 @@ def _raise_effect_with_message(message: str):
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
     from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
     from sugar_lift_py_tests.floor.string_value import StringValue
-    from sugar_lift_py_tests.floor.term_value import TermValue
     from sugar_lift_py_tests.ir import ctor
 
-    identity = TermValue(1).to_term(owner="match-pattern-identity")
     raised = CallSiteValue(
         "ValueError",
         (StringValue(message),),
@@ -735,19 +733,17 @@ def _raise_effect_with_message(message: str):
         None,
     )
 
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence=f"{message}@match-pattern",
+        raised_value=raised,
+    )
+
     class _Handler:
         def exception_type_identity(self):
-            return identity
+            return effect.exception_type_coordinate
 
-    return (
-        RaiseEffect.for_builtin("ValueError",
-            
-            exception_type_coordinate=identity,
-            occurrence=f"{message}@match-pattern",
-            raised_value=raised,
-        ),
-        _Handler(),
-    )
+    return effect, _Handler()
 
 
 @pytest.mark.parametrize(

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1909,12 +1909,16 @@ def test_factored_raise_routing_uses_none_and_pattern_message_faces():
 
     # Disposition law: None-pattern matcher has no message obligation; pattern
     # face carries the projected formal as message_pattern.
-    type_term = ctor("python:exception_type", [str_const("builtins.ValueError")])
+    type_term = ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const("ValueError")],
+    )
     raise_face = Halted(
         true_guard(),
-        RaiseEffect.for_builtin('ValueError', blame='t.py:2:8', exception_type_coordinate=type_term, exception_type_mro=(type_term,), raised_value=StringValue('needle'), occurrence='t.py:2:8'),
+        RaiseEffect.for_builtin('ValueError', blame='t.py:2:8', exception_type_mro=(type_term,), raised_value=StringValue('needle'), occurrence='t.py:2:8'),
         None,
     )
+    assert raise_face.effect.exception_type_coordinate == type_term
     body = ExitSet((raise_face,))
     for guard, semantics in guarded:
         pattern = None


### PR DESCRIPTION
## What changed

- Updated all 21 stale `RaiseEffect.for_builtin(...)` callers to stop passing the retired `exception_type_coordinate=` keyword.
- Kept builtin exception identity single-owned by `for_builtin`; `raise_effect.py` and the production API are unchanged.
- Rebound noncanonical test fixtures (`TermValue(1)` and `python:exception_type`) to the minted `python:exception_type_identity`, with explicit assertions on the minted coordinate.
- Kept the missing-coordinate lying twin meaningful by presenting a duck-typed incomplete face; `for_builtin` itself makes that illegal state unconstructable.
- Tightened the message-evidence twin so the authenticated source locus must appear as panic blame but cannot impersonate the rendered-message subject.

## Why

Commit `8a3ceb2c` (#6965), diffed against its real parent `ac7a96a84`, introduced the API already narrowed: language-owned builtin identity is minted from `exception_name` instead of accepted from callers. The same change migrated tests to `for_builtin` while leaving 21 call sites passing `exception_type_coordinate=`, producing 492 `TypeError` failures that masked the product's real construction state.

This is caller drift, not a product capability regression. Restoring the keyword would let tests and callers spell arbitrary type identities, creating a second authority beside the builtin identity minted by the constructor. It is the second large suite mask found today; the other was the missing `AuthenticatedRaiseLocus` import worth 664 failures.

Historical correction: the earlier PR body attributed the narrowing to `df07b3f88` (#6971) based on blame from a shallow boundary. After fetching its actual parent `42fede699`, the real `42fede699..df07b3f88` diff is 12 files and does not touch `raise_effect.py`; that attribution was wrong.

## Instrument and floors

- `R_stale_for_builtin_coordinate_callers`: `21 -> 0` by AST inspection over `implementations/python/**/*.py`.
- Deleted shell: caller-supplied builtin type identity at the `for_builtin` entrance.
- Floors preserved: authenticated occurrence remains required; builtin type identity remains minted; no taxonomy, compatibility parameter, fallback, or production behavior was added.

## Validation

- Battleaxe, authenticated CPython 3.12.13 / pandas 3.0.3 environment: exact migrated-behavior subset, `30 passed in 1.23s`, unpiped exit `0`.
- Wider exact selection: `30 passed, 3 failed in 1.85s`, unpiped exit `1`; the three survivors passed the repaired constructor and were reattributed to separate pre-existing axes:
  - missing `AuthenticatedRaiseLocus` import in an untouched helper;
  - `_CompletedProtocol.enter_resource_outcome_for` API drift;
  - `OpaqueOpCallsite` versus `CallSiteValue` pattern-shape drift.
- `git diff --check` clean.

This PR does not claim the full pandas product receipt; that remote receipt follows after this repair lands on `main`.
