### PR TITLE
Preserve brun payload status and failed-run evidence

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -294,7 +294,8 @@ sugar_bx_run_ambient() {
   # Quiet path: exclusive remote lease → load under lock → corpus pin →
   # measure. Do not exec-replace the shell that holds the flock fd.
   # Three gates, one law: quiet box, exclusive lease, correct corpus.
-  local lock wait_s max_lit host_lit measured_cmd wrapper selector_def
+  local lock wait_s max_lit host_lit measured_cmd wrapper selector_def login_exec
+  local compact_wrapper
   local pin_path pin_py pin_skip
   lock="${SUGAR_BX_TIMING_LEASE:-}"
   selector_def="$(declare -f sugar_bx_select_timing_lease)"
@@ -455,7 +456,16 @@ printf 'sugarbin: bx-load-gate phase=after host=%s load1_before=%s load1_after=%
   \"\$HOST\" \"\$l1\" \"\$l2\" \"\$idle_pct\" \"\$idle_after\" \"\$n\" \"\$QUIET_METRIC\" >&2
 printf 'sugarbin: bx-timing-lease phase=release host=%s path=%s status=%s\\n' \"\$HOST\" \"\$LOCK\" \"\$st\" >&2
 exit \"\$st\""
-  sugar_bx_ssh "bash -lc $(sugar_bx_quote "$wrapper")"
+  # OpenSSH multiplexes the command through a bounded Unix-domain socket
+  # packet. Comments are not executable testimony; sending them made valid
+  # artifact commands cross that transport boundary. Gate logic is unchanged.
+  compact_wrapper="$(printf '%s\n' "$wrapper" | sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d')"
+  # Keep login-shell initialization, then replace that shell before it can run
+  # a status-bearing logout hook. On battleaxe /etc/bash.bash_logout invokes
+  # clear_console, whose exit 1 replaced both remote success and remote 23.
+  # The non-login wrapper's explicit exit is therefore the SSH verdict.
+  login_exec='exec "$@"'
+  sugar_bx_ssh "bash -lc $(sugar_bx_quote "$login_exec") bash bash -c $(sugar_bx_quote "$compact_wrapper")"
 }
 
 sugar_bx_docker_bind_source() {
@@ -558,12 +568,18 @@ sugar_bx_run_docker() {
 
 sugar_bx_is_foreign() { [[ "$(uname -s 2>/dev/null)" != Linux ]] && [[ "$(file -b "$1" 2>/dev/null || true)" == *ELF* ]]; }
 sugar_bx_sync_back() {
-  local remote="$1" local_path="$2" tmp
+  local remote="$1" local_path="$2" tmp transfer_status
   if [[ "${SUGAR_BX_LOCAL:-0}" == 1 && "$remote" == "$local_path" ]]; then return 0; fi
   mkdir -p "$(dirname "$local_path")"; tmp="$(mktemp "${local_path}.sugar-bx-sync.XXXXXX")"
   local src="$SUGAR_BX_HOST:$remote"
   [[ "${SUGAR_BX_LOCAL:-0}" == 1 ]] && src="$remote"
-  "$SUGAR_BX_RSYNC" -az "$src" "$tmp"
+  if "$SUGAR_BX_RSYNC" -az "$src" "$tmp"; then
+    :
+  else
+    transfer_status=$?
+    rm -f "$tmp"
+    return "$transfer_status"
+  fi
   if sugar_bx_is_foreign "$tmp"; then
     echo "sugarbin: refusing to deposit foreign-platform binary: crime=foreign-platform-binary owner=bin/lib/sugar-bx.sh path=$local_path replacement=run the binary on $SUGAR_BX_HOST or rebuild locally" >&2
     rm -f "$tmp"; [[ -e "$local_path" ]] && sugar_bx_is_foreign "$local_path" && rm -f "$local_path"; return 0

--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -258,6 +258,7 @@ dispatch_execution_subcommand() {
   ((${#env_names[@]} == 0)) || SUGAR_BX_ENV_NAMES=("${env_names[@]}")
   ((${#sync_backs[@]} == 0)) || SUGAR_BX_SYNC_BACKS=("${sync_backs[@]}")
   local repo_root local_cwd status=0 pair
+  local run_status=0 sync_status=0 pair_status=0 final_status=0
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
   [[ -n "$repo_root" ]] || { echo "sugarbin: must be run from inside a git checkout" >&2; return 2; }
   local_cwd="$(pwd -P)"
@@ -315,17 +316,32 @@ dispatch_execution_subcommand() {
   fi
   set +e
   sugar_bx_run_ambient "${command[@]}"
-  status=$?
+  run_status=$?
   set -e
   sugar_bx_report_load_after
-  if [[ "$status" == 0 ]]; then
-    if ((${#SUGAR_BX_SYNC_BACKS[@]} != 0)); then
-      for pair in "${SUGAR_BX_SYNC_BACKS[@]}"; do
-        sugar_bx_sync_back "${pair%%:*}" "${pair#*:}" || { status=$?; break; }
-      done
-    fi
+  # Sync-back is evidence collection, not a reward for exit 0. A failed run's
+  # artifact can be the only explanation of its failure, so attempt every
+  # requested pull regardless of the remote verdict. Keep the two statuses
+  # separate: a real remote failure is primary and can never be laundered by a
+  # successful transfer (or replaced by a transfer failure). A transfer
+  # failure only closes an otherwise-successful run.
+  if ((${#SUGAR_BX_SYNC_BACKS[@]} != 0)); then
+    for pair in "${SUGAR_BX_SYNC_BACKS[@]}"; do
+      set +e
+      sugar_bx_sync_back "${pair%%:*}" "${pair#*:}"
+      pair_status=$?
+      set -e
+      if [[ "$pair_status" != 0 && "$sync_status" == 0 ]]; then
+        sync_status="$pair_status"
+      fi
+    done
   fi
-  sugar_bx_finish "$status"
+  final_status="$run_status"
+  if [[ "$final_status" == 0 && "$sync_status" != 0 ]]; then
+    final_status="$sync_status"
+  fi
+  sugar_bx_finish "$final_status"
+  return "$final_status"
 }
 
 sugarbin_bx_cargo() {

--- a/tests/brun_remote_exec.sh
+++ b/tests/brun_remote_exec.sh
@@ -7,8 +7,10 @@ set -euo pipefail
 #   2. --path-prefix lands in PATH and --env forwards values without provisioning
 #   3. repo-root paths in command args are rewritten to the remote root
 #   4. the remote exit code propagates
-#   5. --sync-back pulls the remote artifact into place
-#   6. a foreign (ELF) sync-back is refused and deposits nothing
+#   5. --sync-back pulls the remote artifact into place after success
+#   6. --sync-back also preserves evidence after remote failure without
+#      laundering the failure status
+#   7. a foreign (ELF) sync-back is refused and deposits nothing
 
 repo_root="${1:-}"
 if [[ -z "$repo_root" ]]; then
@@ -33,6 +35,19 @@ cat >"$fake_bin/ssh" <<'SH'
     printf '<%s>\n' "$arg"
   done
 } >>"$BRUN_FAKE_SSH_LOG"
+if [[ "${BRUN_FAKE_EXEC_REMOTE:-0}" == "1" ]]; then
+  remote_command="${*: -1}"
+  remote_status=0
+  PATH="$BRUN_FAKE_BIN:$PATH" bash -lc "$remote_command" || remote_status=$?
+  # Battleaxe's login-shell logout hook runs clear_console after the generated
+  # wrapper and returns 1, replacing both success and nonzero remote verdicts.
+  # An exec bridge replaces the login shell before that hook can run.
+  if [[ "${BRUN_FAKE_POISON_LOGIN_LOGOUT:-0}" == "1" \
+      && "$remote_command" != *"exec \"\$@\""* ]]; then
+    exit 1
+  fi
+  exit "$remote_status"
+fi
 if [[ "${BRUN_FAKE_CMD_FAIL:-0}" == "1" ]]; then
   for arg in "$@"; do
     case "$arg" in
@@ -45,6 +60,14 @@ fi
 exit 0
 SH
 chmod +x "$fake_bin/ssh"
+
+cat >"$fake_bin/flock" <<'SH'
+#!/usr/bin/env bash
+# The real-shaped local transport arm is serialized by the test process. Its
+# job is to execute the generated quiet wrapper, not to re-test util-linux.
+exit 0
+SH
+chmod +x "$fake_bin/flock"
 
 cat >"$fake_bin/rsync" <<'SH'
 #!/usr/bin/env bash
@@ -65,6 +88,9 @@ for arg in "$@"; do
   esac
 done
 if [[ "$src" == *:* && -n "$dest" ]]; then
+  if [[ "${BRUN_FAKE_PULL_FAIL:-0}" == "1" ]]; then
+    exit 29
+  fi
   printf '%s' "${BRUN_FAKE_PULL_CONTENT:-remote-artifact}" >"$dest"
 fi
 exit 0
@@ -85,7 +111,29 @@ run_brun() {
     BCARGO_RSYNC="$fake_bin/rsync" \
     BRUN_FAKE_SSH_LOG="$ssh_log" \
     BRUN_FAKE_RSYNC_LOG="$rsync_log" \
+    BRUN_FAKE_PULL_CONTENT="${BRUN_FAKE_PULL_CONTENT-}" \
+    BRUN_FAKE_PULL_FAIL="${BRUN_FAKE_PULL_FAIL-}" \
     BCARGO_REAP_DAYS=0 \
+    "$repo_root/bin/brun" "$@"
+  )
+}
+
+run_brun_real_shaped_quiet() {
+  (
+    cd "$repo_root"
+    PATH="$fake_bin:$PATH" \
+    BCARGO_SSH="$fake_bin/ssh" \
+    BCARGO_RSYNC="$fake_bin/rsync" \
+    BRUN_FAKE_SSH_LOG="$ssh_log" \
+    BRUN_FAKE_RSYNC_LOG="$rsync_log" \
+    BRUN_FAKE_BIN="$fake_bin" \
+    BRUN_FAKE_EXEC_REMOTE=1 \
+    BRUN_FAKE_POISON_LOGIN_LOGOUT=1 \
+    BCARGO_REMOTE_ROOT="$tmp/real-shaped-remote" \
+    BCARGO_REAP_DAYS=0 \
+    SUGAR_BX_REQUIRE_QUIET=1 \
+    SUGAR_BX_SKIP_CORPUS_PIN=1 \
+    SUGAR_BX_TIMING_LEASE_PATH="$tmp/real-shaped.lease" \
     "$repo_root/bin/brun" "$@"
   )
 }
@@ -126,6 +174,20 @@ status=0
 BRUN_FAKE_CMD_FAIL=1 run_brun -- true >/dev/null 2>&1 || status=$?
 [[ "$status" -eq 23 ]] || fail "remote exit code not propagated (got $status, want 23)"
 
+# Execute the generated quiet wrapper rather than asking the fake SSH boundary
+# to mint an answer. Success and two distinct failures prove status identity;
+# a wrapper that collapses every nonzero to 1 cannot satisfy these arms.
+status=0
+run_brun_real_shaped_quiet -- true >/dev/null 2>&1 || status=$?
+[[ "$status" -eq 0 ]] || fail "real-shaped quiet success collapsed to $status"
+for expected in 23 41; do
+  status=0
+  run_brun_real_shaped_quiet -- bash -lc "exit $expected" \
+    >/dev/null 2>&1 || status=$?
+  [[ "$status" -eq "$expected" ]] \
+    || fail "real-shaped quiet exit $expected collapsed to $status"
+done
+
 # --- 5: sync-back pulls the artifact ------------------------------------------
 : >"$ssh_log"; : >"$rsync_log"
 dest="$tmp/pulled/report.json"
@@ -134,7 +196,44 @@ run_brun --sync-back "/remote/out/report.json:$dest" -- true >/dev/null
 [[ "$(cat "$dest")" == "remote-artifact" ]] || fail "--sync-back deposited wrong content"
 grep -Fq "/remote/out/report.json" "$rsync_log" || fail "sync-back pull not logged"
 
-# --- 6: foreign ELF sync-back refused -----------------------------------------
+# --- 6: failed remote run still syncs its evidence -----------------------------
+: >"$ssh_log"; : >"$rsync_log"
+failed_dest="$tmp/pulled/failed-report.json"
+status=0
+BRUN_FAKE_CMD_FAIL=1 \
+  run_brun --sync-back "/remote/out/failed-report.json:$failed_dest" -- true \
+  >/dev/null 2>&1 || status=$?
+[[ "$status" -eq 23 ]] \
+  || fail "sync-back laundered remote failure (got $status, want 23)"
+[[ -f "$failed_dest" ]] \
+  || fail "remote failure suppressed its evidence sync-back"
+[[ "$(cat "$failed_dest")" == "remote-artifact" ]] \
+  || fail "failed-run sync-back deposited wrong content"
+grep -Fq "/remote/out/failed-report.json" "$rsync_log" \
+  || fail "failed-run sync-back pull not logged"
+
+# A transfer failure cannot turn a successful remote command green, and it
+# cannot replace a real remote failure with a different verdict. The run
+# status is primary; transfer status only closes an otherwise-successful run.
+: >"$ssh_log"; : >"$rsync_log"
+status=0
+BRUN_FAKE_PULL_FAIL=1 \
+  run_brun --sync-back "/remote/out/missing.json:$tmp/pulled/missing.json" \
+  -- true >/dev/null 2>&1 || status=$?
+[[ "$status" -eq 29 ]] \
+  || fail "sync-back failure reported remote success (got $status, want 29)"
+
+: >"$ssh_log"; : >"$rsync_log"
+status=0
+BRUN_FAKE_CMD_FAIL=1 BRUN_FAKE_PULL_FAIL=1 \
+  run_brun --sync-back "/remote/out/failed-missing.json:$tmp/pulled/failed-missing.json" \
+  -- true >/dev/null 2>&1 || status=$?
+[[ "$status" -eq 23 ]] \
+  || fail "sync-back replaced remote failure (got $status, want 23)"
+grep -Fq "/remote/out/failed-missing.json" "$rsync_log" \
+  || fail "remote failure suppressed attempted sync-back after transfer failure"
+
+# --- 7: foreign ELF sync-back refused -----------------------------------------
 if [[ "$(uname -s)" != "Linux" ]]; then
   : >"$ssh_log"; : >"$rsync_log"
   elf_dest="$tmp/pulled/elf-bin"


### PR DESCRIPTION
## Why

Closes #7154.

Battleaxe's **login-shell logout** runs `/usr/bin/clear_console -q`. Its status became the SSH shell verdict and overwrote the faithful payload status after the payload completed. That is why successful `bin/brun` runs returned 1.

Dispatch was correct throughout. The overwrite happened remotely after the payload, in the logout path.

## Repair

- Preserve login-shell initialization, then use an exec bridge so the login shell cannot run a status-bearing logout hook after the payload.
- Keep remote execution status and sync-back status separate.
- Attempt evidence sync after remote failure.
- Never install a pre-created empty temporary after `rsync` failure.
- Compact only whole-line comments and blank lines before the SSH ControlMaster transport; gate logic is unchanged.

## Ordered landing and exact restack proof

This is the second landing, after #7165 / #7155. Exact head `d193bfd0798ea079d435d22dcd0b526aa4e840ba` has direct parent and merge-base `274e3b21cb643f8a611a6c83a0a209f92461b465`, with one commit ahead and zero behind.

Old `f8de2e4d4` is not an ancestor. The new tree is byte-for-byte Git-tree identical to the previously combined `7a8c366434f5006c12f8f46acec0ab5cf14d543c` tree.

## Evidence and honest caveat

Focused evidence reproduced after the final restack:

- Bash syntax: 1/1
- `brun_remote_exec`: 1/1
- `sugarbin_bx_exec`: 1/1
- `sugarbin_bx_load_gate`: 1/1
- diff check: 1/1

**No fresh Battleaxe real-gate run was made after the restack.** The real-gate receipt below was measured on the previously combined #7155 + #7154 tree. Exact Git-tree identity proves this restacked branch preserves that measured tree byte-for-byte; this is carried evidence, not a claim of fresh post-restack measurement.

Measured combined-tree acceptance:

- gated 0 returned 0
- gated 23 returned 23
- gated 41 returned 41
- success artifact: 124 bytes, byte-identical, SHA-256 `759ffb1a5756f2ae097c95eeafadc6cd79308c4fbc174bd714c513dd861e6bc9`
- **failed-run artifact:** 126 bytes, byte-identical, SHA-256 `e0943f42a40eb55cfc2679e86b6749f9063afc699f354f3a679bdb1d76f47ed3`
- gate testimony intact; host selection correct; 0 acceptance failures

Failed-run artifact survival is load-bearing: evidence from a failed remote run no longer disappears.

The two longer-command ControlMaster refusals tracked in #7164 were excluded from acceptance: both returned wrapper 255 with zero artifacts. Shortening whole-line comments and blanks avoids that tested case but does not claim to eliminate the transport ceiling.

## Scope and non-claims

- changed files: `bin/lib/sugar-bx.sh`, `bin/sugarbin`, `tests/brun_remote_exec.sh`
- no category, kind, label, taxonomy, or residual-bucket additions
- no runner-autoscaler or CI-capacity changes
- no fresh post-restack Battleaxe run claimed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve brun payload exit status and sync-back evidence after failed remote runs
> - Fixes `sugar_bx_run_ambient` to run the remote wrapper via a login-shell exec bridge, so the wrapper's exit status is returned directly without being overwritten by login-shell logout hooks; wrapper content is compacted (comments/blanks stripped) before transmission.
> - Fixes `sugar_bx_sync_back` to propagate rsync transfer failures and clean up the temp file on error instead of proceeding to `mv`.
> - Changes `dispatch_execution_subcommand` in [sugarbin](https://github.com/TSavo/sugar/pull/7167/files#diff-2b8f7e68bdef16827d284767f61c9a26ffa589c12f114f50129677d05e35383b) to always attempt all configured sync-backs even when the remote run fails; `run_status` takes priority over `sync_status` in the final exit code.
> - Expands [tests/brun_remote_exec.sh](https://github.com/TSavo/sugar/pull/7167/files#diff-6a14690ee6d89c043b723cb99694f53cd74d25173ca0b1afaf7e42c73d4d5885) to cover exit-code preservation, sync-back after failure, and sync-back failure semantics.
> - Behavioral Change: sync-backs now always run after a failed remote execution, and the overall exit code is the remote run status unless the run succeeded and a sync-back failed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d193bfd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->