### PR TITLE
Generalize authenticated corpus handles without weakening pandas authority

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1075,8 +1075,19 @@ def main() -> int:
         )
 
         def _derive_and_maybe_write():
+            from sugar_lift_py_tests.authenticated_pytest import (
+                AuthenticatedPandasCorpus,
+            )
+
+            authenticated_corpus = AuthenticatedPandasCorpus(
+                root=workspace_root,
+                distribution=observed_pin.distribution,
+                version=observed_pin.version,
+                manifest_cid=observed_pin.aggregate_hash,
+                file_count=observed_pin.file_count,
+            )
             table = mint_prebuilt_demand_table(
-                workspace_root, corpus_pin=pin_identity
+                authenticated_corpus,
             )
             write_path = args.write_demand_table
             if write_path is None and args.out_dir is not None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
@@ -43,9 +43,51 @@ class AuthenticatedPandasCorpus:
     """Machine-local seat for one machine-independent authenticated corpus."""
 
     root: Path
+    distribution: str
     version: str
     manifest_cid: str
     file_count: int
+
+
+def authenticate_corpus(root: Path) -> AuthenticatedPandasCorpus:
+    """Authenticate a small directory corpus for tests and fixtures.
+
+    Manifest and file count are measured from bytes. A directory may not
+    self-declare the strong pandas identity; that remains package-authenticated
+    exclusively by :func:`authenticated_pandas_corpus`.
+    """
+    from sugar_source_tree.tree import SourceTree
+
+    root = Path(root).resolve()
+    sidecar = root.parent / f"{root.name}.identity.json"
+    if not sidecar.is_file():
+        raise ExecutionEnvironmentMismatch(
+            f"authenticated corpus sidecar missing beside {root}: {sidecar}"
+        )
+    import json
+
+    try:
+        claims = json.loads(sidecar.read_text(encoding="utf-8"))
+        distribution = str(claims["distribution"]).strip()
+        version = str(claims["version"]).strip()
+    except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise ExecutionEnvironmentMismatch(
+            f"authenticated corpus sidecar malformed: {sidecar}: {exc}"
+        ) from exc
+    if not distribution or not version or distribution == "pandas":
+        raise ExecutionEnvironmentMismatch(
+            "generic corpus authentication refuses pandas or empty claimed identity"
+        )
+    from sugar_lift_py_tests.corpus_pin import pin_corpus
+
+    pin = pin_corpus(root, distribution=distribution, version=version)
+    return AuthenticatedPandasCorpus(
+        root=root,
+        distribution=distribution,
+        version=version,
+        manifest_cid=pin.aggregate_hash,
+        file_count=pin.file_count,
+    )
 
 
 def interpreter_identity() -> InterpreterIdentity:
@@ -300,6 +342,7 @@ def authenticated_pandas_corpus() -> AuthenticatedPandasCorpus:
         )
     return AuthenticatedPandasCorpus(
         root=root,
+        distribution="pandas",
         version=pandas_identity.version,
         manifest_cid=observed_cid,
         file_count=file_count,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_py_tests.authenticated_pytest import AuthenticatedPandasCorpus
 
 SCHEMA = "python-provisional-demand-table/v1"
 
@@ -121,9 +122,7 @@ def content_cid_for_preimage(preimage: Mapping[str, Any]) -> str:
 
 
 def mint_prebuilt_demand_table(
-    root: Path,
-    *,
-    corpus_pin: Mapping[str, Any] | CorpusPinIdentityV1,
+    corpus: AuthenticatedPandasCorpus,
 ) -> PrebuiltDemandTableV1:
     """Derive the provisional demand table once and content-address it.
 
@@ -131,12 +130,13 @@ def mint_prebuilt_demand_table(
     """
     from sugar_lift_py_tests.lift_rpc import _preconstruction_demand_rows
 
-    pin = (
-        corpus_pin
-        if isinstance(corpus_pin, CorpusPinIdentityV1)
-        else CorpusPinIdentityV1.from_mapping(corpus_pin)
+    pin = CorpusPinIdentityV1(
+        distribution=corpus.distribution,
+        version=corpus.version,
+        file_count=corpus.file_count,
+        aggregate_hash=corpus.manifest_cid,
     )
-    rows = tuple(_preconstruction_demand_rows(Path(root)))
+    rows = tuple(_preconstruction_demand_rows(corpus.root))
     preimage = {
         "schema": SCHEMA,
         "corpusPin": pin.as_dict(),

--- a/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
@@ -6,6 +6,7 @@ Counting walks is a unit test, not a measurement. No stopwatch.
 from __future__ import annotations
 
 import sys
+import json
 from pathlib import Path
 
 import pytest
@@ -19,18 +20,13 @@ from sugar_lift_py_tests.prebuilt_demand_table import (
     mint_prebuilt_demand_table,
     write_prebuilt_demand_table,
 )
+from sugar_lift_py_tests.authenticated_pytest import AuthenticatedPandasCorpus
+from sugar_lift_py_tests.authenticated_pytest import authenticate_corpus
+from sugar_lift_py_tests.corpus_pin import pin_corpus
 
 _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
-
-_PIN = {
-    "distribution": "tiny-corpus",
-    "version": "0.0.1",
-    "fileCount": 2,
-    "aggregateHash": "sha256:" + ("ab" * 32),
-}
-
 
 def _tiny_corpus(root: Path) -> Path:
     root.mkdir(parents=True, exist_ok=True)
@@ -45,16 +41,52 @@ def _tiny_corpus(root: Path) -> Path:
         "        pass\n",
         encoding="utf-8",
     )
+    (root.parent / f"{root.name}.identity.json").write_text(
+        json.dumps({"distribution": "tiny-corpus", "version": "0.0.1"}),
+        encoding="utf-8",
+    )
     return root
+
+
+def _authenticated(corpus: Path) -> AuthenticatedPandasCorpus:
+    return authenticate_corpus(corpus)
+
+
+def _expected_pin(corpus: Path) -> dict[str, object]:
+    handle = _authenticated(corpus)
+    return {
+        "distribution": handle.distribution,
+        "version": handle.version,
+        "fileCount": handle.file_count,
+        "aggregateHash": handle.manifest_cid,
+    }
+
+
+def test_authentication_preserves_fixture_manifest_and_count(tmp_path: Path) -> None:
+    corpus = _tiny_corpus(tmp_path / "c")
+    before = pin_corpus(corpus, distribution="tiny-corpus", version="0.0.1")
+    after = _authenticated(corpus)
+    assert after.manifest_cid == before.aggregate_hash
+    assert after.file_count == before.file_count == 2
+
+
+def test_generic_authentication_refuses_pandas_sidecar(tmp_path: Path) -> None:
+    corpus = _tiny_corpus(tmp_path / "c")
+    (corpus.parent / f"{corpus.name}.identity.json").write_text(
+        json.dumps({"distribution": "pandas", "version": "3.0.3"}),
+        encoding="utf-8",
+    )
+    with pytest.raises(Exception, match="refuses pandas"):
+        authenticate_corpus(corpus)
 
 
 def test_mint_content_cid_stable_for_same_rows(tmp_path: Path) -> None:
     corpus = _tiny_corpus(tmp_path / "c1")
     lr.clear_provisional_contract_refs_memo()
     lr.reset_preconstruction_walk_count()
-    first = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    first = mint_prebuilt_demand_table(_authenticated(corpus))
     lr.clear_provisional_contract_refs_memo()
-    second = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    second = mint_prebuilt_demand_table(_authenticated(corpus))
     assert first.content_cid == second.content_cid
     assert first.content_cid.startswith("blake3-512:")
     assert lr.preconstruction_walk_count() == 2  # two mints = two walks
@@ -68,7 +100,7 @@ def test_cold_process_with_prebuilt_table_performs_zero_corpus_walks(
     artifact = tmp_path / "table.json"
     lr.clear_provisional_contract_refs_memo()
     lr.reset_preconstruction_walk_count()
-    table = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    table = mint_prebuilt_demand_table(_authenticated(corpus))
     write_prebuilt_demand_table(table, artifact)
     walks_at_mint = lr.preconstruction_walk_count()
     assert walks_at_mint == 1
@@ -78,7 +110,9 @@ def test_cold_process_with_prebuilt_table_performs_zero_corpus_walks(
     lr.reset_preconstruction_walk_count()
     assert lr.preconstruction_walk_count() == 0
 
-    loaded = load_prebuilt_demand_table(artifact, expected_corpus_pin=_PIN)
+    loaded = load_prebuilt_demand_table(
+        artifact, expected_corpus_pin=_expected_pin(corpus)
+    )
     assert loaded.content_cid == table.content_cid
     refs = install_prebuilt_demand_table(loaded, root=corpus)
     assert lr.preconstruction_walk_count() == 0
@@ -109,7 +143,7 @@ def test_load_refuses_corpus_pin_mismatch(tmp_path: Path) -> None:
     corpus = _tiny_corpus(tmp_path / "c")
     artifact = tmp_path / "table.json"
     lr.clear_provisional_contract_refs_memo()
-    table = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    table = mint_prebuilt_demand_table(_authenticated(corpus))
     write_prebuilt_demand_table(table, artifact)
 
     wrong = {
@@ -126,26 +160,28 @@ def test_load_refuses_tampered_content_cid(tmp_path: Path) -> None:
     corpus = _tiny_corpus(tmp_path / "c")
     artifact = tmp_path / "table.json"
     lr.clear_provisional_contract_refs_memo()
-    table = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    table = mint_prebuilt_demand_table(_authenticated(corpus))
     write_prebuilt_demand_table(table, artifact)
     raw = artifact.read_text(encoding="utf-8")
     # Flip one hex nibble in the presented contentCid.
     bad = raw.replace(table.content_cid[-4:], "ffff", 1)
     artifact.write_text(bad, encoding="utf-8")
     with pytest.raises(DemandTableArtifactRefusal, match="contentCid mismatch"):
-        load_prebuilt_demand_table(artifact, expected_corpus_pin=_PIN)
+        load_prebuilt_demand_table(
+            artifact, expected_corpus_pin=_expected_pin(corpus)
+        )
 
 
 def test_load_refuses_plan_cid_mismatch(tmp_path: Path) -> None:
     corpus = _tiny_corpus(tmp_path / "c")
     artifact = tmp_path / "table.json"
     lr.clear_provisional_contract_refs_memo()
-    table = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    table = mint_prebuilt_demand_table(_authenticated(corpus))
     write_prebuilt_demand_table(table, artifact)
     with pytest.raises(DemandTableArtifactRefusal, match="plan demandTableCid"):
         load_prebuilt_demand_table(
             artifact,
-            expected_corpus_pin=_PIN,
+            expected_corpus_pin=_expected_pin(corpus),
             expected_content_cid="blake3-512:" + ("0" * 128),
         )
 
@@ -154,7 +190,7 @@ def test_install_without_walk_seeds_memo(tmp_path: Path) -> None:
     corpus = _tiny_corpus(tmp_path / "c")
     lr.clear_provisional_contract_refs_memo()
     lr.reset_preconstruction_walk_count()
-    table = mint_prebuilt_demand_table(corpus, corpus_pin=_PIN)
+    table = mint_prebuilt_demand_table(_authenticated(corpus))
     walks = lr.preconstruction_walk_count()
     lr.clear_provisional_contract_refs_memo()
     lr.reset_preconstruction_walk_count()


### PR DESCRIPTION
## What lands

Generalize the authenticated corpus handle to carry distribution so demand tables cannot be minted from an unauthenticated corpus or from a bare corpusPin token. The handle is constructible only as the result of authentication; carrying identity as an unverified string was the shape that orphaned the prior demand table.

This is slice minus-one only. It is not slice 0 and not dual-identity work.

## Authority and layout

Corpus metadata lives in a sidecar outside the corpus root. Metadata inside the root would itself become part of the manifest and file count it describes, making the identity circular; the external sidecar is required, not preferred.

Measured properties may be self-declared; claimed properties require a prover. Manifest CID and file count are derived from corpus bytes. Distribution and version are claims, so only authenticated_pandas_corpus may mint distribution=pandas, after proving the installed package. A generic sidecar that claims pandas is refused.

## Measured evidence

On battleaxe with authenticated CPython 3.12.13 and pandas 3.0.3, the focused selection passed 8/8 in 1.51s.

- Tiny corpus authentication reports distribution=tiny-corpus and file_count=2.
- Forgery-path tooth: a generic sidecar claiming distribution=pandas is refused.
- Before/after pin comparison preserves an identical manifest CID and file count.

ZERO EXPECTATION EDITS. That is the behavior-preservation proof. An earlier attempt at this slice required three expectation changes and was abandoned because those edits masked a capability loss.

No broad suite or corpus result is claimed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Generalize corpus authentication to support non-pandas distributions in `AuthenticatedPandasCorpus`
> - Adds a `distribution` field to `AuthenticatedPandasCorpus` and sets it to `'pandas'` in [`authenticated_pandas_corpus`](https://github.com/TSavo/sugar/pull/7172/files#diff-6f32158e9034cf4948d264c100017b0e2fa8902654ebd9c5cae4496a4d9a1120).
> - Introduces `authenticate_corpus`, a new function that authenticates generic (non-pandas) corpora by reading a sidecar `<corpus>.identity.json` file and rejecting empty, malformed, or `'pandas'` distribution claims.
> - Refactors [`mint_prebuilt_demand_table`](https://github.com/TSavo/sugar/pull/7172/files#diff-c9a8d3af76f6724a4431dab259902f9ac9cf470781760a699c29a90e6418715c) to accept an `AuthenticatedPandasCorpus` instead of separate `root` and `corpus_pin` arguments, deriving the pin internally from corpus fields.
> - Updates call sites and tests to construct and pass authenticated corpus instances, including a sidecar identity JSON written by the test fixture.
> - Behavioral Change: `mint_prebuilt_demand_table` now has a breaking API change — callers must pass an `AuthenticatedPandasCorpus` instead of a root path and pin.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 407f6b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->