### PR TITLE
Evaluate chained Compare operands once

### DIFF
--- a/docs/superpowers/plans/2026-08-02-chained-compare-evaluate-once.md
+++ b/docs/superpowers/plans/2026-08-02-chained-compare-evaluate-once.md
@@ -26,7 +26,9 @@
 
 **Interfaces:**
 - Consumes: production `Compare.sugar()` result with ordered `.values` leg sugars.
-- Produces: a count tooth and a semantic-effect tooth that both fail on the current BoolOp-of-pairs reduction.
+- Produces: exact-count, left-to-right, short-circuit, per-leg-ownership, and
+  semantic-effect teeth. The count, order, and semantic-effect assertions fail
+  on the current BoolOp-of-pairs reduction.
 
 - [ ] **Step 1: Write the shared-middle probe and production-chain fixture**
 
@@ -55,7 +57,14 @@ The production mutation caught is removal of the carried reduced-right value: th
 
 Use a `_ChangingMiddleSugar` that returns `TermValue(1)` on its first desugar and `TermValue(2)` on its second. Assert `0 < middle() < 2` returns `TrueBoolLiteralSugar`; the broken implementation returns false because its second leg observes `2 < 2`.
 
-- [ ] **Step 4: Run the focused file and verify RED**
+- [ ] **Step 4: Write order, short-circuit, and ownership regressions**
+
+Wrap all three operand sugars with labeled recording sugars. Assert the true
+chain trace is exactly `left, middle, right`; assert a false first leg records
+only `left, middle`; and assert a mixed `<` then `==` chain retains
+`ComparisonOpSugar` then `EqualityOpSugar` legs.
+
+- [ ] **Step 5: Run the focused file and verify RED**
 
 Run:
 
@@ -63,9 +72,11 @@ Run:
 PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src /usr/local/opt/python@3.12/bin/python3.12 -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_chained_compare_evaluate_once.py
 ```
 
-Expected: two assertion failures for count `2` and false semantic result, with successful collection.
+Expected: three assertion failures for count `2`, the duplicated-middle order
+trace, and the false semantic result, with all five tests collected. The
+short-circuit and ownership floors already pass.
 
-- [ ] **Step 5: Commit the red teeth**
+- [ ] **Step 6: Commit the red teeth**
 
 ```bash
 git add implementations/python/sugar-lift-py-tests/tests/test_chained_compare_evaluate_once.py

--- a/docs/superpowers/plans/2026-08-02-chained-compare-evaluate-once.md
+++ b/docs/superpowers/plans/2026-08-02-chained-compare-evaluate-once.md
@@ -128,7 +128,7 @@ return ChainedCompareSugar(values=pairs, site=self.fragment)
 
 - [ ] **Step 5: Run the new focused teeth and verify GREEN**
 
-Run the exact Task 1 pytest command. Expected: `2 passed`.
+Run the exact Task 1 pytest command. Expected: `5 passed`.
 
 - [ ] **Step 6: Run focused existing BoolOp/Compare floors**
 
@@ -139,6 +139,10 @@ PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python
 ```
 
 Expected: all collected focused tests pass with no collection loss.
+
+If `test_bool_op_operand_sequence.py` refuses its legacy `_ProbeSugar` because
+it is not `ConstructedTermSugar`, report that separately as the announced
+current-main API drift; do not weaken the codomain or repair it in this lane.
 
 - [ ] **Step 7: Commit the implementation**
 

--- a/docs/superpowers/plans/2026-08-02-chained-compare-evaluate-once.md
+++ b/docs/superpowers/plans/2026-08-02-chained-compare-evaluate-once.md
@@ -1,0 +1,165 @@
+# Chained Compare Evaluate-Once Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make multi-operand Python Compare evaluate every source operand at most once while preserving short-circuiting and each existing per-leg law.
+
+**Architecture:** `Compare` constructs `ChainedCompareSugar` only when it has more than one operator. The chain evaluates each next operand once, carries its reduced value into the following leg, asks the existing leg sugar to apply its law to reduced operands, and delegates non-final truth selection to the BoolOp short-circuit helper.
+
+**Tech Stack:** Python 3.12, dataclasses, pytest, Sugar source tree and ExitSet outcome algebra.
+
+## Global Constraints
+
+- Work only in `/Users/tsavo/.herdr/worktrees/provekit/hockney-work` on `hockney/work`.
+- `Compare._construct_sugar` is the only source-construction door for chained comparisons.
+- Do not add categories, kinds, labels, global desugar caching, fabricated bindings, or per-call-site patches.
+- Preserve existing per-leg equality, ordering, membership, identity, occurrence, and exceptional-exit owners.
+- Run only focused local pytest teeth; do not run pandas walks, corpus scans, profiles, or broad pytest locally.
+- Kujan merges; Hockney pushes the branch and never merges it.
+
+---
+
+### Task 1: Add falsifiable evaluate-once teeth
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/tests/test_chained_compare_evaluate_once.py`
+
+**Interfaces:**
+- Consumes: production `Compare.sugar()` result with ordered `.values` leg sugars.
+- Produces: a count tooth and a semantic-effect tooth that both fail on the current BoolOp-of-pairs reduction.
+
+- [ ] **Step 1: Write the shared-middle probe and production-chain fixture**
+
+Use `SourceFile` to construct `0 < 1 < 2`, obtain its production Compare sugar, wrap the one shared middle sugar, and replace both adjacent leg references with that same wrapper:
+
+```python
+compare = next(node for node in tree.nodes() if isinstance(node, Compare))
+chain = compare.sugar()
+middle = _ProbeSugar(chain.values[0].right, evaluations)
+first = replace(chain.values[0], right=middle)
+second = replace(chain.values[1], left=middle)
+instrumented = replace(chain, values=(first, second))
+```
+
+- [ ] **Step 2: Write the exact-count regression**
+
+```python
+outcome = instrumented.desugar(None)
+assert isinstance(outcome, Complete)
+assert evaluations == [1]
+```
+
+The production mutation caught is removal of the carried reduced-right value: the broken implementation appends twice.
+
+- [ ] **Step 3: Write the observable semantic-effect regression**
+
+Use a `_ChangingMiddleSugar` that returns `TermValue(1)` on its first desugar and `TermValue(2)` on its second. Assert `0 < middle() < 2` returns `TrueBoolLiteralSugar`; the broken implementation returns false because its second leg observes `2 < 2`.
+
+- [ ] **Step 4: Run the focused file and verify RED**
+
+Run:
+
+```bash
+PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src /usr/local/opt/python@3.12/bin/python3.12 -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_chained_compare_evaluate_once.py
+```
+
+Expected: two assertion failures for count `2` and false semantic result, with successful collection.
+
+- [ ] **Step 5: Commit the red teeth**
+
+```bash
+git add implementations/python/sugar-lift-py-tests/tests/test_chained_compare_evaluate_once.py
+git commit -m "Test chained Compare middle evaluation once"
+```
+
+### Task 2: Route chained Compare through one evaluate-once sugar
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/chained_compare_sugar.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py`
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py`
+- Modify: `implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py`
+
+**Interfaces:**
+- Consumes: adjacent `ComparisonOpSugar`/`EqualityOpSugar` legs with shared child sugar identity.
+- Produces: `apply_reduced(left, right, ctx)` on each leg owner, a shared BoolOp truth-selection helper, and `ChainedCompareSugar(values, site)`.
+
+- [ ] **Step 1: Extract BoolOp's existing truth-selection law**
+
+Move the current formal-carrier truth dispatch, exact stopping operand return,
+continuing callback, and undecided partition into the module-private function
+`select_boolop_operand(value, *, op_kind, site, index, on_continue)`.
+
+Keep `BoolOpSugar.desugar` behavior unchanged by calling the helper from its existing left-to-right fold.
+
+- [ ] **Step 2: Let each comparison leg apply its law to reduced operands**
+
+Add `apply_reduced(left, right, ctx)` to both existing leg types. `ComparisonOpSugar.desugar` evaluates its children and delegates to that method; `EqualityOpSugar.desugar` does the same. The new methods retain the current receiver projection, refinement coordinate, carrier, floor dispatch, and exceptional-exit code.
+
+- [ ] **Step 3: Implement `ChainedCompareSugar`**
+
+Evaluate `values[0].left` once. For each leg, evaluate `leg.right` once, call
+`leg.apply_reduced(carried_left, right, ctx)`, return the final leg result raw,
+and for non-final legs call `select_boolop_operand` with that comparison value,
+`op_kind="And"`, the chain site, the leg index, and
+`on_continue=lambda: reduce_from(index + 1, right)`. Delegate `to_term` to the
+existing BoolOp-of-leg-pairs construction testimony so canonical testimony
+does not drift.
+
+- [ ] **Step 4: Wire the production Compare door**
+
+Keep single-leg behavior unchanged. Replace only the multi-leg return in `Compare._construct_sugar`:
+
+```python
+return ChainedCompareSugar(values=pairs, site=self.fragment)
+```
+
+- [ ] **Step 5: Run the new focused teeth and verify GREEN**
+
+Run the exact Task 1 pytest command. Expected: `2 passed`.
+
+- [ ] **Step 6: Run focused existing BoolOp/Compare floors**
+
+Run:
+
+```bash
+PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-source-tree/src:implementations/python/sugar-lift-python-source/src /usr/local/opt/python@3.12/bin/python3.12 -m pytest -q implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py implementations/python/sugar-lift-py-tests/tests/test_boolop_middle_leg_control.py implementations/python/sugar-lift-py-tests/tests/test_chained_compare_production_instrument.py
+```
+
+Expected: all collected focused tests pass with no collection loss.
+
+- [ ] **Step 7: Commit the implementation**
+
+```bash
+git add implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/chained_compare_sugar.py implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+git commit -m "Evaluate chained Compare operands once"
+```
+
+### Task 3: Verify and hand off without merging
+
+**Files:**
+- Modify: none.
+
+**Interfaces:**
+- Consumes: committed focused fix.
+- Produces: exact focused receipts, pushed `hockney/work`, and a Keyser handoff naming what is and is not measured.
+
+- [ ] **Step 1: Run formatting and static diff checks**
+
+Run `git diff --check HEAD~2..HEAD`. The repository has no mandatory Python
+formatter hook for these files, so do not introduce a formatting-only rewrite.
+
+- [ ] **Step 2: Re-run both focused pytest commands from Task 2**
+
+Record the discovered/passed counts and exit codes. Do not quote a corpus or product delta.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin hockney/work
+```
+
+- [ ] **Step 4: Notify Keyser with two enters**
+
+Report branch `hockney/work`, exact focused counts on `HEAD`, the original `2 -> 1` middle-evaluation correction, and explicitly state that no pandas corpus delta or broad suite result is claimed.

--- a/docs/superpowers/specs/2026-08-02-chained-compare-evaluate-once-design.md
+++ b/docs/superpowers/specs/2026-08-02-chained-compare-evaluate-once-design.md
@@ -57,7 +57,13 @@ replaces the shared middle child with a falsifiable probe.
 
 1. Exact-count tooth: `middle_desugar_count == 1`. Removing the carry-forward
    behavior makes this fail with `2` even though the outcome remains Complete.
-2. Semantic-effect tooth: the middle probe returns `1` on its first evaluation
+2. Left-to-right tooth: the complete evaluation trace is exactly
+   `left, middle, right`, with no duplicated or reordered operand.
+3. Short-circuit tooth: a false first leg evaluates `left, middle` and never
+   evaluates the later right operand.
+4. Per-leg ownership tooth: mixed chains retain their ordered
+   `ComparisonOpSugar` and `EqualityOpSugar` owners.
+5. Semantic-effect tooth: the middle probe returns `1` on its first evaluation
    and `2` on its second. `0 < middle() < 2` must be true. The broken double
    evaluation makes the second leg `2 < 2` and produces false.
 

--- a/docs/superpowers/specs/2026-08-02-chained-compare-evaluate-once-design.md
+++ b/docs/superpowers/specs/2026-08-02-chained-compare-evaluate-once-design.md
@@ -1,0 +1,66 @@
+# Chained Compare Evaluate-Once Design
+
+## Goal
+
+Make Python chained comparisons preserve source evaluation semantics: in
+`a < b < c`, evaluate `b` exactly once, reuse that reduced value as the right
+operand of the first leg and the left operand of the second leg, and evaluate
+`c` only when the first comparison continues.
+
+## Proven defect
+
+At `84b104f06`, `Compare._construct_sugar` constructs adjacent comparison
+sugars and wraps them in `BoolOpSugar("And", ...)`. Each comparison desugars
+both of its operands independently, so the shared middle sugar is desugared
+twice. A focused probe measured `middle_desugar_count=2` while the overall
+outcome was `Complete`. This is a silent correctness defect, not a missing
+construct.
+
+## Architecture
+
+`Compare._construct_sugar` remains the only source-construction door. A
+single-operator `Compare` continues to return its existing
+`EqualityOpSugar` or `ComparisonOpSugar`. A multi-operator `Compare` returns
+`ChainedCompareSugar`, holding the same ordered per-leg sugars and exact
+per-leg source occurrences already constructed today.
+
+`ChainedCompareSugar.desugar` evaluates the first operand once, then evaluates
+each next operand once only when that leg is reached. It passes the reduced
+right value forward as the next leg's reduced left value. Each existing leg
+owner gains a narrow `apply_reduced(left, right, ctx)` entry so chaining reuses
+its equality, ordering, membership, identity, exceptional-exit, and refinement
+law without redispatching on operator kind.
+
+The non-final comparison result is routed through the same operand-selecting
+truth helper as `BoolOpSugar("And", ...)`. A stopping face returns that exact
+comparison result; only a continuing face evaluates the next operand. The
+final comparison result is returned without truth coercion, matching Python's
+`and`-equivalent result rule.
+
+Canonical construction testimony remains compatible with the existing
+BoolOp-of-leg-pairs term. The change corrects reduction order and does not add
+a new taxonomy, result category, label, cache, or fabricated binding.
+
+## Rejected alternatives
+
+- Global `Sugar.desugar` caching would change evaluation semantics for every
+  sugar to repair one source construct.
+- A synthesized temporary binding would invent source identity absent from the
+  authenticated Python source.
+- Teaching `BoolOpSugar` to recognize comparison species would make a caller
+  interrogate operand kinds and move Compare ownership into the wrong door.
+
+## Teeth
+
+The regression test uses the production `Compare` construction door and
+replaces the shared middle child with a falsifiable probe.
+
+1. Exact-count tooth: `middle_desugar_count == 1`. Removing the carry-forward
+   behavior makes this fail with `2` even though the outcome remains Complete.
+2. Semantic-effect tooth: the middle probe returns `1` on its first evaluation
+   and `2` on its second. `0 < middle() < 2` must be true. The broken double
+   evaluation makes the second leg `2 < 2` and produces false.
+
+Existing focused BoolOp and chained-Compare tests remain the discrimination
+floor for short-circuiting, exact selected operands, per-leg occurrences,
+mixed comparison laws, and authenticated exceptional exits.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -61,6 +61,97 @@ def refuse_undecided_boolean_truth(value, site, op_kind: str) -> None:
     )
 
 
+def select_boolop_operand(
+    value,
+    *,
+    op_kind: str,
+    site,
+    index: int,
+    on_continue,
+):
+    """Truth-test one already-evaluated operand and select its Python face."""
+    from sugar_lift_py_tests.outcome import Complete, ExitSet, outcome_to_exitset
+    from sugar_lift_py_tests.outcome.exit_set import (
+        complement_guard,
+        false_guard,
+        partition,
+        true_guard,
+    )
+
+    stop_formula = false_guard() if op_kind == "And" else true_guard()
+    continue_formula = true_guard() if op_kind == "And" else false_guard()
+
+    def truth_formula(truth_value):
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
+            FalseBoolLiteralSugar,
+        )
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        if isinstance(truth_value, TrueBoolLiteralSugar):
+            return true_guard()
+        if isinstance(truth_value, FalseBoolLiteralSugar):
+            return false_guard()
+        if isinstance(truth_value, PredicateValue):
+            return truth_value.formula
+
+        from sugar_lift_py_tests.gap.info import GapKind, GapLocus
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="BoolOpSugar.truth_formula",
+            blame=site,
+            observed=type(truth_value).__name__,
+            requested="a truth-floor boolean or PredicateValue",
+            fix=(
+                "make the selected operand's truth floor return its native "
+                "truth value without re-evaluating the operand"
+            ),
+            gap_kind=GapKind.FLOOR,
+            gap_locus=GapLocus.CONSTRUCTION,
+        )
+
+    def continue_from(selected_operand, formula):
+        if formula == stop_formula:
+            return Complete(selected_operand)
+        if formula == continue_formula:
+            return on_continue()
+
+        rhs_guard = formula if op_kind == "And" else complement_guard(formula)
+        rhs_face, stop_face = partition(
+            ("BoolOpSugar", str(site), index, op_kind)
+        )
+        rhs = outcome_to_exitset(on_continue()).guarded(rhs_guard, rhs_face)
+        stopped = ExitSet.completed(
+            selected_operand, complement_guard(rhs_guard)
+        ).guarded(true_guard(), stop_face)
+        return rhs.union(stopped)
+
+    formal_coordinate = getattr(value, "formal_coordinate", None)
+    if formal_coordinate is not None:
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            NativeOperationExitCarrierV1,
+        )
+
+        tested = NativeOperationExitCarrierV1.mint(
+            site=site,
+            operator="boolop_truth",
+            operands=(value,),
+            coordinates=(formal_coordinate,),
+        )
+    else:
+        refuse_undecided_boolean_truth(value, site, op_kind)
+        tested = value.boolop_truth(site)
+
+    return tested.and_then(
+        lambda selection: continue_from(
+            selection.operand, truth_formula(selection.truth_value)
+        )
+    )
+
+
 @dataclass(frozen=True)
 class BoolOpSugar(ConstructedTermSugar):
     op_kind: str  # "And" | "Or"
@@ -110,49 +201,7 @@ class BoolOpSugar(ConstructedTermSugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        from sugar_lift_py_tests.outcome import Complete, ExitSet, outcome_to_exitset
-        from sugar_lift_py_tests.outcome.exit_set import (
-            complement_guard,
-            factored_operand,
-            false_guard,
-            partition,
-            true_guard,
-        )
-
-        stop_formula = false_guard() if self.op_kind == "And" else true_guard()
-        continue_formula = true_guard() if self.op_kind == "And" else false_guard()
-
-        def truth_formula(truth_value):
-            from sugar_lift_py_tests.floor.predicate_value import PredicateValue
-            from sugar_lift_py_tests.sugar.false_bool_literal_sugar import (
-                FalseBoolLiteralSugar,
-            )
-            from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
-                TrueBoolLiteralSugar,
-            )
-
-            if isinstance(truth_value, TrueBoolLiteralSugar):
-                return true_guard()
-            if isinstance(truth_value, FalseBoolLiteralSugar):
-                return false_guard()
-            if isinstance(truth_value, PredicateValue):
-                return truth_value.formula
-
-            from sugar_lift_py_tests.gap.info import GapKind, GapLocus
-            from sugar_lift_py_tests.gap.panic import construction_panic_gap
-
-            construction_panic_gap(
-                owner="BoolOpSugar.truth_formula",
-                blame=self.site,
-                observed=type(truth_value).__name__,
-                requested="a truth-floor boolean or PredicateValue",
-                fix=(
-                    "make the selected operand's truth floor return its native "
-                    "truth value without re-evaluating the operand"
-                ),
-                gap_kind=GapKind.FLOOR,
-                gap_locus=GapLocus.CONSTRUCTION,
-            )
+        from sugar_lift_py_tests.outcome.exit_set import factored_operand
 
         def reduce_from(index: int):
             operand = self.values[index]
@@ -161,53 +210,14 @@ class BoolOpSugar(ConstructedTermSugar):
             if index == len(self.values) - 1:
                 return factored_operand(operand.desugar(ctx))
 
-            def project_truth(value):
-                formal_coordinate = getattr(value, "formal_coordinate", None)
-                if formal_coordinate is not None:
-                    from sugar_lift_py_tests.caller_parameter_contract import (
-                        NativeOperationExitCarrierV1,
-                    )
-
-                    tested = NativeOperationExitCarrierV1.mint(
-                        site=self.site,
-                        operator="boolop_truth",
-                        operands=(value,),
-                        coordinates=(formal_coordinate,),
-                    )
-                else:
-                    refuse_undecided_boolean_truth(value, self.site, self.op_kind)
-                    tested = value.boolop_truth(self.site)
-
-                return tested.and_then(
-                    lambda selection: continue_from(
-                        selection.operand, truth_formula(selection.truth_value)
-                    )
+            return factored_operand(operand.desugar(ctx)).and_then(
+                lambda value: select_boolop_operand(
+                    value,
+                    op_kind=self.op_kind,
+                    site=self.site,
+                    index=index,
+                    on_continue=lambda: reduce_from(index + 1),
                 )
-
-            def continue_from(value, formula):
-                # A decided stopping face never evaluates the RHS at all.
-                if formula == stop_formula:
-                    return Complete(value)
-                if formula == continue_formula:
-                    return reduce_from(index + 1)
-
-                # An undecided truth result splits the sequence.  Only the
-                # continuing face evaluates the tail; the complement returns
-                # the already-evaluated operand itself.
-                rhs_guard = (
-                    formula if self.op_kind == "And" else complement_guard(formula)
-                )
-                rhs_face, stop_face = partition(
-                    ("BoolOpSugar", str(self.site), index, self.op_kind)
-                )
-                rhs = outcome_to_exitset(reduce_from(index + 1)).guarded(
-                    rhs_guard, rhs_face
-                )
-                stopped = ExitSet.completed(value, complement_guard(rhs_guard)).guarded(
-                    true_guard(), stop_face
-                )
-                return rhs.union(stopped)
-
-            return factored_operand(operand.desugar(ctx)).and_then(project_truth)
+            )
 
         return reduce_from(0)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/chained_compare_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/chained_compare_sugar.py
@@ -1,0 +1,100 @@
+"""Evaluate a multi-operand Python Compare without re-evaluating its middle."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+from typing import TYPE_CHECKING
+
+from sugar_lift_py_tests.outcome import Outcome
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+from sugar_lift_py_tests.sugar.witnesses import _boolop_wrapped_pair
+
+if TYPE_CHECKING:
+    from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
+    from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
+
+
+@dataclass(frozen=True)
+class ChainedCompareSugar(ConstructedTermSugar):
+    """Adjacent comparison legs sharing each reduced middle operand."""
+
+    values: tuple[ComparisonOpSugar | EqualityOpSugar, ...]
+    site: object = dataclass_field(compare=False)
+
+    def __post_init__(self) -> None:
+        if len(self.values) < 2:
+            self._panic(
+                observed=f"{len(self.values)} comparison legs",
+                requested="at least two ordered legs for a chained Compare",
+                fix=(
+                    "construct a single Compare leg directly; reserve "
+                    "ChainedCompareSugar for len(ops) > 1"
+                ),
+            )
+        for index, (left_leg, right_leg) in enumerate(
+            zip(self.values, self.values[1:])
+        ):
+            if left_leg.right is not right_leg.left:
+                self._panic(
+                    observed=f"legs {index} and {index + 1} do not share one middle sugar",
+                    requested="adjacent Compare legs sharing the same constructed middle operand",
+                    fix=(
+                        "construct all adjacent legs once at "
+                        "Compare._construct_sugar and preserve operand identity"
+                    ),
+                )
+
+    def _panic(self, *, observed: str, requested: str, fix: str) -> None:
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
+        construction_panic_gap(
+            owner="ChainedCompareSugar",
+            blame=self.site,
+            observed=observed,
+            requested=requested,
+            fix=fix,
+        )
+
+    @classmethod
+    def witnesses(cls):
+        return _boolop_wrapped_pair(
+            name="chained_compare",
+            owner_sugar="ChainedCompareSugar",
+            truthful="1 < 2 < 3",
+            lying="3 < 2 < 1",
+        )
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
+
+        return BoolOpSugar("And", self.values, self.site).to_term(owner=owner)
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.outcome.exit_set import factored_operand
+
+        first = self.values[0]
+        return factored_operand(first.left.desugar(ctx)).and_then(
+            lambda left: self._reduce_from(0, left, ctx)
+        )
+
+    def _reduce_from(self, index: int, left, ctx: object) -> Outcome:
+        from sugar_lift_py_tests.outcome.exit_set import factored_operand
+        from sugar_lift_py_tests.sugar.bool_op_sugar import select_boolop_operand
+
+        leg = self.values[index]
+
+        def apply(right):
+            compared = factored_operand(leg.apply_reduced(left, right, ctx))
+            if index == len(self.values) - 1:
+                return compared
+            return compared.and_then(
+                lambda value: select_boolop_operand(
+                    value,
+                    op_kind="And",
+                    site=self.site,
+                    index=index,
+                    on_continue=lambda: self._reduce_from(index + 1, right, ctx),
+                )
+            )
+
+        return factored_operand(leg.right.desugar(ctx)).and_then(apply)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -15,7 +15,7 @@ Compare construction is partitioned by law — not one monomorphic refusal:
 - **equality** (`==` / `!=`): ``__eq__`` / ``__ne__`` may complete or raise
 - **identity** (`is` / `is not`): total object identity; never user-code dispatch
 - **chaining** (`a < b < c`): pair laws composed under short-circuit ``And`` at
-  ``Compare._construct_sugar`` (BoolOpSugar over adjacent pair sugars)
+  ``Compare._construct_sugar`` (ChainedCompareSugar carrying adjacent values)
 """
 
 from __future__ import annotations
@@ -320,18 +320,22 @@ class ComparisonOpSugar(ConstructedTermSugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        left = self.left.desugar(ctx)
-        right = lambda l: self.right.desugar(ctx).and_then(  # noqa: E731
-            lambda r: self._apply(
-                l.project_operation_receiver(
-                    ctx, owner="ComparisonOpSugar left operation receiver"
-                ),
-                r.project_operation_receiver(
-                    ctx, owner="ComparisonOpSugar right operation receiver"
-                ),
+        return self.left.desugar(ctx).and_then(
+            lambda left: self.right.desugar(ctx).and_then(
+                lambda right: self.apply_reduced(left, right, ctx)
             )
         )
-        return left.and_then(right)
+
+    def apply_reduced(self, left, right, ctx: object = None) -> Outcome:
+        """Apply this leg's existing law to operands already evaluated once."""
+        return self._apply(
+            left.project_operation_receiver(
+                ctx, owner="ComparisonOpSugar left operation receiver"
+            ),
+            right.project_operation_receiver(
+                ctx, owner="ComparisonOpSugar right operation receiver"
+            ),
+        )
 
     def _membership(self, container, item):
         """Membership law: container owns containment; undecided dispatch dual-edges."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
@@ -72,10 +72,14 @@ class EqualityOpSugar(ConstructedTermSugar):
         # whether it equals the right. That is all `==` desugars to.
         return self.left.desugar(ctx).and_then(
             lambda left: self.right.desugar(ctx).and_then(
-                lambda right: _equals_and_refine(
-                    left, right, self.site, ctx, self.left_coordinate
-                )
+                lambda right: self.apply_reduced(left, right, ctx)
             )
+        )
+
+    def apply_reduced(self, left, right, ctx: object = None) -> Outcome:
+        """Apply equality/refinement to operands already evaluated once."""
+        return _equals_and_refine(
+            left, right, self.site, ctx, self.left_coordinate
         )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_chained_compare_evaluate_once.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_chained_compare_evaluate_once.py
@@ -1,0 +1,92 @@
+"""A chained Compare evaluates each source operand exactly once."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Compare
+from sugar_source_tree.tree import SourceFile
+
+
+@dataclass(frozen=True)
+class _CountingMiddleSugar(ConstructedTermSugar):
+    inner: ConstructedTermSugar
+    evaluations: list[int] = field(compare=False)
+
+    @property
+    def site(self):
+        return self.inner.site
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        self.evaluations.append(len(self.evaluations) + 1)
+        return self.inner.desugar(ctx)
+
+    def to_term(self, *, owner: str):
+        return self.inner.to_term(owner=owner)
+
+
+@dataclass(frozen=True)
+class _ChangingMiddleSugar(ConstructedTermSugar):
+    inner: ConstructedTermSugar
+    evaluations: list[int] = field(compare=False)
+
+    @property
+    def site(self):
+        return self.inner.site
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        observed = len(self.evaluations) + 1
+        self.evaluations.append(observed)
+        return Complete(TermValue(observed))
+
+    def to_term(self, *, owner: str):
+        return self.inner.to_term(owner=owner)
+
+
+def _production_chain(middle_type):
+    source = "result = 0 < 1 < 2\n"
+    tree = SourceFile(
+        (source, "chained-compare-once.py", blake3_512_of(source.encode()))
+    )
+    compare = next(node for node in tree.nodes() if isinstance(node, Compare))
+    chain = compare.sugar()
+    assert len(chain.values) == 2
+    assert chain.values[0].right is chain.values[1].left
+
+    evaluations: list[int] = []
+    middle = middle_type(chain.values[0].right, evaluations)
+    first = replace(chain.values[0], right=middle)
+    second = replace(chain.values[1], left=middle)
+    return replace(chain, values=(first, second)), evaluations
+
+
+def test_chained_compare_desugars_middle_operand_exactly_once() -> None:
+    chain, evaluations = _production_chain(_CountingMiddleSugar)
+
+    outcome = chain.desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert evaluations == [1]
+
+
+def test_second_middle_evaluation_would_change_the_comparison_result() -> None:
+    chain, _evaluations = _production_chain(_ChangingMiddleSugar)
+
+    outcome = chain.desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, TrueBoolLiteralSugar)

--- a/implementations/python/sugar-lift-py-tests/tests/test_chained_compare_evaluate_once.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_chained_compare_evaluate_once.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass, field, replace
 
 from sugar_lift_py_tests.floor import TermValue
 from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.comparison_op_sugar import ComparisonOpSugar
+from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
+from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
 from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 from sugar_lift_python_source.canonical import blake3_512_of
@@ -57,8 +60,29 @@ class _ChangingMiddleSugar(ConstructedTermSugar):
         return self.inner.to_term(owner=owner)
 
 
-def _production_chain(middle_type):
-    source = "result = 0 < 1 < 2\n"
+@dataclass(frozen=True)
+class _RecordingSugar(ConstructedTermSugar):
+    inner: ConstructedTermSugar
+    evaluations: list[str] = field(compare=False)
+    label: str
+
+    @property
+    def site(self):
+        return self.inner.site
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        self.evaluations.append(self.label)
+        return self.inner.desugar(ctx)
+
+    def to_term(self, *, owner: str):
+        return self.inner.to_term(owner=owner)
+
+
+def _chain(source: str = "result = 0 < 1 < 2\n"):
     tree = SourceFile(
         (source, "chained-compare-once.py", blake3_512_of(source.encode()))
     )
@@ -66,6 +90,11 @@ def _production_chain(middle_type):
     chain = compare.sugar()
     assert len(chain.values) == 2
     assert chain.values[0].right is chain.values[1].left
+    return chain
+
+
+def _production_chain(middle_type):
+    chain = _chain()
 
     evaluations: list[int] = []
     middle = middle_type(chain.values[0].right, evaluations)
@@ -90,3 +119,42 @@ def test_second_middle_evaluation_would_change_the_comparison_result() -> None:
 
     assert isinstance(outcome, Complete)
     assert isinstance(outcome.value, TrueBoolLiteralSugar)
+
+
+def test_chained_compare_evaluates_operands_once_in_left_to_right_order() -> None:
+    chain = _chain()
+    evaluations: list[str] = []
+    left = _RecordingSugar(chain.values[0].left, evaluations, "left")
+    middle = _RecordingSugar(chain.values[0].right, evaluations, "middle")
+    right = _RecordingSugar(chain.values[1].right, evaluations, "right")
+    first = replace(chain.values[0], left=left, right=middle)
+    second = replace(chain.values[1], left=middle, right=right)
+    instrumented = replace(chain, values=(first, second))
+
+    instrumented.desugar(None)
+
+    assert evaluations == ["left", "middle", "right"]
+
+
+def test_false_first_leg_does_not_evaluate_the_later_operand() -> None:
+    chain = _chain("result = 2 < 1 < 0\n")
+    evaluations: list[str] = []
+    left = _RecordingSugar(chain.values[0].left, evaluations, "left")
+    middle = _RecordingSugar(chain.values[0].right, evaluations, "middle")
+    right = _RecordingSugar(chain.values[1].right, evaluations, "right")
+    first = replace(chain.values[0], left=left, right=middle)
+    second = replace(chain.values[1], left=middle, right=right)
+    instrumented = replace(chain, values=(first, second))
+
+    outcome = instrumented.desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, FalseBoolLiteralSugar)
+    assert evaluations == ["left", "middle"]
+
+
+def test_chained_compare_preserves_each_leg_owner() -> None:
+    chain = _chain("result = 0 < 1 == 1\n")
+
+    assert isinstance(chain.values[0], ComparisonOpSugar)
+    assert isinstance(chain.values[1], EqualityOpSugar)

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -893,17 +893,16 @@ def test_identity_law_never_publishes_a_raise_partition(
 
 
 def test_chained_comparison_composes_pair_ordering_laws() -> None:
-    """Chaining law: ``a < b < c`` is And of pair ordering sugars.
+    """Chaining law: ``a < b < c`` carries one middle through pair owners.
 
-    Construction lives at ``Compare._construct_sugar`` (BoolOpSugar over
-    adjacent ComparisonOpSugar pairs). Undecided free names refuse named at
-    the first ordering floor — not a monomorphic chain panic and not a
+    Construction lives at ``Compare._construct_sugar`` (ChainedCompareSugar
+    over adjacent ComparisonOpSugar pairs). Undecided free names refuse named
+    at the first ordering floor — not a monomorphic chain panic and not a
     fabricated dual-edge completion.
     """
     node = _synthetic_compare("a < b < c")
     sugar = node.sugar()
-    assert type(sugar).__name__ == "BoolOpSugar"
-    assert sugar.op_kind == "And"
+    assert type(sugar).__name__ == "ChainedCompareSugar"
     assert len(sugar.values) == 2
     _assert_named_ordering_or_membership_refusal(lambda: sugar.desugar(None))
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -10278,10 +10278,8 @@ class Compare(Expression):
         """A comparison constructs its operator's sugar, built WITH its
         children's sugar. `==` is EqualityOpSugar (it also refines); the ordering
         family and `!=` are ComparisonOpSugar. A CHAINED comparison `a < b < c`
-        is `(a < b) and (b < c)` -- each adjacent pair becomes its own comparison
-        sugar and they conjoin (b is the same reduced term in both, as Python
-        evaluates it once). Identity/membership operators (is/in/...) inherit the
-        loud throw until written.
+        constructs each adjacent pair under ChainedCompareSugar, which evaluates
+        `b` once and carries that reduced value from the first leg into the second.
         """
         from .operators import Eq
         from sugar_lift_py_tests.sugar.comparison_op_sugar import (
@@ -10326,9 +10324,11 @@ class Compare(Expression):
         pairs = tuple(pair(i) for i in range(len(self.ops)))
         if len(pairs) == 1:
             return pairs[0]
-        from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
+        from sugar_lift_py_tests.sugar.chained_compare_sugar import (
+            ChainedCompareSugar,
+        )
 
-        return BoolOpSugar(op_kind="And", values=pairs, site=self.fragment)
+        return ChainedCompareSugar(values=pairs, site=self.fragment)
 
 
 class Call(Expression):


### PR DESCRIPTION
## What changed

Multi-operand `Compare` now constructs one `ChainedCompareSugar` at the shared `Compare` door. It evaluates operands left to right once, carries each reduced right operand into the next leg, short-circuits through the existing BoolOp truth-selection law, and preserves each `ComparisonOpSugar` / `EqualityOpSugar` leg as the owner of its operation.

## Why this is a correctness fix

This was a wrong-result defect, not an efficiency defect. With a state-changing middle operand, `0 < middle() < 2` returned `Complete(False)` on `84b104f06`; it now returns `True`. The old adjacent-pair lowering evaluated the middle twice while still claiming complete construction.

## Counterfactual detector

The same five-tooth detector run against product code at `84b104f06` produced exactly `3 failed, 2 passed`:

- the middle evaluation count was `[1, 2]`, not `[1]`
- the state-changing middle produced `False`, not `True`
- evaluation order was `left, middle, middle, right`, not `left, middle, right`

Its short-circuit and per-leg ownership floors already passed there. On this branch the detector passes `5/5`, proving:

- the middle evaluates exactly once
- operands evaluate left to right
- a false first leg skips later operands
- each leg retains its comparison/equality owner
- the state-changing semantic twin yields the correct result

Focused branch verification: `25 passed` across the new detector and affected BoolOp/Compare testimony floors.

## Instrument accounting

- `R(chained_middle_double_evaluation)`: `1 -> 0`
- predicted `Epsilon R`: `-1`
- preserved floors: exact-once evaluation, left-to-right order, short-circuit, per-leg ownership, canonical BoolOp testimony

No broad suite or corpus result is claimed; known current-main API drift still masks those signals.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Evaluate chained Compare operands once using `ChainedCompareSugar`
> - Introduces `ChainedCompareSugar` in [chained_compare_sugar.py](https://github.com/TSavo/sugar/pull/7145/files#diff-2eecc05716b9114eca9f7907ba03774f846dac2dfabfa29956d1075e200230bc) to handle multi-operand `Compare` chains, evaluating each shared middle operand exactly once instead of once per adjacent pair.
> - `Compare._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/7145/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) now returns `ChainedCompareSugar` instead of `BoolOpSugar("And", pairs)` for multi-leg comparisons.
> - Adds `apply_reduced` to `ComparisonOpSugar` and `EqualityOpSugar` so `ChainedCompareSugar` can pass already-evaluated operands directly, skipping re-evaluation.
> - Extracts `select_boolop_operand` helper in [bool_op_sugar.py](https://github.com/TSavo/sugar/pull/7145/files#diff-73c2a5ae1e04df48a3942a0cb20fba48229df0773e79787ec3b8a7f11aae8199) to share short-circuit logic between `BoolOpSugar` and `ChainedCompareSugar`.
> - Behavioral Change: expressions like `a < b < c` now evaluate `b` once; previously `b` was evaluated twice (once per comparison pair).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72a0fc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->