### PR TITLE
Preserve With panic terminals with canonical keys

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -378,6 +378,35 @@ def demand_context_manager_resolution_events(
     return events, list(result.get("gaps") or [])
 
 
+def _provisional_resolution_events(
+    *, contract_refs: object, source_cid: str
+) -> list[dict[str, Any]]:
+    """Project the exact canonical fallback keys after enrichment panics.
+
+    ``contract_refs`` is the same installed table the enumerate request used.
+    This projects its coordinate-keyed rows directly; it never reconstructs
+    membership from counters or deleted resolution-kind names.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        context_manager_resolution_outcome,
+    )
+
+    events: list[dict[str, Any]] = []
+    for coordinate, resolution in sorted(
+        (getattr(contract_refs, "by_use_site", None) or {}).items()
+    ):
+        if getattr(coordinate, "source_cid", None) != source_cid:
+            continue
+        events.append(
+            {
+                "inputKey": coordinate.wire(),
+                "observedEventType": _qualified_type(resolution),
+                "outcome": context_manager_resolution_outcome(resolution),
+            }
+        )
+    return events
+
+
 def demand_construction_residual(
     *,
     workspace_root: Path,
@@ -672,10 +701,14 @@ def measure_file_via_enumerate(
     Never raises after a roster is banked — residual panic becomes a terminal
     row with functionsTotal preserved (roster-floor).
     """
-    if contract_refs is not None:
-        from sugar_lift_py_tests.lift_rpc import install_provisional_contract_refs
+    from sugar_lift_py_tests.lift_rpc import (
+        install_provisional_contract_refs,
+        provisional_contract_refs_from_demands,
+    )
 
-        install_provisional_contract_refs(Path(workspace_root), contract_refs)
+    if contract_refs is None:
+        contract_refs = provisional_contract_refs_from_demands(Path(workspace_root))
+    install_provisional_contract_refs(Path(workspace_root), contract_refs)
 
     path = (workspace_root / file_rel).resolve()
     ast_fn = count_ast_function_defs(path)
@@ -797,6 +830,12 @@ def measure_file_via_enumerate(
             clean_ratio_refused=True,
             clean_refuse_reason="CM resolution panic after roster; clean not measured",
             ast_fn=ast_fn,
+        )
+        row["constructionPanics"] = [panic]
+        row["enumerateConstructionPanics"] = [panic]
+        row["contextManagerResolutionEvents"] = _provisional_resolution_events(
+            contract_refs=contract_refs,
+            source_cid=source_cid,
         )
         return _attest_terminal_row(
             row,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2380,25 +2380,17 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
 
                 # Walk-scoped multi-resolve owner: same session as other opens
                 # under this workspace root (census / re-open amortization).
-                from sugar_source_tree.panic import (
-                    ContextManagerResolutionConstructionGap,
-                )
-
-                try:
+                # Construction terminals stay loud here. The recensus consumer
+                # preserves the already-authenticated provisional key manifest
+                # alongside the panic; this producer never converts panic into a
+                # completed resolution response.
+                if level == "context-manager-resolutions":
                     populate_source_derived_resource_refs(
                         tree_file,
                         root=root,
                         path=full_path,
                         session=walk_session_for(root),
                     )
-                except ContextManagerResolutionConstructionGap:
-                    # Enumeration owns attendance, not construction. Provider-call
-                    # projection can reach an unresolved With while enriching this
-                    # table; retain the already-authenticated provisional rows so
-                    # the context-manager edge conserves exact coordinates. The
-                    # construction demand still reaches and reports this same panic.
-                    pass
-                if level == "context-manager-resolutions":
                     from sugar_lift_py_tests.context_manager_resolution import (
                         context_manager_resolution_outcome,
                         effective_context_manager_resolutions_for_source,

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
@@ -330,7 +330,7 @@ def test_enumerate_with_rows_reach_partition_with_identical_keys(
 def test_resolution_enumeration_keeps_rows_when_provider_projection_reaches_gap(
     tmp_path: Path,
 ) -> None:
-    """A provider-call projection cannot erase its own unresolved With seat."""
+    """The raw producer keeps a provider construction terminal loud."""
     _load()
     from recensus_enumerate_consumer import demand_context_manager_resolution_events
     from sugar_lift_py_tests.lift_rpc import (
@@ -338,6 +338,7 @@ def test_resolution_enumeration_keeps_rows_when_provider_projection_reaches_gap(
         provisional_contract_refs_from_demands,
     )
     from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.panic import ContextManagerResolutionConstructionGap
 
     path = tmp_path / "provider.py"
     path.write_text(
@@ -351,13 +352,43 @@ def test_resolution_enumeration_keeps_rows_when_provider_projection_reaches_gap(
     install_provisional_contract_refs(tmp_path, refs)
     source_cid = path_source(str(path))[2]
 
-    events, gaps = demand_context_manager_resolution_events(
+    with pytest.raises(ContextManagerResolutionConstructionGap):
+        demand_context_manager_resolution_events(
+            workspace_root=tmp_path,
+            file_rel="provider.py",
+            source_cid=source_cid,
+        )
+
+
+def test_provider_resolution_gap_is_enrolled_once_without_losing_with_key(
+    tmp_path: Path,
+) -> None:
+    """A logged provider gap is one panic terminal, never completed testimony."""
+    _load()
+    from recensus_enumerate_consumer import measure_file_via_enumerate
+    from sugar_lift_py_tests.lift_rpc import provisional_contract_refs_from_demands
+
+    path = tmp_path / "provider.py"
+    path.write_text(
+        "def run():\n"
+        "    handle_data = get_data()\n"
+        "    with handle_data as payload:\n"
+        "        return payload\n",
+        encoding="utf-8",
+    )
+    refs = provisional_contract_refs_from_demands(tmp_path)
+
+    row = measure_file_via_enumerate(
         workspace_root=tmp_path,
         file_rel="provider.py",
-        source_cid=source_cid,
+        contract_refs=refs,
     )
 
-    assert gaps == []
-    assert len(events) == 1
-    assert events[0]["outcome"] == "unconstructed"
-    assert events[0]["inputKey"]["sourceCid"] == source_cid
+    assert row["category"] == "panic", row
+    assert row["terminalKind"] == "construction-panic", row
+    assert row["panic"]["observedEventType"] == (
+        "sugar_source_tree.panic.ContextManagerResolutionConstructionGap"
+    )
+    assert row["constructionPanics"] == [row["panic"]]
+    assert len(row["contextManagerResolutionEvents"]) == 1
+    assert row["contextManagerResolutionEvents"][0]["outcome"] == "unconstructed"


### PR DESCRIPTION
## Last conservation blocker

Compose has refused `frontierWidth` since the first attested census on exactly three surviving With-conservation causes:

- `pandas/io/parsers/readers.py`: 1
- `pandas/io/pytables.py`: 8
- `pandas/io/stata.py`: 3

The raw context-manager resolution producer caught `ContextManagerResolutionConstructionGap` while enriching the table and continued by returning provisional rows. That let a construction terminal and its coordinate-keyed membership diverge across the producer/consumer boundary.

## Repair

The raw producer now keeps provider construction terminals loud. The recensus consumer catches the typed panic at its owned membrane, enrolls it exactly once as `category=panic` / `terminalKind=construction-panic`, and preserves the already-authenticated provisional coordinate keys alongside it.

The fallback key manifest is projected from the same installed `contract_refs.by_use_site` table the enumerate request consumed. It is never reconstructed from counters, manager spelling, or deleted resolution-kind names.

## Full authenticated corpus diagnostic

Measured at content-equivalent diagnostic head `f28b3e1f7a04682ed7bd1583e7b89a239b22d5ee` over authenticated pandas:

- attendance: 1,421/1,421 files
- functions: 28,264
- diagnostic conservation causes: 0
- `readers.py`: 1/1 accounted
- `pytables.py`: 8/8 accounted
- `stata.py`: 3/3 accounted
- corpus-wide conservation mismatches: 0
- edge diffs: 0
- per-file instrument failures: 0

Checkpoint SHA-256: `6549e43eddf6cb863fcbce9501c27378594c6870fb0b116edc318400378a3345`.

This clears the three conservation causes that have blocked compose. The remaining prerequisite to a first attested width is `runtimeIdentity/v1`.

## Mandatory receipt caveat

This does NOT produce an attested frontier width, and no sealed census receipt is claimed. The full walk completed, but post-walk aggregation exited 1 on the pre-existing stale `denominator["complete"]` lookup. Landing this change removes a refusal reason; it does not make the census speak.

## Preflight and scope

Exact remote head: `f28b3e1f7a04682ed7bd1583e7b89a239b22d5ee`, one commit directly on main `e3085744aab1c9c14ef10424c82e36bf65b21767`, 0 behind / 1 ahead.

All changed files, reconciled against this body:

- `implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py`
- `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py`
- `implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py`

Deleted paths: 0. File operations: no creates, deletes, or renames. Stable patch ID `6b32b8ec4478b387e8739d37d4119365a99b1116` matches the previously held unmeasured repair.

The additions scan found only the existing `panic` category in a discrimination assertion and a comment rejecting reconstruction from deleted resolution-kind names. It adds no category, kind, label, taxonomy, residual bucket, runner-autoscaler, or CI-capacity surface.

## IDD accounting

Observed diagnostic delta for With-conservation causes: 3 files / 12 seats to 0 causes, with all 12 seats accounted. Floor invariants remain: zero edge differences and zero per-file instrument failures. The sealed-width axis remains explicitly unmeasured pending runtime identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved context-manager resolution handling when required provider information is unavailable.
  - Resolution enumeration now reports construction failures clearly instead of returning incomplete results.
  - Measurement and census output now preserves unresolved context-manager events while recording each construction failure only once.
  - Added provisional resolution information during measurement to retain useful coordinate-linked event data, even when resolution construction cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve construction-panic terminals with canonical With keys during context-manager resolution enumeration
> - When `measure_file_via_enumerate` encounters a construction panic, the returned terminal now includes `constructionPanics`, `enumerateConstructionPanics`, and `contextManagerResolutionEvents` (with outcome `'unconstructed'`), preserving the With key.
> - `measure_file_via_enumerate` now derives and installs provisional contract refs automatically when none are provided, rather than skipping installation.
> - In `_handle_enumerate`, `populate_source_derived_resource_refs` is now only called at `level == "context-manager-resolutions"`, and `ContextManagerResolutionConstructionGap` is no longer swallowed — it propagates as a JSON-RPC error.
> - A new test `test_provider_resolution_gap_is_enrolled_once_without_losing_with_key` asserts the full shape of the panic terminal including the preserved With key and provisional resolution event.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f28b3e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->