### PR TITLE
Separate demand-table storage and semantic identities

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
@@ -106,6 +106,29 @@ class DemandTableIdentityV1:
             "fileCount": self.file_count,
         }
 
+    def as_dict(self) -> dict[str, object]:
+        body = dict(self.preimage())
+        body["contentKey"] = self.content_key
+        return body
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, object]) -> "DemandTableIdentityV1":
+        required = ("contentKey", "corpusManifestCid", "schemaVersion",
+                    "producerSourceCid", "resolutionConfigCid",
+                    "parserIdentity", "fileCount")
+        missing = [key for key in required if key not in raw]
+        if missing:
+            raise ValueError(f"demand table semantic identity missing fields: {missing}")
+        return cls(
+            content_key=str(raw["contentKey"]),
+            corpus_manifest_cid=str(raw["corpusManifestCid"]),
+            schema_version=str(raw["schemaVersion"]),
+            producer_source_cid=str(raw["producerSourceCid"]),
+            resolution_config_cid=str(raw["resolutionConfigCid"]),
+            parser_identity=str(raw["parserIdentity"]),
+            file_count=int(raw["fileCount"]),
+        )
+
 
 @dataclass(frozen=True)
 class CorpusManifestDigestAliasesV1:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
@@ -27,6 +27,7 @@ from typing import Any, Mapping
 
 from sugar_lift_python_source.canonical import cid_of_json
 from sugar_lift_py_tests.authenticated_pytest import AuthenticatedPandasCorpus
+from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1, demand_table_identity
 
 SCHEMA = "python-provisional-demand-table/v1"
 
@@ -101,6 +102,7 @@ class PrebuiltDemandTableV1:
     content_cid: str
     corpus_pin: CorpusPinIdentityV1
     rows: tuple[dict[str, Any], ...]
+    semantic_identity: DemandTableIdentityV1
     schema: str = SCHEMA
 
     def preimage(self) -> dict[str, Any]:
@@ -114,6 +116,7 @@ class PrebuiltDemandTableV1:
     def to_json_dict(self) -> dict[str, Any]:
         body = self.preimage()
         body["contentCid"] = self.content_cid
+        body["semanticIdentity"] = self.semantic_identity.as_dict()
         return body
 
 
@@ -137,6 +140,11 @@ def mint_prebuilt_demand_table(
         aggregate_hash=corpus.manifest_cid,
     )
     rows = tuple(_preconstruction_demand_rows(corpus.root))
+    semantic_identity = demand_table_identity(
+        corpus.root,
+        sorted(corpus.root.rglob("*.py")),
+        source_root=Path(__file__).resolve().parents[1],
+    )
     preimage = {
         "schema": SCHEMA,
         "corpusPin": pin.as_dict(),
@@ -146,6 +154,7 @@ def mint_prebuilt_demand_table(
         content_cid=content_cid_for_preimage(preimage),
         corpus_pin=pin,
         rows=rows,
+        semantic_identity=semantic_identity,
     )
 
 
@@ -192,6 +201,12 @@ def load_prebuilt_demand_table(
             f"prebuilt demand table schema mismatch got={raw.get('schema')!r} "
             f"want={SCHEMA!r}"
         )
+    try:
+        semantic_identity = DemandTableIdentityV1.from_mapping(raw.get("semanticIdentity") or {})
+    except (TypeError, ValueError) as exc:
+        raise DemandTableArtifactRefusal(
+            f"prebuilt demand table semantic identity invalid: {exc}"
+        ) from exc
     if not isinstance(raw.get("rows"), list):
         raise DemandTableArtifactRefusal("prebuilt demand table carries no rows list")
     pin = CorpusPinIdentityV1.from_mapping(raw.get("corpusPin") or {})
@@ -228,6 +243,7 @@ def load_prebuilt_demand_table(
         content_cid=str(presented),
         corpus_pin=pin,
         rows=tuple(raw["rows"]),
+        semantic_identity=semantic_identity,
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
@@ -92,6 +92,18 @@ def test_mint_content_cid_stable_for_same_rows(tmp_path: Path) -> None:
     assert lr.preconstruction_walk_count() == 2  # two mints = two walks
 
 
+def test_mint_carries_distinct_storage_and_semantic_identities(tmp_path: Path) -> None:
+    first_corpus = _tiny_corpus(tmp_path / "first")
+    second_corpus = _tiny_corpus(tmp_path / "second")
+    (second_corpus / "b.py").write_text("def different():\n    return 2\n", encoding="utf-8")
+    first = mint_prebuilt_demand_table(_authenticated(first_corpus))
+    second = mint_prebuilt_demand_table(_authenticated(second_corpus))
+    assert first.semantic_identity.content_key != second.semantic_identity.content_key
+    assert first.content_cid != second.content_cid
+    assert first.content_cid == first.to_json_dict()["contentCid"]
+    assert first.semantic_identity.as_dict()["contentKey"] != first.content_cid
+
+
 def test_cold_process_with_prebuilt_table_performs_zero_corpus_walks(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What lands

Minted demand tables now carry two identities with distinct roles:

- contentCid is the storage key: the hash of the serialized payload preimage.
- semanticIdentity is the meaning: corpusManifestCid, schemaVersion, producerSourceCid, resolutionConfigCid, parserIdentity, and fileCount.

Conflating these roles is exactly what orphaned the July demand table. A caller-supplied recipe identity was used as a storage key, was never proven equal to the payload hash, and became unreachable when e0598d3ad began hashing payloads at publish. Separating storage identity from semantic identity makes that orphan class impossible: neither identity stands in for the other.

## Discrimination and evidence

The load-bearing discriminator changes the corpus and proves that the semantic identity and storage payload both change while remaining independently derived: the semantic identity CID is not the payload contentCid. This is the proof that the two roles are not one identity wearing two names.

Focused battleaxe selection: 9/9 passed in 1.11s.

ZERO EXPECTATION EDITS. Existing behavior expectations were preserved.

This is slice 1 only. No broad suite, corpus magnitude, or completed demand-table publication is claimed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Separate semantic identity from storage identity in prebuilt demand tables
> - Adds `DemandTableIdentityV1` in [demand_table_identity.py](https://github.com/TSavo/sugar/pull/7173/files#diff-e2634b6c8c519b6db39aaaaf4c06749e13de74ddf792b909d25b5f74017f3165) to represent a semantic identity derived from source files, distinct from the content-addressed `contentCid`.
> - `PrebuiltDemandTableV1` now carries a `semantic_identity` field; minting computes it from the corpus root and Python source files, and loading validates its presence.
> - JSON output gains a `semanticIdentity` object alongside `contentCid`, and the loader rejects artifacts missing a valid `semanticIdentity`.
> - Behavioral Change: existing prebuilt demand table artifacts without a `semanticIdentity` field will be rejected by the loader.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93dac30.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->