### PR TITLE
Wire authenticated demand table into process floors

### DIFF
--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -43,6 +43,25 @@ jobs:
           name: python-test-wheelhouse
           path: ${{ steps.env.outputs.env-dir }}/wheelhouse/
           if-no-files-found: error
+      - name: Pull authenticated shared Python demand table
+        shell: bash
+        env:
+          PYTHONPATH: ${{ github.workspace }}/tools:${{ github.workspace }}/implementations/python/sugar-lift-py-tests/src:${{ github.workspace }}/implementations/python/sugar-lift-python-source/src:${{ github.workspace }}/implementations/python/sugar-source-tree/src
+          SUGAR_BINARY_ALLOW_BUILD: "0"
+          SUGAR_BINARY_PUBLISH: "0"
+        run: |
+          set -euo pipefail
+          demand_dir="${RUNNER_TEMP}/python-demand-table"
+          mkdir -p "$demand_dir"
+          python3 -c 'import sys; from pathlib import Path; from sugar_lift_py_tests.no_call_body_attribution import pull_shared_demand_table; pull_shared_demand_table(Path(sys.argv[1]), Path(sys.argv[2]))' \
+            "$GITHUB_WORKSPACE" "$demand_dir/python-demand-table.json"
+          test -s "$demand_dir/python-demand-table.json"
+      - name: Upload authenticated shared Python demand table
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-demand-table
+          path: ${{ runner.temp }}/python-demand-table/python-demand-table.json
+          if-no-files-found: error
 
   process-floor:
     name: process-floor ${{ matrix.axisSeat }}
@@ -255,6 +274,11 @@ jobs:
         with:
           name: python-test-wheelhouse
           path: ${{ runner.temp }}/python-test-wheelhouse
+      - name: Download authenticated shared Python demand table
+        uses: actions/download-artifact@v4
+        with:
+          name: python-demand-table
+          path: ${{ runner.temp }}/python-demand-table
       - name: Install from shared wheelhouse (no network resolve)
         uses: ./.github/actions/python-test-environment-from-wheelhouse
         with:
@@ -322,7 +346,7 @@ jobs:
           set -uo pipefail
           chmod +x tools/run_one_process_floor_axis.sh
           set +e
-          bash tools/run_one_process_floor_axis.sh "${{ matrix.axis }}" "${{ matrix.script }}" "${{ matrix.shard }}" "${{ matrix.shardCount }}"
+          bash tools/run_one_process_floor_axis.sh "${{ matrix.axis }}" "${{ matrix.script }}" "${{ matrix.shard }}" "${{ matrix.shardCount }}" "${RUNNER_TEMP}/python-demand-table/python-demand-table.json"
           code=$?
           set -e
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"

--- a/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
@@ -130,6 +130,35 @@ def add_lpt_shard_args(parser) -> None:
     )
 
 
+def add_demand_table_arg(parser) -> None:
+    """Expose the authenticated shared demand-table entrance on process floors."""
+    parser.add_argument(
+        "--demand-table-path",
+        type=Path,
+        default=None,
+        help=(
+            "authenticated python-demand-table JSON; omission is an immediate "
+            "UNMEASURED refusal, never local demand derivation"
+        ),
+    )
+
+
+def require_demand_table(path: Path | None) -> Path:
+    """Refuse before scanning when the authenticated table was not supplied."""
+    if path is None:
+        raise ValueError(
+            "authenticated python-demand-table is required; refusing local "
+            "demand derivation (pass --demand-table-path)"
+        )
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise ValueError(
+            "authenticated python-demand-table is not a file: "
+            f"{resolved}; refusing local demand derivation"
+        )
+    return resolved
+
+
 def apply_lpt_file_shard(
     paths: Sequence[Path],
     *,

--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -29,7 +29,9 @@ from _enum_floor_runtime import (  # noqa: E402
     require_explicit_scan_roots,
     require_python_paths,
     add_lpt_shard_args,
+    add_demand_table_arg,
     apply_lpt_file_shard,
+    require_demand_table,
 )
 from _production_lift_child import (  # noqa: E402
     NON_FAILURE_OUTCOMES,
@@ -125,7 +127,14 @@ def main() -> int:
         help="Write pandas-floor-summary-v1 with R_bare_exceptions magnitude.",
     )
     add_lpt_shard_args(parser)
+    add_demand_table_arg(parser)
     args = parser.parse_args()
+
+    try:
+        demand_table_path = require_demand_table(args.demand_table_path)
+    except ValueError as error:
+        print(f"BARE-EXCEPTION ZERO-TOLERANCE UNMEASURED: {error}")
+        return 2
 
     boot_error = production_lift_bootstrap_error()
     if boot_error is not None:
@@ -169,7 +178,10 @@ def main() -> int:
         encoding="utf-8",
     )
     terminals = scan_paths(
-        paths, root=args.repo_root, file_timeout=float(args.file_timeout)
+        paths,
+        root=args.repo_root,
+        file_timeout=float(args.file_timeout),
+        demand_table_path=demand_table_path,
     )
     rows = tuple(_from_terminal(t) for t in terminals)
     with progress_path.open("a", encoding="utf-8") as progress:

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -30,7 +30,9 @@ from _enum_floor_runtime import (  # noqa: E402
     require_explicit_scan_roots,
     require_python_paths,
     add_lpt_shard_args,
+    add_demand_table_arg,
     apply_lpt_file_shard,
+    require_demand_table,
 )
 from _production_lift_child import production_lift_bootstrap_error  # noqa: E402
 from _supervised_enum_supervisor import FileTerminal, scan_paths  # noqa: E402
@@ -124,6 +126,7 @@ def audit_paths(
     *,
     root: Path,
     file_timeout: int,
+    demand_table_path: Path,
     progress_path: Path | None = None,
 ) -> AuditSummary:
     """Measure every path. Durable reuse is the content-addressed process-floor
@@ -132,7 +135,12 @@ def audit_paths(
     """
     if file_timeout > 30:
         raise ValueError("per-file timeout may not exceed 30 seconds")
-    terminals = scan_paths(paths, root=root, file_timeout=float(file_timeout))
+    terminals = scan_paths(
+        paths,
+        root=root,
+        file_timeout=float(file_timeout),
+        demand_table_path=demand_table_path,
+    )
     if progress_path is not None:
         progress_path.parent.mkdir(parents=True, exist_ok=True)
         with progress_path.open("w", encoding="utf-8") as stream:
@@ -176,7 +184,14 @@ def main() -> int:
     parser.add_argument("--engine-log", type=Path, default=None)
     parser.add_argument("--progress", type=Path, default=None)
     add_lpt_shard_args(parser)
+    add_demand_table_arg(parser)
     args = parser.parse_args()
+
+    try:
+        demand_table_path = require_demand_table(args.demand_table_path)
+    except ValueError as error:
+        print(f"NATIVE-CRASH ZERO-TOLERANCE UNMEASURED: {error}")
+        return 2
 
     boot_error = production_lift_bootstrap_error()
     if boot_error is not None:
@@ -218,6 +233,7 @@ def main() -> int:
         paths,
         root=args.repo_root,
         file_timeout=args.file_timeout,
+        demand_table_path=demand_table_path,
         progress_path=progress_path,
     )
     if args.json is not None:

--- a/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/timeout_zero_tolerance.py
@@ -27,7 +27,9 @@ from _enum_floor_runtime import (  # noqa: E402
     require_explicit_scan_roots,
     require_python_paths,
     add_lpt_shard_args,
+    add_demand_table_arg,
     apply_lpt_file_shard,
+    require_demand_table,
 )
 from _production_lift_child import production_lift_bootstrap_error  # noqa: E402
 from _supervised_enum_supervisor import FileTerminal, scan_paths  # noqa: E402
@@ -72,6 +74,7 @@ def audit_paths(
     *,
     root: Path,
     file_timeout: int,
+    demand_table_path: Path,
     progress_path: Path | None = None,
 ) -> AuditSummary:
     """Measure every path. Durable reuse is the content-addressed process-floor
@@ -79,7 +82,12 @@ def audit_paths(
     """
     if file_timeout > 30:
         raise ValueError("per-file timeout may not exceed 30 seconds")
-    terminals = scan_paths(paths, root=root, file_timeout=float(file_timeout))
+    terminals = scan_paths(
+        paths,
+        root=root,
+        file_timeout=float(file_timeout),
+        demand_table_path=demand_table_path,
+    )
     if progress_path is not None:
         progress_path.parent.mkdir(parents=True, exist_ok=True)
         with progress_path.open("w", encoding="utf-8") as stream:
@@ -118,7 +126,14 @@ def main() -> int:
     parser.add_argument("--engine-log", type=Path, default=None)
     parser.add_argument("--progress", type=Path, default=None)
     add_lpt_shard_args(parser)
+    add_demand_table_arg(parser)
     args = parser.parse_args()
+
+    try:
+        demand_table_path = require_demand_table(args.demand_table_path)
+    except ValueError as error:
+        print(f"TIMEOUT ZERO-TOLERANCE UNMEASURED: {error}")
+        return 2
 
     boot_error = production_lift_bootstrap_error()
     if boot_error is not None:
@@ -159,6 +174,7 @@ def main() -> int:
         paths,
         root=args.repo_root,
         file_timeout=args.file_timeout,
+        demand_table_path=demand_table_path,
         progress_path=progress_path,
     )
     rows = summary.rows

--- a/tests/test_process_floor_demand_table.py
+++ b/tests/test_process_floor_demand_table.py
@@ -1,0 +1,88 @@
+"""Process floors must enter through the authenticated shared demand table."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "implementations/python/sugar-lift-py-tests/scripts"
+WORKFLOW = ROOT / ".github/workflows/factory-zero-tolerance.yml"
+FLOOR_SCRIPTS = (
+    "native_crash_zero_tolerance.py",
+    "bare_exception_zero_tolerance.py",
+    "timeout_zero_tolerance.py",
+)
+
+
+def _load_runtime():
+    path = SCRIPTS / "_enum_floor_runtime.py"
+    spec = importlib.util.spec_from_file_location("enum_floor_runtime_tooth", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_missing_demand_table_refuses_without_waiting_for_scan(tmp_path: Path) -> None:
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(
+            str(path)
+            for path in (
+                ROOT / "tools",
+                ROOT / "implementations/python/sugar-lift-py-tests/src",
+                ROOT / "implementations/python/sugar-lift-python-source/src",
+                ROOT / "implementations/python/sugar-source-tree/src",
+            )
+        ),
+    }
+    for script in FLOOR_SCRIPTS:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS / script), "--repo-root", str(tmp_path)],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert result.returncode == 2, (script, result.stdout, result.stderr)
+        assert "authenticated python-demand-table" in result.stdout
+        assert "refusing local demand derivation" in result.stdout
+
+
+def test_demand_table_helper_accepts_existing_file_and_rejects_missing(
+    tmp_path: Path,
+) -> None:
+    runtime = _load_runtime()
+    table = tmp_path / "python-demand-table.json"
+    table.write_text("{}\n", encoding="utf-8")
+    assert runtime.require_demand_table(table) == table.resolve()
+    try:
+        runtime.require_demand_table(tmp_path / "missing.json")
+    except ValueError as error:
+        assert "not a file" in str(error)
+    else:
+        raise AssertionError("missing demand table must refuse")
+
+
+def test_all_process_floor_doors_forward_the_supplied_table() -> None:
+    for script in FLOOR_SCRIPTS:
+        source = (SCRIPTS / script).read_text(encoding="utf-8")
+        assert "--demand-table-path" not in source or "add_demand_table_arg" in source
+        assert "require_demand_table(args.demand_table_path)" in source
+        assert "demand_table_path=demand_table_path" in source
+        assert "scan_paths" in source
+
+
+def test_factory_workflow_enrolls_the_authenticated_table_artifact() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    assert "Pull authenticated shared Python demand table" in workflow
+    assert "name: python-demand-table" in workflow
+    assert "Download authenticated shared Python demand table" in workflow
+    assert "python-demand-table.json" in workflow
+    assert "run_one_process_floor_axis.sh" in workflow
+    assert "RUNNER_TEMP}/python-demand-table/python-demand-table.json" in workflow

--- a/tools/run_one_process_floor_axis.sh
+++ b/tools/run_one_process_floor_axis.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Run exactly one Criterion-2 process floor axis file-shard; emit identity-bound report.
 #
-# Usage: tools/run_one_process_floor_axis.sh <axis_base> <script_name> <shard_index> <shard_count>
+# Usage: tools/run_one_process_floor_axis.sh <axis_base> <script_name> <shard_index> <shard_count> <demand_table_path>
 #   axis_base: silent | native-crash | bare-exception | timeout
 #   seat id minted as ${axis_base}-s${shard_index:02d}
 #
@@ -19,6 +19,7 @@ axis_base="${1:?axis_base}"
 script_name="${2:?script}"
 shard_index="${3:?shard_index}"
 shard_count="${4:?shard_count}"
+demand_table_path="${5:?authenticated demand table path}"
 
 axis_seat="$(printf '%s-s%02d' "$axis_base" "$shard_index")"
 
@@ -28,6 +29,10 @@ SCRIPT="$SCRIPTS/$script_name"
 
 if [ ! -f "$SCRIPT" ]; then
   echo "::error::process floor script missing: $SCRIPT"
+  exit 2
+fi
+if [ ! -s "$demand_table_path" ]; then
+  echo "::error::authenticated python-demand-table missing or empty: $demand_table_path"
   exit 2
 fi
 
@@ -90,6 +95,7 @@ mkdir -p "$FLOOR_SCRATCH"
 
 set +e
 python -u "$SCRIPT" "$PANDAS_CORPUS" \
+  --demand-table-path "$demand_table_path" \
   --repo-root "$PANDAS_CORPUS" \
   --out-dir "$FLOOR_SCRATCH" \
   --json "$FLOOR_SUMMARY" \

--- a/tools/run_sole_construction_floors.sh
+++ b/tools/run_sole_construction_floors.sh
@@ -54,6 +54,12 @@ PANDAS_CORPUS="$(
   exit 1
 }
 echo "process-floor population: authenticated pandas corpus at $PANDAS_CORPUS"
+DEMAND_TABLE_PATH="${DEMAND_TABLE_PATH:-}"
+if [ -z "$DEMAND_TABLE_PATH" ] || [ ! -s "$DEMAND_TABLE_PATH" ]; then
+  echo "::error::authenticated python-demand-table required for process floors; set DEMAND_TABLE_PATH to the pulled table"
+  exit 2
+fi
+echo "process-floor demand table: $DEMAND_TABLE_PATH"
 # --repo-root is the population (relative loci). Scratch must NOT nest under it
 # (vendor site-packages is read-only; mutating the population is wrong even when
 # mkdir succeeds). Workspace/tmp only — same vocabulary as prepare_floor_io.
@@ -74,14 +80,17 @@ echo "process-floor cache: dir=${SUGAR_PROCESS_FLOOR_CACHE_DIR} tip=${SUGAR_MEAS
 # Axis names: R_axis only — never "R_axis = 0" (false banked zero on pre-measure crash).
 axis "R_native_crashes" \
   python "$SCRIPTS/native_crash_zero_tolerance.py" "$PANDAS_CORPUS" \
+  --demand-table-path "$DEMAND_TABLE_PATH" \
   --repo-root "$PANDAS_CORPUS" \
   --out-dir "$FLOOR_SCRATCH/native-crash"
 axis "R_bare_exceptions" \
   python "$SCRIPTS/bare_exception_zero_tolerance.py" "$PANDAS_CORPUS" \
+  --demand-table-path "$DEMAND_TABLE_PATH" \
   --repo-root "$PANDAS_CORPUS" \
   --out-dir "$FLOOR_SCRATCH/bare-exception"
 axis "R_timeouts" \
   python "$SCRIPTS/timeout_zero_tolerance.py" "$PANDAS_CORPUS" \
+  --demand-table-path "$DEMAND_TABLE_PATH" \
   --repo-root "$PANDAS_CORPUS" \
   --out-dir "$FLOOR_SCRATCH/timeout"
 # R_silent is Criterion 2's fourth simultaneous term — same population as the


### PR DESCRIPTION
## Why

Closes #7156.

The native, bare, and timeout process-floor entrances called `scan_paths` without a demand table. Their parsers had no `--demand-table-path`, and `factory-zero-tolerance.yml` supplied no authenticated Python demand-table artifact. The observed result was not a floor magnitude: all three axes timed out after about 1801 seconds during context initialization, having reached 0 of 1,421 files.

Wiring the entrance makes these axes measurable. It does not measure them.

## Entrance and refusal contract

- Add `--demand-table-path` to the native-crash, bare-exception, and timeout floor CLIs and forward the authenticated path into `scan_paths`.
- A missing path or a path that is not a file produces an **immediate named UNMEASURED refusal**. The old behavior was an approximately 1801-second timeout at 0/1,421; the new behavior gives the same honest non-measurement in about one second with a usable reason.
- The entrance must not silently derive a local demand table and must not report a zero when the authenticated table is missing.
- The local serial wrapper requires `DEMAND_TABLE_PATH` and refuses when it is absent or not a non-empty file.

## Workflow wiring

The preparation job pulls the authenticated shared `python-demand-table` once, uploads it once, and the process-floor job downloads that artifact and passes its file path through `run_one_process_floor_axis.sh` into the selected floor CLI.

The 1800-second workflow budget was not changed. Floor semantics were not changed.

## Measured evidence at `316957830af1e47ef2311edb4a519525e143419d`

Measured by McManus:

- 36 focused/topology tests passed.
- Workflow YAML parsed.
- Touched shell scripts passed syntax checks.
- Touched Python modules passed `py_compile`.
- Diff check passed.

CI is intentionally paused for the first attested corpus census. Checks on this PR are expected to queue, not run; queued is not passing and absent checks are not approval to merge.

## Measurement status and explicit non-claims

`R_silent = 0` over 1,421/1,421 files with 8/8 conserved seats remains **MEASURED**.

Native, bare, and timeout remain **UNMEASURED**, with the missing demand-table entrance as the named reason for the prior attempts. **This PR claims no new native, bare, or timeout magnitudes.** It makes those axes measurable; it does not report their values.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require authenticated demand table in all process floor scripts and CI workflow
> - All three process floor scripts ([bare_exception_zero_tolerance.py](https://github.com/TSavo/sugar/pull/7157/files#diff-8cd0cee7c147392021704bf9d8981be3b6602e0294835ef10700494caccde38c), [native_crash_zero_tolerance.py](https://github.com/TSavo/sugar/pull/7157/files#diff-0afa1fcbcdf461113f1af22c2c6d507d45869ce9e6e41cedb8475b4fdcbd0ff7), [timeout_zero_tolerance.py](https://github.com/TSavo/sugar/pull/7157/files#diff-675012bc77eeb75501b7f32a613b46f1c7f2f030a576086fa8067211ef36f9c8)) now require `--demand-table-path`; missing or invalid paths cause exit 2 with an UNMEASURED message.
> - [run_one_process_floor_axis.sh](https://github.com/TSavo/sugar/pull/7157/files#diff-e2f37947c64a438368c7b6c2e4b00a46231fdc6065bcaaec43954d2ada2be00e) adds a fifth positional argument for the demand table path, validates it exists and is non-empty, and forwards it to the invoked script.
> - [run_sole_construction_floors.sh](https://github.com/TSavo/sugar/pull/7157/files#diff-2425932b3b3850c1dce0e1350ce9dadb9c8d59942a7fb072ba19c29e2f913421) now requires `DEMAND_TABLE_PATH` env var to be set to a valid file and passes it to each floor invocation.
> - The CI workflow builds a `python-demand-table` artifact during test env setup and downloads it in each process-floor job before running the floor runner.
> - Risk: all existing invocations of process floor scripts and runner tools will fail if not updated to supply the demand table path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3169578.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->