### PR TITLE
Preserve canonical With demand rows across provider gaps

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2293,12 +2293,24 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
 
                 # Walk-scoped multi-resolve owner: same session as other opens
                 # under this workspace root (census / re-open amortization).
-                populate_source_derived_resource_refs(
-                    tree_file,
-                    root=root,
-                    path=full_path,
-                    session=walk_session_for(root),
+                from sugar_source_tree.panic import (
+                    ContextManagerResolutionConstructionGap,
                 )
+
+                try:
+                    populate_source_derived_resource_refs(
+                        tree_file,
+                        root=root,
+                        path=full_path,
+                        session=walk_session_for(root),
+                    )
+                except ContextManagerResolutionConstructionGap:
+                    # Enumeration owns attendance, not construction. Provider-call
+                    # projection can reach an unresolved With while enriching this
+                    # table; retain the already-authenticated provisional rows so
+                    # the context-manager edge conserves exact coordinates. The
+                    # construction demand still reaches and reports this same panic.
+                    pass
                 if level == "context-manager-resolutions":
                     from sugar_lift_py_tests.context_manager_resolution import (
                         context_manager_resolution_outcome,

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
@@ -325,3 +325,39 @@ def test_enumerate_with_rows_reach_partition_with_identical_keys(
     assert edge["missingKeys"] == []
     assert edge["extraKeys"] == []
     assert edge["duplicateKeys"] == []
+
+
+def test_resolution_enumeration_keeps_rows_when_provider_projection_reaches_gap(
+    tmp_path: Path,
+) -> None:
+    """A provider-call projection cannot erase its own unresolved With seat."""
+    _load()
+    from recensus_enumerate_consumer import demand_context_manager_resolution_events
+    from sugar_lift_py_tests.lift_rpc import (
+        install_provisional_contract_refs,
+        provisional_contract_refs_from_demands,
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+
+    path = tmp_path / "provider.py"
+    path.write_text(
+        "def run():\n"
+        "    handle_data = get_data()\n"
+        "    with handle_data as payload:\n"
+        "        return payload\n",
+        encoding="utf-8",
+    )
+    refs = provisional_contract_refs_from_demands(tmp_path)
+    install_provisional_contract_refs(tmp_path, refs)
+    source_cid = path_source(str(path))[2]
+
+    events, gaps = demand_context_manager_resolution_events(
+        workspace_root=tmp_path,
+        file_rel="provider.py",
+        source_cid=source_cid,
+    )
+
+    assert gaps == []
+    assert len(events) == 1
+    assert events[0]["outcome"] == "unconstructed"
+    assert events[0]["inputKey"]["sourceCid"] == source_cid


### PR DESCRIPTION
## Defect and conservation law

`_with_census_partition` must preserve the canonical keys emitted by `_tally_cm_resolutions`; it must not reconstruct identity from `Counter` names. Provider projection could reach `ContextManagerResolutionConstructionGap` while enriching the table and erase the unresolved With seat that the census was required to conserve.

The law is exact:

`site:with-item == constructed + unconstructed`

There is no residual-kind taxonomy or fallback bucket.

## Exact rebased head and focused evidence

Authoritative head: `67c9a25668886365943303e43bf823de3fd0de8d`

- direct parent and merge-base: `4574d84beb1fd3edf3853b5233c55c9467e85045`
- commits over main: 1
- old `b8d3092a0914b84b223ccb1867ba0e5d26dd9aa8` is not an ancestor
- old/new stable patch-id: `112f16ae569f6ccfa52b953f2c735a932c0c527f`

Reproduced after rebase in one authenticated shell:

- 17 passed / 6 failed in 23 focused Battleaxe tests
- branch-relevant teeth: 16/16 green
  - With: 10/10
  - demand: 6/6
- the only failures were the same six pre-existing retired-`_measure_file` callers reproduced on bare main

## Corpus diagnostic provenance — not a rebased-head run

The corpus diagnostic was measured at pre-rebase head `b8d3092a0914b84b223ccb1867ba0e5d26dd9aa8`, not at the rebased head. No corpus re-run was performed after rebase.

The old and new commits have identical patch-id `112f16ae569f6ccfa52b953f2c735a932c0c527f`, so the corpus effect is carried as content-equivalent evidence. It is not represented as fresh testimony at `67c9a256…`.

Diagnostic population:

- pandas 3.0.3
- files: 1,421/1,421
- functions: 28,264
- receipt SHA-256: `4459fae7b0140750a19a33857da38bfac3d97076ffbe3ccdf54f28ece6ff25df`

## With-conservation result

Prior causal With-conservation refusals: 8. After the content-equivalent repair: 3.

Five cleared coordinates, with their prior unaccounted counts:

- `io/formats/xml.py`: 2
- `io/xml.py`: 4
- `tests/io/parser/common/test_file_buffer_url.py`: 20
- `tests/io/test_pickle.py`: 17
- `tests/io/test_sql.py`: 187

Three survivors are unchanged, including identical unaccounted counts:

- `io/parsers/readers.py`: 1
- `io/pytables.py`: 8
- `io/stata.py`: 3

These three survivors are a **known distinct second defect**, not a partial fix. Diagnose them separately; this PR makes no causal speculation about them.

The receipt's six `instrumentFailure` rows are **3 causes + 3 consequences**, not six defects. Each conservation refusal produces one consequent `edgeWitnesses-absent` row.

## Mandatory measurement status

**This does not produce a frontier width.** The receipt is `UNMEASURED` with `frontierWidth` **ABSENT**. Kobayashi requires `runtimeIdentity/v1` before any measured width, and that work is still in progress.

Landing this repair means the census can get further. It does not mean the census can speak.

## Six pre-existing focused failures

The six failures are exactly the stale retired-door callers tracked and being rewritten independently under #7168:

- `test_recensus_projects_construction_panic_as_a_loud_counted_gap`
- `test_mid_file_construction_panic_does_not_shrink_function_denominator`
- `test_control_effect_recensus_enumerates_one_file`
- `test_unresolved_with_is_typed_gap_on_enum_path`
- `test_with_census_injects_construction_context`
- `test_construction_gap_occurrence_counted_once`

They fail identically on bare control and on this head. They are not regressions caused by this repair and clear independently through #7168's enumerate-consumer rewrite.

## Scope and non-claims

- changed files: `lift_rpc.py` plus one With conservation tooth
- no category, kind, label, taxonomy, or residual-bucket additions
- no runner-autoscaler or CI-capacity changes
- no full conservation repair claimed
- no corpus run at the rebased head claimed
- no `frontierWidth` claimed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve canonical `With` demand rows when provider projection reaches a gap
> - In [lift_rpc.py](https://github.com/TSavo/sugar/pull/7170/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335), the `_handle_enumerate` handler now catches `ContextManagerResolutionConstructionGap` from `populate_source_derived_resource_refs` and ignores it instead of aborting with an internal error.
> - This allows enumeration to complete normally and return results even when a provider projection hits a gap, preserving canonical `With` demand rows.
> - A new test in [test_with_census_conservation.py](https://github.com/TSavo/sugar/pull/7170/files#diff-ad74fd1e5a9b313c7e8b6aaae9ee7a6982d6b3d43ddeb0536de5c1e1b305058e) verifies that a file with an unresolved with-seat returns exactly one `unconstructed` event with no gaps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67c9a25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context-manager resolution enumeration to continue when source-derived resource references cannot be fully constructed.
  * Preserved provisional resolution records instead of stopping enumeration.

* **Tests**
  * Added regression coverage confirming provider-call projections retain unresolved context-manager resolution records with accurate source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->