### PR TITLE
Bind authenticated raise test rewrite casualties

### DIFF
--- a/.receipts/authenticated-raise-rewrite-casualties/RECEIPT.md
+++ b/.receipts/authenticated-raise-rewrite-casualties/RECEIPT.md
@@ -1,0 +1,306 @@
+# Authenticated Raise Rewrite Casualty Receipt
+
+## Snapshots and measured counts
+
+- Mechanical introducer: `bf847eb9363fd050b326ffd16543275b231d783e`.
+- Introducer parent: `9f8675d24` (the exact parent used by the AST delta).
+- Introducer population: 115 changed Python files.
+- Introduced unbound loads: 187 `AuthenticatedRaiseLocus` loads in 71 offender
+  files within that 115-file population.
+- Current survivor snapshot after production PR #7147: `3cdc88c01`.
+- Current survivor population: 20 unbound loads in 14 test files.
+- Exact current line ancestry: 1 load from `bf847eb93`, 18 loads from `8a3ceb2c0`, and 1 load from `1eeb80bb3`.
+- Exact local test-repair worktree snapshot excluding this receipt: `abf5a9f78735ed1ca21562a6d0aec8e477943d38`.
+- Local binding instruments on that snapshot: 0 files with an unbound `AuthenticatedRaiseLocus`; 0 of the five bounded `_identity` files remain unbound.
+
+These are file/load measurements. They are not suite-failure counts.
+
+## First-terminal chains
+
+### BoolOp legacy probe
+
+- Exact baseline SHA: `b02b333d8`.
+- Input and coordinate: `test_bool_op_operand_sequence.py::test_left_operand_is_evaluated_and_truth_tested_exactly_once`, BoolOp construction at baseline line 164.
+- First observed terminal: `TypeError: BoolOpSugar.values requires ConstructedTermSugar, got _ProbeSugar`.
+- Entrance: `BoolOpSugar.__post_init__`.
+- After repair snapshot `abf5a9f78735ed1ca21562a6d0aec8e477943d38`: the probe is a genuine `ConstructedTermSugar`; the exact file constructs through all 12 tests, `12 passed`.
+
+### BoolOp synthetic halted operand
+
+- Exact baseline SHA: `b02b333d8`.
+- Input and coordinate: `test_bool_op_operand_sequence.py:225`, synthetic `LeftTruthError`.
+- First observed terminal: unbound `AuthenticatedRaiseLocus` at the test construction entrance.
+- Entrance: direct test `RaiseEffect` construction.
+- After binding the name: the next terminal was `TypeError` because the narrowed constructor required `exception_type_coordinate`.
+- After repair snapshot `abf5a9f78735ed1ca21562a6d0aec8e477943d38`: the synthetic non-builtin carries an explicit test coordinate and the halt constructs.
+
+### Native exceptional projection
+
+- Exact baseline SHA: `b02b333d8`.
+- Input and coordinate: BoolOp formal-truth discharge with `_ExceptionalTruth()`; source coordinate `boolop_caller.py:2:11-2:25`.
+- First observed terminal: `NameError: AuthenticatedRaiseLocus is not defined`.
+- Entrance: `NativeOperationResolutionV1.project` at `caller_parameter_contract.py:153`.
+- After production SHA `3cdc88c01`: projection constructs one `Halted` face with the requested type coordinate and authenticated operation occurrence.
+- Next test terminal: unbound `_identity` in the assertion; after repair snapshot `abf5a9f78735ed1ca21562a6d0aec8e477943d38`, the complete BoolOp file is `12 passed`.
+
+### Generator manager first-resume refusal
+
+- Exact baseline SHA: `b02b333d8`.
+- Inputs and coordinates: premature return at `test_generator_context_manager_construction.py:76`; never-yield at line 102.
+- First terminal at the production entrance: the unbound `AuthenticatedRaiseLocus` in `GeneratorWithSugar._entry_refusal_exit`.
+- Entrance: `generator_with_sugar.py:128`.
+- After binding the name: the next observed terminal was `TypeError: RaiseEffect.__init__() missing exception_type_coordinate`.
+- After production SHA `3cdc88c01`: the observed builtin refusal routes through `RaiseEffect.for_builtin`; both focused twins pass, `2 passed`.
+
+### Function-formal identity assertion
+
+- Exact current-main SHA: `3cdc88c01`.
+- Input and coordinate: `test_function_formal_native_operation_binding.py::test_positional_actuals_discharge_through_python_binder`, `helper(None, 2)`.
+- First terminal before the test repair: unbound `_identity` at line 60.
+- Entrance: `_assert_named_halt`.
+- After repair snapshot `abf5a9f78735ed1ca21562a6d0aec8e477943d38`: the identity assertion passes; the next terminal is the separate occurrence-shape assertion at line 61. This receipt does not claim that later drift is fixed.
+
+### Unary identity assertion
+
+- Exact current-main SHA: `3cdc88c01`.
+- Input and coordinate: `test_unary_not_bool_law.py::test_halted_truth_is_not_negated`.
+- First observed terminal: `TypeError: UnaryOpSugar.operand requires ConstructedTermSugar, got _ValueSugar`.
+- Entrance: `UnaryOpSugar.__post_init__`.
+- After binding `_identity`: the same earlier terminal remains, so the identity load is not yet executable. This receipt does not claim the separate unary fixture drift is fixed.
+
+### Try identity assertions
+
+- Exact current-main SHA: `3cdc88c01`.
+- Inputs and coordinates: `test_bare_reraise_reemits_the_exact_inflight_raise` and `test_finally_raise_supersedes_break_instead_of_fabricating_loop_exit`.
+- First observed terminal: the tests receive `ExitSet` where their older assertions require `Incomplete`.
+- Entrance: the assertion immediately after `function.sugar().desugar()`.
+- After replacing the unbound helper with typed-source identity derivation: the same earlier outcome-shape terminal remains. This receipt does not claim that separate outcome drift is fixed.
+
+### Local processes without a terminal receipt
+
+- Exact repair snapshot: `abf5a9f78735ed1ca21562a6d0aec8e477943d38`.
+- Inputs: the focused pandas-subscript and source-setattr identity tests.
+- Observation: the local pytest processes exited 143 with no pytest terminal output.
+- Claim boundary: exit 143 is not counted as a product terminal, pass, failure, or timeout.
+
+## Rewrite mechanism callability
+
+- `bf847eb93` changed 115 Python files and added no script, codemod, workflow, or agent instruction.
+- `8a3ceb2c0` likewise contains the mechanical call-site rewrite but no callable rewrite artifact.
+- `1eeb80bb3` changed 50 Python tests plus `docs/presence-only-retirement-partition.md`; it added no callable tool.
+- A current search of `.claude`, `.briefs`, `docs`, `bin`, and `scripts` finds the symbol only in the retirement document, not in a source-rewrite mechanism.
+
+Repository evidence therefore finds no rewrite mechanism that remains callable. The evidence is consistent with a one-time mechanical agent or hand pass whose edits were committed without its generator. It does not prove that no external or uncommitted prompt/tool ever existed.
+
+## Raw 187 introducer coordinates
+
+- `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py:153` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py:281` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/generator_with_sugar.py:128` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/raise_sugar.py:92` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py:232` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py:256` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py:259` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py:613` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py:642` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py:680` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py:712` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py:64` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py:177` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py:10` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py:19` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py:221` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_callsite_positional_actual_exitset.py:87` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_callsite_positional_actual_exitset.py:94` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_comprehension_value_length.py:116` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_delete_state_joins.py:390` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_desugar_axis_twins.py:52` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_effect_boundary_observation_conserves_demands.py:101` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_effect_router.py:33` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:101` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:102` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:135` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:136` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:137` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:183` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:50` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:81` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py:197` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_exit_suppression_contract.py:31` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_exit_suppression_contract.py:63` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py:31` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py:75` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py:84` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:29` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:36` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:64` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:77` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:99` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:106` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:107` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:114` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:131` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:158` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:165` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:166` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:173` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:183` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:193` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:204` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:217` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:230` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py:49` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py:72` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_nested_exit_faces.py:150` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_source_resource_stack.py:259` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_try_finally.py:130` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py:231` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py:49` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_generator_construction_v1.py:107` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py:436` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_generator_if_guard_outcome_sequencing.py:111` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_generator_if_guard_outcome_sequencing.py:228` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py:212` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_generator_value_exitset_sequencing.py:324` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_generator_value_exitset_sequencing.py:122` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_generator_value_exitset_sequencing.py:135` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_generator_value_exitset_sequencing.py:279` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_generator_value_exitset_sequencing.py:286` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_generator_value_exitset_sequencing.py:408` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py:23` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py:118` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_loop_stop_iteration_coordinate.py:30` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_loop_stop_iteration_coordinate.py:36` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_loop_stop_iteration_coordinate.py:52` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py:284` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_method_raise_transport.py:392` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py:709` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_native_operation_prefix_carrier.py:92` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py:42` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py:48` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py:54` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py:163` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py:83` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_partition_demand_conservation.py:83` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:310` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:524` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:545` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:84` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:106` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:184` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:484` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:504` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:208` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py:437` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py:18` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py:39` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_raise_from_try_composition.py:248` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py:74` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py:159` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py:174` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py:192` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py:212` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py:10` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py:26` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:80` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:95` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:305` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:327` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:340` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:353` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:371` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:388` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:397` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:321` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_store_formal_caller.py:163` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py:9` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_source_constructed_exit_truthiness.py:25` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py:399` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:135` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:138` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:140` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py:72` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_state_survival_matrix.py:354` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_subscript_refusal_preservation.py:68` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_subscript_refusal_preservation.py:92` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py:187` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py:221` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py:573` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py:574` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py:798` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py:893` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py:621` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py:618` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py:831` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py:915` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py:920` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py:270` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py:447` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:194` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:218` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:303` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:339` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:366` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:383` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:394` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:413` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:685` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:662` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:292` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:634` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:96` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py:170` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py:183` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py:197` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py:248` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py:147` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:663` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py:134` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/tests/test_generator_manager_renamed_lifecycle.py:268` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/tests/test_generator_nested_managers.py:184` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py:743` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py:65` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py:91` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py:889` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py:924` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py:1915` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/tests/test_source_resource_nested_exit_faces.py:146` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/tests/test_source_resource_nested_exit_faces.py:294` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/tests/test_source_resource_nested_exit_faces.py:324` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-lift-python-source/tests/test_source_resource_nested_exit_faces.py:325` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py:440` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py:590` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:275` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:385` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:441` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:476` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:358` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-source-tree/tests/test_store_target_effect.py:205` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py:365` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py:421` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py:435` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py:383` — `AuthenticatedRaiseLocus`
+- `implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py:737` — `AuthenticatedRaiseLocus`
+
+## Raw current survivor coordinates
+
+- `implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py:64` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py:221` — line introducer `1eeb80bb3af8e318486412a670909e6ab29623ca`
+- `implementations/python/sugar-lift-py-tests/tests/test_effect_boundary_observation_conserves_demands.py:101` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_exit_suppression_contract.py:31` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py:31` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py:75` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_nested_exit_faces.py:150` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_source_resource_stack.py:259` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_try_finally.py:130` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py:23` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py:118` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py:42` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py:54` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:94` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:387` — line introducer `bf847eb9363fd050b326ffd16543275b231d783e`
+- `implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py:187` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py:221` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:96` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py:440` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`
+- `implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py:590` — line introducer `8a3ceb2c09699d48f666d66552cb3a83ea9a85f9`

--- a/.receipts/authenticated-raise-rewrite-casualties/RECEIPT.md
+++ b/.receipts/authenticated-raise-rewrite-casualties/RECEIPT.md
@@ -7,10 +7,10 @@
 - Introducer population: 115 changed Python files.
 - Introduced unbound loads: 187 `AuthenticatedRaiseLocus` loads in 71 offender
   files within that 115-file population.
-- Current survivor snapshot after production PR #7147: `3cdc88c01`.
+- Current survivor snapshot after production PR #7147: `3cdc88c01269140c8b88d45b47d5ee38ec272163`.
 - Current survivor population: 20 unbound loads in 14 test files.
 - Exact current line ancestry: 1 load from `bf847eb93`, 18 loads from `8a3ceb2c0`, and 1 load from `1eeb80bb3`.
-- Exact local test-repair worktree snapshot excluding this receipt: `abf5a9f78735ed1ca21562a6d0aec8e477943d38`.
+- Exact test-repair snapshot: `0ef212b9a8d4e59da9d754483ff6f04be8a6c4e7`.
 - Local binding instruments on that snapshot: 0 files with an unbound `AuthenticatedRaiseLocus`; 0 of the five bounded `_identity` files remain unbound.
 
 These are file/load measurements. They are not suite-failure counts.
@@ -19,50 +19,50 @@ These are file/load measurements. They are not suite-failure counts.
 
 ### BoolOp legacy probe
 
-- Exact baseline SHA: `b02b333d8`.
+- Exact baseline SHA: `b02b333d871c97df33821c9d3918ddadccbed971`.
 - Input and coordinate: `test_bool_op_operand_sequence.py::test_left_operand_is_evaluated_and_truth_tested_exactly_once`, BoolOp construction at baseline line 164.
 - First observed terminal: `TypeError: BoolOpSugar.values requires ConstructedTermSugar, got _ProbeSugar`.
 - Entrance: `BoolOpSugar.__post_init__`.
-- After repair snapshot `abf5a9f78735ed1ca21562a6d0aec8e477943d38`: the probe is a genuine `ConstructedTermSugar`; the exact file constructs through all 12 tests, `12 passed`.
+- After repair snapshot `0ef212b9a8d4e59da9d754483ff6f04be8a6c4e7`: the probe is a genuine `ConstructedTermSugar`; the exact file constructs through all 12 tests, `12 passed`.
 
 ### BoolOp synthetic halted operand
 
-- Exact baseline SHA: `b02b333d8`.
+- Exact baseline SHA: `b02b333d871c97df33821c9d3918ddadccbed971`.
 - Input and coordinate: `test_bool_op_operand_sequence.py:225`, synthetic `LeftTruthError`.
 - First observed terminal: unbound `AuthenticatedRaiseLocus` at the test construction entrance.
 - Entrance: direct test `RaiseEffect` construction.
 - After binding the name: the next terminal was `TypeError` because the narrowed constructor required `exception_type_coordinate`.
-- After repair snapshot `abf5a9f78735ed1ca21562a6d0aec8e477943d38`: the synthetic non-builtin carries an explicit test coordinate and the halt constructs.
+- After repair snapshot `0ef212b9a8d4e59da9d754483ff6f04be8a6c4e7`: the synthetic non-builtin carries an explicit test coordinate and the halt constructs.
 
 ### Native exceptional projection
 
-- Exact baseline SHA: `b02b333d8`.
+- Exact baseline SHA: `b02b333d871c97df33821c9d3918ddadccbed971`.
 - Input and coordinate: BoolOp formal-truth discharge with `_ExceptionalTruth()`; source coordinate `boolop_caller.py:2:11-2:25`.
 - First observed terminal: `NameError: AuthenticatedRaiseLocus is not defined`.
 - Entrance: `NativeOperationResolutionV1.project` at `caller_parameter_contract.py:153`.
-- After production SHA `3cdc88c01`: projection constructs one `Halted` face with the requested type coordinate and authenticated operation occurrence.
-- Next test terminal: unbound `_identity` in the assertion; after repair snapshot `abf5a9f78735ed1ca21562a6d0aec8e477943d38`, the complete BoolOp file is `12 passed`.
+- After production SHA `3cdc88c01269140c8b88d45b47d5ee38ec272163`: projection constructs one `Halted` face with the requested type coordinate and authenticated operation occurrence.
+- Next test terminal: unbound `_identity` in the assertion; after repair snapshot `0ef212b9a8d4e59da9d754483ff6f04be8a6c4e7`, the complete BoolOp file is `12 passed`.
 
 ### Generator manager first-resume refusal
 
-- Exact baseline SHA: `b02b333d8`.
+- Exact baseline SHA: `b02b333d871c97df33821c9d3918ddadccbed971`.
 - Inputs and coordinates: premature return at `test_generator_context_manager_construction.py:76`; never-yield at line 102.
 - First terminal at the production entrance: the unbound `AuthenticatedRaiseLocus` in `GeneratorWithSugar._entry_refusal_exit`.
 - Entrance: `generator_with_sugar.py:128`.
 - After binding the name: the next observed terminal was `TypeError: RaiseEffect.__init__() missing exception_type_coordinate`.
-- After production SHA `3cdc88c01`: the observed builtin refusal routes through `RaiseEffect.for_builtin`; both focused twins pass, `2 passed`.
+- After production SHA `3cdc88c01269140c8b88d45b47d5ee38ec272163`: the observed builtin refusal routes through `RaiseEffect.for_builtin`; both focused twins pass, `2 passed`.
 
 ### Function-formal identity assertion
 
-- Exact current-main SHA: `3cdc88c01`.
+- Exact current-main SHA: `3cdc88c01269140c8b88d45b47d5ee38ec272163`.
 - Input and coordinate: `test_function_formal_native_operation_binding.py::test_positional_actuals_discharge_through_python_binder`, `helper(None, 2)`.
 - First terminal before the test repair: unbound `_identity` at line 60.
 - Entrance: `_assert_named_halt`.
-- After repair snapshot `abf5a9f78735ed1ca21562a6d0aec8e477943d38`: the identity assertion passes; the next terminal is the separate occurrence-shape assertion at line 61. This receipt does not claim that later drift is fixed.
+- After repair snapshot `0ef212b9a8d4e59da9d754483ff6f04be8a6c4e7`: the identity assertion passes; the next terminal is the separate occurrence-shape assertion at line 61. This receipt does not claim that later drift is fixed.
 
 ### Unary identity assertion
 
-- Exact current-main SHA: `3cdc88c01`.
+- Exact current-main SHA: `3cdc88c01269140c8b88d45b47d5ee38ec272163`.
 - Input and coordinate: `test_unary_not_bool_law.py::test_halted_truth_is_not_negated`.
 - First observed terminal: `TypeError: UnaryOpSugar.operand requires ConstructedTermSugar, got _ValueSugar`.
 - Entrance: `UnaryOpSugar.__post_init__`.
@@ -70,7 +70,7 @@ These are file/load measurements. They are not suite-failure counts.
 
 ### Try identity assertions
 
-- Exact current-main SHA: `3cdc88c01`.
+- Exact current-main SHA: `3cdc88c01269140c8b88d45b47d5ee38ec272163`.
 - Inputs and coordinates: `test_bare_reraise_reemits_the_exact_inflight_raise` and `test_finally_raise_supersedes_break_instead_of_fabricating_loop_exit`.
 - First observed terminal: the tests receive `ExitSet` where their older assertions require `Incomplete`.
 - Entrance: the assertion immediately after `function.sugar().desugar()`.
@@ -78,7 +78,7 @@ These are file/load measurements. They are not suite-failure counts.
 
 ### Local processes without a terminal receipt
 
-- Exact repair snapshot: `abf5a9f78735ed1ca21562a6d0aec8e477943d38`.
+- Exact repair snapshot: `0ef212b9a8d4e59da9d754483ff6f04be8a6c4e7`.
 - Inputs: the focused pandas-subscript and source-setattr identity tests.
 - Observation: the local pytest processes exited 143 with no pytest terminal output.
 - Claim boundary: exit 143 is not counted as a product terminal, pass, failure, or timeout.

--- a/docs/superpowers/plans/2026-08-02-boolop-constructed-probe-drift.md
+++ b/docs/superpowers/plans/2026-08-02-boolop-constructed-probe-drift.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Restore the 12 BoolOp operand-sequence tests without reopening the deliberately closed `ConstructedTermSugar` door, then enumerate other caller drift introduced by `df07b3f88`.
+**Goal:** Restore the 12 BoolOp operand-sequence tests without reopening the deliberately closed `ConstructedTermSugar` door, then bind the test-only names left by two measured mechanical rewrites.
 
-**Architecture:** The product contract stays unchanged. The test-only evaluation probe joins the existing `ConstructedTermSugar` hierarchy and supplies canonical fixed testimony; a bounded commit audit reports other stale caller shapes without fixing them.
+**Architecture:** The product contract stays unchanged. The test-only evaluation probe joins the existing `ConstructedTermSugar` hierarchy and supplies canonical fixed testimony; test-only missing bindings are repaired at their files and tied to raw two-commit evidence.
 
 **Tech Stack:** Python 3.12, dataclasses, pytest, git history.
 
@@ -12,7 +12,7 @@
 
 - Work only in `/Users/tsavo/.herdr/worktrees/provekit/hockney-work`.
 - Do not loosen `BoolOpSugar.values` or its runtime admission.
-- Do not fix other `df07b3f88` caller drift in this lane.
+- Do not widen history beyond `bf847eb93` and `1eeb80bb3`.
 - Run only focused local tests; no broad suite or corpus scan.
 
 ---
@@ -57,28 +57,30 @@ Run all of `test_bool_op_operand_sequence.py` with `--noconftest`. Expected:
 
 Run `test_constructed_term_sugar.py::test_constructed_term_nested_children_are_closed_at_construction` with the `bool-op` parameter. Expected: the good constructed child is admitted and arbitrary `Sugar` remains rejected.
 
-### Task 2: Audit the source commit for sibling drift
+### Task 2: Repair bounded test-only rewrite casualties
 
 **Files:**
-- Read: commit `df07b3f88`
-- Read: callers of every narrowed annotation, removed parameter, and new runtime admission found in that commit
+- Modify: fourteen tests that load `AuthenticatedRaiseLocus` without importing it
+- Modify: five tests retaining ten unbound `_identity` loads
+- Create: `.receipts/authenticated-raise-rewrite-casualties/RECEIPT.md`
 
 **Interfaces:**
-- Consumes: the exact `df07b3f88` diff and repository callers on current `origin/main`
-- Produces: a door-by-door list with measured caller sites and current/stale status
+- Consumes: exact AST load/binding deltas for `bf847eb93` and `1eeb80bb3`
+- Produces: zero unbound locus/identity loads in the measured current test files, plus raw coordinates and first-terminal chains
 
-- [ ] **Step 1: Extract candidate doors from the bounded diff**
+- [ ] **Step 1: Bind the fourteen locus test files**
 
-Inspect only changed Python production files for type narrowing, signature
-removal, and new `isinstance`/admission checks.
+Import `AuthenticatedRaiseLocus` from its defining module in every measured
+test file. Do not alter the product constructor to admit unbound callers.
 
-- [ ] **Step 2: Trace every candidate to its callers**
+- [ ] **Step 2: Repair the five remaining identity expectations**
 
-For each candidate, compare old and new signatures and search current Python
-callers for the removed or rejected shape.
+Use existing builtin identity testimony for builtin exceptions. For the
+source-defined cleanup exception, derive identity from the typed source name;
+do not fabricate a builtin coordinate from spelling.
 
-- [ ] **Step 3: Report without repairing sibling doors**
+- [ ] **Step 3: Verify bindings and preserve raw evidence**
 
-State the number of doors inspected, the site count for each stale caller set,
-and what the audit does not claim. Commit only the focused BoolOp fixture repair
-and these design/plan receipts.
+Run the AST binding detector to zero, run the 12 BoolOp tests, compile all
+changed tests, and preserve all 187 introducer coordinates, current survivors,
+and first-terminal chains. Do not infer a suite-failure count.

--- a/docs/superpowers/plans/2026-08-02-boolop-constructed-probe-drift.md
+++ b/docs/superpowers/plans/2026-08-02-boolop-constructed-probe-drift.md
@@ -1,0 +1,84 @@
+# BoolOp Constructed Probe Drift Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the 12 BoolOp operand-sequence tests without reopening the deliberately closed `ConstructedTermSugar` door, then enumerate other caller drift introduced by `df07b3f88`.
+
+**Architecture:** The product contract stays unchanged. The test-only evaluation probe joins the existing `ConstructedTermSugar` hierarchy and supplies canonical fixed testimony; a bounded commit audit reports other stale caller shapes without fixing them.
+
+**Tech Stack:** Python 3.12, dataclasses, pytest, git history.
+
+## Global Constraints
+
+- Work only in `/Users/tsavo/.herdr/worktrees/provekit/hockney-work`.
+- Do not loosen `BoolOpSugar.values` or its runtime admission.
+- Do not fix other `df07b3f88` caller drift in this lane.
+- Run only focused local tests; no broad suite or corpus scan.
+
+---
+
+### Task 1: Repair the stale BoolOp test probe
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py`
+- Test: `implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py`
+
+**Interfaces:**
+- Consumes: `ConstructedTermSugar.to_term(*, owner: str) -> Term`
+- Produces: `_ProbeSugar`, an admissible constructed term retaining its existing evaluation log and floor-value result
+
+- [ ] **Step 1: Preserve the red receipt**
+
+Run the first test with `--noconftest`. Expected: `TypeError` naming
+`BoolOpSugar.values`, `ConstructedTermSugar`, and `_ProbeSugar`.
+
+- [ ] **Step 2: Promote the test fixture at the existing door**
+
+Replace the base import and class base, then add fixed canonical testimony:
+
+```python
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+
+@dataclass(frozen=True)
+class _ProbeSugar(ConstructedTermSugar):
+    ...
+
+    def to_term(self, *, owner: str):
+        del owner
+        return str_const(self.label)
+```
+
+- [ ] **Step 3: Verify the exact file is green**
+
+Run all of `test_bool_op_operand_sequence.py` with `--noconftest`. Expected:
+`12 passed` with no collection loss.
+
+- [ ] **Step 4: Verify the closed product door remains green**
+
+Run `test_constructed_term_sugar.py::test_constructed_term_nested_children_are_closed_at_construction` with the `bool-op` parameter. Expected: the good constructed child is admitted and arbitrary `Sugar` remains rejected.
+
+### Task 2: Audit the source commit for sibling drift
+
+**Files:**
+- Read: commit `df07b3f88`
+- Read: callers of every narrowed annotation, removed parameter, and new runtime admission found in that commit
+
+**Interfaces:**
+- Consumes: the exact `df07b3f88` diff and repository callers on current `origin/main`
+- Produces: a door-by-door list with measured caller sites and current/stale status
+
+- [ ] **Step 1: Extract candidate doors from the bounded diff**
+
+Inspect only changed Python production files for type narrowing, signature
+removal, and new `isinstance`/admission checks.
+
+- [ ] **Step 2: Trace every candidate to its callers**
+
+For each candidate, compare old and new signatures and search current Python
+callers for the removed or rejected shape.
+
+- [ ] **Step 3: Report without repairing sibling doors**
+
+State the number of doors inspected, the site count for each stale caller set,
+and what the audit does not claim. Commit only the focused BoolOp fixture repair
+and these design/plan receipts.

--- a/docs/superpowers/specs/2026-08-02-boolop-constructed-probe-drift-design.md
+++ b/docs/superpowers/specs/2026-08-02-boolop-constructed-probe-drift-design.md
@@ -1,0 +1,53 @@
+# BoolOp Constructed Probe Drift Design
+
+## Problem
+
+Commit `df07b3f88` deliberately closed `BoolOpSugar.values` to
+`ConstructedTermSugar` and added construction-time admission that rejects an
+arbitrary `Sugar`. `test_bool_op_operand_sequence.py` still supplies
+`_ProbeSugar(Sugar)`, so BoolOp rejects the fixture before the 12 semantic tests
+can exercise operand selection.
+
+The measured stale surface is one test file, seven `BoolOpSugar` construction
+sites, and fourteen `_ProbeSugar` operands. These are site counts, not fourteen
+independent test failures.
+
+## Authority
+
+The product door is authoritative. The same commit added the hierarchy-based
+admission rule and a bad twin proving that arbitrary `Sugar` must remain
+inadmissible. Changing `BoolOpSugar.values` back to `Sugar` would undo that
+correctness boundary.
+
+## Considered Repairs
+
+1. Promote the test probe to `ConstructedTermSugar` and give it canonical test
+   testimony. This preserves its observable evaluation behavior and satisfies
+   the same contract as every nested term. This is the selected repair.
+2. Replace the probe with production literal sugars. Those construct real
+   terms, but cannot return the arbitrary floor values and symbolic formal used
+   by these operand-selection tests without losing the behavior under test.
+3. Loosen the product door. This would make the old fixture pass by reopening
+   the deliberately forbidden arbitrary-Sugar path, so it is rejected.
+
+## Change
+
+Only `test_bool_op_operand_sequence.py` changes. `_ProbeSugar` subclasses
+`ConstructedTermSugar` and implements `to_term` as canonical test testimony
+from its fixed label. Its `desugar` behavior, evaluation log, returned floor
+value, and every product type remain unchanged.
+
+## Proof
+
+Before the repair, the file collects 12 tests and the first test fails at
+`BoolOpSugar.values requires ConstructedTermSugar, got _ProbeSugar`. After the
+repair, all 12 must execute and pass. The existing closed-door bad twin in
+`test_constructed_term_sugar.py` must also remain green, proving arbitrary
+`Sugar` is still rejected.
+
+## Bounded Follow-up Audit
+
+After the focused repair, inspect only the `df07b3f88` diff for narrowed type
+annotations, removed parameters, and new runtime admission checks. For each
+door, report whether repository callers use the current contract or retain the
+old shape. Do not repair other doors in this lane.

--- a/docs/superpowers/specs/2026-08-02-boolop-constructed-probe-drift-design.md
+++ b/docs/superpowers/specs/2026-08-02-boolop-constructed-probe-drift-design.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-Commit `df07b3f88` deliberately closed `BoolOpSugar.values` to
+Commit `ebf1ee5b4` deliberately closed `BoolOpSugar.values` to
 `ConstructedTermSugar` and added construction-time admission that rejects an
 arbitrary `Sugar`. `test_bool_op_operand_sequence.py` still supplies
 `_ProbeSugar(Sugar)`, so BoolOp rejects the fixture before the 12 semantic tests
@@ -32,7 +32,8 @@ correctness boundary.
 
 ## Change
 
-Only `test_bool_op_operand_sequence.py` changes. `_ProbeSugar` subclasses
+The BoolOp portion changes only `test_bool_op_operand_sequence.py`.
+`_ProbeSugar` subclasses
 `ConstructedTermSugar` and implements `to_term` as canonical test testimony
 from its fixed label. Its `desugar` behavior, evaluation log, returned floor
 value, and every product type remain unchanged.
@@ -45,9 +46,15 @@ repair, all 12 must execute and pass. The existing closed-door bad twin in
 `test_constructed_term_sugar.py` must also remain green, proving arbitrary
 `Sugar` is still rejected.
 
-## Bounded Follow-up Audit
+## Bounded Rewrite-Casualty Repair
 
-After the focused repair, inspect only the `df07b3f88` diff for narrowed type
-annotations, removed parameters, and new runtime admission checks. For each
-door, report whether repository callers use the current contract or retain the
-old shape. Do not repair other doors in this lane.
+The separate authenticated-raise sweep found fourteen test files with twenty
+unbound `AuthenticatedRaiseLocus` loads after the two production crash paths
+landed. A two-commit audit also found five current test files with ten unbound
+`_identity` loads. Bind those names in test code without changing product
+contracts, and preserve the raw commit/file/line evidence in the receipt.
+
+The bounded history evidence is not a new product taxonomy: it explains one
+mechanical rewrite casualty. `bf847eb93` introduced 187 unbound
+`AuthenticatedRaiseLocus` loads; `1eeb80bb3` introduced eleven unbound
+`_identity` loads plus one locus load. Do not widen beyond those commits.

--- a/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
@@ -18,6 +18,7 @@ from sugar_lift_py_tests.context_manager_contract import (
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
     ExpectationNotMetEffect,
 )
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect, UndeterminedRaiseEffect
 from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
 from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue

--- a/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
@@ -13,6 +13,7 @@ from sugar_lift_py_tests.context_manager_contract import (
 )
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.effect import RaiseEffect
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.floor import FloorValue, SymbolicValue, TermValue
 from sugar_lift_py_tests.floor.ground_exit import ground_type_error
 from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
@@ -20,7 +21,7 @@ from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var, str_const
 from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted, outcome_to_exitset
 from sugar_lift_py_tests.sugar.bool_op_sugar import BoolOpSugar
 from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
-from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import BoolOp
@@ -55,7 +56,7 @@ class _Operand(FloorValue):
 
 
 @dataclass(frozen=True)
-class _ProbeSugar(Sugar):
+class _ProbeSugar(ConstructedTermSugar):
     label: str
     value: FloorValue
     evaluations: list[str] = field(compare=False)
@@ -68,6 +69,10 @@ class _ProbeSugar(Sugar):
         del ctx
         self.evaluations.append(self.label)
         return Complete(self.value)
+
+    def to_term(self, *, owner: str):
+        del owner
+        return str_const(self.label)
 
 
 @dataclass(frozen=True)
@@ -155,6 +160,10 @@ class _ExpectedType:
         return self._identity
 
 
+def _identity(name: str):
+    return _ExpectedType(name).exception_type_identity()
+
+
 def test_left_operand_is_evaluated_and_truth_tested_exactly_once() -> None:
     evaluations: list[str] = []
     truth_calls: list[str] = []
@@ -218,7 +227,14 @@ def test_true_left_continues_to_right_without_truth_testing_final_operand() -> N
 def test_halted_left_truth_test_propagates_and_never_reaches_right() -> None:
     evaluations: list[str] = []
     truth_calls: list[str] = []
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('test_bool_op_operand_sequence.py:1:0'), exception_name='LeftTruthError', blame='test_bool_op_operand_sequence.py:1:0')
+    effect = RaiseEffect(
+        exception_type_coordinate=_identity("LeftTruthError"),
+        occurrence=AuthenticatedRaiseLocus.of(
+            "test_bool_op_operand_sequence.py:1:0"
+        ),
+        exception_name="LeftTruthError",
+        blame="test_bool_op_operand_sequence.py:1:0",
+    )
     left = _Operand("left", ExitSet.halted(effect), truth_calls)
     right = _Operand("right", _truth(True), truth_calls)
 
@@ -299,7 +315,7 @@ def test_halted_caller_truth_propagates_and_never_reaches_right() -> None:
     assert evaluations == ["left"]
     assert len(exits.exits) == 1
     assert isinstance(exits.exits[0], Halted)
-    assert exits.exits[0].effect.exception_type_coordinate == _identity('TypeError')
+    assert exits.exits[0].effect.exception_type_coordinate == _identity("TypeError")
 
 
 def test_wrong_boundary_type_does_not_consume_caller_truth_halt() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_boundary_observation_conserves_demands.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_boundary_observation_conserves_demands.py
@@ -36,6 +36,7 @@ from sugar_lift_py_tests.context_manager_contract import (
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
     ExpectationNotMetEffect,
 )
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.floor.inv_value import InvValue
 from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
 from sugar_lift_py_tests.ir import PrimitiveSort, atomic, ctor, make_var, num

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_exit_suppression_contract.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_exit_suppression_contract.py
@@ -12,6 +12,7 @@ from dataclasses import replace
 
 import pytest
 
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 from sugar_lift_py_tests.floor.call_site_value import ExitSuppressionContract
 from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py
@@ -13,6 +13,7 @@ from dataclasses import replace
 import pytest
 
 from sugar_lift_py_tests.context_manager_contract import EffectMatcher, Suppresses
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
 from sugar_lift_py_tests.ir import atomic, ctor, str_const

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_nested_exit_faces.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_nested_exit_faces.py
@@ -34,6 +34,7 @@ from sugar_lift_py_tests.context_manager_contract import (
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
     ExpectationNotMetEffect,
 )
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 from sugar_lift_py_tests.floor import ReturnValue, StringValue, TermValue
 from sugar_lift_py_tests.floor.call_site_value import CallSiteValue

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_source_resource_stack.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_source_resource_stack.py
@@ -30,6 +30,7 @@ from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordin
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
     ExpectationNotMetEffect,
 )
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 from sugar_lift_py_tests.floor import StringValue, TermValue
 from sugar_lift_py_tests.floor.call_site_value import CallSiteValue

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_try_finally.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_try_finally.py
@@ -33,6 +33,7 @@ from sugar_lift_py_tests.context_manager_contract import (
 from sugar_lift_py_tests.effect.expectation_not_met_effect import (
     ExpectationNotMetEffect,
 )
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 from sugar_lift_py_tests.floor import StringValue
 from sugar_lift_py_tests.floor.call_site_value import CallSiteValue

--- a/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
@@ -57,7 +57,7 @@ def _assert_named_halt(outcome) -> None:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate == _identity('TypeError')
+    assert halted.effect.exception_type_coordinate == _Expected("TypeError").identity
     assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"

--- a/implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py
@@ -1,3 +1,6 @@
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
+
+
 def _identity(module: str, name: str):
     from sugar_lift_py_tests.ir import ctor, str_const
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from sugar_lift_py_tests.effect import RaiseEffect, UndeterminedRaiseEffect
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.floor import RaiseValue
 from sugar_lift_py_tests.ir import str_const
 from sugar_lift_py_tests.no_call_body_attribution import (
@@ -729,4 +730,3 @@ def test_undischarged_with_none_coordinates_is_constructible() -> None:
         ((None, None),),
     )
     assert body.exceptional_exit_coordinates == ((None, None),)
-

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_subscript_caller_gap.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_subscript_caller_gap.py
@@ -329,7 +329,7 @@ def test_caller_actuals_can_name_an_exception_at_the_original_subscript() -> Non
     assert isinstance(halted, Halted)
     # ListValue[1] on len-1 list is IndexError (not TypeError). Presence-only
     # used to green either; the value pin must name IndexError or it is a false tooth.
-    assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert halted.effect.exception_type_coordinate == _Expected("IndexError").identity
     assert halted.effect.occurrence == str(carrier.demand.source_node.wire())
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
@@ -47,6 +47,7 @@ from pathlib import Path
 import pytest
 
 from sugar_lift_py_tests.effect import RaiseEffect, UndeterminedRaiseEffect
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.floor.raise_value import (
     FABRICATED_EXCEPTIONAL_EXIT_MEANING_LITERALS,
     RaiseValue,

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py
@@ -49,6 +49,7 @@ from sugar_lift_py_tests.floor import (
 )
 from sugar_lift_py_tests.floor.block_value import BlockValue
 from sugar_lift_py_tests.floor.class_definition_value import ClassDefinitionValue
+from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
 from sugar_lift_py_tests.floor.return_value import ReturnValue
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
 from sugar_lift_py_tests.sugar.sugar_base import Sugar
@@ -60,6 +61,11 @@ MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
     "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
 )
+
+
+def _identity(name: str):
+    coordinate, _ = _builtin_exception_identity(name)
+    return coordinate
 
 
 def _tree(source: str, name: str = "setattr_caller.py") -> SourceFile:

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import pytest
 
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.floor import (
     BytesValue,
     ListValue,

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_not_bool_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_not_bool_law.py
@@ -53,6 +53,13 @@ from sugar_source_tree.nodes import UnaryOp
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
+
+def _identity(name: str):
+    return ctor(
+        "python:exception_type_identity",
+        [str_const("builtins"), str_const(name)],
+    )
+
 MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
     "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -15,6 +15,7 @@ from sugar_lift_py_tests.context_manager_contract import (
 )
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 from sugar_lift_py_tests.effect import LoopControlEffect, RaiseEffect
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.floor import ObjectValue, SymbolicValue, TermValue
 from sugar_lift_py_tests.floor.block_value import BlockValue
 from sugar_lift_py_tests.floor.call_site_value import ExitSuppressionContract

--- a/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
+++ b/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from types import MappingProxyType
 
+from sugar_lift_py_tests.effect.authenticated_raise_locus import AuthenticatedRaiseLocus
 from sugar_lift_py_tests.context_manager_contract import (
     CallParameterV1,
     EffectBoundarySemanticsV1,

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -34,6 +34,17 @@ def _fn(src):
     return next(source_file_with_preconstruction(Path(path)).functions())
 
 
+def _exception_identity(function, name: str):
+    occurrence = next(
+        node
+        for node in function.walk()
+        if node.kind == "Name" and node.id == name
+    )
+    identity = function.unit.exception_type_identity(occurrence)
+    assert identity is not None
+    return identity
+
+
 def _incompletes(v):
     from sugar_lift_py_tests.outcome import Incomplete
 
@@ -227,20 +238,19 @@ def test_bare_reraise_reemits_the_exact_inflight_raise():
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
     from sugar_lift_py_tests.outcome import Incomplete
 
-    out = (
-        _fn(
-            "def A():\n"
-            "    try:\n"
-            "        raise ValueError\n"
-            "    except ValueError:\n"
-            "        raise\n"
-        )
-        .sugar()
-        .desugar()
+    function = _fn(
+        "def A():\n"
+        "    try:\n"
+        "        raise ValueError\n"
+        "    except ValueError:\n"
+        "        raise\n"
     )
+    out = function.sugar().desugar()
     assert isinstance(out, Incomplete)
     assert isinstance(out.effect, RaiseEffect)
-    assert out.effect.exception_type_coordinate == _identity('ValueError')
+    assert out.effect.exception_type_coordinate == _exception_identity(
+        function, "ValueError"
+    )
     assert out.effect.exception_name == "ValueError"
     assert out.effect.occurrence.endswith(":6:8")
 
@@ -513,24 +523,23 @@ def test_finally_raise_supersedes_break_instead_of_fabricating_loop_exit():
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
     from sugar_lift_py_tests.outcome import Incomplete
 
-    out = (
-        _fn(
-            "class ArbitraryCleanupFault(Exception):\n"
-            "    pass\n"
-            "def A():\n"
-            "    for item in [1]:\n"
-            "        try:\n"
-            "            break\n"
-            "        finally:\n"
-            "            raise ArbitraryCleanupFault\n"
-            "    return 11\n"
-        )
-        .sugar()
-        .desugar()
+    function = _fn(
+        "class ArbitraryCleanupFault(Exception):\n"
+        "    pass\n"
+        "def A():\n"
+        "    for item in [1]:\n"
+        "        try:\n"
+        "            break\n"
+        "        finally:\n"
+        "            raise ArbitraryCleanupFault\n"
+        "    return 11\n"
     )
+    out = function.sugar().desugar()
     assert isinstance(out, Incomplete)
     assert isinstance(out.effect, RaiseEffect)
-    assert out.effect.exception_type_coordinate == _identity('ArbitraryCleanupFault')
+    assert out.effect.exception_type_coordinate == _exception_identity(
+        function, "ArbitraryCleanupFault"
+    )
     assert out.effect.exception_name == "ArbitraryCleanupFault"
 
 


### PR DESCRIPTION
## Closed-door product-surface tooth — 1/1

The existing closed-door bad twin passes `1/1`: `test_constructed_term_nested_children_are_closed_at_construction` still admits `ConstructedTermSugar` and rejects arbitrary `Sugar` with `TypeError`. Its file blob is identical on main `3cdc88c01269140c8b88d45b47d5ee38ec272163` and this branch (`55bceddfc35a60b306c41dd57acc44f29d1caf4a`). This repair binds test-only names; it does not widen the product export or BoolOp admission surface.

## What changed

Bind 20 unresolved `AuthenticatedRaiseLocus` loads across 14 test files after the production construction-path repair in #7147. The branch also repairs the bounded BoolOp test probe without reopening the deliberately closed `ConstructedTermSugar` door, and preserves raw casualty coordinates in the receipt.

## Blame correction

Eighteen of the surviving loads are **line-blame churn, not introductions**: `bf847eb93` is an ancestor of `8a3ceb2c0`, so later line attribution must not double-count an earlier introduction as a new casualty. The receipt preserves exact ancestry rather than flattening blame into the latest touching commit.

## Bounded rewrite-tool refusal

Repository evidence found no callable generator in the three named introducer/touch histories—`bf847eb93`, `8a3ceb2c0`, and `1eeb80bb3`—and a current search of `.claude`, `.briefs`, `docs`, `bin`, and `scripts` found the symbol only in the retirement document, not in a callable rewrite mechanism. This supports a one-time mechanical agent or hand pass whose generator was not committed. It is **not proof that no external or uncommitted prompt/tool ever existed**.

## Measured evidence

- BoolOp semantics: `12/12` passed.
- Closed-door bad twin: `1/1` passed.
- Changed Python files: `19` compiled.
- `git diff --check`: clean.
- Current casualty population: 20 unresolved loads across 14 test files, reduced to zero in the branch instrument.

These are bounded focused and static receipts. No broad suite, corpus, or global failure-count delta is claimed.

## Scope floors

- no category, kind, label, taxonomy, or residual-bucket product surface added;
- no runner autoscaler or CI-capacity changes;
- no test deleted, skipped, or xfailed to reach green.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AuthenticatedRaiseLocus` and `_identity` NameErrors across sugar-lift test suite
> - Adds missing `AuthenticatedRaiseLocus` imports to ~12 test modules that referenced the symbol without importing it, resolving `NameError` failures at runtime.
> - Fixes `_ProbeSugar` in [`test_bool_op_operand_sequence.py`](https://github.com/TSavo/sugar/pull/7148/files#diff-8fae4275320de6a845a351c7af6a2dbe4be4ccacc6ffc43fe3473a2f0b04c856) by changing its base class from `Sugar` to `ConstructedTermSugar` and adding `to_term`, making it admissible by `BoolOpSugar.values`.
> - Adds local `_identity` helpers in several modules to compute concrete builtin exception identities, replacing references to an undefined `_identity` symbol.
> - Refactors two tests in [`test_try_sugar.py`](https://github.com/TSavo/sugar/pull/7148/files#diff-e08e75c8aa18050f22f6a4f3eab47a900f9605097a7ac8dc38f92f9c906a7e07) to derive `exception_type_identity` from the typed source function rather than a fabricated helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6adc89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->