### PR TITLE
Inspect venv-local metadata without mistaking checkout PYTHONPATH for contamination

### DIFF
--- a/.github/actions/python-test-environment-from-wheelhouse/action.yml
+++ b/.github/actions/python-test-environment-from-wheelhouse/action.yml
@@ -88,12 +88,8 @@ runs:
           "${wheels[@]}"
         "$venv/bin/python" -m pip freeze --all > "$env_dir/resolved-distributions.txt"
 
-        for pkg in sugar-lift-py-tests sugar-lift-python-source sugar-source-tree; do
-          if "$venv/bin/python" -m pip show "$pkg" >/dev/null 2>&1; then
-            echo "::error::first-party package $pkg present in venv; must resolve from checkout only"
-            exit 1
-          fi
-        done
+        "$venv/bin/python" tools/refuse_first_party_venv_contamination.py \
+          sugar-lift-py-tests sugar-lift-python-source sugar-source-tree
 
         checkout_pythonpath="$(
           python3 tools/managed_checkout_pythonpath.py --repo-root .

--- a/.github/actions/python-test-environment/action.yml
+++ b/.github/actions/python-test-environment/action.yml
@@ -189,16 +189,11 @@ runs:
           "${third_party[@]}"
         "$venv/bin/python" -m pip freeze --all > "$env_dir/resolved-distributions.txt"
 
-        # Refuse if a first-party package snuck into site-packages. Check each
-        # name alone: `pip show a b` exits non-zero if any is missing, which
-        # would mask a partial install.
-        for pkg in sugar-lift-py-tests sugar-lift-python-source sugar-source-tree; do
-          if "$venv/bin/python" -m pip show "$pkg" >/dev/null 2>&1; then
-            echo "::error::first-party package $pkg present in venv; must resolve from checkout only"
-            "$venv/bin/python" -m pip show "$pkg" || true
-            exit 1
-          fi
-        done
+        # Search only this interpreter's site-packages. `pip show` also searches
+        # ambient PYTHONPATH, which is the required checkout binding at job
+        # scope and is not evidence that a distribution entered this venv.
+        "$venv/bin/python" tools/refuse_first_party_venv_contamination.py \
+          sugar-lift-py-tests sugar-lift-python-source sugar-source-tree
 
         # Checkout roots BEFORE any subsequent import of sugar_lift_py_tests.
         # tools/managed_checkout_pythonpath.py is stdlib-only so it can run

--- a/tests/test_first_party_venv_contamination_guard.py
+++ b/tests/test_first_party_venv_contamination_guard.py
@@ -1,0 +1,79 @@
+"""The immutable-venv guard inspects the venv, not ambient PYTHONPATH."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import venv
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUARD = ROOT / "tools/refuse_first_party_venv_contamination.py"
+PACKAGE = "sugar-lift-py-tests"
+
+
+def _venv_python(path: Path) -> Path:
+    venv.create(path, with_pip=False, clear=True)
+    python = path / ("Scripts" if os.name == "nt" else "bin") / "python"
+    assert python.is_file()
+    return python
+
+
+def _purelib(python: Path) -> Path:
+    completed = subprocess.run(
+        [str(python), "-c", "import sysconfig; print(sysconfig.get_path('purelib'))"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(completed.stdout.strip())
+
+
+def _run_guard(python: Path, *, pythonpath: Path | None = None) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    if pythonpath is None:
+        env.pop("PYTHONPATH", None)
+    else:
+        env["PYTHONPATH"] = str(pythonpath)
+    return subprocess.run(
+        [str(python), str(GUARD), PACKAGE],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_job_pythonpath_metadata_does_not_contaminate_venv(tmp_path: Path) -> None:
+    """Checkout metadata visible only through job PYTHONPATH is not installed."""
+    python = _venv_python(tmp_path / "venv")
+    checkout_src = tmp_path / "checkout/src"
+    metadata = checkout_src / "sugar_lift_py_tests.egg-info"
+    metadata.mkdir(parents=True)
+    (metadata / "PKG-INFO").write_text(
+        "Metadata-Version: 2.1\nName: sugar-lift-py-tests\nVersion: 1\n",
+        encoding="utf-8",
+    )
+
+    completed = _run_guard(python, pythonpath=checkout_src)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "venv-contamination status=clean" in completed.stdout
+
+
+def test_venv_local_first_party_distribution_is_refused(tmp_path: Path) -> None:
+    """A first-party distribution physically installed in the venv stays red."""
+    python = _venv_python(tmp_path / "venv")
+    metadata = _purelib(python) / "sugar_lift_py_tests-1.dist-info"
+    metadata.mkdir(parents=True)
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: sugar-lift-py-tests\nVersion: 1\n",
+        encoding="utf-8",
+    )
+
+    completed = _run_guard(python)
+
+    assert completed.returncode != 0
+    combined = completed.stdout + completed.stderr
+    assert "first-party package sugar-lift-py-tests present in venv" in combined
+    assert str(metadata) in combined

--- a/tools/refuse_first_party_venv_contamination.py
+++ b/tools/refuse_first_party_venv_contamination.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Refuse first-party distributions physically installed in this interpreter.
+
+Ambient ``PYTHONPATH`` is deliberately excluded from the search.  The managed
+CI environment imports first-party code from the checkout, while its immutable
+venv may contain third-party distributions only.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import re
+import sys
+import sysconfig
+from pathlib import Path
+
+
+def _canonical_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value).lower()
+
+
+def main(argv: list[str]) -> int:
+    requested = {_canonical_name(value): value for value in argv}
+    if not requested:
+        raise SystemExit("usage: refuse_first_party_venv_contamination.py PACKAGE [...]")
+
+    search_paths = sorted(
+        {
+            str(Path(path).resolve())
+            for key in ("purelib", "platlib")
+            if (path := sysconfig.get_path(key))
+        }
+    )
+    contaminants: list[tuple[str, Path]] = []
+    for distribution in importlib.metadata.distributions(path=search_paths):
+        name = distribution.metadata.get("Name")
+        if not name or _canonical_name(name) not in requested:
+            continue
+        metadata_path = Path(
+            getattr(distribution, "_path", distribution.locate_file(""))
+        ).resolve()
+        contaminants.append((requested[_canonical_name(name)], metadata_path))
+
+    if contaminants:
+        for name, metadata_path in contaminants:
+            print(
+                f"::error::first-party package {name} present in venv; "
+                f"metadata={metadata_path}; must resolve from checkout only",
+                file=sys.stderr,
+            )
+        return 1
+
+    print(
+        "venv-contamination status=clean "
+        f"searched={','.join(search_paths)} packages={','.join(requested.values())}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Closes #7180.

The law is unchanged and remains authoritative. Commit `83663535d705df901f1271e23ae26daa10523d82` forbids first-party distributions inside the immutable venv. This PR changes only how that law is detected: instead of `pip show`, which searches ambient job `PYTHONPATH`, the guard inspects distribution metadata physically present in this interpreter’s `purelib` and `platlib`.

Bare exception zero tolerance failed on every measured main SHA from `824165d12` through `ef380dca6` in `Prepare immutable Python test environment`, before the axis began. The workflow own job-scope checkout path was visible to `pip show`, so authenticated checkout metadata was misclassified as venv contamination. The axis was skipped, never refused.

Both environment actions now call the same `tools/refuse_first_party_venv_contamination.py` door. There is one detection dialect.

## Discrimination

Both twins are load-bearing:

- **Truthful ambient arm:** checkout metadata exposed only through job `PYTHONPATH` is accepted because it is not physically installed in the venv.
- **Lying contamination arm:** first-party `dist-info` planted inside the venv remains refused, and the refusal names its physical metadata path.

The refusal twin proves the guard was not weakened or deleted. Only the false-positive search scope changed.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | environment-boundary repair only |
| `mandatory_panics` | 0 | no product traversal change |
| `suppressed_descendants` | 0 | no product traversal change |
| `typed_effects` | 0 | no effect behavior change |
| `silent` | 0 | the contamination law remains loud |

## Validation

Reproduced after rebase at exact head `11df3d0afb691e3a51569d224f43cabfcb62bf6d`:

- 7/7 passed in 0.63 seconds
- authenticated CPython 3.12.13
- pandas 3.0.3 / authenticated 1,421-file corpus
- ambient job-`PYTHONPATH` twin accepted
- venv-local first-party metadata twin refused with its physical path
- all five bare-exception zero-tolerance teeth executed after being skipped on main from `824165d12` through `ef380dca6`

## Floors preserved

- The 83663535d first-party-in-venv prohibition is unchanged.
- Both environment actions share one purelib/platlib-only guard.
- The negative arm remains red for real contamination.
- No category, kind, label, taxonomy, residual bucket, runner-autoscaler, or CI-capacity surface is added.
- No test was skipped or weakened.

## Scope warning

This does **not** establish `R_bare_exceptions` and does not measure the CI workflow corpus. It proves the axis **can begin**. An axis that starts running is not an axis that has reported.

When CI runs the bare axis for the first time in days, it may reveal a genuine downstream failure that nobody has yet seen. Such a terminal would be a new finding exposed by restored execution, not a regression caused by this repair.

Not claimed: broad suite green, a corpus bare-exception magnitude, a demand-table refusal, or that the first post-merge workflow run will pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix venv contamination check to ignore ambient PYTHONPATH when detecting first-party packages
> - Replaces inline `pip show` loops in both CI action files with calls to a new script, [refuse_first_party_venv_contamination.py](https://github.com/TSavo/sugar/pull/7184/files#diff-a3437673af34df02b77da915500c5410dbb9f245169e0f81353d2c384a3ad001), that inspects only the venv's purelib/platlib paths via `importlib.metadata.distributions`.
> - The old approach could produce false positives when checkout paths were present in `PYTHONPATH`; the new script ignores packages visible only through ambient `PYTHONPATH`.
> - On contamination, the script emits GitHub Actions error annotations to stderr and exits 1; on success it prints the searched paths and checked package names and exits 0.
> - New tests in [test_first_party_venv_contamination_guard.py](https://github.com/TSavo/sugar/pull/7184/files#diff-0b22efa3266abdf38f61c2d09229dd40ad8c3f26067da7fdd2fba1132a0a2498) verify both the false-positive fix (PYTHONPATH-only metadata is ignored) and true-positive detection (dist-info in purelib triggers failure).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11df3d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->