### PR TITLE
Require authenticated distribution authority for census manager enrollment

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_production_lift_child.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_production_lift_child.py
@@ -69,6 +69,8 @@ def production_lift_testimony(
     *,
     corpus_root: Path,
     construction_context,
+    source_workspace_root: Path | None = None,
+    distribution: str | None = None,
 ) -> dict[str, object]:
     """Enumerate one file with the caller's frozen corpus context."""
     from sugar_source_tree.reporter import CollectingReporter
@@ -85,6 +87,8 @@ def production_lift_testimony(
             root=corpus_root,
             reporter=reporter,
             construction_context=construction_context,
+            source_workspace_root=source_workspace_root,
+            distribution=distribution,
         )
     except BaseException as error:
         row = _typed_construction_row(error)

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
@@ -25,6 +25,8 @@ import sys
 from pathlib import Path
 
 _CORPUS_ROOT: Path | None = None
+_SOURCE_WORKSPACE_ROOT: Path | None = None
+_DISTRIBUTION: str | None = None
 _CONSTRUCTION_CONTEXT = None
 
 
@@ -69,6 +71,8 @@ def _lift(path: str, rel: str) -> dict:
         rel,
         corpus_root=_CORPUS_ROOT,
         construction_context=_CONSTRUCTION_CONTEXT,
+        source_workspace_root=_SOURCE_WORKSPACE_ROOT,
+        distribution=_DISTRIBUTION,
     )
     return {"kind": "lift-result", "file": rel, "terminal": terminal}
 
@@ -91,7 +95,7 @@ def _initialize(
     allow_local_demand_derivation: bool,
     source_workspace_root: str | None = None,
 ) -> dict:
-    global _CONSTRUCTION_CONTEXT, _CORPUS_ROOT
+    global _CONSTRUCTION_CONTEXT, _CORPUS_ROOT, _SOURCE_WORKSPACE_ROOT, _DISTRIBUTION
     import os
 
     # Test-only plant: hang after first progress so supervisor timeout names phase.
@@ -226,6 +230,7 @@ def _initialize(
                 f"{SHARED_DEMAND_TABLE_CONTENT_KEY}"
             )
         validate_prebuilt_demand_table(table, corpus)
+        _DISTRIBUTION = corpus.distribution
         contract_refs = provisional_contract_refs_from_demand_rows(list(table.rows))
         demand_table_identity = table.semantic_identity.content_key
     elif not allow_local_demand_derivation:
@@ -262,6 +267,7 @@ def _initialize(
         using_provisional_demands=demand_table_path is None,
     )
     _CORPUS_ROOT = root
+    _SOURCE_WORKSPACE_ROOT = workspace_root
     _CONSTRUCTION_CONTEXT = tree_construction_context_for_workspace(
         workspace_root, contract_refs=contract_refs
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -290,6 +290,8 @@ def open_source_file_for_construction(
     construction_context=None,
     populate_derived: bool = True,
     resolution_session=None,
+    source_workspace_root: Path | None = None,
+    distribution: str | None = None,
 ):
     """Open a SourceFile the way production enumerate does — never bare context.
 
@@ -352,7 +354,12 @@ def open_source_file_for_construction(
         # here — that was the two-costume allowlist that left the class open.
         try:
             populate_source_derived_resource_refs(
-                source_file, root=root, path=path, session=session
+                source_file,
+                root=root,
+                path=path,
+                session=session,
+                source_workspace_root=source_workspace_root,
+                distribution=distribution,
             )
         except Exception as populate_gap:  # noqa: BLE001 — floor law; see above
             _record_populate_path_residual(source_file, populate_gap)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1188,6 +1188,32 @@ def _exception_class_testimony_or_absence(unit, node):
         return None
 
 
+def _qualified_enrollment_coordinate(
+    path,
+    *,
+    source_workspace_root,
+    distribution: str | None,
+) -> str:
+    """Qualify a source seat from authenticated authority, never path guesses."""
+    from pathlib import Path
+
+    if not distribution:
+        raise ValueError(
+            "source workspace distribution authority is required; "
+            "refusing to infer it from a relative path segment"
+        )
+    try:
+        relative = Path(path).resolve().relative_to(
+            Path(source_workspace_root).resolve()
+        )
+    except ValueError as error:
+        raise ValueError(
+            "source seat is outside the authenticated source workspace: "
+            f"path={path} source_workspace_root={source_workspace_root}"
+        ) from error
+    return "/".join((distribution, *relative.parts))
+
+
 def populate_source_derived_resource_refs(
     source_file,
     *,
@@ -1246,10 +1272,11 @@ def populate_source_derived_resource_refs(
     # segment under the locus root), not test-only deps (pytest) or stdlib.
     # Without this, one open of pandas/tests/io/json/test_pandas.py projected
     # 40 pytest frames (~3.8s) after the stdlib-only membrane.
-    if source_workspace_root is not None and not distribution:
-        raise ValueError(
-            "source workspace distribution authority is required; "
-            "refusing to infer it from a relative path segment"
+    if source_workspace_root is not None:
+        _qualified_enrollment_coordinate(
+            path,
+            source_workspace_root=source_workspace_root,
+            distribution=distribution,
         )
     if distribution is not None:
         session.enrolled_distributions = frozenset({distribution})

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1197,6 +1197,8 @@ def populate_source_derived_resource_refs(
     artifact_graph_cache: dict | None = None,
     session=None,
     selected_coordinates: frozenset | None = None,
+    source_workspace_root=None,
+    distribution: str | None = None,
 ) -> None:
     """Preconstruct imported resource managers and freeze exact use-site rows.
 
@@ -1244,9 +1246,17 @@ def populate_source_derived_resource_refs(
     # segment under the locus root), not test-only deps (pytest) or stdlib.
     # Without this, one open of pandas/tests/io/json/test_pandas.py projected
     # 40 pytest frames (~3.8s) after the stdlib-only membrane.
-    if session.enrolled_distributions is None:
+    if source_workspace_root is not None and not distribution:
+        raise ValueError(
+            "source workspace distribution authority is required; "
+            "refusing to infer it from a relative path segment"
+        )
+    if distribution is not None:
+        session.enrolled_distributions = frozenset({distribution})
+    elif session.enrolled_distributions is None:
         try:
-            rel = Path(path).resolve().relative_to(Path(root).resolve())
+            coordinate_root = source_workspace_root or root
+            rel = Path(path).resolve().relative_to(Path(coordinate_root).resolve())
             top = rel.parts[0] if rel.parts else None
         except ValueError:
             top = None

--- a/implementations/python/sugar-lift-python-source/tests/test_manager_enrollment_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_manager_enrollment_authority.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_python_source.manager_summary_derivation import (
+    _qualified_enrollment_coordinate,
+)
+
+
+def test_package_seat_uses_authenticated_distribution(tmp_path: Path) -> None:
+    workspace = tmp_path / "site-packages" / "pandas"
+    path = workspace / "_config" / "config.py"
+    path.parent.mkdir(parents=True)
+    path.write_text("x = 1\n", encoding="utf-8")
+
+    assert (
+        _qualified_enrollment_coordinate(
+            path,
+            source_workspace_root=workspace,
+            distribution="pandas",
+        )
+        == "pandas/_config/config.py"
+    )
+
+
+def test_missing_distribution_refuses_instead_of_bare_segment(tmp_path: Path) -> None:
+    path = tmp_path / "pandas" / "_config" / "config.py"
+    path.parent.mkdir(parents=True)
+    with pytest.raises(ValueError, match="distribution authority is required"):
+        _qualified_enrollment_coordinate(
+            path,
+            source_workspace_root=tmp_path,
+            distribution=None,
+        )


### PR DESCRIPTION
## What this fixes

`manager_summary_derivation.py` previously derived enrollment authority from one overloaded path variable. At the census entrance, `root` is the pandas package directory, so:

```text
pandas/_config/config.py -> path.relative_to(root) -> _config/config.py -> top=_config
```

That silent fallback made authenticated pandas files appear off-population and produced 77 of the 471 measured `With` resolution gaps.

This three-commit lane installs the explicit authority door, threads `source_workspace_root` plus the authenticated distribution through the worker and production construction path, and adds both discrimination arms. The census manager-summary consumer now receives `distribution=pandas` from the authenticated corpus handle instead of inferring it from a relative path segment.

## This is the census path, not #7197 duplicated

The census actually reads:

```text
control_effect_recensus
-> recensus_enumerate_consumer
-> lift_file_via_enumerate
-> lift_rpc.open_source_file_for_construction
-> populate_source_derived_resource_refs
```

#7197 correctly fixed the same defect shape in `discover_no_call_body_probes`, reached through `run_authenticated_attribution`. The census never calls that route, which is why #7197 moved zero census rows. This PR repairs the distinct manager-summary consumer that the census does execute.

## Discrimination teeth

Reproduced on battleaxe in 0.96s:

- authenticated package seat qualifies as `pandas/_config/config.py`
- missing distribution authority **refuses by name** with `source workspace distribution authority is required`; it never falls back to `_config/...`

**2/2 passed.** The refusal arm is load-bearing: a positive-only test would preserve the exact silent fallback that created the 77 apparently off-population rows.

## Repeated shape and replacement architecture

This is the fifth observed instance of one variable carrying two meanings:

1. recipe key as storage key
2. distribution implied by class
3. floor worker corpus root as workspace root
4. probe enrollment coordinate as population authority
5. census manager-summary root as distribution authority

Five occurrences identify a missing type, not five unrelated bugs. Measurement root, source workspace root, and authenticated distribution are now separate named inputs at this door.

## Scope and preflight

The exact three-commit range changes only:

- `implementations/python/sugar-lift-py-tests/scripts/_production_lift_child.py`
- `implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py`
- `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py`
- `implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py`
- `implementations/python/sugar-lift-python-source/tests/test_manager_enrollment_authority.py`

No files are deleted. No runner, autoscaler, CI-capacity, new residual kind, category, label, or taxonomy change is present.

## Mandatory non-claim

**The 77-row reduction is not measured.** This PR repairs the authority derivation; only a corpus census at the merged head, read from `enumerateConstructionPanics`, can establish whether and how those rows move. #7197 demonstrated why code-path plausibility is not corpus testimony.

This does not claim a frontier width or close the broader frontier classification record before that census.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require authenticated distribution authority for census manager enrollment
> - Adds `_qualified_enrollment_coordinate` in [`manager_summary_derivation.py`](https://github.com/TSavo/sugar/pull/7208/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to validate that a source file path falls within an authenticated workspace root and that a distribution is present, raising `ValueError` otherwise.
> - Extends `populate_source_derived_resource_refs` to accept `source_workspace_root` and `distribution`; when provided, seat validation is enforced and session enrollment is set explicitly rather than inferred.
> - Threads the authenticated workspace root and distribution from initialization through the supervised enum worker and lift RPC layer into population.
> - Risk: callers that supply `source_workspace_root` without `distribution`, or with a path outside the workspace, will now receive a `ValueError` where previously no error was raised.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e04ff95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->