### PR TITLE
Separate authenticated corpus and source workspace roots

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
@@ -144,6 +144,7 @@ class SupervisedEnumSupervisor:
         python: str | None = None,
         env: Mapping[str, str] | None = None,
         corpus_root: Path,
+        source_workspace_root: Path | None = None,
         demand_table_path: Path | None = None,
         allow_local_demand_derivation: bool = False,
     ) -> None:
@@ -154,6 +155,11 @@ class SupervisedEnumSupervisor:
         self.env = dict(env or os.environ)
         self.env.setdefault("PYTHONFAULTHANDLER", "1")
         self.corpus_root = corpus_root.resolve()
+        self.source_workspace_root = (
+            self.corpus_root
+            if source_workspace_root is None
+            else source_workspace_root.resolve()
+        )
         self.demand_table_path = (
             None if demand_table_path is None else demand_table_path.resolve()
         )
@@ -323,7 +329,11 @@ class SupervisedEnumSupervisor:
             f"{self.demand_table_path if self.demand_table_path else None}",
             flush=True,
         )
-        initialize = {"kind": "initialize", "corpus_root": str(self.corpus_root)}
+        initialize = {
+            "kind": "initialize",
+            "corpus_root": str(self.corpus_root),
+            "source_workspace_root": str(self.source_workspace_root),
+        }
         if self.demand_table_path is not None:
             initialize["demand_table_path"] = str(self.demand_table_path)
         initialize["allow_local_demand_derivation"] = self.allow_local_demand_derivation
@@ -756,6 +766,7 @@ def scan_paths(
     paths: Sequence[Path],
     *,
     root: Path,
+    source_workspace_root: Path | None = None,
     file_timeout: float = 30.0,
     context_init_timeout: float | None = None,
     demand_table_path: Path | None = None,
@@ -770,6 +781,7 @@ def scan_paths(
         file_timeout=file_timeout,
         context_init_timeout=context_init_timeout,
         corpus_root=root,
+        source_workspace_root=source_workspace_root,
         demand_table_path=demand_table_path,
         allow_local_demand_derivation=demand_table_path is None,
     )

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
@@ -89,6 +89,7 @@ def _initialize(
     demand_table_path: str | None,
     *,
     allow_local_demand_derivation: bool,
+    source_workspace_root: str | None = None,
 ) -> dict:
     global _CONSTRUCTION_CONTEXT, _CORPUS_ROOT
     import os
@@ -132,6 +133,20 @@ def _initialize(
         }
 
     root = Path(corpus_root).resolve()
+    workspace_root = Path(source_workspace_root or corpus_root).resolve()
+    if root != workspace_root and workspace_root not in root.parents:
+        return {
+            "kind": "initialize-refusal",
+            "coordinate": "supervised-enum-worker.construction-context",
+            "reason": (
+                f"source_workspace_root does not contain corpus_root: "
+                f"source_workspace_root={workspace_root} corpus_root={root}"
+            ),
+            "corpus_root": str(root),
+            "source_workspace_root": str(workspace_root),
+            "demand_table_path": demand_table_path,
+            "phase": "resolve-corpus-root",
+        }
     _progress(
         "resolve-corpus-root",
         corpus_root=str(root),
@@ -248,11 +263,12 @@ def _initialize(
     )
     _CORPUS_ROOT = root
     _CONSTRUCTION_CONTEXT = tree_construction_context_for_workspace(
-        root, contract_refs=contract_refs
+        workspace_root, contract_refs=contract_refs
     )
     return {
         "kind": "context-ready",
         "corpus_root": str(root),
+        "source_workspace_root": str(workspace_root),
         "demand_table_identity": demand_table_identity,
     }
 
@@ -303,6 +319,11 @@ def main() -> int:
                 response = _initialize(
                     corpus_root,
                     demand_table_path,
+                    source_workspace_root=(
+                        str(msg["source_workspace_root"])
+                        if msg.get("source_workspace_root")
+                        else None
+                    ),
                     allow_local_demand_derivation=bool(
                         msg.get("allow_local_demand_derivation", False)
                     ),

--- a/implementations/python/sugar-lift-py-tests/tests/test_worker_demand_table_gate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_worker_demand_table_gate.py
@@ -45,9 +45,31 @@ def test_worker_accepts_current_table_and_reaches_context(tmp_path: Path, monkey
     )
     worker._CONSTRUCTION_CONTEXT = None
     worker._CORPUS_ROOT = None
-    result = worker._initialize(str(root), str(artifact), allow_local_demand_derivation=False)
-    assert result["kind"] == "context-ready"
+    result = worker._initialize(
+        str(root),
+        str(artifact),
+        allow_local_demand_derivation=False,
+        source_workspace_root=str(tmp_path),
+    )
+    assert result["kind"] == "context-ready", result
     assert result["demand_table_identity"] == table.semantic_identity.content_key
+
+
+def test_worker_refuses_workspace_root_that_does_not_contain_corpus(
+    tmp_path: Path,
+):
+    root, _handle, table = _fixture(tmp_path)
+    artifact = write_prebuilt_demand_table(table, tmp_path / "table.json")
+    worker._CONSTRUCTION_CONTEXT = None
+    worker._CORPUS_ROOT = None
+    result = worker._initialize(
+        str(root),
+        str(artifact),
+        allow_local_demand_derivation=False,
+        source_workspace_root=str(tmp_path / "unrelated"),
+    )
+    assert result["kind"] == "initialize-refusal"
+    assert "source_workspace_root does not contain corpus_root" in result["reason"]
 
 
 def test_worker_refuses_legacy_key_by_name(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Finding

The floor worker carried one variable for two different authorities:

- `corpus_root` is the authenticated measurement root, the pandas package directory.
- `source_workspace_root` is the site-packages parent against which RECORD seats resolve.

Those roots differ by construction. Before this repair, the package root passed corpus validation but rejected all 1,421 source lookups; the checkout root passed lookups but failed validation. The measured result was `discovered=1421`, `completed=0`, `non_native_red=1421`, followed by an honest `UNMEASURED` rather than a fabricated zero.

## Repair

The supervisor and worker now carry `corpus_root` and `source_workspace_root` independently. The worker authenticates the corpus against `corpus_root`, seats construction context against `source_workspace_root`, and refuses when the workspace root does not contain the corpus root.

Writing the refusal arm exposed and fixed an inversion in the containment check: `source_workspace_root` must be an ancestor of `corpus_root`. The first version tested that relationship backwards. A positive-only tooth would have shipped the inversion green.

## Measured teeth

Battleaxe: 3 passed in 0.58 seconds.

- truthful arm: a valid separated workspace root reaches `context-ready`
- lying arm: an unrelated `source_workspace_root` refuses with the named reason `source_workspace_root does not contain corpus_root`
- the existing legacy demand-table identity refusal remains enrolled

The refusal arm is load-bearing evidence that the boundary did not become a permissive fallback.

## Repeated architecture

This is the fourth instance of one variable carrying two meanings: recipe key versus storage key, distribution implied by class, floor worker roots, and enrollment coordinates. The repair is the same each time: give the two authorities two names and authenticate each at its own boundary.

## Scope and preflight

Exact head: `5c04f337d7526dc474c1f56b7e016fde91359457`, one commit directly on `a67d6a00f2f469f7133b24ca9133967876925ed3`.

All changed files, reconciled against this body:

- `implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py`
- `implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py`
- `implementations/python/sugar-lift-py-tests/tests/test_worker_demand_table_gate.py`

Deleted paths: 0. The old mux commit `1882aa28f...` and old worker commit `7280a8b14...` are absent and non-ancestors. The only `kind` additions use the existing initialize/context-ready/initialize-refusal protocol; this adds no category, kind, label, taxonomy, residual bucket, autoscaler, or CI-capacity surface.

## IDD accounting

Targeted axis: worker root-conflation at the authenticated floor entrance. Predicted epsilon is removal of the root-caused 1,421 source-lookup reds on the next corpus run; this PR carries no observed corpus delta. Floors preserved: no zero from incomplete work, no silent derivation, and named refusal on an invalid root relationship.

## Explicit non-claims

This does not address the third enrollment site in `discover_no_call_body_probes`, worth 77 classified frontier rows. It claims no corpus-scale floor result and does not establish any native, bare, or timeout magnitude. It makes the worker entrance capable of using the two authenticated roots; it does not claim the axes have spoken.

Main remains red on the known #7190 path-smoke fallout pending the Keaton tooth repair, so this PR is opened held rather than presented as check-green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Separate authenticated corpus root from source workspace root in enum supervisor and worker
> - Adds an optional `source_workspace_root` parameter to `SupervisedEnumSupervisor`, `scan_paths`, and the worker's `_initialize` function, defaulting to `corpus_root` when not provided.
> - The worker validates that `source_workspace_root` contains `corpus_root` and refuses initialization with a structured error if it does not.
> - When `source_workspace_root` is provided and valid, the `TreeConstructionContext` is created for the workspace root rather than the corpus root.
> - New test `test_worker_refuses_workspace_root_that_does_not_contain_corpus` covers the refusal path; the existing acceptance test is updated to pass `source_workspace_root`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c04f33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->