### PR TITLE
Interpret staged battleaxe wrappers through bash

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -464,7 +464,7 @@ exit \"\$st\""
   # a status-bearing logout hook. On battleaxe /etc/bash.bash_logout invokes
   # clear_console, whose exit 1 replaced both remote success and remote 23.
   # The non-login wrapper's explicit exit is therefore the SSH verdict.
-  login_exec='exec "$@"'
+  login_exec='exec bash "$1"'
   # The OpenSSH ControlMaster mux has a bounded command packet. Passing the
   # full wrapper through bash -c makes a large payload fail as rc=255 with no
   # artifact. Stage the wrapper over stdin, then invoke it by reference so the


### PR DESCRIPTION
## Blocking regression

#7192 stages the compact battleaxe wrapper over SSH stdin and invokes it by remote reference. A stdin-created file has mode `0644`, so the landed bridge tried to execute a non-executable file directly. Every real gated invocation stopped before the lease, gates, corpus pin, or pytest with exit 126 and `bash: Permission denied`.

The exact mechanism is at `bin/lib/sugar-bx.sh`: under `bash -c`, the first argument becomes `$0`. The command supplied only the wrapper path, so the argument list available to `login_exec` held that non-executable path and `exec "$@"` attempted to execute it directly. The comment said invoke by reference; the code never interpreted the reference.

## Repair

The bridge is now explicit:

- `login_exec` is `exec bash "$1"`
- the remote command supplies a dummy `$0=bash`
- the staged wrapper path occupies `$1`

The non-executable `0644` staged file is interpreted and never exec-ed.

This is deliberately an interpreter invocation, not `chmod`. An executable mode bit can be lost to a umask, filesystem, or sync path; `bash <path>` cannot fail for that reason. The explicit `$1` form also avoids the `$0` trap. A naive `bash -c "$WRAPPER"` would consume the path as `$0` and run nothing, failing silently, which is worse than the loud exit 126.

## Real below-bound evidence at the exact head

At `49d7bb70a75b9c6d21c657e375bc24c1eb7ee2bd`, a real gated battleaxe invocation using `SUGAR_BX_REQUIRE_QUIET=1 bin/brun` with a `printf` payload:

- printed `staged-wrapper-ok`
- returned exit 0
- acquired and released the lease
- passed the authenticated corpus pin

This is the real below-bound execution arm that unblocks gated work on battleaxe.

## Honest transport gap

The oversized both-arm ControlMaster transport tooth remains uncommitted and unclaimed. The prior attempted tooth hit the local shell argv ceiling rather than the remote mux and would have measured the wrong boundary. This repair does not upgrade that missing evidence.

## Observability record

Exit 126 with `Permission denied` is the seventh terminal today that looked like an absence rather than a failure. Hockney excluded it as pre-measurement instead of counting it as RED; that distinction is why the wrapper entrance was diagnosed rather than misread as a product result.

## Preflight and scope

Exact remote head: `49d7bb70a75b9c6d21c657e375bc24c1eb7ee2bd`, one commit directly on main `1671664cd674878a5a996f1cacfb8f058a062883`, 0 behind / 1 ahead. The dead force-pushed head `ebc48c307cbbcf700f2ff121bd5fdf91415bc522` is not an ancestor.

All changed files:

- `bin/lib/sugar-bx.sh`

Diff: one insertion, one deletion. Deleted paths: 0. File operations: no creates, deletes, or renames. The additions scan found no category, kind, label, taxonomy, residual bucket, runner-autoscaler, or CI-capacity surface.

## Non-claims

This does not claim the oversized mux boundary has a committed both-arm tooth, that any blocked census has now run, or that the five Hockney nodes and two Keaton items are measured. It repairs the gate entrance so those measurements can begin.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Invoke staged battleaxe wrapper scripts through bash explicitly
> In [sugar-bx.sh](https://github.com/TSavo/sugar/pull/7200/files#diff-bdd6c46eb799e81d8c3cc8b50ab4a809668391cedbc25e468f6efe8ef9d86ebc), changes the login-shell exec from `exec "$@"` to `exec bash "$1"`, so staged wrapper scripts are always interpreted by bash rather than executed directly. This fixes cases where the wrapper script lacks an executable bit or a shebang line.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49d7bb7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->