### PR TITLE
Bind deferred reducer continuations to their source statements

### DIFF
--- a/.receipts/mcmanus-late-bound-loop-closures/RECEIPT.md
+++ b/.receipts/mcmanus-late-bound-loop-closures/RECEIPT.md
@@ -1,0 +1,60 @@
+# Late-bound loop-closure negative
+
+This receipt bounds the follow-up to the deferred `reduce_next` defect fixed by
+commit `034218936a4e1fb029b83db4fd3f6cdfadfc83fc`. It records a measured
+negative; it does not broaden that product change. The equivalent product diff
+was restacked onto `73647afdebdb483b038519782530ce68075a980b` before this
+receipt was committed; the resulting commit is named in the handoff because a
+commit cannot truthfully cite its own not-yet-computed identity.
+
+## Population and detector
+
+The scan parsed **269 non-test Python files** under `implementations/python`
+containing **1,612 `ast.For` / `ast.AsyncFor` nodes**. For each loop, it found
+every nested `FunctionDef`, `AsyncFunctionDef`, or `Lambda` whose body loaded a
+name bound by that loop target without receiving the name as a function
+argument. Each finding was then inspected for whether the closure could be
+invoked after its creating iteration advanced.
+
+The detector found **7 candidates across 5 files**. The non-empty candidate
+set is part of the evidence: the detector recognized real loop-target captures
+rather than returning an uncalibrated zero.
+
+## Candidate triage
+
+All **7/7 candidates** were synchronous within their creating iteration;
+**0/7 deferred past it**.
+
+1. `scripts/comprehension_iteration_recensus.py`: `construct_file` captures
+   `path`, but `_collect_file_construction` immediately calls
+   `collect_construction_panic`, whose first operation is `walker()`. The
+   callback finishes before the file loop advances.
+2. `floor/dict_value.py`: `project` captures `position` and is invoked for the
+   guarded true and false faces immediately before returning from the current
+   iteration.
+3. `floor/string_value.py`: `branch` captures `index` and is invoked for both
+   guarded tuple faces immediately before returning from the current
+   iteration.
+4. `sugar/with_effect_boundary_sugar.py`: `successful` and `failed` capture
+   `face`; both helpers are invoked directly while routing that same face,
+   before the `body_es.exits` loop continues.
+5. `manager_construction.py`: `obligation` and `seat_receipt` capture the
+   current `receipt`; every call is direct within the same respective receipt
+   iteration, and neither function object is stored or passed onward.
+
+## Result
+
+Within this measured Python population, the reducer's loop-target
+late-binding defect is a singleton: **7 candidates found, 7 cleared, 0 sibling
+closures deferred beyond their creating iteration**.
+
+This receipt does **not** cover:
+
+- closures defined outside a loop then queued inside it
+- indirect callback assembly the syntactic detector cannot recognize
+- tests
+- Rust
+- runtime-generated code
+
+Those exclusions are boundaries of this measurement, not claims that the
+excluded mechanisms are clean or corrupt.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/caller_parameter_contract.py
@@ -151,7 +151,11 @@ class NativeOperationResolutionV1:
             testimony = self.pre_effect_state
             effect = self.effect
             if testimony is None:
-                effect = RaiseEffect(exception_type_coordinate=self.exception_type_coordinate, occurrence=AuthenticatedRaiseLocus.of(str(occurrence.wire())), blame=str(occurrence.wire()))
+                effect = RaiseEffect(
+                    exception_type_coordinate=self.exception_type_coordinate,
+                    occurrence=AuthenticatedRaiseLocus.of(str(occurrence.wire())),
+                    blame=str(occurrence.wire()),
+                )
             if not isinstance(effect, RaiseEffect):
                 raise TypeError(
                     "exceptional native operation effect must be RaiseEffect"
@@ -1029,7 +1033,14 @@ class NativeOperationExitCarrierV1:
             def resume(value, *, step=continuation):
                 next_outcome = step(value)
                 if isinstance(next_outcome, NativeOperationExitCarrierV1):
-                    if self.pre_effect_state is not None:
+                    # A reducer continuation can mint a later carrier with the
+                    # state reached after this operation completed. Preserve
+                    # that newer reducer-issued testimony; inherit ours only
+                    # when the nested carrier has no state of its own.
+                    if (
+                        self.pre_effect_state is not None
+                        and next_outcome.pre_effect_state is None
+                    ):
                         next_outcome = next_outcome._enroll_pre_effect_state(
                             self.pre_effect_state
                         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -246,7 +246,12 @@ def reduce_block_to_exitset(
 
     for index, head in enumerate(statements):
 
-        def reduce_next(state: _ReducedBlock) -> ExitSet[_ReducedBlock]:
+        def reduce_next(
+            state: _ReducedBlock, *, statement=head
+        ) -> ExitSet[_ReducedBlock]:
+            # A native-operation carrier may retain this callback until after
+            # the outer reducer loop advances. Bind the current statement now;
+            # a late-bound ``head`` skips the deferred tail to the final node.
             if not state.can_fall_through:
                 # A terminal Completed face (return, including return from
                 # finally) owns the exit.  It is completed rather than halted,
@@ -282,7 +287,7 @@ def reduce_block_to_exitset(
                     statement_ctx = statement_ctx.with_observed_effect(
                         binding.slot_id, binding.effect
                     )
-            outcome = head.desugar(statement_ctx)
+            outcome = statement.desugar(statement_ctx)
             from sugar_lift_py_tests.floor.guarded_faces import GuardedFaces
 
             def project(value):

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -301,29 +301,64 @@ def test_continuation_carrier_inherits_enclosing_reducer_pre_effect_state():
     assert halted.state is state
 
 
-def test_continuation_carrier_rejects_conflicting_pre_effect_state():
+def test_continuation_carrier_preserves_newer_reducer_pre_effect_state():
+    """A nested reducer carrier supersedes the enclosing carrier's older state.
+
+    The deleted expectation was that discharge panic on any differing nested
+    state.  That made the enclosing carrier falsely authoritative over state
+    reached later by the reducer continuation.
+    """
     first, left, right = _carrier(operator="less_than")
     outer_state = _ReducedBlock((TermValue(71),), True, ())
-    conflicting_state = _ReducedBlock((TermValue(72),), True, ())
-    second, _second_left, _second_right = _carrier(operator="less_than")
-    second = second.and_then(
+    newer_state = _ReducedBlock((TermValue(72),), True, ())
+    second_left = _coordinate("second_left", 2)
+    second_right = _coordinate("second_right", 3)
+    second = NativeOperationExitCarrierV1.mint(
+        site=_site(),
+        operator="less_than",
+        operands=(
+            SymbolicValue(make_var("second_left"), second_left),
+            SymbolicValue(make_var("second_right"), second_right),
+        ),
+        coordinates=(second_left, second_right),
+    ).and_then(
         lambda value: Complete(value),
-        pre_effect_state=ReducerPreEffectStateV1._from_reducer(conflicting_state),
+        pre_effect_state=ReducerPreEffectStateV1._from_reducer(newer_state),
     )
     chained = first.and_then(
         lambda _value: second,
         pre_effect_state=ReducerPreEffectStateV1._from_reducer(outer_state),
     )
 
+    exits = chained.discharge(
+        {
+            left.coordinate_cid: TermValue(1),
+            right.coordinate_cid: TermValue(2),
+            second_left.coordinate_cid: NoneValue(),
+            second_right.coordinate_cid: TermValue(2),
+        }
+    )
+
+    halted = next(exit_ for exit_ in exits.exits if isinstance(exit_, Halted))
+    assert halted.state is newer_state
+
+
+def test_direct_conflicting_pre_effect_state_reenrollment_stays_loud():
+    carrier, _left, _right = _carrier(operator="less_than")
+    first_state = _ReducedBlock((TermValue(71),), True, ())
+    conflicting_state = _ReducedBlock((TermValue(72),), True, ())
+    enrolled = carrier.and_then(
+        lambda value: Complete(value),
+        pre_effect_state=ReducerPreEffectStateV1._from_reducer(first_state),
+    )
+
     with pytest.raises(
         ConstructionPanic,
         match="a second conflicting reducer pre-effect state",
     ):
-        chained.discharge(
-            {
-                left.coordinate_cid: TermValue(1),
-                right.coordinate_cid: TermValue(2),
-            }
+        enrolled.and_then(
+            lambda value: Complete(value),
+            pre_effect_state=ReducerPreEffectStateV1._from_reducer(conflicting_state),
         )
 
 

--- a/implementations/python/sugar-source-tree/tests/native_carrier_testimony.py
+++ b/implementations/python/sugar-source-tree/tests/native_carrier_testimony.py
@@ -1,0 +1,41 @@
+"""Test doors for the deliberately non-projectable native-operation carrier."""
+
+import pytest
+
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.floor import SymbolicValue
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet
+
+
+def completed_function_value(function):
+    """Project only an outcome that really completed; never accept a carrier."""
+    outcome = function.sugar().desugar()
+    assert isinstance(outcome, Complete), outcome
+    return outcome.value
+
+
+def native_carrier_for(function, *, operator):
+    """Pin the pending operation and prove that it has no value projection."""
+    outcome = function.sugar().desugar()
+    assert isinstance(outcome, NativeOperationExitCarrierV1), outcome
+    with pytest.raises(AttributeError, match="value"):
+        _ = outcome.value
+    assert outcome.demand.operator == operator
+    return outcome
+
+
+def authenticated_function_value(function, *, operator, actuals=None):
+    """Complete through the function's own source-frame binder testimony."""
+    carrier = native_carrier_for(function, operator=operator)
+    frame = function.source_visible_call_frame()
+    if actuals is None:
+        actuals = tuple(SymbolicValue(make_var(name)) for name in frame.parameters)
+    bound = frame.bind_actuals(tuple(actuals), ())
+    projected = bound.project_native_carrier(carrier)
+    assert isinstance(projected, ExitSet), projected
+    completed = tuple(
+        exit_ for exit_ in projected.exits if isinstance(exit_, Completed)
+    )
+    assert len(completed) == 1, projected.exits
+    return completed[0].value

--- a/implementations/python/sugar-source-tree/tests/test_bool_literals.py
+++ b/implementations/python/sugar-source-tree/tests/test_bool_literals.py
@@ -6,14 +6,22 @@ floor value: `return True` -> out == True; a ground `assert True` states nothing
 import tempfile
 
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.outcome import Complete
 from sugar_source_tree.tree import SourceFile
+
+from native_carrier_testimony import authenticated_function_value
 
 
 def _uni(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
         f.write(src)
         path = f.name
-    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value
+    function = next(SourceFile(path_source(path)).functions())
+    outcome = function.sugar().desugar()
+    if isinstance(outcome, Complete):
+        return outcome.value
+    # Deleted expectation: a formal equality was an immediate completed universe.
+    return authenticated_function_value(function, operator="equals")
 
 
 def test_return_true_and_false_are_bool_consts():

--- a/implementations/python/sugar-source-tree/tests/test_comparison_operators.py
+++ b/implementations/python/sugar-source-tree/tests/test_comparison_operators.py
@@ -10,16 +10,24 @@ import tempfile
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
 
+from native_carrier_testimony import authenticated_function_value, native_carrier_for
+
 
 def _inv(src: str):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
         f.write(src)
         path = f.name
-    return (
-        next(SourceFile(path_source(path)).functions())
-        .sugar()
-        .desugar()
-        .value.invs()[0]
+    function = next(SourceFile(path_source(path)).functions())
+    # Deleted expectation: an undecided formal equality was already completed.
+    return authenticated_function_value(function, operator="equals").invs()[0]
+
+
+def _carrier(src: str, operator: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return native_carrier_for(
+        next(SourceFile(path_source(path)).functions()), operator=operator
     )
 
 
@@ -30,31 +38,40 @@ def test_not_equal_is_equals_negated():
 
 
 def test_ordering_operators_emit_their_atoms():
-    assert _inv("def A(z):\n    assert z < 10\n    return z\n").name == "py.lt"
-    assert _inv("def A(z):\n    assert z <= 10\n    return z\n").name == "py.le"
-    assert _inv("def A(z):\n    assert z > 0\n    return z\n").name == "py.gt"
-    assert _inv("def A(z):\n    assert z >= 0\n    return z\n").name == "py.ge"
+    """Deleted expectation: formal orderings immediately emitted py.lt/le/gt/ge."""
+    for spelling, operator, right_value in (
+        ("<", "less_than", 10),
+        ("<=", "less_equal", 10),
+        (">", "greater_than", 0),
+        (">=", "greater_equal", 0),
+    ):
+        carrier = _carrier(
+            f"def A(z):\n    assert z {spelling} {right_value}\n    return z\n",
+            operator,
+        )
+        left, right = carrier.operands
+        assert left.to_term(owner="ordering carrier tooth").name == "z"
+        assert right.value == right_value
 
 
 def test_chained_comparison_conjoins_adjacent_pairs():
-    # 0 < z < 10  ->  (0 < z) and (z < 10)
-    inv = _inv("def A(z):\n    assert 0 < z < 10\n    return z\n")
-    assert inv.kind == "and"
-    left, right = inv.operands
-    assert left.name == "py.lt" and left.args[0].value == 0 and left.args[1].name == "z"
-    assert (
-        right.name == "py.lt"
-        and right.args[0].name == "z"
-        and right.args[1].value == 10
-    )
+    """Deleted expectation: a formal chain was one completed conjunction."""
+    carrier = _carrier("def A(z):\n    assert 0 < z < 10\n    return z\n", "less_than")
+    left, right = carrier.operands
+    assert left.value == 0
+    assert right.to_term(owner="comparison-chain carrier tooth").name == "z"
+    assert len(carrier.continuations) == 6
 
 
 def test_comparison_composes_inside_boolop():
-    # the case that was blocked before: (z == 1) and (z != 2)
-    inv = _inv("def A(z):\n    assert (z == 1) and (z != 2)\n    return z\n")
-    assert inv.kind == "and"
-    assert inv.operands[0].name == "py.eq"
-    assert inv.operands[1].kind == "not"  # z != 2
+    """Deleted expectation: a formal BoolOp projected a completed conjunction."""
+    carrier = _carrier(
+        "def A(z):\n    assert (z == 1) and (z != 2)\n    return z\n", "equals"
+    )
+    left, right = carrier.operands
+    assert left.to_term(owner="boolop carrier tooth").name == "z"
+    assert right.value == 1
+    assert len(carrier.continuations) == 6
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_comprehension_dissolves.py
@@ -21,6 +21,8 @@ from sugar_lift_py_tests.proofir.terms import term_from_ir
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
+from native_carrier_testimony import completed_function_value, native_carrier_for
+
 
 def _fn(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
@@ -30,7 +32,7 @@ def _fn(src):
 
 
 def _out(src):
-    return _fn(src).sugar().desugar().value.post().args[1]
+    return completed_function_value(_fn(src)).post().args[1]
 
 
 def _is_binding_coordinate(value):
@@ -44,8 +46,15 @@ def test_filtered_listcomp_keeps_ground_true_elements():
 
 
 def test_undecidable_filtered_listcomp_retains_guard_without_guessing_verdict():
-    term = _out("def A(limit):\n    return [x for x in [1, 2] if x > limit]\n")
-    assert term.args[1].body.name == "python:loop.filter_guard"
+    """Deleted expectation: an undecided filter was an immediately projectable term."""
+    carrier = native_carrier_for(
+        _fn("def A(limit):\n    return [x for x in [1, 2] if x > limit]\n"),
+        operator="greater_than",
+    )
+    left, right = carrier.operands
+    assert left.to_term(owner="comprehension carrier tooth").name == "x"
+    assert right.formal_coordinate.declared_name == "limit"
+    assert len(carrier.continuations) == 5
 
 
 def test_dictcomp_over_concrete_range_dissolves():

--- a/implementations/python/sugar-source-tree/tests/test_for_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_for_unroll.py
@@ -8,8 +8,11 @@ import tempfile
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.outcome import Complete
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
+
+from native_carrier_testimony import authenticated_function_value
 
 
 def _fn(src):
@@ -20,7 +23,12 @@ def _fn(src):
 
 
 def _invs(src):
-    return _fn(src).sugar().desugar().value.invs()
+    function = _fn(src)
+    outcome = function.sugar().desugar()
+    if isinstance(outcome, Complete):
+        return outcome.value.invs()
+    # Deleted expectation: each formal loop-body equality completed before binding.
+    return authenticated_function_value(function, operator="equals").invs()
 
 
 def test_concrete_for_unrolls_the_body_per_element():

--- a/implementations/python/sugar-source-tree/tests/test_fstring_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_fstring_sugar.py
@@ -4,6 +4,9 @@ import tempfile
 
 import pytest
 
+from sugar_lift_py_tests.caller_parameter_contract import NativeOperationExitCarrierV1
+from sugar_lift_py_tests.floor.string_value import StringValue
+from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.backend import Leaf, MaybeChild, materialize
 from sugar_source_tree.panic import BackendDefect
@@ -54,12 +57,24 @@ def _with_bare_format_spec(node):
     )
 
 
-def test_fstring_concatenates_literal_and_interpolation():
-    # f"n={z}" -> "n=" ++ python:fstring_value(z, None, None)
-    term = _post_term('def A(z):\n    return f"n={z}"\n')
-    assert term.name == "+"
-    assert term.args[0].value == "n="
-    assert term.args[1].name == "python:fstring_value"
+def test_fstring_concat_preserves_operands_in_native_operation_carrier():
+    """Do not restore the deleted ``.value`` false-completion expectation.
+
+    ``str + SymbolicValue`` deliberately stays pending until native-operation
+    discharge.  The carrier must retain the exact f-string operands instead of
+    fabricating the completed ``+`` term this test asserted before #7060.
+    """
+    outcome = _fn('def A(z):\n    return f"n={z}"\n').sugar().desugar()
+
+    assert isinstance(outcome, NativeOperationExitCarrierV1)
+    with pytest.raises(AttributeError, match="value"):
+        _ = outcome.value
+
+    assert outcome.demand.operator == "add"
+    left, right = outcome.operands
+    assert isinstance(left, StringValue) and left.value == "n="
+    assert isinstance(right, SymbolicValue)
+    assert right.to_term(owner="f-string carrier tooth").name == "python:fstring_value"
 
 
 def test_fstring_with_only_a_literal_is_the_string():

--- a/implementations/python/sugar-source-tree/tests/test_identity_and_literals.py
+++ b/implementations/python/sugar-source-tree/tests/test_identity_and_literals.py
@@ -10,6 +10,8 @@ import tempfile
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
 
+from native_carrier_testimony import completed_function_value, native_carrier_for
+
 
 def _fn(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
@@ -19,7 +21,7 @@ def _fn(src):
 
 
 def _inv(src):
-    return _fn(src).sugar().desugar().value.invs()[0]
+    return completed_function_value(_fn(src)).invs()[0]
 
 
 def test_is_is_identity():
@@ -39,10 +41,14 @@ def test_float_literal_is_real_sorted():
 
 
 def test_membership_lifts_for_a_symbolic_container():
-    # `x in xs` is `xs.contains(x)`: a symbolic container is the py.in coordinate.
-    inv = _inv("def A(x, xs):\n    assert x in xs\n    return x\n")
-    assert inv.name == "py.in"
-    assert inv.args[0].name == "x" and inv.args[1].name == "xs"
+    """Deleted expectation: formal membership immediately projected py.in."""
+    carrier = native_carrier_for(
+        _fn("def A(x, xs):\n    assert x in xs\n    return x\n"),
+        operator="contains",
+    )
+    container, item = carrier.operands
+    assert container.to_term(owner="membership carrier tooth").name == "xs"
+    assert item.to_term(owner="membership carrier tooth").name == "x"
 
 
 if __name__ == "__main__":

--- a/implementations/python/sugar-source-tree/tests/test_if_exp_and_phi_lift.py
+++ b/implementations/python/sugar-source-tree/tests/test_if_exp_and_phi_lift.py
@@ -15,16 +15,23 @@ This also exercises the finished temporal cut: substitute is the sole binder
 import tempfile
 
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.floor import TermValue
+from sugar_lift_py_tests.outcome import Complete
 from sugar_source_tree.tree import SourceFile
+
+from native_carrier_testimony import authenticated_function_value, native_carrier_for
 
 
 def _post(src: str):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
         f.write(src)
         path = f.name
-    return (
-        next(SourceFile(path_source(path)).functions()).sugar().desugar().value.post()
-    )
+    function = next(SourceFile(path_source(path)).functions())
+    outcome = function.sugar().desugar()
+    if isinstance(outcome, Complete):
+        return outcome.value.post()
+    # Deleted expectation: a formal predicate was completed before caller binding.
+    return authenticated_function_value(function, operator="equals").post()
 
 
 def _no_py_conditional(post):
@@ -43,10 +50,20 @@ def test_substitute_is_the_sole_binder_straight_line():
 def test_single_assignment_fold_reads_the_old_binding():
     # x = z + 1; x = x + 1; return x  ->  out == (z + 1) + 1 : the rebind reads
     # the OLD x, the loop-as-repeated-substitute shape.
-    post = _post("def A(z):\n    x = z + 1\n    x = x + 1\n    return x\n")
-    assert post.name == "="
-    outer = post.args[1]
-    assert outer.name == "+" and outer.args[0].name == "+"  # (z+1)+1
+    source = "def A(z):\n    x = z + 1\n    x = x + 1\n    return x\n"
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(source)
+        path = f.name
+    function = next(SourceFile(path_source(path)).functions())
+    # Deleted expectation: z+1 projected before the caller authenticated z.
+    carrier = native_carrier_for(function, operator="add")
+    left, right = carrier.operands
+    assert left.to_term(owner="assignment-fold carrier tooth").name == "z"
+    assert right.value == 1
+    post = authenticated_function_value(
+        function, operator="add", actuals=(TermValue(2),)
+    ).post()
+    assert post.name == "=" and post.args[1].value == 4
 
 
 def test_direct_ifexp_predicate_distributes():

--- a/implementations/python/sugar-source-tree/tests/test_inert_statements.py
+++ b/implementations/python/sugar-source-tree/tests/test_inert_statements.py
@@ -12,14 +12,22 @@ nothing left for them to say.
 import tempfile
 
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.outcome import Complete
 from sugar_source_tree.tree import SourceFile
+
+from native_carrier_testimony import authenticated_function_value
 
 
 def _val(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
         f.write(src)
         path = f.name
-    return next(SourceFile(path_source(path)).functions()).sugar().desugar().value
+    function = next(SourceFile(path_source(path)).functions())
+    outcome = function.sugar().desugar()
+    if isinstance(outcome, Complete):
+        return outcome.value
+    # Deleted expectation: the later formal equality completed without caller testimony.
+    return authenticated_function_value(function, operator="equals")
 
 
 def test_import_is_inert():

--- a/implementations/python/sugar-source-tree/tests/test_listcomp_dissolves.py
+++ b/implementations/python/sugar-source-tree/tests/test_listcomp_dissolves.py
@@ -9,6 +9,8 @@ import tempfile
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
 
+from native_carrier_testimony import completed_function_value, native_carrier_for
+
 
 def _fn(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
@@ -18,7 +20,7 @@ def _fn(src):
 
 
 def _out(src):
-    return _fn(src).sugar().desugar().value.post().args[1]
+    return completed_function_value(_fn(src)).post().args[1]
 
 
 def test_identity_comprehension_is_the_display():
@@ -47,11 +49,15 @@ def test_undecidable_filtered_comprehension_is_typed_filter_guard():
     ``[x for x in [1,2] if x > limit]`` constructs as ``py.listcomp`` carrying
     ``python:loop.filter_guard`` — typed residual, not construction silence.
     """
-    t = _out("def A(limit):\n    return [x for x in [1, 2] if x > limit]\n")
-    assert t.name == "py.listcomp"
-    # Nested transform includes the filter guard over the formal ``limit``.
-    text = str(t)
-    assert "python:loop.filter_guard" in text or "py.gt" in text
+    # Deleted expectation: the pending comparison already projected py.listcomp.
+    carrier = native_carrier_for(
+        _fn("def A(limit):\n    return [x for x in [1, 2] if x > limit]\n"),
+        operator="greater_than",
+    )
+    left, right = carrier.operands
+    assert left.to_term(owner="listcomp carrier tooth").name == "x"
+    assert right.formal_coordinate.declared_name == "limit"
+    assert len(carrier.continuations) == 5
 
 
 def test_symbolic_comprehension_builds_coordinate():

--- a/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_method_call_sugar.py
@@ -8,6 +8,12 @@ import tempfile
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
 
+from native_carrier_testimony import (
+    authenticated_function_value,
+    completed_function_value,
+    native_carrier_for,
+)
+
 
 def _fn(src):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
@@ -17,7 +23,7 @@ def _fn(src):
 
 
 def _out(src):
-    return _fn(src).sugar().desugar().value.post().args[1]
+    return completed_function_value(_fn(src)).post().args[1]
 
 
 def test_method_call_is_the_method_coordinate():
@@ -36,12 +42,11 @@ def test_method_chains_compose():
 
 
 def test_assert_consumes_the_coordinate():
-    inv = (
-        _fn("def A(s):\n    assert s.upper() == s\n    return s\n")
-        .sugar()
-        .desugar()
-        .value.invs()[0]
-    )
+    # Deleted expectation: the formal equality completed before its caller bound s.
+    inv = authenticated_function_value(
+        _fn("def A(s):\n    assert s.upper() == s\n    return s\n"),
+        operator="equals",
+    ).invs()[0]
     assert inv.name == "py.eq"
     assert inv.args[0].name == "call:upper"
 
@@ -55,13 +60,15 @@ def test_keyword_args_lift():
 
 
 def test_spread_keyword_args_build_reference_method_call():
-    t = _out("def A(z, d):\n    return z.get(1, **d)\n")
-
-    assert t.name == "python:call"
-    assert t.args[0].value == "z.get"
-    spread = t.args[-1]
-    assert spread.name == "python:double_starred_kwarg"
-    assert spread.args[0].name == "d"
+    """Deleted expectation: formal attribute lookup completed before binding z."""
+    carrier = native_carrier_for(
+        _fn("def A(z, d):\n    return z.get(1, **d)\n"),
+        operator="attribute_named",
+    )
+    receiver, name = carrier.operands
+    assert receiver.to_term(owner="method receiver carrier tooth").name == "z"
+    assert name.value == "get"
+    assert len(carrier.continuations) == 5
 
 
 def test_spread_call_is_a_constructed_method_argument_coordinate():

--- a/implementations/python/sugar-source-tree/tests/test_range_unroll.py
+++ b/implementations/python/sugar-source-tree/tests/test_range_unroll.py
@@ -8,8 +8,11 @@ import tempfile
 import pytest
 
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_py_tests.outcome import Complete
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
+
+from native_carrier_testimony import authenticated_function_value
 
 
 def _fn(src):
@@ -20,7 +23,12 @@ def _fn(src):
 
 
 def _invs(src):
-    return _fn(src).sugar().desugar().value.invs()
+    function = _fn(src)
+    outcome = function.sugar().desugar()
+    if isinstance(outcome, Complete):
+        return outcome.value.invs()
+    # Deleted expectation: range-body formal equalities completed before binding.
+    return authenticated_function_value(function, operator="equals").invs()
 
 
 def test_range_stop_unrolls_the_body_per_element():

--- a/implementations/python/sugar-source-tree/tests/test_unary_bool_attribute_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_unary_bool_attribute_sugar.py
@@ -11,6 +11,8 @@ import tempfile
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
 
+from native_carrier_testimony import native_carrier_for
+
 
 def _fn(src: str):
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
@@ -19,96 +21,87 @@ def _fn(src: str):
     return next(SourceFile(path_source(path)).functions())
 
 
-def _post(src):
-    return _fn(src).sugar().desugar().value.post()
-
-
-def _invs(src):
-    return _fn(src).sugar().desugar().value.invs()
+def _carrier(src, operator):
+    return native_carrier_for(_fn(src), operator=operator)
 
 
 # ---- UnaryOp -----------------------------------------------------------------
 
 
 def test_undecided_unary_ops_are_named_refusals():
-    """``-z`` / ``~z`` / ``+z`` cannot invent a success face without z's type."""
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
-
+    """Deleted expectation: formal unary operations panicked before caller binding."""
     for source, operator in (
-        ("def A(z):\n    return -z\n", "-"),
-        ("def A(z):\n    return ~z\n", "~"),
-        ("def A(z):\n    return +z\n", "+"),
+        ("def A(z):\n    return -z\n", "unary_minus"),
+        ("def A(z):\n    return ~z\n", "bitwise_invert"),
+        ("def A(z):\n    return +z\n", "unary_plus"),
     ):
-        try:
-            _post(source)
-        except ConstructionPanic as panic:
-            assert panic.info.owner == "unary_operation_exception_floor"
-            assert panic.info.observed == f"SymbolicValue {operator}"
-        else:
-            raise AssertionError(f"undecided unary {operator} invented a completion")
+        carrier = _carrier(source, operator)
+        assert carrier.operands[0].to_term(owner="unary carrier tooth").name == "z"
 
 
 def test_not_is_truth_then_negate():
-    # if not (z == 1): the guard is not(z == 1), so the body's fact rides under it.
-    invs = _invs(
-        "def A(z):\n    if not (z == 1):\n        assert z == z\n    return z\n"
+    """Deleted expectation: formal equality/truth projected a completed guard."""
+    carrier = _carrier(
+        "def A(z):\n    if not (z == 1):\n        assert z == z\n    return z\n",
+        "equals",
     )
-    authentication = invs[0]
-    observed = authentication.operands[0].operands[1]
-    assert observed.kind == "not"
-    assert observed.operands[0].name == "py.eq"
+    left, right = carrier.operands
+    assert left.to_term(owner="not carrier tooth").name == "z"
+    assert right.value == 1
+    assert len(carrier.continuations) >= 6
 
 
 # ---- BoolOp ------------------------------------------------------------------
 
 
 def test_and_conjoins_operand_truthiness():
-    invs = _invs("def A(z):\n    assert (z == 1) and (z == 3)\n    return z\n")
-    assert invs[0].kind == "and"
-    assert all(op.name == "py.eq" for op in invs[0].operands)
+    """Deleted expectation: formal BoolOp projected a completed conjunction."""
+    carrier = _carrier(
+        "def A(z):\n    assert (z == 1) and (z == 3)\n    return z\n", "equals"
+    )
+    assert carrier.operands[0].to_term(owner="and carrier tooth").name == "z"
+    assert carrier.operands[1].value == 1
+    assert len(carrier.continuations) == 6
 
 
 def test_or_disjoins_operand_truthiness():
-    invs = _invs("def A(z):\n    assert (z == 1) or (z == 2)\n    return z\n")
-    assert invs[0].kind == "or"
+    """Deleted expectation: formal BoolOp projected a completed disjunction."""
+    carrier = _carrier(
+        "def A(z):\n    assert (z == 1) or (z == 2)\n    return z\n", "equals"
+    )
+    assert carrier.operands[0].to_term(owner="or carrier tooth").name == "z"
+    assert carrier.operands[1].value == 1
+    assert len(carrier.continuations) == 6
 
 
 def test_bare_operands_refuse_undecided_truth():
-    """``a and b`` cannot invent ``py.truthy`` when operand runtime types are open."""
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
-
-    try:
-        _invs("def A(a, b):\n    assert a and b\n    return a\n")
-    except ConstructionPanic as panic:
-        assert panic.info.owner == "boolean_operation_exception_floor"
-        assert panic.info.observed == "SymbolicValue and"
-    else:
-        raise AssertionError("undecided BoolOp invented py.truthy")
+    """Deleted expectation: bare formal BoolOp truth panicked before binding."""
+    carrier = _carrier(
+        "def A(a, b):\n    assert a and b\n    return a\n", "boolop_truth"
+    )
+    assert carrier.operands[0].to_term(owner="boolop truth carrier tooth").name == "a"
 
 
 # ---- Attribute ---------------------------------------------------------------
 
 
 def _attribute_refusal(source):
-    from sugar_lift_py_tests.gap.panic import ConstructionPanic
-
-    try:
-        _post(source)
-    except ConstructionPanic as panic:
-        return panic.info
-    raise AssertionError("symbolic attribute invented a completed projection")
+    # Deleted expectation: formal attribute lookup panicked before caller binding.
+    return _carrier(source, "attribute_named")
 
 
 def test_attribute_is_named_undecided():
-    info = _attribute_refusal("def A(z):\n    return z.numerator\n")
-    assert info.owner == "SymbolicValue.attribute"
-    assert info.observed.endswith("SymbolicValue.numerator")
+    carrier = _attribute_refusal("def A(z):\n    return z.numerator\n")
+    receiver, name = carrier.operands
+    assert receiver.to_term(owner="attribute carrier tooth").name == "z"
+    assert name.value == "numerator"
 
 
 def test_attribute_chain_refuses_at_the_first_unowned_lookup():
-    info = _attribute_refusal("def A(z):\n    return z.a.b\n")
-    assert info.owner == "SymbolicValue.attribute"
-    assert info.observed.endswith("SymbolicValue.a")
+    carrier = _attribute_refusal("def A(z):\n    return z.a.b\n")
+    receiver, name = carrier.operands
+    assert receiver.to_term(owner="attribute chain carrier tooth").name == "z"
+    assert name.value == "a"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Wrong-result defect and construction law

`reduce_block_to_exitset` created each `reduce_next` closure over the loop variable `head`. When an early `NativeOperationExitCarrierV1` retained that continuation and discharged later, the closure could observe a newer statement instead of the statement that minted it. The repair binds every continuation to its source statement. Nested discharge also preserves newer reducer-issued pre-effect-state testimony while direct conflicting reenrollment remains loud.

The defect requires all three adjacent conditions: at least two statements; an early `NativeOperationExitCarrierV1`; and later discharge.

## Reproduced terminal accounting

- `observed_chain_length=3`
- `blocking_terminal_count=2`
- `final_terminal=constructed`

Convention: `observed_chain_length` counts every observed state including the final constructed result; `blocking_terminal_count` counts only states that prevented lawful construction.

The population was 12 files, with 1 observed misbound entrance at `function_universe_sugar.py:579`; that population does not exercise the other 29 conditional entrances, and those entrances are neither shown clean nor shown corrupt.

The disappearance of an intermediate terminal after restacking does not make the state repair unnecessary: the independent state-authority teeth still prove that nested newer testimony wins and that direct conflicting reenrollment panics.

## Positive teeth

Every positive tooth was rerun after both restacks:

- **REPRODUCED-ACROSS-TWO-RESTACKS:** f-string 7/7
- **REPRODUCED-ACROSS-TWO-RESTACKS:** replacement 25/25
- **REPRODUCED-ACROSS-TWO-RESTACKS:** bind-site 2/2, with iterable 3/3 and range 4/4
- **REPRODUCED-ACROSS-TWO-RESTACKS:** state-authority 3/3

The branch also preserves the #7147 `AuthenticatedRaiseLocus` import and `NativeOperationResolutionV1.project` repair in `caller_parameter_contract.py`.

## Bounded negative and exclusions

A static scan parsed 269 non-test Python files and 1,612 `ast.For` / `ast.AsyncFor` nodes. It found 7 loop-target capture candidates across 5 files; 7/7 were synchronous within their creating iteration and 0/7 were deferred beyond it. This does not cover closures defined outside a loop then queued inside it, indirect callback assembly the syntactic detector cannot recognize, tests, Rust, or runtime-generated code.

No broad suite result is claimed. The other 29 conditional entrances are not claimed exercised. No tests were deleted, skipped, or xfailed to obtain these focused results.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix deferred reducer continuations to close over the correct loop statement
> - Fixes a late-binding bug in [`reduce_block_to_exitset`](https://github.com/TSavo/sugar/pull/7149/files#diff-1a034881b3b9f8294d507d8d13e7d0addd04ec63a0ccc585b95ed6ae81f9f21b) where the inner `reduce_next` callback closed over the loop variable `head` by reference, causing all continuations to desugar the final statement when invoked after the loop advanced. The fix binds `head` as a default keyword argument at each iteration.
> - Fixes `NativeOperationExitCarrierV1.discharge` to preserve a nested carrier's own `pre_effect_state` instead of overwriting it with the outer carrier's state; the outer state is now only inherited when the nested carrier has no state of its own.
> - Updates a broad set of sugar-source-tree tests to reflect deferred-completion semantics, asserting on native operation carriers and their operands rather than expecting immediate completions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 196fa74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->