### PR TITLE
Migrate verified legacy shelf cells without rebuilding

### DIFF
--- a/tests/sugarbin_legacy_shelf_migration.py
+++ b/tests/sugarbin_legacy_shelf_migration.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Behavioral teeth for the legacy binary-shelf migration."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO = Path(__file__).resolve().parents[1]
+TOOL = REPO / "tools" / "migrate_legacy_binary_shelf.py"
+PLATFORM = "linux-x86_64"
+PROFILE = "release"
+
+
+def stamp(digit: str) -> str:
+    return f"blake3-512_{digit * 128}"
+
+
+def content_key(payload: bytes) -> str:
+    result = subprocess.run(
+        ["b3sum", "-l", "64", "--no-names"],
+        input=payload,
+        check=True,
+        capture_output=True,
+    )
+    return f"blake3-512_{result.stdout.decode().strip()}"
+
+
+def legacy_cell(
+    shelf: Path,
+    *,
+    source_stamp: str,
+    payload: bytes,
+    binary: str = "sugar",
+    build_identity: str | None = None,
+    legacy_colon_keys: bool = False,
+    malformed_manifest: bool = False,
+    corrupt_payload: bool = False,
+) -> Path:
+    build_identity = build_identity or source_stamp
+    name = f"{binary}-{PLATFORM}-{PROFILE}-{build_identity}"
+    cell = shelf / PLATFORM / PROFILE / source_stamp / name
+    cell.mkdir(parents=True)
+    declared_payload = payload
+    stored_payload = payload + b"-corrupt" if corrupt_payload else payload
+    with gzip.GzipFile(
+        filename=str(cell / f"{name}.gz"), mode="wb", mtime=0
+    ) as target:
+        target.write(stored_payload)
+    sha256 = hashlib.sha256(declared_payload).hexdigest()
+    manifest_source_stamp = source_stamp
+    manifest_build_identity = build_identity
+    if legacy_colon_keys:
+        manifest_source_stamp = source_stamp.replace("blake3-512_", "blake3-512:")
+        manifest_build_identity = build_identity.replace(
+            "blake3-512_", "blake3-512:"
+        )
+    metadata = {
+        "actor": "fixture",
+        "buildStamp": manifest_source_stamp,
+        "platform": PLATFORM,
+        "profile": PROFILE,
+        "publishedAt": "2026-08-03T00:00:00+00:00",
+        "sha256": sha256,
+        "source": f"/fixture/{binary}",
+        "transport": "filesystem-cas-v2",
+    }
+    manifest = {
+        "binary": binary,
+        "buildIdentity": manifest_build_identity,
+        "built": True,
+        "cargo": "cargo fixture",
+        "executed": False,
+        "features": [],
+        "package": f"{binary}-package",
+        "platform": PLATFORM,
+        "profile": PROFILE,
+        "rustc": "rustc fixture",
+        "schema": 1,
+        "sha256": sha256,
+        "sourceStamp": manifest_source_stamp,
+        "targetTriple": "x86_64-unknown-linux-gnu",
+    }
+    (cell / f"{name}.metadata.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    manifest_path = cell / f"{name}.sugarbin.json"
+    if malformed_manifest:
+        manifest_path.write_text('{"schema": 1}{"second": true}\n', encoding="utf-8")
+    else:
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    return cell
+
+
+def plant_current_cell(
+    shelf: Path,
+    *,
+    source_stamp: str,
+    payload: bytes,
+    binary: str = "sugar",
+) -> tuple[str, Path, Path]:
+    key = content_key(payload)
+    cell = shelf / "cas" / key / binary
+    cell.mkdir(parents=True)
+    sha256 = hashlib.sha256(payload).hexdigest()
+    with gzip.GzipFile(
+        filename=str(cell / f"{binary}.gz"), mode="wb", mtime=0
+    ) as target:
+        target.write(payload)
+    manifest = {
+        "binary": binary,
+        "buildIdentity": source_stamp,
+        "built": True,
+        "cargo": "cargo fixture",
+        "executed": False,
+        "features": [],
+        "package": f"{binary}-package",
+        "platform": PLATFORM,
+        "profile": PROFILE,
+        "rustc": "rustc fixture",
+        "schema": 1,
+        "sha256": sha256,
+        "sourceStamp": source_stamp,
+        "targetTriple": "x86_64-unknown-linux-gnu",
+    }
+    metadata = {
+        "actor": "fixture",
+        "buildStamp": source_stamp,
+        "contentKey": key,
+        "platform": PLATFORM,
+        "profile": PROFILE,
+        "sha256": sha256,
+        "source": f"/fixture/{binary}",
+        "transport": "filesystem-cas-v3",
+    }
+    (cell / f"{binary}.sugarbin.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (cell / f"{binary}.metadata.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    ref = shelf / PLATFORM / PROFILE / "by-stamp" / source_stamp / f"{binary}.ref"
+    ref.parent.mkdir(parents=True, exist_ok=True)
+    ref.write_text(key + "\n", encoding="utf-8")
+    return key, cell, ref
+
+
+def tree_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(root.rglob("*")):
+        digest.update(str(path.relative_to(root)).encode())
+        if path.is_file():
+            digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+class LegacyShelfMigrationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="legacy-shelf-migration.")
+        self.shelf = Path(self.temporary.name) / "shelf"
+        self.shelf.mkdir()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def run_tool(
+        self, *extra: str, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(TOOL),
+                "--shelf-root",
+                str(self.shelf),
+                "--platform",
+                PLATFORM,
+                "--profile",
+                PROFILE,
+                *extra,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=env,
+        )
+
+    def test_dry_run_reports_every_outcome_without_writing(self) -> None:
+        legacy_cell(self.shelf, source_stamp=stamp("1"), payload=b"eligible")
+        legacy_cell(
+            self.shelf,
+            source_stamp=stamp("2"),
+            payload=b"checksum",
+            corrupt_payload=True,
+        )
+        legacy_cell(
+            self.shelf,
+            source_stamp=stamp("3"),
+            payload=b"malformed",
+            malformed_manifest=True,
+        )
+        legacy_cell(self.shelf, source_stamp=stamp("4"), payload=b"current")
+        plant_current_cell(
+            self.shelf, source_stamp=stamp("4"), payload=b"current"
+        )
+        evidence = self.shelf / "cas" / "evidence" / ".incoming" / "survives"
+        evidence.mkdir(parents=True)
+        (evidence / "raw.txt").write_text("do-not-touch\n", encoding="utf-8")
+        before = tree_digest(self.shelf)
+
+        result = self.run_tool()
+
+        self.assertEqual(result.returncode, 3, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(report["mode"], "dry-run")
+        self.assertEqual(
+            report["counts"],
+            {
+                "alreadyPresent": 1,
+                "checksumFailed": 1,
+                "conflict": 0,
+                "discovered": 4,
+                "malformedManifest": 1,
+                "wouldMigrate": 1,
+                "writesPerformed": 0,
+            },
+        )
+        self.assertEqual(tree_digest(self.shelf), before)
+        self.assertFalse(
+            (self.shelf / PLATFORM / PROFILE / "by-stamp" / stamp("1")).exists()
+        )
+
+    def test_apply_is_idempotent_and_preserves_legacy_and_incoming(self) -> None:
+        source_stamp = stamp("5")
+        legacy = legacy_cell(
+            self.shelf, source_stamp=source_stamp, payload=b"migrate-me"
+        )
+        legacy_before = tree_digest(legacy)
+        evidence = self.shelf / "cas" / "evidence" / ".incoming" / "survives"
+        evidence.mkdir(parents=True)
+        (evidence / "raw.txt").write_text("do-not-touch\n", encoding="utf-8")
+        incoming_before = tree_digest(self.shelf / "cas" / "evidence")
+
+        first = self.run_tool("--apply")
+
+        self.assertEqual(first.returncode, 0, first.stderr)
+        first_report = json.loads(first.stdout)
+        self.assertEqual(first_report["counts"]["migrated"], 1)
+        self.assertEqual(first_report["counts"]["writesPerformed"], 1)
+        key = content_key(b"migrate-me")
+        current = self.shelf / "cas" / key / "sugar"
+        ref = (
+            self.shelf
+            / PLATFORM
+            / PROFILE
+            / "by-stamp"
+            / source_stamp
+            / "sugar.ref"
+        )
+        self.assertEqual(ref.read_text(encoding="utf-8"), key + "\n")
+        self.assertEqual(
+            gzip.decompress((current / "sugar.gz").read_bytes()), b"migrate-me"
+        )
+        current_metadata = json.loads(
+            (current / "sugar.metadata.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(current_metadata["contentKey"], key)
+        self.assertEqual(current_metadata["transport"], "filesystem-cas-v3")
+        self.assertEqual(current_metadata["buildStamp"], source_stamp)
+        self.assertEqual(tree_digest(legacy), legacy_before)
+        self.assertEqual(
+            tree_digest(self.shelf / "cas" / "evidence"), incoming_before
+        )
+        current_before = tree_digest(current)
+        ref_before = ref.read_bytes()
+
+        second = self.run_tool("--apply")
+
+        self.assertEqual(second.returncode, 0, second.stderr)
+        second_report = json.loads(second.stdout)
+        self.assertEqual(second_report["counts"]["migrated"], 0)
+        self.assertEqual(second_report["counts"]["alreadyPresent"], 1)
+        self.assertEqual(second_report["counts"]["writesPerformed"], 0)
+        self.assertEqual(tree_digest(current), current_before)
+        self.assertEqual(ref.read_bytes(), ref_before)
+
+    def test_apply_never_overwrites_a_resolving_ref(self) -> None:
+        source_stamp = stamp("6")
+        legacy_cell(self.shelf, source_stamp=source_stamp, payload=b"old-build")
+        key, current, ref = plant_current_cell(
+            self.shelf, source_stamp=source_stamp, payload=b"newer-build"
+        )
+        current_before = tree_digest(current)
+        ref_before = ref.read_bytes()
+
+        result = self.run_tool("--apply")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(report["counts"]["alreadyPresent"], 1)
+        self.assertEqual(report["counts"]["writesPerformed"], 0)
+        self.assertEqual(ref.read_text(encoding="utf-8"), key + "\n")
+        self.assertEqual(ref.read_bytes(), ref_before)
+        self.assertEqual(tree_digest(current), current_before)
+
+    def test_apply_heals_a_matching_dangling_ref_without_rewriting_it(self) -> None:
+        source_stamp = stamp("7")
+        payload = b"restore-cas-cell"
+        legacy_cell(self.shelf, source_stamp=source_stamp, payload=payload)
+        key = content_key(payload)
+        ref = (
+            self.shelf
+            / PLATFORM
+            / PROFILE
+            / "by-stamp"
+            / source_stamp
+            / "sugar.ref"
+        )
+        ref.parent.mkdir(parents=True)
+        ref.write_text(key + "\n", encoding="utf-8")
+        ref_before = ref.read_bytes()
+
+        result = self.run_tool("--apply")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(report["counts"]["migrated"], 1)
+        self.assertEqual(ref.read_bytes(), ref_before)
+        self.assertTrue((self.shelf / "cas" / key / "sugar" / "sugar.gz").is_file())
+
+    def test_same_payload_at_two_source_stamps_is_refused_before_writing(self) -> None:
+        payload = b"identical-build-output"
+        legacy_cell(self.shelf, source_stamp=stamp("8"), payload=payload)
+        legacy_cell(self.shelf, source_stamp=stamp("9"), payload=payload)
+        before = tree_digest(self.shelf)
+
+        result = self.run_tool("--apply")
+
+        self.assertEqual(result.returncode, 3, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(report["counts"]["conflict"], 2)
+        self.assertEqual(report["counts"]["migrated"], 0)
+        self.assertEqual(report["counts"]["writesPerformed"], 0)
+        self.assertEqual(tree_digest(self.shelf), before)
+
+    def test_checksum_failure_is_refused_before_blake3_addressing(self) -> None:
+        legacy_cell(
+            self.shelf,
+            source_stamp=stamp("a"),
+            payload=b"declared-payload",
+            corrupt_payload=True,
+        )
+        fake_bin = Path(self.temporary.name) / "fake-bin"
+        fake_bin.mkdir()
+        marker = Path(self.temporary.name) / "b3sum-was-called"
+        fake_b3sum = fake_bin / "b3sum"
+        fake_b3sum.write_text(
+            f"#!/usr/bin/env bash\n: >{marker!s}\nexit 99\n", encoding="utf-8"
+        )
+        fake_b3sum.chmod(0o755)
+        env = dict(os.environ)
+        env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+        result = self.run_tool(env=env)
+
+        self.assertEqual(result.returncode, 3, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(report["counts"]["checksumFailed"], 1)
+        self.assertFalse(marker.exists(), "BLAKE3 ran before SHA-256 validation")
+
+    def test_legacy_split_identity_is_named_as_a_conflict_not_skipped(self) -> None:
+        source_stamp = stamp("b")
+        build_identity = stamp("c")
+        legacy_cell(
+            self.shelf,
+            source_stamp=source_stamp,
+            build_identity=build_identity,
+            legacy_colon_keys=True,
+            binary="coretests_sweep",
+            payload=b"pre-identity-collapse",
+        )
+
+        result = self.run_tool()
+
+        self.assertEqual(result.returncode, 3, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(report["counts"]["conflict"], 1)
+        self.assertEqual(report["counts"]["malformedManifest"], 0)
+        row = report["rows"][0]
+        self.assertEqual(row["binary"], "coretests_sweep")
+        self.assertEqual(row["sourceStamp"], source_stamp)
+        self.assertIn("buildIdentity", row["detail"])
+
+    def test_apply_normalizes_equal_legacy_key_spelling_for_current_pull(self) -> None:
+        source_stamp = stamp("d")
+        legacy_cell(
+            self.shelf,
+            source_stamp=source_stamp,
+            legacy_colon_keys=True,
+            payload=b"same-identity-legacy-spelling",
+        )
+
+        result = self.run_tool("--apply")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(report["counts"]["migrated"], 1)
+        key = content_key(b"same-identity-legacy-spelling")
+        current_manifest = json.loads(
+            (
+                self.shelf
+                / "cas"
+                / key
+                / "sugar"
+                / "sugar.sugarbin.json"
+            ).read_text(encoding="utf-8")
+        )
+        self.assertEqual(current_manifest["sourceStamp"], source_stamp)
+        self.assertEqual(current_manifest["buildIdentity"], source_stamp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/migrate_legacy_binary_shelf.py
+++ b/tools/migrate_legacy_binary_shelf.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""Migrate verified stamp-keyed binary shelf cells into the current CAS layout.
+
+The default is a read-only dry run. ``--apply`` copies existing compressed
+payloads and manifests into ``cas/<h(payload)>/<binary>`` and creates the
+``sourceStamp -> h(payload)`` reference. Legacy cells are never removed.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import gzip
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+CONTENT_KEY = re.compile(r"blake3-512_[0-9a-f]{128}\Z")
+SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+BINARY = re.compile(r"[A-Za-z0-9._-]+\Z")
+CHUNK_SIZE = 1024 * 1024
+
+
+class InstrumentFailure(RuntimeError):
+    """The migration instrument could not render a trustworthy verdict."""
+
+
+class MalformedManifest(ValueError):
+    """A legacy cell's identity testimony is incomplete or contradictory."""
+
+
+class ChecksumFailure(ValueError):
+    """A legacy or current cell's payload does not match its testimony."""
+
+
+@dataclass(frozen=True)
+class LegacyCell:
+    path: Path
+    source_stamp: str
+    build_identity: str
+    binary: str
+    legacy_name: str
+    gzip_path: Path
+    manifest_path: Path
+    metadata_path: Path
+
+
+@dataclass
+class Row:
+    legacyCell: str
+    sourceStamp: str | None = None
+    binary: str | None = None
+    contentKey: str | None = None
+    status: str = "malformed-manifest"
+    detail: str = ""
+    candidate: LegacyCell | None = None
+    manifest: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
+
+    def render(self) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in {
+                "legacyCell": self.legacyCell,
+                "sourceStamp": self.sourceStamp,
+                "binary": self.binary,
+                "contentKey": self.contentKey,
+                "status": self.status,
+                "detail": self.detail,
+            }.items()
+            if value is not None
+        }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--shelf-root", type=Path, required=True)
+    parser.add_argument("--platform", default="linux-x86_64")
+    parser.add_argument("--profile", default="release")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="atomically install eligible cells and refs (default: dry run)",
+    )
+    args = parser.parse_args()
+    for label in ("platform", "profile"):
+        value = getattr(args, label)
+        if not BINARY.fullmatch(value):
+            parser.error(f"--{label} must be path-safe")
+    return args
+
+
+def load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise MalformedManifest(f"{label} is not readable JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise MalformedManifest(f"{label} root is not an object")
+    return value
+
+
+def require_equal(data: dict[str, Any], field: str, expected: Any, label: str) -> None:
+    if data.get(field) != expected:
+        raise MalformedManifest(
+            f"{label}.{field}={data.get(field)!r}, expected {expected!r}"
+        )
+
+
+def require_nonempty_string(data: dict[str, Any], field: str, label: str) -> None:
+    value = data.get(field)
+    if not isinstance(value, str) or not value:
+        raise MalformedManifest(f"{label}.{field} is not a non-empty string")
+
+
+def normalize_content_key(value: Any, label: str) -> str:
+    if not isinstance(value, str):
+        raise MalformedManifest(f"{label} is not a string")
+    normalized = value.replace("blake3-512:", "blake3-512_", 1)
+    if not CONTENT_KEY.fullmatch(normalized):
+        raise MalformedManifest(f"{label} is not a blake3-512 key: {value!r}")
+    return normalized
+
+
+def parse_legacy_cell(
+    path: Path, *, platform: str, profile: str
+) -> tuple[LegacyCell, dict[str, Any], dict[str, Any]]:
+    source_stamp = normalize_content_key(
+        path.parent.name, "source-stamp directory"
+    )
+    identity_separator = f"-{platform}-{profile}-"
+    binary, separator, identity_text = path.name.rpartition(identity_separator)
+    if not separator:
+        raise MalformedManifest(
+            f"legacy leaf {path.name!r} does not contain {identity_separator!r}"
+        )
+    if not BINARY.fullmatch(binary):
+        raise MalformedManifest(f"legacy binary name is not path-safe: {binary!r}")
+    build_identity = normalize_content_key(identity_text, "legacy leaf build identity")
+    candidate = LegacyCell(
+        path=path,
+        source_stamp=source_stamp,
+        build_identity=build_identity,
+        binary=binary,
+        legacy_name=path.name,
+        gzip_path=path / f"{path.name}.gz",
+        manifest_path=path / f"{path.name}.sugarbin.json",
+        metadata_path=path / f"{path.name}.metadata.json",
+    )
+    for artifact in (
+        candidate.gzip_path,
+        candidate.manifest_path,
+        candidate.metadata_path,
+    ):
+        if not artifact.is_file():
+            raise MalformedManifest(f"legacy cell is missing {artifact.name}")
+
+    manifest = load_json(candidate.manifest_path, "manifest")
+    metadata = load_json(candidate.metadata_path, "metadata")
+    expected_manifest = {
+        "schema": 1,
+        "binary": binary,
+        "platform": platform,
+        "profile": profile,
+        "features": [],
+        "built": True,
+        "executed": False,
+    }
+    for field, expected in expected_manifest.items():
+        require_equal(manifest, field, expected, "manifest")
+    if normalize_content_key(manifest.get("sourceStamp"), "manifest.sourceStamp") != source_stamp:
+        raise MalformedManifest("manifest.sourceStamp does not equal the parent stamp")
+    if normalize_content_key(
+        manifest.get("buildIdentity"), "manifest.buildIdentity"
+    ) != build_identity:
+        raise MalformedManifest("manifest.buildIdentity does not equal the leaf identity")
+    for field in ("package", "targetTriple", "rustc", "cargo"):
+        require_nonempty_string(manifest, field, "manifest")
+    expected_metadata = {
+        "platform": platform,
+        "profile": profile,
+        "transport": "filesystem-cas-v2",
+    }
+    for field, expected in expected_metadata.items():
+        require_equal(metadata, field, expected, "metadata")
+    if normalize_content_key(metadata.get("buildStamp"), "metadata.buildStamp") != source_stamp:
+        raise MalformedManifest("metadata.buildStamp does not equal the parent stamp")
+    for field in ("actor", "publishedAt", "source"):
+        require_nonempty_string(metadata, field, "metadata")
+    manifest_sha = manifest.get("sha256")
+    metadata_sha = metadata.get("sha256")
+    if not isinstance(manifest_sha, str) or not SHA256.fullmatch(manifest_sha):
+        raise MalformedManifest("manifest.sha256 is not a SHA-256 digest")
+    if metadata_sha != manifest_sha:
+        raise MalformedManifest(
+            "metadata.sha256 does not equal the manifest payload checksum"
+        )
+    return candidate, manifest, metadata
+
+
+def hash_gzip_payload(path: Path, expected_sha256: str) -> tuple[str, str]:
+    """Validate SHA-256, then derive BLAKE3 from the verified payload."""
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix="sugarbin-legacy-payload.", delete=False
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            sha256 = hashlib.sha256()
+            with gzip.open(path, "rb") as source:
+                while chunk := source.read(CHUNK_SIZE):
+                    sha256.update(chunk)
+                    temporary.write(chunk)
+    except (OSError, EOFError) as error:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+        raise ChecksumFailure(f"payload gzip cannot be decompressed: {error}") from error
+    actual_sha256 = sha256.hexdigest()
+    if actual_sha256 != expected_sha256:
+        assert temporary_path is not None
+        temporary_path.unlink(missing_ok=True)
+        raise ChecksumFailure(
+            f"decompressed payload sha256={actual_sha256}, manifest={expected_sha256}"
+        )
+    assert temporary_path is not None
+    try:
+        result = subprocess.run(
+            ["b3sum", "-l", "64", "--no-names", str(temporary_path)],
+            check=False,
+            capture_output=True,
+        )
+    except OSError as error:
+        raise InstrumentFailure(f"cannot execute b3sum: {error}") from error
+    finally:
+        temporary_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise InstrumentFailure(
+            f"b3sum exited {result.returncode}: "
+            f"{result.stderr.decode(errors='replace').strip()}"
+        )
+    digest = result.stdout.decode("ascii", errors="strict").strip()
+    if not re.fullmatch(r"[0-9a-f]{128}", digest):
+        raise InstrumentFailure(f"b3sum emitted a malformed digest: {digest!r}")
+    return actual_sha256, f"blake3-512_{digest}"
+
+
+def discover_legacy_cells(root: Path, platform: str, profile: str) -> list[Path]:
+    population = root / platform / profile
+    if not population.is_dir():
+        raise InstrumentFailure(f"legacy shelf population does not exist: {population}")
+    cells: list[Path] = []
+    for stamp_dir in sorted(population.iterdir()):
+        if not stamp_dir.is_dir() or stamp_dir.name == "by-stamp":
+            continue
+        for cell in sorted(stamp_dir.iterdir()):
+            if cell.is_dir() and cell.name != ".incoming":
+                cells.append(cell)
+    return cells
+
+
+def current_paths(
+    root: Path, platform: str, profile: str, source_stamp: str, binary: str, key: str
+) -> tuple[Path, Path]:
+    cell = root / "cas" / key / binary
+    ref = root / platform / profile / "by-stamp" / source_stamp / f"{binary}.ref"
+    return cell, ref
+
+
+def read_ref(ref: Path) -> str | None:
+    if not ref.exists():
+        return None
+    try:
+        key = "".join(ref.read_text(encoding="utf-8").split())
+    except (OSError, UnicodeError) as error:
+        raise MalformedManifest(f"current ref is unreadable: {error}") from error
+    if not CONTENT_KEY.fullmatch(key):
+        raise MalformedManifest(f"current ref is not a blake3-512 key: {key!r}")
+    return key
+
+
+def current_cell_complete(cell: Path, binary: str) -> bool:
+    return all(
+        (cell / f"{binary}{suffix}").is_file()
+        for suffix in (".gz", ".sugarbin.json", ".metadata.json")
+    )
+
+
+def current_cell_resolves(
+    cell: Path,
+    *,
+    binary: str,
+    source_stamp: str,
+    content_key: str,
+    platform: str,
+    profile: str,
+) -> bool:
+    if not current_cell_complete(cell, binary):
+        return False
+    manifest_path = cell / f"{binary}.sugarbin.json"
+    try:
+        manifest = load_json(manifest_path, "current manifest")
+        for field, expected in {
+            "schema": 1,
+            "binary": binary,
+            "sourceStamp": source_stamp,
+            "buildIdentity": source_stamp,
+            "platform": platform,
+            "profile": profile,
+            "built": True,
+            "executed": False,
+        }.items():
+            require_equal(manifest, field, expected, "current manifest")
+        manifest_sha = manifest.get("sha256")
+        if not isinstance(manifest_sha, str) or not SHA256.fullmatch(manifest_sha):
+            return False
+        actual_sha, actual_key = hash_gzip_payload(
+            cell / f"{binary}.gz", manifest_sha
+        )
+    except (MalformedManifest, ChecksumFailure):
+        return False
+    return actual_key == content_key and manifest.get("sha256") == actual_sha
+
+
+def classify_cell(
+    path: Path, *, root: Path, platform: str, profile: str
+) -> Row:
+    row = Row(legacyCell=str(path))
+    try:
+        candidate, manifest, metadata = parse_legacy_cell(
+            path, platform=platform, profile=profile
+        )
+        row.sourceStamp = candidate.source_stamp
+        row.binary = candidate.binary
+        actual_sha, content_key = hash_gzip_payload(
+            candidate.gzip_path, manifest["sha256"]
+        )
+        row.contentKey = content_key
+        row.candidate = candidate
+        row.manifest = manifest
+        row.metadata = metadata
+        if candidate.build_identity != candidate.source_stamp:
+            row.status = "conflict"
+            row.detail = (
+                f"legacy buildIdentity={candidate.build_identity} differs from "
+                f"sourceStamp={candidate.source_stamp}; current build_identity(sourceStamp) "
+                "requires equality, and migration cannot fabricate it"
+            )
+            return row
+        current_cell, ref = current_paths(
+            root,
+            platform,
+            profile,
+            candidate.source_stamp,
+            candidate.binary,
+            content_key,
+        )
+        try:
+            ref_key = read_ref(ref)
+        except MalformedManifest as error:
+            row.status = "conflict"
+            row.detail = str(error)
+            return row
+        if ref_key is not None:
+            referred_cell = root / "cas" / ref_key / candidate.binary
+            if current_cell_resolves(
+                referred_cell,
+                binary=candidate.binary,
+                source_stamp=candidate.source_stamp,
+                content_key=ref_key,
+                platform=platform,
+                profile=profile,
+            ):
+                row.status = "already-present"
+                row.detail = "existing ref already resolves to a verified current cell"
+                return row
+            if ref_key != content_key:
+                row.status = "conflict"
+                row.detail = (
+                    f"existing unresolved ref names {ref_key}; migration will not overwrite it"
+                )
+                return row
+        if current_cell.exists() and not current_cell_resolves(
+            current_cell,
+            binary=candidate.binary,
+            source_stamp=candidate.source_stamp,
+            content_key=content_key,
+            platform=platform,
+            profile=profile,
+        ):
+            row.status = "conflict"
+            row.detail = (
+                "target CAS leaf exists but is incomplete or carries different identity testimony"
+            )
+            return row
+        row.status = "candidate"
+        row.detail = "verified legacy bytes can populate current CAS and stamp ref"
+        return row
+    except ChecksumFailure as error:
+        row.status = "checksum-failed"
+        row.detail = str(error)
+        return row
+    except MalformedManifest as error:
+        row.status = "malformed-manifest"
+        row.detail = str(error)
+        return row
+
+
+def reject_unrepresentable_collisions(rows: list[Row]) -> None:
+    groups: dict[tuple[str, str], list[Row]] = {}
+    for row in rows:
+        if row.status == "candidate" and row.contentKey and row.binary:
+            groups.setdefault((row.contentKey, row.binary), []).append(row)
+    for (content_key, binary), group in groups.items():
+        stamps = {row.sourceStamp for row in group}
+        if len(stamps) <= 1:
+            continue
+        detail = (
+            f"{len(stamps)} source stamps share CAS payload {content_key} for {binary}, "
+            "but the current leaf carries one source-specific manifest"
+        )
+        for row in group:
+            row.status = "conflict"
+            row.detail = detail
+
+
+def copy_verified_cell(row: Row, *, root: Path, platform: str, profile: str) -> str:
+    assert row.candidate is not None
+    assert row.contentKey is not None
+    candidate = row.candidate
+    target, ref = current_paths(
+        root,
+        platform,
+        profile,
+        candidate.source_stamp,
+        candidate.binary,
+        row.contentKey,
+    )
+
+    # Re-evaluate both protected destinations immediately before writing. A
+    # concurrent publisher may have completed either after the dry scan.
+    existing_ref = read_ref(ref)
+    if existing_ref is not None:
+        referred_cell = root / "cas" / existing_ref / candidate.binary
+        if current_cell_resolves(
+            referred_cell,
+            binary=candidate.binary,
+            source_stamp=candidate.source_stamp,
+            content_key=existing_ref,
+            platform=platform,
+            profile=profile,
+        ):
+            return "already-present"
+        if existing_ref != row.contentKey:
+            raise MalformedManifest(
+                f"existing unresolved ref names {existing_ref}; refusing overwrite"
+            )
+
+    if target.exists():
+        if not current_cell_resolves(
+            target,
+            binary=candidate.binary,
+            source_stamp=candidate.source_stamp,
+            content_key=row.contentKey,
+            platform=platform,
+            profile=profile,
+        ):
+            raise MalformedManifest(
+                "target CAS leaf appeared with incomplete or different testimony"
+            )
+    else:
+        target.parent.mkdir(parents=True, exist_ok=True, mode=0o777)
+        stage = Path(
+            tempfile.mkdtemp(
+                prefix=f".{candidate.binary}.legacy-migration.", dir=target.parent
+            )
+        )
+        try:
+            shutil.copyfile(candidate.gzip_path, stage / f"{candidate.binary}.gz")
+            current_manifest = dict(row.manifest or {})
+            current_manifest["sourceStamp"] = candidate.source_stamp
+            current_manifest["buildIdentity"] = candidate.source_stamp
+            (stage / f"{candidate.binary}.sugarbin.json").write_text(
+                json.dumps(current_manifest, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            current_metadata = dict(row.metadata or {})
+            current_metadata["contentKey"] = row.contentKey
+            current_metadata["transport"] = "filesystem-cas-v3"
+            (stage / f"{candidate.binary}.metadata.json").write_text(
+                json.dumps(current_metadata, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            os.chmod(stage, 0o777)
+            for child in stage.iterdir():
+                os.chmod(child, 0o644)
+            try:
+                os.rename(stage, target)
+            except OSError:
+                if not current_cell_resolves(
+                    target,
+                    binary=candidate.binary,
+                    source_stamp=candidate.source_stamp,
+                    content_key=row.contentKey,
+                    platform=platform,
+                    profile=profile,
+                ):
+                    raise
+        finally:
+            if stage.exists():
+                shutil.rmtree(stage)
+
+    if existing_ref is None:
+        ref.parent.mkdir(parents=True, exist_ok=True, mode=0o777)
+        fd, temporary_name = tempfile.mkstemp(prefix=f".{candidate.binary}.ref.", dir=ref.parent)
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as output:
+                output.write(row.contentKey + "\n")
+                output.flush()
+                os.fsync(output.fileno())
+            os.chmod(temporary, 0o644)
+            try:
+                os.link(temporary, ref)
+            except FileExistsError:
+                raced_key = read_ref(ref)
+                if raced_key != row.contentKey:
+                    raise MalformedManifest(
+                        f"stamp ref appeared concurrently with {raced_key}; refusing overwrite"
+                    )
+        finally:
+            temporary.unlink(missing_ok=True)
+    return "migrated"
+
+
+def make_report(
+    rows: list[Row], *, root: Path, platform: str, profile: str, apply: bool
+) -> dict[str, Any]:
+    counts: dict[str, int] = {
+        "alreadyPresent": sum(row.status == "already-present" for row in rows),
+        "checksumFailed": sum(row.status == "checksum-failed" for row in rows),
+        "conflict": sum(row.status == "conflict" for row in rows),
+        "discovered": len(rows),
+        "malformedManifest": sum(row.status == "malformed-manifest" for row in rows),
+    }
+    if apply:
+        counts["migrated"] = sum(row.status == "migrated" for row in rows)
+        counts["writesPerformed"] = counts["migrated"]
+    else:
+        counts["wouldMigrate"] = sum(row.status == "candidate" for row in rows)
+        counts["writesPerformed"] = 0
+    return {
+        "schema": 1,
+        "mode": "apply" if apply else "dry-run",
+        "shelfRoot": str(root),
+        "platform": platform,
+        "profile": profile,
+        "counts": counts,
+        "rows": [row.render() for row in rows],
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.shelf_root.resolve()
+    try:
+        paths = discover_legacy_cells(root, args.platform, args.profile)
+        rows = [
+            classify_cell(
+                path, root=root, platform=args.platform, profile=args.profile
+            )
+            for path in paths
+        ]
+        reject_unrepresentable_collisions(rows)
+        if args.apply:
+            for row in rows:
+                if row.status != "candidate":
+                    continue
+                try:
+                    row.status = copy_verified_cell(
+                        row, root=root, platform=args.platform, profile=args.profile
+                    )
+                    row.detail = (
+                        "legacy bytes installed without rebuild"
+                        if row.status == "migrated"
+                        else "concurrent publisher completed an existing resolution"
+                    )
+                except MalformedManifest as error:
+                    row.status = "conflict"
+                    row.detail = str(error)
+        report = make_report(
+            rows,
+            root=root,
+            platform=args.platform,
+            profile=args.profile,
+            apply=args.apply,
+        )
+    except InstrumentFailure as error:
+        print(f"legacy shelf migration unmeasured: {error}", file=sys.stderr)
+        return 2
+    json.dump(report, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    counts = report["counts"]
+    refusal_counts = ("checksumFailed", "malformedManifest", "conflict")
+    return 3 if any(counts[name] for name in refusal_counts) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## End-to-end proof

An independently derived current sourceStamp for sugar-walk-rpc, 32221760 with no override, matched a migrated row. With an empty materialization cache and self-heal disabled, resolution returned phase=resolve-hit and source=filesystem-shelf in 575 milliseconds: wrapper 0, no build phase, executable delivered.

Hit receipt sha256: 824282fe15ae41befa096d3bc7cd8638b65829b351e0ba50e60448727eea1ae6.

## Root cause and repair

e0598d3ad migrated the filesystem shelf to two-stage addressing: a by-stamp reference supplies h(payload), then cas/h(payload)/binary supplies the artifact. It never moved the 757 binaries already present in the legacy layout. Every sugarbin --profile release resolution therefore missed and paid for a cold Cargo build. This is the root cause recorded in #7202 and cost at least four measurements today.

This adds a dry-run-first migration instrument. It validates each legacy payload against its SHA-256 testimony, derives the current BLAKE3 storage key from the verified payload bytes, admits only identities representable under the current contract, installs through atomic staging, and never deletes a legacy cell.

## Measured apply and conservation

First apply over all 757 legacy leaves:

- migrated: 686
- already present: 3
- checksum failed: 0
- malformed/quarantined: 2
- conflicts: 66
- total conserved: 757

Apply receipt sha256: 02ea790972f03f7c23f2e1049e385d0525f5b871c07f3246d4087827b8d510ff.

The second apply was idempotent: 689 already present, 0 migrated, 0 writes, the same exclusions, and no unexpected transitions.

Idempotence receipt sha256: 1a916af36c909d24d1df97f67b982a5455e444fe1792ebf44f9876561549ea96.

One dry-run/apply delta is explained by concurrent state, not hand-waved: rust_test_assertions_rpc at 72b58320 moved from candidate to verified already-present because a concurrent publisher landed the cell during apply. Its identity and content key did not change.

## Named exclusions

Nothing excluded was transformed:

- 64 split legacy buildIdentity/sourceStamp cells remain schema conflicts; migration would fabricate an equivalence
- 2 source stamps sharing one payload but carrying source-specific manifests remain conflicts
- 2 non-stamp roots remain malformed/quarantined
- all 757 legacy leaves remain on disk
- the 3 pre-existing .incoming stages remain untouched

The migration receipt vocabulary is local and explicit: candidate, migrated, already-present, checksum-failed, malformed-manifest, and conflict. It adds no product residual kind or floor magnitude.

## Discrimination and verification

A pre-apply tooth caught a real hazard: legacy manifests use colon key spelling while current verify_artifact_manifest requires the path-safe underscore spelling. Blindly copied manifests would have populated the shelf while remaining unreadable, causing continued rebuilds. The migration normalizes spelling only when sourceStamp and buildIdentity are already identical; split identities remain conflicts.

Verification:

- 8/8 migration teeth
- existing R_shelf_content_addressed tooth
- py_compile
- diff check

## Non-claims

The 64 split identities are not claimed equivalent. Conflicts and quarantines are not migrated. Nothing is deleted. Existing .incoming stages are not cleaned by this migration. sugar-ir-smt-lib coverage is not claimed; it has 0 eligible of 4.

Closes #7202.
Closes #7206.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CLI tool to migrate verified legacy shelf cells to current CAS layout without rebuilding
> - Adds [tools/migrate_legacy_binary_shelf.py](https://github.com/TSavo/sugar/pull/7211/files#diff-7b6e54f3b90f7378727306eb465cdce16b7872478fa462a091ea492346199102), a CLI that discovers legacy `filesystem-cas-v2` shelf cells, validates manifests and gzip payloads (SHA-256 before BLAKE3), derives a `blake3-512` content key, and classifies each cell as `already-present`, `candidate`, `conflict`, `checksum-failed`, or `malformed-manifest`.
> - In dry-run mode, prints a structured JSON report and exits 0 (or 3 if any refusals/conflicts exist) without writing anything. With `--apply`, atomically installs CAS cells and `by-stamp` refs, skipping cells that already resolve correctly.
> - Adds [tests/sugarbin_legacy_shelf_migration.py](https://github.com/TSavo/sugar/pull/7211/files#diff-9fb513bec77f51726e5fb89233dcba513dd93dfd2f79ebb81055c01399f57a67) with end-to-end tests covering dry-run reporting, apply idempotency, ref protection, dangling-ref healing, conflict detection, checksum ordering, and legacy colon-key normalization.
> - Conflict detection prevents ambiguous migrations where identical payload would be addressed under multiple source stamps.
> - Risk: the tool invokes `b3sum` as an external process; if the binary is absent or fails, the tool exits with code 2 rather than migrating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30bb9b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->