### PR TITLE
Select Battleaxe timing lease from the remote host filesystem

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -178,6 +178,27 @@ sugar_bx_quiet_armed() {
   [[ -n "$max_env" || "$require" == 1 || "$require" == true || "$require" == yes ]]
 }
 
+# Select the one lease that is physically shared by host brun processes and
+# CI containers. This judgment belongs to the host that will take the lock,
+# not to the caller assembling the remote command. /var/tmp is deliberately
+# not a fallback: on containerized runners it produces a different inode and
+# only simulates serialization.
+sugar_bx_select_timing_lease() {
+  local tsavo_cache="${1:-/home/tsavo/.cache/sugar/binaries}"
+  local runner_cache="${2:-/home/runner/.cache/sugar/binaries}"
+  if [[ -d "$tsavo_cache" ]]; then
+    printf '%s\n' "$tsavo_cache/.sugar-heavy-measurement.lease"
+    return 0
+  fi
+  if [[ -d "$runner_cache" ]]; then
+    printf '%s\n' "$runner_cache/.sugar-heavy-measurement.lease"
+    return 0
+  fi
+  printf 'sugarbin: crime=timing-lease-path-unavailable candidates=%s,%s replacement=restore one shared host binary-cache directory; do not substitute a container-local lease\n' \
+    "$tsavo_cache" "$runner_cache" >&2
+  return 77
+}
+
 sugar_bx_sample_load() {
   # Prints: load1 nproc  (one line). Uses /proc/loadavg on Linux; falls back
   # to python getloadavg on platforms without it (local-mode macOS tests).
@@ -204,17 +225,13 @@ sugar_bx_require_quiet() {
   fi
   SUGAR_BX_QUIET_ARMED=1
   SUGAR_BX_LOAD_MAX="${SUGAR_BX_MAX_LOADAVG:-}"
-  # Prefer host bind-mount lease (serializes CI containers + host brun).
-  # /var/tmp is per-container lock theatre on battleaxe (same bootId, different
-  # inode). See docs/contributing/heavy-measurement-lease.md.
+  # An explicit path remains an explicit operator assertion. Otherwise leave
+  # selection to the remote host, whose filesystem is authoritative. The
+  # caller cannot truthfully choose between host paths from its own namespace.
   if [[ -n "${SUGAR_BX_TIMING_LEASE_PATH:-}" ]]; then
     SUGAR_BX_TIMING_LEASE="$SUGAR_BX_TIMING_LEASE_PATH"
-  elif [[ -d /home/runner/.cache/sugar/binaries ]]; then
-    SUGAR_BX_TIMING_LEASE=/home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease
-  elif [[ -d /home/tsavo/.cache/sugar/binaries ]]; then
-    SUGAR_BX_TIMING_LEASE=/home/tsavo/.cache/sugar/binaries/.sugar-heavy-measurement.lease
   else
-    SUGAR_BX_TIMING_LEASE=/var/tmp/sugar-bx-timing-measurement.lease
+    SUGAR_BX_TIMING_LEASE=""
   fi
   # Default wait 2h (queue). Set SUGAR_BX_TIMING_LEASE_WAIT_S=0 to refuse
   # immediately with exit 77 when another measurement holds the lease.
@@ -228,7 +245,7 @@ sugar_bx_require_quiet() {
   SUGAR_BX_SKIP_CORPUS_PIN="${SUGAR_BX_SKIP_CORPUS_PIN:-0}"
   printf 'sugarbin: bx-load-gate phase=arm host=%s max=%s lease=%s wait_s=%s corpus_pin=%s skip_pin=%s\n' \
     "$SUGAR_BX_HOST" "${SUGAR_BX_LOAD_MAX:-auto(nproc/4,floor=2)}" \
-    "$SUGAR_BX_TIMING_LEASE" "$SUGAR_BX_TIMING_LEASE_WAIT" \
+    "${SUGAR_BX_TIMING_LEASE:-host-selected}" "$SUGAR_BX_TIMING_LEASE_WAIT" \
     "$SUGAR_BX_CORPUS_PIN_PATH" "$SUGAR_BX_SKIP_CORPUS_PIN" >&2
   return 0
 }
@@ -277,18 +294,10 @@ sugar_bx_run_ambient() {
   # Quiet path: exclusive remote lease → load under lock → corpus pin →
   # measure. Do not exec-replace the shell that holds the flock fd.
   # Three gates, one law: quiet box, exclusive lease, correct corpus.
-  local lock wait_s max_lit host_lit measured_cmd wrapper
+  local lock wait_s max_lit host_lit measured_cmd wrapper selector_def
   local pin_path pin_py pin_skip
   lock="${SUGAR_BX_TIMING_LEASE:-}"
-  if [[ -z "$lock" ]]; then
-    if [[ -d /home/runner/.cache/sugar/binaries ]]; then
-      lock=/home/runner/.cache/sugar/binaries/.sugar-heavy-measurement.lease
-    elif [[ -d /home/tsavo/.cache/sugar/binaries ]]; then
-      lock=/home/tsavo/.cache/sugar/binaries/.sugar-heavy-measurement.lease
-    else
-      lock=/var/tmp/sugar-bx-timing-measurement.lease
-    fi
-  fi
+  selector_def="$(declare -f sugar_bx_select_timing_lease)"
   wait_s="${SUGAR_BX_TIMING_LEASE_WAIT:-7200}"
   max_lit="${SUGAR_BX_LOAD_MAX:-}"
   host_lit="$SUGAR_BX_HOST"
@@ -306,7 +315,8 @@ sugar_bx_run_ambient() {
   # 78s — only absolute /tmp pins worked. Pin against SUGAR_BX_REPO, not
   # remote_cwd (may be a subdir when REL_CWD is set). measured_cmd still cds
   # to the caller's cwd via prefix_cmd after the pin authenticates.
-  wrapper="set -euo pipefail
+  wrapper="$selector_def
+set -euo pipefail
 LOCK=$(sugar_bx_quote "$lock")
 WAIT=$(sugar_bx_quote "$wait_s")
 MAX_LIT=$(sugar_bx_quote "$max_lit")
@@ -315,6 +325,14 @@ SKIP_PIN=$(sugar_bx_quote "$pin_skip")
 PIN_PATH=$(sugar_bx_quote "$pin_path")
 PIN_PY=$(sugar_bx_quote "$pin_py")
 REPO_ROOT=$(sugar_bx_quote "$SUGAR_BX_REPO")
+if [[ -z \"\$LOCK\" ]]; then
+  if LOCK=\$(sugar_bx_select_timing_lease); then
+    :
+  else
+    selector_status=\$?
+    exit \"\$selector_status\"
+  fi
+fi
 cd \"\$REPO_ROOT\" || { printf 'sugarbin: crime=corpus-pin-cwd-missing path=%s replacement=synced checkout at SUGAR_BX_REPO must exist before pin check\\n' \"\$REPO_ROOT\" >&2; exit 78; }
 # Root relative pin/python against the synced checkout. Absolute paths (e.g.
 # /tmp/pin.json or a fleet venv) pass through unchanged.

--- a/tests/sugarbin_bx_load_gate.sh
+++ b/tests/sugarbin_bx_load_gate.sh
@@ -162,7 +162,7 @@ export BX_FAKE_LEASE_BUSY=0
 
 # 7) brun adapter surfaces quiet + lease + pin env.
 grep -Fq 'SUGAR_BX_REQUIRE_QUIET' "$repo_root/bin/brun" || fail "brun --help text missing quiet gate"
-grep -Fq 'sugar-bx-timing-measurement.lease' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing timing lease path"
+grep -Fq '.sugar-heavy-measurement.lease' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing shared timing lease path"
 grep -Fq 'timing-lease-busy' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing lease-busy crime"
 grep -Fq 'bx_corpus_pin_gate' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing corpus pin gate"
 grep -Fq 'exit 78' "$repo_root/bin/lib/sugar-bx.sh" || fail "sugar-bx missing pin exit 78"
@@ -201,5 +201,40 @@ grep -Fq 'bx_corpus_pin_gate' "$remote_exec_log" \
 grep -Fq 'PIN_PATH=' "$remote_exec_log" "$ssh_log" 2>/dev/null \
   || grep -Fq 'pandas-3.0.3.pin.json' "$remote_exec_log" "$ssh_log" \
   || fail "quiet+pin wrapper missing pin path"
+
+# 9) Lease selection is a host-filesystem judgment. Prefer the authentic
+# host-side tsavo cache when both candidates exist; do not inherit the caller's
+# filesystem shape.
+# shellcheck source=bin/lib/sugar-bx.sh
+source "$repo_root/bin/lib/sugar-bx.sh"
+lease_host="$tmp/lease-host"
+tsavo_cache="$lease_host/home/tsavo/.cache/sugar/binaries"
+runner_cache="$lease_host/home/runner/.cache/sugar/binaries"
+mkdir -p "$tsavo_cache" "$runner_cache"
+selected="$(sugar_bx_select_timing_lease "$tsavo_cache" "$runner_cache")"
+[[ "$selected" == "$tsavo_cache/.sugar-heavy-measurement.lease" ]] \
+  || fail "host with tsavo cache selected $selected"
+
+# 10) No real shared cache means no lease. Refuse with both physical
+# candidates named instead of fabricating a /var/tmp lock that cannot
+# serialize host and container work.
+missing_tsavo="$lease_host/missing/tsavo"
+missing_runner="$lease_host/missing/runner"
+status=0
+sugar_bx_select_timing_lease "$missing_tsavo" "$missing_runner" \
+  >"$tmp/missing-lease.out" 2>"$tmp/missing-lease.err" || status=$?
+[[ "$status" -eq 77 ]] || fail "missing lease candidates status=$status want 77"
+grep -Fq 'crime=timing-lease-path-unavailable' "$tmp/missing-lease.err" \
+  || fail "missing lease candidates did not name the refusal"
+grep -Fq "$missing_tsavo" "$tmp/missing-lease.err" \
+  || fail "missing lease refusal omitted tsavo candidate"
+grep -Fq "$missing_runner" "$tmp/missing-lease.err" \
+  || fail "missing lease refusal omitted runner candidate"
+
+# The selector itself must run on the remote wrapper, after transport. A local
+# selection can only testify to the caller's filesystem.
+grep -Fq 'sugar_bx_select_timing_lease' "$remote_exec_log" \
+  || grep -Fq 'sugar_bx_select_timing_lease' "$ssh_log" \
+  || fail "quiet wrapper did not defer lease selection to the remote host"
 
 echo "PASS: sugarbin_bx_load_gate"


### PR DESCRIPTION
## Why

Closes #7155.

`bin/lib/sugar-bx.sh` selected `/home/runner/.cache/sugar/binaries` over the authentic `/home/tsavo/.cache/sugar/binaries`. The resulting lease was uncreatable, so the entire gated run died before load admission, corpus-pin authentication, or census execution. That destroyed the first attested census attempt before it could measure anything.

Lease selection is a remote-host filesystem judgment. The caller cannot authenticate which host path exists from its own namespace.

## Contract

- Select the authentic host-side `/home/tsavo/.cache/sugar/binaries` when it exists.
- Fall back to `/home/runner/.cache/sugar/binaries` only when that is the existing shared host cache.
- If neither candidate exists, refuse with exit 77 and name **both candidate paths**.
- Do not fabricate a `/var/tmp` lease; it does not serialize the host and container work.
- Keep an explicitly supplied lease path as an explicit operator assertion.

The refusal arm naming both candidates is load-bearing. A selector that fails without saying what it inspected recreates the invisible lease-slot loss that exposed this defect.

## Measured teeth

Measured by Hockney at `f8de2e4d4e15bc5e681eaf2ae56283d95f20b28e`:

- selector twin: 1/1 green, both arms
  - both candidates present: selects `/home/tsavo/.cache/sugar/binaries`
  - neither candidate present: exits 77 and names both paths
- real Battleaxe testimony: tsavo path exists=1, runner path exists=0, selected `/home/tsavo/.cache/sugar/binaries`
- Bash syntax: 1/1
- diff check: 1/1

## Scope and non-claims

- changed files: `bin/lib/sugar-bx.sh`, `tests/sugarbin_bx_load_gate.sh`
- no category, kind, label, taxonomy, or residual-bucket additions
- no runner-autoscaler or CI-capacity changes
- no census magnitude claimed; the destroyed attempt reached neither pin nor census


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Select Battleaxe timing lease from the remote host filesystem
> - `sugar_bx_select_timing_lease` checks for tsavo or runner cache directories on the remote host and emits the appropriate lease path, or exits 77 with an error message if neither exists.
> - `sugar_bx_require_quiet` no longer sets a local default lease path; when no explicit `SUGAR_BX_TIMING_LEASE_PATH` is given, it defers selection to the remote host and logs `host-selected`.
> - `sugar_bx_run_ambient` embeds the selector function definition into the remote wrapper script and invokes it remotely when no lock is pre-set, removing the previous `/var/tmp` fallback.
> - Behavioral Change: commands that previously fell back to a `/var/tmp` lease path now exit with status 77 if no shared cache directory exists on the remote host.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8de2e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->