### PR TITLE
Preserve per-file panic enrollment before contract-ref fallback

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -701,14 +701,10 @@ def measure_file_via_enumerate(
     Never raises after a roster is banked — residual panic becomes a terminal
     row with functionsTotal preserved (roster-floor).
     """
-    from sugar_lift_py_tests.lift_rpc import (
-        install_provisional_contract_refs,
-        provisional_contract_refs_from_demands,
-    )
+    if contract_refs is not None:
+        from sugar_lift_py_tests.lift_rpc import install_provisional_contract_refs
 
-    if contract_refs is None:
-        contract_refs = provisional_contract_refs_from_demands(Path(workspace_root))
-    install_provisional_contract_refs(Path(workspace_root), contract_refs)
+        install_provisional_contract_refs(Path(workspace_root), contract_refs)
 
     path = (workspace_root / file_rel).resolve()
     ast_fn = count_ast_function_defs(path)
@@ -796,6 +792,19 @@ def measure_file_via_enumerate(
             ast_fn=ast_fn,
             source_cid=source_cid,
         )
+
+    if contract_refs is None:
+        from sugar_lift_py_tests.lift_rpc import (
+            install_provisional_contract_refs,
+            provisional_contract_refs_from_demands,
+        )
+
+        # The per-file roster is the sanctioned ConstructionPanic membrane.
+        # Bank it before entering the corpus-wide fallback. A panic from this
+        # fallback remains loud: it is not a terminal for this one file and
+        # must never be absorbed or misattributed as one.
+        contract_refs = provisional_contract_refs_from_demands(Path(workspace_root))
+        install_provisional_contract_refs(Path(workspace_root), contract_refs)
 
     try:
         cm_events, cm_gaps = demand_context_manager_resolution_events(

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 from sugar_lift_py_tests.gap.info import ConstructionGap
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
@@ -55,6 +57,45 @@ def test_recensus_projects_construction_panic_as_a_loud_counted_terminal(
     assert row["blocking_terminal_count"] == 1
     assert row["panic"]["observedEventType"].endswith(".ConstructionPanic")
     assert len(row["constructionPanics"]) == 1
+
+
+def test_contract_ref_fallback_panic_stays_loud_after_roster_bank(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Fallback derivation follows roster banking and never absorbs its panic."""
+    path = tmp_path / "fixture.py"
+    path.write_text("def a():\n    return 1\n", encoding="utf-8")
+    calls: list[str] = []
+
+    def roster(**_kwargs):
+        calls.append("roster")
+        return ([{"kind": "function-memento"}], [])
+
+    def fallback(_root):
+        calls.append("fallback")
+        raise ConstructionPanic(
+            ConstructionGap(
+                owner="fallback-demand-table-panic",
+                blame="fixture.py:1:0",
+                observed="fallback demand-table construction",
+                requested="authenticated contract refs",
+                fix="keep fallback failure loud after the per-file roster bank",
+            )
+        )
+
+    import sugar_lift_py_tests.lift_rpc as lift_rpc
+
+    monkeypatch.setattr(CONSUMER, "demand_function_roster", roster)
+    monkeypatch.setattr(lift_rpc, "provisional_contract_refs_from_demands", fallback)
+
+    with pytest.raises(ConstructionPanic) as raised:
+        CONSUMER.measure_file_via_enumerate(
+            workspace_root=tmp_path,
+            file_rel="fixture.py",
+        )
+
+    assert raised.value.info.owner == "fallback-demand-table-panic"
+    assert calls == ["roster", "fallback"]
 
 
 def test_mid_file_construction_panic_does_not_shrink_function_denominator(


### PR DESCRIPTION
## Finding and repair

The contract_refs=None fallback performed a corpus demand-table walk before the per-file ConstructionPanic membrane. A planted ConstructionPanic therefore escaped through import_binding._run_lexical_import_pass and terminated recensus at exit 1.

This change narrows the fallback, not panic propagation: it banks the per-file function roster before entering the corpus-wide contract-ref fallback. A panic from that fallback remains loud and escapes unchanged rather than being absorbed or misattributed as a per-file terminal. With-specific ConstructionPanic propagation remains loud.

## Evidence

Measured at exact head dbb089f62c22b18821e23a6a89c21e7155a4281e:

- positive smoke: PATH_OK
- constructed 1 + unconstructed 1 = accounted 2/2
- construction panic count: 1
- four negative arms all still bite:
  - constructed_zero -> PATH_RED, failedTooth=known_constructed
  - swallow_panic -> PATH_RED, failedTooth=known_panic
  - drop_opaque -> PATH_RED, failedTooth=known_unconstructed
  - crash_mid -> PATH_UNMEASURED, failedTooth=crash_not_green

Those four arms are load-bearing: narrowing a fallback is exactly where an absorbing site could otherwise be reintroduced.

## Scope and attestation caveat

The branch is one commit directly on main and changes only recensus_enumerate_consumer.py plus its focused panic-collection tooth. It adds no result category, kind, label, taxonomy, or residual bucket.

The path-smoke measurement ran under the battleaxe census venv at CPython 3.12.12. It is focused behavioral evidence, not runtimeIdentity-attested census evidence, and this PR claims no frontier width or sealed census receipt.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve per-file panic enrollment before contract-ref fallback in `measure_file_via_enumerate`
> - When `contract_refs` is `None`, provisional contract refs are now derived and installed only after `path_source` succeeds and after per-file roster banking, rather than up-front.
> - When `contract_refs` is provided, refs are installed immediately without importing the derivation function.
> - Adds a test in [test_recensus_panic_collection.py](https://github.com/TSavo/sugar/pull/7210/files#diff-4ae95f3eb7ec62a0f5b1b052a6ed60801932afc953bacaf26eec9dd5734617df) that verifies the fallback derivation occurs after roster banking and that a `ConstructionPanic` raised during derivation propagates correctly.
> - Behavioral Change: if `path_source` fails and `contract_refs` is `None`, no provisional contract refs are installed (previously they were installed unconditionally).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81c594b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contract references are now derived only after per-file roster collection completes successfully.
  * Failures during fallback contract-reference derivation now propagate correctly instead of being hidden or incorrectly attributed to the file.
  * Supplied contract references continue to be installed immediately.

* **Tests**
  * Added regression coverage confirming roster processing occurs before fallback derivation and that construction failures remain attributable to their original source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->