### PR TITLE
Construct source modules through one ordered ModuleBlockSugar

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/module_block_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/module_block_sugar.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.outcome import Outcome
+from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_body
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.witnesses import NotVerdictBearing
+
+
+@dataclass(frozen=True)
+class ModuleBlockSugar(Sugar):
+    """The already-constructed statements of one source module, in order."""
+
+    statements: tuple[Sugar, ...]
+    site: object = field(compare=False)
+
+    @classmethod
+    def witnesses(cls):
+        return NotVerdictBearing(
+            sugar_name=cls.__name__,
+            floor_name="BlockValue",
+            reason="module blocks project the ordinary constructed block",
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        return reduce_body(self.statements, ctx)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3105,6 +3105,30 @@ class Module(Node):
             return self
         return rewrite(self, body=new_body)
 
+    def _construct_sugar(self):
+        """Construct the module block after its one temporal scope fold.
+
+        ``Module`` owns only source order and module-level binding scope.  Each
+        statement owns its own meaning and constructs through ``Statement.sugar``
+        exactly once.  A child construction gap therefore propagates with the
+        child's owner; the module neither skips it nor invents completion.
+        """
+        from sugar_lift_py_tests.engine_log import reduction_span
+        from sugar_lift_py_tests.sugar.module_block_sugar import ModuleBlockSugar
+
+        lc = self.line_col_span()
+        where = f"{self.unit.filename}:{lc.start_line} Module"
+        with reduction_span(sugar="ModuleBlock", role="construction", site=where):
+            with reduction_span(sugar="Substitute", role="temporal", site=where):
+                substituted = self.substitute({})
+            with reduction_span(sugar="Construct", role="construction", site=where):
+                return ModuleBlockSugar(
+                    statements=tuple(
+                        statement.sugar() for statement in substituted.body
+                    ),
+                    site=self.fragment,
+                )
+
 
 class FunctionDef(Statement):
     name: str

--- a/implementations/python/sugar-source-tree/tests/test_module_block_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_module_block_construction.py
@@ -1,0 +1,135 @@
+"""Module construction owns one source-ordered block, never child meaning."""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor.block_value import BlockValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_source_tree.cpython_adapter import CPythonAstBackend
+from sugar_source_tree.nodes import Assert, FunctionDef, Module, Name
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+
+
+def _tree(
+    source: str,
+    name: str = "module-block.py",
+    *,
+    backend: CPythonAstBackend | None = None,
+) -> SourceFile:
+    return SourceFile(
+        (source, name, blake3_512_of(source.encode())),
+        backend=backend,
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def test_module_constructs_each_child_once_in_source_order(monkeypatch) -> None:
+    tree = _tree(
+        "def first():\n"
+        "    return 1\n"
+        "\n"
+        "def second():\n"
+        "    return 2\n"
+    )
+    calls: list[tuple[str, int]] = []
+    constructed: dict[str, object] = {}
+    original = FunctionDef.sugar
+
+    def observed(child: FunctionDef):
+        calls.append((child.name, child.line_col_span().start_line))
+        result = original(child)
+        constructed[child.name] = result
+        return result
+
+    monkeypatch.setattr(FunctionDef, "sugar", observed)
+
+    sugar = tree.root.sugar()
+
+    assert type(sugar).__name__ == "ModuleBlockSugar"
+    assert calls == [("first", 1), ("second", 4)]
+    assert sugar.statements[0] is constructed["first"]
+    assert sugar.statements[1] is constructed["second"]
+
+
+def test_module_threads_temporal_scope_before_constructing_children(monkeypatch) -> None:
+    tree = _tree("x = 1\nassert x == 1\n")
+    observed_asserts: list[Assert] = []
+    original = Assert.sugar
+
+    def observed(child: Assert):
+        observed_asserts.append(child)
+        return original(child)
+
+    monkeypatch.setattr(Assert, "sugar", observed)
+
+    sugar = tree.root.sugar()
+
+    assert type(sugar).__name__ == "ModuleBlockSugar"
+    assert len(observed_asserts) == 1
+    assert not any(
+        isinstance(node, Name) and node.id == "x"
+        for node in observed_asserts[0].walk()
+    )
+
+
+def test_module_propagates_the_child_owner_panic_and_stops_the_tail(
+    monkeypatch,
+) -> None:
+    tree = _tree(
+        "type Alias = int\n"
+        "def never_reached():\n"
+        "    return 1\n"
+    )
+    tail_calls = 0
+    original = FunctionDef.sugar
+
+    def observed(child: FunctionDef):
+        nonlocal tail_calls
+        tail_calls += 1
+        return original(child)
+
+    monkeypatch.setattr(FunctionDef, "sugar", observed)
+
+    with pytest.raises(SugarNotWritten) as caught:
+        tree.root.sugar()
+
+    assert caught.value.owner == "TypeAlias.sugar"
+    assert tail_calls == 0
+
+
+def test_module_block_reduces_to_the_ordinary_block_floor() -> None:
+    tree = _tree("pass\npass\n")
+
+    sugar = tree.root.sugar()
+    outcome = sugar.desugar()
+
+    assert isinstance(tree.root, Module)
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, BlockValue)
+    assert outcome.value.can_fall_through is True
+
+
+def test_backend_materializes_one_module_before_module_block_construction(
+    monkeypatch,
+) -> None:
+    materialized = []
+    original = CPythonAstBackend.materialize_module
+
+    def observed(backend, unit, reporter):
+        result = original(backend, unit, reporter)
+        materialized.append(result)
+        return result
+
+    monkeypatch.setattr(CPythonAstBackend, "materialize_module", observed)
+    backend = CPythonAstBackend()
+    tree = _tree("pass\n", backend=backend)
+
+    sugar = tree.root.sugar()
+
+    assert materialized == [tree.constructed_module]
+    assert tree.constructed_module.root is tree.root
+    assert type(sugar).__name__ == "ModuleBlockSugar"


### PR DESCRIPTION
## Summary

Tracks #7189. **Do not close #7189 and do not merge this PR until the census redistribution at this exact head is recorded.** Implementation alone is not the deliverable.

This PR adds one `Module._construct_sugar` door and one non-variant `ModuleBlockSugar` codomain. It does **not** add a `ModuleSugar` variant family, category, kind, taxonomy, label, or residual bucket.

A distinct codomain is required:

- `SourceVisibleFunctionBodySugar` represents call-frame semantics and would lie about module identity;
- a raw tuple or `BlockValue` would bypass Sugar testimony;
- `ModuleBlockSugar` represents one already-constructed, source-ordered module block.

The construction door:

1. threads module scope through the existing top-level temporal fold;
2. sequences the module body in source order;
3. calls each child `Statement.sugar` exactly once;
4. propagates any child `ConstructionPanic` unchanged, preserving the child owner and coordinate.

## Complete changed-file scope

Preflight enumerates exactly three changed files:

1. `implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py`
   - adds the single `Module._construct_sugar` door.
2. `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/module_block_sugar.py`
   - adds the one non-variant `ModuleBlockSugar` codomain.
3. `implementations/python/sugar-source-tree/tests/test_module_block_construction.py`
   - adds five focused discrimination teeth.

No other test rewrite, production file, workflow, runner-autoscaler, or CI-capacity change rides in this branch.

## Red before green

Counterfactual measured through the same authenticated entrance:

- exact base `20f564f4c1aa2aef43bdad75d99202bfb65edece` fails the first tooth at owner `Module.sugar`, coordinate `module-block.py:1:0`, with **zero child calls**;
- implementation head `387c37704ddec09e538e2539f9ae2c5bc86a038f` passes 5/5 in 0.29 seconds through authenticated `bin/brun`.

The child-panic tooth preserves the real `TypeAlias.sugar` owner unchanged and proves the tail was not evaluated: `tail_calls=0`.

## Backend boundary

The backend tooth wraps the final `CPythonAstBackend.materialize_module` method and calls its original body. It proves:

- backend materialization runs exactly once;
- it yields one exact `_ConstructedModuleV1` root;
- that root exists before `ModuleBlockSugar` construction;
- the backend does not consume or reinterpret the Sugar codomain.

An earlier tooth attempted to override the final method and was correctly refused by `Backend.__init_subclass__`. That was a test-entrance error, not a product refusal. Backend finality remains authoritative.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `Module.sugar first terminals` | -1,418 predicted | remove the measured outer mask |
| `next construct terminals` | unknown redistribution | must be measured by the census at this head |
| `constructed` | unknown | implementation is not a corpus result |
| `mandatory_panics` | unknown redistribution | child panics propagate unchanged |
| `suppressed_descendants` | expected decrease, unmeasured | next owners become visible |
| `typed_effects` | 0 | no effect-door change |
| `silent` | 0 | all child construction failures remain loud |

## Existing frontier teeth

The two existing teeth that authenticate `Module.sugar` as the sole current frontier are unchanged and are expected to turn red when this implementation runs. That is the instrument working.

Do not weaken them or change only an expected count. Rule on each tooth individually using the measured owner/coordinate redistribution.

## Hold and closing condition

Corpus redistribution has **not** run at `387c37704ddec09e538e2539f9ae2c5bc86a038f`.

This PR is held until Hockney reports a census at this exact SHA showing how the measured 1,418 `Module.sugar` rows redistribute across construct owners and coordinates. A moved mask and a lifted mask are distinguishable only by that receipt.

## Non-goal

This does not make the corpus green. It removes the outer mask and exposes the next terminals. The panic count may stay high or redistribute; redistribution is the success condition.

Not claimed: corpus redistribution, frontier width, corpus green, lower total panic count, or completion of #7189.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for constructing and processing complete source modules as ordered blocks.
  * Module statements now retain their source order and are converted consistently into executable block representations.
  * Module processing respects scope behavior and reduces to the standard block format for downstream use.
  * Construction errors are now surfaced instead of being silently skipped.

* **Bug Fixes**
  * Improved module materialization to ensure exactly one module is prepared before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct source modules through a single ordered `ModuleBlockSugar`
> - Adds `ModuleBlockSugar`, a frozen dataclass in [module_block_sugar.py](https://github.com/TSavo/sugar/pull/7190/files#diff-589b96b4034635586bd698a5652ec86bb7e9dd39aa149df2e42d72c217041746) that holds an ordered tuple of child `Sugar` nodes and desugars them as a block via `reduce_body`.
> - Adds `Module._construct_sugar` in [nodes.py](https://github.com/TSavo/sugar/pull/7190/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) that performs one temporal scope substitution (`substitute({})`), then constructs a `ModuleBlockSugar` from the resulting statements in source order.
> - Adds tests in [test_module_block_construction.py](https://github.com/TSavo/sugar/pull/7190/files#diff-67dce379417acedba870acb0261c5e3732a99922332122e4afab7189eaa9578e) covering child construction order, temporal scope threading, panic propagation, block desugaring, and backend module materialization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 387c377.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->