### PR TITLE
Qualify enrollment coordinates from the source workspace root

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -548,8 +548,28 @@ def pull_shared_demand_table(repo_root: Path, output: Path) -> dict:
     )
 
 
-def _use_site_coordinate(path: Path, corpus_root: Path, use_site: Mapping) -> str:
-    rel = path.relative_to(corpus_root).as_posix()
+def _use_site_coordinate(
+    path: Path,
+    corpus_root: Path,
+    use_site: Mapping,
+    *,
+    source_workspace_root: Path | None = None,
+) -> str:
+    coordinate_root = source_workspace_root or corpus_root
+    try:
+        rel = path.resolve().relative_to(coordinate_root.resolve()).as_posix()
+    except ValueError as error:
+        raise AttributionInvariantError(
+            "enrollment coordinate root cannot qualify source seat: "
+            f"source={path} source_workspace_root={coordinate_root} "
+            f"corpus_root={corpus_root}"
+        ) from error
+    if source_workspace_root is not None and "/" not in rel:
+        raise AttributionInvariantError(
+            "enrollment coordinate is not distribution-qualified: "
+            f"source={path} coordinate={rel} "
+            f"source_workspace_root={coordinate_root}"
+        )
     return (
         f"{rel}:{use_site.get('startLine')}:{use_site.get('startCol')}"
         f"-{use_site.get('endLine')}:{use_site.get('endCol')}"
@@ -561,6 +581,7 @@ def discover_no_call_body_probes(
     corpus_root: Path,
     *,
     families: frozenset[ProducerFamily] | None = None,
+    source_workspace_root: Path | None = None,
 ) -> DiscoveryDisposition:
     """Project authenticated assertion demands to their native body producer.
 
@@ -652,7 +673,12 @@ def discover_no_call_body_probes(
                     [],
                 ).append(node)
         for use_site in demands:
-            coordinate = _use_site_coordinate(path, corpus_root, use_site)
+            coordinate = _use_site_coordinate(
+                path,
+                corpus_root,
+                use_site,
+                source_workspace_root=source_workspace_root,
+            )
             managers = managers_by_span.get(
                 (
                     use_site.get("startLine"),

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -24,6 +24,7 @@ from sugar_lift_py_tests.no_call_body_attribution import (
     require_expected_denominators,
     summarize_attribution_outcomes,
     validate_shared_demand_table,
+    _use_site_coordinate,
 )
 from sugar_lift_py_tests.outcome import Complete
 from sugar_source_tree.panic import SugarNotWritten, UnattributableRefusal
@@ -43,6 +44,35 @@ def _raise_value():
             RaiseEffect(exception_type_coordinate=str_const('TypeError'), occurrence=AuthenticatedRaiseLocus.of('pandas/example.py:1:4'))
         )
     )
+
+
+def test_enrollment_coordinate_qualifies_distribution_from_workspace_root(tmp_path):
+    workspace = tmp_path / "site-packages"
+    corpus = workspace / "pandas"
+    path = corpus / "_config" / "config.py"
+    path.parent.mkdir(parents=True)
+    path.write_text("x = 1\n", encoding="utf-8")
+    coordinate = _use_site_coordinate(
+        path,
+        corpus,
+        {"startLine": 1, "startCol": 0, "endLine": 1, "endCol": 1},
+        source_workspace_root=workspace,
+    )
+    assert coordinate.startswith("pandas/_config/config.py:1:0-1:1")
+
+
+def test_enrollment_coordinate_refuses_unqualifiable_workspace_root(tmp_path):
+    corpus = tmp_path / "pandas"
+    path = corpus / "_config" / "config.py"
+    path.parent.mkdir(parents=True)
+    path.write_text("x = 1\n", encoding="utf-8")
+    with pytest.raises(AttributionInvariantError, match="cannot qualify source seat"):
+        _use_site_coordinate(
+            path,
+            corpus,
+            {"startLine": 1, "startCol": 0, "endLine": 1, "endCol": 1},
+            source_workspace_root=tmp_path / "elsewhere",
+        )
 
 
 def _nameless_raise_value():


### PR DESCRIPTION
## Finding

`discover_no_call_body_probes` built `SourceTree(corpus_root)` and derived `_use_site_coordinate(path.relative_to(corpus_root))`. For authenticated pandas that produced bare first segments such as `_config` and `io`, rather than distribution-qualified coordinates such as `pandas/_config/config.py`.

That underqualification accounts for 77 of the 471 measured With resolution gaps: call targets appeared outside the authenticated population solely because the coordinate was rooted at the package instead of its source workspace.

## Repair

Enrollment now carries two distinct roots:

- `corpus_root` authenticates and enumerates the pandas population.
- `source_workspace_root` qualifies RECORD seats with the distribution path.

`_use_site_coordinate` derives the enrollment coordinate relative to the workspace root and refuses when the source cannot be qualified. It never falls back silently to a bare segment.

## Measured teeth

Battleaxe focused selection: 2 passed, 28 deselected, 0.68 seconds.

- truthful arm: a package-root seat qualifies as `pandas/_config/config.py`
- lying arm: an unrelated workspace root refuses with the named `enrollment coordinate root cannot qualify source seat` reason

The refusal arm is load-bearing. A silent fallback to a bare segment is exactly what produced the 77-row population.

## Repeated architecture

This is the fourth site today where one variable carried two meanings: recipe key versus storage key, distribution implied by class, floor worker roots, and enrollment coordinates. The repair is always to give the two authorities two names.

## Preflight and scope

Exact head: `91dde9cf439bf1ac4fdec2ab5a37383228f7ef03`, one commit directly on main `f8ccaca907b05db28ab613ca07aacac80766f651`, 0 behind / 1 ahead.

All changed files, reconciled against this body:

- `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py`
- `implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py`

Deleted paths: 0. File operations: no creates, deletes, or renames. The additions scan found no category, kind, label, taxonomy, residual bucket, runner-autoscaler, or CI-capacity surface.

## IDD accounting

Targeted axis: 77 first-terminal rows classified as off-population because their enrollment coordinate is underqualified. Predicted epsilon is removal or redistribution of those 77 coordinate-derived rows on the next authenticated census. The observed corpus delta remains unmeasured.

## Pre-existing test signal

The unfiltered test file run collected 30, passed 27, and failed three pre-existing nameless-halted-face teeth. Neither new coordinate tooth is among them. They are recorded together as one likely cause in #7196 and are not attributed to this branch.

## Mandatory non-claims

The 77-row corpus reduction has NOT been measured. This PR fixes the derivation; only a census at the merged head can show whether those rows resolve or redistribute. It claims no frontier width, no corpus-scale residual reduction, and no repair of the other authority classes in #7191.

Main is still red on the known #7190 path-smoke fallout pending the Keaton identity-tooth repair, so this PR is opened held rather than presented as check-green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Qualify enrollment coordinates relative to source workspace root in `_use_site_coordinate`
> - Adds an optional `source_workspace_root` parameter to `_use_site_coordinate` and `discover_no_call_body_probes` in [no_call_body_attribution.py](https://github.com/TSavo/sugar/pull/7197/files#diff-63dc4df7d670fe2740ec87663a519f79002baa69eb853f03a8559b42d8f325e4).
> - When provided, coordinates are computed relative to `source_workspace_root` instead of `corpus_root`, and the function validates that the resulting relative path contains a `/` (i.e. is distribution-qualified).
> - Raises `AttributionInvariantError` if the source path is not under the workspace root or if the coordinate is not distribution-qualified.
> - New tests in [test_no_call_body_attribution.py](https://github.com/TSavo/sugar/pull/7197/files#diff-1e9a303b50b18c61fae64f67414871f8a70627ad861506b60b958def25145321) cover both the qualified coordinate case and the unqualifiable workspace root error case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58a9fa2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Source coordinates can now be resolved relative to a specified workspace root.
  * Invalid paths outside the workspace or without sufficient qualification are rejected.

* **Bug Fixes**
  * Improved attribution for use sites located within workspace package directories.

* **Tests**
  * Added coverage for valid workspace-relative paths and rejection of unqualifiable paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->