### PR TITLE
Add a standalone demand-table identity validator

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
@@ -40,6 +40,10 @@ class DemandTableArtifactRefusal(ValueError):
     """Artifact is missing, malformed, or its contentCid does not recompute."""
 
 
+class DemandTableSemanticIdentityMismatch(DemandTableArtifactRefusal):
+    """Table meaning does not describe the authenticated current corpus."""
+
+
 @dataclass(frozen=True)
 class CorpusPinIdentityV1:
     """Minimal corpus pin fields the demand table authenticates against."""
@@ -122,6 +126,40 @@ class PrebuiltDemandTableV1:
 
 def content_cid_for_preimage(preimage: Mapping[str, Any]) -> str:
     return cid_of_json(dict(preimage))
+
+
+def validate_prebuilt_demand_table(
+    table: PrebuiltDemandTableV1,
+    corpus: AuthenticatedPandasCorpus,
+    *,
+    source_root: Path | None = None,
+    config: Mapping[str, object] | None = None,
+) -> None:
+    """Validate storage bytes and semantic meaning against current inputs.
+
+    This is intentionally standalone: Slice 2 defines the shared door, while
+    workers begin consuming it only in Slice 3.
+    """
+    payload_cid = content_cid_for_preimage(table.preimage())
+    if payload_cid != table.content_cid:
+        raise DemandTableArtifactRefusal(
+            f"demand table payload contentCid mismatch: "
+            f"presented={table.content_cid!r} recomputed={payload_cid!r}"
+        )
+    root = corpus.root
+    expected_identity = demand_table_identity(
+        root,
+        sorted(root.rglob("*.py")),
+        source_root=source_root or Path(__file__).resolve().parents[1],
+        config=config,
+    )
+    if table.semantic_identity != expected_identity:
+        raise DemandTableSemanticIdentityMismatch(
+            "demand table semantic identity mismatch: "
+            f"table={table.semantic_identity.as_dict()!r} "
+            f"expected={expected_identity.as_dict()!r}; "
+            "refuse table for a different corpus, producer, parser, or config"
+        )
 
 
 def mint_prebuilt_demand_table(

--- a/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
@@ -18,6 +18,8 @@ from sugar_lift_py_tests.prebuilt_demand_table import (
     install_prebuilt_demand_table,
     load_prebuilt_demand_table,
     mint_prebuilt_demand_table,
+    validate_prebuilt_demand_table,
+    DemandTableSemanticIdentityMismatch,
     write_prebuilt_demand_table,
 )
 from sugar_lift_py_tests.authenticated_pytest import AuthenticatedPandasCorpus
@@ -102,6 +104,22 @@ def test_mint_carries_distinct_storage_and_semantic_identities(tmp_path: Path) -
     assert first.content_cid != second.content_cid
     assert first.content_cid == first.to_json_dict()["contentCid"]
     assert first.semantic_identity.as_dict()["contentKey"] != first.content_cid
+
+
+def test_validator_accepts_current_table(tmp_path: Path) -> None:
+    corpus = _tiny_corpus(tmp_path / "c")
+    handle = _authenticated(corpus)
+    table = mint_prebuilt_demand_table(handle)
+    validate_prebuilt_demand_table(table, handle)
+
+
+def test_validator_refuses_table_for_different_corpus(tmp_path: Path) -> None:
+    corpus = _tiny_corpus(tmp_path / "c")
+    other = _tiny_corpus(tmp_path / "other")
+    (other / "b.py").write_text("def different():\n    return 2\n", encoding="utf-8")
+    table = mint_prebuilt_demand_table(_authenticated(corpus))
+    with pytest.raises(DemandTableSemanticIdentityMismatch, match="semantic identity mismatch"):
+        validate_prebuilt_demand_table(table, _authenticated(other))
 
 
 def test_cold_process_with_prebuilt_table_performs_zero_corpus_walks(


### PR DESCRIPTION
## What lands

Add a shared validator that independently recomputes both demand-table identities from current inputs:

- payload contentCid from the payload preimage, for storage integrity
- semantic identity from the current authenticated corpus, producer source, resolution config, parser identity, and file count, for meaning

The validator is deliberately standalone. Slice 3 workers remain untouched, so this changes no measurement behavior yet. It makes the floors CAPABLE of validating a current table; it does not yet let them consume that validation. Refusal machinery lands before anything depends on it. Slice 3 replaces the hardcoded SHARED_DEMAND_TABLE_CONTENT_KEY check.

## Discrimination and evidence

Focused battleaxe selection: 11/11 passed in 1.26s.

- Current-table validation arm PASSED.
- Mismatched-corpus arm REFUSED with the named DemandTableSemanticIdentityMismatch.

The named refusal is load-bearing. Acceptance alone would be half a validator and would leave open the same door the orphaned July table crossed.

No worker consumption, measurement behavior change, repaired floor axis, corpus magnitude, or broad-suite result is claimed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `validate_prebuilt_demand_table` to verify demand table identity against a corpus
> - Adds `validate_prebuilt_demand_table(table, corpus)` in [`prebuilt_demand_table.py`](https://github.com/TSavo/sugar/pull/7175/files#diff-c9a8d3af76f6724a4431dab259902f9ac9cf470781760a699c29a90e6418715c) that checks both content CID integrity and semantic identity against an `AuthenticatedPandasCorpus`.
> - Adds `DemandTableSemanticIdentityMismatch`, a new exception subclassing `DemandTableArtifactRefusal`, raised when the table's semantic identity does not match the recomputed identity for the current corpus.
> - Adds two tests covering the accept and reject cases in [`test_prebuilt_demand_table.py`](https://github.com/TSavo/sugar/pull/7175/files#diff-d0bfca5fa44601c91de7ce0dbb42184e1b0666656cddfb459faefc7145e54460).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2425ddc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for prebuilt demand tables.
  * Tables are checked against their payload integrity and current corpus inputs.
  * Added a dedicated error for tables with mismatched semantic identities.

* **Bug Fixes**
  * Prevented demand tables from being accepted when used with an incompatible corpus.
  * Added coverage confirming valid tables remain accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->