### PR TITLE
Stage quiet brun wrappers past the ControlMaster command ceiling

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -295,7 +295,7 @@ sugar_bx_run_ambient() {
   # measure. Do not exec-replace the shell that holds the flock fd.
   # Three gates, one law: quiet box, exclusive lease, correct corpus.
   local lock wait_s max_lit host_lit measured_cmd wrapper selector_def login_exec
-  local compact_wrapper
+  local compact_wrapper remote_wrapper
   local pin_path pin_py pin_skip
   lock="${SUGAR_BX_TIMING_LEASE:-}"
   selector_def="$(declare -f sugar_bx_select_timing_lease)"
@@ -465,7 +465,25 @@ exit \"\$st\""
   # clear_console, whose exit 1 replaced both remote success and remote 23.
   # The non-login wrapper's explicit exit is therefore the SSH verdict.
   login_exec='exec "$@"'
-  sugar_bx_ssh "bash -lc $(sugar_bx_quote "$login_exec") bash bash -c $(sugar_bx_quote "$compact_wrapper")"
+  # The OpenSSH ControlMaster mux has a bounded command packet. Passing the
+  # full wrapper through bash -c makes a large payload fail as rc=255 with no
+  # artifact. Stage the wrapper over stdin, then invoke it by reference so the
+  # transport payload stays small. A staging failure is named, never mistaken
+  # for a measurement result.
+  remote_wrapper="$SUGAR_BX_REPO/.sugar-bx-wrapper-$$"
+  if ! printf '%s\n' "$compact_wrapper" | sugar_bx_ssh "cat > $(sugar_bx_quote "$remote_wrapper")"; then
+    printf 'sugarbin: crime=controlmaster-command-payload-refused limit=unknown stage=%s replacement=retry with staged command reference\n' "$remote_wrapper" >&2
+    return 255
+  fi
+  set +e
+  sugar_bx_ssh "bash -lc $(sugar_bx_quote "$login_exec") bash "$remote_wrapper""
+  st=$?
+  set -e
+  if ((st != 0)); then
+    sugar_bx_ssh "rm -f $(sugar_bx_quote "$remote_wrapper")" >/dev/null 2>&1 || true
+    return "$st"
+  fi
+  sugar_bx_ssh "rm -f $(sugar_bx_quote "$remote_wrapper")" >/dev/null 2>&1 || true
 }
 
 sugar_bx_docker_bind_source() {


### PR DESCRIPTION
## Summary

Closes #7164.

OpenSSH ControlMaster refuses oversized inline commands. Quiet `bin/brun` now stages its compact wrapper over SSH stdin and invokes it by remote reference, keeping the wrapper out of the bounded command packet.

If staging fails, the failure is named:

```text
crime=controlmaster-command-payload-refused
```

That diagnostic was explicitly authorized for this transport refusal. It is a failure reason, not a new result category, residual kind, or taxonomy bucket.

## Measured boundary

The observed inline-command threshold is exact:

- 131,071-byte inline command: succeeds
- 131,072-byte inline command: refuses immediately
- terminal: `/bin/bash: Argument list too long`
- status: 1
- payload execution: none

The boundary refuses during connection/command setup, before a measurement payload runs.

## Honest test gap

No both-arm transport tooth is committed.

The attempted 131,072-byte test embedded the payload in the **local shell argv** and hit the local argument ceiling before it could exercise the remote OpenSSH mux packet. Such a tooth would have measured the wrong boundary.

McManus refused to fabricate that evidence. This PR does not convert the observed threshold into a committed discrimination claim and does not imply the missing arm exists.

## Distinction from #7188

This is not Hockney’s zero-output bpytest artifact blocker in #7188.

- ControlMaster ceiling: immediate connection/command-setup refusal; no payload.
- #7188: concatenated artifact JSON plus checksum mismatch, exit 70 after approximately 86 seconds during artifact resolution.

They are separate defects and remain separate records.

## Restack and deletion proof

Exact head: `1f874d297f0a5416f0eab70225ba9332fff280de`.

- parent and merge-base: current main `ce223ec7030db2dc9376b6cf19212b0a8a089523`
- range: exactly 1 commit, 0 behind
- old worker commits `c8dc74e76` and `70bb8b995`: absent and non-ancestors
- changed files: exactly `bin/lib/sugar-bx.sh`
- deleted paths: 0
- other changed paths: 0
- commits touching `bin/lib/sugar-bx.sh` between `d0f97bc87` and current main: 0

Therefore the restack cannot delete or reverse any landing made after `d0f97bc87`: its only touched file has no post-`d0f97bc87` commits, and every other path is identical to current main.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `ControlMaster inline-wrapper refusals` | expected decrease | quiet wrapper travels over stdin and is invoked by reference |
| `constructed` | 0 | transport-only change |
| `mandatory_panics` | 0 | transport-only change |
| `suppressed_descendants` | 0 | transport-only change |
| `typed_effects` | 0 | transport-only change |
| `silent` | 0 | staging failure remains named and loud |

## Validation and floors

- The exact 131,071/131,072 observed threshold is recorded.
- No both-arm transport tooth is claimed.
- Existing quiet gate, lease, corpus pin, payload status, and sync-back code remain in place.
- No path is deleted.
- No category, kind, label, taxonomy, residual bucket, runner-autoscaler, or CI-capacity surface is added.

Not claimed: a committed transport discrimination twin, arbitrary command-size support, #7188 repair, payload execution beyond the observed ceiling, or broad suite green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stage quiet brun wrappers to a remote file to avoid ControlMaster command size limits
> In quiet mode (`SUGAR_BX_QUIET_ARMED==1`), `sugar_bx_run_ambient` in [sugar-bx.sh](https://github.com/TSavo/sugar/pull/7192/files#diff-bdd6c46eb799e81d8c3cc8b50ab4a809668391cedbc25e468f6efe8ef9d86ebc) previously inlined the full wrapper script into a single SSH command, which could exceed ControlMaster packet size limits.
>
> - The function now uploads the compacted wrapper to `$SUGAR_BX_REPO/.sugar-bx-wrapper-$$` on the remote host via `cat` over SSH, then executes it by filename reference.
> - On staging failure, the function prints a named error to stderr and returns exit code 255.
> - The staged file is cleaned up on both success and failure.
> - Behavioral Change: quiet mode now requires two SSH round-trips instead of one, and leaves a brief window where a temp file exists on the remote host.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f874d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->