### PR TITLE
Authenticate the exact known path-smoke panic identities

### DIFF
--- a/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/README.md
+++ b/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/README.md
@@ -10,8 +10,11 @@ Planted teeth (mr_blue conservation fixtures + panic):
 | --- | --- |
 | `planted_constructed_with.py` | one with-item; inject SourceDerived → constructed≥1 |
 | `planted_opaque_with.py` | one with-item; unconstructed and accounted, not silently dropped |
-| `planted_clean.py` | no with; completed row |
-| panic plant | ConstructionPanic enrolled as cpanic=1 (harness inject) |
+| `planted_clean.py` | no with; authentic `Module.sugar` first terminal at the module coordinate |
+| panic plant | injected `recensus-path-smoke-planted-panic` first terminal at the roster entrance |
+
+The panic tooth compares the complete stable identity rows for both terminals.
+It does not accept a count: a duplicate and a missing terminal cannot cancel.
 
 Smoke retires the serial rot tax of full-corpus walks for *path integrity*
 defects. It does **not** retire the full pandas walk or Class B aggregation

--- a/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/planted_clean.py
+++ b/implementations/python/sugar-lift-py-tests/fixtures/recensus_path_smoke/planted_clean.py
@@ -1,4 +1,4 @@
-"""Clean function plant — completed row, no with-items."""
+"""No-With plant whose authentic first terminal is unwritten ``Module.sugar``."""
 
 
 def ok():

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
@@ -8,8 +8,9 @@ WALLS (advisor, binding):
      and refuse CommitMeasurement panics ingestion by construction.
   2. SCOREBOARD_AUTHORITY stays False here. Sole bankable panics producer is
      control_effect_recensus on the authenticated pandas corpus.
-  3. Teeth are the instrument: constructed>0, cpanic=1, unconstructed not
-     vanish, exact two-item accounting closes, sealed body on PATH_OK.
+  3. Teeth are the instrument: constructed>0, the exact named construction-
+     panic identities are conserved, unconstructed does not vanish, exact
+     two-item accounting closes, sealed body on PATH_OK.
      Crash → PATH_UNMEASURED.
   4. Coverage honesty: four planted files retire serial path-rot discovery,
      not Class B corpus scale (thousands of with-items) or the full walk.
@@ -56,6 +57,49 @@ _FORBIDDEN_PRODUCT_KEYS = frozenset(
         "SCOREBOARD_AUTHORITY",
     }
 )
+
+_EXPECTED_CONSTRUCTION_PANIC_IDENTITIES = (
+    {
+        "file": "planted_clean.py",
+        "owner": "Module.sugar",
+        "coordinate": "planted_clean.py:1:0-6:0[Module]",
+        "observedEventType": "sugar_source_tree.panic.SugarNotWritten",
+        "requested": "a constructed sugar object",
+        "entrance": "sugar.enumerate:facts:auditFrontier",
+    },
+    {
+        "file": "planted_panic_host.py",
+        "owner": "recensus-path-smoke-planted-panic",
+        "coordinate": "planted_panic_host.py:1:0",
+        "observedEventType": "sugar_lift_py_tests.gap.panic.ConstructionPanic",
+        "requested": "constructed value",
+        "entrance": "sugar.enumerate:roster",
+    },
+)
+
+
+def _construction_panic_identity(panic: dict[str, Any]) -> dict[str, str | None]:
+    """Project the stable fields that distinguish real terminals and duplicates."""
+    return {
+        key: panic.get(key) if isinstance(panic.get(key), str) else None
+        for key in (
+            "file",
+            "owner",
+            "coordinate",
+            "observedEventType",
+            "requested",
+            "entrance",
+        )
+    }
+
+
+def _sorted_panic_identities(
+    panics: list[dict[str, Any]],
+) -> list[dict[str, str | None]]:
+    return sorted(
+        (_construction_panic_identity(panic) for panic in panics),
+        key=lambda row: tuple(str(row.get(key) or "") for key in sorted(row)),
+    )
 
 
 def _narrate(msg: str) -> None:
@@ -260,7 +304,7 @@ def _measure_opaque(module, path: Path, workspace: Path) -> dict[str, Any]:
 
 
 def _measure_clean(module, path: Path, workspace: Path) -> dict[str, Any]:
-    """Production enumerate consumer for a clean function."""
+    """Production enumerate consumer for the planted Module.sugar terminal."""
     import shutil
     import tempfile
 
@@ -333,6 +377,7 @@ def _run_teeth(
     with_items_total: int,
     accounted: int,
     cpanic: int,
+    construction_panics: list[dict[str, Any]],
     conserves: bool,
     sealed_path: Path | None,
     path_verdict_so_far: str,
@@ -355,10 +400,23 @@ def _run_teeth(
     else:
         fail("known_constructed", f"constructed={constructed} expected >0")
 
-    if cpanic == 1:
-        ok("known_panic", f"cpanic={cpanic}")
+    observed_panic_identities = _sorted_panic_identities(construction_panics)
+    expected_panic_identities = _sorted_panic_identities(
+        [dict(row) for row in _EXPECTED_CONSTRUCTION_PANIC_IDENTITIES]
+    )
+    if observed_panic_identities == expected_panic_identities:
+        ok(
+            "known_panic",
+            "exact terminal identities conserved: "
+            + json.dumps(observed_panic_identities, sort_keys=True),
+        )
     else:
-        fail("known_panic", f"cpanic={cpanic} expected 1")
+        fail(
+            "known_panic",
+            f"cpanic={cpanic}; exact terminal identity mismatch: "
+            f"observed={json.dumps(observed_panic_identities, sort_keys=True)} "
+            f"expected={json.dumps(expected_panic_identities, sort_keys=True)}",
+        )
 
     if unconstructed >= 1:
         ok("known_unconstructed", f"unconstructed={unconstructed}")
@@ -606,6 +664,9 @@ def main(argv: list[str] | None = None) -> int:
             "constructed": constructed,
             "unconstructed": unconstructed,
             "cpanic": cpanic,
+            "constructionPanicIdentities": _sorted_panic_identities(
+                construction_panics
+            ),
             "families": dict(sorted(families.items())),
             "cmResolutions": dict(sorted(cm.items())),
             "firstTerminalChain": first_terminal_chain,
@@ -648,6 +709,7 @@ def main(argv: list[str] | None = None) -> int:
             with_items_total=with_items_total,
             accounted=accounted,
             cpanic=cpanic,
+            construction_panics=construction_panics,
             conserves=conserves,
             sealed_path=sealed,
             path_verdict_so_far="PATH_OK",


### PR DESCRIPTION
## Why

The recensus path smoke previously asserted only a construction-panic count. After #7178 seated the D3 reporter correctly, a second real panic became visible and the count-only tooth went red. Merely changing the expected count to two would make the check green without preserving what the two terminals mean.

This change strengthens the tooth to authenticate the complete stable identity of both exact terminals and to prove they are distinct:

- the newly visible real terminal in `planted_clean.py`: owner `Module.sugar`, coordinate `planted_clean.py:1:0-6:0[Module]`, event `sugar_source_tree.panic.SugarNotWritten`, entrance `sugar.enumerate:facts:auditFrontier`
- the injected fixture terminal in `planted_panic_host.py`: owner `recensus-path-smoke-planted-panic`, coordinate `planted_panic_host.py:1:0`, event `sugar_lift_py_tests.gap.panic.ConstructionPanic`, entrance `sugar.enumerate:roster`

The identities are compared as complete rows, so a missing terminal and a duplicate cannot cancel into an accepted count.

The second panic is real and was previously discarded by the null-reporter defect. It is the same missing `Module.sugar` construct that accounts for all 1,418 first-terminal occurrences in the authenticated corpus exposure measurement. The micro-population is reproducing the corpus outer mask, not a fixture quirk.

## Measured evidence

At exact head `eaf6839c455fdbb6561270e87df08bc9c7588dc5`:

- positive recensus path smoke: `PATH_OK`
- `constructed_zero`: bites as `PATH_RED / known_constructed`
- `swallow_panic`: bites as `PATH_RED / known_panic`
- `drop_opaque`: bites as `PATH_RED / known_unconstructed`
- `crash_mid`: bites as `PATH_UNMEASURED / crash_not_green`

The change is three files only: the fixture script, the fixture description, and the no-With fixture description. It adds no category, kind, label, taxonomy, residual bucket, runner-autoscaler change, or CI-capacity change.

## Shot accounting

Predicted impact: the shared `known_panic` path-smoke red on main becomes `PATH_OK` by authenticating both real identities, while all four negative arms remain able to fail. Floors preserved: no count-only expectation bump, no deleted tests, no weakened lie, and no product scoreboard authority.

Not claimed: corpus frontier width, remaining-work count, full-suite green, or any measurement for the separate With-survivor repair. That branch remains corpus-unmeasured and is not queued.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate exact construction panic identities in `_run_teeth` instead of checking count
> - Replaces the `cpanic==1` count check in [`recensus_path_smoke.py`](https://github.com/TSavo/sugar/pull/7179/files#diff-419ffb7c8217e7e524f04dca798335ee64add79efdc1d1a2b5a824686a4d0933) with a comparison of normalized, sorted identity rows against `_EXPECTED_CONSTRUCTION_PANIC_IDENTITIES`.
> - Adds `_construction_panic_identity` and `_sorted_panic_identities` helpers to project and sort panic dicts by stable fields (`file`, `owner`, `coordinate`, `observedEventType`, `requested`, `entrance`).
> - On success, the `known_panic` tooth records the exact matched identities as a JSON string; on failure it reports the full mismatch with observed and expected rows.
> - The emitted `smokeCounts` dict gains a `constructionPanicIdentities` field with the normalized, sorted panic rows.
> - Behavioral Change: a duplicate and a missing panic terminal no longer cancel each other out — the exact identity set must match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eaf6839.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->