### PR TITLE
Repair stale sugarbin wrapper compatibility contract

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -945,7 +945,7 @@ build_from_source() {
   require_writable_build_root "$build_root" || return 1
   built="$build_root/$profile/$bin_name"
   # SUGAR_BUILD_STAMP is the authenticated sourceStamp (source matter only).
-  # SUGAR_BUILD_GIT_HEAD remains a version/attestation label, not a shelf key.
+  # monorepo_head remains a version/attestation label, not a shelf key.
   monorepo_head="$(attestation_git_head)"
   [[ -n "$monorepo_head" ]] || monorepo_head="unknown"
   # Cargo can sit for minutes with no stdout in CI. Heartbeat to the job log

--- a/tests/sugarbin_wrapper_compat.sh
+++ b/tests/sugarbin_wrapper_compat.sh
@@ -63,6 +63,7 @@ status=0
 (cd "$fixture" && SUGARBIN_WRAPPER_STATUS=37 bin/bpytest -q tests/unit) || status=$?
 [[ "$status" -eq 37 ]] || { echo "bpytest returned $status, expected 37" >&2; exit 1; }
 [[ "$(wc -c <"$SUGARBIN_WRAPPER_COUNT" | tr -d ' ')" -eq 1 ]] || { echo "bpytest invoked sugarbin more than once" >&2; exit 1; }
-assert_args run --host bx --task python-unit -- -q tests/unit
+assert_args run --host bx --env SUGAR_BINARY_ALLOW_BUILD \
+  --task authenticated-python-lift -- -q tests/unit
 
 echo "PASS: sugarbin wrapper compatibility contract"


### PR DESCRIPTION
## What this lands

Repairs the standalone wrapper compatibility contract that diverged when it was introduced in `d9ea360f1` alongside the wrapper.

The contract now matches the live `bpytest` entrance:

- forwards `SUGAR_BINARY_ALLOW_BUILD`
- uses the authenticated `authenticated-python-lift` task
- preserves the wrapper's exact argument and exit-status assertions

It also corrects the nearby `bin/sugarbin` comment so the attestation label is named by the variable that actually carries it.

## Discovery provenance

References #7153 for discovery provenance only. This PR does **not** close or resolve #7153.

The shell tier remains independently unenrolled: 9/9 shell tests have no Makefile, script, or workflow execution edge; the measured standalone run was 7/9 passing and 2/9 red, with both red tests still unowned. This PR repairs one stale contract; it does not bulk-enroll that tier or triage those two reds.

## Scope and claims

- changed files: `bin/sugarbin`, `tests/sugarbin_wrapper_compat.sh`
- no category, kind, label, taxonomy, or residual-bucket additions
- no runner-autoscaler or CI-capacity changes
- no broad suite-green claim
- no claim that the 9-test shell tier is enrolled
- closes nothing


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale compatibility contract in sugarbin wrapper test
> Updates [sugarbin_wrapper_compat.sh](https://github.com/TSavo/sugar/pull/7158/files#diff-032577a54c419787c2600559b23a4faf9ad4ff8b61540d6340003a6ce0fd2885) to reflect the current expected behavior of the sugarbin wrapper. The test now asserts `--env SUGAR_BINARY_ALLOW_BUILD` is passed and that the task is `authenticated-python-lift` instead of `python-unit`. Also updates an inline comment in [bin/sugarbin](https://github.com/TSavo/sugar/pull/7158/files#diff-2b8f7e68bdef16827d284767f61c9a26ffa589c12f114f50129677d05e35383b) to use `monorepo_head` instead of `SUGAR_BUILD_GIT_HEAD` as the version label.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84f891a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated compatibility coverage to reflect the current build environment configuration and task execution flow.
  - Improved validation of wrapper behavior for build-related commands.

- **Chores**
  - Updated build metadata references to align with the current terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->