### PR TITLE
Restore construct-or-panic recensus consumer

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/corpus_fatal_triage.py
@@ -280,7 +280,7 @@ def _run_parent(args: argparse.Namespace) -> int:
                 "assertionCount": 0,
                 "terminal": {
                     "file": rel,
-                    "category": "backend-defect",
+                    "category": "panic",
                     "reason": f"{type(error).__name__}: {error}",
                 },
             }

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -5,38 +5,27 @@ Binding law: protocol/specs/2026-08-02-recensus-as-enumerate-consumer.md
   AUTHORITY(work) = sugar.enumerate
   _measure_file is a retired side door and is not imported here.
 
-Demands per enrolled file:
-  D2: level=functions  → function roster (functionsTotal population when banked)
-  D3: level=facts + options.auditFrontier → construction residual
+Law: construct or panic. No residual kinds. A file either constructs or the
+panic names what could not be built.
 
-Denominator laws (restored after #7073 regression):
-  1. Roster-preserved mass: when D2 returns a non-empty roster, functionsTotal
-     is that roster size even if a later phase (D3) fails or panics. The retired
-     door banked full functionsTotal on mid-file ConstructionPanic; dropping to
-     0 on residual failure is the clean%-over-shrunken-set lie one level up.
-  2. Open/roster-absent failure still banks functionsTotal=0 (true empty).
-  3. Clean is never a tautology: do not default functionsClean = functionsTotal.
-     Honest clean comes from sourceAudit.functionsClean or an explicit residual
-     count; otherwise functionsClean is null and cleanRatioRefused=True.
+Roster-floor (survives): when D2 banks a non-empty function roster, that mass
+stays even if D3 panics. Do not lose work already done.
 """
 
 from __future__ import annotations
 
 import ast
-from collections import Counter
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 SCOREBOARD_AUTHORITY = False
 
-# Hard law: this module must never open SourceFile for measurement.
 _FORBIDDEN_IMPORTS = frozenset(
     {
         "open_source_file_for_construction",
         "_measure_file",
     }
 )
-
 
 
 def enumerate_rpc(
@@ -95,10 +84,7 @@ def file_memento(*, file_rel: str, source_cid: str | None = None) -> dict[str, A
 
 
 def count_ast_function_defs(path: Path) -> int | None:
-    """Authenticated AST FunctionDef population (site prevalence, not clean%).
-
-    Returns None when the file cannot be parsed (true open failure for AST).
-    """
+    """Authenticated AST FunctionDef population (site prevalence, not clean%)."""
     try:
         text = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
@@ -137,11 +123,7 @@ def demand_construction_residual(
     file_rel: str,
     source_cid: str | None = None,
 ) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
-    """D3: sugar.enumerate level=facts + auditFrontier → construction residual.
-
-    Returns (audit_leaf_or_none, gaps). Construction panics/gaps live on the
-    audit envelope produced by the kit's enumerate path — not a private walk.
-    """
+    """D3: sugar.enumerate level=facts + auditFrontier → construction residual."""
     at = file_memento(file_rel=file_rel, source_cid=source_cid)
     result = enumerate_rpc(
         level="facts",
@@ -158,6 +140,16 @@ def demand_construction_residual(
     return (audit if isinstance(audit, dict) else None), gaps
 
 
+def _panic_payload(error: BaseException, *, file_rel: str, phase: str) -> dict[str, Any]:
+    """What could not be built — type + message. No residual kind ladder."""
+    return {
+        "file": file_rel,
+        "type": type(error).__name__,
+        "message": str(error),
+        "phase": phase,
+    }
+
+
 def _empty_shell(
     *,
     file_rel: str,
@@ -172,7 +164,7 @@ def _empty_shell(
     clean_refuse_reason: str | None = None,
     ast_fn: int | None = None,
 ) -> dict[str, Any]:
-    """Common terminal fields; never default clean to total."""
+    """One terminal shell. category is completed or panic only."""
     not_enum = max(0, functions_total - functions_enumerated)
     row: dict[str, Any] = {
         "category": category,
@@ -184,9 +176,7 @@ def _empty_shell(
         and not_enum == 0,
         "functionsClean": functions_clean,
         "cleanRatioRefused": bool(clean_ratio_refused),
-        "cleanRefuseReason": clean_refuse_reason
-        if clean_ratio_refused
-        else None,
+        "cleanRefuseReason": clean_refuse_reason if clean_ratio_refused else None,
         "families": dict(families or {}),
         "backendDefects": {},
         "R_backend_defects": 0,
@@ -208,6 +198,10 @@ def _empty_shell(
         "desugarDefects": [],
         "desugarDesignedGaps": [],
         "enumerateSource": True,
+        "enumerateFunctionMementos": functions_enumerated,
+        "rosterPreservedAfterResidualFailure": bool(
+            category == "panic" and functions_total > 0 and functions_enumerated > 0
+        ),
     }
     if defect is not None:
         row["defect"] = defect
@@ -217,28 +211,18 @@ def _empty_shell(
     return row
 
 
-def _honest_functions_clean(
+def _functions_clean(
     *,
     functions_total: int,
     audit: dict[str, Any] | None,
-    panics: list[dict[str, Any]],
     construction_panics: list[dict[str, Any]],
-    residual_phase_failed: bool,
+    residual_failed: bool,
 ) -> tuple[int | None, bool, str | None]:
-    """Return (clean, refused, reason). Never default clean == total.
-
-    Honest sources (in order):
-      1. sourceAudit.functionsClean when present (kit-authored residual count)
-      2. residual_phase_failed after a banked roster → refuse (no per-fn walk)
-      3. construction panics / audit panics with known total → total - min(total, n)
-      4. completed residual phase, zero panics, zero construction_panics → total
-         (earned clean, residual phase testified empty)
-      5. otherwise refuse
-    """
+    """Clean count without inventing full-clean tautologies."""
     if functions_total <= 0:
-        # Empty population: clean is 0, not a ratio claim.
         return 0, False, None
-
+    if residual_failed:
+        return None, True, "residual panic after roster; clean not measured"
     if isinstance(audit, dict):
         aux = audit.get("auxiliaryRows") or {}
         source_audit = aux.get("sourceAudit") if isinstance(aux, dict) else None
@@ -246,52 +230,19 @@ def _honest_functions_clean(
             try:
                 clean = int(source_audit["functionsClean"])
             except (TypeError, ValueError):
-                return (
-                    None,
-                    True,
-                    "sourceAudit.functionsClean unreadable; refuse clean ratio",
-                )
+                return None, True, "sourceAudit.functionsClean unreadable"
             if clean < 0 or clean > functions_total:
-                return (
-                    None,
-                    True,
-                    f"sourceAudit.functionsClean={clean} outside [0,{functions_total}]",
-                )
+                return None, True, f"functionsClean={clean} outside [0,{functions_total}]"
             return clean, False, None
-
-    if residual_phase_failed:
-        return (
-            None,
-            True,
-            "residual phase failed after roster; clean not measured (refuse tautology)",
-        )
-
-    residual_n = len(construction_panics) if construction_panics else len(panics)
+    residual_n = len(construction_panics)
     if residual_n > 0:
-        # Distinct residual events subtract from clean, never inflate total.
         return max(0, functions_total - min(functions_total, residual_n)), False, None
-
     if isinstance(audit, dict):
         core = audit.get("semanticCore") or audit
         if isinstance(core, dict) and core.get("status") == "failed":
-            # Failed without countable panics — refuse, do not claim full clean.
-            return (
-                None,
-                True,
-                "semanticCore.status=failed without countable panics; refuse clean",
-            )
-        # Residual phase returned an audit with no panics → earned full clean.
+            return None, True, "semanticCore.status=failed without countable panics"
         return functions_total, False, None
-
-    # No audit at all after residual demand — refuse.
-    return (
-        None,
-        True,
-        "no audit and no residual count; refuse clean ratio (would be tautological)",
-    )
-
-
-
+    return None, True, "no audit after residual demand"
 
 
 def terminal_from_enumerate(
@@ -305,11 +256,197 @@ def terminal_from_enumerate(
     residual_error: BaseException | None = None,
     ast_fn: int | None = None,
 ) -> dict[str, Any]:
-    """Map enumerate products → one recensus terminal row (compose input).
+    """Map enumerate products → one recensus terminal (compose input).
 
     Roster-preserved mass: when function_nodes is non-empty, functionsTotal is
     len(function_nodes) even if residual_phase_failed.
     """
-    families: Counter[str] = Counter()
+    if function_gaps and not function_nodes:
+        reason = function_gaps[0].get("reason") or "functions demand gap"
+        panic = {
+            "file": file_rel,
+            "type": "ConstructionPanic",
+            "message": str(reason),
+            "phase": "roster",
+            "gap": dict(function_gaps[0]),
+        }
+        return _empty_shell(
+            file_rel=file_rel,
+            category="panic",
+            functions_total=0,
+            functions_enumerated=0,
+            defect=panic,
+            panic=panic,
+            functions_clean=0,
+            clean_ratio_refused=False,
+            ast_fn=ast_fn,
+        )
+
+    functions_total = len(function_nodes)
+    functions_enumerated = functions_total
     construction_panics: list[dict[str, Any]] = []
-    defects: list[dict[str, Any]] = []
+
+    panics: list[dict[str, Any]] = []
+    if isinstance(audit, dict):
+        core = audit.get("semanticCore") or audit
+        if isinstance(core, dict):
+            raw_panics = core.get("panics") or []
+            if isinstance(raw_panics, list):
+                panics = [p for p in raw_panics if isinstance(p, dict)]
+    for panic in panics:
+        gap = panic.get("gap") if isinstance(panic.get("gap"), dict) else {}
+        construction_panics.append(
+            {
+                "file": file_rel,
+                "type": "ConstructionPanic",
+                "message": str(panic.get("reason") or gap.get("reason") or ""),
+                "gap": gap,
+                "locus": panic.get("locus"),
+            }
+        )
+    for gap in construction_gaps:
+        construction_panics.append(
+            {
+                "file": file_rel,
+                "type": "ConstructionPanic",
+                "message": str(gap.get("reason") or gap),
+                "gap": dict(gap),
+            }
+        )
+
+    residual_panic: dict[str, Any] | None = None
+    if residual_phase_failed and residual_error is not None:
+        residual_panic = _panic_payload(
+            residual_error, file_rel=file_rel, phase="residual"
+        )
+        construction_panics.append(residual_panic)
+
+    clean, clean_refused, clean_reason = _functions_clean(
+        functions_total=functions_total,
+        audit=audit,
+        construction_panics=construction_panics,
+        residual_failed=residual_phase_failed,
+    )
+
+    failed = residual_phase_failed or bool(construction_panics)
+    category = "panic" if failed else "completed"
+    primary_panic = residual_panic or (
+        construction_panics[0] if construction_panics else None
+    )
+
+    row = _empty_shell(
+        file_rel=file_rel,
+        category=category,
+        functions_total=functions_total,
+        functions_enumerated=functions_enumerated,
+        defect=primary_panic if category == "panic" else None,
+        panic=primary_panic if category == "panic" else None,
+        functions_clean=clean,
+        clean_ratio_refused=clean_refused,
+        clean_refuse_reason=clean_reason,
+        ast_fn=ast_fn if ast_fn is not None else functions_total,
+    )
+    if construction_panics:
+        row["constructionPanics"] = list(construction_panics)
+        row["enumerateConstructionPanics"] = list(construction_panics)
+    return row
+
+
+def measure_file_via_enumerate(
+    *,
+    workspace_root: Path,
+    file_rel: str,
+    source_cid: str | None = None,
+    contract_refs=None,
+) -> dict[str, Any]:
+    """Produce one terminal solely from sugar.enumerate demands.
+
+    Never raises after a roster is banked — residual panic becomes a terminal
+    row with functionsTotal preserved (roster-floor).
+    """
+    if contract_refs is not None:
+        from sugar_lift_py_tests.lift_rpc import install_provisional_contract_refs
+
+        install_provisional_contract_refs(Path(workspace_root), contract_refs)
+
+    path = (workspace_root / file_rel).resolve()
+    ast_fn = count_ast_function_defs(path)
+
+    def _is_process_control(error: BaseException) -> bool:
+        return isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit))
+
+    try:
+        function_nodes, function_gaps = demand_function_roster(
+            workspace_root=workspace_root,
+            file_rel=file_rel,
+            source_cid=source_cid,
+        )
+    except BaseException as error:  # noqa: BLE001 — includes ConstructionPanic
+        if _is_process_control(error):
+            raise
+        auth = int(ast_fn) if ast_fn is not None else 0
+        panic = _panic_payload(error, file_rel=file_rel, phase="roster")
+        return _empty_shell(
+            file_rel=file_rel,
+            category="panic",
+            functions_total=auth,
+            functions_enumerated=0,
+            defect=panic,
+            panic=panic,
+            functions_clean=None if auth > 0 else 0,
+            clean_ratio_refused=auth > 0,
+            clean_refuse_reason=(
+                "roster demand panicked; clean not measured" if auth > 0 else None
+            ),
+            ast_fn=ast_fn,
+        )
+
+    if function_gaps and not function_nodes:
+        return terminal_from_enumerate(
+            file_rel=file_rel,
+            function_nodes=function_nodes,
+            function_gaps=function_gaps,
+            audit=None,
+            construction_gaps=[],
+            ast_fn=ast_fn,
+        )
+
+    try:
+        audit, construction_gaps = demand_construction_residual(
+            workspace_root=workspace_root,
+            file_rel=file_rel,
+            source_cid=source_cid,
+        )
+    except BaseException as error:  # noqa: BLE001 — residual failed; roster stands
+        if _is_process_control(error):
+            raise
+        return terminal_from_enumerate(
+            file_rel=file_rel,
+            function_nodes=function_nodes,
+            function_gaps=[],
+            audit=None,
+            construction_gaps=[],
+            residual_phase_failed=True,
+            residual_error=error,
+            ast_fn=ast_fn,
+        )
+
+    return terminal_from_enumerate(
+        file_rel=file_rel,
+        function_nodes=function_nodes,
+        function_gaps=function_gaps,
+        audit=audit,
+        construction_gaps=construction_gaps,
+        residual_phase_failed=False,
+        ast_fn=ast_fn,
+    )
+
+
+def assert_no_side_door_imports() -> None:
+    """Tooth: this module's source must not name the retired private walk."""
+    text = Path(__file__).read_text(encoding="utf-8")
+    for name in _FORBIDDEN_IMPORTS:
+        if text.count(name) > 2:
+            raise AssertionError(
+                f"recensus_enumerate_consumer must not use side door {name!r}"
+            )

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
@@ -456,7 +456,7 @@ def main(argv: list[str] | None = None) -> int:
             cm.update({k: int(v) for k, v in (row.get("cmResolutions") or {}).items()})
             sites.update({k: int(v) for k, v in (row.get("sites") or {}).items()})
             families.update({k: int(v) for k, v in (row.get("families") or {}).items()})
-            if row.get("category") == "construction-panic":
+            if row.get("category") == "panic":
                 panic = row.get("panic")
                 if isinstance(panic, dict):
                     construction_panics.append(panic)

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_spread_literal_roster.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_spread_literal_roster.py
@@ -141,7 +141,7 @@ def test_multi_function_file_with_star_call_enumerates_full_roster() -> None:
             workspace_root=workspace,
             file_rel="mod.py",
         )
-    assert row.get("category") != "backend-defect", (
+    assert row.get("category") in {"completed", "panic"}, (
         f"spread call zero-banked the file: {row.get('defect') or row}"
     )
     # Full roster: helper, body, other

--- a/tests/test_recensus_enumerate_mass_and_clean.py
+++ b/tests/test_recensus_enumerate_mass_and_clean.py
@@ -66,7 +66,7 @@ def test_residual_failure_preserves_roster_functions_total(monkeypatch) -> None:
     assert row["functionsTotal"] == 3
     assert row["functionsEnumerated"] == 3
     assert row["rosterPreservedAfterResidualFailure"] is True
-    assert row["category"] == "backend-defect"
+    assert row["category"] == "panic"
     # Clean must not claim 3/3 perfection after residual failure.
     assert row["functionsClean"] is None
     assert row["cleanRatioRefused"] is True
@@ -87,7 +87,7 @@ def test_open_roster_failure_still_zero_when_no_ast(monkeypatch) -> None:
     )
     assert row["functionsTotal"] == 0
     assert row["functionsEnumerated"] == 0
-    assert row["category"] == "backend-defect"
+    assert row["category"] == "panic"
 
 
 def test_roster_failure_banks_ast_population_not_silent_zero(monkeypatch) -> None:
@@ -179,7 +179,7 @@ def test_compose_refuses_tautological_clean_on_board() -> None:
         (
             "blind.py",
             {
-                "category": "backend-defect",
+                "category": "panic",
                 "functionsTotal": 10,
                 "functionsEnumerated": 0,
                 "functionsClean": None,
@@ -282,7 +282,7 @@ def test_outer_shell_escape_banks_recovered_roster_not_zero(
         relative="multi.py",
         workspace_root=tmp_path,
         error=NewBaseExceptionGap("escaped past consumer"),
-        category="backend-defect",
+        category="panic",
     )
     assert row["functionsTotal"] == 3, (
         f"outer shell must bank recovered roster, got {row.get('functionsTotal')}"
@@ -322,7 +322,7 @@ def test_outer_shell_escape_banks_ast_when_roster_demand_also_fails(
         relative="multi.py",
         workspace_root=tmp_path,
         error=RuntimeError("outer escape"),
-        category="backend-defect",
+        category="panic",
     )
     assert row["functionsTotal"] == 2  # AST FunctionDef count
     assert row["functionsEnumerated"] == 0


### PR DESCRIPTION
## What changed

- rescue `f5e5a598b` onto landed main after the taxonomy deletion truncated `terminal_from_enumerate` and removed `measure_file_via_enumerate`
- restore the sugar.enumerate D2/D3 consumer and roster-preservation floor
- keep its terminal codomain closed to `completed | panic`
- preserve raw gap payloads without inventing enumerate-gap labels
- update the touched callers/tests from deleted backend/legacy panic categories to `panic`

## Semantic rebase

The candidate conflicted in `manager_summary_derivation.py`. Main already removed the dead `enrolled_demand_unresolved_ground` call and carries the stronger consume-time `ContextManagerResolutionConstructionGap` wording, so the conflict resolves entirely to main and produces no diff in that file. The rescued result is five changed files, not the candidate's six.

I stripped candidate compatibility that would have restored deleted vocabulary:

- `construction-panic` is not accepted alongside `panic`
- `EnumerateFunctionsGap` and `EnumerateConstructionGap` labels are not introduced
- upstream raw gap objects remain attached to the panic row for triage

Static additions scan found zero `enrolled_demand`, legacy `construction-panic`/`backend-defect`, decidability/refusal-kind/residual-bucket vocabulary, test deletion, skip, or xfail additions.

## R / floors

- `R_callable_recensus_enumerate_consumer`: `0 -> 1`
- no test deleted, skipped, xfailed, or broadened
- no taxonomy, fallback, side-door measurement, or fabricated clean count introduced

## Validation

- battleaxe exact consumer/touched detectors: `10 passed in 0.75s`, exit `0`
- battleaxe two-file selection: `14 passed, 1 failed`; sole failure is the untouched pre-existing missing `Constant` import in `test_ellipsis_literal_is_constructed_term_in_subscript`
- battleaxe static recensus-path-smoke teeth: PASS
- focused Python 3.12 `py_compile`: exit `0`
- `git diff --check`: exit `0`

Not claiming the broader live path smoke is green: after its stale authority assertion/retired entrance is bypassed for diagnosis, it reaches a separate existing With-conservation failure (`with_items_total=2`, `constructed=0`, `gaps=0`, `unaccounted=2`). This PR does not paper that boundary.

## Predicted impact

The full authenticated corpus receipt can start through its intended consumer after this lands. The receipt itself remains unmeasured until the new landed SHA is run on quiet battleaxe.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore construct-or-panic semantics in recensus enumerate consumer
> - Replaces `'backend-defect'` category with `'panic'` across the recensus enumerate pipeline, aligning error reporting with construct-or-panic semantics.
> - `terminal_from_enumerate` in [recensus_enumerate_consumer.py](https://github.com/TSavo/sugar/pull/7146/files#diff-f44306c90c4bcc279a33763d110fe23086857b9b1f1afc83ea45e09c2d004b79) now returns a `'panic'` terminal row instead of raising when residual fails after a roster is banked, preserving `functionsTotal` and recording construction panics.
> - `_empty_shell` now includes `enumerateFunctionMementos` and `rosterPreservedAfterResidualFailure` fields; category is constrained to `'completed'` or `'panic'`.
> - `_functions_clean` (renamed from `_honest_functions_clean`) narrows its inputs to `construction_panics` and a `residual_failed` flag, removing generic panic fallback counting.
> - Adds an import-time assertion in `recensus_enumerate_consumer.py` that raises `AssertionError` if forbidden private-walk identifiers appear more than twice in the source.
> - Behavioral Change: any code downstream that checked for `'backend-defect'` category must now handle `'panic'` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 069706d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->