### PR TITLE
Refuse unconserved floor magnitudes as UNMEASURED

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -178,11 +178,14 @@ def main() -> int:
 
     offenders = tuple(row.offender for row in rows if row.offender is not None)
     if args.json is not None:
-        from pandas_floor_summary import relative_files, write_floor_summary_or_residual
+        from pandas_floor_summary import (
+            relative_files,
+            write_floor_summary_or_unmeasured,
+        )
 
         files = relative_files(paths, args.repo_root)
         residual_count = len(offenders)
-        write_floor_summary_or_residual(
+        write_floor_summary_or_unmeasured(
             args.json,
             floor="bare-exception",
             residual_key="R_bare_exceptions",

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -221,11 +221,14 @@ def main() -> int:
         progress_path=progress_path,
     )
     if args.json is not None:
-        from pandas_floor_summary import relative_files, write_floor_summary_or_residual
+        from pandas_floor_summary import (
+            relative_files,
+            write_floor_summary_or_unmeasured,
+        )
 
         files = relative_files(paths, args.repo_root)
         residual_count = len(summary.offenders)
-        write_floor_summary_or_residual(
+        write_floor_summary_or_unmeasured(
             args.json,
             floor="native-crash",
             residual_key="R_native_crashes",

--- a/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
@@ -4,10 +4,22 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+_PACKAGE_SRC = Path(__file__).resolve().parents[1] / "src"
+if str(_PACKAGE_SRC) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_SRC))
+
+from sugar_lift_py_tests.conservation_mint import (  # noqa: E402
+    ConservationFailure,
+    ConservedBody,
+    seal_after_validation,
+)
+
 SCHEMA = "pandas-floor-summary-v1"
+VALIDATOR_STAGE_ID = "pandas-floor-summary.rows-account-for-corpus/v1"
 
 
 def relative_files(paths: Sequence[Path], root: Path) -> list[str]:
@@ -21,7 +33,7 @@ def corpus_cid(files: Sequence[str]) -> str:
     return "sha256:" + hashlib.sha256(preimage.encode("utf-8")).hexdigest()
 
 
-def floor_summary(
+def _floor_summary_outcome(
     *,
     floor: str,
     files: Sequence[str],
@@ -29,21 +41,14 @@ def floor_summary(
     totals: Mapping[str, int],
     measured: bool,
     unmeasurable_reasons: Sequence[str] = (),
-) -> dict[str, Any]:
+) -> ConservedBody | ConservationFailure:
     ordered_files = sorted(files)
     ordered_rows = sorted((dict(row) for row in rows), key=lambda row: str(row["file"]))
-    if not ordered_files:
-        raise ValueError("a floor summary requires a non-empty measured corpus")
-    if [str(row["file"]) for row in ordered_rows] != ordered_files:
-        raise ValueError("floor rows must account for every corpus file exactly once")
     reasons = sorted(set(unmeasurable_reasons))
-    if measured and reasons:
-        raise ValueError("a measured floor cannot carry unmeasurable reasons")
-    return {
+    payload = {
         "kind": SCHEMA,
         "floor": floor,
-        "measurement": "measured" if measured else "unmeasurable",
-        "unmeasurableReasons": reasons,
+        "unmeasurableReasons": [],
         "corpus": {
             "files": ordered_files,
             "filesTotal": len(ordered_files),
@@ -53,6 +58,60 @@ def floor_summary(
         "totals": dict(sorted(totals.items())),
     }
 
+    def validate() -> None:
+        if not measured:
+            reason = "; ".join(reasons) or "floor producer marked measurement incomplete"
+            raise ValueError(reason)
+        if not ordered_files:
+            raise ValueError("a floor summary requires a non-empty measured corpus")
+        if [str(row["file"]) for row in ordered_rows] != ordered_files:
+            raise ValueError("floor rows must account for every corpus file exactly once")
+        if reasons:
+            raise ValueError("a measured floor cannot carry unmeasurable reasons")
+
+    return seal_after_validation(
+        measured_payload=payload,
+        input_key_manifest=[{"file": file} for file in ordered_files],
+        output_key_manifest=[{"file": str(row["file"])} for row in ordered_rows],
+        validator_stage_id=VALIDATOR_STAGE_ID,
+        validator_source_path=Path(__file__).resolve(),
+        validate=validate,
+    )
+
+
+def floor_summary(
+    *,
+    floor: str,
+    files: Sequence[str],
+    rows: Sequence[Mapping[str, Any]],
+    totals: Mapping[str, int],
+    measured: bool,
+    unmeasurable_reasons: Sequence[str] = (),
+) -> dict[str, Any]:
+    outcome = _floor_summary_outcome(
+        floor=floor,
+        files=files,
+        rows=rows,
+        totals=totals,
+        measured=measured,
+        unmeasurable_reasons=unmeasurable_reasons,
+    )
+    if isinstance(outcome, ConservationFailure):
+        if not measured:
+            body = outcome.to_wire()
+            body.update(
+                {
+                    "kind": "floor-unmeasured-v1",
+                    "floor": floor,
+                    "residualCount": None,
+                    "unmeasurableReasons": [outcome.reason],
+                }
+            )
+            return body
+        reason = outcome.reason.partition(": ")[2] or outcome.reason
+        raise ValueError(reason)
+    return outcome.to_wire()
+
 
 def write_json(path: Path, value: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -61,34 +120,33 @@ def write_json(path: Path, value: Mapping[str, Any]) -> None:
     )
 
 
-def write_floor_residual_v1(
+def write_floor_unmeasured_v1(
     path: Path,
     *,
     residual_key: str,
-    residual_count: int,
     floor: str,
-    emission_fallback: str | None = None,
+    failure: ConservationFailure,
 ) -> None:
-    """Minimal residual body for enrollment mint when full summary cannot seal.
+    """Emit an explicit refusal when full-summary conservation cannot seal.
 
-    Enrollment cites residualCount under residualKey — never invents from exit.
+    The producer may already hold an in-memory candidate magnitude, but failed
+    conservation makes that candidate non-testimony.  The refusal therefore
+    carries no numeric residual for a downstream reader to reseal.
     """
-    if type(residual_count) is not int or residual_count < 0:
-        raise ValueError(
-            f"residual_count must be non-negative int; got {residual_count!r}"
-        )
-    body: dict[str, Any] = {
-        "kind": "floor-residual-v1",
-        "floor": floor,
-        "residualKey": residual_key,
-        "residualCount": residual_count,
-    }
-    if emission_fallback:
-        body["emissionFallback"] = emission_fallback
+    body = failure.to_wire()
+    body.update(
+        {
+            "kind": "floor-unmeasured-v1",
+            "floor": floor,
+            "residualKey": residual_key,
+            "residualCount": None,
+            "unmeasurableReasons": [failure.reason],
+        }
+    )
     write_json(path, body)
 
 
-def write_floor_summary_or_residual(
+def write_floor_summary_or_unmeasured(
     path: Path,
     *,
     floor: str,
@@ -100,29 +158,28 @@ def write_floor_summary_or_residual(
     measured: bool = True,
     unmeasurable_reasons: Sequence[str] = (),
 ) -> str:
-    """Always emit residual magnitude for mint; full summary when conservation holds.
+    """Emit conserved testimony, otherwise an explicit UNMEASURED envelope.
 
-    Product residual is already computed (residual_count). A conservation failure
-    in floor_summary must not erase that mass — fall back to floor-residual-v1
-    so enrollment can cite residualCount (freeze night: exit=1 + no summary).
+    ``residual_count`` is deliberately accepted at the shared producer door so
+    callers cannot accidentally route around it.  It is serialized only inside
+    a conserved full summary (through ``totals``).  A conservation failure must
+    never promote the in-memory candidate into a sealed residual body.
     """
-    try:
-        payload = floor_summary(
-            floor=floor,
-            files=files,
-            rows=rows,
-            totals=totals,
-            measured=measured,
-            unmeasurable_reasons=unmeasurable_reasons,
-        )
-        write_json(path, payload)
-        return "full"
-    except ValueError as error:
-        write_floor_residual_v1(
+    outcome = _floor_summary_outcome(
+        floor=floor,
+        files=files,
+        rows=rows,
+        totals=totals,
+        measured=measured,
+        unmeasurable_reasons=unmeasurable_reasons,
+    )
+    if isinstance(outcome, ConservationFailure):
+        write_floor_unmeasured_v1(
             path,
             residual_key=residual_key,
-            residual_count=residual_count,
             floor=floor,
-            emission_fallback=f"{type(error).__name__}: {error}",
+            failure=outcome,
         )
-        return "residual-only"
+        return "unmeasured"
+    write_json(path, outcome.to_wire())
+    return "full"

--- a/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
@@ -64,8 +65,23 @@ def _floor_summary_outcome(
             raise ValueError(reason)
         if not ordered_files:
             raise ValueError("a floor summary requires a non-empty measured corpus")
-        if [str(row["file"]) for row in ordered_rows] != ordered_files:
-            raise ValueError("floor rows must account for every corpus file exactly once")
+        row_files = [str(row["file"]) for row in ordered_rows]
+        if row_files != ordered_files:
+            expected = Counter(ordered_files)
+            observed = Counter(row_files)
+            missing = sorted((expected - observed).elements())
+            extra = sorted((observed - expected).elements())
+            duplicates = sorted(
+                file for file, count in observed.items() if count > 1
+            )
+            raise ValueError(
+                "floor rows must account for every corpus file exactly once: "
+                f"expectedRows={len(ordered_files)} observedRows={len(row_files)} "
+                f"missing={len(missing)} extra={len(extra)} "
+                f"duplicateKeys={len(duplicates)} "
+                f"missingSample={missing[:5]!r} extraSample={extra[:5]!r} "
+                f"duplicateSample={duplicates[:5]!r}"
+            )
         if reasons:
             raise ValueError("a measured floor cannot carry unmeasurable reasons")
 

--- a/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/silent_zero_tolerance.py
@@ -449,11 +449,14 @@ def main() -> int:
         progress_stdout=args.progress_stdout,
     )
     if args.json is not None:
-        from pandas_floor_summary import relative_files, write_floor_summary_or_residual
+        from pandas_floor_summary import (
+            relative_files,
+            write_floor_summary_or_unmeasured,
+        )
 
         files = relative_files(paths, args.repo_root)
         residual_count = r_silent(summary.offenders)
-        write_floor_summary_or_residual(
+        write_floor_summary_or_unmeasured(
             args.json,
             floor="silent",
             residual_key="R_silent",

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -164,11 +164,14 @@ def main() -> int:
     rows = summary.rows
     offenders = summary.offenders
     if args.json is not None:
-        from pandas_floor_summary import relative_files, write_floor_summary_or_residual
+        from pandas_floor_summary import (
+            relative_files,
+            write_floor_summary_or_unmeasured,
+        )
 
         files = relative_files(paths, args.repo_root)
         residual_count = len(offenders)
-        write_floor_summary_or_residual(
+        write_floor_summary_or_unmeasured(
             args.json,
             floor="timeout",
             residual_key="R_timeouts",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/conservation_mint.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/conservation_mint.py
@@ -1,0 +1,236 @@
+"""Universal conservation seal for measurement artifacts.
+
+A measured body has one entrance: a schema validator executes successfully,
+then this module mints its witness and attaches it to ``ConservedBody``.  A
+validator failure has one honest outcome, ``ConservationFailure``.  It carries
+diagnostics only; the candidate measured payload is deliberately discarded so
+raw in-memory magnitudes cannot cross the write boundary after validation red.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CONSERVATION_WITNESS_SCHEMA = "sugar.conservation-witness.v1"
+
+_CID_PATTERN = re.compile(
+    r"(?:blake3-512:[0-9a-f]{128}|sha256:[0-9a-f]{64})"
+)
+_WITNESS_AUTHORITY = object()
+
+
+def _content_cid(data: bytes) -> str:
+    try:
+        import blake3  # type: ignore
+
+        return "blake3-512:" + blake3.blake3(data, max_threads=1).digest(64).hex()
+    except Exception:  # noqa: BLE001 - deterministic stdlib fallback
+        return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _canonical_key_manifest(
+    keys: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    rows = [dict(key) for key in keys]
+    return sorted(
+        rows,
+        key=lambda row: json.dumps(
+            row, sort_keys=True, separators=(",", ":"), default=str
+        ),
+    )
+
+
+def key_manifest_cid(keys: Sequence[Mapping[str, Any]]) -> str:
+    """CID over canonical key members, never a count-only surrogate."""
+    payload = json.dumps(
+        {"keys": _canonical_key_manifest(keys)},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return _content_cid(payload)
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class ConservationWitnessV1:
+    input_key_manifest_cid: str
+    input_key_count: int
+    output_key_manifest_cid: str
+    output_key_count: int
+    validator_stage_id: str
+    validator_source_cid: str
+
+    def __init__(
+        self,
+        *,
+        input_key_manifest_cid: str,
+        input_key_count: int,
+        output_key_manifest_cid: str,
+        output_key_count: int,
+        validator_stage_id: str,
+        validator_source_cid: str,
+        _authority: object,
+    ) -> None:
+        if _authority is not _WITNESS_AUTHORITY:
+            raise TypeError(
+                "ConservationWitnessV1 is minted only by the shared validation door"
+            )
+        for name, cid in (
+            ("inputKeyManifestCid", input_key_manifest_cid),
+            ("outputKeyManifestCid", output_key_manifest_cid),
+            ("validatorSourceCid", validator_source_cid),
+        ):
+            if not isinstance(cid, str) or not _CID_PATTERN.fullmatch(cid):
+                raise ValueError(f"{name} is not a supported content CID: {cid!r}")
+        for name, count in (
+            ("inputKeyCount", input_key_count),
+            ("outputKeyCount", output_key_count),
+        ):
+            if type(count) is not int or count < 0:
+                raise ValueError(f"{name} must be a non-negative int")
+        if not isinstance(validator_stage_id, str) or not validator_stage_id.strip():
+            raise ValueError("validatorStageId must be non-empty")
+        object.__setattr__(self, "input_key_manifest_cid", input_key_manifest_cid)
+        object.__setattr__(self, "input_key_count", input_key_count)
+        object.__setattr__(self, "output_key_manifest_cid", output_key_manifest_cid)
+        object.__setattr__(self, "output_key_count", output_key_count)
+        object.__setattr__(self, "validator_stage_id", validator_stage_id)
+        object.__setattr__(self, "validator_source_cid", validator_source_cid)
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "witnessSchema": CONSERVATION_WITNESS_SCHEMA,
+            "inputKeyManifestCid": self.input_key_manifest_cid,
+            "inputKeyCount": self.input_key_count,
+            "outputKeyManifestCid": self.output_key_manifest_cid,
+            "outputKeyCount": self.output_key_count,
+            "validatorStageId": self.validator_stage_id,
+            "validatorSourceCid": self.validator_source_cid,
+            "status": "passed",
+        }
+
+    @classmethod
+    def _from_wire(cls, value: Mapping[str, Any]) -> "ConservationWitnessV1":
+        expected = {
+            "witnessSchema",
+            "inputKeyManifestCid",
+            "inputKeyCount",
+            "outputKeyManifestCid",
+            "outputKeyCount",
+            "validatorStageId",
+            "validatorSourceCid",
+            "status",
+        }
+        if set(value) != expected:
+            raise ValueError(
+                "conservationWitness fields differ from universal v1 contract"
+            )
+        if value.get("witnessSchema") != CONSERVATION_WITNESS_SCHEMA:
+            raise ValueError("conservationWitness witnessSchema is unsupported")
+        if value.get("status") != "passed":
+            raise ValueError("conservationWitness status is not passed")
+        return cls(
+            input_key_manifest_cid=value.get("inputKeyManifestCid"),
+            input_key_count=value.get("inputKeyCount"),
+            output_key_manifest_cid=value.get("outputKeyManifestCid"),
+            output_key_count=value.get("outputKeyCount"),
+            validator_stage_id=value.get("validatorStageId"),
+            validator_source_cid=value.get("validatorSourceCid"),
+            _authority=_WITNESS_AUTHORITY,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ConservedBody:
+    payload: Mapping[str, Any]
+    witness: ConservationWitnessV1
+
+    def to_wire(self) -> dict[str, Any]:
+        body = dict(self.payload)
+        if body.get("measurement") not in (None, "measured"):
+            raise ValueError("ConservedBody payload contradicts measurement=measured")
+        if "conservationWitness" in body:
+            raise ValueError("ConservedBody payload may not supply its own witness")
+        body["measurement"] = "measured"
+        body["conservationWitness"] = self.witness.to_wire()
+        return body
+
+
+@dataclass(frozen=True, slots=True)
+class ConservationFailure:
+    validator_stage_id: str
+    reason: str
+    validator_source_cid: str | None = None
+
+    def to_wire(self) -> dict[str, Any]:
+        diagnostic: dict[str, Any] = {
+            "validatorStageId": self.validator_stage_id,
+            "reason": self.reason,
+        }
+        if self.validator_source_cid is not None:
+            diagnostic["validatorSourceCid"] = self.validator_source_cid
+        return {
+            "kind": "measurement-conservation-failure-v1",
+            "measurement": "unmeasured",
+            "conservationFailure": diagnostic,
+        }
+
+
+def seal_after_validation(
+    *,
+    measured_payload: Mapping[str, Any],
+    input_key_manifest: Sequence[Mapping[str, Any]],
+    output_key_manifest: Sequence[Mapping[str, Any]],
+    validator_stage_id: str,
+    validator_source_path: Path,
+    validate: Callable[[], object],
+) -> ConservedBody | ConservationFailure:
+    """Execute the schema validator, then construct exactly one outcome."""
+    try:
+        validator_source_cid = _content_cid(Path(validator_source_path).read_bytes())
+    except OSError as error:
+        return ConservationFailure(
+            validator_stage_id=validator_stage_id,
+            reason=f"{type(error).__name__}: validator source unavailable: {error}",
+        )
+    try:
+        result = validate()
+        if result is not None and result is not True:
+            raise ValueError(
+                f"validator returned non-pass result {type(result).__name__}={result!r}"
+            )
+    except Exception as error:  # noqa: BLE001 - failure is the typed outcome
+        return ConservationFailure(
+            validator_stage_id=validator_stage_id,
+            validator_source_cid=validator_source_cid,
+            reason=f"{type(error).__name__}: {error}",
+        )
+    witness = ConservationWitnessV1(
+        input_key_manifest_cid=key_manifest_cid(input_key_manifest),
+        input_key_count=len(input_key_manifest),
+        output_key_manifest_cid=key_manifest_cid(output_key_manifest),
+        output_key_count=len(output_key_manifest),
+        validator_stage_id=validator_stage_id,
+        validator_source_cid=validator_source_cid,
+        _authority=_WITNESS_AUTHORITY,
+    )
+    return ConservedBody(payload=dict(measured_payload), witness=witness)
+
+
+def decode_conserved_body(value: Mapping[str, Any]) -> ConservedBody:
+    """Reject any measured/sealed body without the universal passed witness."""
+    if value.get("measurement") != "measured":
+        raise ValueError("body does not claim measurement=measured")
+    raw_witness = value.get("conservationWitness")
+    if not isinstance(raw_witness, Mapping):
+        raise ValueError("measured body lacks conservationWitness")
+    witness = ConservationWitnessV1._from_wire(raw_witness)
+    payload = dict(value)
+    payload.pop("conservationWitness", None)
+    return ConservedBody(payload=payload, witness=witness)

--- a/tests/test_conservation_mint_contract.py
+++ b/tests/test_conservation_mint_contract.py
@@ -1,0 +1,102 @@
+"""Universal write-door contract: validation testimony or explicit refusal."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG_SRC = ROOT / "implementations/python/sugar-lift-py-tests/src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+from sugar_lift_py_tests.conservation_mint import (  # noqa: E402
+    CONSERVATION_WITNESS_SCHEMA,
+    ConservationFailure,
+    ConservedBody,
+    decode_conserved_body,
+    key_manifest_cid,
+    seal_after_validation,
+)
+
+
+def test_passed_validator_is_the_only_measured_constructor(tmp_path: Path) -> None:
+    source = tmp_path / "validator.py"
+    source.write_text("def validate(): pass\n", encoding="utf-8")
+    inputs = [{"file": "a.py"}, {"file": "b.py"}]
+    outputs = list(reversed(inputs))
+    called = 0
+
+    def validate() -> None:
+        nonlocal called
+        called += 1
+        assert sorted(row["file"] for row in inputs) == sorted(
+            row["file"] for row in outputs
+        )
+
+    outcome = seal_after_validation(
+        measured_payload={"kind": "example-measured-v1", "totals": {"R": 2}},
+        input_key_manifest=inputs,
+        output_key_manifest=outputs,
+        validator_stage_id="example-validator/v1",
+        validator_source_path=source,
+        validate=validate,
+    )
+
+    assert called == 1
+    assert isinstance(outcome, ConservedBody)
+    body = outcome.to_wire()
+    assert body["measurement"] == "measured"
+    witness = body["conservationWitness"]
+    assert witness == {
+        "witnessSchema": CONSERVATION_WITNESS_SCHEMA,
+        "inputKeyManifestCid": key_manifest_cid(inputs),
+        "inputKeyCount": 2,
+        "outputKeyManifestCid": key_manifest_cid(outputs),
+        "outputKeyCount": 2,
+        "validatorStageId": "example-validator/v1",
+        "validatorSourceCid": witness["validatorSourceCid"],
+        "status": "passed",
+    }
+    assert witness["validatorSourceCid"].startswith(("blake3-512:", "sha256:"))
+    assert decode_conserved_body(body).witness.to_wire() == witness
+
+
+def test_failed_validator_has_no_magnitude_constructor(tmp_path: Path) -> None:
+    source = tmp_path / "validator.py"
+    source.write_text("raise ValueError('no')\n", encoding="utf-8")
+
+    def validate() -> None:
+        raise ValueError("input/output key conservation failed")
+
+    outcome = seal_after_validation(
+        measured_payload={
+            "kind": "example-measured-v1",
+            "residualCount": 47,
+            "totals": {"R": 47},
+        },
+        input_key_manifest=[{"file": "a.py"}, {"file": "b.py"}],
+        output_key_manifest=[{"file": "a.py"}],
+        validator_stage_id="example-validator/v1",
+        validator_source_path=source,
+        validate=validate,
+    )
+
+    assert isinstance(outcome, ConservationFailure)
+    body = outcome.to_wire()
+    assert body["measurement"] == "unmeasured"
+    assert body["conservationFailure"]["reason"] == (
+        "ValueError: input/output key conservation failed"
+    )
+    assert "residualCount" not in body
+    assert "totals" not in body
+    assert "47" not in str(body)
+
+
+def test_consumer_rejects_measured_body_without_witness() -> None:
+    with pytest.raises(ValueError, match="conservationWitness"):
+        decode_conserved_body(
+            {"kind": "lying-measured-v1", "measurement": "measured", "totals": {}}
+        )

--- a/tests/test_floor_summary_residual_emission.py
+++ b/tests/test_floor_summary_residual_emission.py
@@ -46,9 +46,11 @@ def test_conservation_failure_emits_unmeasured_without_residual_mass(
     assert body["residualKey"] == "R_native_crashes"
     assert body["residualCount"] is None
     assert "totals" not in body
-    assert body["unmeasurableReasons"] == [
-        "ValueError: floor rows must account for every corpus file exactly once"
-    ]
+    [reason] = body["unmeasurableReasons"]
+    assert "floor rows must account for every corpus file exactly once" in reason
+    assert "expectedRows=2 observedRows=1" in reason
+    assert "missing=1 extra=0 duplicateKeys=0" in reason
+    assert "missingSample=['b.py']" in reason
 
     enr = _load(
         "sole_construction_floor_enrollment",
@@ -58,10 +60,11 @@ def test_conservation_failure_emits_unmeasured_without_residual_mass(
         out, residual_key="R_native_crashes"
     )
     assert reading.residual_count is None
-    assert reading.unmeasured_reason == (
+    assert reading.unmeasured_reason.startswith(
         "floor summary conservation failed: ValueError: floor rows must account "
         "for every corpus file exactly once"
     )
+    assert "expectedRows=2 observedRows=1" in reading.unmeasured_reason
 
 
 def test_legacy_fallback_residual_is_rejected_not_resealed(tmp_path: Path) -> None:

--- a/tests/test_floor_summary_residual_emission.py
+++ b/tests/test_floor_summary_residual_emission.py
@@ -1,4 +1,4 @@
-"""Emission: residual mass must land even when full floor_summary conservation fails."""
+"""Emission: failed floor conservation must stay explicitly UNMEASURED."""
 
 from __future__ import annotations
 
@@ -23,11 +23,13 @@ def _load(name: str, path: Path):
     return mod
 
 
-def test_conservation_failure_still_emits_residual_v1(tmp_path: Path) -> None:
+def test_conservation_failure_emits_unmeasured_without_residual_mass(
+    tmp_path: Path,
+) -> None:
     pfs = _load("pandas_floor_summary", SCRIPTS / "pandas_floor_summary.py")
     out = tmp_path / "floor-summary.json"
     # rows missing a file → conservation fails
-    mode = pfs.write_floor_summary_or_residual(
+    mode = pfs.write_floor_summary_or_unmeasured(
         out,
         floor="native-crash",
         residual_key="R_native_crashes",
@@ -37,29 +39,65 @@ def test_conservation_failure_still_emits_residual_v1(tmp_path: Path) -> None:
         totals={"R_native_crashes": 47},
         measured=True,
     )
-    assert mode == "residual-only"
+    assert mode == "unmeasured"
     body = json.loads(out.read_text(encoding="utf-8"))
-    assert body["kind"] == "floor-residual-v1"
+    assert body["kind"] == "floor-unmeasured-v1"
+    assert body["measurement"] == "unmeasured"
     assert body["residualKey"] == "R_native_crashes"
-    assert body["residualCount"] == 47
-    assert "emissionFallback" in body
+    assert body["residualCount"] is None
+    assert "totals" not in body
+    assert body["unmeasurableReasons"] == [
+        "ValueError: floor rows must account for every corpus file exactly once"
+    ]
 
     enr = _load(
         "sole_construction_floor_enrollment",
         TOOLS / "sole_construction_floor_enrollment.py",
     )
-    assert (
-        enr.load_residual_count_from_floor_summary(
-            out, residual_key="R_native_crashes"
-        )
-        == 47
+    reading = enr.load_floor_measurement_from_summary(
+        out, residual_key="R_native_crashes"
     )
+    assert reading.residual_count is None
+    assert reading.unmeasured_reason == (
+        "floor summary conservation failed: ValueError: floor rows must account "
+        "for every corpus file exactly once"
+    )
+
+
+def test_legacy_fallback_residual_is_rejected_not_resealed(tmp_path: Path) -> None:
+    """#7051 fallback bodies carried unverified mass; readers fail them closed."""
+    out = tmp_path / "floor-summary.json"
+    out.write_text(
+        json.dumps(
+            {
+                "kind": "floor-residual-v1",
+                "floor": "native-crash",
+                "residualKey": "R_native_crashes",
+                "residualCount": 47,
+                "emissionFallback": (
+                    "ValueError: floor rows must account for every corpus file "
+                    "exactly once"
+                ),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    enr = _load(
+        "sole_construction_floor_enrollment_legacy_refusal",
+        TOOLS / "sole_construction_floor_enrollment.py",
+    )
+    reading = enr.load_floor_measurement_from_summary(
+        out, residual_key="R_native_crashes"
+    )
+    assert reading.residual_count is None
+    assert "unconserved #7051 fallback" in reading.unmeasured_reason
 
 
 def test_full_summary_when_conservation_holds(tmp_path: Path) -> None:
     pfs = _load("pandas_floor_summary", SCRIPTS / "pandas_floor_summary.py")
     out = tmp_path / "floor-summary.json"
-    mode = pfs.write_floor_summary_or_residual(
+    mode = pfs.write_floor_summary_or_unmeasured(
         out,
         floor="timeout",
         residual_key="R_timeouts",
@@ -76,3 +114,36 @@ def test_full_summary_when_conservation_holds(tmp_path: Path) -> None:
     body = json.loads(out.read_text(encoding="utf-8"))
     assert body["kind"] == "pandas-floor-summary-v1"
     assert body["totals"]["R_timeouts"] == 2
+    witness = body["conservationWitness"]
+    assert witness["witnessSchema"] == "sugar.conservation-witness.v1"
+    assert witness["status"] == "passed"
+    assert witness["validatorStageId"] == (
+        "pandas-floor-summary.rows-account-for-corpus/v1"
+    )
+    assert witness["inputKeyManifestCid"] == witness["outputKeyManifestCid"]
+    assert witness["inputKeyCount"] == witness["outputKeyCount"] == 2
+
+
+def test_measured_floor_body_without_conservation_witness_is_unmeasured(
+    tmp_path: Path,
+) -> None:
+    pfs = _load("pandas_floor_summary_missing_witness", SCRIPTS / "pandas_floor_summary.py")
+    out = tmp_path / "floor-summary.json"
+    body = pfs.floor_summary(
+        floor="timeout",
+        files=["a.py"],
+        rows=[{"file": "a.py", "category": "completed"}],
+        totals={"R_timeouts": 0},
+        measured=True,
+    )
+    body.pop("conservationWitness")
+    out.write_text(json.dumps(body) + "\n", encoding="utf-8")
+    enr = _load(
+        "sole_construction_floor_enrollment_missing_witness",
+        TOOLS / "sole_construction_floor_enrollment.py",
+    )
+    reading = enr.load_floor_measurement_from_summary(
+        out, residual_key="R_timeouts"
+    )
+    assert reading.residual_count is None
+    assert "lacks conservationWitness" in reading.unmeasured_reason

--- a/tests/test_python_package_suite_shards.py
+++ b/tests/test_python_package_suite_shards.py
@@ -13,6 +13,20 @@ ATTENDANCE = ROOT / "tools" / "python_package_suite_shard_attendance.py"
 WORKFLOW = ROOT / ".github" / "workflows" / "python-package-suite.yml"
 
 
+def _identity_gate_receipt(report: dict) -> str:
+    conservation = report["conservation"]
+    return (
+        "### Suite identity gate: R_identity = 0\n\n"
+        f"- measuredCommit: `{report['measuredCommit']}`\n"
+        f"- sourceStamp: `{report['sourceStamp']}`\n"
+        f"- binarySourceStamp: `{report['binarySourceStamp']}` (agrees)\n"
+        f"- testExtraInputHash: `{report['testExtraInputHash']}`\n"
+        f"- environmentIdentityHash: `{report['environmentIdentityHash']}`\n"
+        f"- conservation: `{conservation['collected']}` collected, "
+        f"`{conservation['verdicts']}` verdicts, buckets sum to collected\n"
+    )
+
+
 def _run(argv: list[str], **kwargs) -> subprocess.CompletedProcess:
     return subprocess.run(
         [sys.executable, *argv],
@@ -134,6 +148,9 @@ def test_missing_shard_makes_attendance_red_not_a_smaller_pass() -> None:
             (d / "suite-report.json").write_text(
                 json.dumps(report(i)) + "\n", encoding="utf-8"
             )
+            (d / "identity-gate.md").write_text(
+                _identity_gate_receipt(report(i)), encoding="utf-8"
+            )
         result = _run(
             [
                 str(ATTENDANCE),
@@ -227,6 +244,9 @@ def test_full_roster_attendance_is_green() -> None:
             (d / "suite-report.json").write_text(
                 json.dumps(report(i)) + "\n", encoding="utf-8"
             )
+            (d / "identity-gate.md").write_text(
+                _identity_gate_receipt(report(i)), encoding="utf-8"
+            )
         result = _run(
             [
                 str(ATTENDANCE),
@@ -242,6 +262,93 @@ def test_full_roster_attendance_is_green() -> None:
         )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "R_suite_shard_attendance = 0" in result.stdout
+
+
+def test_empty_or_unparseable_identity_gate_is_not_attendance(tmp_path: Path) -> None:
+    stamp = "blake3-512_" + ("ab" * 64)
+    extras = "cd" * 32
+    identity = {
+        "environmentIdentityHash": "ee" * 32,
+        "sourceStamp": {"value": stamp},
+        "dependencyAuthority": {
+            "testExtraInputHash": extras,
+            "declared": {"optional-dependencies": {"test": ["pytest"]}},
+        },
+    }
+    report = {
+        "schemaVersion": 1,
+        "label": "python-package-suite-canonical-shard-00",
+        "order": "canonical",
+        "shardIndex": 0,
+        "shardCount": 1,
+        "measuredCommit": "abc1234",
+        "sourceStamp": stamp,
+        "testExtraInputHash": extras,
+        "environmentIdentityHash": identity["environmentIdentityHash"],
+        "binarySourceStamp": stamp,
+        "environmentIdentity": identity,
+        "runnerIdentity": {"githubSha": "abc1234"},
+        "collectedNodeIds": [],
+        "executedOrderNodeIds": [],
+        "failedNodeIds": [],
+        "errorNodeIds": [],
+        "skippedNodeIds": [],
+        "xfailedNodeIds": [],
+        "xpassedNodeIds": [],
+        "passedNodeIds": [],
+        "collectionErrorNodeIds": [],
+        "notReportedNodeIds": [],
+        "counts": {
+            "collected": 0,
+            "passed": 0,
+            "failed": 0,
+            "error": 0,
+            "skipped": 0,
+            "xfailed": 0,
+            "xpassed": 0,
+            "collectionError": 0,
+            "notReported": 0,
+        },
+        "conservation": {
+            "collected": 0,
+            "verdicts": 0,
+            "executedOrder": 0,
+            "buckets": {
+                "passed": 0,
+                "failed": 0,
+                "error": 0,
+                "skipped": 0,
+                "xfailed": 0,
+                "xpassed": 0,
+                "notReported": 0,
+            },
+            "collectionError": 0,
+        },
+    }
+    for label, receipt in (("empty", ""), ("unparseable", "not a gate\n")):
+        root = tmp_path / label
+        shard = root / "python-package-suite-canonical-shard-0"
+        shard.mkdir(parents=True)
+        (shard / "suite-report.json").write_text(
+            json.dumps(report) + "\n", encoding="utf-8"
+        )
+        (shard / "identity-gate.md").write_text(receipt, encoding="utf-8")
+        result = _run(
+            [
+                str(ATTENDANCE),
+                "--reports-dir",
+                str(root),
+                "--shard-count",
+                "1",
+                "--require-commit",
+                "abc1234",
+                "--order",
+                "canonical",
+            ]
+        )
+        assert result.returncode != 0, (label, result.stdout)
+        assert "R_suite_shard_attendance = 1" in result.stdout
+        assert label in result.stdout + result.stderr
 
 
 def test_workflow_has_no_shared_suite_report_merge_and_uses_enrollment() -> None:

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -52,6 +52,21 @@ def _enroll_mod():
     return mod
 
 
+def _witness():
+    from sugar_lift_py_tests.conservation_mint import ConservedBody, seal_after_validation
+
+    outcome = seal_after_validation(
+        measured_payload={"kind": "test-source-body"},
+        input_key_manifest=[{"key": "same"}],
+        output_key_manifest=[{"key": "same"}],
+        validator_stage_id="test-floor-validator/v1",
+        validator_source_path=Path(__file__),
+        validate=lambda: None,
+    )
+    assert isinstance(outcome, ConservedBody)
+    return outcome.witness
+
+
 def test_workflow_is_parallel_matrix_not_serial_monolith() -> None:
     workflow = WORKFLOW.read_text()
     assert "tools/heavy_measurement_lease.py" not in workflow
@@ -110,6 +125,7 @@ def test_enrollment_missing_axis_is_unmeasured(tmp_path: Path) -> None:
         exit_code=0,
         kind="process",
         residual_count=0,
+        conservation_witness=_witness(),
     )
     path = tmp_path / "floor-axis-silent-s00" / mod.REPORT_FILENAME
     path.parent.mkdir(parents=True)
@@ -133,6 +149,7 @@ def test_enrollment_complete_with_all_axes(tmp_path: Path) -> None:
             kind=axis.kind,
             # Magnitude from floor summary identity — not invented from exit.
             residual_count=3 if is_timeout else 0,
+            conservation_witness=_witness(),
         )
         path = tmp_path / f"floor-axis-{axis.axis_id}" / mod.REPORT_FILENAME
         path.parent.mkdir(parents=True)

--- a/tests/test_sole_construction_floor_enrollment_measured.py
+++ b/tests/test_sole_construction_floor_enrollment_measured.py
@@ -19,14 +19,38 @@ ENR = importlib.util.module_from_spec(_SPEC)
 sys.modules[_SPEC.name] = ENR
 _SPEC.loader.exec_module(ENR)
 
+from sugar_lift_py_tests.conservation_mint import (  # noqa: E402
+    ConservedBody,
+    seal_after_validation,
+)
+
 
 def _seat(base: str, shard: int = 0) -> str:
     return f"{base}-s{shard:02d}"
 
 
+def _witness():
+    outcome = seal_after_validation(
+        measured_payload={"kind": "test-source-body"},
+        input_key_manifest=[{"key": "same"}],
+        output_key_manifest=[{"key": "same"}],
+        validator_stage_id="test-floor-validator/v1",
+        validator_source_path=Path(__file__),
+        validate=lambda: None,
+    )
+    assert isinstance(outcome, ConservedBody)
+    return outcome.witness
+
+
+def _mint_axis_report(**kwargs):
+    if kwargs.get("residual_count") is not None:
+        kwargs.setdefault("conservation_witness", _witness())
+    return ENR.mint_axis_report(**kwargs)
+
+
 def test_crash_before_scan_mints_unmeasured_not_completed() -> None:
     """Plant infrastructure death (exit 2): body must be UNMEASURED, not residual."""
-    report = ENR.mint_axis_report(
+    report = _mint_axis_report(
         axis_id=_seat("silent"),
         display="R_silent[s00]",
         commit_sha="deadbeef",
@@ -49,14 +73,23 @@ def test_crash_before_scan_mints_unmeasured_not_completed() -> None:
 def test_genuine_nonzero_residual_requires_count_not_exit_invent() -> None:
     """Measured residual must carry magnitude from floor summary — not exit=1 invent."""
     with pytest.raises(ValueError, match="residual_count|floor summary|invent"):
-        ENR.mint_axis_report(
+        _mint_axis_report(
             axis_id=_seat("native-crash"),
             display="R_native_crashes[s00]",
             commit_sha="deadbeef",
             exit_code=1,
             kind="process",
         )
-    report = ENR.mint_axis_report(
+    with pytest.raises(ValueError, match="conservation witness"):
+        ENR.mint_axis_report(
+            axis_id=_seat("native-crash"),
+            display="R_native_crashes[s00]",
+            commit_sha="deadbeef",
+            exit_code=1,
+            kind="process",
+            residual_count=47,
+        )
+    report = _mint_axis_report(
         axis_id=_seat("native-crash"),
         display="R_native_crashes[s00]",
         commit_sha="deadbeef",
@@ -77,7 +110,7 @@ def test_genuine_nonzero_residual_requires_count_not_exit_invent() -> None:
 
 
 def test_green_residual_is_measured_with_zero_count() -> None:
-    report = ENR.mint_axis_report(
+    report = _mint_axis_report(
         axis_id=_seat("timeout"),
         display="R_timeouts[s00]",
         commit_sha="deadbeef",
@@ -93,7 +126,9 @@ def test_green_residual_is_measured_with_zero_count() -> None:
     assert report["totals"]["failed"] == 0
 
 
-def test_load_residual_from_pandas_floor_summary(tmp_path: Path) -> None:
+def test_pandas_floor_summary_without_conservation_witness_is_refused(
+    tmp_path: Path,
+) -> None:
     summary = {
         "kind": "pandas-floor-summary-v1",
         "floor": "native-crash",
@@ -101,43 +136,40 @@ def test_load_residual_from_pandas_floor_summary(tmp_path: Path) -> None:
     }
     path = tmp_path / "floor-summary.json"
     path.write_text(json.dumps(summary), encoding="utf-8")
-    assert (
+    with pytest.raises(ValueError, match="did not complete measurement"):
         ENR.load_residual_count_from_floor_summary(
             path, residual_key="R_native_crashes"
         )
-        == 12
-    )
 
 
-def test_load_residual_from_floor_residual_v1(tmp_path: Path) -> None:
+def test_unwitnessed_floor_residual_v1_is_refused(tmp_path: Path) -> None:
     path = tmp_path / "static.json"
     path.write_text(
         json.dumps(
-            {
-                "kind": "floor-residual-v1",
-                "residualKey": "R_static_sole_construction",
+                {
+                    "kind": "floor-residual-v1",
+                    "measurement": "measured",
+                    "residualKey": "R_static_sole_construction",
                 "residualCount": 3,
             }
         ),
         encoding="utf-8",
     )
-    assert (
+    with pytest.raises(ValueError, match="conservationWitness"):
         ENR.load_residual_count_from_floor_summary(
             path, residual_key="R_static_sole_construction"
         )
-        == 3
-    )
 
 
 def test_crash_and_residual_never_look_alike() -> None:
-    crash = ENR.mint_axis_report(
+    crash = _mint_axis_report(
         axis_id=_seat("bare-exception"),
         display="R_bare_exceptions[s00]",
         commit_sha="c",
         exit_code=2,
         kind="process",
     )
-    residual = ENR.mint_axis_report(
+    residual = _mint_axis_report(
         axis_id=_seat("bare-exception"),
         display="R_bare_exceptions[s00]",
         commit_sha="c",
@@ -160,7 +192,7 @@ def test_enrollment_roll_call_unmeasured_not_residual_red(tmp_path: Path) -> Non
         if axis.axis_id == _seat("silent") or axis.axis_id.startswith("silent-"):
             if axis.axis_id != _seat("silent"):
                 # only plant unmeasured on silent-s00; other silent seats green
-                report = ENR.mint_axis_report(
+                report = _mint_axis_report(
                     axis_id=axis.axis_id,
                     display=axis.display,
                     commit_sha="tip",
@@ -169,7 +201,7 @@ def test_enrollment_roll_call_unmeasured_not_residual_red(tmp_path: Path) -> Non
                     residual_count=0,
                 )
             else:
-                report = ENR.mint_axis_report(
+                report = _mint_axis_report(
                     axis_id=axis.axis_id,
                     display=axis.display,
                     commit_sha="tip",
@@ -178,7 +210,7 @@ def test_enrollment_roll_call_unmeasured_not_residual_red(tmp_path: Path) -> Non
                     unmeasured_reason="planted crash before measurement",
                 )
         else:
-            report = ENR.mint_axis_report(
+            report = _mint_axis_report(
                 axis_id=axis.axis_id,
                 display=axis.display,
                 commit_sha="tip",
@@ -203,7 +235,7 @@ def test_residual_magnitude_drives_residual_red_not_exit_alone(
     """residualCount>0 is residual red even if someone mints exit=0 wrongly."""
     for axis in ENR.ENROLLED:
         if axis.axis_id == _seat("native-crash"):
-            report = ENR.mint_axis_report(
+            report = _mint_axis_report(
                 axis_id=axis.axis_id,
                 display=axis.display,
                 commit_sha="tip",
@@ -212,7 +244,7 @@ def test_residual_magnitude_drives_residual_red_not_exit_alone(
                 residual_count=5,
             )
         else:
-            report = ENR.mint_axis_report(
+            report = _mint_axis_report(
                 axis_id=axis.axis_id,
                 display=axis.display,
                 commit_sha="tip",
@@ -227,3 +259,25 @@ def test_residual_magnitude_drives_residual_red_not_exit_alone(
     assert code == 0
     assert summary["status"] == "complete"
     assert _seat("native-crash") in summary["residualRed"]
+
+
+def test_campaign_seal_requires_complete_witnessed_enrollment() -> None:
+    complete = {
+        "status": "complete",
+        "attended": list(ENR.enrolled_ids()),
+        "residualRed": [],
+    }
+    measured = ENR.mint_campaign_body(complete, commit_sha="tip")
+    assert measured["measurement"] == "measured"
+    assert measured["conservationWitness"]["status"] == "passed"
+
+    incomplete = {
+        "status": "UNMEASURED",
+        "attended": list(ENR.enrolled_ids())[:-1],
+        "residualRed": [],
+    }
+    refused = ENR.mint_campaign_body(incomplete, commit_sha="tip")
+    assert refused["measurement"] == "unmeasured"
+    assert refused["measured"] is False
+    assert "totals" not in refused
+    assert "conservationFailure" in refused

--- a/tests/test_static_floor_residual_report.py
+++ b/tests/test_static_floor_residual_report.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_static_residual_is_witnessed_and_consumer_accepted(tmp_path: Path) -> None:
+    mint = _load("static_floor_residual_report", ROOT / "tools/static_floor_residual_report.py")
+    body, code = mint.mint_static_residual(
+        input_axes=["a", "b"], green_axes=["a"], red_axes=["b"]
+    )
+    assert code == 0
+    assert body["measurement"] == "measured"
+    assert body["residualCount"] == 1
+    assert body["conservationWitness"]["status"] == "passed"
+    path = tmp_path / "floor-static-residual.json"
+    path.write_text(json.dumps(body), encoding="utf-8")
+    enrollment = _load(
+        "static_floor_enrollment_reader",
+        ROOT / "tools/sole_construction_floor_enrollment.py",
+    )
+    reading = enrollment.load_floor_measurement_from_summary(
+        path, residual_key="R_static_sole_construction"
+    )
+    assert reading.residual_count == 1
+    assert reading.conservation_witness is not None
+
+
+def test_static_partition_failure_emits_no_magnitude() -> None:
+    mint = _load(
+        "static_floor_residual_report_failure",
+        ROOT / "tools/static_floor_residual_report.py",
+    )
+    body, code = mint.mint_static_residual(
+        input_axes=["a", "b"], green_axes=["a"], red_axes=[]
+    )
+    assert code == 1
+    assert body["measurement"] == "unmeasured"
+    assert body["residualCount"] is None
+    assert "conservationFailure" in body
+    assert "totals" not in body

--- a/tests/test_suite_report_lpt_prior_import.py
+++ b/tests/test_suite_report_lpt_prior_import.py
@@ -60,6 +60,55 @@ def test_write_lpt_prior_name_is_defined_with_path() -> None:
     assert hasattr(mod.SuiteReporter, "_write_lpt_prior")
 
 
+def test_enabled_lpt_prior_writes_content_addressed_cost(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """An enabled shelf persists a duration under the measured file's CID."""
+    mod = _load_suite_report()
+    prior_root = tmp_path / "prior"
+    monkeypatch.setenv("SUGAR_LPT_PRIOR_DIR", str(prior_root))
+    test_path = tmp_path / "pkg" / "tests" / "test_x.py"
+    test_path.parent.mkdir(parents=True)
+    test_path.write_text("def test_one():\n    pass\n", encoding="utf-8")
+    identity_path = tmp_path / "environment-identity.json"
+    identity_path.write_text(
+        json.dumps(
+            {
+                "environmentIdentityHash": "a" * 64,
+                "sourceStamp": {"value": "stamp"},
+                "dependencyAuthority": {"testExtraInputHash": "b" * 64},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    reporter = mod.SuiteReporter(
+        _FakeConfig(
+            {
+                "suite_identity": str(identity_path),
+                "suite_commit": "c" * 40,
+            },
+            rootpath=tmp_path,
+        )
+    )
+    reporter._file_duration_s = {"pkg/tests/test_x.py": 1.25}
+    reporter._write_lpt_prior()
+
+    from lpt_file_shards import ContentAddressedCostPrior
+
+    hit = ContentAddressedCostPrior(prior_root).get_for_path(test_path)
+    assert hit is not None, "enabled LPT shelf must write the measured file's CID"
+    assert hit.cost_s == 1.25
+    assert hit.source == "suite-pytest-call-duration"
+    assert len(list(prior_root.glob("*.json"))) == 1
+    output = capsys.readouterr().out
+    assert "status=ok" in output
+    assert "files_written=1" in output
+    assert "files_measured=1" in output
+    assert "unresolved_paths=0" in output
+
+
 class _FakeConfig:
     def __init__(self, options: dict, *, rootpath: Path):
         self._options = options

--- a/tools/python_package_suite_shard_attendance.py
+++ b/tools/python_package_suite_shard_attendance.py
@@ -35,7 +35,7 @@ if str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
 
 from python_package_suite_shards import SHARD_COUNT, roster_ids  # noqa: E402
-from python_suite_identity_gate import gate  # noqa: E402
+from python_suite_identity_gate import gate, render_resolved_receipt  # noqa: E402
 
 
 class ShardAttendanceError(RuntimeError):
@@ -123,6 +123,30 @@ def attendance(
             for crime in gate_crimes:
                 crimes.append(f"  {crime}")
             # Present but unresolved is not attendance.
+            missing.append(shard_id)
+            continue
+        receipt_path = path.with_name("identity-gate.md")
+        try:
+            receipt = receipt_path.read_text(encoding="utf-8")
+        except OSError as error:
+            crimes.append(
+                f"{shard_id} at {receipt_path}: identity gate receipt missing: {error}"
+            )
+            missing.append(shard_id)
+            continue
+        if not receipt:
+            crimes.append(
+                f"{shard_id} at {receipt_path}: identity gate receipt empty; "
+                "presence is not testimony"
+            )
+            missing.append(shard_id)
+            continue
+        expected_receipt = render_resolved_receipt(report) + "\n"
+        if receipt != expected_receipt:
+            crimes.append(
+                f"{shard_id} at {receipt_path}: identity gate receipt "
+                "unparseable or disagrees with suite-report.json"
+            )
             missing.append(shard_id)
             continue
         # Shard self-description must match enrollment seat when present.

--- a/tools/python_suite_identity_gate.py
+++ b/tools/python_suite_identity_gate.py
@@ -75,6 +75,21 @@ IDENTITY_FIELDS = (
 UNAVAILABLE_KEYS = ("unavailable", "unresolved")
 
 
+def render_resolved_receipt(report: dict) -> str:
+    """Canonical successful gate receipt consumed by shard attendance."""
+    conservation = report.get("conservation") or {}
+    return (
+        "### Suite identity gate: R_identity = 0\n\n"
+        f"- measuredCommit: `{report.get('measuredCommit')}`\n"
+        f"- sourceStamp: `{report.get('sourceStamp')}`\n"
+        f"- binarySourceStamp: `{report.get('binarySourceStamp')}` (agrees)\n"
+        f"- testExtraInputHash: `{report.get('testExtraInputHash')}`\n"
+        f"- environmentIdentityHash: `{report.get('environmentIdentityHash')}`\n"
+        f"- conservation: `{conservation.get('collected')}` collected, "
+        f"`{conservation.get('verdicts')}` verdicts, buckets sum to collected"
+    )
+
+
 def unavailable_marker(node, path="$"):
     """Return the JSON path of the first unavailable marker, or None.
 
@@ -404,17 +419,7 @@ def main(argv=None):
         )
         return 1
 
-    print("### Suite identity gate: R_identity = 0\n")
-    print(f"- measuredCommit: `{report.get('measuredCommit')}`")
-    print(f"- sourceStamp: `{report.get('sourceStamp')}`")
-    print(f"- binarySourceStamp: `{report.get('binarySourceStamp')}` (agrees)")
-    print(f"- testExtraInputHash: `{report.get('testExtraInputHash')}`")
-    print(f"- environmentIdentityHash: `{report.get('environmentIdentityHash')}`")
-    conservation = report.get("conservation") or {}
-    print(
-        f"- conservation: `{conservation.get('collected')}` collected, "
-        f"`{conservation.get('verdicts')}` verdicts, buckets sum to collected"
-    )
+    print(render_resolved_receipt(report))
     return 0
 
 

--- a/tools/run_static_sole_construction_floors.sh
+++ b/tools/run_static_sole_construction_floors.sh
@@ -13,12 +13,14 @@ SCRIPTS="$TESTS/scripts"
 
 red_axes=()
 green_axes=()
+all_axes=()
 axis_index=0
 # Count axis() invocations for progress (updated as axes are declared below).
 AXIS_TOTAL=22
 
 axis() {
   local name="$1"; shift
+  all_axes+=("$name")
   axis_index=$((axis_index + 1))
   echo "static_floors phase=axis index=${axis_index}/${AXIS_TOTAL} name=${name} status=start"
   echo "::group::[${axis_index}/${AXIS_TOTAL}] $name"
@@ -28,7 +30,7 @@ axis() {
     echo "static_floors phase=axis index=${axis_index}/${AXIS_TOTAL} name=${name} status=green running_green=${#green_axes[@]} running_red=${#red_axes[@]}"
   else
     local status=$?
-    red_axes+=("$name (exit $status)")
+    red_axes+=("$name")
     echo "::error::$name is RED (exit $status)"
     echo "static_floors phase=axis index=${axis_index}/${AXIS_TOTAL} name=${name} status=red exit=${status} running_green=${#green_axes[@]} running_red=${#red_axes[@]}"
   fi
@@ -102,28 +104,14 @@ echo "static_floors phase=end green=${#green_axes[@]} red=${#red_axes[@]}"
 echo "static sole-construction floors: ${#green_axes[@]} green, ${#red_axes[@]} red"
 # Residual magnitude for enrollment mint — count of red static axes, not exit invent.
 residual_json="${SUGAR_STATIC_FLOOR_RESIDUAL_JSON:-floor-static-residual.json}"
-python3 -u -c "
-import json
-from pathlib import Path
-path = Path('''${residual_json}''')
-red = ${#red_axes[@]}
-path.write_text(
-    json.dumps(
-        {
-            'kind': 'floor-residual-v1',
-            'residualKey': 'R_static_sole_construction',
-            'residualCount': red,
-            'greenAxes': ${#green_axes[@]},
-            'redAxes': red,
-        },
-        indent=2,
-        sort_keys=True,
-    )
-    + '\n',
-    encoding='utf-8',
-)
-print(f'static_floors residual_written path={path} residualCount={red}', flush=True)
-"
+mint_args=(--out "$residual_json")
+for name in "${all_axes[@]}"; do mint_args+=(--input-axis "$name"); done
+for name in "${green_axes[@]}"; do mint_args+=(--green-axis "$name"); done
+for name in "${red_axes[@]}"; do mint_args+=(--red-axis "$name"); done
+if ! python3 -u tools/static_floor_residual_report.py "${mint_args[@]}"; then
+  echo "::error::static floor conservation refused; residual is UNMEASURED"
+  exit 2
+fi
 if [ ${#red_axes[@]} -gt 0 ]; then
   echo "RED AXES:"
   printf '  - %s\n' "${red_axes[@]}"

--- a/tools/sole_construction_floor_enrollment.py
+++ b/tools/sole_construction_floor_enrollment.py
@@ -25,6 +25,22 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
 
+_PACKAGE_SRC = (
+    Path(__file__).resolve().parents[1]
+    / "implementations/python/sugar-lift-py-tests/src"
+)
+if str(_PACKAGE_SRC) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_SRC))
+
+from sugar_lift_py_tests.conservation_mint import (  # noqa: E402
+    ConservationFailure,
+    ConservationWitnessV1,
+    ConservedBody,
+    decode_conserved_body,
+    key_manifest_cid,
+    seal_after_validation,
+)
+
 SCOREBOARD_AUTHORITY = False
 
 REPORT_KIND = "sole-construction-floor-axis-report"
@@ -148,29 +164,183 @@ def residual_key_for_axis(axis_id: str) -> str:
     return key
 
 
-def load_residual_count_from_floor_summary(
-    summary_path: Path, *, residual_key: str
-) -> int:
-    """Cite residual magnitude from a floor summary body — never invent.
+@dataclass(frozen=True, slots=True)
+class FloorMeasurementReading:
+    residual_count: int | None
+    unmeasured_reason: str | None
+    conservation_witness: ConservationWitnessV1 | None = None
 
-    Accepts:
-      - pandas-floor-summary-v1 with totals[residual_key]
-      - floor-residual-v1 with residualKey + residualCount
+
+def load_floor_measurement_from_summary(
+    summary_path: Path, *, residual_key: str
+) -> FloorMeasurementReading:
+    """Read conserved residual testimony or an explicit refusal.
+
+    ``floor-residual-v1`` remains valid for producers that directly measure a
+    residual without a per-file conservation table (the static floor), but it
+    must carry its schema manifests and universal passed witness.  The #7051
+    variant is distinguishable by ``emissionFallback`` and is refused: its
+    number was written only because conservation had failed.
     """
     try:
         payload = json.loads(summary_path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
-        raise ValueError(
-            f"cannot read floor summary {summary_path}: {exc}"
-        ) from exc
+        raise ValueError(f"cannot read floor summary {summary_path}: {exc}") from exc
     if not isinstance(payload, dict):
         raise ValueError(f"floor summary {summary_path} is not a JSON object")
     kind = payload.get("kind")
+    if kind == "floor-unmeasured-v1":
+        if payload.get("residualKey") != residual_key:
+            raise ValueError(
+                f"floor-unmeasured-v1 residualKey={payload.get('residualKey')!r} "
+                f"!= expected {residual_key!r}"
+            )
+        reasons = payload.get("unmeasurableReasons")
+        if (
+            payload.get("measurement") != "unmeasured"
+            or payload.get("residualCount") is not None
+            or not isinstance(reasons, list)
+            or not reasons
+            or not all(isinstance(reason, str) and reason for reason in reasons)
+        ):
+            raise ValueError(
+                "floor-unmeasured-v1 must carry measurement=unmeasured, "
+                "residualCount=null, and at least one named reason"
+            )
+        return FloorMeasurementReading(
+            residual_count=None,
+            unmeasured_reason="floor summary conservation failed: "
+            + "; ".join(reasons),
+            conservation_witness=None,
+        )
+    if kind == "floor-residual-v1" and payload.get("emissionFallback"):
+        return FloorMeasurementReading(
+            residual_count=None,
+            unmeasured_reason=(
+                "unconserved #7051 fallback refused: "
+                + str(payload["emissionFallback"])
+            ),
+            conservation_witness=None,
+        )
+    if kind == "pandas-floor-summary-v1" and payload.get("measurement") != "measured":
+        reasons = payload.get("unmeasurableReasons") or [
+            "pandas floor summary did not complete measurement"
+        ]
+        return FloorMeasurementReading(
+            residual_count=None,
+            unmeasured_reason="; ".join(str(reason) for reason in reasons),
+            conservation_witness=None,
+        )
+    if kind == "pandas-floor-summary-v1":
+        try:
+            conserved = decode_conserved_body(payload)
+        except ValueError as error:
+            return FloorMeasurementReading(
+                residual_count=None,
+                unmeasured_reason=f"measured floor body refused: {error}",
+                conservation_witness=None,
+            )
+        witness = conserved.witness
+        files = ((payload.get("corpus") or {}).get("files"))
+        rows = payload.get("rows")
+        if not isinstance(files, list) or not all(
+            isinstance(file, str) for file in files
+        ):
+            return FloorMeasurementReading(
+                residual_count=None,
+                unmeasured_reason="measured floor body has no canonical corpus files",
+                conservation_witness=None,
+            )
+        if not isinstance(rows, list) or not all(
+            isinstance(row, dict) and isinstance(row.get("file"), str)
+            for row in rows
+        ):
+            return FloorMeasurementReading(
+                residual_count=None,
+                unmeasured_reason="measured floor body has no canonical row keys",
+                conservation_witness=None,
+            )
+        input_keys = [{"file": file} for file in sorted(files)]
+        output_keys = [
+            {"file": str(row["file"])}
+            for row in sorted(rows, key=lambda row: str(row["file"]))
+        ]
+        witness_crimes: list[str] = []
+        if witness.validator_stage_id != (
+            "pandas-floor-summary.rows-account-for-corpus/v1"
+        ):
+            witness_crimes.append("validatorStageId is not the floor validator")
+        if witness.input_key_manifest_cid != key_manifest_cid(input_keys):
+            witness_crimes.append("inputKeyManifestCid disagrees with corpus files")
+        if witness.output_key_manifest_cid != key_manifest_cid(output_keys):
+            witness_crimes.append("outputKeyManifestCid disagrees with row files")
+        if witness.input_key_count != len(input_keys):
+            witness_crimes.append("inputKeyCount disagrees with corpus files")
+        if witness.output_key_count != len(output_keys):
+            witness_crimes.append("outputKeyCount disagrees with row files")
+        if (
+            witness.input_key_manifest_cid != witness.output_key_manifest_cid
+            or witness.input_key_count != witness.output_key_count
+        ):
+            witness_crimes.append("floor input/output key conservation did not pass")
+        if witness_crimes:
+            return FloorMeasurementReading(
+                residual_count=None,
+                unmeasured_reason="measured floor conservation witness refused: "
+                + "; ".join(witness_crimes),
+                conservation_witness=None,
+            )
+        raw = (payload.get("totals") or {}).get(residual_key)
+        if type(raw) is not int or raw < 0:
+            raise ValueError(
+                f"floor summary residual {residual_key!r} must be a non-negative "
+                f"int; got {type(raw).__name__}={raw!r}"
+            )
+        return FloorMeasurementReading(
+            residual_count=raw,
+            unmeasured_reason=None,
+            conservation_witness=witness,
+        )
     if kind == "floor-residual-v1":
+        try:
+            conserved = decode_conserved_body(payload)
+        except ValueError as error:
+            return FloorMeasurementReading(
+                residual_count=None,
+                unmeasured_reason=f"measured residual body refused: {error}",
+                conservation_witness=None,
+            )
         if payload.get("residualKey") != residual_key:
             raise ValueError(
                 f"floor-residual-v1 residualKey={payload.get('residualKey')!r} "
                 f"!= expected {residual_key!r}"
+            )
+        input_manifest = payload.get("inputKeyManifest")
+        output_manifest = payload.get("outputKeyManifest")
+        if not isinstance(input_manifest, list) or not isinstance(output_manifest, list):
+            return FloorMeasurementReading(
+                residual_count=None,
+                unmeasured_reason=(
+                    "measured residual body lacks schema key manifests"
+                ),
+                conservation_witness=None,
+            )
+        witness = conserved.witness
+        crimes: list[str] = []
+        if witness.input_key_manifest_cid != key_manifest_cid(input_manifest):
+            crimes.append("inputKeyManifestCid disagrees with input manifest")
+        if witness.output_key_manifest_cid != key_manifest_cid(output_manifest):
+            crimes.append("outputKeyManifestCid disagrees with output manifest")
+        if witness.input_key_count != len(input_manifest):
+            crimes.append("inputKeyCount disagrees with input manifest")
+        if witness.output_key_count != len(output_manifest):
+            crimes.append("outputKeyCount disagrees with output manifest")
+        if crimes:
+            return FloorMeasurementReading(
+                residual_count=None,
+                unmeasured_reason="measured residual witness refused: "
+                + "; ".join(crimes),
+                conservation_witness=None,
             )
         raw = payload.get("residualCount")
         if type(raw) is not int or raw < 0:
@@ -178,25 +348,36 @@ def load_residual_count_from_floor_summary(
                 f"floor-residual-v1 residualCount must be non-negative int; "
                 f"got {type(raw).__name__}={raw!r}"
             )
-        return raw
-    totals = payload.get("totals")
-    if not isinstance(totals, dict):
-        raise ValueError(
-            f"floor summary {summary_path} missing totals object "
-            f"(need residual key {residual_key!r} under identity)"
+        return FloorMeasurementReading(
+            residual_count=raw,
+            unmeasured_reason=None,
+            conservation_witness=witness,
         )
-    if residual_key not in totals:
+    return FloorMeasurementReading(
+        residual_count=None,
+        unmeasured_reason=(
+            f"floor summary kind {kind!r} has no conservation-witness consumer"
+        ),
+        conservation_witness=None,
+    )
+
+
+def load_residual_count_from_floor_summary(
+    summary_path: Path, *, residual_key: str
+) -> int:
+    """Cite residual magnitude from a floor summary body — never invent.
+
+    Accepts only a witnessed ``pandas-floor-summary-v1`` or witnessed
+    ``floor-residual-v1``.  A bare magnitude is not testimony.
+    """
+    reading = load_floor_measurement_from_summary(
+        summary_path, residual_key=residual_key
+    )
+    if reading.residual_count is None:
         raise ValueError(
-            f"floor summary {summary_path} totals missing residual key "
-            f"{residual_key!r}; present={sorted(totals)!r}"
+            reading.unmeasured_reason or "floor summary is explicitly unmeasured"
         )
-    raw = totals[residual_key]
-    if type(raw) is not int or raw < 0:
-        raise ValueError(
-            f"floor summary residual {residual_key!r} must be a non-negative "
-            f"int; got {type(raw).__name__}={raw!r}"
-        )
-    return raw
+    return reading.residual_count
 
 
 def mint_axis_report(
@@ -211,12 +392,14 @@ def mint_axis_report(
     residual_count: int | None = None,
     residual_source: str | None = None,
     residual_key: str | None = None,
+    conservation_witness: ConservationWitnessV1 | None = None,
 ) -> dict:
     """Mint an identity-bound axis body.
 
     ``measured=True`` only when the scan completed (exit 0 or 1 by default)
-    **and** residual_count is cited from the floor summary. Auth/init/crash
-    (exit >= 2, or scan_completed=False) mints UNMEASURED with a named reason.
+    **and** residual_count plus its passed conservation witness are cited from
+    the floor summary. Auth/init/crash (exit >= 2, or scan_completed=False)
+    mints UNMEASURED with a named reason.
 
     Do **not** invent residual magnitude from exit code: exit 1 only says
     R>0; the count lives in the floor's own summary under residual_key.
@@ -232,13 +415,18 @@ def mint_axis_report(
                 f"measured mint for {axis_id!r} requires residual_count from "
                 f"the floor summary (do not invent R from exit code={code})"
             )
+        if conservation_witness is None:
+            raise ValueError(
+                f"measured mint for {axis_id!r} requires a passed "
+                "conservation witness from the floor validator"
+            )
         if type(residual_count) is not int or residual_count < 0:
             raise ValueError(
                 f"residual_count must be a non-negative int; got "
                 f"{type(residual_count).__name__}={residual_count!r}"
             )
         rkey = residual_key or residual_key_for_axis(axis_id)
-        return {
+        payload = {
             "schemaVersion": 1,
             "kind": REPORT_KIND,
             "axisId": axis_id,
@@ -262,6 +450,10 @@ def mint_axis_report(
                 "residual": residual_count,
             },
         }
+        return ConservedBody(
+            payload=payload,
+            witness=conservation_witness,
+        ).to_wire()
     reason = unmeasured_reason or (
         f"scan did not complete (exit={code}); infrastructure/auth/init/crash "
         "— not a residual reading"
@@ -421,6 +613,16 @@ def check_attendance(
                 f"axis={axis.axis_id} spoke=partial status=UNRESOLVED"
             )
             continue
+        try:
+            decode_conserved_body(row)
+        except ValueError as error:
+            unresolved.append(axis.axis_id)
+            _log(
+                f"floor_enrollment result index={index}/{len(ENROLLED)} "
+                f"axis={axis.axis_id} spoke=partial status=UNRESOLVED "
+                f"reason=conservation-witness:{error}"
+            )
+            continue
         attended.append(axis.axis_id)
         exit_code = int(row.get("exitCode", 1))
         # Prefer residualCount magnitude when present (S1.1 mass ranking).
@@ -470,20 +672,55 @@ def mint_campaign_body(attendance: dict, *, commit_sha: str) -> dict:
     """Identity-bound campaign body for heavy-measurement attendance roll call."""
     residual = list(attendance.get("residualRed") or [])
     unmeasured = attendance.get("status") != "complete"
-    return {
+    expected = [{"axisId": axis_id} for axis_id in enrolled_ids()]
+    observed = [
+        {"axisId": str(axis_id)} for axis_id in attendance.get("attended") or []
+    ]
+    payload = {
         "schemaVersion": 1,
         "measurementClass": CAMPAIGN_CLASS,
         "measuredCommit": commit_sha,
-        "status": "unmeasured" if unmeasured else "completed",
+        "status": "completed",
+        "measured": True,
         "enrollment": attendance,
-        "exitCode": 1 if unmeasured or residual else 0,
+        "exitCode": 1 if residual else 0,
         "totals": {
-            "failed": 0 if not residual and not unmeasured else 1,
+            "failed": 0 if not residual else 1,
             "enrolledAxes": len(enrolled_ids()),
             "attendedAxes": len(attendance.get("attended") or []),
             "residualRedAxes": len(residual),
         },
     }
+
+    def validate() -> None:
+        if unmeasured:
+            raise ValueError("floor enrollment is incomplete")
+        if sorted(expected, key=lambda row: row["axisId"]) != sorted(
+            observed, key=lambda row: row["axisId"]
+        ):
+            raise ValueError("floor enrollment input/output axis keys differ")
+
+    outcome = seal_after_validation(
+        measured_payload=payload,
+        input_key_manifest=expected,
+        output_key_manifest=observed,
+        validator_stage_id="sole-construction-floor.enrollment-roll-call/v1",
+        validator_source_path=Path(__file__).resolve(),
+        validate=validate,
+    )
+    if isinstance(outcome, ConservationFailure):
+        body = outcome.to_wire()
+        body.update(
+            {
+                "measurementClass": CAMPAIGN_CLASS,
+                "measuredCommit": commit_sha,
+                "status": "unmeasured",
+                "measured": False,
+                "exitCode": 1,
+            }
+        )
+        return body
+    return outcome.to_wire()
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -514,21 +751,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Named reason when minting UNMEASURED (auth/init/crash).",
     )
     parser.add_argument(
-        "--residual-count",
-        type=int,
-        default=None,
-        help=(
-            "Residual magnitude from the floor summary (required for measured "
-            "mints). Do not invent from exit code."
-        ),
-    )
-    parser.add_argument(
         "--residual-from-summary",
         type=Path,
         default=None,
         help=(
             "pandas-floor-summary-v1 JSON; residual_count is read from "
-            "totals[residual_key] under identity (preferred over --residual-count)."
+            "totals[residual_key] under its passed conservation witness."
         ),
     )
     parser.add_argument(
@@ -568,16 +796,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 0
     if args.mint_report is not None:
-        residual_count = args.residual_count
+        residual_count = None
         residual_source = None
         residual_key = args.residual_key
+        conservation_witness = None
         if args.residual_from_summary is not None:
             rkey = residual_key or residual_key_for_axis(args.axis_id)
-            residual_count = load_residual_count_from_floor_summary(
+            reading = load_floor_measurement_from_summary(
                 args.residual_from_summary, residual_key=rkey
             )
             residual_source = str(args.residual_from_summary.resolve())
             residual_key = rkey
+            if reading.residual_count is None:
+                residual_count = None
+                args.scan_completed = False
+                args.unmeasured_reason = reading.unmeasured_reason
+            else:
+                residual_count = reading.residual_count
+                conservation_witness = reading.conservation_witness
         _log(
             f"floor_enrollment phase=mint_report axis={args.axis_id} "
             f"exit={args.exit_code} residual_count={residual_count!r} "
@@ -594,6 +830,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             residual_count=residual_count,
             residual_source=residual_source,
             residual_key=residual_key,
+            conservation_witness=conservation_witness,
         )
         args.mint_report.parent.mkdir(parents=True, exist_ok=True)
         args.mint_report.write_text(

--- a/tools/static_floor_residual_report.py
+++ b/tools/static_floor_residual_report.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Seal the static-floor outcome partition behind the universal witness door."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_SRC = ROOT / "implementations/python/sugar-lift-py-tests/src"
+if str(PACKAGE_SRC) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_SRC))
+
+from sugar_lift_py_tests.conservation_mint import (  # noqa: E402
+    ConservationFailure,
+    seal_after_validation,
+)
+
+
+def mint_static_residual(
+    *,
+    input_axes: list[str],
+    green_axes: list[str],
+    red_axes: list[str],
+) -> tuple[dict, int]:
+    input_manifest = [{"axis": axis} for axis in input_axes]
+    output_manifest = [{"axis": axis} for axis in [*green_axes, *red_axes]]
+    payload = {
+        "kind": "floor-residual-v1",
+        "residualKey": "R_static_sole_construction",
+        "residualCount": len(red_axes),
+        "greenAxes": len(green_axes),
+        "redAxes": len(red_axes),
+        "inputKeyManifest": input_manifest,
+        "outputKeyManifest": output_manifest,
+    }
+
+    def validate() -> None:
+        if not input_axes:
+            raise ValueError("static floor input axis roster is empty")
+        if len(input_axes) != len(set(input_axes)):
+            raise ValueError("static floor input axis roster contains duplicates")
+        if Counter(input_axes) != Counter([*green_axes, *red_axes]):
+            raise ValueError("static floor outcomes do not conserve the axis roster")
+
+    outcome = seal_after_validation(
+        measured_payload=payload,
+        input_key_manifest=input_manifest,
+        output_key_manifest=output_manifest,
+        validator_stage_id="static-sole-construction.axis-outcome-partition/v1",
+        validator_source_path=Path(__file__).resolve(),
+        validate=validate,
+    )
+    if isinstance(outcome, ConservationFailure):
+        body = outcome.to_wire()
+        body.update(
+            {
+                "kind": "floor-unmeasured-v1",
+                "residualKey": "R_static_sole_construction",
+                "residualCount": None,
+                "unmeasurableReasons": [outcome.reason],
+            }
+        )
+        return body, 1
+    return outcome.to_wire(), 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--input-axis", action="append", default=[])
+    parser.add_argument("--green-axis", action="append", default=[])
+    parser.add_argument("--red-axis", action="append", default=[])
+    args = parser.parse_args(argv)
+    body, code = mint_static_residual(
+        input_axes=args.input_axis,
+        green_axes=args.green_axis,
+        red_axes=args.red_axis,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(body, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(
+        f"static_floors residual_written path={args.out} "
+        f"measurement={body.get('measurement')} "
+        f"residualCount={body.get('residualCount')}",
+        flush=True,
+    )
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Severity: a fabricated sealed magnitude survives into campaign planning

#7051 at `f6e2d26842` catches a `floor_summary` conservation `ValueError` and nevertheless writes `floor-residual-v1` from the in-memory `residualCount`. That number has not passed conservation, but it enters the reader chain as if it had:

`loader -> measured axis report -> attendance/residual ranking -> campaign body`

The projected axis report drops the fallback provenance. Downstream, the fabricated fallback magnitude is therefore indistinguishable from a conserved magnitude. That indistinguishability is the severity: a sealed campaign body can carry a number whose validating door refused it.

This change makes failed conservation emit `UNMEASURED` with no magnitude, and requires measured floor and residual bodies to carry a passed conservation witness before readers admit their counts.

## Red before green

- **RED-BEFORE-GREEN:** the lying-constructor tooth was red 3/3 on current main because the honest constructors did not exist; it passes only after the shared conservation door is present.
- **RED-BEFORE-GREEN:** the identity-gate twin was red 1/1 on both empty and garbage gate receipts before implementation; attendance now refuses both.
- The existing `test_conservation_failure_still_emits_residual_v1` was **INVERTED, not deleted**. Before this change it explicitly asserted that fabricating `floor-residual-v1` with `residualCount=47` after conservation failure was correct. The inverted tooth now requires `floor-unmeasured-v1`, `residualCount=null`, and named diagnostics.

## Refusal diagnostics

The refusal names the failed check and preserves `expectedRows`, `observedRows`, missing, extra, and duplicate-key counts with bounded samples. It never preserves the rejected magnitude.

## Named gaps and bounded claims

- Repo-preserved post-#7051 floor, axis, or campaign JSON found: **0**.
- GitHub-side artifacts: **UNCHECKED**, because CI is intentionally dark.
- Only projected artifacts would have been ambiguous; no historical artifact population is claimed.
- The enabled LPT prior tooth writes **1 CID record for 1 measured file at 1.25s**. This does **not** show that historical splits used cold-degrade.
- The suite reporter can speak. This does **not** show that 8 pandas shards attended.
- Four floor magnitudes remain **UNMEASURED** pending the quiet measurement box.
- No broad-suite or CI result is claimed.

## Commit stack

- `9fdd8416d` — honest refusal: failed conservation emits `UNMEASURED`, never a magnitude
- `3a443a005` — refusal diagnostics name the check and conservation quantities
- `ef37466ff` — identity-gate fail-closed tooth plus enabled LPT prior write proof

This PR deliberately adds conservation/refusal schema kinds and residual-envelope handling. It is opened for review only and must not merge without explicit authorization after CI is restored and checks run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conservation witnesses to validate and authenticate measured floor summaries.
  * Failed or unmeasurable measurements now produce explicit unmeasured results without residual mass.
  * Added validated static-floor residual reporting with clear failure handling.
  * Campaign and axis reports now distinguish measured, unmeasured, malformed, and invalid results.
  * Identity-gate attendance now requires a valid, matching receipt for each shard.

* **Bug Fixes**
  * Prevented unwitnessed or malformed measurements from being accepted as measured results.
  * Improved detection of missing, empty, unreadable, or invalid identity receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse unconserved floor magnitudes as UNMEASURED and seal valid summaries with a conservation witness
> - Introduces a `conservation_mint` module with `seal_after_validation`, `ConservedBody`, `ConservationFailure`, and `decode_conserved_body` to produce and verify signed conservation witnesses on measured bodies.
> - Floor summaries that cannot be proven conserved now emit a `floor-unmeasured-v1` refusal body (with `residualCount=null` and reasons) instead of a residual-only fallback; successful summaries embed a `conservationWitness`.
> - `sole_construction_floor_enrollment.py` refuses legacy unconserved residual bodies, requires a passed witness to mint measured axis reports, and seals campaign bodies with enrollment key manifests.
> - A new `static_floor_residual_report.py` tool seals static floor outcomes with a witness; the `run_static_sole_construction_floors.sh` pipeline exits with UNMEASURED if sealing fails.
> - Shard attendance now verifies a canonical `identity-gate.md` receipt per shard; missing or mismatched receipts mark the shard absent.
> - Risk: all existing measured floor summary consumers must present a valid `conservationWitness`; bodies without one are now rejected as UNRESOLVED or UNMEASURED.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef37466.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->