### PR TITLE
Emit the three live-edge witnesses required by the landed refusal seal

### DIFF
--- a/.github/workflows/recensus-path-smoke.yml
+++ b/.github/workflows/recensus-path-smoke.yml
@@ -1,7 +1,7 @@
 # Recensus PATH smoke — production-path integrity over a planted micro-population.
 #
 # COVERAGE HONESTY (binding):
-#   This job measures the RECENSUS PRODUCTION PATH (per_file_lift → aggregation
+#   This job measures the RECENSUS PRODUCTION PATH (sugar.enumerate → aggregation
 #   → with-census conservation → sealed path body) over ~4 planted files in
 #   under 60s. It retires the SERIAL ROT TAX that made path defects cost one
 #   full 73-minute corpus walk each.
@@ -38,6 +38,7 @@ jobs:
     env:
       PYTHONUNBUFFERED: "1"
       RECENSUS_PATH_SMOKE_OUT: ${{ github.workspace }}/.sugar/recensus-path-smoke
+      WITH_WIRE_WORKTREE_SHA: ${{ github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/README.md
+++ b/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/README.md
@@ -9,7 +9,7 @@ Planted teeth (mr_blue conservation fixtures + panic):
 | File | Known answer |
 | --- | --- |
 | `planted_constructed_with.py` | one with-item; inject SourceDerived → constructed≥1 |
-| `planted_opaque_with.py` | one with-item; typed gap residual, not silent drop |
+| `planted_opaque_with.py` | one with-item; unconstructed and accounted, not silently dropped |
 | `planted_clean.py` | no with; completed row |
 | panic plant | ConstructionPanic enrolled as cpanic=1 (harness inject) |
 

--- a/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/planted_opaque_with.py
+++ b/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/planted_opaque_with.py
@@ -1,4 +1,4 @@
-"""Unconstructed with-item plant: must residual (typed gap), never vanish."""
+"""Unconstructed with-item plant: must remain accounted, never vanish."""
 
 
 def run():

--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -46,6 +46,7 @@ STAGE_ENUMERATE_FILE_TERMINAL = "recensus-enumerate-file-terminal/v1"
 STAGE_WITH_TALLY_PARTITION = "control-effect-with-tally-partition/v1"
 STAGE_TERMINAL_AGGREGATE_SEAL = "compose-terminal-aggregate-seal/v1"
 _CONSTRUCTION_PANIC_TYPE = "sugar_lift_py_tests.gap.panic.ConstructionPanic"
+_SOURCE_PANIC_PREFIX = "sugar_source_tree.panic."
 _TERMINAL_KINDS = frozenset({"constructed", "construction-panic"})
 _TERMINAL_CONVENTION = {
     "observed_chain_length": "number of observed terminals in order",
@@ -302,6 +303,30 @@ def _terminal_row_failures(file: str, row: Mapping[str, Any]) -> list[dict[str, 
     input_key = row.get("inputKey")
     if not isinstance(input_key, dict) or not isinstance(input_key.get("sourceCid"), str):
         failures.append({"file": file, "reason": "inputKey lacks sourceCid"})
+    elif "functionKeyManifest" in input_key:
+        function_keys = input_key.get("functionKeyManifest")
+        if not isinstance(function_keys, list):
+            failures.append({"file": file, "reason": "functionKeyManifest is not a list"})
+        else:
+            if len(function_keys) != int(row.get("functionsTotal") or 0):
+                failures.append(
+                    {
+                        "file": file,
+                        "reason": "function key attendance disagrees with functionsTotal",
+                        "functionKeyCount": len(function_keys),
+                        "functionsTotal": int(row.get("functionsTotal") or 0),
+                    }
+                )
+            observed_function_cid = key_manifest_cid(function_keys)
+            if input_key.get("functionKeyCid") != observed_function_cid:
+                failures.append(
+                    {
+                        "file": file,
+                        "reason": "functionKeyCid mismatch",
+                        "claimed": input_key.get("functionKeyCid"),
+                        "observed": observed_function_cid,
+                    }
+                )
     expected_row_id = (
         canonical_cid({"inputKey": input_key}) if isinstance(input_key, dict) else None
     )
@@ -347,7 +372,9 @@ def _terminal_row_failures(file: str, row: Mapping[str, Any]) -> list[dict[str, 
     if row.get("final_terminal") != terminal_kind:
         failures.append({"file": file, "reason": "final_terminal disagrees"})
     if terminal_kind == "construction-panic":
-        if observed_type != _CONSTRUCTION_PANIC_TYPE:
+        if observed_type != _CONSTRUCTION_PANIC_TYPE and not str(
+            observed_type
+        ).startswith(_SOURCE_PANIC_PREFIX):
             failures.append(
                 {
                     "file": file,
@@ -700,7 +727,8 @@ def mint_partial(
     malformed = [
         f
         for f, raw in terminals
-        if not isinstance(raw, dict) or not raw.get("category")
+        if not isinstance(raw, dict)
+        or (not raw.get("category") and not raw.get("instrumentFailure"))
     ]
     files_complete = (
         not missing
@@ -834,7 +862,8 @@ def aggregate_terminal_rows(
     malformed_rows = sorted(
         file
         for file, raw in measured_rows
-        if not isinstance(raw, dict) or not raw.get("category")
+        if not isinstance(raw, dict)
+        or (not raw.get("category") and not raw.get("instrumentFailure"))
     )
 
     families: Counter[str] = Counter()
@@ -843,6 +872,7 @@ def aggregate_terminal_rows(
     desugar_by_category_owner: Counter[str] = Counter()
     backend_defects: Counter[str] = Counter()
     cm_resolutions: Counter[str] = Counter()
+    with_resolution_rows: list[dict[str, Any]] = []
     unrecognized_cm_kinds: Counter[str] = Counter()
     ast_sites: Counter[str] = Counter()
     desugar_construction_panics: list[dict[str, Any]] = []
@@ -888,6 +918,7 @@ def aggregate_terminal_rows(
         desugar_by_category_owner.update(row.get("desugarByCategoryOwner") or {})
         backend_defects.update(row.get("backendDefects") or {})
         cm_resolutions.update(row.get("cmResolutions") or {})
+        with_resolution_rows.extend(row.get("withResolutionRows") or [])
         unrecognized_cm_kinds.update(row.get("unrecognizedCmResolutionKinds") or {})
         ast_sites.update(row.get("astSites") or {})
         desugar_construction_panics.extend(row.get("desugarConstructionPanics") or [])
@@ -925,6 +956,7 @@ def aggregate_terminal_rows(
         "desugar_by_category_owner": desugar_by_category_owner,
         "backend_defects": backend_defects,
         "cm_resolutions": cm_resolutions,
+        "with_resolution_rows": with_resolution_rows,
         "unrecognized_cm_kinds": unrecognized_cm_kinds,
         "ast_sites": ast_sites,
         "desugar_construction_panics": desugar_construction_panics,
@@ -1345,7 +1377,7 @@ def compose_from_partials(
     with_census = None
     if with_census_fn is not None:
         with_census = with_census_fn(
-            Counter(agg["cm_resolutions"]),
+            list(agg["with_resolution_rows"]),
             Counter(agg["ast_sites"]),
             Counter(agg["unrecognized_cm_kinds"]),
         )

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -297,42 +297,16 @@ WITH_CENSUS_CONSERVATION_IDENTITY = (
     "site:with-item == constructed + unconstructed "
     "(no residual kind taxonomy)"
 )
-
-
-def _effective_cm_resolutions_for_source(context, *, source_cid: str) -> dict:
-    """Resolutions With construction will see for one source unit.
-
-    Same precedence as ``With._prebound_manager_resolution``: source-derived
-    overwrites ``contract_refs``. Filter by ``source_cid`` so a shared corpus
-    provisional table is counted once per site, not once per file walk.
-    """
-    effective: dict = {}
-    refs = getattr(context, "contract_refs", None)
-    by_use = getattr(refs, "by_use_site", None) or {}
-    for coordinate, resolution in by_use.items():
-        if getattr(coordinate, "source_cid", None) != source_cid:
-            continue
-        effective[coordinate] = resolution
-    derived = getattr(context, "source_derived_contract_refs", None) or {}
-    for coordinate, resolution in derived.items():
-        if getattr(coordinate, "source_cid", None) != source_cid:
-            continue
-        # Derived wins — identical to With construction.
-        effective[coordinate] = resolution
-    return effective
-
-
 def _tally_cm_resolutions(
-    context,
+    context=None,
     *,
     source_cid: str,
-) -> tuple[Counter[str], Counter[str]]:
-    """Count constructed vs unconstructed CM prebinds. No kind buckets."""
+    resolution_events: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Emit one canonical coordinate row per With resolution, no name buckets."""
     from sugar_lift_py_tests.context_manager_resolution import (
-        ContextManagerContractRefV1,
-        ContextManagerResolutionGapV1,
-        SourceDerivedContextManagerRefV1,
-        SourceDerivedGeneratorResourceRefV1,
+        context_manager_resolution_outcome,
+        effective_context_manager_resolutions_for_source,
     )
 
     if not source_cid:
@@ -341,65 +315,127 @@ def _tally_cm_resolutions(
             "are not multiplied across every file in the census"
         )
 
-    buckets: Counter[str] = Counter()
-    empty: Counter[str] = Counter()
-    for resolution in _effective_cm_resolutions_for_source(
-        context, source_cid=source_cid
-    ).values():
-        if isinstance(
-            resolution,
-            (
-                SourceDerivedContextManagerRefV1,
-                SourceDerivedGeneratorResourceRefV1,
-                ContextManagerContractRefV1,
-            ),
-        ):
-            buckets["constructed"] += 1
-            continue
-        if isinstance(resolution, ContextManagerResolutionGapV1):
-            buckets["unconstructed"] += 1
-            continue
-        raise TypeError(
-            "With resolution table value is neither constructed ref nor gap: "
-            f"{type(resolution).__name__}"
-        )
-    return buckets, empty
+    rows: list[dict[str, Any]] = []
+    if resolution_events is not None:
+        for event in resolution_events:
+            if not isinstance(event, dict):
+                raise TypeError("With resolution event must be an object")
+            key = event.get("inputKey")
+            outcome = event.get("outcome")
+            observed_type = event.get("observedEventType")
+            if (
+                not isinstance(key, dict)
+                or key.get("sourceCid") != source_cid
+                or outcome not in {"constructed", "unconstructed"}
+                or not isinstance(observed_type, str)
+                or "." not in observed_type
+            ):
+                raise TypeError(f"malformed With resolution event: {event}")
+            rows.append(
+                {
+                    "inputKey": dict(key),
+                    "observedEventType": observed_type,
+                    "outcome": outcome,
+                }
+            )
+    else:
+        if context is None:
+            raise TypeError("With resolution tally requires context or raw events")
+        for coordinate, resolution in effective_context_manager_resolutions_for_source(
+            context, source_cid=source_cid
+        ).items():
+            rows.append(
+                {
+                    "inputKey": coordinate.wire(),
+                    "observedEventType": (
+                        f"{type(resolution).__module__}.{type(resolution).__qualname__}"
+                    ),
+                    "outcome": context_manager_resolution_outcome(resolution),
+                }
+            )
+    return sorted(rows, key=lambda row: json.dumps(row["inputKey"], sort_keys=True))
 
 
 def _with_census_partition(
-    cm_resolutions: Counter[str],
+    cm_resolution_rows: list[dict[str, Any]],
     ast_sites: Counter[str],
     unrecognized_kinds: Counter[str] | None = None,
 ) -> dict[str, Any]:
-    """Count constructed vs gap rows. No kind taxonomy, no 42-member vocabulary."""
-    del unrecognized_kinds  # taxonomy deleted
+    """Preserve coordinate keys while splitting constructed/unconstructed."""
+    del unrecognized_kinds
+    from compose_control_effect_board import (
+        STAGE_WITH_TALLY_PARTITION,
+        key_edge_witness,
+    )
+
+    constructed_rows = [
+        dict(row) for row in cm_resolution_rows if row.get("outcome") == "constructed"
+    ]
+    unconstructed_rows = [
+        dict(row) for row in cm_resolution_rows if row.get("outcome") == "unconstructed"
+    ]
+    if len(constructed_rows) + len(unconstructed_rows) != len(cm_resolution_rows):
+        raise TypeError("With partition received a row outside its closed outcomes")
+    input_keys = [dict(row["inputKey"]) for row in cm_resolution_rows]
+    output_rows = [*constructed_rows, *unconstructed_rows]
+    output_keys = [dict(row["inputKey"]) for row in output_rows]
+    edge_witness = key_edge_witness(
+        stage_id=STAGE_WITH_TALLY_PARTITION,
+        input_keys=input_keys,
+        output_keys=output_keys,
+    )
+    if (
+        edge_witness["missingKeys"]
+        or edge_witness["extraKeys"]
+        or edge_witness["duplicateKeys"]
+    ):
+        raise TypeError(
+            "With coordinate-key partition does not conserve: "
+            f"missing={edge_witness['missingKeys']} "
+            f"extra={edge_witness['extraKeys']} "
+            f"duplicate={edge_witness['duplicateKeys']}"
+        )
     total = int(ast_sites.get("site:with-item", 0))
-    constructed = int(cm_resolutions.get("derived-contract", 0))
-    gap_total = sum(v for k, v in cm_resolutions.items() if k.startswith("gap:"))
-    accounted = constructed + gap_total
+    constructed = len(constructed_rows)
+    unconstructed = len(unconstructed_rows)
+    accounted = constructed + unconstructed
     if accounted != total:
         unaccounted = total - accounted
         raise ValueError(
             "With census does not conserve. "
             f"LAW: {WITH_CENSUS_CONSERVATION_IDENTITY}. "
             f"REFUSED: with_items_total={total} constructed={constructed} "
-            f"gaps={gap_total} accounted={accounted} unaccounted={unaccounted}. "
+            f"unconstructed={unconstructed} accounted={accounted} "
+            f"unaccounted={unaccounted}. "
             "Construct or panic — fix the partition or write the missing construction."
         )
     return {
         "conservationIdentity": WITH_CENSUS_CONSERVATION_IDENTITY,
+        "edgeWitness": edge_witness,
+        "constructedRows": constructed_rows,
+        "unconstructedRows": unconstructed_rows,
         "with_items_total": total,
         "constructed": constructed,
-        "typed_gap_kinds_total": 0,
-        "typed_gaps": {},
-        "unrecognized_resolution_kinds": {},
+        "unconstructed": unconstructed,
         "accounted": accounted,
         "unaccounted": 0,
         "reconciliation": (
-            f"{total} = {constructed} constructed + {gap_total} gaps"
+            f"{total} = {constructed} constructed + {unconstructed} unconstructed"
         ),
         "conserves": True,
     }
+
+
+def _attested_cm_counts(result: dict[str, Any]) -> tuple[int, int]:
+    with_census = result.get("withCensus")
+    if not isinstance(with_census, dict):
+        raise ValueError("CM zero lacks key attestation")
+    edge = with_census.get("edgeWitness")
+    if not isinstance(edge, dict) or edge.get("missingKeys") or edge.get("extraKeys"):
+        raise ValueError("CM zero lacks conserving key attestation")
+    return int(with_census.get("constructed", 0)), int(
+        with_census.get("unconstructed", 0)
+    )
 
 
 
@@ -1367,6 +1403,7 @@ def main() -> int:
                     # workspace_root for enumerate is the corpus root; at.file is
                     # the path relative to that root (not the pin-prefixed key).
                     from recensus_enumerate_consumer import (
+                        _instrument_failure_row,
                         measure_file_via_enumerate,
                     )
 
@@ -1375,46 +1412,45 @@ def main() -> int:
                         file_rel=relative,
                         contract_refs=contract_refs,
                     )
-                except (ImportError, AttributeError) as error:
-                    # An arm that cannot resolve its dispatch target is UNWRITTEN,
-                    # wearing a working arm's clothes. Own category, named, loud
-                    # (#6329). Still recover roster/AST mass when possible — never
-                    # bank silent 0 over a file that has functions.
-                    row = terminal_after_measure_escape(
-                        path=path,
-                        relative=relative,
-                        workspace_root=corpus_root,
-                        error=error,
-                        category="panic",
-                    )
-                    # Preserve #6329 owner metadata on the defect object.
-                    defect = dict(row.get("defect") or {})
-                    defect.update(
-                        {
-                            "file": relative,
-                            "type": type(error).__name__,
-                            "message": str(error),
-                            "owner": "kit dispatch target",
-                            "fix": (
-                                "the arm imports a name that does not exist; write "
-                                "the target or delete the arm"
+                    if row.get("terminalKind") in {
+                        "constructed",
+                        "construction-panic",
+                    }:
+                        source_cid = str((row.get("inputKey") or {}).get("sourceCid"))
+                        resolution_rows = _tally_cm_resolutions(
+                            source_cid=source_cid,
+                            resolution_events=list(
+                                row.pop("contextManagerResolutionEvents", [])
                             ),
+                        )
+                        sites = _ast_site_prevalence(path)
+                        with_partition = _with_census_partition(
+                            resolution_rows, sites
+                        )
+                        row["withResolutionRows"] = resolution_rows
+                        row["cmResolutions"] = {
+                            "constructed": with_partition["constructed"],
+                            "unconstructed": with_partition["unconstructed"],
                         }
-                    )
-                    row["defect"] = defect
-                    row["category"] = "panic"
+                        row["astSites"] = dict(sites)
+                        from compose_control_effect_board import EDGE_WITH_PARTITION
+
+                        row.setdefault("edgeWitnesses", {})[
+                            EDGE_WITH_PARTITION
+                        ] = with_partition["edgeWitness"]
                 except BaseException as error:  # noqa: BLE001 -- per-file terminal
-                    # Last-resort shell. Must NOT bank functionsTotal=0 over known
-                    # mass: recover D2 roster (or AST) and name the escape residual.
-                    # ConstructionPanic is BaseException; other escapes will be too.
                     if _is_process_control(error):
                         raise
-                    row = terminal_after_measure_escape(
-                        path=path,
-                        relative=relative,
-                        workspace_root=corpus_root,
-                        error=error,
-                        category="panic",
+                    row = _instrument_failure_row(
+                        error,
+                        file_rel=relative,
+                        phase="main-file-producer",
+                        source_cid=None,
+                        function_nodes=[],
+                        functions_total=int(
+                            _ast_site_prevalence(path).get("site:function-def", 0)
+                        ),
+                        functions_enumerated=0,
                     )
                 file_s = time.perf_counter() - t_file
                 checkpoint.append(file, row)
@@ -1629,7 +1665,8 @@ def main() -> int:
     malformed_rows = sorted(
         file
         for file, raw in measured_rows
-        if not isinstance(raw, dict) or not raw.get("category")
+        if not isinstance(raw, dict)
+        or (not raw.get("category") and not raw.get("instrumentFailure"))
     )
 
     for file, raw in measured_rows:
@@ -1652,12 +1689,19 @@ def main() -> int:
         desugar_construction_panics.extend(row.get("desugarConstructionPanics") or [])
         desugar_defects.extend(row.get("desugarDefects") or [])
         desugar_designed_gaps.extend(row.get("desugarDesignedGaps") or [])
+        if row.get("instrumentFailure"):
+            continue
         if category == "completed":
             files_completed += 1
         elif category == "panic":
             panic = row.get("panic")
             if isinstance(panic, dict):
                 construction_panics.append(panic)
+            defect = row.get("defect") or panic
+            if isinstance(defect, dict):
+                defects.append(dict(defect))
+                if defect.get("owner") == "kit dispatch target":
+                    unresolvable_dispatch.append(dict(defect))
             # Measure now enrolls ConstructionPanic into the row's families
             # (file-level BaseException path). Prefer that; only fill if a
             # legacy checkpoint row still omits it. Use get+assign so a plain
@@ -1666,39 +1710,11 @@ def main() -> int:
                 families["ConstructionPanic"] = (
                     int(families.get("ConstructionPanic") or 0) + 1
                 )
-        elif category == "panic":
-            defect = row.get("defect")
-            if isinstance(defect, dict):
-                unresolvable_dispatch.append(dict(defect))
-            defects.append(
-                dict(defect)
-                if isinstance(defect, dict)
-                else {"file": file, "type": category, "message": category}
-            )
         else:
-            defect = row.get("defect")
-            defects.append(
-                dict(defect)
-                if isinstance(defect, dict)
-                else {"file": file, "type": category, "message": category}
+            raise TypeError(
+                "control-effect recensus terminal category must be completed or "
+                f"panic; got {category!r} for {file}"
             )
-            # Demand/resolution table hygiene — own counter, not mass residual.
-            # Keep CM-demand vs call-demand bijection failures separate.
-            if isinstance(defect, dict):
-                msg = f"{defect.get('type', '')}: {defect.get('message', '')}"
-            else:
-                msg = str(category)
-            if (
-                "BackendDefect" in msg
-                or "backend defect" in msg.lower()
-                or (
-                    isinstance(defect, dict)
-                    and "BackendDefect" in str(defect.get("type", ""))
-                )
-            ):
-                backend_defects[_backend_defect_key(msg)] += 1
-            elif category == "panic":
-                backend_defects[_backend_defect_key(msg)] += 1
 
     from pandas_floor_summary import floor_summary
 
@@ -1793,9 +1809,7 @@ def main() -> int:
             "R_control_effect": r_construction + len(defects),
             "R_desugar": r_desugar,
             "R_backend_defects": r_backend,
-            "R_cm_derived_contract": int(
-                (result.get("cmResolutions") or {}).get("derived-contract", 0)
-            ),
+            "R_cm_derived_contract": _attested_cm_counts(result)[0],
             "desugarConstructionPanics": len(desugar_construction_panics),
             "desugarDefects": len(desugar_defects),
             "constructionPanics": len(construction_panics),

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 SCOREBOARD_AUTHORITY = False
 
@@ -98,6 +98,235 @@ def count_ast_function_defs(path: Path) -> int | None:
     )
 
 
+def _qualified_type(value: object) -> str:
+    kind = type(value)
+    return f"{kind.__module__}.{kind.__qualname__}"
+
+
+def _function_key_manifest(
+    *, file_rel: str, source_cid: str, function_nodes: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    keys: list[dict[str, Any]] = []
+    for node in function_nodes:
+        memento = node.get("memento") if isinstance(node, dict) else None
+        if not isinstance(memento, dict):
+            continue
+        keys.append(
+            {
+                "sourceCid": source_cid,
+                "file": file_rel,
+                "functionSourceCid": memento.get("source_cid"),
+                "functionName": memento.get("source_function_name")
+                or memento.get("function_name"),
+                "span": memento.get("span"),
+            }
+        )
+    return keys
+
+
+def _terminal_input_key(
+    *, file_rel: str, source_cid: str, function_keys: list[dict[str, Any]]
+) -> dict[str, Any]:
+    from compose_control_effect_board import key_manifest_cid
+
+    return {
+        "sourceCid": source_cid,
+        "file": file_rel,
+        "functionKeyManifest": list(function_keys),
+        "functionKeyCid": key_manifest_cid(function_keys),
+    }
+
+
+def _exception_trace(
+    error: BaseException,
+    *,
+    owner: str,
+    coordinate: str,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = [
+        {
+            "kind": "source-construct",
+            "constructOwner": owner,
+            "coordinate": coordinate,
+        }
+    ]
+    tb = error.__traceback__
+    while tb is not None:
+        frame = tb.tb_frame
+        rows.append(
+            {
+                "kind": "dispatch-frame",
+                "module": str(frame.f_globals.get("__name__") or ""),
+                "qualname": frame.f_code.co_qualname,
+                "file": frame.f_code.co_filename,
+                "line": tb.tb_lineno,
+            }
+        )
+        tb = tb.tb_next
+    if len(rows) > 1:
+        final = dict(rows[-1])
+        final["kind"] = "panic-site"
+        rows.append(final)
+    return rows
+
+
+def _panic_from_exception(
+    error: BaseException, *, file_rel: str, phase: str
+) -> dict[str, Any] | None:
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from sugar_source_tree.panic import SugarNotWritten
+
+    if isinstance(error, ConstructionPanic):
+        info = error.info.to_json()
+        owner = str(info["owner"])
+        coordinate = str(info["blame"])
+        observed = str(info["observed"])
+        requested = str(info["requested"])
+        fix = str(info["fix"])
+    elif isinstance(error, SugarNotWritten):
+        owner = str(error.owner)
+        coordinate = str(error.blame)
+        observed = str(error.observed)
+        requested = str(error.requested)
+        fix = str(error.fix)
+    else:
+        return None
+    entrance = f"sugar.enumerate:{phase}"
+    return {
+        "owner": owner,
+        "coordinate": coordinate,
+        "observed": observed,
+        "requested": requested,
+        "fix": fix,
+        "entrance": entrance,
+        "construction_trace": _exception_trace(
+            error, owner=owner, coordinate=coordinate
+        ),
+        "observedEventType": _qualified_type(error),
+        "file": file_rel,
+        "message": str(error),
+    }
+
+
+def _panic_from_audit(raw: Mapping[str, Any], *, file_rel: str) -> dict[str, Any] | None:
+    gap = raw.get("gap")
+    if not isinstance(gap, dict):
+        return None
+    required = {
+        "owner",
+        "coordinate",
+        "observed",
+        "requested",
+        "fix",
+        "entrance",
+        "construction_trace",
+        "observedEventType",
+    }
+    if not required.issubset(gap) or not isinstance(gap["construction_trace"], list):
+        return None
+    return {
+        **{field: gap[field] for field in required},
+        "file": file_rel,
+        "message": str(raw.get("reason") or gap.get("observed") or raw),
+    }
+
+
+def _attest_terminal_row(
+    row: dict[str, Any],
+    *,
+    file_rel: str,
+    source_cid: str,
+    function_nodes: list[dict[str, Any]],
+) -> dict[str, Any]:
+    from compose_control_effect_board import (
+        EDGE_ENUMERATE_FILE,
+        STAGE_ENUMERATE_FILE_TERMINAL,
+        canonical_cid,
+        key_edge_witness,
+    )
+
+    function_keys = _function_key_manifest(
+        file_rel=file_rel, source_cid=source_cid, function_nodes=function_nodes
+    )
+    input_key = _terminal_input_key(
+        file_rel=file_rel, source_cid=source_cid, function_keys=function_keys
+    )
+    row["inputKey"] = input_key
+    row["rowId"] = canonical_cid({"inputKey": input_key})
+    row["stageId"] = STAGE_ENUMERATE_FILE_TERMINAL
+    terminal_kind = "construction-panic" if row.get("panic") else "constructed"
+    row["terminalKind"] = terminal_kind
+    row["observedEventType"] = (
+        row["panic"].get("observedEventType")
+        if terminal_kind == "construction-panic"
+        else "builtins.dict"
+    )
+    trace = row["panic"].get("construction_trace") if row.get("panic") else None
+    row["observed_chain_length"] = len(trace) if isinstance(trace, list) else 1
+    row["blocking_terminal_count"] = 1 if terminal_kind == "construction-panic" else 0
+    row["final_terminal"] = terminal_kind
+    row.setdefault("edgeWitnesses", {})[EDGE_ENUMERATE_FILE] = key_edge_witness(
+        stage_id=STAGE_ENUMERATE_FILE_TERMINAL,
+        input_keys=function_keys,
+        output_keys=function_keys,
+    )
+    return row
+
+
+def _instrument_failure_row(
+    error: BaseException | str,
+    *,
+    file_rel: str,
+    phase: str,
+    source_cid: str | None,
+    function_nodes: list[dict[str, Any]],
+    functions_total: int,
+    functions_enumerated: int,
+) -> dict[str, Any]:
+    observed_type = _qualified_type(error) if isinstance(error, BaseException) else "builtins.str"
+    functions_not_enumerated = max(0, functions_total - functions_enumerated)
+    row: dict[str, Any] = {
+        "functionsTotal": functions_total,
+        "functionsEnumerated": functions_enumerated,
+        "functionsNotEnumerated": functions_not_enumerated,
+        "functionsEnumerationComplete": (
+            functions_total > 0
+            and functions_enumerated == functions_total
+            and functions_not_enumerated == 0
+        ),
+        "functionsClean": None,
+        "cleanRatioRefused": True,
+        "cleanRefuseReason": f"instrument failure during {phase}",
+        "functionsAuthenticated": functions_total,
+        "astSites": (
+            {"site:function-def": functions_total} if functions_total else {}
+        ),
+        "rosterPreservedAfterResidualFailure": bool(
+            phase in {"residual", "outer-shell-escape"}
+            and functions_total > 0
+            and functions_enumerated > 0
+        ),
+        "enumerateSource": True,
+        "enumerateFunctionMementos": functions_enumerated,
+        "families": {},
+        "instrumentFailure": {
+            "file": file_rel,
+            "stageId": "recensus-enumerate-file-terminal/v1",
+            "observedEventType": observed_type,
+            "phase": phase,
+            "message": str(error),
+        },
+    }
+    if source_cid:
+        function_keys = _function_key_manifest(
+            file_rel=file_rel, source_cid=source_cid, function_nodes=function_nodes
+        )
+        row["inputKey"] = _terminal_input_key(
+            file_rel=file_rel, source_cid=source_cid, function_keys=function_keys
+        )
+    return row
+
+
 def demand_function_roster(
     *,
     workspace_root: Path,
@@ -115,6 +344,38 @@ def demand_function_roster(
     nodes = list(result.get("nodes") or [])
     gaps = list(result.get("gaps") or [])
     return nodes, gaps
+
+
+def demand_context_manager_resolution_events(
+    *,
+    workspace_root: Path,
+    file_rel: str,
+    source_cid: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Enumerate the raw, coordinate-keyed table With construction consumed."""
+    result = enumerate_rpc(
+        level="context-manager-resolutions",
+        workspace_root=workspace_root,
+        at=file_memento(file_rel=file_rel, source_cid=source_cid),
+        seek=False,
+    )
+    events: list[dict[str, Any]] = []
+    for node in result.get("nodes") or []:
+        if not isinstance(node, dict):
+            continue
+        memento = node.get("memento")
+        audit = node.get("audit")
+        coordinate = memento.get("coordinate") if isinstance(memento, dict) else None
+        if not isinstance(coordinate, dict) or not isinstance(audit, dict):
+            continue
+        events.append(
+            {
+                "inputKey": dict(coordinate),
+                "observedEventType": audit.get("observedEventType"),
+                "outcome": audit.get("outcome"),
+            }
+        )
+    return events, list(result.get("gaps") or [])
 
 
 def demand_construction_residual(
@@ -140,16 +401,6 @@ def demand_construction_residual(
     return (audit if isinstance(audit, dict) else None), gaps
 
 
-def _panic_payload(error: BaseException, *, file_rel: str, phase: str) -> dict[str, Any]:
-    """What could not be built — type + message. No residual kind ladder."""
-    return {
-        "file": file_rel,
-        "type": type(error).__name__,
-        "message": str(error),
-        "phase": phase,
-    }
-
-
 def _empty_shell(
     *,
     file_rel: str,
@@ -163,6 +414,7 @@ def _empty_shell(
     clean_ratio_refused: bool = True,
     clean_refuse_reason: str | None = None,
     ast_fn: int | None = None,
+    roster_preserved_after_residual_failure: bool = False,
 ) -> dict[str, Any]:
     """One terminal shell. category is completed or panic only."""
     not_enum = max(0, functions_total - functions_enumerated)
@@ -200,7 +452,7 @@ def _empty_shell(
         "enumerateSource": True,
         "enumerateFunctionMementos": functions_enumerated,
         "rosterPreservedAfterResidualFailure": bool(
-            category == "panic" and functions_total > 0 and functions_enumerated > 0
+            roster_preserved_after_residual_failure
         ),
     }
     if defect is not None:
@@ -255,6 +507,8 @@ def terminal_from_enumerate(
     residual_phase_failed: bool = False,
     residual_error: BaseException | None = None,
     ast_fn: int | None = None,
+    source_cid: str | None = None,
+    context_manager_resolution_events: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Map enumerate products → one recensus terminal (compose input).
 
@@ -262,24 +516,14 @@ def terminal_from_enumerate(
     len(function_nodes) even if residual_phase_failed.
     """
     if function_gaps and not function_nodes:
-        reason = function_gaps[0].get("reason") or "functions demand gap"
-        panic = {
-            "file": file_rel,
-            "type": "ConstructionPanic",
-            "message": str(reason),
-            "phase": "roster",
-            "gap": dict(function_gaps[0]),
-        }
-        return _empty_shell(
+        return _instrument_failure_row(
+            str(function_gaps[0]),
             file_rel=file_rel,
-            category="panic",
+            phase="roster-gap",
+            source_cid=source_cid,
+            function_nodes=function_nodes,
             functions_total=0,
             functions_enumerated=0,
-            defect=panic,
-            panic=panic,
-            functions_clean=0,
-            clean_ratio_refused=False,
-            ast_fn=ast_fn,
         )
 
     functions_total = len(function_nodes)
@@ -294,31 +538,44 @@ def terminal_from_enumerate(
             if isinstance(raw_panics, list):
                 panics = [p for p in raw_panics if isinstance(p, dict)]
     for panic in panics:
-        gap = panic.get("gap") if isinstance(panic.get("gap"), dict) else {}
-        construction_panics.append(
-            {
-                "file": file_rel,
-                "type": "ConstructionPanic",
-                "message": str(panic.get("reason") or gap.get("reason") or ""),
-                "gap": gap,
-                "locus": panic.get("locus"),
-            }
-        )
+        authenticated = _panic_from_audit(panic, file_rel=file_rel)
+        if authenticated is None:
+            return _instrument_failure_row(
+                f"audit panic lacks authenticated payload: {panic}",
+                file_rel=file_rel,
+                phase="audit-panic-decode",
+                source_cid=source_cid,
+                function_nodes=function_nodes,
+                functions_total=functions_total,
+                functions_enumerated=functions_enumerated,
+            )
+        construction_panics.append(authenticated)
     for gap in construction_gaps:
-        construction_panics.append(
-            {
-                "file": file_rel,
-                "type": "ConstructionPanic",
-                "message": str(gap.get("reason") or gap),
-                "gap": dict(gap),
-            }
+        return _instrument_failure_row(
+            f"construction gap lacks terminal witness: {gap}",
+            file_rel=file_rel,
+            phase="residual-gap-decode",
+            source_cid=source_cid,
+            function_nodes=function_nodes,
+            functions_total=functions_total,
+            functions_enumerated=functions_enumerated,
         )
 
     residual_panic: dict[str, Any] | None = None
     if residual_phase_failed and residual_error is not None:
-        residual_panic = _panic_payload(
+        residual_panic = _panic_from_exception(
             residual_error, file_rel=file_rel, phase="residual"
         )
+        if residual_panic is None:
+            return _instrument_failure_row(
+                residual_error,
+                file_rel=file_rel,
+                phase="residual",
+                source_cid=source_cid,
+                function_nodes=function_nodes,
+                functions_total=functions_total,
+                functions_enumerated=functions_enumerated,
+            )
         construction_panics.append(residual_panic)
 
     clean, clean_refused, clean_reason = _functions_clean(
@@ -345,10 +602,25 @@ def terminal_from_enumerate(
         clean_ratio_refused=clean_refused,
         clean_refuse_reason=clean_reason,
         ast_fn=ast_fn if ast_fn is not None else functions_total,
+        roster_preserved_after_residual_failure=(
+            residual_phase_failed
+            and functions_total > 0
+            and functions_enumerated > 0
+        ),
     )
     if construction_panics:
         row["constructionPanics"] = list(construction_panics)
         row["enumerateConstructionPanics"] = list(construction_panics)
+    row["contextManagerResolutionEvents"] = list(
+        context_manager_resolution_events or []
+    )
+    if source_cid is not None:
+        row = _attest_terminal_row(
+            row,
+            file_rel=file_rel,
+            source_cid=source_cid,
+            function_nodes=function_nodes,
+        )
     return row
 
 
@@ -372,6 +644,34 @@ def measure_file_via_enumerate(
     path = (workspace_root / file_rel).resolve()
     ast_fn = count_ast_function_defs(path)
 
+    try:
+        from sugar_lift_python_source.source_oracle import path_source
+
+        _source, _filename, observed_source_cid = path_source(str(path))
+    except BaseException as error:  # noqa: BLE001 — source identity is attendance
+        if isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit)):
+            raise
+        return _instrument_failure_row(
+            error,
+            file_rel=file_rel,
+            phase="source-identity",
+            source_cid=None,
+            function_nodes=[],
+            functions_total=int(ast_fn or 0),
+            functions_enumerated=0,
+        )
+    if source_cid is not None and source_cid != observed_source_cid:
+        return _instrument_failure_row(
+            "requested source CID no longer matches loaded file",
+            file_rel=file_rel,
+            phase="source-identity",
+            source_cid=observed_source_cid,
+            function_nodes=[],
+            functions_total=int(ast_fn or 0),
+            functions_enumerated=0,
+        )
+    source_cid = observed_source_cid
+
     def _is_process_control(error: BaseException) -> bool:
         return isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit))
 
@@ -385,8 +685,18 @@ def measure_file_via_enumerate(
         if _is_process_control(error):
             raise
         auth = int(ast_fn) if ast_fn is not None else 0
-        panic = _panic_payload(error, file_rel=file_rel, phase="roster")
-        return _empty_shell(
+        panic = _panic_from_exception(error, file_rel=file_rel, phase="roster")
+        if panic is None:
+            return _instrument_failure_row(
+                error,
+                file_rel=file_rel,
+                phase="roster",
+                source_cid=source_cid,
+                function_nodes=[],
+                functions_total=auth,
+                functions_enumerated=0,
+            )
+        row = _empty_shell(
             file_rel=file_rel,
             category="panic",
             functions_total=auth,
@@ -400,6 +710,12 @@ def measure_file_via_enumerate(
             ),
             ast_fn=ast_fn,
         )
+        return _attest_terminal_row(
+            row,
+            file_rel=file_rel,
+            source_cid=source_cid,
+            function_nodes=[],
+        )
 
     if function_gaps and not function_nodes:
         return terminal_from_enumerate(
@@ -409,6 +725,58 @@ def measure_file_via_enumerate(
             audit=None,
             construction_gaps=[],
             ast_fn=ast_fn,
+            source_cid=source_cid,
+        )
+
+    try:
+        cm_events, cm_gaps = demand_context_manager_resolution_events(
+            workspace_root=workspace_root,
+            file_rel=file_rel,
+            source_cid=source_cid,
+        )
+    except BaseException as error:  # noqa: BLE001 — distinct instrument/product paths
+        if _is_process_control(error):
+            raise
+        panic = _panic_from_exception(
+            error, file_rel=file_rel, phase="context-manager-resolutions"
+        )
+        if panic is None:
+            return _instrument_failure_row(
+                error,
+                file_rel=file_rel,
+                phase="context-manager-resolutions",
+                source_cid=source_cid,
+                function_nodes=function_nodes,
+                functions_total=len(function_nodes),
+                functions_enumerated=len(function_nodes),
+            )
+        row = _empty_shell(
+            file_rel=file_rel,
+            category="panic",
+            functions_total=len(function_nodes),
+            functions_enumerated=len(function_nodes),
+            defect=panic,
+            panic=panic,
+            functions_clean=None,
+            clean_ratio_refused=True,
+            clean_refuse_reason="CM resolution panic after roster; clean not measured",
+            ast_fn=ast_fn,
+        )
+        return _attest_terminal_row(
+            row,
+            file_rel=file_rel,
+            source_cid=source_cid,
+            function_nodes=function_nodes,
+        )
+    if cm_gaps:
+        return _instrument_failure_row(
+            f"context-manager resolution enumeration gaps: {cm_gaps}",
+            file_rel=file_rel,
+            phase="context-manager-resolutions",
+            source_cid=source_cid,
+            function_nodes=function_nodes,
+            functions_total=len(function_nodes),
+            functions_enumerated=len(function_nodes),
         )
 
     try:
@@ -429,6 +797,8 @@ def measure_file_via_enumerate(
             residual_phase_failed=True,
             residual_error=error,
             ast_fn=ast_fn,
+            source_cid=source_cid,
+            context_manager_resolution_events=cm_events,
         )
 
     return terminal_from_enumerate(
@@ -439,6 +809,8 @@ def measure_file_via_enumerate(
         construction_gaps=construction_gaps,
         residual_phase_failed=False,
         ast_fn=ast_fn,
+        source_cid=source_cid,
+        context_manager_resolution_events=cm_events,
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
@@ -8,9 +8,10 @@ WALLS (advisor, binding):
      and refuse CommitMeasurement panics ingestion by construction.
   2. SCOREBOARD_AUTHORITY stays False here. Sole bankable panics producer is
      control_effect_recensus on the authenticated pandas corpus.
-  3. Teeth are the instrument: constructed>0, cpanic=1, residual not vanish,
-     conservation closes, sealed body on PATH_OK. Crash → PATH_UNMEASURED.
-  4. Coverage honesty: five planted files retire serial path-rot discovery,
+  3. Teeth are the instrument: constructed>0, cpanic=1, unconstructed not
+     vanish, exact two-item accounting closes, sealed body on PATH_OK.
+     Crash → PATH_UNMEASURED.
+  4. Coverage honesty: four planted files retire serial path-rot discovery,
      not Class B corpus scale (thousands of with-items) or the full walk.
   5. measurementClass = recensus-path-smoke — never control-effect-recensus.
 
@@ -26,6 +27,7 @@ SCOREBOARD_AUTHORITY = False
 import importlib.util
 import json
 import os
+import re
 import sys
 import time
 import traceback
@@ -60,6 +62,15 @@ def _narrate(msg: str) -> None:
     print(msg, flush=True)
 
 
+def _worktree_sha() -> str:
+    value = os.environ.get("WITH_WIRE_WORKTREE_SHA", "")
+    if not re.fullmatch(r"[0-9a-f]{40}", value):
+        raise RuntimeError(
+            "WITH_WIRE_WORKTREE_SHA must carry the exact committed reproducer SHA"
+        )
+    return value
+
+
 def _load_recensus():
     path = _SCRIPTS / "control_effect_recensus.py"
     if str(_SCRIPTS) not in sys.path:
@@ -68,10 +79,16 @@ def _load_recensus():
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    # Path smoke must never promote the recensus module's authority flag.
-    assert getattr(module, "SCOREBOARD_AUTHORITY", None) is True, (
-        "control_effect_recensus must remain SCOREBOARD_AUTHORITY=True; "
-        "this smoke module is False and separate"
+    # Workers stay non-authoritative. The separate compose door owns the seal.
+    assert getattr(module, "SCOREBOARD_AUTHORITY", None) is False, (
+        "control_effect_recensus must remain SCOREBOARD_AUTHORITY=False"
+    )
+    from compose_control_effect_board import (
+        SCOREBOARD_AUTHORITY as compose_authority,
+    )
+
+    assert compose_authority is True, (
+        "compose_control_effect_board must remain the sole scoreboard authority"
     )
     return module
 
@@ -123,7 +140,7 @@ def _seal_path(
 
 
 def _measure_constructed(module, path: Path, workspace: Path) -> dict[str, Any]:
-    """mr_blue plant: SourceDerived at live use-site → derived-contract tally.
+    """mr_blue plant: SourceDerived at live use-site → constructed tally.
 
     Isolate the plant in a single-file workspace so provisional demands see
     exactly one use-site (same isolation as test_with_census_conservation).
@@ -182,14 +199,18 @@ def _measure_constructed(module, path: Path, workspace: Path) -> dict[str, Any]:
             import_signature=ImportSignatureV2(()),
             protocol=_Protocol(),
         )
-        buckets, unrecognized = module._tally_cm_resolutions(
+        resolution_rows = module._tally_cm_resolutions(
             ctx, source_cid=source_file.unit.source_cid
         )
         sites = module._ast_site_prevalence(plant)
+        partition = module._with_census_partition(resolution_rows, sites)
         return {
             "category": "completed",
-            "cmResolutions": dict(buckets),
-            "unrecognizedCmResolutionKinds": dict(unrecognized),
+            "cmResolutions": {
+                "constructed": partition["constructed"],
+                "unconstructed": partition["unconstructed"],
+            },
+            "withResolutionRows": resolution_rows,
             "families": {},
             "sites": dict(sites),
             "relative": f"recensus_path_smoke/{path.name}",
@@ -199,7 +220,7 @@ def _measure_constructed(module, path: Path, workspace: Path) -> dict[str, Any]:
 
 
 def _measure_opaque(module, path: Path, workspace: Path) -> dict[str, Any]:
-    """mr_blue plant: opaque with → typed gap residual (isolated workspace)."""
+    """mr_blue plant: opaque With stays present as unconstructed."""
     import shutil
     import tempfile
 
@@ -218,14 +239,18 @@ def _measure_opaque(module, path: Path, workspace: Path) -> dict[str, Any]:
         source_file = open_source_file_for_construction(
             plant, root=iso, construction_context=ctx, populate_derived=True
         )
-        buckets, unrecognized = module._tally_cm_resolutions(
+        resolution_rows = module._tally_cm_resolutions(
             ctx, source_cid=source_file.unit.source_cid
         )
         sites = module._ast_site_prevalence(plant)
+        partition = module._with_census_partition(resolution_rows, sites)
         return {
             "category": "completed",
-            "cmResolutions": dict(buckets),
-            "unrecognizedCmResolutionKinds": dict(unrecognized),
+            "cmResolutions": {
+                "constructed": partition["constructed"],
+                "unconstructed": partition["unconstructed"],
+            },
+            "withResolutionRows": resolution_rows,
             "families": {},
             "sites": dict(sites),
             "relative": f"recensus_path_smoke/{path.name}",
@@ -235,20 +260,20 @@ def _measure_opaque(module, path: Path, workspace: Path) -> dict[str, Any]:
 
 
 def _measure_clean(module, path: Path, workspace: Path) -> dict[str, Any]:
-    """Production per-file lift door for a clean function (isolated workspace)."""
+    """Production enumerate consumer for a clean function."""
     import shutil
     import tempfile
 
     from sugar_lift_py_tests.lift_rpc import provisional_contract_refs_from_demands
+    from recensus_enumerate_consumer import measure_file_via_enumerate
 
     iso = Path(tempfile.mkdtemp(prefix="recensus-path-smoke-clean-"))
     try:
         plant = iso / path.name
         shutil.copy2(path, plant)
         refs = provisional_contract_refs_from_demands(iso)
-        row = module._measure_file(
-            plant,
-            relative=f"recensus_path_smoke/{path.name}",
+        row = measure_file_via_enumerate(
+            file_rel=path.name,
             workspace_root=iso,
             contract_refs=refs,
         )
@@ -261,12 +286,13 @@ def _measure_clean(module, path: Path, workspace: Path) -> dict[str, Any]:
 
 
 def _measure_panic(module, path: Path, workspace: Path) -> dict[str, Any]:
-    """Known panic through production _measure_file + ConstructionPanic inject."""
+    """Known panic through the production enumerate consumer."""
     import shutil
     import tempfile
 
     from sugar_lift_py_tests.gap.info import ConstructionGap
     from sugar_lift_py_tests.gap.panic import ConstructionPanic
+    from recensus_enumerate_consumer import measure_file_via_enumerate
     import sugar_source_tree.tree as tree_mod
 
     iso = Path(tempfile.mkdtemp(prefix="recensus-path-smoke-panic-"))
@@ -287,9 +313,8 @@ def _measure_panic(module, path: Path, workspace: Path) -> dict[str, Any]:
         plant = iso / path.name
         shutil.copy2(path, plant)
         tree_mod.SourceFile.__init__ = boom  # type: ignore[method-assign]
-        row = module._measure_file(
-            plant,
-            relative=f"recensus_path_smoke/{path.name}",
+        row = measure_file_via_enumerate(
+            file_rel=path.name,
             workspace_root=iso,
         )
     finally:
@@ -304,7 +329,9 @@ def _measure_panic(module, path: Path, workspace: Path) -> dict[str, Any]:
 def _run_teeth(
     *,
     constructed: int,
-    typed_gaps: int,
+    unconstructed: int,
+    with_items_total: int,
+    accounted: int,
     cpanic: int,
     conserves: bool,
     sealed_path: Path | None,
@@ -333,10 +360,25 @@ def _run_teeth(
     else:
         fail("known_panic", f"cpanic={cpanic} expected 1")
 
-    if typed_gaps >= 1:
-        ok("unconstructed_residual", f"typed_gaps={typed_gaps}")
+    if unconstructed >= 1:
+        ok("known_unconstructed", f"unconstructed={unconstructed}")
     else:
-        fail("unconstructed_residual", f"typed_gaps={typed_gaps} expected >=1")
+        fail(
+            "known_unconstructed",
+            f"unconstructed={unconstructed} expected >=1",
+        )
+
+    if with_items_total == 2 and accounted == with_items_total:
+        ok(
+            "with_items_accounted",
+            f"accounted={accounted} with_items_total={with_items_total}",
+        )
+    else:
+        fail(
+            "with_items_accounted",
+            f"accounted={accounted} with_items_total={with_items_total}; "
+            "expected planted population 2/2",
+        )
 
     if conserves:
         ok("conservation", "with census conserves")
@@ -397,6 +439,7 @@ def main(argv: list[str] | None = None) -> int:
         phases.append("load_recensus_module")
         _narrate("PATH_SMOKE phase=load_recensus_module")
         module = _load_recensus()
+        worktree_sha = _worktree_sha()
 
         phases.append("enroll_micro_population")
         _narrate("PATH_SMOKE phase=enroll_micro_population")
@@ -448,12 +491,13 @@ def main(argv: list[str] | None = None) -> int:
         phases.append("aggregation")
         _narrate("PATH_SMOKE phase=aggregation")
         cm: Counter[str] = Counter()
+        with_resolution_rows: list[dict[str, Any]] = []
         sites: Counter[str] = Counter()
         families: Counter[str] = Counter()
         construction_panics: list[dict[str, Any]] = []
-        unrecognized: Counter[str] = Counter()
         for row in rows:
             cm.update({k: int(v) for k, v in (row.get("cmResolutions") or {}).items()})
+            with_resolution_rows.extend(row.get("withResolutionRows") or [])
             sites.update({k: int(v) for k, v in (row.get("sites") or {}).items()})
             families.update({k: int(v) for k, v in (row.get("families") or {}).items()})
             if row.get("category") == "panic":
@@ -464,8 +508,6 @@ def main(argv: list[str] | None = None) -> int:
                     families["ConstructionPanic"] = (
                         int(families.get("ConstructionPanic") or 0) + 1
                     )
-            for k, v in (row.get("unrecognizedCmResolutionKinds") or {}).items():
-                unrecognized[k] += int(v)
 
         cpanic = len(construction_panics)
         if cpanic == 0 and families.get("ConstructionPanic", 0) > 0:
@@ -474,10 +516,46 @@ def main(argv: list[str] | None = None) -> int:
         # With-census conservation identity (the Class B door).
         phases.append("conservation")
         _narrate("PATH_SMOKE phase=conservation")
-        partition = module._with_census_partition(cm, sites, unrecognized)
+        partition = module._with_census_partition(with_resolution_rows, sites)
         constructed = int(partition.get("constructed") or 0)
-        typed_gaps = int(sum(partition.get("typed_gaps", {}).values()))
+        unconstructed = int(partition.get("unconstructed") or 0)
+        with_items_total = int(partition.get("with_items_total") or 0)
+        accounted = int(partition.get("accounted") or 0)
         conserves = bool(partition.get("conserves"))
+        key_conservation = dict(partition.get("edgeWitness") or {})
+        first_terminal_chain = {
+            "worktreeSha": worktree_sha,
+            "input": {
+                "cmResolutions": dict(sorted(cm.items())),
+                "site:with-item": with_items_total,
+            },
+            "coordinate": [
+                "planted_constructed_with.py:10:4",
+                "planted_opaque_with.py:5:4",
+            ],
+            "firstObservedTerminal": (
+                "ValueError: with_items_total=2 constructed=0 gaps=0 "
+                "accounted=0 unaccounted=2"
+            ),
+            "entrance": (
+                "control_effect_recensus._with_census_partition "
+                "(scripts/control_effect_recensus.py)"
+            ),
+            "afterFix": {
+                "terminal": "constructed-result",
+                "constructed": constructed,
+                "unconstructed": unconstructed,
+                "accounted": accounted,
+                "with_items_total": with_items_total,
+                "keyMissing": key_conservation.get("missingKeys"),
+                "keyExtra": key_conservation.get("extraKeys"),
+                "keyDuplicates": key_conservation.get("duplicateKeys"),
+            },
+        }
+        _narrate(
+            "PATH_SMOKE FIRST_TERMINAL_CHAIN "
+            + json.dumps(first_terminal_chain, sort_keys=True)
+        )
 
         # Discrimination lies (optional): one fault at a time so negative arms
         # are OBSERVED, not reasoned. Env RECENSUS_PATH_SMOKE_LIE=
@@ -487,6 +565,13 @@ def main(argv: list[str] | None = None) -> int:
         if lie == "constructed_zero":
             _narrate("PATH_SMOKE LIE planted=constructed_zero")
             constructed = 0
+            accounted = unconstructed
+            conserves = accounted == with_items_total
+            partition = dict(partition)
+            partition["constructed"] = constructed
+            partition["accounted"] = accounted
+            partition["unaccounted"] = with_items_total - accounted
+            partition["conserves"] = conserves
         elif lie == "swallow_panic":
             _narrate("PATH_SMOKE LIE planted=swallow_panic")
             cpanic = 0
@@ -494,13 +579,16 @@ def main(argv: list[str] | None = None) -> int:
             families.pop("ConstructionPanic", None)
         elif lie == "drop_opaque":
             _narrate("PATH_SMOKE LIE planted=drop_opaque")
-            # Vanish typed-gap residual; residual tooth must PATH_RED.
-            typed_gaps = 0
+            # Vanish the unconstructed item; accounting teeth must PATH_RED.
+            unconstructed = 0
+            accounted = constructed
+            conserves = accounted == with_items_total
             partition = dict(partition)
-            partition["typed_gaps"] = {
-                k: 0 for k in (partition.get("typed_gaps") or {})
-            }
+            partition["unconstructed"] = unconstructed
             partition["constructed"] = constructed
+            partition["accounted"] = accounted
+            partition["unaccounted"] = with_items_total - accounted
+            partition["conserves"] = conserves
         elif lie == "crash_mid":
             _narrate("PATH_SMOKE LIE planted=crash_mid phase=after-conservation")
             raise RuntimeError(
@@ -516,14 +604,17 @@ def main(argv: list[str] | None = None) -> int:
             ),
             "filesMeasured": len(rows),
             "constructed": constructed,
-            "typedGaps": typed_gaps,
+            "unconstructed": unconstructed,
             "cpanic": cpanic,
             "families": dict(sorted(families.items())),
             "cmResolutions": dict(sorted(cm.items())),
+            "firstTerminalChain": first_terminal_chain,
             "withCensus": {
                 "with_items_total": partition.get("with_items_total"),
                 "constructed": constructed,
-                "typed_gaps_sum": typed_gaps,
+                "unconstructed": unconstructed,
+                "accounted": accounted,
+                "keyMultisetConservation": key_conservation,
                 "conserves": conserves,
                 "conservationIdentity": partition.get("conservationIdentity"),
             },
@@ -553,7 +644,9 @@ def main(argv: list[str] | None = None) -> int:
         _narrate("PATH_SMOKE phase=teeth")
         teeth, failed = _run_teeth(
             constructed=constructed,
-            typed_gaps=typed_gaps,
+            unconstructed=unconstructed,
+            with_items_total=with_items_total,
+            accounted=accounted,
             cpanic=cpanic,
             conserves=conserves,
             sealed_path=sealed,
@@ -584,7 +677,8 @@ def main(argv: list[str] | None = None) -> int:
         elapsed = time.time() - started
         _narrate(
             f"PATH_SMOKE DONE pathVerdict={path_verdict} failedTooth={failed} "
-            f"constructed={constructed} typed_gaps={typed_gaps} cpanic={cpanic} "
+            f"constructed={constructed} unconstructed={unconstructed} "
+            f"accounted={accounted}/{with_items_total} cpanic={cpanic} "
             f"elapsed_s={elapsed:.1f} sealed={sealed}"
         )
         if elapsed > 60:

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke_discrimination.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke_discrimination.py
@@ -8,7 +8,7 @@ path verdict — not reasoned, not asserted from positive-arm silence.
 Arms (binding):
   1. constructed_zero -> PATH_RED, failedTooth=known_constructed
   2. swallow_panic    -> PATH_RED, failedTooth=known_panic
-  3. drop_opaque      -> PATH_RED, failedTooth=unconstructed_residual
+  3. drop_opaque      -> PATH_RED, failedTooth=known_unconstructed
   4. crash_mid        -> PATH_UNMEASURED, failedTooth=crash_not_green
      (NOT green, NOT PATH_RED — crash-banks-measured / crash-prints-zero class)
 
@@ -34,7 +34,7 @@ _SMOKE = _SCRIPTS / "recensus_path_smoke.py"
 ARMS: list[tuple[str, str, str, int]] = [
     ("constructed_zero", "PATH_RED", "known_constructed", 1),
     ("swallow_panic", "PATH_RED", "known_panic", 1),
-    ("drop_opaque", "PATH_RED", "unconstructed_residual", 1),
+    ("drop_opaque", "PATH_RED", "known_unconstructed", 1),
     ("crash_mid", "PATH_UNMEASURED", "crash_not_green", 2),
 ]
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -406,6 +406,43 @@ class SourceDerivedGeneratorResourceRefV1:
         return self.protocol.protocol_construction_cid
 
 
+def effective_context_manager_resolutions_for_source(
+    context: object, *, source_cid: str
+) -> dict[SourceFragmentCoordinateV1, object]:
+    """Project the exact resolution table consumed by With for one source."""
+    effective: dict[SourceFragmentCoordinateV1, object] = {}
+    refs = getattr(context, "contract_refs", None)
+    for coordinate, resolution in (getattr(refs, "by_use_site", None) or {}).items():
+        if getattr(coordinate, "source_cid", None) == source_cid:
+            effective[coordinate] = resolution
+    for coordinate, resolution in (
+        getattr(context, "source_derived_contract_refs", None) or {}
+    ).items():
+        if getattr(coordinate, "source_cid", None) == source_cid:
+            # Same precedence as With._prebound_manager_resolution.
+            effective[coordinate] = resolution
+    return effective
+
+
+def context_manager_resolution_outcome(resolution: object) -> str:
+    """Closed census projection: exactly constructed or unconstructed."""
+    if isinstance(
+        resolution,
+        (
+            SourceDerivedContextManagerRefV1,
+            SourceDerivedGeneratorResourceRefV1,
+            ContextManagerContractRefV1,
+        ),
+    ):
+        return "constructed"
+    if isinstance(resolution, ContextManagerResolutionGapV1):
+        return "unconstructed"
+    raise TypeError(
+        "With resolution table value is neither constructed ref nor gap: "
+        f"{type(resolution).__module__}.{type(resolution).__qualname__}"
+    )
+
+
 @dataclass(frozen=True)
 class FactoredSourceDerivedContextManagerRefV1:
     """Source-derived EffectBoundary with factored message-pattern faces.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1831,6 +1831,34 @@ def _roll_call_audit_leaf(full_path: Path, file_rel: str) -> dict:
     ]
     absent_seen = set(absent_keys)
     absent_keys.extend(key for key in gaps_by_key if key not in absent_seen)
+
+    def _construction_trace(panic, *, owner: str, coordinate: str) -> list[dict]:
+        trace = [
+            {
+                "kind": "source-construct",
+                "constructOwner": owner,
+                "coordinate": coordinate,
+            }
+        ]
+        tb = getattr(panic, "__traceback__", None)
+        while tb is not None:
+            frame = tb.tb_frame
+            trace.append(
+                {
+                    "kind": "dispatch-frame",
+                    "module": str(frame.f_globals.get("__name__") or ""),
+                    "qualname": frame.f_code.co_qualname,
+                    "file": frame.f_code.co_filename,
+                    "line": tb.tb_lineno,
+                }
+            )
+            tb = tb.tb_next
+        if len(trace) > 1:
+            final = dict(trace[-1])
+            final["kind"] = "panic-site"
+            trace.append(final)
+        return trace
+
     for key in absent_keys:
         node = nodes_by_key[key]
         panic = gaps_by_key.get(key)
@@ -1848,6 +1876,35 @@ def _roll_call_audit_leaf(full_path: Path, file_rel: str) -> dict:
             if panic is not None
             else f"{node.kind} registered but never answered the roll call"
         )
+        authenticated_gap = {
+            "blame": terminal,
+            "kind": panic_kind,
+            "nodeKind": node.kind,
+            "reason": reason,
+        }
+        if panic is not None:
+            owner = str(getattr(panic, "owner", node.kind))
+            coordinate = terminal
+            authenticated_gap.update(
+                {
+                    "owner": owner,
+                    "coordinate": coordinate,
+                    "observed": str(getattr(panic, "observed", reason)),
+                    "requested": str(
+                        getattr(panic, "requested", f"constructed {node.kind}")
+                    ),
+                    "fix": str(
+                        getattr(panic, "fix", f"write {node.kind}.sugar")
+                    ),
+                    "entrance": "sugar.enumerate:facts:auditFrontier",
+                    "observedEventType": (
+                        f"{type(panic).__module__}.{type(panic).__qualname__}"
+                    ),
+                    "construction_trace": _construction_trace(
+                        panic, owner=owner, coordinate=coordinate
+                    ),
+                }
+            )
         panics.append(
             {
                 # Closed-envelope discriminators required by the current Rust
@@ -1859,12 +1916,7 @@ def _roll_call_audit_leaf(full_path: Path, file_rel: str) -> dict:
                 "locus": locus,
                 "demandedSource": demanded_source,
                 "terminalGapLocus": terminal,
-                "gap": {
-                    "blame": terminal,
-                    "kind": panic_kind,
-                    "nodeKind": node.kind,
-                    "reason": reason,
-                },
+                "gap": authenticated_gap,
             }
         )
 
@@ -2059,6 +2111,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
 
         if level in (
             "functions",
+            "context-manager-resolutions",
             "call_sites",
             "assertions",
             "facts",
@@ -2165,7 +2218,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 )
                 return
 
-            if level == "functions":
+            if level in {"functions", "context-manager-resolutions"}:
                 # The functions level IS SourceFile.functions(): every function
                 # definition in the file, enumerated from the typed tree over
                 # oracle-pinned text. No lift runs, no IR rows are consulted,
@@ -2246,6 +2299,43 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     path=full_path,
                     session=walk_session_for(root),
                 )
+                if level == "context-manager-resolutions":
+                    from sugar_lift_py_tests.context_manager_resolution import (
+                        context_manager_resolution_outcome,
+                        effective_context_manager_resolutions_for_source,
+                    )
+
+                    resolution_nodes = []
+                    for coordinate, resolution in sorted(
+                        effective_context_manager_resolutions_for_source(
+                            construction_context, source_cid=file_cid
+                        ).items()
+                    ):
+                        resolution_nodes.append(
+                            {
+                                "memento": {
+                                    "kind": "context-manager-resolution",
+                                    "file": file_rel,
+                                    "source_cid": file_cid,
+                                    "coordinate": coordinate.wire(),
+                                },
+                                "audit": {
+                                    "observedEventType": (
+                                        f"{type(resolution).__module__}."
+                                        f"{type(resolution).__qualname__}"
+                                    ),
+                                    "outcome": context_manager_resolution_outcome(
+                                        resolution
+                                    ),
+                                },
+                                "payload": None,
+                            }
+                        )
+                    _send_enumerate_result(msg_id, resolution_nodes, [])
+                    _log_enumeration_demand(
+                        str(level), at, cache="miss", started=demand_started
+                    )
+                    return
                 nodes = []
                 for fn in tree_file.functions():
                     lc = fn.line_col_span()

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_spread_literal_roster.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_spread_literal_roster.py
@@ -30,7 +30,7 @@ from sugar_lift_py_tests.sugar.spread_sugar import (
     SpreadDictSugar,
 )
 from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
-from sugar_source_tree.nodes import BinOp, Call, List, Subscript
+from sugar_source_tree.nodes import BinOp, Call, Constant, List, Subscript
 from sugar_source_tree.tree import SourceFile
 
 _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
@@ -1,12 +1,13 @@
-"""With census conservation: Class B refusal + measurement partition teeth.
+"""With census conservation: construct-or-panic partition teeth.
 
 Conservation identity (binding):
-  site:with-item == constructed + typed_gaps
+  site:with-item == constructed + unconstructed
   over the effective use-site set With construction sees.
 
-Landmine class A (fixed elsewhere): families rebind.
-This module: Class B honest refusal when the identity fails, and teeth that
-discriminate measurement defect (wrong table) from product residual.
+The tally owns canonical coordinate-keyed rows. The partition consumes those
+same keys exactly once while splitting the closed constructed/unconstructed
+outcomes; deleted resolution kinds and gap buckets never re-enter through a
+compatibility decoder.
 """
 
 from __future__ import annotations
@@ -32,34 +33,106 @@ def _load():
     return module
 
 
+def _resolution_row(index: int, outcome: str) -> dict[str, object]:
+    return {
+        "inputKey": {
+            "sourceCid": "sha256:" + ("a" * 64),
+            "startLine": index,
+            "startCol": 4,
+            "endLine": index,
+            "endCol": 8,
+        },
+        "observedEventType": "tests.PlantedResolution",
+        "outcome": outcome,
+    }
+
+
 def test_conservation_identity_is_stated_on_partition_and_refusal():
     module = _load()
     law = module.WITH_CENSUS_CONSERVATION_IDENTITY
     assert "site:with-item" in law
     assert "constructed" in law
-    assert "typed_gaps" in law
+    assert "unconstructed" in law
 
     # Conserving case embeds the law.
+    rows = [
+        *[_resolution_row(index, "constructed") for index in range(1, 3)],
+        *[_resolution_row(index, "unconstructed") for index in range(3, 6)],
+    ]
     ok = module._with_census_partition(
-        Counter({"derived-contract": 2, "gap:runtime-selected": 3}),
+        rows,
         Counter({"site:with-item": 5}),
     )
     assert ok["conserves"] is True
     assert ok["conservationIdentity"] == law
     assert ok["unaccounted"] == 0
+    assert ok["accounted"] == 5
+    assert ok["unconstructed"] == 3
+    assert ok["edgeWitness"]["inputKeyManifest"] == ok["edgeWitness"][
+        "outputKeyManifest"
+    ]
+    assert ok["edgeWitness"]["missingKeys"] == []
+    assert ok["edgeWitness"]["extraKeys"] == []
+    assert "typed_gaps" not in ok
+    assert "typed_gap_kinds_total" not in ok
+    assert "unrecognized_resolution_kinds" not in ok
 
     # Refusal names the law and which side is short.
     with pytest.raises(ValueError, match="LAW:") as caught:
         module._with_census_partition(
-            Counter({"gap:runtime-selected": 12}),
+            [_resolution_row(index, "unconstructed") for index in range(12)],
             Counter({"site:with-item": 7915}),
         )
     msg = str(caught.value)
     assert "with_items_total=7915" in msg
     assert "constructed=0" in msg
-    assert "typed_gaps=12" in msg
+    assert "unconstructed=12" in msg
     assert "unaccounted=7903" in msg
-    assert "Do not suppress" in msg
+    assert "Construct or panic" in msg
+
+
+def test_partition_rejects_deleted_resolution_vocabulary() -> None:
+    module = _load()
+    with pytest.raises(TypeError, match="closed outcomes"):
+        module._with_census_partition(
+            [_resolution_row(1, "derived-contract")],
+            Counter({"site:with-item": 1}),
+        )
+
+
+def test_partition_rejects_duplicate_coordinate_rows() -> None:
+    module = _load()
+    row = _resolution_row(1, "constructed")
+    with pytest.raises(TypeError, match="duplicate"):
+        module._with_census_partition(
+            [row, row],
+            Counter({"site:with-item": 2}),
+        )
+
+
+def test_cm_zero_requires_separate_key_attestation() -> None:
+    module = _load()
+    with pytest.raises(ValueError, match="key attestation"):
+        module._attested_cm_counts({"cmResolutions": {}})
+
+    measured_zero = module._with_census_partition(
+        [],
+        Counter({"site:with-item": 0}),
+    )
+    assert module._attested_cm_counts(
+        {
+            "cmResolutions": {"constructed": 0, "unconstructed": 0},
+            "withCensus": measured_zero,
+        }
+    ) == (0, 0)
+
+
+def test_seal_board_additive_legacy_reads_remain_reconciled() -> None:
+    compose_path = _SCRIPTS / "compose_control_effect_board.py"
+    source = compose_path.read_text(encoding="utf-8")
+    assert 'cm.get("constructed", 0) + cm.get("derived-contract", 0)' in source
+    assert 'cm.get("unconstructed", 0)' in source
+    assert 'str(k).startswith("gap:")' in source
 
 
 def test_known_constructed_with_item_shows_constructed_gt_zero(tmp_path: Path):
@@ -125,21 +198,19 @@ def test_known_constructed_with_item_shows_constructed_gt_zero(tmp_path: Path):
         import_signature=ImportSignatureV2(()),
         protocol=_Protocol(),
     )
-    buckets, _ = module._tally_cm_resolutions(
+    rows = module._tally_cm_resolutions(
         ctx, source_cid=source_file.unit.source_cid
     )
     sites = module._ast_site_prevalence(path)
     assert sites.get("site:with-item", 0) == 1
-    assert buckets.get("derived-contract", 0) >= 1, (
-        f"known-constructed with must show constructed>0; got {dict(buckets)}"
-    )
-    partition = module._with_census_partition(buckets, sites)
+    assert sum(row["outcome"] == "constructed" for row in rows) >= 1, rows
+    partition = module._with_census_partition(rows, sites)
     assert partition["constructed"] >= 1
     assert partition["conserves"] is True
 
 
-def test_unconstructed_with_item_appears_in_typed_gap_not_silent_drop(tmp_path: Path):
-    """Planted opaque with must land in residual (typed gap), never vanish."""
+def test_unconstructed_with_item_is_counted_not_silently_dropped(tmp_path: Path):
+    """Planted opaque With must remain present as unconstructed, never vanish."""
     module = _load()
     from sugar_lift_py_tests.lift_rpc import (
         open_source_file_for_construction,
@@ -159,17 +230,16 @@ def test_unconstructed_with_item_appears_in_typed_gap_not_silent_drop(tmp_path: 
     source_file = open_source_file_for_construction(
         path, root=tmp_path, construction_context=ctx, populate_derived=True
     )
-    buckets, _ = module._tally_cm_resolutions(
+    rows = module._tally_cm_resolutions(
         ctx, source_cid=source_file.unit.source_cid
     )
     sites = module._ast_site_prevalence(path)
     assert sites.get("site:with-item", 0) == 1
-    typed = sum(v for k, v in buckets.items() if k.startswith("gap:"))
-    assert typed >= 1, f"unconstructed with must residual; got {dict(buckets)}"
-    assert buckets.get("derived-contract", 0) == 0
-    partition = module._with_census_partition(buckets, sites)
+    assert sum(row["outcome"] == "unconstructed" for row in rows) == 1, rows
+    assert sum(row["outcome"] == "constructed" for row in rows) == 0
+    partition = module._with_census_partition(rows, sites)
     assert partition["constructed"] == 0
-    assert sum(partition["typed_gaps"].values()) == 1
+    assert partition["unconstructed"] == 1
     assert partition["conserves"] is True
 
 
@@ -199,7 +269,59 @@ def test_effective_tally_includes_contract_refs_not_only_source_derived(
     # Old defect shape: derived empty, provisional has the gap.
     assert len(ctx.source_derived_contract_refs) == 0
     assert len(refs.by_use_site) == 1
-    buckets, _ = module._tally_cm_resolutions(
+    rows = module._tally_cm_resolutions(
         ctx, source_cid=source_file.unit.source_cid
     )
-    assert sum(buckets.values()) == 1, dict(buckets)
+    assert len(rows) == 1, rows
+
+
+def test_enumerate_with_rows_reach_partition_with_identical_keys(
+    tmp_path: Path,
+) -> None:
+    """The production enumerate door and partition conserve the same members."""
+    module = _load()
+    from recensus_enumerate_consumer import demand_context_manager_resolution_events
+    from sugar_lift_py_tests.lift_rpc import (
+        install_provisional_contract_refs,
+        provisional_contract_refs_from_demands,
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+
+    path = tmp_path / "opaque.py"
+    path.write_text(
+        "def run():\n"
+        "    with mystery():\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    refs = provisional_contract_refs_from_demands(tmp_path)
+    install_provisional_contract_refs(tmp_path, refs)
+    source_cid = path_source(str(path))[2]
+
+    events, gaps = demand_context_manager_resolution_events(
+        workspace_root=tmp_path,
+        file_rel="opaque.py",
+        source_cid=source_cid,
+    )
+    assert gaps == []
+    assert len(events) == 1
+    assert events[0]["outcome"] == "unconstructed"
+    assert "." in str(events[0]["observedEventType"])
+
+    rows = module._tally_cm_resolutions(
+        source_cid=source_cid,
+        resolution_events=events,
+    )
+    partition = module._with_census_partition(
+        rows,
+        module._ast_site_prevalence(path),
+    )
+    event_keys = [event["inputKey"] for event in events]
+    row_keys = [row["inputKey"] for row in rows]
+    edge = partition["edgeWitness"]
+    assert event_keys == row_keys
+    assert edge["inputKeyManifest"] == row_keys
+    assert edge["outputKeyManifest"] == row_keys
+    assert edge["missingKeys"] == []
+    assert edge["extraKeys"] == []
+    assert edge["duplicateKeys"] == []

--- a/tests/recensus_path_smoke.sh
+++ b/tests/recensus_path_smoke.sh
@@ -33,7 +33,8 @@ for lie in constructed_zero swallow_panic drop_opaque crash_mid; do
 done
 grep -Fq 'known_constructed' "$disc" || fail 'disc must expect known_constructed tooth'
 grep -Fq 'known_panic' "$disc" || fail 'disc must expect known_panic tooth'
-grep -Fq 'unconstructed_residual' "$disc" || fail 'disc must expect unconstructed_residual tooth'
+grep -Fq 'known_unconstructed' "$disc" || fail 'disc must expect known_unconstructed tooth'
+grep -Fq 'with_items_accounted' "$script" || fail 'smoke must prove exact with-item accounting'
 grep -Fq 'crash_not_green' "$disc" || fail 'disc must expect crash_not_green tooth'
 grep -Fq 'PATH_UNMEASURED' "$disc" || fail 'disc must expect PATH_UNMEASURED for crash_mid'
 

--- a/tests/test_board_function_facts_c4.py
+++ b/tests/test_board_function_facts_c4.py
@@ -231,6 +231,49 @@ def test_compose_seal_uses_three_sealed_meanings() -> None:
     def _row(file: str, *, fn: int = 1, auth: int | None = None, panic: bool = False):
         authenticated = fn if auth is None else auth
         enumerated = 0 if panic else fn
+        source_cid = "sha256:" + ("a" if file.endswith("a.py") else "b") * 64
+        function_keys = [
+            {
+                "sourceCid": source_cid,
+                "file": file,
+                "functionSourceCid": source_cid,
+                "functionName": f"f{index}",
+                "span": {
+                    "startLine": index + 1,
+                    "startCol": 0,
+                    "endLine": index + 1,
+                    "endCol": 1,
+                },
+            }
+            for index in range(authenticated)
+        ]
+        input_key = {
+            "sourceCid": source_cid,
+            "file": file,
+            "functionKeyManifest": function_keys,
+            "functionKeyCid": compose.key_manifest_cid(function_keys),
+        }
+        terminal_kind = "construction-panic" if panic else "constructed"
+        panic_payload = {
+            "file": file,
+            "owner": "FunctionSugar",
+            "coordinate": f"{file}:1:0",
+            "observed": "UnconstructedFunction",
+            "requested": "constructed function",
+            "fix": "write the missing function sugar",
+            "entrance": "sugar.enumerate:facts",
+            "observedEventType": (
+                "sugar_lift_py_tests.gap.panic.ConstructionPanic"
+            ),
+            "construction_trace": [
+                {
+                    "kind": "source-construct",
+                    "constructOwner": "FunctionSugar",
+                    "coordinate": f"{file}:1:0",
+                }
+            ],
+            "message": "x",
+        }
         return (
             file,
             {
@@ -242,17 +285,29 @@ def test_compose_seal_uses_three_sealed_meanings() -> None:
                 "functionsAuthenticated": authenticated,
                 "astSites": {"site:function-def": authenticated},
                 "families": {"ConstructionPanic": 1} if panic else {},
-                **(
-                    {
-                        "panic": {
-                            "file": file,
-                            "type": "ConstructionPanic",
-                            "message": "x",
-                        }
-                    }
-                    if panic
-                    else {}
+                "inputKey": input_key,
+                "rowId": compose.canonical_cid({"inputKey": input_key}),
+                "stageId": compose.STAGE_ENUMERATE_FILE_TERMINAL,
+                "observedEventType": (
+                    panic_payload["observedEventType"] if panic else "builtins.dict"
                 ),
+                "terminalKind": terminal_kind,
+                "observed_chain_length": 1,
+                "blocking_terminal_count": 1 if panic else 0,
+                "final_terminal": terminal_kind,
+                "edgeWitnesses": {
+                    compose.EDGE_ENUMERATE_FILE: compose.key_edge_witness(
+                        stage_id=compose.STAGE_ENUMERATE_FILE_TERMINAL,
+                        input_keys=function_keys,
+                        output_keys=function_keys,
+                    ),
+                    compose.EDGE_WITH_PARTITION: compose.key_edge_witness(
+                        stage_id=compose.STAGE_WITH_TALLY_PARTITION,
+                        input_keys=[],
+                        output_keys=[],
+                    ),
+                },
+                **({"panic": panic_payload} if panic else {}),
                 "R_instrument_blind": 0,
             },
         )

--- a/tests/test_recensus_enumerate_mass_and_clean.py
+++ b/tests/test_recensus_enumerate_mass_and_clean.py
@@ -10,6 +10,7 @@ can only report 1.0 is refused, not banked as perfection.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import sys
 from pathlib import Path
@@ -41,8 +42,13 @@ COMPOSE = _load(
 )
 
 
-def test_residual_failure_preserves_roster_functions_total(monkeypatch) -> None:
-    """D2 banks 3 functions; D3 raises; row still has functionsTotal=3."""
+def test_residual_failure_preserves_roster_functions_total(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """D2 banks 3 functions; an ordinary D3 failure is unmeasured at mass 3."""
+    src = tmp_path / "pkg/mod.py"
+    src.parent.mkdir()
+    src.write_text("def a(): pass\ndef b(): pass\ndef c(): pass\n", encoding="utf-8")
     nodes = [
         {"memento": {"function_name": "a"}},
         {"memento": {"function_name": "b"}},
@@ -56,51 +62,64 @@ def test_residual_failure_preserves_roster_functions_total(monkeypatch) -> None:
         raise RuntimeError("sugar.enumerate error: residual phase crashed")
 
     monkeypatch.setattr(CONSUMER, "demand_function_roster", fake_roster)
+    monkeypatch.setattr(
+        CONSUMER, "demand_context_manager_resolution_events", lambda **_k: ([], [])
+    )
     monkeypatch.setattr(CONSUMER, "demand_construction_residual", boom_residual)
     monkeypatch.setattr(CONSUMER, "count_ast_function_defs", lambda _p: 3)
 
     row = CONSUMER.measure_file_via_enumerate(
-        workspace_root=Path("/tmp"),
+        workspace_root=tmp_path,
         file_rel="pkg/mod.py",
     )
     assert row["functionsTotal"] == 3
     assert row["functionsEnumerated"] == 3
     assert row["rosterPreservedAfterResidualFailure"] is True
-    assert row["category"] == "panic"
+    assert "category" not in row
+    assert row["instrumentFailure"]["phase"] == "residual"
     # Clean must not claim 3/3 perfection after residual failure.
     assert row["functionsClean"] is None
     assert row["cleanRatioRefused"] is True
 
 
-def test_open_roster_failure_still_zero_when_no_ast(monkeypatch) -> None:
+def test_open_roster_failure_still_zero_when_no_ast(
+    tmp_path: Path, monkeypatch
+) -> None:
     """True open failure (no roster, no AST) keeps empty denominator."""
 
     def boom_roster(**_k):
         raise RuntimeError("no such file")
 
+    (tmp_path / "missing.py").write_text("", encoding="utf-8")
     monkeypatch.setattr(CONSUMER, "demand_function_roster", boom_roster)
     monkeypatch.setattr(CONSUMER, "count_ast_function_defs", lambda _p: None)
 
     row = CONSUMER.measure_file_via_enumerate(
-        workspace_root=Path("/tmp"),
+        workspace_root=tmp_path,
         file_rel="missing.py",
     )
     assert row["functionsTotal"] == 0
     assert row["functionsEnumerated"] == 0
-    assert row["category"] == "panic"
+    assert "category" not in row
+    assert row["instrumentFailure"]["phase"] == "roster"
 
 
-def test_roster_failure_banks_ast_population_not_silent_zero(monkeypatch) -> None:
+def test_roster_failure_banks_ast_population_not_silent_zero(
+    tmp_path: Path, monkeypatch
+) -> None:
     """Instrument crash before roster still names AST mass (instrument-blind)."""
 
     def boom_roster(**_k):
         raise RuntimeError("sugar.enumerate error: mid-roster crash")
 
+    src = tmp_path / "pkg/heavy.py"
+    src.parent.mkdir()
+    src.write_text("def one(): pass\n", encoding="utf-8")
     monkeypatch.setattr(CONSUMER, "demand_function_roster", boom_roster)
     monkeypatch.setattr(CONSUMER, "count_ast_function_defs", lambda _p: 12)
 
     row = CONSUMER.measure_file_via_enumerate(
-        workspace_root=Path("/tmp"),
+        workspace_root=tmp_path,
         file_rel="pkg/heavy.py",
     )
     assert row["functionsTotal"] == 12
@@ -162,8 +181,67 @@ def test_honest_source_audit_clean_is_used() -> None:
     assert row["cleanRatioRefused"] is False
 
 
-def test_compose_refuses_tautological_clean_on_board() -> None:
-    """Board must not mint functionsConstructClean when any file refused clean."""
+def test_audit_panic_is_not_mislabeled_as_residual_phase_failure() -> None:
+    """A returned D3 panic is not an escaped D3 call."""
+    nodes = [{"memento": {"function_name": "a"}}]
+    row = CONSUMER.terminal_from_enumerate(
+        file_rel="x.py",
+        function_nodes=nodes,
+        function_gaps=[],
+        audit={
+            "semanticCore": {
+                "status": "failed",
+                "panics": [
+                    {
+                        "reason": "unconstructed child",
+                        "gap": {
+                            "owner": "WithSugar",
+                            "coordinate": "x.py:1:0",
+                            "observed": "OpaqueValue",
+                            "requested": "ContextManagerResolution",
+                            "fix": "construct the manager resolution",
+                            "entrance": "sugar.enumerate:facts",
+                            "observedEventType": "sugar_source_tree.panic.SugarNotWritten",
+                            "construction_trace": [
+                                {
+                                    "kind": "source-construct",
+                                    "constructOwner": "WithSugar",
+                                    "coordinate": "x.py:1:0",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        },
+        construction_gaps=[],
+        residual_phase_failed=False,
+        ast_fn=1,
+    )
+    assert row["category"] == "panic"
+    assert row["rosterPreservedAfterResidualFailure"] is False
+
+
+def test_reasonless_unauthenticated_audit_panic_is_instrument_failure() -> None:
+    """A raw row without construction testimony cannot enter frontier width."""
+    nodes = [{"memento": {"function_name": "a"}}]
+    raw_panic = {"gap": {"observed": "OpaqueValue"}, "locus": "x.py:1:0"}
+    row = CONSUMER.terminal_from_enumerate(
+        file_rel="x.py",
+        function_nodes=nodes,
+        function_gaps=[],
+        audit={"semanticCore": {"status": "failed", "panics": [raw_panic]}},
+        construction_gaps=[],
+        residual_phase_failed=False,
+        ast_fn=1,
+    )
+    assert "category" not in row
+    assert row["instrumentFailure"]["phase"] == "audit-panic-decode"
+    assert str(raw_panic) in row["instrumentFailure"]["message"]
+
+
+def test_compose_refuses_unattested_clean_board() -> None:
+    """Legacy rows cannot mint a clean ratio or authenticated frontier width."""
     rows = [
         (
             "good.py",
@@ -197,14 +275,11 @@ def test_compose_refuses_tautological_clean_on_board() -> None:
         aggregate_hash="agg",
         manifest_shape_cid="cid",
     )
-    assert status == "sealed"
-    # Population includes instrument-blind mass (10), not dropped to 2.
-    assert body["functionsTotal"] == 12
-    # Clean ratio refused — not 2/2 perfection.
-    assert body["cleanRatioRefused"] is True
-    assert body["functionsConstructClean"] is None
-    assert body["denominator"]["functions"].get("cleanRatioRefused") is True
-    assert body["denominator"]["functions"].get("clean") is None
+    assert status == "unmeasured"
+    assert body["status"] == "unmeasured"
+    assert "frontierWidth" not in body
+    assert "productPanicCount" not in body
+    assert body["instrumentFailures"]
 
 
 
@@ -237,6 +312,48 @@ def test_consumer_source_forbids_clean_equal_total_assignment() -> None:
     assert not crimes, (
         "ANY RATIO WHOSE NUMERATOR DEFAULTS TO ITS DENOMINATOR IS NOT A "
         "MEASUREMENT.\n" + "\n".join(crimes)
+    )
+
+
+def test_main_has_one_reachable_panic_enrollment_arm() -> None:
+    """Taxonomy deletion must not create duplicate, unreachable elif arms."""
+    recensus_path = SCRIPTS / "control_effect_recensus.py"
+    tree = ast.parse(recensus_path.read_text(encoding="utf-8"))
+    main = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "main"
+    )
+
+    def is_panic_test(node) -> bool:
+        return (
+            isinstance(node, ast.Compare)
+            and isinstance(node.left, ast.Name)
+            and node.left.id == "category"
+            and len(node.ops) == 1
+            and isinstance(node.ops[0], ast.Eq)
+            and len(node.comparators) == 1
+            and isinstance(node.comparators[0], ast.Constant)
+            and node.comparators[0].value == "panic"
+        )
+
+    duplicate_chains: list[list[int]] = []
+    for node in ast.walk(main):
+        if not isinstance(node, ast.If):
+            continue
+        lines: list[int] = []
+        cursor = node
+        while True:
+            if is_panic_test(cursor.test):
+                lines.append(cursor.lineno)
+            if len(cursor.orelse) != 1 or not isinstance(cursor.orelse[0], ast.If):
+                break
+            cursor = cursor.orelse[0]
+        if len(lines) > 1:
+            duplicate_chains.append(lines)
+    assert duplicate_chains == [], (
+        "duplicate category == 'panic' elif arms make later enrollment "
+        f"unreachable: {duplicate_chains}"
     )
 
 
@@ -290,9 +407,9 @@ def test_outer_shell_escape_banks_recovered_roster_not_zero(
     assert row.get("rosterPreservedAfterResidualFailure") is True
     assert row.get("cleanRatioRefused") is True
     assert row.get("functionsClean") is None
-    defect = row.get("defect") or {}
-    assert defect.get("type") == "NewBaseExceptionGap" or "NewBaseExceptionGap" in str(
-        row.get("families") or {}
+    assert "category" not in row
+    assert row["instrumentFailure"]["observedEventType"].endswith(
+        ".NewBaseExceptionGap"
     )
 
 


### PR DESCRIPTION
## Why this lands second

PR-A installed the consumer-side refusal seal first at `c0a9974dc760d1c1a0a5df6748fbc0181526a36d`. This PR now teaches the three live producer edges to emit the witnesses that landed seal requires. It was reproduced after the PR-A squash at exact SHA `6b5122cce5bb1b734e1ed37221312f5a87c7d564`.

**Producers landing means the census CAN speak, not that it HAS spoken.** No source-only receipt from the intentional-red interval may be quoted.

## Producer-only shape

- The range from `c0a9974d` to `6b5122cce` contains exactly one producer commit.
- Range-diff maps old producer `4cf15c679` to new producer `6b5122cce` exactly.
- Old seal `8dfa66e63` is absent and is not an ancestor of this head (`RC=1`).
- Old and new producer trees are identical at `24964a27b35ec6ec5b4bed9cc0aacf320c688d31`.
- `conservation_mint.py` remains the main-owned blob `937248d5f1c15c80b2d227647ae30baf4b6c5d01`, with zero branch diff.

## Measured at the exact head

- Fresh exact-SHA smoke reached 4 files.
- 2 With keys conserved as 1 constructed + 1 unconstructed = 2/2.
- Missing keys = 0, extra keys = 0, duplicate keys = 0; `cpanic=1`; exit 0.
- Fresh focused battleaxe selection: 73/73 passed, exit 0.
- No files or tests deleted; no skips or xfails added.

## Explicit non-claims

This PR does not claim a corpus `frontierWidth`, a 1421-file/28264-function receipt, or any source-only receipt from the intentional-red interval. The first attested corpus run has not happened yet.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit three live-edge witnesses required by the landed refusal seal
> - Adds `edgeWitnesses` to terminal rows for the enumerate-file and with-partition stages, plus a `rowId`/`inputKey`/`stageId`/`terminalKind` attestation layer in [`recensus_enumerate_consumer.py`](https://github.com/TSavo/sugar/pull/7152/files#diff-f44306c90c4bcc279a33763d110fe23086857b9b1f1afc83ea45e09c2d004b79).
> - Replaces counter-based CM resolution tallying with per-coordinate resolution rows keyed by `inputKey`, enforcing closed outcomes (`constructed`/`unconstructed`) and duplicate-key detection in [`control_effect_recensus.py`](https://github.com/TSavo/sugar/pull/7152/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d).
> - The with-partition edge witness validates key-set conservation (input manifest == output manifest); `_attested_cm_counts` raises if attestation is missing or non-conserving.
> - Instrument failures (unrecognized exceptions, unauthenticated audit panics, decode errors) now emit structured `instrumentFailure` rows instead of panic defects; aggregation skips these rows for category/defect classification.
> - Smoke test teeth renamed (`known_unconstructed`, `with_items_accounted`) and the `WITH_WIRE_WORKTREE_SHA` env var is now required by the workflow.
> - Behavioral Change: `_with_census_partition` input changed from a `Counter` to a list of resolution rows; callers passing the old shape will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b5122c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->