### PR TITLE
Resolve imported Name With managers by exact coordinate

### DIFF
--- a/docs/plans/2026-08-03-import-backed-with-manager-resolution.md
+++ b/docs/plans/2026-08-03-import-backed-with-manager-resolution.md
@@ -1,0 +1,56 @@
+# Import-backed `With` manager resolution
+
+## Measured problem
+
+On the authenticated pandas 3.0.3 / 1,421-file corpus, 18
+`ContextManagerResolutionConstructionGap` rows are direct, import-bound pandas
+callables used as context managers. All 18 calls contain keyword arguments:
+17 contain named keywords and one `TextParser` call also contains `**kwargs`.
+
+The rows remain `runtime-selected` because the call-contract receipt surface is
+deliberately positional-only. Commit `614fa939c6ed95efb7cd665da283ddfd86ca59be`
+introduced that boundary together with a tooth asserting that `pair(x=1)` is
+not a `call-contract-demand`. Removing the guard would make the call-contract
+signature claim more than it authenticates.
+
+## Authority and design
+
+The existing lexical pass already emits an `import-value-use-demand` for the
+callee `Name`. That receipt authenticates the exact source occurrence, import
+binding, target symbol, and consumer source CID. The existing source-derived
+manager producer already owns the typed parent `Call`, the manager-use
+coordinate, keyword actual binding, dependency resolution, and manager protocol
+construction.
+
+The consumer will therefore:
+
+1. retain full-call `call-contract-demand` receipts as the first authority;
+2. for a typed manager `Call` with no full-call receipt, derive the exact
+   coordinate of its `Call.func` child;
+3. admit only the one `import-value-use-demand` whose source CID and complete
+   physical coordinate equal that child;
+4. pass that final-checked receipt through the existing
+   `resolve_import_binding` and source-derived manager construction path.
+
+No callee spelling or target name participates in the join. Multiple receipts
+for one coordinate are a backend defect; absence stays an unresolved manager
+gap.
+
+## Discrimination teeth
+
+- A direct imported `Name` manager with a named keyword reaches the existing
+  source-derived protocol and no longer reports `runtime-selected`.
+- A shadowed or otherwise non-import callee remains unresolved.
+- A `TextParser`-shaped `**kwargs` call may move to the deeper
+  `incomplete-call-actuals` terminal; the consumer must not fabricate support.
+- The existing positional-only call-contract tooth remains unchanged and
+  green: `pair(x=1)` is still absent from `call-contract-demand` rows.
+- Existing imported attribute-call managers remain on the full-call receipt
+  path.
+
+## Non-claims
+
+This wiring does not claim that all 18 managers complete. Each row is a first
+terminal and may reattribute to a deeper, honestly named construction gap. It
+does not widen the corpus pin, admit external dependencies, or change the
+call-contract schema.

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1218,7 +1218,10 @@ def populate_source_derived_resource_refs(
     from sugar_lift_py_tests.context_manager_resolution import (
         SourceDerivedContextManagerRefV1,
     )
-    from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+    from sugar_lift_py_tests.import_binding import (
+        authenticated_import_use_receipts,
+        authenticated_import_value_use_receipts,
+    )
     from sugar_lift_py_tests.ir import _term_content_cid
     from sugar_lift_py_tests.outcome import Complete
     from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
@@ -1263,6 +1266,14 @@ def populate_source_derived_resource_refs(
         module_identities={},
         module=source_file.root,
     )
+    value_receipts, _ = authenticated_import_value_use_receipts(
+        Path(root),
+        Path(path),
+        source_file.unit.source,
+        source_file.unit.source_cid,
+        module_identities={},
+        module=source_file.root,
+    )
     uses = _projected_manager_call_uses(source_file)
     if selected_coordinates is not None:
         uses = {
@@ -1270,23 +1281,72 @@ def populate_source_derived_resource_refs(
             for key, value in uses.items()
             if value[0] in selected_coordinates
         }
+
+    def _receipt_site_key(receipt):
+        raw_site = receipt.use["useSite"]
+        return (
+            raw_site["sourceCid"],
+            raw_site["startLine"],
+            raw_site["startCol"],
+            raw_site["endLine"],
+            raw_site["endCol"],
+        )
+
+    def _unique_receipts_by_site(rows, *, owner: str):
+        indexed = {}
+        for row in rows:
+            key = _receipt_site_key(row)
+            if key in indexed:
+                from sugar_source_tree.panic import BackendDefect
+
+                raise BackendDefect(
+                    blame=Path(path),
+                    owner=owner,
+                    observed=f"duplicate authenticated import receipts at {key}",
+                    requested="one authenticated import receipt per physical coordinate",
+                    fix="repair lexical receipt enrollment uniqueness; never choose by order",
+                )
+            indexed[key] = row
+        return indexed
+
+    call_receipts_by_site = _unique_receipts_by_site(
+        receipts,
+        owner="manager_summary_derivation imported manager call receipt pairing",
+    )
+    value_receipts_by_site = _unique_receipts_by_site(
+        value_receipts,
+        owner="manager_summary_derivation imported manager value receipt pairing",
+    )
+    paired_receipts = []
+    for call_key, selected in uses.items():
+        _, call, _ = selected
+        source_cid = call.unit.source_cid
+        # The closed call-contract door remains authoritative whenever it
+        # admitted the full Call.  Only a keyword-bearing direct Name that it
+        # deliberately excludes may fall back to the independently minted
+        # value-use receipt at the exact callee occurrence.  No spelling or
+        # target-symbol join is admissible here.
+        receipt = call_receipts_by_site.get((source_cid, *call_key))
+        if receipt is None and call.func.kind == "Name" and call.keywords:
+            callee_span = call.func.line_col_span()
+            callee_key = (
+                source_cid,
+                callee_span.start_line,
+                callee_span.start_col,
+                callee_span.end_line,
+                callee_span.end_col,
+            )
+            receipt = value_receipts_by_site.get(callee_key)
+        if receipt is not None:
+            paired_receipts.append((receipt, selected))
+
     graphs = {} if artifact_graph_cache is None else artifact_graph_cache
     # Seed from session so tops already resolved in frame/prefix projection
     # are not re-asked (warnings/re/inspect ×21 on test_pandas).
     if session.enabled:
         for top, graph in session.dependency_graphs.items():
             graphs.setdefault(top, graph)
-    for receipt in receipts:
-        raw_site = receipt.use["useSite"]
-        key = (
-            raw_site["startLine"],
-            raw_site["startCol"],
-            raw_site["endLine"],
-            raw_site["endCol"],
-        )
-        selected = uses.get(key)
-        if selected is None:
-            continue
+    for receipt, selected in paired_receipts:
         coordinate, call, exit_face_id = selected
         top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
         graph = graphs.get(top_level)

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_manager.py
@@ -270,6 +270,78 @@ def test_returned_manager_pattern_preserves_message_obligation(tmp_path: Path):
     assert all(_observed_binding(face) is None for face in exits.exits if isinstance(face, Halted))
 
 
+def test_direct_imported_name_manager_with_keyword_uses_source_contract(
+    tmp_path: Path,
+):
+    """Exact imported callee identity advances to its deeper source-body gap."""
+    dist = _distribution(
+        tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary"
+    )
+    consumer = (
+        "from arbitrary import boundary as hold\n"
+        "def use():\n"
+        "    pattern = 'needle'\n"
+        "    with hold(ValueError, match=pattern) as info:\n"
+        "        raise ValueError('needle')\n"
+    )
+    tree, context, _ = _populate(tmp_path, consumer, dist=dist)
+    reference, _ = _reference(context, tree)
+
+    assert isinstance(reference, ContextManagerResolutionGapV1), reference
+    assert reference.target_symbol == "python:arbitrary.boundary"
+    assert reference.kind == "source-body-gap"
+    assert "CallSiteSugar at arbitrary/manager.py:18:11" in reference.detail
+    assert (
+        "source call definition is not this call's exact typed occurrence"
+        in reference.detail
+    )
+
+
+def test_direct_imported_name_manager_with_double_star_stays_loud(
+    tmp_path: Path,
+):
+    """Imported ``**kwargs`` call advances to the same earlier provider-body gap."""
+    dist = _distribution(
+        tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary"
+    )
+    consumer = (
+        "from arbitrary import boundary as hold\n"
+        "def use(options):\n"
+        "    with hold(ValueError, **options) as info:\n"
+        "        raise ValueError('needle')\n"
+    )
+    tree, context, _ = _populate(tmp_path, consumer, dist=dist)
+    reference, _ = _reference(context, tree)
+
+    assert isinstance(reference, ContextManagerResolutionGapV1), reference
+    assert reference.target_symbol == "python:arbitrary.boundary"
+    # The provider body fails before actual binding, so the prospective
+    # ``incomplete-call-actuals`` terminal is not observable yet.  Pin the
+    # earlier owner rather than pretending the **kwargs layer executed.
+    assert reference.kind == "source-body-gap"
+    assert "CallSiteSugar at arbitrary/manager.py:18:11" in reference.detail
+    assert (
+        "source call definition is not this call's exact typed occurrence"
+        in reference.detail
+    )
+
+
+def test_shadowed_imported_name_manager_is_not_authorized(tmp_path: Path):
+    """A nearby import cannot authorize a parameter-shadowed manager call."""
+    dist = _distribution(
+        tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary"
+    )
+    consumer = (
+        "from arbitrary import boundary\n"
+        "def use(boundary):\n"
+        "    with boundary(ValueError, match='needle') as info:\n"
+        "        raise ValueError('needle')\n"
+    )
+    _, context, _ = _populate(tmp_path, consumer, dist=dist)
+
+    assert context.source_derived_contract_refs == {}
+
+
 def test_returned_manager_pattern_mismatch_preserves_halt_without_binding(
     tmp_path: Path,
 ):


### PR DESCRIPTION
## What this lands

At the manager-summary consumer only, pair an exact typed manager `Call` with its exact callee value-use receipt at the `Call.func` coordinate.

Full `Call` receipts remain authoritative and are preferred wherever they exist. Only an unmatched, keyword-bearing direct `Name` call may use the exact callee value-use receipt. Duplicate receipts at one physical coordinate panic; absence emits nothing. No spelling or target-symbol join participates.

The deliberate positional-only call-contract door is unchanged. Per `614fa939c6ed95efb7cd665da283ddfd86ca59be`, its live tooth still asserts that `pair(x=1)` is not a `call-contract-demand`, because that schema authenticates positional arity only.

## Honest measured result: reattribution, not reduction

**Class-2 does not reduce the frontier count.** Two positive rows move from `runtime-selected` to authenticated target `python:arbitrary.boundary`, then stop at the deeper `source-body-gap` owned by `CallSiteSugar` at `arbitrary/manager.py:18:11`. That deeper owner is recorded in #7204.

The shadow twin emits **0 producer rows**: a same-spelling parameter-shadowed callee authorizes nothing, so there is no fabricated gap to resolve.

This is the same shape as `Module.sugar`: a real fix moves rows to their next truthful owner rather than deleting them from the frontier.

## Unobservable layer

The `**kwargs` `incomplete-call-actuals` layer is **unobservable**, not claimed implemented. The provider-body `CallSiteSugar` gap fires first. An assertion that cannot be reached is not a passing assertion.

## Reproduced after rebase

At exact head `819e9c32dcada39b24dfd09ce7cc65c35d2373da`, on authenticated pandas 3.0.3 / 1,421 files:

- class twins: **3/3 passed** in 0.39s
- load1: 3.57
- CPU idle: 91.02% to 92.89%
- lease release: 0

Two preserved floor nodes were excluded as orthogonal cold release-build-bound evidence. They are not counted as class-2 tests and do not describe this change.

## Scope proof

The three-commit range changes exactly:

- `docs/plans/2026-08-03-import-backed-with-manager-resolution.md`
- `implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py`
- `implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_manager.py`

No files are deleted. No runner, autoscaler, CI-capacity, new residual kind, category, label, or taxonomy change is present.

## Non-claims

- No frontier-count reduction.
- No pandas corpus magnitude change.
- No claim that the `**kwargs` layer executed.
- No weakening of the positional-only call-contract boundary.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve imported Name context manager calls with keyword arguments by exact coordinate
> - `populate_source_derived_resource_refs` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/7207/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) now pairs manager call sites to authenticated import receipts by exact physical coordinates (source, line, col).
> - When no full call-contract receipt exists and the callee is a directly imported `Name` with keyword arguments, it falls back to matching a value-use receipt keyed by the Name node's span.
> - Manager uses with no matching receipt are skipped; shadowed names without an authenticated value-use receipt remain unprocessed.
> - Risk: if multiple authenticated import receipts share the same physical coordinate, a `BackendDefect` is raised.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 819e9c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->