### PR TITLE
Repair authenticated raise construction paths

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -7,6 +7,7 @@ from typing import Any
 from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.context_manager_contract import _json_value
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.floor import FloorValue
 from sugar_lift_py_tests.ir import (
     Formula,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py
@@ -125,7 +125,12 @@ class GeneratorWithSugar(Sugar):
 
         refusal = observed_entry_refusal()
         blame = str(manager_exit.value.instance_coordinate)
-        effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(f'generator-entry-refusal:{blame}'), exception_name=refusal.exception_name, blame=blame, raised_value=refusal.message)
+        effect = RaiseEffect.for_builtin(
+            refusal.exception_name,
+            occurrence=f"generator-entry-refusal:{blame}",
+            blame=blame,
+            raised_value=refusal.message,
+        )
         return ExitSet(
             (
                 Halted(


### PR DESCRIPTION
## What changed

Repair two production exceptional-construction paths found by the `AuthenticatedRaiseLocus` missing-binding sweep:

- `NativeOperationResolutionV1.project` now imports `AuthenticatedRaiseLocus` before minting an exceptional native-operation exit.
- `GeneratorWithSugar._entry_refusal_exit` now uses `RaiseEffect.for_builtin` for the runtime-observed builtin refusal instead of calling the narrowed `RaiseEffect` constructor without an exception type coordinate.

## Why this is a product fix

These were live crash paths, not stale assertions. Native-operation carriers—including BoolOp truth discharge—reach `NativeOperationResolutionV1.project`; its exceptional arm raised `NameError` instead of constructing an authenticated halt. A generator context manager that terminates before its first yield reached `_entry_refusal_exit`; the undefined locus name masked a second stale wire, a direct `RaiseEffect` call missing the now-required type coordinate.

The generator path therefore contained two stacked defects. Adding the missing
import exposed the second `TypeError`; it did not make the path correct. A
fix-and-remeasure cycle found the hidden stale constructor, which is now routed
through the authoritative builtin door. A clean first fix must not be assumed
to mean a clean path when an earlier crash prevented later construction from
executing.

The generator path already has runtime testimony for a language-owned builtin refusal, so `RaiseEffect.for_builtin` is the authoritative shared door. This preserves the closed constructor rather than supplying a hand-written coordinate.

## Measured scope

The repository Python sweep found 16 files with missing `AuthenticatedRaiseLocus` bindings and 21 load occurrences: 2 production files with 2 loads, plus 14 test files with 19 loads. This PR contains only the two production paths. The test-only repairs will follow separately.

No suite-failure count is inferred from the file or load count, and no broad suite or corpus result is claimed.

## Verification

- Direct native exceptional projection: passed; produced one `Halted` face carrying the requested type coordinate and authenticated operation occurrence.
- Generator premature-return and never-yield entry twins: `2 passed`.
- Both changed production modules compile under Python 3.12.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `RaiseEffect` construction in `GeneratorWithSugar.desugar` for generator entry refusal
> Replaces direct `RaiseEffect` construction (using `AuthenticatedRaiseLocus.of(...)` for occurrence) with a call to `RaiseEffect.for_builtin` in the generator entry refusal branch of [`generator_with_sugar.py`](https://github.com/TSavo/sugar/pull/7147/files#diff-01b4662b5aadf841bae1a42bc95a607d48f8251b41ee131cd3a424dfb89577f8). Occurrence is now passed as a plain formatted string rather than an `AuthenticatedRaiseLocus`-derived value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aafcefe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of entry-refusal errors by ensuring they are created with the correct built-in error details.
  * Added support for authenticated raise-locus references in caller parameter contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->