### PR TITLE
Preserve nameless halted faces in attribution

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -293,25 +293,36 @@ class AttributionReport:
 
 
 def _exceptional_exit_effects(outcome: object) -> tuple[object, ...]:
-    from sugar_lift_py_tests.effect import RaiseEffect
+    from sugar_lift_py_tests.effect import RaiseEffect, UndeterminedRaiseEffect
     from sugar_lift_py_tests.floor import RaiseValue
     from sugar_lift_py_tests.outcome import Complete, ExitSet, Incomplete
     from sugar_lift_py_tests.outcome.exit_set import Halted
 
+    # A type-undetermined raise is still a halted face that this ledger must
+    # retain.  Its distinct type prevents it from entering the authenticated
+    # exceptional-exit arm; dropping it here would instead erase the face
+    # before the UNDISCHARGED identity tripwire can make it loud.
+    raise_effect_types = (RaiseEffect, UndeterminedRaiseEffect)
     if isinstance(outcome, Incomplete):
-        return (outcome.effect,) if isinstance(outcome.effect, RaiseEffect) else ()
+        return (
+            (outcome.effect,)
+            if isinstance(outcome.effect, raise_effect_types)
+            else ()
+        )
     if isinstance(outcome, Complete):
         value = outcome.value
         return (
             (value.effect,)
-            if isinstance(value, RaiseValue) and isinstance(value.effect, RaiseEffect)
+            if isinstance(value, RaiseValue)
+            and isinstance(value.effect, raise_effect_types)
             else ()
         )
     if isinstance(outcome, ExitSet):
         return tuple(
             face.effect
             for face in outcome.exits
-            if isinstance(face, Halted) and isinstance(face.effect, RaiseEffect)
+            if isinstance(face, Halted)
+            and isinstance(face.effect, raise_effect_types)
         )
     return ()
 


### PR DESCRIPTION
## Root cause

Exact ancestry, not blame, identifies the regression boundary.

Commit 8a3ceb2c09699d48f666d66552cb3a83ea9a85f9 deliberately split nameless exceptional halts into the distinct UndeterminedRaiseEffect type and updated _nameless_raise_value to construct it. Its parent ac7a96a8409c8bbeecf9817ad6dbe5f8efa5ea51 still used the earlier optional-coordinate RaiseEffect shape.

The migration stopped halfway: _exceptional_exit_effects still admitted only RaiseEffect in all three outcome forms. A nameless halted face was therefore erased before it could reach the ledger.

## Repair

Admit the existing closed raise pair, RaiseEffect and UndeterminedRaiseEffect, at that one attribution entrance across Incomplete, Complete/RaiseValue, and ExitSet/Halted outcomes.

Undetermined remains UNDISCHARGED and still trips the identity discrepancy. It is retained as a halted face but never counted as an authenticated exceptional exit. The change preserves the distinction introduced by 8a3ceb2c rather than collapsing it back, and it does not loosen RaiseEffect.

## Evidence

Authenticated CPython 3.12.13 and pandas 3.0.3:

- exact three teeth: 3/3 passed in 0.62s
- complete test_no_call_body_attribution.py: 30/30 passed in 0.74s
- one production source file changed
- zero test changes

The three formerly failing teeth were one cause with three witnesses:

- nameless halted face remains loud in the exit ledger
- corpus tally remains 503 faces and does not count the nameless face as authenticated
- None-coordinate identity discrepancy tripwire fires

Those teeth were authoritative throughout; none was superseded.

## Migration pattern

This is the fourth unfinished migration surfaced today: a type was split, its producer was updated, and its consumer was not. The other three were the two-identity demand-table architecture, the retired _measure_file door, and the b2a03b3ca contract plane.

## Non-claims

No corpus impact is claimed. No broader Effect family is admitted. Module.sugar is unrelated: ce223ec7 changed neither this file nor the nameless raise producer.

Closes #7196.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include `UndeterminedRaiseEffect` in exceptional exit effect attribution
> Updates `_exceptional_exit_effects` in [no_call_body_attribution.py](https://github.com/TSavo/sugar/pull/7214/files#diff-63dc4df7d670fe2740ec87663a519f79002baa69eb853f03a8559b42d8f325e4) to match `UndeterminedRaiseEffect` alongside `RaiseEffect` in all three branches: `Incomplete` outcomes, `Complete` outcomes with a `RaiseValue`, and `Halted` faces within an `ExitSet`. Previously, nameless halted faces carrying an `UndeterminedRaiseEffect` were silently dropped from attribution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a54bdf4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->