### PR TITLE
Consume sealed file denominator testimony

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -155,6 +155,65 @@ def _phase_call(name: str, fn):
         raise
 
 
+def _consume_sealed_files_complete(
+    result: dict[str, Any],
+    *,
+    measured_commit: str,
+) -> tuple[bool | None, dict[str, Any] | None]:
+    """Read the file-completeness testimony owned by the compose seal.
+
+    A sealed board can only carry ``denominator.files.complete is True``.
+    Missing, malformed, or contradictory testimony is instrument failure and
+    must replace the purported board with an unmeasured envelope.
+    """
+    try:
+        denominator = result["denominator"]
+        if not isinstance(denominator, dict):
+            raise TypeError("sealed board denominator testimony is not an object")
+        files = denominator["files"]
+        if not isinstance(files, dict):
+            raise TypeError(
+                "sealed board denominator.files testimony is not an object"
+            )
+        complete = files["complete"]
+        if complete is not True:
+            raise ValueError(
+                "sealed board denominator.files.complete testimony is not true"
+            )
+    except (KeyError, TypeError, ValueError) as exc:
+        from compose_control_effect_board import (
+            STAGE_TERMINAL_AGGREGATE_SEAL,
+            unmeasured_envelope,
+        )
+
+        reason = (
+            "sealed board missing denominator.files.complete testimony"
+            if isinstance(exc, KeyError)
+            else str(exc)
+        )
+        refusal = unmeasured_envelope(
+            plan={
+                "planCid": result.get("planCid"),
+                "measuredCommit": measured_commit,
+            },
+            missing_shards=["compose"],
+            unmeasured_reasons={"compose": reason},
+            measured_commit=measured_commit,
+            instrument_failures=[
+                {
+                    "stageId": STAGE_TERMINAL_AGGREGATE_SEAL,
+                    "observedEventType": (
+                        f"{type(exc).__module__}.{type(exc).__qualname__}"
+                    ),
+                    "phase": "post-compose-denominator-consumer",
+                    "reason": reason,
+                }
+            ],
+        )
+        return None, refusal
+    return True, None
+
+
 def _git_commit(root: Path) -> str:
     return subprocess.check_output(
         ["git", "rev-parse", "HEAD"], cwd=root, text=True
@@ -1800,6 +1859,23 @@ def main() -> int:
         result_path.write_text(json.dumps(result, indent=2) + "\n")
         return 2
 
+    denominator_complete, denominator_refusal = _consume_sealed_files_complete(
+        result,
+        measured_commit=tip_commit,
+    )
+    if denominator_refusal is not None:
+        _narrate(
+            "RECENSUS POST-COMPOSE UNMEASURED "
+            f"reasons={denominator_refusal.get('unmeasuredReasons')}"
+        )
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        result_path.write_text(
+            json.dumps(denominator_refusal, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return 2
+    assert denominator_complete is True
+
     r_construction = int(result.get("R_construction") or 0)
     r_desugar = int(result.get("R_desugar") or 0)
     r_backend = int(result.get("R_backend_defects") or 0)
@@ -1858,8 +1934,6 @@ def main() -> int:
     #
     # Every conjunct is reported beside the term, so a false claim is visible
     # in the same object that makes it.
-    denominator = result["denominator"]
-
     def _matching(needle: str) -> int:
         """Count a named shape wherever it can land — never one hopeful key.
 
@@ -1879,7 +1953,7 @@ def main() -> int:
 
     stable_zero_terms = {
         "completedDenominatorPositive": files_completed > 0,
-        "denominatorComplete": bool(denominator["complete"]),
+        "denominatorComplete": denominator_complete,
         # This instrument has no timeout mechanism: it runs in-process and a
         # hang is a hang, not a row. Any timeout testimony can only arrive as a
         # named defect, so that is where it is counted from.
@@ -1927,7 +2001,7 @@ def main() -> int:
             "files produced a terminal row that is not a completion "
             "(denominator is complete; the completion count is not)"
         )
-    if not denominator["complete"]:
+    if not denominator_complete:
         red_reasons.append("denominator contaminated (missing/duplicate/malformed)")
     result["red"] = bool(red_reasons)
     result["redReasons"] = red_reasons
@@ -1965,7 +2039,7 @@ def main() -> int:
         or desugar_construction_panics
         or desugar_defects
         or files_completed != len(file_names)
-        or not denominator["complete"]
+        or not denominator_complete
         else 0
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_denominator_complete_schema.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_denominator_complete_schema.py
@@ -1,0 +1,95 @@
+"""The post-compose consumer must use the denominator testimony the seal owns."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SCRIPT = _SCRIPTS / "control_effect_recensus.py"
+
+
+def _load():
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    spec = importlib.util.spec_from_file_location(
+        "control_effect_recensus_denominator_schema", _SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_post_compose_consumer_uses_sealed_file_completeness() -> None:
+    """A stale top-level spelling must not override sealed nested testimony."""
+    module = _load()
+    complete, refusal = module._consume_sealed_files_complete(
+        {
+            "planCid": "sha256:plan",
+            "denominator": {
+                "complete": False,
+                "files": {"complete": True},
+            },
+        },
+        measured_commit="227089c8",
+    )
+
+    assert complete is True
+    assert refusal is None
+
+
+def test_missing_sealed_file_completeness_refuses_without_width() -> None:
+    """Missing testimony is instrument failure, never an assumed completion."""
+    module = _load()
+    complete, refusal = module._consume_sealed_files_complete(
+        {
+            "planCid": "sha256:plan",
+            "frontierWidth": 7,
+            "denominator": {"complete": True, "files": {}},
+        },
+        measured_commit="227089c8",
+    )
+
+    assert complete is None
+    assert refusal is not None
+    assert refusal["kind"] == "control-effect-recensus-unmeasured/v1"
+    assert refusal["measured"] is False
+    assert refusal["measuredCommit"] == "227089c8"
+    assert refusal["planCid"] == "sha256:plan"
+    assert refusal["missingShards"] == ["compose"]
+    assert "frontierWidth" not in refusal
+    assert refusal["instrumentFailures"] == [
+        {
+            "stageId": "compose-terminal-aggregate-seal/v1",
+            "observedEventType": "builtins.KeyError",
+            "phase": "post-compose-denominator-consumer",
+            "reason": "sealed board missing denominator.files.complete testimony",
+        }
+    ]
+
+
+def test_false_sealed_file_completeness_refuses_as_contradictory() -> None:
+    """Compose cannot seal an incomplete file denominator; false is not a board."""
+    module = _load()
+    complete, refusal = module._consume_sealed_files_complete(
+        {
+            "planCid": "sha256:plan",
+            "frontierWidth": 7,
+            "denominator": {"files": {"complete": False}},
+        },
+        measured_commit="227089c8",
+    )
+
+    assert complete is None
+    assert refusal is not None
+    assert refusal["measured"] is False
+    assert "frontierWidth" not in refusal
+    assert refusal["instrumentFailures"][0]["observedEventType"] == (
+        "builtins.ValueError"
+    )
+    assert refusal["instrumentFailures"][0]["reason"] == (
+        "sealed board denominator.files.complete testimony is not true"
+    )


### PR DESCRIPTION
## Root cause

After a clean full-corpus walk, post-walk aggregation still exited 1 while reading a stale denominator.complete field.

Compose already proves denominator.files.complete=True before sealing. The later top-level consumer continued reading the pre-schema-move spelling, raised after the walk, and suppressed the result write.

## Repair

Consume the file-completeness testimony from the owner that seals it: denominator.files.complete.

This does not default completeness to true. Missing, malformed, false, or contradictory testimony replaces the purported board with an Unmeasured envelope carrying a named post-compose-denominator-consumer instrument failure. No frontierWidth survives that refusal.

That refusal arm is load-bearing: absence of completeness testimony must refuse, never assume.

## Discrimination

The focused schema teeth cover:

- nested denominator.files.complete=True is consumed even when the stale top-level field says false
- a missing nested completeness field refuses, emits no frontierWidth, and names the missing testimony
- nested completeness=False refuses as contradictory and emits no frontierWidth

The post-compose stable-zero terms and final process verdict now consume the already-authenticated boolean returned by that one door.

## Scope

One production script and one dedicated test file change. No result category, residual kind, or CI/runner-capacity surface is added.

This is a frontier-width prerequisite, not a width claim. Together with runtimeIdentity/v1 it lets compose stop refusing; this PR alone emits no attested frontier width and claims no sealed census receipt.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consume sealed file denominator testimony in recensus CLI and validate completeness
> - Adds `_consume_sealed_files_complete` helper in [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/7216/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) that reads `result['denominator']['files']['complete']` and returns a structured refusal envelope on missing, malformed, or non-`True` values.
> - Updates the CLI entrypoint to call this helper after the seal step; a refusal causes an `UNMEASURED` narration, writes the envelope to `result_path`, and exits with code 2.
> - Replaces prior reliance on the top-level `denominator['complete']` field with the sealed `denominator.files.complete` value for `denominatorComplete`, red-reason construction, and exit decisions.
> - Adds tests in [test_recensus_denominator_complete_schema.py](https://github.com/TSavo/sugar/pull/7216/files#diff-ae9e4578fdaebe5f5b7f4da5019828cdee3899d1f63f80051b6e728042e20e5f) covering: correct `(True, None)` return when sealed completeness is `True`, and refusal envelopes when the field is missing or `False`.
> - Behavioral Change: the CLI now exits 2 and writes an unmeasured envelope when `denominator.files.complete` is absent or not `True`, where previously it would proceed using the top-level field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7366071.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->