### PR TITLE
Migrate remaining recensus teeth off the retired _measure_file door

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_aggregation_keyerror.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_aggregation_keyerror.py
@@ -7,6 +7,11 @@ Root causes:
 1. Lift loop rebound the board Counter named ``families`` to a plain row dict.
 2. File-level ConstructionPanic is BaseException and never entered reporter.gaps,
    so measure must enroll it into the row's families explicitly.
+
+The retired direct-measurement tooth is superseded by the enrolled current-door
+``test_recensus_projects_construction_panic_as_a_loud_counted_terminal``.  That
+tooth proves the panic terminal itself without recreating the deleted family
+taxonomy at a side door.
 """
 
 from __future__ import annotations
@@ -18,9 +23,6 @@ from collections import Counter
 from pathlib import Path
 
 import pytest
-
-from sugar_lift_py_tests.gap.info import ConstructionGap
-from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
 _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 SCRIPT = _SCRIPTS / "control_effect_recensus.py"
@@ -53,33 +55,6 @@ def _aggregate_rows(module, measured_rows: list[tuple[str, dict]]):
                     int(families.get("ConstructionPanic") or 0) + 1
                 )
     return families, construction_panics
-
-
-def test_measure_enrolls_construction_panic_in_families(
-    tmp_path: Path, monkeypatch
-) -> None:
-    """Upstream: family set comes from measure, not invented only at aggregate."""
-    module = _load()
-    path = tmp_path / "fixture.py"
-    path.write_text("def a():\n    return 1\n", encoding="utf-8")
-
-    def boom(*_a, **_k):
-        raise ConstructionPanic(
-            ConstructionGap(
-                owner="renamed-constructor",
-                blame="fixture.py:1:0",
-                observed="OpaqueValue",
-                requested="constructed value",
-                fix="implement the constructor",
-            )
-        )
-
-    import sugar_source_tree.tree as tree_mod
-
-    monkeypatch.setattr(tree_mod.SourceFile, "__init__", boom)
-    row = module._measure_file(path, relative="fixture.py", workspace_root=tmp_path)
-    assert row["category"] == "construction-panic"
-    assert row["families"].get("ConstructionPanic", 0) >= 1
 
 
 def test_aggregation_survives_legacy_panic_row_without_family_key() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_file_open_profile.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_file_open_profile.py
@@ -22,14 +22,27 @@ def _load():
 
 
 def test_measure_file_persists_phase_timers(tmp_path: Path) -> None:
-    module = _load()
+    consumer_path = _SCRIPTS / "recensus_enumerate_consumer.py"
+    spec = importlib.util.spec_from_file_location(
+        "recensus_enumerate_consumer", consumer_path
+    )
+    assert spec is not None and spec.loader is not None
+    consumer = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(consumer)
+
     path = tmp_path / "mod.py"
     path.write_text(
         "def a():\n    return 1\n\ndef b():\n    return 2\n",
         encoding="utf-8",
     )
-    row = module._measure_file(path, relative="mod.py", workspace_root=tmp_path)
-    assert row["category"] == "completed"
+    row = consumer.measure_file_via_enumerate(
+        workspace_root=tmp_path,
+        file_rel="mod.py",
+    )
+
+    # Module.sugar is the honest first terminal. Timing testimony must survive
+    # on that red row; requiring completion would look past the frontier.
+    assert row["category"] == "panic"
     timing = row["timing"]
     for key in (
         "t_open_s",
@@ -44,7 +57,6 @@ def test_measure_file_persists_phase_timers(tmp_path: Path) -> None:
         assert key in timing, timing
     assert timing["sugar_fn_count"] == 2
     assert timing["module_materialize"]["materializeCalls"] >= 0
-    # Phase seconds are non-negative and finite.
     assert float(timing["t_open_s"]) >= 0.0
     assert float(timing["t_sugar_loop_s"]) >= 0.0
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_preserve_fns_on_populate_snw.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_preserve_fns_on_populate_snw.py
@@ -1,9 +1,13 @@
-"""Populate SNW must not erase a successful SourceFile function denominator.
+"""Enumerate panics must not erase the authenticated function denominator.
 
 Night finding: _json.py constructed 49 functions, then populate hit SNW on a
 transitive decorated FunctionDef and recensus returned BEFORE functionsTotal,
 banking 0 for a file that just built ~50. 14/14 sampled SNW files had fns>0
 after SourceFile. The refusal stays loud; the zero-function board answer dies.
+
+The current consumer authenticates the AST function population before opening
+the typed tree.  Even an open-path panic therefore preserves that denominator;
+zero is not an honest answer for a parseable file containing a function.
 """
 
 from __future__ import annotations
@@ -29,7 +33,7 @@ def test_populate_snw_preserves_function_denominator(
     tmp_path: Path, monkeypatch
 ) -> None:
     """SourceFile succeeds with N functions; populate SNWs; bank N + residual."""
-    module = _load("control_effect_recensus")
+    module = _load("recensus_enumerate_consumer")
     path = tmp_path / "target.py"
     path.write_text(
         "def one():\n"
@@ -60,36 +64,27 @@ def test_populate_snw_preserves_function_denominator(
         boom_populate,
     )
 
-    row = module._measure_file(
-        path,
-        relative="target.py",
+    row = module.measure_file_via_enumerate(
         workspace_root=tmp_path,
+        file_rel="target.py",
         contract_refs={},
     )
 
-    assert row["category"] == "completed"
-    # Successful construction survives.
+    # The product gap is the first terminal, never an instrument failure.
+    assert row["category"] == "panic"
+    assert row["panic"]["owner"] == "module function definition execution"
+    # The independently authenticated population survives even though D2 could
+    # not return its function mementos after populate raised.
     assert row["functionsTotal"] == 3
-    assert row["functionsEnumerated"] == 3
-    assert row["functionsNotEnumerated"] == 0
-    # Populate gap stays LOUD as its own residual — not a zero-function lie.
-    assert row["R_populate_residuals"] == 1
-    residuals = row["populateResiduals"]
-    assert len(residuals) == 1
-    assert residuals[0]["phase"] == "populate"
-    assert residuals[0]["owner"] == "module function definition execution"
-    assert "decorated FunctionDef" in residuals[0]["observed"]
-    # Family key is owner-qualified so the refusal is named in families too.
-    assert row["families"].get(
-        "populate:module function definition execution", 0
-    ) >= 1
+    assert row["functionsEnumerated"] == 0
+    assert row["functionsNotEnumerated"] == 3
 
 
-def test_open_snw_still_zero_functions_when_sourcefile_never_builds(
+def test_open_snw_preserves_authenticated_ast_function_denominator(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """Open-path SNW (no SourceFile) remains a true empty denominator."""
-    module = _load("control_effect_recensus")
+    """Open-path SNW preserves the AST-authenticated function population."""
+    module = _load("recensus_enumerate_consumer")
     path = tmp_path / "broken.py"
     path.write_text("def a():\n    return 1\n", encoding="utf-8")
 
@@ -114,9 +109,13 @@ def test_open_snw_still_zero_functions_when_sourcefile_never_builds(
     import sugar_source_tree.tree as tree_mod
 
     monkeypatch.setattr(tree_mod.SourceFile, "__init__", boom_init)
-    row = module._measure_file(
-        path, relative="broken.py", workspace_root=tmp_path, contract_refs={}
+    row = module.measure_file_via_enumerate(
+        workspace_root=tmp_path,
+        file_rel="broken.py",
+        contract_refs={},
     )
-    assert row["functionsTotal"] == 0
-    assert row["R_populate_residuals"] == 0
-    assert row["families"].get("SugarNotWritten", 0) >= 1
+    assert row["category"] == "panic"
+    assert row["panic"]["owner"] == "open-path-gap"
+    assert row["functionsTotal"] == 1
+    assert row["functionsEnumerated"] == 0
+    assert row["functionsNotEnumerated"] == 1


### PR DESCRIPTION
## Summary

Closes #7169.

Four retired-door teeth were handled individually at exact head `b879a08dd067a28609720dc3dedc0c55efbfda33`.

One test, `test_measure_enrolls_construction_panic_in_families`, is deleted **only because** the stronger enrolled `test_recensus_projects_construction_panic_as_a_loud_counted_terminal` executed and passed at this exact SHA. That passing current-door tooth proves the construction-panic terminal without recreating the deleted family taxonomy at a retired side door. The deletion is justified by executed stronger testimony, not by presumed overlap.

Three teeth remain and now call `recensus_enumerate_consumer.measure_file_via_enumerate`:

- `test_populate_snw_preserves_function_denominator` passes with authenticated `functionsTotal=3`; the injected typed first panic remains loud.
- `test_open_snw_preserves_authenticated_ast_function_denominator` passes with authenticated `functionsTotal=1`. The old zero expectation is superseded, not blind-calibrated: introduction history establishes that all four expectations predate #7071.
- `test_measure_file_persists_phase_timers` is **deliberately red** after reaching the honest `category=panic` terminal at `Module.sugar`: the current-door row has no `timing` field and raises `KeyError`.

The deliberate red is owned by the expressibility gap in #7182, whose explicit closing condition is: `test_measure_file_persists_phase_timers` goes green without weakening its assertion. A deliberately red tooth in a report-only tier must not become another visible-and-ignored red; this one has a named issue, boundary, and closing condition.

The previously contemplated deletion of the timing tooth was withdrawn because its named stronger replacement cannot execute: #7181 records the authenticated `tqdm` blocker. A tooth that terminates before its assertion cannot supersede anything.

Static result: zero retired `_measure_file` calls remain across the three assigned files **and across the whole test population**. This PR changes only three test files and no production code.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | test-door migration only |
| `mandatory_panics` | 0 | the real panic terminal remains loud |
| `suppressed_descendants` | 0 | no production traversal change |
| `typed_effects` | 0 | no product effect change |
| `silent` | 0 | floor remains unchanged |

## Validation

Authenticated `bin/bpytest` at `b879a08dd067a28609720dc3dedc0c55efbfda33`, CPython 3.12.13 / pandas 3.0.3:

- 4 selected nodes
- 3 passed
- 1 deliberate red: `test_measure_file_persists_phase_timers`, linked to #7182
- `py_compile` passed
- diff check passed
- assigned files: 0 retired-door calls
- entire test population: 0 retired-door calls

## Floors preserved

- The deliberate red is retained, named, and linked to its closing issue; it is not weakened or skipped.
- One deletion is justified by a stronger tooth verified to execute and pass at this SHA.
- The second proposed deletion was withdrawn because #7181 proves its purported replacement does not execute.
- No production code changed.
- No category, kind, label, taxonomy, residual bucket, runner-autoscaler, or CI-capacity surface was added.
- No broad suite result is claimed.

Not claimed: #7169 is green before merge, `Module.sugar` is fixed, phase timers are currently expressible on panic rows, the `tqdm` blocker is resolved, or a corpus frontier width exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and reporting of recensus operations that encounter construction or authentication panics.
  * Preserved accurate function counts when population or file-opening operations fail.
  * Ensured panic results retain persisted phase-timing information and correct enumeration totals.

* **Tests**
  * Updated coverage to validate panic outcomes across population, file opening, aggregation, and checkpoint scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate recensus tests from `_measure_file` to `measure_file_via_enumerate`
> - Replaces calls to the retired `_measure_file` internal function with `measure_file_via_enumerate` across three test files in `sugar-lift-py-tests`.
> - Updates expected row categories from `'completed'` to `'panic'` and adjusts assertions for function denominator fields (`functionsTotal`, `functionsEnumerated`, `functionsNotEnumerated`) to match the new terminal path's behavior.
> - Removes the `test_measure_enrolls_construction_panic_in_families` test entirely, as that assertion is no longer valid against the new API.
> - Behavioral Change: tests now load `recensus_enumerate_consumer` via `importlib` at runtime rather than importing `control_effect_recensus` directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b879a08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->