### PR TITLE
Preserve directory artifacts through brun sync-back

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -568,23 +568,60 @@ sugar_bx_run_docker() {
 
 sugar_bx_is_foreign() { [[ "$(uname -s 2>/dev/null)" != Linux ]] && [[ "$(file -b "$1" 2>/dev/null || true)" == *ELF* ]]; }
 sugar_bx_sync_back() {
-  local remote="$1" local_path="$2" tmp transfer_status
+  local remote="$1" local_path="$2" staging payload artifact prior
+  local remote_base transfer_status deposit_status restore_status
   if [[ "${SUGAR_BX_LOCAL:-0}" == 1 && "$remote" == "$local_path" ]]; then return 0; fi
-  mkdir -p "$(dirname "$local_path")"; tmp="$(mktemp "${local_path}.sugar-bx-sync.XXXXXX")"
+  while [[ "$local_path" != / && "$local_path" == */ ]]; do local_path="${local_path%/}"; done
+  mkdir -p "$(dirname "$local_path")"
+  staging="$(mktemp -d "${local_path}.sugar-bx-sync.XXXXXX")" || return $?
+  payload="$staging/payload"
   local src="$SUGAR_BX_HOST:$remote"
   [[ "${SUGAR_BX_LOCAL:-0}" == 1 ]] && src="$remote"
-  if "$SUGAR_BX_RSYNC" -az "$src" "$tmp"; then
+  if "$SUGAR_BX_RSYNC" -az "$src" "$payload"; then
     :
   else
     transfer_status=$?
-    rm -f "$tmp"
+    rm -rf "$staging"
     return "$transfer_status"
   fi
-  if sugar_bx_is_foreign "$tmp"; then
-    echo "sugarbin: refusing to deposit foreign-platform binary: crime=foreign-platform-binary owner=bin/lib/sugar-bx.sh path=$local_path replacement=run the binary on $SUGAR_BX_HOST or rebuild locally" >&2
-    rm -f "$tmp"; [[ -e "$local_path" ]] && sugar_bx_is_foreign "$local_path" && rm -f "$local_path"; return 0
+  artifact="$payload"
+  if [[ "$remote" != */ && -d "$payload" ]]; then
+    remote_base="${remote##*/}"
+    [[ ! -d "$payload/$remote_base" ]] || artifact="$payload/$remote_base"
   fi
-  mv -f "$tmp" "$local_path"
+  if sugar_bx_is_foreign "$artifact"; then
+    echo "sugarbin: refusing to deposit foreign-platform binary: crime=foreign-platform-binary owner=bin/lib/sugar-bx.sh path=$local_path replacement=run the binary on $SUGAR_BX_HOST or rebuild locally" >&2
+    rm -rf "$staging"; [[ -e "$local_path" ]] && sugar_bx_is_foreign "$local_path" && rm -f "$local_path"; return 0
+  fi
+  prior=""
+  if [[ -e "$local_path" || -L "$local_path" ]]; then
+    prior="$staging/prior"
+    if mv "$local_path" "$prior"; then
+      :
+    else
+      deposit_status=$?
+      rm -rf "$staging"
+      return "$deposit_status"
+    fi
+  fi
+  if mv "$artifact" "$local_path"; then
+    rm -rf "$staging"
+    return 0
+  else
+    deposit_status=$?
+    if [[ -z "$prior" ]]; then
+      rm -rf "$staging"
+      return "$deposit_status"
+    fi
+    if mv "$prior" "$local_path"; then
+      rm -rf "$staging"
+      return "$deposit_status"
+    else
+      restore_status=$?
+      echo "sugarbin: crime=sync-back-prior-restore-failed local=$local_path staged_prior=$prior deposit_status=$deposit_status restore_status=$restore_status replacement=restore the byte-preserved prior from staged_prior; do not treat LOCAL existence as evidence" >&2
+      return "$restore_status"
+    fi
+  fi
 }
 sugar_bx_cleanup() { sugar_bx_ssh "rm -rf $(sugar_bx_quote "$SUGAR_BX_ROOT")"; }
 sugar_bx_finish() { local status="$1"; if [[ "$SUGAR_BX_CLEAN" == always || ( "$SUGAR_BX_CLEAN" == success && "$status" == 0 ) ]]; then sugar_bx_cleanup || true; fi; return "$status"; }

--- a/tests/sugarbin_bx_exec.sh
+++ b/tests/sugarbin_bx_exec.sh
@@ -101,4 +101,129 @@ if [[ "$(uname -s)" != Linux ]]; then
   grep -Fq 'crime=foreign-platform-binary' "$tmp/elf.err" || fail "foreign ELF diagnostic missing"
 fi
 
+# Directory artifacts cross the real rsync boundary. Existence is not
+# testimony: compare the complete physical file population and every byte.
+# Exercise both rsync source spellings because requiring a trailing slash
+# would leave existing callers with a directory-without-slash trap.
+assert_tree_identical() {
+  local expected="$1" actual="$2" expected_files actual_files relative
+  expected_files="$tmp/expected-files.txt"
+  actual_files="$tmp/actual-files.txt"
+  (cd "$expected" && find . -type f -print | LC_ALL=C sort) >"$expected_files"
+  (cd "$actual" && find . -type f -print | LC_ALL=C sort) >"$actual_files"
+  cmp "$expected_files" "$actual_files" \
+    || fail "directory sync changed the physical file population"
+  while IFS= read -r relative; do
+    cmp "$expected/$relative" "$actual/$relative" \
+      || fail "directory sync changed bytes at $relative"
+  done <"$expected_files"
+}
+
+real_rsync="$(command -v rsync)"
+real_source="$tmp/real-directory-source"
+mkdir -p "$real_source/nested/deeper"
+printf 'root-evidence\n' >"$real_source/root.txt"
+printf 'nested-evidence\n' >"$real_source/nested/report.json"
+printf '\000\001\002binary-evidence\377' >"$real_source/nested/deeper/payload.bin"
+mkdir -p "$tmp/real-directory-trailing"
+
+(
+  # Directly exercise the production sync door with real rsync. SUGAR_BX_LOCAL
+  # changes transport only; staging and deposit are the production function.
+  source "$repo_root/bin/lib/sugar-bx.sh"
+  SUGAR_BX_LOCAL=1
+  SUGAR_BX_HOST=local-test
+  SUGAR_BX_RSYNC="$real_rsync"
+  sugar_bx_sync_back "$real_source/" "$tmp/real-directory-trailing/"
+)
+assert_tree_identical "$real_source" "$tmp/real-directory-trailing"
+
+(
+  source "$repo_root/bin/lib/sugar-bx.sh"
+  SUGAR_BX_LOCAL=1
+  SUGAR_BX_HOST=local-test
+  SUGAR_BX_RSYNC="$real_rsync"
+  sugar_bx_sync_back "$real_source" "$tmp/real-directory-no-slash"
+)
+assert_tree_identical "$real_source" "$tmp/real-directory-no-slash"
+
+# A successful replacement is a tree replacement, not a merge that can retain
+# plausible stale evidence from the prior run.
+replacement_destination="$tmp/real-directory-replacement"
+mkdir -p "$replacement_destination/stale"
+printf 'must-disappear\n' >"$replacement_destination/stale/old-row.json"
+(
+  source "$repo_root/bin/lib/sugar-bx.sh"
+  SUGAR_BX_LOCAL=1
+  SUGAR_BX_HOST=local-test
+  SUGAR_BX_RSYNC="$real_rsync"
+  sugar_bx_sync_back "$real_source/" "$replacement_destination/"
+)
+assert_tree_identical "$real_source" "$replacement_destination"
+
+# The directory staging path must preserve the already-proven file contract.
+real_file_source="$tmp/real-file-source.bin"
+real_file_destination="$tmp/real-file-destination.bin"
+printf '\000\377file-evidence\001\002' >"$real_file_source"
+printf 'stale-file-evidence\n' >"$real_file_destination"
+(
+  source "$repo_root/bin/lib/sugar-bx.sh"
+  SUGAR_BX_LOCAL=1
+  SUGAR_BX_HOST=local-test
+  SUGAR_BX_RSYNC="$real_rsync"
+  sugar_bx_sync_back "$real_file_source" "$real_file_destination"
+)
+cmp "$real_file_source" "$real_file_destination" \
+  || fail "directory staging regressed file sync-back bytes"
+
+# Empty is valid only when the source is itself empty.
+empty_source="$tmp/real-empty-source"
+mkdir -p "$empty_source"
+(
+  source "$repo_root/bin/lib/sugar-bx.sh"
+  SUGAR_BX_LOCAL=1
+  SUGAR_BX_HOST=local-test
+  SUGAR_BX_RSYNC="$real_rsync"
+  sugar_bx_sync_back "$empty_source/" "$tmp/real-empty-destination/"
+)
+[[ -d "$tmp/real-empty-destination" ]] \
+  || fail "empty source directory did not produce a directory artifact"
+[[ -z "$(find "$tmp/real-empty-destination" -mindepth 1 -print -quit)" ]] \
+  || fail "empty source directory acquired fabricated content"
+
+# Recovery is part of the evidence contract, not cleanup trivia. Force only
+# the final staged-artifact deposit to fail, after PRIOR has moved aside, and
+# require the entire prior tree to return byte-identical.
+prior_expected="$tmp/prior-expected"
+prior_destination="$tmp/prior-destination"
+mkdir -p "$prior_expected/nested" "$prior_destination"
+printf 'prior-root\n' >"$prior_expected/root.txt"
+printf 'prior-nested\n' >"$prior_expected/nested/report.json"
+printf '\377\003prior-binary\000' >"$prior_expected/nested/payload.bin"
+"$real_rsync" -a "$prior_expected/" "$prior_destination/"
+
+status=0
+(
+  source "$repo_root/bin/lib/sugar-bx.sh"
+  SUGAR_BX_LOCAL=1
+  SUGAR_BX_HOST=local-test
+  SUGAR_BX_RSYNC="$real_rsync"
+  failed_deposit=0
+  mv() {
+    if [[ "$failed_deposit" == 0 && "$1" == *'.sugar-bx-sync.'*'/payload' \
+        && "$2" == "$prior_destination" ]]; then
+      failed_deposit=1
+      return 71
+    fi
+    command mv "$@"
+  }
+  sugar_bx_sync_back "$real_source/" "$prior_destination/"
+) || status=$?
+[[ "$status" -eq 71 ]] \
+  || fail "forced deposit failure returned $status, want 71"
+assert_tree_identical "$prior_expected" "$prior_destination"
+[[ -z "$(find "$(dirname "$prior_destination")" -maxdepth 1 \
+  -name "$(basename "$prior_destination").sugar-bx-sync.*" -print -quit)" ]] \
+  || fail "deposit recovery left a staged prior tree behind"
+
 echo "PASS: sugarbin bx execution contract"


### PR DESCRIPTION
A FAILED run returned wrapper=23 and still delivered its COMPLETE directory evidence tree byte-identical per file. This extends the failed-run evidence-survival property #7167 proved for individual files to directory artifacts; it would have preserved the 1,418-file exposure receipt without read-only SSH recovery.

## Defect and repair

RED mechanism: directory sync-back targeted a pre-created temporary FILE, so rsync refused the directory with mkpath: Not a directory. An instrument producing a directory of evidence could lose the whole directory at the sync boundary.

The repair stages into a directory and deposits transactionally while preserving payload-status precedence and the existing gates. Comparisons are per-file population and byte identity throughout, never mere existence.

## Real gated arms

3/3 real gated arms passed under authenticated pandas 3.0.3 / 1,421 files with CPU idle 98.91-99.94 percent:

- failed directory run: wrapper=23, complete directory artifact byte-identical per file
- successful directory run: wrapper=0, complete directory artifact byte-identical per file
- existing individual-file run: wrapper=0, artifact byte-identical

Legitimately empty source directories remain accepted. Empty is lawful when the authenticated source directory is actually empty; this repair does not tighten that case into a false refusal.

## Transactional restore tooth

A forced final deposit failure returned status 71, restored the complete prior directory tree byte-identical, and left NO STAGING RESIDUE. This directly exercises recovery code that runs only after deposit failure.

## Scope and focused evidence

Changed only bin/lib/sugar-bx.sh and tests/sugarbin_bx_exec.sh. Load gates, authentication gates, and status precedence are untouched.

Fresh focused teeth passed: sugarbin_bx_exec, brun_remote_exec, shell syntax, and diff-check.

## Non-claims

No arbitrary metadata identity is claimed. No frontier width, remaining-work magnitude, #7171 repair, or recovered-panic magnitude is claimed.

Closes #7174.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve directory artifacts through `sugar_bx_sync_back` using transactional staging
> - Reworks [`sugar_bx_sync_back`](https://github.com/TSavo/sugar/pull/7176/files#diff-bdd6c46eb799e81d8c3cc8b50ab4a809668391cedbc25e468f6efe8ef9d86ebc) to sync into a staging directory instead of a single temp file, enabling correct handling of directory sources with or without trailing slashes.
> - Replaces the destination tree atomically: moves the prior destination aside, then moves the artifact into place, restoring the prior if the deposit fails.
> - Performs the foreign-platform ELF check on the resolved artifact path rather than the raw rsync target.
> - Adds end-to-end tests in [`tests/sugarbin_bx_exec.sh`](https://github.com/TSavo/sugar/pull/7176/files#diff-ee5086cda720f4c77597cc34a4be4f6bd55e46d53a352f3481d01a7f7dd46907) covering directory/file sync, replacement semantics, empty directory handling, and transactional recovery on deposit failure.
> - Behavioral Change: directory sync now fully replaces the destination tree rather than merging; rsync and `mv` exit statuses now propagate to the caller.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3578526.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->